### PR TITLE
Update slice-source's use of ReadableStreamReader

### DIFF
--- a/types/slice-source/index.d.ts
+++ b/types/slice-source/index.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Björn Harrtell <https://github.com/bjornharrtell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function slice(source: ReadableStream | ReadableStreamReader | SliceSource): SliceSource;
+// tslint:disable-next-line:use-default-type-parameter
+declare function slice(source: ReadableStream | ReadableStreamReader<any> | SliceSource): SliceSource;
 
 interface SliceChunk {
     value: Uint8Array;


### PR DESCRIPTION
Add a TS-4.2-required type parameter, plus a tslint exception for older versions.