### PR TITLE
[sharedb] Server event support

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -9,6 +9,7 @@
 /// <reference path="lib/sharedb.d.ts" />
 
 import { Duplex } from 'stream';
+import { EventEmitter } from 'events';
 import Agent = require('./lib/agent');
 import { Connection } from './lib/client';
 import * as ShareDB from './lib/sharedb';
@@ -22,7 +23,7 @@ interface Stream {
 
 export = sharedb;
 
-declare class sharedb {
+declare class sharedb extends EventEmitter {
     db: sharedb.DB;
     pubsub: sharedb.PubSub;
     extraDbs: {[extraDbName: string]: sharedb.ExtraDB};
@@ -74,6 +75,13 @@ declare class sharedb {
         action: A,
         fn: (context: sharedb.middleware.ActionContextMap[A], callback: (err?: any) => void) => void,
     ): void;
+
+    on(event: 'timing', callback: (type: string, time: number, request: any) => void): this;
+    on(event: 'error', callback: (err: Error) => void): this;
+
+    addListener(event: 'timing', callback: (type: string, time: number, request: any) => void): this;
+    addListener(event: 'error', callback: (err: Error) => void): this;
+
     static types: ShareDB.Types;
 }
 

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -39,6 +39,8 @@ const backend = new ShareDB({
     extraDbs: {myDb: new CustomExtraDb()}
 });
 console.log(backend.db);
+backend.on('error', (error) => console.error(error));
+backend.addListener('timing', (type, time, request) => console.log(type, new Date(time), request));
 
 // getOps allows for `from` and `to` to both be `null`:
 // https://github.com/share/sharedb/blob/960f5d152f6a8051ed2dcb00a57681a3ebbd7dc2/README.md#getops


### PR DESCRIPTION
This change makes the default `sharedb` class extend `EventEmitter`,
like it does [in the library][1].

We also add support for the [`error`][2] and [`timing`][3] events.

[1]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/backend.js#L21
[2]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/backend.js#L91
[3]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/backend.js#L220

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.