### PR TITLE
fix(leaflet): Add optional parameters in Map class

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1731,7 +1731,7 @@ export class Map extends Evented {
     closeTooltip(tooltip?: Tooltip): this;
 
     // Methods for modifying map state
-    setView(center: LatLngExpression, zoom: number, options?: ZoomPanOptions): this;
+    setView(center: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;
     setZoom(zoom: number, options?: ZoomPanOptions): this;
     zoomIn(delta?: number, options?: ZoomOptions): this;
     zoomOut(delta?: number, options?: ZoomOptions): this;
@@ -1778,10 +1778,10 @@ export class Map extends Evented {
     getPixelWorldBounds(zoom?: number): Bounds;
 
     // Conversion methods
-    getZoomScale(toZoom: number, fromZoom: number): number;
-    getScaleZoom(scale: number, fromZoom: number): number;
-    project(latlng: LatLngExpression, zoom: number): Point;
-    unproject(point: PointExpression, zoom: number): LatLng;
+    getZoomScale(toZoom: number, fromZoom?: number): number;
+    getScaleZoom(scale: number, fromZoom?: number): number;
+    project(latlng: LatLngExpression, zoom?: number): Point;
+    unproject(point: PointExpression, zoom?: number): LatLng;
     layerPointToLatLng(point: PointExpression): LatLng;
     latLngToLayerPoint(latlng: LatLngExpression): Point;
     wrapLatLng(latlng: LatLngExpression): LatLng;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -233,6 +233,10 @@ zoom = map.getBoundsZoom(latLngBounds, true);
 zoom = map.getBoundsZoom(latLngBoundsLiteral);
 zoom = map.getBoundsZoom(latLngBoundsLiteral, true);
 zoom = map.getBoundsZoom(latLngBoundsLiteral, true, point);
+zoom = map.getZoomScale(10);
+zoom = map.getZoomScale(10, 7);
+zoom = map.getScaleZoom(10);
+zoom = map.getScaleZoom(10, 7);
 
 let mapLatLngBounds: L.LatLngBounds;
 mapLatLngBounds = map.getBounds();
@@ -240,6 +244,10 @@ mapLatLngBounds = map.getBounds();
 let mapPoint: L.Point;
 mapPoint = map.getSize();
 mapPoint = map.getPixelOrigin();
+mapPoint = map.project(coordinates);
+mapPoint = map.project(coordinates, 10);
+coordinates = map.unproject(mapPoint);
+coordinates = map.unproject(mapPoint, 10);
 
 let mapPixelBounds: L.Bounds;
 mapPixelBounds = map.getPixelBounds();
@@ -431,6 +439,7 @@ map = map
     .openTooltip(htmlElement, latLngTuple, tooltipOptions)
     .closeTooltip()
     .closeTooltip(L.tooltip())
+    .setView(latLng)
     .setView(latLng, 12)
     .setView(latLng, 12, zoomPanOptions)
     .setView(latLngLiteral, 12)


### PR DESCRIPTION
According to the source code of Leaflet (https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js), the parameters I'm marking in this commit are all optional.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js - tip: find "=== undefined" in the source code to locate those parameters quickly.

