### PR TITLE
MJML-React loosen children type

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for mjml-react 1.0
 // Project: https://github.com/wix-incubator/mjml-react
 // Definitions by: Henri Normak <https://github.com/henrinormak>
+//                 Ian Edington <https://github.com/IanEdington>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -21,6 +22,9 @@ export function render(email: React.ReactElement, options?: Mjml2HtmlOptions): {
 
 // Components
 
+/**
+ * @deprecated forcing MJML components to define children prevents them from being used in the header element see https://github.com/wix-incubator/mjml-react/issues/32
+ */
 export interface RequiredChildrenProps {
     children: React.ReactNode;
 }
@@ -58,13 +62,13 @@ export interface MjmlProps {
     owa?: string;
 }
 
-export class Mjml extends React.Component<MjmlProps & RequiredChildrenProps> { }
+export class Mjml extends React.Component<MjmlProps> { }
 
 // mj-head
-export class MjmlHead extends React.Component<RequiredChildrenProps> { }
+export class MjmlHead extends React.Component { }
 
 // mj-attributes
-export class MjmlAttributes extends React.Component<RequiredChildrenProps> { }
+export class MjmlAttributes extends React.Component { }
 export class MjmlAll extends React.Component<{ [key: string]: any; children?: React.ReactNode }> { }
 export class MjmlClass extends React.Component<{ [key: string]: any; children?: React.ReactNode; name: string }> { }
 
@@ -81,7 +85,7 @@ export interface MjmlBodyProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlBody extends React.Component<RequiredChildrenProps & MjmlBodyProps & ClassNameProps> { }
+export class MjmlBody extends React.Component<MjmlBodyProps & ClassNameProps> { }
 
 // mj-font
 export interface MjmlFontProps {
@@ -101,7 +105,7 @@ export class MjmlStyle extends React.Component<{ children: string, inline?: bool
 export class MjmlTitle extends React.Component<{ children: string }> { }
 
 // mj-accordion
-export class MjmlAccordion extends React.Component<RequiredChildrenProps & MjmlAccordionElementProps> { }
+export class MjmlAccordion extends React.Component<MjmlAccordionElementProps> { }
 
 export interface MjmlAccordionElementProps {
     fontFamily?: string;
@@ -116,7 +120,7 @@ export interface MjmlAccordionElementProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlAccordionElement extends React.Component<RequiredChildrenProps & MjmlAccordionElementProps & ClassNameProps> { }
+export class MjmlAccordionElement extends React.Component<MjmlAccordionElementProps & ClassNameProps> { }
 
 export interface MjmlAccordionTextProps {
     color?: React.CSSProperties['color'];
@@ -125,7 +129,7 @@ export interface MjmlAccordionTextProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlAccordionText extends React.Component<RequiredChildrenProps & MjmlAccordionTextProps & PaddingProps & ClassNameProps> { }
+export class MjmlAccordionText extends React.Component<MjmlAccordionTextProps & PaddingProps & ClassNameProps> { }
 
 export interface MjmlAccordionTitleProps {
     color?: React.CSSProperties['color'];
@@ -134,7 +138,7 @@ export interface MjmlAccordionTitleProps {
     fontSize?: string | number;
 }
 
-export class MjmlAccordionTitle extends React.Component<RequiredChildrenProps & MjmlAccordionTitleProps & PaddingProps & ClassNameProps> { }
+export class MjmlAccordionTitle extends React.Component<MjmlAccordionTitleProps & PaddingProps & ClassNameProps> { }
 
 // mj-button
 export interface MjmlButtonProps {
@@ -156,7 +160,7 @@ export interface MjmlButtonProps {
     height?: string | number;
 }
 
-export class MjmlButton extends React.Component<RequiredChildrenProps & MjmlButtonProps & PaddingProps & ClassNameProps & HrefProps & BorderProps> { }
+export class MjmlButton extends React.Component<MjmlButtonProps & PaddingProps & ClassNameProps & HrefProps & BorderProps> { }
 
 // mj-carousel
 export interface MjmlCarouselProps {
@@ -174,7 +178,7 @@ export interface MjmlCarouselProps {
     iconWidth?: string;
 }
 
-export class MjmlCarousel extends React.Component<RequiredChildrenProps & MjmlCarouselProps & ClassNameProps> {}
+export class MjmlCarousel extends React.Component<MjmlCarouselProps & ClassNameProps> {}
 
 export interface MjmlCarouselImageProps {
     src?: string;
@@ -192,7 +196,7 @@ export interface MjmlColumnProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlColumn extends React.Component<RequiredChildrenProps & MjmlColumnProps & PaddingProps & ClassNameProps & BorderProps> { }
+export class MjmlColumn extends React.Component<MjmlColumnProps & PaddingProps & ClassNameProps & BorderProps> { }
 
 // mj-divider
 export interface MjmlDividerProps {
@@ -212,7 +216,7 @@ export interface MjmlGroupProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlGroup extends React.Component<MjmlGroupProps & RequiredChildrenProps & ClassNameProps> { }
+export class MjmlGroup extends React.Component<MjmlGroupProps & ClassNameProps> { }
 
 // mj-hero
 export interface MjmlHeroProps {
@@ -266,7 +270,7 @@ export interface MjmlNavbarProps {
     icoLineHeight?: string;
 }
 
-export class MjmlNavbar extends React.Component<MjmlNavbarProps & RequiredChildrenProps> { }
+export class MjmlNavbar extends React.Component<MjmlNavbarProps> { }
 
 export interface MjmlNavbarLinkProps {
     color?: React.CSSProperties['color'];
@@ -282,7 +286,7 @@ export interface MjmlNavbarLinkProps {
 export class MjmlNavbarLink extends React.Component<MjmlNavbarLinkProps & HrefProps & PaddingProps> { }
 
 // mj-raw
-export class MjmlRaw extends React.Component<RequiredChildrenProps> { }
+export class MjmlRaw extends React.Component { }
 
 // mj-section
 export interface MjmlSectionProps {
@@ -296,7 +300,7 @@ export interface MjmlSectionProps {
     direction?: 'ltr' | 'rtl';
 }
 
-export class MjmlSection extends React.Component<MjmlSectionProps & RequiredChildrenProps & BorderProps & PaddingProps & ClassNameProps> { }
+export class MjmlSection extends React.Component<MjmlSectionProps & BorderProps & PaddingProps & ClassNameProps> { }
 
 // mj-social
 export interface MjmlSocialProps {
@@ -335,7 +339,7 @@ export interface MjmlSocialElementProps {
     alt?: string;
 }
 
-export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & RequiredChildrenProps & HrefProps & PaddingProps> { }
+export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & HrefProps & PaddingProps> { }
 
 // mj-spacer
 export interface MjmlSpacerProps {
@@ -362,7 +366,7 @@ export interface MjmlTableProps {
     align?: 'left' | 'right' | 'center';
 }
 
-export class MjmlTable extends React.Component<MjmlTableProps & RequiredChildrenProps & PaddingProps> { }
+export class MjmlTable extends React.Component<MjmlTableProps & PaddingProps> { }
 
 // mj-text
 export interface MjmlTextProps {
@@ -393,4 +397,4 @@ export interface MjmlWrapperProps {
     textAlign?: React.CSSProperties['textAlign'];
 }
 
-export class MjmlWrapper extends React.Component<MjmlWrapperProps & RequiredChildrenProps & BorderProps & PaddingProps & ClassNameProps> { }
+export class MjmlWrapper extends React.Component<MjmlWrapperProps & BorderProps & PaddingProps & ClassNameProps> { }

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -10,15 +10,33 @@ import {
     MjmlColumn,
     MjmlButton,
     MjmlImage,
-    MjmlText
+    MjmlText,
+    MjmlClass,
+    MjmlAccordion,
+    MjmlAccordionElement,
+    MjmlAccordionText,
+    MjmlAccordionTitle,
+    MjmlAll,
+    MjmlAttributes,
+    MjmlBreakpoint,
+    MjmlCarousel,
+    MjmlCarouselImage,
+    MjmlDivider,
+    MjmlFont,
+    MjmlGroup,
+    MjmlHero,
+    MjmlNavbar,
+    MjmlNavbarLink,
+    MjmlRaw,
+    MjmlSocial,
+    MjmlSocialElement,
+    MjmlSpacer,
+    MjmlStyle,
+    MjmlTable,
+    MjmlWrapper,
 } from 'mjml-react';
 
-import {
-    MjmlComment,
-    MjmlConditionalComment,
-    MjmlTrackingPixel,
-    MjmlYahooStyle
-} from 'mjml-react/extensions';
+import { MjmlComment, MjmlConditionalComment, MjmlTrackingPixel, MjmlYahooStyle } from 'mjml-react/extensions';
 
 import {
     addQueryParams,
@@ -26,12 +44,12 @@ import {
     getTextAlign,
     namedEntityToHexCode,
     toMobileFontSize,
-    useHttps
+    useHttps,
 } from 'mjml-react/utils';
 
 function renderOutTestEmail() {
     // $ExpectType { html: string; errors: Error[]; }
-    const result = render((
+    const result = render(
         <Mjml>
             <MjmlHead>
                 <MjmlTitle>Last Minute Offer</MjmlTitle>
@@ -48,14 +66,211 @@ function renderOutTestEmail() {
                     <MjmlColumn>
                         <MjmlButton padding="20px" backgroundColor="#346DB7" href="https://www.wix.com/">
                             I like it!
-                    </MjmlButton>
+                        </MjmlButton>
                     </MjmlColumn>
                     <MjmlColumn>
-                        <MjmlText/>
+                        <MjmlText />
                         <MjmlText>text</MjmlText>
                     </MjmlColumn>
                 </MjmlSection>
             </MjmlBody>
+        </Mjml>,
+        { validationLevel: 'soft' },
+    );
+}
+
+// TestMjmlTag
+{
+    const minProps: React.ReactNode = <Mjml />;
+    const maxProps: React.ReactNode = (
+        <Mjml lang="" owa="">
+            child
         </Mjml>
-    ), { validationLevel: 'soft' });
+    );
+}
+// TestMjmlHeadTag
+{
+    const minProps: React.ReactNode = <MjmlHead />;
+    const maxProps: React.ReactNode = <MjmlHead>child</MjmlHead>;
+}
+// TestMjmlAttributesTag
+{
+    const minProps: React.ReactNode = <MjmlAttributes />;
+    const maxProps: React.ReactNode = <MjmlAttributes>child</MjmlAttributes>;
+}
+// TestMjmlAllTag
+{
+    const minProps: React.ReactNode = <MjmlAll />;
+    const maxProps: React.ReactNode = <MjmlAll any="any">child</MjmlAll>;
+}
+// TestMjmlClassTag
+{
+    const minProps: React.ReactNode = <MjmlClass name="" />;
+    const maxProps: React.ReactNode = (
+        <MjmlClass name="" any="any">
+            child
+        </MjmlClass>
+    );
+}
+// TestMjmlBreakpointTag
+{
+    const minProps: React.ReactNode = <MjmlBreakpoint />;
+    const maxProps: React.ReactNode = <MjmlBreakpoint width="">child</MjmlBreakpoint>;
+}
+// TestMjmlBodyTag
+{
+    const minProps: React.ReactNode = <MjmlBody />;
+    const maxProps: React.ReactNode = (
+        <MjmlBody cssClass="" width={1} backgroundColor="">
+            child
+        </MjmlBody>
+    );
+}
+// TestMjmlFontTag
+{
+    const minProps: React.ReactNode = <MjmlFont />;
+    const maxProps: React.ReactNode = (
+        <MjmlFont href="" name="">
+            child
+        </MjmlFont>
+    );
+}
+// TestMjmlPreviewTag
+{
+    const minMaxProps: React.ReactNode = <MjmlPreview>""</MjmlPreview>;
+
+    // children cannot be anything other than string
+    // prettier-ignore
+    const childError: React.ReactNode = <MjmlPreview><p>""</p></MjmlPreview>; // $ExpectError
+}
+// TestMjmlStyleTag
+{
+    const minProps: React.ReactNode = <MjmlStyle>""</MjmlStyle>;
+    const maxProps: React.ReactNode = <MjmlStyle inline>child</MjmlStyle>;
+
+    // children cannot be anything other than string
+    // prettier-ignore
+    const childError: React.ReactNode = <MjmlStyle><p>""</p></MjmlStyle>; // $ExpectError
+}
+// TestMjmlTitleTag
+{
+    const minMaxProps: React.ReactNode = <MjmlTitle>""</MjmlTitle>;
+
+    // children cannot be anything other than string
+    // prettier-ignore
+    const childError: React.ReactNode = <MjmlStyle><p>""</p></MjmlStyle>; // $ExpectError
+}
+// TestMjmlButtonTag
+{
+    const minProps: React.ReactNode = <MjmlButton />;
+    const maxProps: React.ReactNode = <MjmlButton>child</MjmlButton>;
+}
+// TestMjmlColumnTag
+{
+    const minProps: React.ReactNode = <MjmlColumn />;
+    const maxProps: React.ReactNode = <MjmlColumn>child</MjmlColumn>;
+}
+// TestMjmlDividerTag
+{
+    const minProps: React.ReactNode = <MjmlDivider />;
+    const maxProps: React.ReactNode = <MjmlDivider>child</MjmlDivider>;
+}
+// TestMjmlGroupTag
+{
+    const minProps: React.ReactNode = <MjmlGroup />;
+    const maxProps: React.ReactNode = <MjmlGroup>child</MjmlGroup>;
+}
+// TestMjmlHeroTag
+{
+    const minProps: React.ReactNode = <MjmlHero />;
+    const maxProps: React.ReactNode = <MjmlHero>child</MjmlHero>;
+}
+// TestMjmlImageTag
+{
+    const minProps: React.ReactNode = <MjmlImage />;
+    const maxProps: React.ReactNode = <MjmlImage>child</MjmlImage>;
+}
+// TestMjmlNavbarTag
+{
+    const minProps: React.ReactNode = <MjmlNavbar />;
+    const maxProps: React.ReactNode = <MjmlNavbar>child</MjmlNavbar>;
+}
+// TestMjmlNavbarLinkTag
+{
+    const minProps: React.ReactNode = <MjmlNavbarLink />;
+    const maxProps: React.ReactNode = <MjmlNavbarLink>child</MjmlNavbarLink>;
+}
+// TestMjmlRawTag
+{
+    const minProps: React.ReactNode = <MjmlRaw />;
+    const maxProps: React.ReactNode = <MjmlRaw>child</MjmlRaw>;
+}
+// TestMjmlSectionTag
+{
+    const minProps: React.ReactNode = <MjmlSection />;
+    const maxProps: React.ReactNode = <MjmlSection>child</MjmlSection>;
+}
+// TestMjmlSpacerTag
+{
+    const minProps: React.ReactNode = <MjmlSpacer />;
+    const maxProps: React.ReactNode = <MjmlSpacer>child</MjmlSpacer>;
+}
+// TestMjmlTableTag
+{
+    const minProps: React.ReactNode = <MjmlTable />;
+    const maxProps: React.ReactNode = <MjmlTable>child</MjmlTable>;
+}
+// TestMjmlTextTag
+{
+    const minProps: React.ReactNode = <MjmlText />;
+    const maxProps: React.ReactNode = <MjmlText>child</MjmlText>;
+}
+// TestMjmlWrapperTag
+{
+    const minProps: React.ReactNode = <MjmlWrapper />;
+    const maxProps: React.ReactNode = <MjmlWrapper>child</MjmlWrapper>;
+}
+
+// TestMjmlAccordionTag
+{
+    {
+        const minProps: React.ReactNode = <MjmlAccordion />;
+    }
+    // MjmlAccordionElement
+    {
+        const minProps: React.ReactNode = <MjmlAccordionElement />;
+    }
+    // MjmlAccordionText
+    {
+        const minProps: React.ReactNode = <MjmlAccordionText />;
+    }
+    // TestMjmlAccordionTitleTag
+    {
+        const minProps: React.ReactNode = <MjmlAccordionTitle />;
+    }
+}
+// TestMjmlCarouselTag
+{
+    // MjmlCarousel
+    {
+        const minProps: React.ReactNode = <MjmlCarousel />;
+        const maxProps: React.ReactNode = <MjmlCarousel>child</MjmlCarousel>;
+    }
+    // MjmlCarouselImage
+    {
+        const minProps: React.ReactNode = <MjmlCarouselImage />;
+        const maxProps: React.ReactNode = <MjmlCarouselImage>child</MjmlCarouselImage>;
+    }
+}
+// TestMjmlSocialElementTag
+{
+    {
+        const minProps: React.ReactNode = <MjmlSocialElement />;
+        const maxProps: React.ReactNode = <MjmlSocialElement>child</MjmlSocialElement>;
+    }
+    // MjmlSocial
+    {
+        const minProps: React.ReactNode = <MjmlSocial />;
+        const maxProps: React.ReactNode = <MjmlSocial>child</MjmlSocial>;
+    }
 }


### PR DESCRIPTION
MJML allows setting global values by using elements in the header.
By forcing children types to be defined it restricts the ability to define mjml tags in the header.
This type checking also doesn't provide much value since the resulting error is immediately visible.

Based on this PR #47420 MjmlText has already been changed.
