### PR TITLE
[json-logic-js] Add function definitions related to operations

### DIFF
--- a/types/json-logic-js/index.d.ts
+++ b/types/json-logic-js/index.d.ts
@@ -57,4 +57,6 @@ export type RulesLogic =
     // MiscOperations
     | { log: RulesLogic };
 
+export function add_operation(name: string, code: (...args: any[]) => any): void;
 export function apply(logic: RulesLogic, data?: unknown): any;
+export function rm_operation(name: string): void;

--- a/types/json-logic-js/json-logic-js-tests.ts
+++ b/types/json-logic-js/json-logic-js-tests.ts
@@ -219,3 +219,17 @@ jsonLogic.apply({ substr: ['jsonlogic', 1, 3] });
 
 // $ExpectType any
 jsonLogic.apply({ log: 'apple' });
+
+// $ExpectType void
+jsonLogic.add_operation('op', () => true);
+// $ExpectError
+jsonLogic.add_operation(1, (x: number, y: number) => x + y);
+// $ExpectError
+jsonLogic.add_operation();
+
+// $ExpectType void
+jsonLogic.rm_operation('op');
+// $ExpectError
+jsonLogic.rm_operation(1);
+// $ExpectError
+jsonLogic.rm_operation();


### PR DESCRIPTION
Simple examples of these very open-ended functions:
https://jsonlogic.com/add_operation.html

Their implementations:
https://github.com/jwadhams/json-logic-js/blob/master/logic.js