### PR TITLE
[sharedb] Presence support

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -31,6 +31,7 @@ declare class sharedb {
         db?: any,
         pubsub?: sharedb.PubSub,
         extraDbs?: {[extraDbName: string]: sharedb.ExtraDB},
+        presence?: boolean,
         disableDocAction?: boolean,
         disableSpaceDelimitedActions?: boolean
     });

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -14,9 +14,12 @@ export class Connection {
     get(collectionName: string, documentID: string): Doc;
     createFetchQuery(collectionName: string, query: any, options: {results?: Query[]} | null, callback: (err: Error, results: any[]) => void): Query;
     createSubscribeQuery(collectionName: string, query: any, options: {results?: Query[]} | null, callback: (err: Error, results: any[]) => void): Query;
+    getPresence(channel: string): Presence;
+    getDocPresence(collection: string, id: string): Presence;
 }
 export type Doc = ShareDB.Doc;
 export type Query = ShareDB.Query;
+export type Presence<T = any> = ShareDB.Presence<T>;
 export type Error = ShareDB.Error;
 export type Op = ShareDB.Op;
 export type AddNumOp = ShareDB.AddNumOp;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -133,6 +133,33 @@ export class Query extends EventEmitter {
     destroy(): void;
 }
 
+export type ReceivePresence<T> = (id: string, value: T) => void;
+export class Presence<T = any> extends EventEmitter {
+    connection: string;
+    channel: string;
+    wantSubscribe: boolean;
+    subscribed: boolean;
+    remotePresences: Record<string, T>;
+    localPresences: Record<string, LocalPresence<T>>;
+    subscribe(callback?: Callback): void;
+    unsubscribe(callback?: Callback): void;
+    create(id?: string): LocalPresence<T>;
+    destroy(callback?: Callback): void;
+    on(event: 'receive', callback: ReceivePresence<T>): this;
+    addListener(event: 'receive', callback: ReceivePresence<T>): this;
+}
+
+export class LocalPresence<T = any> extends EventEmitter {
+    presence: Presence<T>;
+    presenceId: string;
+    connection: string;
+    presenceVersion: number;
+    value: T;
+    submit(value: T, callback?: Callback): void;
+    send(callback?: Callback): void;
+    destroy(callback?: Callback): void;
+}
+
 export type RequestAction = 'qf' | 'qs' | 'qu' | 'bf' | 'bs' | 'bu' | 'f' | 's' | 'u' | 'op' | 'nf' | 'nt';
 
 export interface ClientRequest {

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -248,5 +248,14 @@ function startClient(callback) {
       Math.round(anotherDoc.version);
     }
 
+    interface PresenceValue {
+        foo: number;
+    }
+    const presence: ShareDBClient.Presence<PresenceValue> = connection.getDocPresence('foo', 'bar');
+    presence.subscribe((error) => console.log(error));
+    presence.on('receive', (id, value) => console.log(id, value.foo.toLocaleString()));
+    const localPresence = presence.create('123');
+    localPresence.submit({foo: 123});
+
     connection.close();
 }


### PR DESCRIPTION
ShareDB supports "presence", which is accessed through
[`getPresence`][1] and [`getDocPresence`][2], both of which return an
instance of [`Presence`][3].

This functionality is hidden behind a [feature flag][4], which is also
included in this change.

[1]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/connection.js#L751
[2]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/connection.js#L758
[3]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/presence/presence.js#L8
[4]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/backend.js#L35

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
