### PR TITLE
Fixed parseMetadata types in `blueimp-load-image`.

### DIFF
--- a/types/blueimp-load-image/blueimp-load-image-tests.ts
+++ b/types/blueimp-load-image/blueimp-load-image-tests.ts
@@ -41,3 +41,9 @@ loadImage(imageUrlJPEG, { canvas: true, orientation: true, maxWidth: 100, maxHei
     console.log(url);
   });
 });
+
+// Parse metadata
+loadImage.parseMetaData(imageUrlJPEG, (metadata) => {
+  console.log(metadata.exif && metadata.exif.get('Orientation'));
+  console.log(metadata.exif && metadata.exif[0x0112]);
+});

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -12,10 +12,13 @@ declare namespace loadImage {
         image: HTMLImageElement | FileReader | false;
     };
 
-    type ParseMetaDataCallback = (data: ImageHead) => void;
+    type ParseMetaDataCallback = (data: MetaData) => void;
+
+    type ExifTagValue = number | string | string[];
 
     interface Exif {
-        [tag: number]: number | string | string[];
+        [tag: number]: ExifTagValue;
+        get: (tagName: 'Orientation' | 'Thumbnail' | 'Exif' | 'GPSInfo' | 'Interoperability') => ExifTagValue;
     }
 
     interface Iptc {


### PR DESCRIPTION
- `parseMetaData` now accepts the correct argument type (see https://github.com/blueimp/JavaScript-Load-Image/#metadata-parsing)
- added the `get()` function to the exif parser (see https://github.com/blueimp/JavaScript-Load-Image/#exif-parser)



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/blueimp/JavaScript-Load-Image