### PR TITLE
fix: missing from hydra-box 0.5

### DIFF
--- a/types/hydra-box/hydra-box-tests.ts
+++ b/types/hydra-box/hydra-box-tests.ts
@@ -2,7 +2,7 @@ import express = require('express');
 import hydraBox = require('hydra-box');
 import Api = require('hydra-box/Api');
 import StoreResourceLoader = require('hydra-box/StoreResourceLoader');
-import { Dataset, DatasetCore, NamedNode, Store } from 'rdf-js';
+import { Dataset, NamedNode, Store } from 'rdf-js';
 
 const codePath = '';
 const path = '';
@@ -56,7 +56,8 @@ function appCustomConfig() {
         loader,
         store,
         middleware: {
-            resource: handler
+            resource: handler,
+            operations: handler
         }
     }));
 
@@ -65,7 +66,8 @@ function appCustomConfig() {
         loader,
         store,
         middleware: {
-            resource: [handler, handler]
+            resource: [handler, handler],
+            operations: [handler, handler]
         }
     }));
 }
@@ -79,3 +81,7 @@ async function testStoreResourceLoader() {
     const forClassOperation: hydraBox.Resource[] = await loader.forClassOperation(term, req);
     const forPropertyOperation: hydraBox.PropertyResource[] = await loader.forPropertyOperation(term, req);
 }
+
+const handler: express.RequestHandler = (req) => {
+    const operations: hydraBox.PotentialOperation[] = req.hydra.operations;
+};

--- a/types/hydra-box/index.d.ts
+++ b/types/hydra-box/index.d.ts
@@ -14,11 +14,17 @@ import middleware = require('./middleware');
 import Api = require('./Api');
 
 declare namespace HydraBox {
+    interface PotentialOperation {
+        resource: Resource | PropertyResource;
+        operation: GraphPointer;
+    }
+
     interface HydraBox {
         api: Api;
         term: RDF.NamedNode;
         resource: Resource;
         operation: GraphPointer;
+        operations: PotentialOperation[];
     }
 
     interface Resource {

--- a/types/hydra-box/middleware.d.ts
+++ b/types/hydra-box/middleware.d.ts
@@ -9,6 +9,7 @@ import { ResourceLoader } from '.';
 declare namespace middleware {
     interface HydraBoxMiddleware {
         resource?: express.RequestHandler | express.RequestHandler[];
+        operations?: express.RequestHandler | express.RequestHandler[];
     }
 
     interface Options {


### PR DESCRIPTION
I missed some declaration from the 0.5 version of hydra-box in previous PR

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/zazuko/hydra-box/pull/86>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
