### PR TITLE
codemirror: setBookmark().find() returns a Pos, not a range

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -897,13 +897,13 @@ declare namespace CodeMirror {
         ): CodeMirror.TextMarker<Position>;
 
         /** Returns an array of all the bookmarks and marked ranges found between the given positions. */
-        findMarks(from: CodeMirror.Position, to: CodeMirror.Position): TextMarker<MarkerRange | Position>[];
+        findMarks(from: CodeMirror.Position, to: CodeMirror.Position): TextMarker[];
 
         /** Returns an array of all the bookmarks and marked ranges present at the given position. */
-        findMarksAt(pos: CodeMirror.Position): TextMarker<MarkerRange | Position>[];
+        findMarksAt(pos: CodeMirror.Position): TextMarker[];
 
         /** Returns an array containing all marked ranges in the document. */
-        getAllMarks(): CodeMirror.TextMarker<MarkerRange | Position>[];
+        getAllMarks(): CodeMirror.TextMarker[];
 
         /** Adds a line widget, an element shown below a line, spanning the whole of the editor's width, and moving the lines below it downwards.
         line should be either an integer or a line handle, and node should be a DOM node, which will be displayed below the given line.
@@ -950,7 +950,7 @@ declare namespace CodeMirror {
         to: CodeMirror.Position;
     }
 
-    interface TextMarker<T> extends Partial<TextMarkerOptions> {
+    interface TextMarker<T = MarkerRange | Position> extends Partial<TextMarkerOptions> {
         /** Remove the mark. */
         clear(): void;
 

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -145,22 +145,22 @@ declare namespace CodeMirror {
 
     /** Fired when the cursor enters the marked range. From this event handler, the editor state may be inspected but not modified,
     with the exception that the range on which the event fires may be cleared. */
-    function on(marker: TextMarker, eventName: 'beforeCursorEnter', handler: () => void): void;
-    function off(marker: TextMarker, eventName: 'beforeCursorEnter', handler: () => void): void;
+    function on<T>(marker: TextMarker<T>, eventName: 'beforeCursorEnter', handler: () => void): void;
+    function off<T>(marker: TextMarker<T>, eventName: 'beforeCursorEnter', handler: () => void): void;
 
     /** Fired when the range is cleared, either through cursor movement in combination with clearOnEnter or through a call to its clear() method.
     Will only be fired once per handle. Note that deleting the range through text editing does not fire this event,
     because an undo action might bring the range back into existence. */
-    function on(marker: TextMarker, eventName: 'clear', handler: () => void): void;
-    function off(marker: TextMarker, eventName: 'clear', handler: () => void): void;
+    function on<T>(marker: TextMarker<T>, eventName: 'clear', handler: () => void): void;
+    function off<T>(marker: TextMarker<T>, eventName: 'clear', handler: () => void): void;
 
     /** Fired when the last part of the marker is removed from the document by editing operations. */
-    function on(marker: TextMarker, eventName: 'hide', handler: () => void): void;
-    function off(marker: TextMarker, eventName: 'hide', handler: () => void): void;
+    function on<T>(marker: TextMarker<T>, eventName: 'hide', handler: () => void): void;
+    function off<T>(marker: TextMarker<T>, eventName: 'hide', handler: () => void): void;
 
     /** Fired when, after the marker was removed by editing, a undo operation brought the marker back. */
-    function on(marker: TextMarker, eventName: 'unhide', handler: () => void): void;
-    function off(marker: TextMarker, eventName: 'unhide', handler: () => void): void;
+    function on<T>(marker: TextMarker<T>, eventName: 'unhide', handler: () => void): void;
+    function off<T>(marker: TextMarker<T>, eventName: 'unhide', handler: () => void): void;
 
     /** Fired whenever the editor re-adds the widget to the DOM. This will happen once right after the widget is added (if it is scrolled into view),
     and then again whenever it is scrolled out of view and back in again, or when changes to the editor options
@@ -873,7 +873,7 @@ declare namespace CodeMirror {
             from: CodeMirror.Position,
             to: CodeMirror.Position,
             options?: CodeMirror.TextMarkerOptions,
-        ): TextMarker;
+        ): TextMarker<MarkerRange>;
 
         /** Inserts a bookmark, a handle that follows the text around it as it is being edited, at the given position.
         A bookmark has two methods find() and clear(). The first returns the current position of the bookmark, if it is still in the document,
@@ -894,16 +894,16 @@ declare namespace CodeMirror {
                 /** As with markText, this determines whether mouse events on the widget inserted for this bookmark are handled by CodeMirror. The default is false. */
                 handleMouseEvents?: boolean;
             },
-        ): CodeMirror.TextMarker;
+        ): CodeMirror.TextMarker<Position>;
 
         /** Returns an array of all the bookmarks and marked ranges found between the given positions. */
-        findMarks(from: CodeMirror.Position, to: CodeMirror.Position): TextMarker[];
+        findMarks(from: CodeMirror.Position, to: CodeMirror.Position): TextMarker<MarkerRange | Position>[];
 
         /** Returns an array of all the bookmarks and marked ranges present at the given position. */
-        findMarksAt(pos: CodeMirror.Position): TextMarker[];
+        findMarksAt(pos: CodeMirror.Position): TextMarker<MarkerRange | Position>[];
 
         /** Returns an array containing all marked ranges in the document. */
-        getAllMarks(): CodeMirror.TextMarker[];
+        getAllMarks(): CodeMirror.TextMarker<MarkerRange | Position>[];
 
         /** Adds a line widget, an element shown below a line, spanning the whole of the editor's width, and moving the lines below it downwards.
         line should be either an integer or a line handle, and node should be a DOM node, which will be displayed below the given line.
@@ -945,13 +945,18 @@ declare namespace CodeMirror {
         clientHeight: any;
     }
 
-    interface TextMarker extends Partial<TextMarkerOptions> {
+    interface MarkerRange {
+        from: CodeMirror.Position;
+        to: CodeMirror.Position;
+    }
+
+    interface TextMarker<T> extends Partial<TextMarkerOptions> {
         /** Remove the mark. */
         clear(): void;
 
         /** Returns a {from, to} object (both holding document positions), indicating the current position of the marked range,
         or undefined if the marker is no longer in the document. */
-        find(): { from: CodeMirror.Position; to: CodeMirror.Position };
+        find(): T | undefined;
 
         /**  Called when you've done something that might change the size of the marker and want to cheaply update the display*/
         changed(): void;
@@ -1835,7 +1840,7 @@ declare namespace CodeMirror {
             /**
              * Callback for when stretches of unchanged text are collapsed.
              */
-            onCollapse?(mergeView: MergeViewEditor, line: number, size: number, mark: TextMarker): void;
+            onCollapse?(mergeView: MergeViewEditor, line: number, size: number, mark: TextMarker<MarkerRange>): void;
 
             /**
              * Provides original version of the document to be shown on the right of the editor.

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -157,5 +157,5 @@ textMarker.clear();
 
 const marks = myCodeMirror.getAllMarks();
 
-// $ExpectType TextMarker
+// $ExpectType TextMarker<MarkerRange | Position>
 const mark = marks[0];


### PR DESCRIPTION
This PR attempts to fix an error in the already-published types. It needs careful review, as I'm not sure I fixed it in the best way, and this is a breaking change depending on how the existing types are used.

Here's the problem: According to the old definitions, `markText()` and `setBookmark()` return the same thing, a `TextMarker`. But while the actual results may be very similar, there's an important difference: `find()` on a bookmark does not return a `{ from: Position; to: Position }` object, but a single `Position`. This is both (somewhat vaguely) [documented](https://codemirror.net/doc/manual.html#setBookmark) and I validated it in practice.

To fix this, I've turned `TextMarker` into a generic type `TextMarker<T>`, with `T` being the return type of `find()`. The existing `{ from, to }`-style type got a new name, `MarkerRange`, and the existing uses of `TextMarker` have been classified into `TextMarker<MarkerRange>` or `TextMarker<Position>`. Some methods may return one or another, so they return `TextMarker<MarkerRange | Position>`.
This is breaking any code that uses the `TextMarker` type explicitly.

Note: I did **not** investigate whether there are further differences between a `markText()`-style and a `setBookmark()`-style `TextMarker`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://codemirror.net/doc/manual.html#setBookmark>
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
