### PR TITLE
luxon: Fix tests for stricter DOM types in TS 4.2

### DIFF
--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -129,7 +129,7 @@ dt.isInDST; // $ExpectType boolean
 
 dt.set({ hour: 3 }).hour; // $ExpectType number
 
-const f = { month: 'long', day: 'numeric' } as const;
+const f: { month: 'long', day: 'numeric' } = { month: 'long', day: 'numeric' };
 dt.setLocale('fr').toLocaleString(f);
 dt.setLocale('en-GB').toLocaleString(f);
 dt.setLocale('en-US').toLocaleString(f);

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -129,7 +129,7 @@ dt.isInDST; // $ExpectType boolean
 
 dt.set({ hour: 3 }).hour; // $ExpectType number
 
-const f = { month: 'long', day: 'numeric' };
+const f = { month: 'long', day: 'numeric' } as const;
 dt.setLocale('fr').toLocaleString(f);
 dt.setLocale('en-GB').toLocaleString(f);
 dt.setLocale('en-US').toLocaleString(f);


### PR DESCRIPTION
In Typescript 4.2, `DateTimeFormatOptions` makes `month` and `day` into string literal unions, so object literals need to have `as const` appended.

Edit: `as const` only works in TS 3.4 and above, so I changed to add a type annotation.