### PR TITLE
fix(make-fetch-happen): Add `dom` reference directive

### DIFF
--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jesse Rosenberger <https://github.com/abernix>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
+/// <reference lib="dom" />
 import { ClientRequestArgs, AgentOptions } from 'http';
 import { CommonConnectionOptions, SecureContextOptions } from 'tls';
 import { URL as NodeURL } from 'url';

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -39,15 +39,23 @@ fetcher.defaults()('http://url');
 fetcher.defaults().defaults()('http://url');
 
 // $ExpectError
-fetcher('https://secure', { cache: "invalid-option" });
+fetcher('https://secure', { cache: 'invalid-option' });
 
+// Test existence of a couple important types from the `dom` lib (`Cache`, `Request`)
+// These are type errors when the `dom` types aren't referenced
+// via the triple slash directive <reference lib="dom" />
+// $ExpectType Cache
 const cache = new Cache();
+// $ExpectType Request
+const req = new Request('http://localhost');
+
 // $ExpectType Promise<Response>
 fetcher('https://secure', { cacheManager: cache });
 
 // Test using a `Request` to the `fetcher` instead of URL.
+
 // $ExpectType Promise<Response>
-fetcher(new Request('http://localhost'), { ca: 'MY_CA_PEM' });
+fetcher(req, { ca: 'MY_CA_PEM' });
 
 // Test the SSRI types from `ssri`
 const integrity = new Integrity();
@@ -56,7 +64,7 @@ fetcher('https://url', { integrity });
 
 // Test the `retry` types.
 // $ExpectType Promise<Response>
-fetcher('http://url', { retry: { retries: 1, maxTimeout: 1 }});
+fetcher('http://url', { retry: { retries: 1, maxTimeout: 1 } });
 
 // Test both the DOM URL and the Node.js `url` module.
 // $ExpectType Promise<Response>

--- a/types/make-fetch-happen/tsconfig.json
+++ b/types/make-fetch-happen/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
It seems that specifying `dom` in the `tsconfig.json`'s `compilerOptions.lib` is insufficient for consumers to successfully use the types provided by this package. This commit follows the precedent of other packages which specify it in both locations (`tsconfig.json` and `index.d.ts`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5d96b18c4662021bfa760559b2807dd73c28a3d9/types/auth0-js/index.d.ts#L10
* https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4486794741ccb9f18f562fefade043ac31e817de/types/bent/index.d.ts#L8
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.