### PR TITLE
[sharedb] Generic Doc and Snapshot

### DIFF
--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -15,7 +15,7 @@ export class Connection {
     createFetchQuery(collectionName: string, query: any, options: {results?: Query[]} | null, callback: (err: Error, results: any[]) => void): Query;
     createSubscribeQuery(collectionName: string, query: any, options: {results?: Query[]} | null, callback: (err: Error, results: any[]) => void): Query;
 }
-export type Doc = ShareDB.Doc;
+export type Doc<T = any> = ShareDB.Doc<T>;
 export type Query = ShareDB.Query;
 export type Error = ShareDB.Error;
 export type Op = ShareDB.Op;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -9,11 +9,11 @@ export interface JSONObject {
 export interface JSONArray extends Array<JSONValue> {}
 
 export type Path = ReadonlyArray<string|number>;
-export interface Snapshot {
+export interface Snapshot<T = any> {
     id: string;
     v: number;
     type: string | null;
-    data?: any;
+    data?: T;
     m: SnapshotMeta | null;
 }
 
@@ -89,12 +89,12 @@ export type Callback = (err: Error) => any;
 
 export type DocEvent = 'load' | 'create' | 'before op' | 'op' | 'del' | 'error' | 'no write pending' | 'nothing pending';
 
-export class Doc extends EventEmitter {
+export class Doc<T = any> extends EventEmitter {
     connection: Connection;
     type: Type | null;
     id: string;
     collection: string;
-    data: any;
+    data: T;
     version: number | null;
 
     fetch: (callback: (err: Error) => void) => void;
@@ -112,11 +112,11 @@ export class Doc extends EventEmitter {
     addListener(event: 'del', callback: (data: any, source: boolean) => void): this;
     addListener(event: 'error', callback: (err: Error) => void): this;
 
-    ingestSnapshot(snapshot: Snapshot, callback: Callback): void;
+    ingestSnapshot(snapshot: Snapshot<T>, callback: Callback): void;
     destroy(): void;
-    create(data: any, callback?: Callback): void;
-    create(data: any, type?: OTType, callback?: Callback): void;
-    create(data: any, type?: OTType, options?: ShareDBSourceOptions, callback?: Callback): void;
+    create(data: T, callback?: Callback): void;
+    create(data: T, type?: OTType, callback?: Callback): void;
+    create(data: T, type?: OTType, options?: ShareDBSourceOptions, callback?: Callback): void;
     submitOp(data: ReadonlyArray<Op>, options?: ShareDBSourceOptions, callback?: Callback): void;
     del(options: ShareDBSourceOptions, callback: (err: Error) => void): void;
     whenNothingPending(callback: (err: Error) => void): void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -230,6 +230,17 @@ function startClient(callback) {
         doc.submitOp([{p: ['numClicks'], na: 1}]);
         callback();
     });
+
+    interface MyDoc {
+        foo: number;
+        bar: string;
+    }
+    const typedDoc: ShareDBClient.Doc<MyDoc> = connection.get('example', 'my-doc');
+    typedDoc.create({
+        foo: 123,
+        bar: 'abc',
+    });
+
     // sharedb-mongo query object
     connection.createSubscribeQuery('examples', {numClicks: {$gte: 5}}, null, (err, results) => {
         console.log(err, results);


### PR DESCRIPTION
The `Doc` and `Snapshot` types are both data wrappers around a
potentially well-structured object.

This change makes these types optionally generic (defaulting to `any`
if no type is provided), allowing clients to enforce stricter type
checking on these types if they wish.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

