### PR TITLE
fix(tap): async methods return Promise<void>, not void

### DIFF
--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -80,12 +80,12 @@ declare class Test {
         expectedError: Error,
         message?: string,
         extra?: Options.Assert,
-    ): void;
+    ): Promise<void>;
     rejects(
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         message?: string,
         extra?: Options.Assert,
-    ): void;
+    ): Promise<void>;
 
     // Verifies that the promise (or promise-returning function) resolves, making no expectation about the value that the promise resolves to.
     // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
@@ -94,7 +94,7 @@ declare class Test {
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         message?: string,
         extra?: Options.Assert,
-    ): void;
+    ): Promise<void>;
 
     // Verifies that the promise (or promise-returning function) resolves, and furthermore that the value of the promise matches the wanted pattern using match.
     // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
@@ -104,7 +104,7 @@ declare class Test {
         wanted: string | RegExp | { [key: string]: RegExp },
         message?: string,
         extra?: Options.Assert,
-    ): void;
+    ): Promise<void>;
 
     // Verifies that the promise (or promise-returning function) resolves, and furthermore that the value of the promise matches the snapshot.
     // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
@@ -113,7 +113,7 @@ declare class Test {
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         message?: string,
         extra?: Options.Assert,
-    ): void;
+    ): Promise<void>;
 
     // As of version 11, tap supports saving and then comparing against "snapshot" strings. This is a powerful technique for testing programs that generate output, but it comes with some caveats.
     matchSnapshot(output: any, message?: string, extra?: Options.Assert): boolean;

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -11,8 +11,6 @@ tap.test('all-assertions', t => {
     const fn: (stuff: any) => void = () => {};
     const expectedError: Error = new Error();
     const eventEmitter: EventEmitter = new EventEmitter();
-    const promise: Promise<any> = Promise.resolve(1);
-    const promiseProvider: () => Promise<void> = () => Promise.resolve();
     const pattern: RegExp | string | { [key: string]: RegExp } = 'pattern';
 
     const message = 'message';
@@ -44,40 +42,6 @@ tap.test('all-assertions', t => {
     t.emits(eventEmitter, 'event', message, extra);
     t.emits(eventEmitter, 'event', message);
     t.emits(eventEmitter, 'event');
-
-    t.rejects(promise, expectedError, message, extra);
-    t.rejects(promise, expectedError, message);
-    t.rejects(promise, expectedError);
-    t.rejects(promise, message, extra);
-    t.rejects(promise, message);
-    t.rejects(promise);
-    t.rejects(promiseProvider, expectedError, message, extra);
-    t.rejects(promiseProvider, expectedError, message);
-    t.rejects(promiseProvider, expectedError);
-    t.rejects(promiseProvider, message, extra);
-    t.rejects(promiseProvider, message);
-    t.rejects(promiseProvider);
-
-    t.resolves(promise, message, extra);
-    t.resolves(promise, message);
-    t.resolves(promise);
-    t.resolves(promiseProvider, message, extra);
-    t.resolves(promiseProvider, message);
-    t.resolves(promiseProvider);
-
-    t.resolveMatch(promise, wanted, message, extra);
-    t.resolveMatch(promise, wanted, message);
-    t.resolveMatch(promise, wanted);
-    t.resolveMatch(promiseProvider, wanted, message, extra);
-    t.resolveMatch(promiseProvider, wanted, message);
-    t.resolveMatch(promiseProvider, wanted);
-
-    t.resolveMatchSnapshot(promise, message, extra);
-    t.resolveMatchSnapshot(promise, message);
-    t.resolveMatchSnapshot(promise);
-    t.resolveMatchSnapshot(promiseProvider, message, extra);
-    t.resolveMatchSnapshot(promiseProvider, message);
-    t.resolveMatchSnapshot(promiseProvider);
 
     t.matchSnapshot(found, message, extra);
     t.matchSnapshot(found, message);
@@ -209,7 +173,52 @@ tap.test('all-assertions', t => {
 });
 
 tap.test('async test', async t => {
-    t.pass();
+    const wanted: any = 1;
+    const expectedError: Error = new Error();
+
+    const message = 'message';
+    const extra = {
+        todo: false,
+        skip: 'skip',
+        diagnostic: true,
+        extra_stuff: false,
+    };
+    const promise: Promise<any> = Promise.resolve(1);
+    const promiseProvider: () => Promise<void> = () => Promise.resolve();
+
+    await t.rejects(promise, expectedError, message, extra);
+    await t.rejects(promise, expectedError, message);
+    await t.rejects(promise, expectedError);
+    await t.rejects(promise, message, extra);
+    await t.rejects(promise, message);
+    await t.rejects(promise);
+    await t.rejects(promiseProvider, expectedError, message, extra);
+    await t.rejects(promiseProvider, expectedError, message);
+    await t.rejects(promiseProvider, expectedError);
+    await t.rejects(promiseProvider, message, extra);
+    await t.rejects(promiseProvider, message);
+    await t.rejects(promiseProvider);
+
+    await t.resolves(promise, message, extra);
+    await t.resolves(promise, message);
+    await t.resolves(promise);
+    await t.resolves(promiseProvider, message, extra);
+    await t.resolves(promiseProvider, message);
+    await t.resolves(promiseProvider);
+
+    await t.resolveMatch(promise, wanted, message, extra);
+    await t.resolveMatch(promise, wanted, message);
+    await t.resolveMatch(promise, wanted);
+    await t.resolveMatch(promiseProvider, wanted, message, extra);
+    await t.resolveMatch(promiseProvider, wanted, message);
+    await t.resolveMatch(promiseProvider, wanted);
+
+    await t.resolveMatchSnapshot(promise, message, extra);
+    await t.resolveMatchSnapshot(promise, message);
+    await t.resolveMatchSnapshot(promise);
+    await t.resolveMatchSnapshot(promiseProvider, message, extra);
+    await t.resolveMatchSnapshot(promiseProvider, message);
+    await t.resolveMatchSnapshot(promiseProvider);
 });
 
 tap.only('only', t => {


### PR DESCRIPTION
The comments were already in line with what the function does, but the return type was `void` instead of a Promise.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://node-tap.org/docs/api/asserts/>
