### PR TITLE
js-worker-search: Added terminate method to class definiton

### DIFF
--- a/types/js-worker-search/index.d.ts
+++ b/types/js-worker-search/index.d.ts
@@ -18,4 +18,5 @@ export default class SearchApi {
     });
     indexDocument(uid: string, text: string): void;
     search(query: string): Promise<string[]>;
+    terminate(): void;
 }

--- a/types/js-worker-search/js-worker-search-tests.ts
+++ b/types/js-worker-search/js-worker-search-tests.ts
@@ -33,3 +33,6 @@ searchApi.indexDocument('uid', 'This is foo');
 // And while we're at it, verify that searching returns a promise containing an array of strings
 
 const promise: Promise<string[]> = searchApi.search('foo');
+
+// Try to terminate the web-workers
+searchApi.terminate();


### PR DESCRIPTION
This PR adds the terminate()-method to the type declaration of the SearchApi-class. Without this, you will not be able to access this method with types. The method is briefly described in the [js-worker-search README-file](https://github.com/bvaughn/js-worker-search/blob/master/README.md).