### PR TITLE
[@ember/string] augment @ember/string with htmlSafe and isHTMLSafe

### DIFF
--- a/types/ember__string/ember__string-tests.ts
+++ b/types/ember__string/ember__string-tests.ts
@@ -1,4 +1,15 @@
-import { dasherize, camelize, capitalize, classify, decamelize, loc, underscore, w } from '@ember/string';
+import {
+  dasherize,
+  camelize,
+  capitalize,
+  classify,
+  decamelize,
+  loc,
+  underscore,
+  w,
+  htmlSafe,
+  isHTMLSafe,
+} from '@ember/string';
 
 dasherize(); // $ExpectError
 dasherize('blue man group'); // $ExpectType string
@@ -31,3 +42,10 @@ capitalize('', ''); // $ExpectError
 loc(); // $ExpectError
 loc("_Hello World");  // $ExpectType string
 loc("_Hello %@ %@", ["John", "Smith"]);  // $ExpectType string
+
+htmlSafe(); // $ExpectError
+htmlSafe('foo'); // $ExpectType SafeString
+
+isHTMLSafe(); // $ExpectError
+isHTMLSafe('foo'); // $ExpectType boolean
+isHTMLSafe(htmlSafe('foo')); // $ExpectType boolean

--- a/types/ember__string/index.d.ts
+++ b/types/ember__string/index.d.ts
@@ -7,6 +7,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
+import { htmlSafe as templateHtmlSafe, isHTMLSafe as templateIsHTMLSafe } from '@ember/template';
+
 export function camelize(str: string): string;
 export function capitalize(str: string): string;
 export function classify(str: string): string;
@@ -15,3 +17,8 @@ export function decamelize(str: string): string;
 export function loc(template: string, args?: string[]): string;
 export function underscore(str: string): string;
 export function w(str: string): string[];
+
+declare module '@ember/string' {
+  function htmlSafe(...args: Parameters<typeof templateHtmlSafe>): ReturnType<typeof templateHtmlSafe>;
+  function isHTMLSafe(...args: Parameters<typeof templateIsHTMLSafe>): ReturnType<typeof templateIsHTMLSafe>;
+}


### PR DESCRIPTION
#50545 prematurely removed `htmlSafe` and `isHTMLSafe` from `@ember/string`. This adds them back because they continue to be available to be imported from there in addition to `@ember/template` (this is [deprecated](https://github.com/emberjs/rfc-tracking/issues/26), but not removed). I've added them back using module augmentation so that they will augment the types shipped with the external `@ember/string` *package* when present (it's a dependency of `ember-data` starting with `ember-data@3.24`. Module augmentation does not allow simply re-exporting from `@ember/template`, but, rather than completely redefine the types for these functions, I grab the parameter and return types from `@ember/template` and use them here.

I've opened https://github.com/emberjs/ember.js/pull/19339 to actually deprecate this in the Ember codebase.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
   - `htmlSafe` and `isHTMLSafe` are added to `@ember/string` [here](https://github.com/emberjs/ember.js/blob/ce750104d0f4d2fac6dd7a9ee66a12a9411c3f5d/packages/ember/index.js#L654-L655)
   (`Ember.String` is importable as `@ember/string` in Ember)
   - definition of [htmlSafe](https://github.com/emberjs/ember.js/blob/ce750104d0f4d2fac6dd7a9ee66a12a9411c3f5d/packages/%40ember/-internals/glimmer/lib/utils/string.ts#L61-L85)
   - definition of [isHTMLSafe](https://github.com/emberjs/ember.js/blob/ce750104d0f4d2fac6dd7a9ee66a12a9411c3f5d/packages/%40ember/-internals/glimmer/lib/utils/string.ts#L87-L108)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~