### PR TITLE
[prosemirror-view] Optional `side` param for `domAtPos`

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-view 1.16
+// Type definitions for prosemirror-view 1.17
 // Project: https://github.com/ProseMirror/prosemirror-view
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
@@ -329,11 +329,15 @@ export class EditorView<S extends Schema = any> {
   coordsAtPos(pos: number, side?: number): { left: number; right: number; top: number; bottom: number };
   /**
    * Find the DOM position that corresponds to the given document
-   * position. Note that you should **not** mutate the editor's
-   * internal DOM, only inspect it (and even that is usually not
-   * necessary).
+   * position. When `side` is negative, find the position as close as
+   * possible to the content before the position. When positive,
+   * prefer positions close to the content after the position. When
+   * zero, prefer as shallow a position as possible.
+   *
+   * Note that you should **not** mutate the editor's internal DOM,
+   * only inspect it (and even that is usually not necessary).
    */
-  domAtPos(pos: number): { node: Node; offset: number };
+  domAtPos(pos: number, side?: number): { node: Node; offset: number };
   /**
    * Find the DOM node that represents the document node after the
    * given position. May return null when the position doesn't point

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -24,6 +24,8 @@ const res1_2: { pos: number, inside: number } = res1_1.posAtCoords({ left: 0, to
 const res1_3: boolean = res1_1.editable;
 const res1_4 = res1_1.coordsAtPos(1);
 const res1_5 = res1_1.coordsAtPos(1, 1);
+const res1_6 = res1_1.domAtPos(1);
+const res1_7 = res1_1.domAtPos(1, 1);
 res1_1.setProps({ scrollThreshold: 42 });
 
 const res2_1: view.EditorProps = {} as any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-view/blob/1.17.0/CHANGELOG.md#new-features
https://github.com/ProseMirror/prosemirror-view/commit/d1200b75e55dcf0c47ac3d3bdd0c7a339cdccc7f
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
