### PR TITLE
[Ember] Update htmlSafe and isHTMLSafe types to import from '@ember/template'

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -51,6 +51,7 @@ import { TemplateFactory } from 'htmlbars-inline-precompile';
 import { Registry as ServiceRegistry } from '@ember/service';
 import { Registry as ControllerRegistry } from '@ember/controller';
 import * as EmberStringNs from '@ember/string';
+import * as EmberTemplateNs from '@ember/template';
 import * as EmberTemplateHandlebarsNs from '@ember/template/-private/handlebars';
 // tslint:disable-next-line:no-duplicate-imports
 import * as EmberServiceNs from '@ember/service';
@@ -443,11 +444,13 @@ export namespace Ember {
         const dasherize: typeof EmberStringNs.dasherize;
         const decamelize: typeof EmberStringNs.decamelize;
         function fmt(...args: string[]): string;
-        const htmlSafe: typeof EmberStringNs.htmlSafe;
-        const isHTMLSafe: typeof EmberStringNs.isHTMLSafe;
         const loc: typeof EmberStringNs.loc;
         const underscore: typeof EmberStringNs.underscore;
         const w: typeof EmberStringNs.w;
+    }
+    namespace Template {
+        const htmlSafe: typeof EmberTemplateNs.htmlSafe;
+        const isHTMLSafe: typeof EmberTemplateNs.isHTMLSafe;
     }
     const computed: typeof EmberObjectNs.computed;
     const run: typeof EmberRunloopNs.run;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -444,6 +444,8 @@ export namespace Ember {
         const dasherize: typeof EmberStringNs.dasherize;
         const decamelize: typeof EmberStringNs.decamelize;
         function fmt(...args: string[]): string;
+        const htmlSafe: typeof EmberTemplateNs.htmlSafe;
+        const isHTMLSafe: typeof EmberTemplateNs.isHTMLSafe;
         const loc: typeof EmberStringNs.loc;
         const underscore: typeof EmberStringNs.underscore;
         const w: typeof EmberStringNs.w;
@@ -475,6 +477,9 @@ export namespace Ember {
     const removeListener: typeof EmberObjectEventsNs.removeListener;
     const sendEvent: typeof EmberObjectEventsNs.sendEvent;
     const on: typeof EmberObjectEventedNs.on;
+
+    const htmlSafe: typeof EmberTemplateNs.htmlSafe;
+    const isHTMLSafe: typeof EmberTemplateNs.isHTMLSafe;
 
     const isBlank: typeof EmberUtilsNs.isBlank;
     const isEmpty: typeof EmberUtilsNs.isEmpty;

--- a/types/ember__string/index.d.ts
+++ b/types/ember__string/index.d.ts
@@ -7,6 +7,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
+// FIXME: Should this be removed since it appears these are no longer part of '@ember/string'?
 export { htmlSafe, isHTMLSafe } from '@ember/template';
 
 export function camelize(str: string): string;

--- a/types/ember__string/index.d.ts
+++ b/types/ember__string/index.d.ts
@@ -7,9 +7,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-// FIXME: Should this be removed since it appears these are no longer part of '@ember/string'?
-export { htmlSafe, isHTMLSafe } from '@ember/template';
-
 export function camelize(str: string): string;
 export function capitalize(str: string): string;
 export function classify(str: string): string;


### PR DESCRIPTION
 - [x] Use a meaningful title for the pull request. Include the name of the package modified.
 - [x] Test the change in your own code. (Compile and run.)
 - [x] Add or edit tests to reflect the change.
 - [x] Follow the advice from the readme.
 - [x] Avoid common mistakes.
 - [x] Run npm test <package to test>

Updates types for `htmlSafe` and `isHTMLSafe` to reflect the fact that you can no longer import these functions from `@ember/string` and must now import them from `@ember/template`

Note: it appears that `htmlSafe` and `isHTMLSafe` can no longer be imported from `@ember/string`, but the last version that exported these functions was Ember version [3.7](https://api.emberjs.com/ember/3.7/modules/@ember%2Fstring), so I'm not sure why this is showing up now. 

