### PR TITLE
Make resize-observer types mergeable

### DIFF
--- a/types/resize-observer-browser/index.d.ts
+++ b/types/resize-observer-browser/index.d.ts
@@ -4,7 +4,6 @@
 //                 William Furr <https://github.com/wffurr>
 //                 Alexander Shushunov <https://github.com/AlexanderShushunov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7
 
 interface Window {
     ResizeObserver: typeof ResizeObserver;
@@ -17,7 +16,7 @@ interface ResizeObserverOptions {
      *
      * @default 'content-box'
      */
-    box?: 'content-box' | 'border-box';
+    box?: 'content-box' | 'border-box' | 'device-pixel-content-box';
 }
 
 interface ResizeObserverSize {
@@ -25,19 +24,25 @@ interface ResizeObserverSize {
     readonly blockSize: number;
 }
 
-declare class ResizeObserver {
-    constructor(callback: ResizeObserverCallback);
+interface ResizeObserver {
     disconnect(): void;
     observe(target: Element, options?: ResizeObserverOptions): void;
     unobserve(target: Element): void;
 }
 
-type ResizeObserverCallback = (entries: ReadonlyArray<ResizeObserverEntry>, observer: ResizeObserver) => void;
+declare var ResizeObserver: {
+    new (callback: ResizeObserverCallback): ResizeObserver;
+    prototype: ResizeObserver;
+};
+
+interface ResizeObserverCallback {
+    (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+}
 
 interface ResizeObserverEntry {
     readonly target: Element;
     readonly contentRect: DOMRectReadOnly;
-    readonly borderBoxSize?: ReadonlyArray<ResizeObserverSize>;
-    readonly contentBoxSize?: ReadonlyArray<ResizeObserverSize>;
+    readonly borderBoxSize: ReadonlyArray<ResizeObserverSize>;
+    readonly contentBoxSize: ReadonlyArray<ResizeObserverSize>;
     readonly devicePixelContentBoxSize?: ReadonlyArray<ResizeObserverSize>;
 }

--- a/types/resize-observer-browser/resize-observer-browser-tests.ts
+++ b/types/resize-observer-browser/resize-observer-browser-tests.ts
@@ -1,5 +1,5 @@
 function resizeObserverCreates(): void {
-    const resizeObserver: ResizeObserver = new ResizeObserver((entries) => {
+    const resizeObserver: ResizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
         const div = document.getElementById('display-div')!;
         const rect = entries[0].contentRect;
         div.textContent = `${rect.left} ${rect.right}`;


### PR DESCRIPTION
ResizeObserver and its types are now bundled with TS 4.2. Projects that have `@types/resize-observer-browser` installed when upgrading to 4.2 will have compile errors without this change. This change makes all the types use mergeable structures like `interface` and `var` to get rid of the compile errors.

Even with this change, contextual typing of the callback parameter of `new ResizeObserver` is broken in TS 4.2 if
`@types/resize-observer-browser` is installed. That's why I had to add a type annotation to the tests.

However, this is not a problem pre-4.2 and `@types/resize-observer-browser` isn't needed in 4.2, so it should be a temporary problem except on DT, where tests have to compile on all versions of TS.