### PR TITLE
Change type for callback inside dnsLookup [@types/ioredis]

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1872,7 +1872,7 @@ declare namespace IORedis {
 
     type DNSLookupFunction = (
         hostname: string,
-        callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        callback: (err: NodeJS.ErrnoException | null, address: string, family?: number) => void,
     ) => void;
     interface NatMap {
         [key: string]: { host: string; port: number };

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -733,3 +733,6 @@ redis.options.host;
 redis.status;
 cluster.options.maxRedirections;
 cluster.status;
+
+import { lookup } from 'dns';
+clusterOptions.dnsLookup = lookup;


### PR DESCRIPTION
The problem was mentioned here #50150 

family property is optional in callback for DNSLookupFunction in ioredis:
https://github.com/luin/ioredis/blob/279f67eb18e6c20dc7d461fe6890ac22f63cd0fa/lib/cluster/ClusterOptions.ts#L6-L10

but not in types/ioredis:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/06616fa7d4eb29225165cdd35f1f09f2dbb4a9b4/types/ioredis/index.d.ts#L1873-L1876