### PR TITLE
[mjml-react] Add iconPadding to social elements

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -337,6 +337,7 @@ export interface MjmlSocialElementProps {
         'github' | 'instagram' | 'web' | 'snapchat' | 'youtube' | 'vimeo' | 'medium' | 'soundcloud' | 'dribbble';
     src?: string;
     alt?: string;
+    iconPadding?: string;
 }
 
 export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & HrefProps & PaddingProps> { }

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -267,6 +267,7 @@ function renderOutTestEmail() {
     {
         const minProps: React.ReactNode = <MjmlSocialElement />;
         const maxProps: React.ReactNode = <MjmlSocialElement>child</MjmlSocialElement>;
+        const iconPadProps: React.ReactNode = <MjmlSocialElement iconPadding="5px">child</MjmlSocialElement>;
     }
     // MjmlSocial
     {


### PR DESCRIPTION
The `icon-padding` attribute is available for an [mjml-social element](https://mjml.io/documentation/#mj-social), but this is not reflected in the type. Add this attribute to the `MjmlSocialElementProps` type definition.