### PR TITLE
[d3-dsv] make array parameters readonly

### DIFF
--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -154,6 +154,7 @@ parseRowsMappedArray = d3Dsv.csvParseRows(csvTestString, (rawRow, index) => {
 str = d3Dsv.csvFormat(parseRowsMappedArray);
 str = d3Dsv.csvFormat(parseRowsMappedArray, ["year", "length"]);
 str = d3Dsv.csvFormat(parseRowsMappedArray, ["year", "unknown"]); // $ExpectError
+str = d3Dsv.csvFormat(parseRowsMappedArray as readonly ParsedTestObject[], ["year", "length"] as ReadonlyArray<keyof ParsedTestObject>);
 
 // csvFormatBody(...) ========================================================================
 

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -156,7 +156,7 @@ export function csvParseRows<ParsedRow extends object>(
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
  */
-export function csvFormat<T extends object>(rows: T[], columns?: Array<keyof T>): string;
+export function csvFormat<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T>): string;
 
 // csvFormatBody(...) ============================================================================
 
@@ -166,7 +166,7 @@ export function csvFormat<T extends object>(rows: T[], columns?: Array<keyof T>)
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
  */
-export function csvFormatBody<T extends object>(rows: T[], columns?: Array<keyof T>): string;
+export function csvFormatBody<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T>): string;
 
 // csvFormatRows(...) ========================================================================
 
@@ -183,7 +183,7 @@ export function csvFormatBody<T extends object>(rows: T[], columns?: Array<keyof
  *
  * @param rows An array of array of string rows.
  */
-export function csvFormatRows(rows: string[][]): string;
+export function csvFormatRows(rows: readonly string[][]): string;
 
 // csvFormatRow(...) ========================================================================
 
@@ -192,7 +192,7 @@ export function csvFormatRows(rows: string[][]): string;
  *
  * @param row An array of strings representing a row.
  */
-export function csvFormatRow(row: string[]): string;
+export function csvFormatRow(row: readonly string[]): string;
 
 // csvFormatValue(...) ========================================================================
 
@@ -297,7 +297,7 @@ export function tsvParseRows<ParsedRow extends object>(
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
  */
-export function tsvFormat<T extends object>(rows: T[], columns?: Array<keyof T>): string;
+export function tsvFormat<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T>): string;
 
 // tsvFormatBody(...) ============================================================================
 
@@ -307,7 +307,7 @@ export function tsvFormat<T extends object>(rows: T[], columns?: Array<keyof T>)
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
  */
-export function tsvFormatBody<T extends object>(rows: T[], columns?: Array<keyof T>): string;
+export function tsvFormatBody<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T>): string;
 
 // tsvFormatRows(...) ========================================================================
 
@@ -324,7 +324,7 @@ export function tsvFormatBody<T extends object>(rows: T[], columns?: Array<keyof
  *
  * @param rows An array of array of string rows.
  */
-export function tsvFormatRows(rows: string[][]): string;
+export function tsvFormatRows(rows: readonly string[][]): string;
 
 // tsvFormatRow(...) ========================================================================
 
@@ -333,7 +333,7 @@ export function tsvFormatRows(rows: string[][]): string;
  *
  * @param row An array of strings representing a row.
  */
-export function tsvFormatRow(row: string[]): string;
+export function tsvFormatRow(row: readonly string[]): string;
 
 // tsvFormatValue(...) ========================================================================
 
@@ -432,7 +432,7 @@ export interface DSV {
      * @param rows Array of object rows.
      * @param columns An array of strings representing the column names.
      */
-    format<T extends object>(rows: T[], columns?: Array<keyof T>): string;
+    format<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T>): string;
 
     /**
      * Equivalent to dsv.format, but omits the header row.
@@ -441,7 +441,7 @@ export interface DSV {
      * @param rows Array of object rows.
      * @param columns An array of strings representing the column names.
      */
-    formatBody<T extends object>(rows: T[], columns?: Array<keyof T>): string;
+    formatBody<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T>): string;
 
     /**
      * Formats the specified array of array of string rows as delimiter-separated values, returning a string.
@@ -454,7 +454,7 @@ export interface DSV {
      *
      * @param rows An array of array of string rows.
      */
-    formatRows(rows: string[][]): string;
+    formatRows(rows: readonly string[][]): string;
 
     /**
      * Formats a single array row of strings as delimiter-separated values, returning a string.
@@ -463,7 +463,7 @@ export interface DSV {
      *
      * @param row An array of strings representing a row.
      */
-    formatRow(row: string[]): string;
+    formatRow(row: readonly string[]): string;
 
     /**
      * Format a single value or string as a delimiter-separated value, returning a string.
@@ -490,6 +490,6 @@ export function dsvFormat(delimiter: string): DSV;
  */
 export function autoType<ParsedRow extends object | undefined | null, Columns extends string>(
     // tslint:disable-next-line:no-unnecessary-generics
-    object: DSVRowString<Columns> | string[]
+    object: DSVRowString<Columns> | readonly string[]
 // tslint:disable-next-line:no-unnecessary-generics
 ): ParsedRow;


### PR DESCRIPTION
This PR changes all `Array` parameters to be `ReadonlyArray` (using the `readonly` keyword where approriate).

This allows callers to pass read-only arrays to functions like `csvFormat`. The `d3-dsv` implementation never mutates passed arrays, so this change should be safe. It should also be backwards compatible, as mutable arrays can still be passed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-dsv/blob/master/src/dsv.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
