### PR TITLE
Fix misspelling of valueOf and return types of toArray and valueOf

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2970,8 +2970,8 @@ declare namespace math {
             callback: (a: any, b: number, c: Matrix) => void,
             skipZeros?: boolean
         ): void;
-        toArray(): MathArray | Matrix;
-        valueOff(): MathArray | Matrix;
+        toArray(): MathArray;
+        valueOf(): MathArray;
         format(options?: FormatOptions | number | ((value: any) => string)): string;
         toString(): string;
         toJSON(): any;


### PR DESCRIPTION
1. matrix.valueOf() was spelled valueOff().
2. according to [the docs](https://mathjs.org/docs/reference/classes/densematrix.html#DenseMatrix+valueOf), toArray and valueOf should return arrays, not matrices.