### PR TITLE
[sharedb] Logger method overrides

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -75,6 +75,7 @@ declare class sharedb {
         fn: (context: sharedb.middleware.ActionContextMap[A], callback: (err?: any) => void) => void,
     ): void;
     static types: ShareDB.Types;
+    static logger: ShareDB.Logger;
 }
 
 declare namespace sharedb {

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -35,3 +35,4 @@ export type Path = ShareDB.Path;
 export type ShareDBSourceOptions = ShareDB.ShareDBSourceOptions;
 
 export const types: ShareDB.Types;
+export const logger: ShareDB.Logger;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -76,6 +76,16 @@ export interface Types {
     map: { [key: string]: Type };
 }
 
+export type LoggerFunction = typeof console.log;
+export interface LoggerOverrides {
+    info?: LoggerFunction;
+    warn?: LoggerFunction;
+    error?: LoggerFunction;
+}
+export class Logger {
+    setMethods(overrides: LoggerOverrides): void;
+}
+
 export interface Error {
     code: number;
     message: string;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -222,6 +222,15 @@ const op1 = [{ insert: 'Hello' }];
 const op2 = [{ retain: 5 }, { insert: ' world!' }];
 const op3 = ShareDBClient.types.map['rich-text'].compose(op1, op2);
 
+ShareDB.logger.setMethods({
+    warn: (...args: any[]) => console.log(...args),
+});
+
+ShareDBClient.logger.setMethods({
+    info: () => {},
+    error: (message: string) => console.error(message),
+});
+
 function startClient(callback) {
     const socket = new WebSocket('ws://localhost:8080');
     const connection = new ShareDBClient.Connection(socket);


### PR DESCRIPTION
ShareDB exposes a special [`Logger`][1], which can be used to override
ShareDB's internal logging calls, which default to using the `console`.

There are two logger instances that can be configured:

 - [server-side][2]
 - [client-side][3]

[1]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/logger/logger.js#L7
[2]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/index.js#L8
[3]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/index.js#L6

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.