### PR TITLE
[sharedb] Update Doc definitions

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -96,9 +96,13 @@ export class Doc extends EventEmitter {
     collection: string;
     data: any;
     version: number | null;
+    subscribed: boolean;
+    preventCompose: boolean;
+    paused: boolean;
 
     fetch: (callback: (err: Error) => void) => void;
     subscribe: (callback: (err: Error) => void) => void;
+    unsubscribe: (callback: (error: Error) => void) => void;
 
     on(event: 'load' | 'no write pending' | 'nothing pending', callback: () => void): this;
     on(event: 'create', callback: (source: boolean) => void): this;
@@ -113,13 +117,18 @@ export class Doc extends EventEmitter {
     addListener(event: 'error', callback: (err: Error) => void): this;
 
     ingestSnapshot(snapshot: Snapshot, callback: Callback): void;
-    destroy(): void;
+    destroy(callback?: Callback): void;
     create(data: any, callback?: Callback): void;
     create(data: any, type?: OTType, callback?: Callback): void;
     create(data: any, type?: OTType, options?: ShareDBSourceOptions, callback?: Callback): void;
     submitOp(data: ReadonlyArray<Op>, options?: ShareDBSourceOptions, callback?: Callback): void;
     del(options: ShareDBSourceOptions, callback: (err: Error) => void): void;
-    whenNothingPending(callback: (err: Error) => void): void;
+    whenNothingPending(callback: () => void): void;
+    hasPending(): boolean;
+    hasWritePending(): boolean;
+    pause(): void;
+    resume(): void;
+    flush(): void;
 }
 
 export type QueryEvent = 'ready' | 'error' | 'changed' | 'insert' | 'move' | 'remove' | 'extra';

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -226,9 +226,20 @@ function startClient(callback) {
     const socket = new WebSocket('ws://localhost:8080');
     const connection = new ShareDBClient.Connection(socket);
     const doc = connection.get('examples', 'counter');
+    doc.preventCompose = true;
+    if (doc.subscribed) return;
+    if (doc.paused) doc.resume();
     doc.subscribe(() => {
         doc.submitOp([{p: ['numClicks'], na: 1}]);
-        callback();
+        doc.unsubscribe((error) => {
+            if (error) console.error(error);
+            doc.pause();
+            doc.flush();
+            doc.destroy((error) => {
+                if (error) console.error(error);
+                callback();
+            });
+        });
     });
     // sharedb-mongo query object
     connection.createSubscribeQuery('examples', {numClicks: {$gte: 5}}, null, (err, results) => {
@@ -247,6 +258,11 @@ function startClient(callback) {
     if (anotherDoc.version !== null) {
       Math.round(anotherDoc.version);
     }
+
+    doc.whenNothingPending(() => {
+        if (doc.hasPending()) throw new Error();
+        if (doc.hasWritePending()) throw new Error();
+    });
 
     connection.close();
 }


### PR DESCRIPTION
This change makes multiple fixes to the `Doc` definition:

 - Add [`subscribed`][1], [`preventCompose`][2] and [`paused`][3]
  properties
 - Add [`unsubscribe()`][4]
 - Allow a callback in [`destroy()`][5]
 - Remove the error argument from [`whenNothingPending()`][6], since that
   method will never call the callback with an error
 - Add [`hasPending()`][7], [`hasWritePending()`][8], [`pause()`][9],
   [`resume()`][10] and [`flush()`][11] methods

[1]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L73
[2]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L104
[3]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L109
[4]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L424
[5]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L113
[6]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L221
[7]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L232
[8]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L243
[9]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L901
[10]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L906
[11]: https://github.com/share/sharedb/blob/30badb22192eb04e43f983772058fb129598de51/lib/client/doc.js#L500

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
