### PR TITLE
Make all props in popperConfig optional

### DIFF
--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -132,7 +132,7 @@ element.addEventListener(Modal.Events.hidePrevented, event => {
  */
 
 // $ExpectType Popover
-const popover = new Popover(element, { animation: true });
+const popover = new Popover(element, { delay: 0.5, animation: true });
 
 // $ExpectType Popover
 const instancePopover = Popover.getInstance(element);

--- a/types/bootstrap/js/dist/dropdown.d.ts
+++ b/types/bootstrap/js/dist/dropdown.d.ts
@@ -106,7 +106,7 @@ declare namespace Dropdown {
          * @see {@link https://popper.js.org/docs/v2}
          * @default null
          */
-        popperConfig: Popper.Options | null;
+        popperConfig: Partial<Popper.Options> | null;
     }
 }
 

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -254,7 +254,7 @@ declare namespace Popover {
          * @see {@link https://popper.js.org/docs/v2}
          * @default null
          */
-        popperConfig: Popper.Options | null;
+        popperConfig: Partial<Popper.Options> | null;
     }
 }
 

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -267,7 +267,7 @@ declare namespace Tooltip {
          * @see {@link https://popper.js.org/docs/v2}
          * @default null
          */
-        popperConfig: Popper.Options | null;
+        popperConfig: Partial<Popper.Options> | null;
     }
 }
 


### PR DESCRIPTION
Bootstrap v5:
- Dropdown.Options.popperConfig
- Popover.Options.popperConfig
- Tooltip.Options.popperConfig
Make all props in popperConfig optional as we can use one or more
