### PR TITLE
[breeze] fix modelLibrary typo

### DIFF
--- a/types/breeze/index.d.ts
+++ b/types/breeze/index.d.ts
@@ -1250,7 +1250,7 @@ declare namespace breeze.config {
         /** the name of a previously registered "dataService" adapter */
         dataService?: string;
         /** the name of a previously registered "modelLibrary" adapter */
-        modelLibary?: string;
+        modelLibrary?: string;
         /** the name of a previously registered "uriBuilder" adapter */
         uriBuilder?: string;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

modelLibrary is spelt correctly in the rest of the file, it is just this one type misspelt - this change brings it into line with the correct spelling

You can check http://breeze.github.io/doc-js/model-library.html and https://github.com/Breeze/breeze-client
