### PR TITLE
[auth0] add optional parameters for pagination

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -326,6 +326,60 @@ management.getClients({fields:['name','client_metadata'], include_fields:true})
     // Handle the error
   });
 
+// Connections
+// Get all Connections with promise
+management.getConnections().then((connections: auth0.Connection[]) => {
+  console.log(connections);
+}).catch((err) => {
+  // error handler
+});
+
+// Get all Connections with callback
+management.getConnections((err: Error, connections: auth0.Connection[]) => {});
+
+// Get all Connections with promise and pagination
+management.getConnections({per_page: 25, page: 0}).then((connections: auth0.Connection[]) => {
+  console.log(connections);
+}).catch((err) => {
+  // error handler
+});
+
+// Rules
+// Get all Rules with promise
+management.getRules().then((rules: auth0.Rule[]) => {
+  console.log(rules);
+}).catch((err) => {
+  // error handler
+});
+
+// Get all Rules with callback
+management.getRules((err: Error, rule: auth0.Rule[]) => {});
+
+// Get all Rules with promise and pagination
+management.getRules({per_page: 25, page: 0}).then((rules: auth0.Rule[]) => {
+  console.log(rules);
+}).catch((err) => {
+  // error handler
+});
+
+// Resource Servers
+// Get all Resource Servers with promise
+management.getResourceServers().then((resourceServers: auth0.ResourceServer[]) => {
+  console.log(resourceServers);
+}).catch((err) => {
+  // error handler
+});
+
+// Get all Resource Servers with callback
+management.getResourceServers((err: Error, resourceServers: auth0.ResourceServer[]) => {});
+
+// Get all Resource Servers with promise and pagination
+management.getRules({per_page: 25, page: 0}).then((resourceServers: auth0.ResourceServer[]) => {
+  console.log(resourceServers);
+}).catch((err) => {
+  // error handler
+});
+
 // Get all clients with params (with callback)
 management.getClients({fields:['name','client_metadata'], include_fields:true}, (err:Error, clients:auth0.Client[]) => {});
 

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -932,17 +932,7 @@ export interface Enrollment {
   auth_method: AuthMethod;
 }
 
-export interface GetConnectionOptions {
-  per_page?: number;
-  page?: number;
-}
-
-export interface GetRuleOptions {
-  per_page?: number;
-  page?: number;
-}
-
-export interface GetResourceServerOptions {
+export interface PagingOptions {
   per_page?: number;
   page?: number;
 }
@@ -1006,7 +996,7 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   getClientInfo(): ClientInfo;
 
   // Connections
-  getConnections(params: GetConnectionOptions): Promise<Connection[]>;
+  getConnections(params: PagingOptions): Promise<Connection[]>;
   getConnections(): Promise<Connection[]>;
   getConnections(cb: (err: Error, connections: Connection[]) => void): void;
 
@@ -1110,7 +1100,7 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   getUsersInRole(params: ObjectWithId, cb: (err: Error, users: User<A, U>[]) => void): void;
 
     // Rules
-  getRules(params: GetRuleOptions): Promise<Rule[]>;
+  getRules(params: PagingOptions): Promise<Rule[]>;
   getRules(): Promise<Rule[]>;
   getRules(cb: (err: Error, rules: Rule[]) => void): void;
 
@@ -1298,7 +1288,7 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   createResourceServer(data: CreateResourceServer): Promise<ResourceServer>;
   createResourceServer(data: CreateResourceServer, cb?: (err: Error, data: ResourceServer) => void): void;
 
-  getResourceServers(params: GetResourceServerOptions): Promise<ResourceServer[]>;
+  getResourceServers(params: PagingOptions): Promise<ResourceServer[]>;
   getResourceServers(): Promise<ResourceServer[]>;
   getResourceServers(cb?: (err: Error, data: ResourceServer[]) => void): void;
 

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -932,6 +932,21 @@ export interface Enrollment {
   auth_method: AuthMethod;
 }
 
+export interface GetConnectionOptions {
+  per_page?: number;
+  page?: number;
+}
+
+export interface GetRuleOptions {
+  per_page?: number;
+  page?: number;
+}
+
+export interface GetResourceServerOptions {
+  per_page?: number;
+  page?: number;
+}
+
 export class AuthenticationClient {
 
   // Members
@@ -991,6 +1006,7 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   getClientInfo(): ClientInfo;
 
   // Connections
+  getConnections(params: GetConnectionOptions): Promise<Connection[]>;
   getConnections(): Promise<Connection[]>;
   getConnections(cb: (err: Error, connections: Connection[]) => void): void;
 
@@ -1094,6 +1110,7 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   getUsersInRole(params: ObjectWithId, cb: (err: Error, users: User<A, U>[]) => void): void;
 
     // Rules
+  getRules(params: GetRuleOptions): Promise<Rule[]>;
   getRules(): Promise<Rule[]>;
   getRules(cb: (err: Error, rules: Rule[]) => void): void;
 
@@ -1281,6 +1298,7 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   createResourceServer(data: CreateResourceServer): Promise<ResourceServer>;
   createResourceServer(data: CreateResourceServer, cb?: (err: Error, data: ResourceServer) => void): void;
 
+  getResourceServers(params: GetResourceServerOptions): Promise<ResourceServer[]>;
   getResourceServers(): Promise<ResourceServer[]>;
   getResourceServers(cb?: (err: Error, data: ResourceServer[]) => void): void;
 


### PR DESCRIPTION
- [x]  Use a meaningful title for the pull request. Include the name of the package modified.
- [x]  Test the change in your own code. (Compile and run.)
- [x]  [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x]  Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x]  Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x]  [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If adding a new definition:
- [x]  If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.

If changing an existing definition:
- [x]  Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/auth0/node-auth0/blob/88cdaa93aaa2fb4f1b8a6e77d83667c18138cbaa/src/management/index.js
https://auth0.com/docs/product-lifecycle/deprecations-and-migrations/migrate-to-paginated-queries
The link above explains the migration to Paginaed Queriesin some of the Management API v2 endpoints, after 26 January 2021, requests will return a maximum of 50 items or tenant. To retrieve more items, you must include the `page` and `per_page` parameters.


