### PR TITLE
Import Meteor into http.d.ts in @types/meteor

### DIFF
--- a/types/meteor/http.d.ts
+++ b/types/meteor/http.d.ts
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 declare module "meteor/http" {
     module HTTP {
         interface HTTPRequest {


### PR DESCRIPTION
This fixes the following error that I had in my project:

```
node_modules/@types/meteor/http.d.ts:27:38 - error TS2503: Cannot find namespace 'Meteor'.

27         type AsyncCallback = (error: Meteor.Error | null, result?: HTTPResponse) => void;
```

I think it makes sense to explicitly import `Meteor` here.