### PR TITLE
[DOMPurify] Add forceKeepAttr property to attribute hook event

### DIFF
--- a/types/dompurify/index.d.ts
+++ b/types/dompurify/index.d.ts
@@ -5,6 +5,7 @@
 //                 FlowCrypt <https://github.com/FlowCrypt>
 //                 Exigerr <https://github.com/Exigerr>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Nicholas Ellul <https://github.com/NicholasEllul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="trusted-types"/>
 
@@ -95,5 +96,6 @@ declare namespace DOMPurify {
         attrValue: string;
         keepAttr: boolean;
         allowedAttributes: { [key: string]: boolean };
+        forceKeepAttr?: boolean;
     }
 }

--- a/types/dompurify/test/dompurify-tests.ts
+++ b/types/dompurify/test/dompurify-tests.ts
@@ -96,5 +96,6 @@ dompurify.addHook('uponSanitizeElement', (currentNode: Element, event: DOMPurify
 dompurify.addHook('uponSanitizeAttribute', (currentNode: Element, event: DOMPurify.SanitizeAttributeHookEvent) => {
   if (event.attrName && event.attrName.match(/^\w+-\w+$/) && !event.allowedAttributes[event.attrName]) {
       event.allowedAttributes[event.attrName] = true;
+      event.forceKeepAttr = true;
   }
 });


### PR DESCRIPTION
**TL;DR** Last year the `forceKeepAttr` flag was added to the `sanitizeAttributeHook` event. This PR adds the corresponding type definition. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* The line in the source code can be found here: https://github.com/cure53/DOMPurify/blob/main/src/purify.js#L994
* The PR that introduced this change can be found here: https://github.com/cure53/DOMPurify/pull/385
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
* This PR adds missing types from a very old DOMPurify version (v2.0.8)