### PR TITLE
fix(make-fetch-happen): Update `NodeFetchOptions` to include missing properties

### DIFF
--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -20,7 +20,7 @@ declare const fetch: fetch.FetchInterface;
 declare namespace fetch {
     type NodeFetchOptions = Pick<
         RequestInit,
-        'method' | 'body' | 'redirect' | 'follow' | 'timeout' | 'compress' | 'size'
+        'method' | 'body' | 'redirect' | 'follow' | 'timeout' | 'compress' | 'size' | 'headers' | 'agent'
     >;
 
     type TlsOptions = Pick<SecureContextOptions, 'ca' | 'cert' | 'key'> & {

--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for make-fetch-happen 8.0
 // Project: https://github.com/npm/make-fetch-happen#readme
 // Definitions by: Jesse Rosenberger <https://github.com/abernix>
+//                 Trevor Scheer <https://github.com/trevor-scheer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 import { ClientRequestArgs, AgentOptions } from 'http';

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -1,6 +1,8 @@
 import fetcher = require('make-fetch-happen');
 import { Integrity } from 'ssri';
 import { URL as NodeURL } from 'url';
+import { Agent } from 'http';
+import { Headers } from 'node-fetch';
 
 // Needs arguments when invoked
 // $ExpectError
@@ -39,7 +41,7 @@ fetcher.defaults()('http://url');
 fetcher.defaults().defaults()('http://url');
 
 // $ExpectError
-fetcher('https://secure', { cache: "invalid-option" });
+fetcher('https://secure', { cache: 'invalid-option' });
 
 const cache = new Cache();
 // $ExpectType Promise<Response>
@@ -56,7 +58,7 @@ fetcher('https://url', { integrity });
 
 // Test the `retry` types.
 // $ExpectType Promise<Response>
-fetcher('http://url', { retry: { retries: 1, maxTimeout: 1 }});
+fetcher('http://url', { retry: { retries: 1, maxTimeout: 1 } });
 
 // Test both the DOM URL and the Node.js `url` module.
 // $ExpectType Promise<Response>
@@ -67,6 +69,20 @@ fetcher('http://url', { proxy: new NodeURL('http://secure-proxy') });
 // Test the imported `tls` type `rejectUnauthorized` remapped to `strictSSL`.
 // $ExpectType Promise<Response>
 fetcher('https://url', { strictSSL: true });
+
+// Test the various types of `headers` that can be passed in as options
+// $ExpectType Promise<Response>
+fetcher('http://url', { headers: { key: 'value' } });
+// $ExpectType Promise<Response>
+fetcher('http://url', { headers: new Headers({ key: 'value' }) });
+// $ExpectType Promise<Response>
+fetcher('http://url', { headers: [['key', 'value']] });
+
+// Test the various types of `agent` that can be passed in as options
+// $ExpectType Promise<Response>
+fetcher('http://url', { agent: new Agent() });
+// $ExpectType Promise<Response>
+fetcher('http://url', { agent: () => new Agent() });
 
 // Test the `Cache` return type of the `delete` method.
 // $ExpectType Promise<boolean>


### PR DESCRIPTION
Add the `headers` and `agent` options to the pick list from `RequestInit`.

See: https://github.com/npm/make-fetch-happen#minipass-fetch-options

There are two additional options (`headers`, `agent`) not listed in the
initial, more obvious bulleted list.

Also:
Add myself as a co-owner of the type definitions. I had a large part in authoring these and would like to be considered a maintainer for this package.

See:
npm/make-fetch-happen#31
#50339 (comment)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/make-fetch-happen#minipass-fetch-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.