### PR TITLE
[react-lazyload] add `style` prop from version 3.1.0

### DIFF
--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for react-lazyload ver 3.1.0
+// Type definitions for react-lazyload ver 3.1
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 //                 svobik7 <https://github.com/svobik7>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Component, ReactNode, CSSProperties } from "react";
+import { Component, ReactNode, CSSProperties } from 'react';
 
 export interface LazyLoadProps {
     once?: boolean;

--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for react-lazyload ver 3.0
+// Type definitions for react-lazyload ver 3.1.0
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 //                 svobik7 <https://github.com/svobik7>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Component, ReactNode } from "react";
+import { Component, ReactNode, CSSProperties } from "react";
 
 export interface LazyLoadProps {
     once?: boolean;
@@ -22,6 +22,7 @@ export interface LazyLoadProps {
     unmountIfInvisible?: boolean;
     preventLoading?: boolean;
     classNamePrefix?: string;
+    style?: CSSProperties;
 }
 
 export default class LazyLoad extends Component<LazyLoadProps> {


### PR DESCRIPTION
In the minor version 3.1.0, react-lazyload added the property `style` to allow the user to control the style of the wrapper div (https://github.com/twobin/react-lazyload#style)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twobin/react-lazyload#style
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
