### PR TITLE
fix(express): Add package.json for express

### DIFF
--- a/types/express/package.json
+++ b/types/express/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@types/express-serve-static-core": "^4.17.18"
+  }
+}


### PR DESCRIPTION
Adds a versioned dependency for `@types/express` for `@types/express-serve-static-core` `^4.17.18`.
This fixes a breaking typing issue for `@types/4.17.10` where it strictly requires `@types/express-serve-static-core` `^4.17.18`.
Otherwise, all properties on `Request` are not defined.

Please review the existing discussion on this thread: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50390

~We might be required to modify: https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/definitions-parser/allowedPackageJsonDependencies.txt~ Modification merged.




Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
