### PR TITLE
update(encoding-japanese): minor changes and UMD support

### DIFF
--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for encoding-japanese v1.0
+// Type definitions for encoding-japanese 1.0
 // Project: https://github.com/polygonplanet/encoding.js
 // Definitions by: rhysd <https://github.com/rhysd>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
+export as namespace Encoding;
 
 export type Encoding =
     | 'UTF32'
@@ -26,7 +27,7 @@ type IntArrayType =
     | Int8Array
     | Int16Array
     | Int32Array;
-type RawType = IntArrayType | ReadonlyArray<number> | Buffer;
+type RawType = IntArrayType | ReadonlyArray<number>;
 type EncodingDetection = Encoding | false;
 
 export type ConvertOptions =
@@ -62,35 +63,37 @@ export interface ConvertUnknownOptions {
     bom?: boolean | string;
 }
 
-export declare function detect(data: RawType | string, encodings?: Encoding | Encoding[]): EncodingDetection;
-export declare function convert(data: RawType, to: Encoding, from?: Encoding): number[];
-export declare function convert(data: string, to: Encoding, from?: Encoding): string;
-export declare function convert(data: RawType | string, options: ConvertStringOptions): string;
-export declare function convert(data: RawType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
-export declare function convert(data: RawType | string, options: ConvertArrayOptions): number[];
-export declare function convert(data: string, options: ConvertUnknownOptions): string;
-export declare function convert(data: RawType, options: ConvertUnknownOptions): number[];
-export declare function urlEncode(data: IntArrayType): string;
-export declare function urlDecode(data: string): number[];
-export declare function base64Encode(data: IntArrayType): string;
-export declare function base64Decode(data: string): number[];
-export declare function codeToString(data: IntArrayType): string;
-export declare function stringToCode(data: string): number[];
-export declare function toHankakuCase(data: ReadonlyArray<number>): number[];
-export declare function toHankakuCase(data: string): string;
-export declare function toZenkakuCase(data: ReadonlyArray<number>): number[];
-export declare function toZenkakuCase(data: string): string;
-export declare function toHiraganaCase(data: ReadonlyArray<number>): number[];
-export declare function toHiraganaCase(data: string): string;
-export declare function toKatakanaCase(data: ReadonlyArray<number>): number[];
-export declare function toKatakanaCase(data: string): string;
-export declare function toHankanaCase(data: ReadonlyArray<number>): number[];
-export declare function toHankanaCase(data: string): string;
-export declare function toZenkanaCase(data: ReadonlyArray<number>): number[];
-export declare function toZenkanaCase(data: string): string;
-export declare function toHankakuSpace(data: ReadonlyArray<number>): number[];
-export declare function toHankakuSpace(data: string): string;
-export declare function toZenkakuSpace(data: ReadonlyArray<number>): number[];
-export declare function toZenkakuSpace(data: string): string;
+export function detect(data: RawType | string, encodings?: Encoding | Encoding[]): EncodingDetection;
+export function convert(data: RawType, to: Encoding, from?: Encoding): number[];
+export function convert(data: string, to: Encoding, from?: Encoding): string;
+export function convert(data: RawType | string, options: ConvertStringOptions): string;
+export function convert(data: RawType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
+export function convert(data: RawType | string, options: ConvertArrayOptions): number[];
+export function convert(data: string, options: ConvertUnknownOptions): string;
+export function convert(data: RawType, options: ConvertUnknownOptions): number[];
+export function urlEncode(data: IntArrayType): string;
+export function urlDecode(data: string): number[];
+export function base64Encode(data: IntArrayType): string;
+export function base64Decode(data: string): number[];
+export function codeToString(data: IntArrayType): string;
+export function stringToCode(data: string): number[];
+export function toHankakuCase(data: ReadonlyArray<number>): number[];
+export function toHankakuCase(data: string): string;
+export function toZenkakuCase(data: ReadonlyArray<number>): number[];
+export function toZenkakuCase(data: string): string;
+export function toHiraganaCase(data: ReadonlyArray<number>): number[];
+export function toHiraganaCase(data: string): string;
+export function toKatakanaCase(data: ReadonlyArray<number>): number[];
+export function toKatakanaCase(data: string): string;
+export function toHankanaCase(data: ReadonlyArray<number>): number[];
+export function toHankanaCase(data: string): string;
+export function toZenkanaCase(data: ReadonlyArray<number>): number[];
+export function toZenkanaCase(data: string): string;
+export function toHankakuSpace(data: ReadonlyArray<number>): number[];
+export function toHankakuSpace(data: string): string;
+export function toZenkakuSpace(data: ReadonlyArray<number>): number[];
+export function toZenkakuSpace(data: string): string;
 
-export declare const orders: string[];
+export const orders: string[];
+
+export {};

--- a/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
+++ b/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
@@ -1,9 +1,10 @@
-import * as Encoding from 'encoding-japanese';
+/// <reference types="node" />
+import Encoding = require('encoding-japanese');
 
 // Convert character encoding to Shift_JIS from UTF-8.
 const utf8Array_1 = new Uint8Array([1, 2, 3]);
 const utf8Array_2 = [1, 2, 3];
-const utf8Array_3 = new Buffer([1, 2, 3]);
+const utf8Array_3 = Buffer.from([1, 2, 3]);
 const utf8Array_4 = new Uint16Array([1, 2, 3]);
 const utf8Array_5 = new Uint32Array([1, 2, 3]);
 const utf8Array_6 = new Int16Array([1, 2, 3]);

--- a/types/encoding-japanese/test/encoding-japanese-tests.global.ts
+++ b/types/encoding-japanese/test/encoding-japanese-tests.global.ts
@@ -1,0 +1,10 @@
+// just verify we can use exported namespace
+
+const utf8String = 'ã\u0081\u0093ã\u0082\u0093ã\u0081«ã\u0081¡ã\u0081¯';
+const unicodeString = Encoding.convert(utf8String, {
+    to: 'UNICODE',
+    from: 'UTF8',
+    type: 'string',
+});
+// $ExpectType string
+unicodeString; // こんにちは

--- a/types/encoding-japanese/tsconfig.json
+++ b/types/encoding-japanese/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
-        "encoding-japanese-tests.ts"
+        "test/encoding-japanese-tests.cjs.ts",
+        "test/encoding-japanese-tests.global.ts"
     ]
 }

--- a/types/encoding-japanese/tslint.json
+++ b/types/encoding-japanese/tslint.json
@@ -1,13 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-duplicate-variable": false,
-        "no-trailing-whitespace": false,
-        "no-var-keyword": false,
-        "prefer-const": false,
-        "strict-export-declare-modifiers": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- export as namespace to allow script usage
- trim down dependency using Uint8Array enplace of Buffer
- test global usage
- simplify by defalting to DT defaults for linting
- maintainer added
- tests amended

https://github.com/polygonplanet/encoding.js#in-browser

```ts
export {};
```
added to preserve internal types, not exported originally

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes