### PR TITLE
[new-relic-browser] Add actionText method to BrowserInteraction

### DIFF
--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -127,6 +127,15 @@ declare namespace NewRelic {
 
     interface BrowserInteraction {
         /**
+         * Sets the text value of the HTML element that was clicked to start a browser interaction.
+         *
+         * @param value The text value of the HTML element that represents the action that started the interaction.
+         * @returns This method returns the same API object created by interaction().
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
+         */
+        actionText(value: string): BrowserInteraction;
+
+        /**
          * Times sub-components of a SPA interaction separately, including wait time and JS execution time.
          *
          * @param name This will be used as the name of the tracer. If you do not include a name,

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -62,7 +62,7 @@ newrelic.setCurrentRouteName(null);
 // actionText()
 newrelic
     .interaction()
-    .actionText('Buy Button');
+    .actionText('Create Subscription');
 
 // createTracer()
 newrelic

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -59,6 +59,11 @@ newrelic.setCurrentRouteName(null);
 
 // --- NewRelic.BrowserInteraction methods -----------------------------------
 
+// actionText()
+newrelic
+    .interaction()
+    .actionText('Buy Button');
+
 // createTracer()
 newrelic
     .interaction()


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I've change the version number from 0.1188 to 0.1184 because the API now matches what I see with v1184 of the the New Relic SPA agent, i.e. when running New Relic in my browser application the browser snippet will load `<script src="https://js-agent.newrelic.com/nr-spa-1184.min.js"></script>`
