### PR TITLE
simpl-schema: fix type of check option

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -7,6 +7,9 @@
 //                 Rafa Horo <https://github.com/rafahoro>
 //                 Stepan Yurtsiv <https://github.com/yurtsiv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+import { check } from 'meteor/check';
 
 export interface ValidationContext extends SimpleSchemaValidationContextStatic {
     addValidationErrors(errors: any): void;
@@ -129,7 +132,7 @@ interface CleanOption {
 }
 
 interface SimpleSchemaOptions {
-  check?: boolean;
+  check?: typeof check;
   clean?: CleanOption;
   defaultLabel?: string;
   humanizeAutoLabels?: boolean;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -1,4 +1,5 @@
 import SimpleSchema, { SimpleSchemaDefinition, SchemaDefinition } from 'simpl-schema';
+import { check } from 'meteor/check';
 
 const schema: SimpleSchemaDefinition = {
     basicString: {
@@ -106,7 +107,8 @@ const StringSchemaWithOptions = new SimpleSchema({
         trimStrings: true,
         getAutoValues: true,
         removeNullsFromArrays: true,
-    }
+    },
+    check,
 });
 
 new SimpleSchema({


### PR DESCRIPTION
This is related to [#44774](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44774).

Needed to limit minimum typescript version due to @types/meteor dependency.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/aldeed/simpl-schema/blob/d440902f75d10ab05eef8fa7d189408042ac2a54/package/lib/SimpleSchema.js#L635), [documentation](https://github.com/aldeed/simpl-schema#validate-a-meteor-method-argument-and-satisfy-audit-argument-checks)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
