### PR TITLE
Fix serverless Service.functions

### DIFF
--- a/types/serverless/classes/Service.d.ts
+++ b/types/serverless/classes/Service.d.ts
@@ -30,7 +30,7 @@ declare class Service {
     service: string | null;
     plugins: string[];
     pluginsData: { [key: string]: any };
-    functions: { [key: string]: Serverless.FunctionDefinition };
+    functions: { [key: string]: Serverless.FunctionDefinitionHandler | Serverless.FunctionDefinitionImage };
     resources:
         | {
               Resources: {


### PR DESCRIPTION
It looks like it should have the same return type as `getFunction`, but it doesn't. I think it was missed in #50036

Without this change, the tests fail because the property `handler` was removed.
