### PR TITLE
braintree: fix credit card verification field name

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -457,7 +457,7 @@ declare namespace braintree {
         amount: string;
         avsErrorResponseCode?: string;
         avsPostalCodeResponseCode?: string;
-        avsScreetAddressResponseCode?: string;
+        avsStreetAddressResponseCode?: string;
         billing?: {
             company?: string;
             countryName?: string;


### PR DESCRIPTION
This fixes a typo the `CreditCardVerification` field name: [`avsStreetAddressResponseCode`](https://developers.braintreepayments.com/reference/response/credit-card-verification/node#avs_street_address_response_code)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [correct field name](https://developers.braintreepayments.com/reference/response/credit-card-verification/node#avs_street_address_response_code)
