### PR TITLE
ffprobe: Add missing stream disposition, Enable use of any tag and fix optional attributes

### DIFF
--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -57,7 +57,7 @@ declare namespace getInfo {
             visual_impaired: number;
             clean_effects: number;
             attached_pic: number;
-            timed_thumbnails: number;
+            timed_thumbnails?: number;
         };
         tags: {
             language?: string;

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -57,6 +57,7 @@ declare namespace getInfo {
             visual_impaired: number;
             clean_effects: number;
             attached_pic: number;
+            timed_thumbnails: number;
         };
         tags: {
             language?: string;

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -4,47 +4,73 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace getInfo {
+    type FFProbeBoolean = '0' | '1';
+
     interface Options {
         path: string;
     }
 
+    /**
+     * Based on the XML definition of the ffprobe stream type
+     * {@see https://github.com/FFmpeg/FFmpeg/blob/master/doc/ffprobe.xsd#L206}
+     */
     interface FFProbeStream {
         index: number;
-        codec_name: string;
-        codec_long_name: string;
-        profile: string;
-        codec_type: 'video' | 'audio' | 'images';
+        codec_name?: string;
+        codec_long_name?: string;
+        profile?: string;
+        codec_type?: 'video' | 'audio' | 'images';
         codec_time_base: string;
         codec_tag_string: string;
         codec_tag: string;
+        extradata?: string;
+
+        // Video attributes
         width?: number;
         height?: number;
         coded_width?: number;
         coded_height?: number;
+        closed_captions?: FFProbeBoolean;
         has_b_frames?: number;
         sample_aspect_ratio?: string;
         display_aspect_ratio?: string;
         pix_fmt?: string;
         level?: number;
+        color_range?: string;
+        color_space?: string;
+        color_transfer?: string;
+        color_primaries?: string;
+        chroma_location?: string;
+        field_order?: string;
+        timecode?: string;
+        refs?: number;
+
+        // Audio attributes
         sample_fmt?: string;
         sample_rate?: number;
-        channel_layout?: string;
         channels?: number;
+        channel_layout?: string;
         bits_per_sample?: number;
-        chroma_location?: string;
-        refs?: number;
+
+        id: string;
+        r_frame_rate: string;
+        avg_frame_rate: string;
+        time_base: string;
+        start_pts?: number;
+        start_time?: number;
+        duration_ts?: string;
+        duration?: number;
+        bit_rate?: number;
+        max_bit_rate?: number;
+        bits_per_raw_sample?: number;
+        nb_frames?: number;
+        nb_read_frames?: number;
+        nb_read_packets?: number;
+
+        // Not in XML file, but is still in the output of ffprobe MKV files.
         is_avc?: number;
         nal_length_size?: number;
-        r_frame_rate: string;
-        avg_frame_rate?: string;
-        time_base?: string;
-        start_pts: number;
-        start_time: number;
-        duration_ts: string;
-        duration: number;
-        bit_rate: number;
-        bits_per_raw_sample?: number;
-        nb_frames: number;
+
         disposition: {
             default: number;
             dub: number;
@@ -72,7 +98,11 @@ declare namespace getInfo {
     }
 }
 
-declare function getInfo(filePath: string, options: getInfo.Options, cb: (err: Error, info: getInfo.FFProbeResult) => void): void;
+declare function getInfo(
+    filePath: string,
+    options: getInfo.Options,
+    cb: (err: Error, info: getInfo.FFProbeResult) => void,
+): void;
 
 declare function getInfo(filePath: string, options: getInfo.Options): Promise<getInfo.FFProbeResult>;
 

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -61,8 +61,9 @@ declare namespace getInfo {
         };
         tags: {
             language?: string;
-            handler_name: string;
+            handler_name?: string;
             creation_time?: string;
+            [tag: string]: string | undefined;
         };
     }
 


### PR DESCRIPTION
This PR fixes optional paramaters and includes more parameters, based loosely of FFmpeg's [xml definition file](http://www.ffmpeg.org/schema/ffprobe.xsd)

- Added a new diposition `timed_thumbnails`:
    - As added in 2016 here: https://github.com/FFmpeg/FFmpeg/commit/73ead477ddd9dbfbe6f7e8d3fc90ebfd21b271b0
- Many existing parameters are technically optional and added missing parameters here:
    - As seen in XML schema file here: https://github.com/FFmpeg/FFmpeg/blob/69aeba8a19ac2fa6e1c9bdfb19229b513f314bb1/doc/ffprobe.xsd#L206
- Tags can be `[key: string]: string`
    - As seen in XML schema file here: https://github.com/FFmpeg/FFmpeg/blob/69aeba8a19ac2fa6e1c9bdfb19229b513f314bb1/doc/ffprobe.xsd#L301
    - `.mkv`
      ![image](https://user-images.githubusercontent.com/13886925/104082342-5d76ba00-522d-11eb-8bf6-a60ddea2b942.png)
    - `.mp4`
      ![image](https://user-images.githubusercontent.com/13886925/104082357-72ebe400-522d-11eb-987f-eb35b252a28c.png)



Unfortunately, typing this project is difficult due to the variance in versions of ffprobe that people can use for this package.
I have made `timed_thumbnails` optional in case someone uses a ffprobe older than 4 years (somehow?)
Let me know if that was a good idea or not.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/FFmpeg/FFmpeg/blob/master/doc/ffprobe.xsd#L206).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/FFmpeg/FFmpeg/blob/69aeba8a19ac2fa6e1c9bdfb19229b513f314bb1/doc/ffprobe.xsd
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
