### PR TITLE
[Memory-fs] Update for webpack v5 compatibility 

### DIFF
--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -83,7 +83,7 @@ declare class MemoryFileSystem {
 
     mkdir(path: string, callback: (err: Error | null) => void): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
-    mkdir(arg0: string, arg1: (arg0?: ErrnoException | undefined) => void): void;
+    mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | undefined) => void): void;
 
     readFile(path: string, callback: (err: Error | null, result?: any) => void): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -57,19 +57,19 @@ declare class MemoryFileSystem {
 
     exists(path: string, callback: (isExist: boolean) => void): void;
 
-    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void): void;
+    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void | (arg0?: NodeJS.ErrnoException) => void): void;
     writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
-    writeFile(arg0: string,arg1: string | Buffer,arg2: (arg0?: NodeJS.ErrnoException) => void): void;
+    //writeFile(arg0: string,arg1: string | Buffer,arg2: (arg0?: NodeJS.ErrnoException) => void): void;
 
-    join(path: string, request: string): string;
-  	join?(arg0: string, arg1: string): string;
+    join(path: string, request?: string): string;
+  	// join?(arg0: string, arg1: string): string;
 
     pathToArray(path: string): string[];
 
     normalize(path: string): string;
 
-    stat(path: string, callback: (err: Error | null, result?: any) => void): void;
-    stat(arg0: string,arg1: (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
+    stat(path: string, callback: (err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
+    //stat(arg0: string,arg1: (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -81,16 +81,15 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(path: string, callback: (err: Error | null) => void): void;
+    mkdir(path: string, callback: (err: Error | null) => void | (arg0?: NodeJS.ErrnoException) => void): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
-    mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | undefined) => void): void;
+    //mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | undefined) => void): void;
 
-    readFile(path: string, callback: (err: Error | null, result?: any) => void): void;
+    readFile(path: string, callback: (err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
-    readFile(arg0: string, arg1: (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
+    //readFile(arg0: string, arg1: (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
 
     relative(arg0: string, arg1: string): string;
-
 }
 
 export = MemoryFileSystem;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -66,7 +66,6 @@ declare class MemoryFileSystem {
 
     normalize(path: string): string;
 
-    // stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
     stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error , arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
@@ -80,7 +79,6 @@ declare class MemoryFileSystem {
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
     mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error) => void): void;
-    // mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 
     readFile(path: string, callback: (err: Error, result?: any) => void | ((arg0?: NodeJS.ErrnoException | Error, arg1?: Buffer) => void)): void;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 2.3
 
 /// <reference types="node" />
+import { Stats as FsStats, WriteStream } from "fs";
 
 declare class MemoryFileSystem {
     data: any;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -78,7 +78,7 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
+    mkdir(arg0: string, arg1: (arg0?: ErrnoException | undefined) => void): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 
     readFile(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void)): void;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -67,7 +67,7 @@ declare class MemoryFileSystem {
     normalize(path: string): string;
 
     // stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
-    stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error , arg1?: FsStats ) => void): void;
+    stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error , arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -79,7 +79,7 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error ) => void): void;
+    mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error) => void): void;
     // mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -67,7 +67,7 @@ declare class MemoryFileSystem {
     normalize(path: string): string;
 
     // stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
-    stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error | null, arg1?: Stats | undefined) => void): void;
+    stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error , arg1?: FsStats ) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -83,7 +83,7 @@ declare class MemoryFileSystem {
     // mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 
-    readFile(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException | Error | null, arg1?: Buffer) => void)): void;
+    readFile(path: string, callback: (err: Error, result?: any) => void | ((arg0?: NodeJS.ErrnoException | Error, arg1?: Buffer) => void)): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 }
 

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -50,21 +50,29 @@ declare class MemoryFileSystem {
         }
     ): any;
 
+
+
+
+
     createWriteStream(path: string, options?: any): any;
+
+    dirname?(arg0: string): string;
 
     exists(path: string, callback: (isExist: boolean) => void): void;
 
     writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void): void;
-
     writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
+    writeFile(arg0: string,arg1: string | Buffer,arg2: (arg0?: NodeJS.ErrnoException) => void): void;
 
     join(path: string, request: string): string;
+  	join?(arg0: string, arg1: string): string;
 
     pathToArray(path: string): string[];
 
     normalize(path: string): string;
 
     stat(path: string, callback: (err: Error | null, result?: any) => void): void;
+    stat(arg0: string,arg1: (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -78,9 +86,14 @@ declare class MemoryFileSystem {
 
     mkdir(path: string, callback: (err: Error | null) => void): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
+    mkdir(arg0: string, arg1: (arg0?: ErrnoException | undefined) => void): void;
 
     readFile(path: string, callback: (err: Error | null, result?: any) => void): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
+    readFile(arg0: string, arg1: (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
+
+    relative(arg0: string, arg1: string): string;
+
 }
 
 export = MemoryFileSystem;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -53,11 +53,11 @@ declare class MemoryFileSystem {
 
     createWriteStream(path: string, options?: any): any;
 
-    dirname?(arg0: string): string;
+    dirname?(path: string): string;
 
     exists(path: string, callback: (isExist: boolean) => void): void;
 
-    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
+    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void | ((path?: NodeJS.ErrnoException) => void)): void;
     writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
 
     join(path: string, request?: string): string;
@@ -66,7 +66,7 @@ declare class MemoryFileSystem {
 
     normalize(path: string): string;
 
-    stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error , arg1?: FsStats) => void): void;
+    stat(path: string, callback: (path?: NodeJS.ErrnoException | Error , callback?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -78,10 +78,10 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error) => void): void;
+    mkdir(path: string, optArg: (path?: NodeJS.ErrnoException | Error) => void): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 
-    readFile(path: string, callback: (err: Error, result?: any) => void | ((arg0?: NodeJS.ErrnoException | Error, arg1?: Buffer) => void)): void;
+    readFile(path: string, callback: (err: Error, result?: any) => void | ((path?: NodeJS.ErrnoException | Error, callback?: Buffer) => void)): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 }
 

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -57,7 +57,7 @@ declare class MemoryFileSystem {
 
     exists(path: string, callback: (isExist: boolean) => void): void;
 
-    writeFile(path: string, content: string | Buffer, callback: ((err: Error | undefined) => void | (arg0?: NodeJS.ErrnoException)) => void): void;
+    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
     //writeFile(arg0: string,arg1: string | Buffer,arg2: (arg0?: NodeJS.ErrnoException) => void): void;
 
@@ -68,7 +68,7 @@ declare class MemoryFileSystem {
 
     normalize(path: string): string;
 
-    stat(path: string, callback: ((err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: FsStats)) => void): void;
+    stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
     //stat(arg0: string,arg1: (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
@@ -81,14 +81,13 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(path: string, callback: ((err: Error | null) => void | (arg0?: NodeJS.ErrnoException) => void)): void;
+    mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
     //mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | undefined) => void): void;
 
-    readFile(path: string, callback: ((err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: Buffer)) => void): void;
+    readFile(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void)): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
     //readFile(arg0: string, arg1: (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
-
 }
 
 export = MemoryFileSystem;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -59,17 +59,14 @@ declare class MemoryFileSystem {
 
     writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
-    //writeFile(arg0: string,arg1: string | Buffer,arg2: (arg0?: NodeJS.ErrnoException) => void): void;
 
     join(path: string, request?: string): string;
-  	// join?(arg0: string, arg1: string): string;
 
     pathToArray(path: string): string[];
 
     normalize(path: string): string;
 
     stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
-    //stat(arg0: string,arg1: (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -83,11 +80,9 @@ declare class MemoryFileSystem {
 
     mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
-    //mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | undefined) => void): void;
 
     readFile(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void)): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
-    //readFile(arg0: string, arg1: (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
 }
 
 export = MemoryFileSystem;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -66,7 +66,8 @@ declare class MemoryFileSystem {
 
     normalize(path: string): string;
 
-    stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
+    // stat(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void)): void;
+    stat(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error | null, arg1?: Stats | undefined) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
@@ -78,10 +79,11 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(arg0: string, arg1: (arg0?: ErrnoException | undefined) => void): void;
+    mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | Error ) => void): void;
+    // mkdir(path: string, callback: (err: Error | null) => void | ((arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 
-    readFile(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void)): void;
+    readFile(path: string, callback: (err: Error | null, result?: any) => void | ((arg0?: NodeJS.ErrnoException | Error | null, arg1?: Buffer) => void)): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 }
 

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -57,7 +57,7 @@ declare class MemoryFileSystem {
 
     exists(path: string, callback: (isExist: boolean) => void): void;
 
-    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void | (arg0?: NodeJS.ErrnoException) => void): void;
+    writeFile(path: string, content: string | Buffer, callback: ((err: Error | undefined) => void | (arg0?: NodeJS.ErrnoException)) => void): void;
     writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
     //writeFile(arg0: string,arg1: string | Buffer,arg2: (arg0?: NodeJS.ErrnoException) => void): void;
 
@@ -68,7 +68,7 @@ declare class MemoryFileSystem {
 
     normalize(path: string): string;
 
-    stat(path: string, callback: (err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
+    stat(path: string, callback: ((err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: FsStats)) => void): void;
     //stat(arg0: string,arg1: (arg0?: NodeJS.ErrnoException, arg1?: FsStats) => void): void;
 
     readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
@@ -81,15 +81,14 @@ declare class MemoryFileSystem {
 
     readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(path: string, callback: (err: Error | null) => void | (arg0?: NodeJS.ErrnoException) => void): void;
+    mkdir(path: string, callback: ((err: Error | null) => void | (arg0?: NodeJS.ErrnoException) => void)): void;
     mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
     //mkdir(arg0: string, arg1: (arg0?: NodeJS.ErrnoException | undefined) => void): void;
 
-    readFile(path: string, callback: (err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
+    readFile(path: string, callback: ((err: Error | null, result?: any) => void | (arg0?: NodeJS.ErrnoException, arg1?: Buffer)) => void): void;
     readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
     //readFile(arg0: string, arg1: (arg0?: NodeJS.ErrnoException, arg1?: Buffer) => void): void;
 
-    relative(arg0: string, arg1: string): string;
 }
 
 export = MemoryFileSystem;

--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -50,10 +50,6 @@ declare class MemoryFileSystem {
         }
     ): any;
 
-
-
-
-
     createWriteStream(path: string, options?: any): any;
 
     dirname?(arg0: string): string;


### PR DESCRIPTION
Please fill in this template.
Match definition for OutputFileSystem which previously was compatible in webpack v4. 
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/master/types.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

