### PR TITLE
React-Calendar: Add missing value property to ViewCallbackProperties interface

### DIFF
--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -75,6 +75,7 @@ export interface CalendarTileProperties {
 
 export interface ViewCallbackProperties {
   activeStartDate: Date;
+  value: Date;
   view: Detail;
 }
 


### PR DESCRIPTION
Ran `npm run lint react-big-scheduler` and `npm test react-calendar`, no error messages:
![Screenshot 2021-01-12 at 20 34 18](https://user-images.githubusercontent.com/20384291/104369569-8b058100-5515-11eb-9cbd-75e4acba7294.png)

Original repository here: https://github.com/wojtekmaj/react-calendar

Relevant PullRequest in original repository: https://github.com/wojtekmaj/react-calendar/pull/379/files

In the original repository, the `value` property (of type `Date`) was added recently to the list of parameters in the callback function(s) shown. This is not represented by the current DefinitelyTyped definition, so attempting to access that value is causing TypeScript compilation failures.