### PR TITLE
[webpack-manifest-plugin] Minor change - compatible w/ webpack v5 types

### DIFF
--- a/types/webpack-manifest-plugin/index.d.ts
+++ b/types/webpack-manifest-plugin/index.d.ts
@@ -92,4 +92,4 @@ export interface Options {
     writeToFileEmit?: boolean;
 }
 
-export function getCompilerHooks(compiler: Compiler): { afterEmit: SyncWaterfallHook; beforeEmit: SyncWaterfallHook };
+export function getCompilerHooks(compiler: Compiler): { afterEmit: SyncWaterfallHook<any>; beforeEmit: SyncWaterfallHook<any> };


### PR DESCRIPTION
To be compatible with webpack v5 
otherwise faces error - `"Generic type 'SyncWaterfallHook<T>' requires 1 type argument(s)."`