### PR TITLE
[css-tree]: Rename HexColor -> Hash

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -347,7 +347,7 @@ switch (ast.type) {
         ast.children; // $ExpectType List<CssNode>
         break;
 
-    case 'HexColor':
+    case 'Hash':
         ast.value; // $ExpectType string
         break;
 
@@ -526,7 +526,7 @@ switch (toPlain.type) {
         toPlain.children; // $ExpectType CssNodePlain[]
         break;
 
-    case 'HexColor':
+    case 'Hash':
         toPlain.value; // $ExpectType string
         break;
 

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -205,8 +205,8 @@ export interface FunctionNodePlain extends CssNodeCommon {
     children: CssNodePlain[];
 }
 
-export interface HexColor extends CssNodeCommon {
-    type: 'HexColor';
+export interface Hash extends CssNodeCommon {
+    type: 'Hash';
     value: string;
 }
 
@@ -411,7 +411,7 @@ export type CssNode =
     | DeclarationList
     | Dimension
     | FunctionNode
-    | HexColor
+    | Hash
     | IdSelector
     | Identifier
     | MediaFeature
@@ -453,7 +453,7 @@ export type CssNodePlain =
     | DeclarationListPlain
     | Dimension
     | FunctionNodePlain
-    | HexColor
+    | Hash
     | IdSelector
     | Identifier
     | MediaFeature
@@ -559,7 +559,7 @@ export type WalkOptions =
     | WalkOptionsVisit<DeclarationList>
     | WalkOptionsVisit<Dimension>
     | WalkOptionsVisit<FunctionNode>
-    | WalkOptionsVisit<HexColor>
+    | WalkOptionsVisit<Hash>
     | WalkOptionsVisit<IdSelector>
     | WalkOptionsVisit<Identifier>
     | WalkOptionsVisit<MediaFeature>


### PR DESCRIPTION
This changes the type HexColor into Hash, as was changed during the [official 1.0 release of `css-tree`](https://github.com/csstree/csstree/releases/tag/v1.0.0). HexColor has been removed, so the types should be updated. Obviously the types could use an in-depth checkup, but i'm just patching what's obvious here.
Edit: This fix is potentially a breaking change, because I'm removing a type. However, I don't know how to force a major version, and I don't know if it's a good idea to do so.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/csstree/csstree/releases/tag/v1.0.0
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
