### PR TITLE
New typings: imagemin-zopfli

### DIFF
--- a/types/imagemin-zopfli/imagemin-zopfli-tests.ts
+++ b/types/imagemin-zopfli/imagemin-zopfli-tests.ts
@@ -1,0 +1,17 @@
+import imagemin = require('imagemin');
+import imageminZopfli = require('./index');
+
+imagemin(['*.png'], {
+    plugins: [
+        imageminZopfli(),
+        imageminZopfli({}),
+        imageminZopfli({
+            '8bit': true,
+            transparent: true,
+            iterations: 256,
+            more: true,
+        }),
+    ],
+});
+
+imageminZopfli(); // $ExpectType Plugin

--- a/types/imagemin-zopfli/imagemin-zopfli-tests.ts
+++ b/types/imagemin-zopfli/imagemin-zopfli-tests.ts
@@ -1,5 +1,5 @@
-import imagemin = require('imagemin');
-import imageminZopfli = require('./index');
+import imagemin = require('imagemin')
+import imageminZopfli = require('imagemin-zopfli')
 
 imagemin(['*.png'], {
     plugins: [
@@ -12,6 +12,6 @@ imagemin(['*.png'], {
             more: true,
         }),
     ],
-});
+})
 
-imageminZopfli(); // $ExpectType Plugin
+imageminZopfli() // $ExpectType Plugin

--- a/types/imagemin-zopfli/imagemin-zopfli-tests.ts
+++ b/types/imagemin-zopfli/imagemin-zopfli-tests.ts
@@ -1,5 +1,5 @@
-import imagemin = require('imagemin')
-import imageminZopfli = require('imagemin-zopfli')
+import imagemin = require('imagemin');
+import imageminZopfli = require('imagemin-zopfli');
 
 imagemin(['*.png'], {
     plugins: [
@@ -12,6 +12,6 @@ imagemin(['*.png'], {
             more: true,
         }),
     ],
-})
+});
 
-imageminZopfli() // $ExpectType Plugin
+imageminZopfli(); // $ExpectType Plugin

--- a/types/imagemin-zopfli/index.d.ts
+++ b/types/imagemin-zopfli/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for imagemin-zopfli 7.0
+// Project: https://github.com/imagemin/imagemin-zopfli
+// Definitions by: Marius Metzger <https://github.com/crushedpixel>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'imagemin';
+
+declare function imageminZopfli(options?: imageminZopfli.Options): Plugin;
+
+declare namespace imageminZopfli {
+    interface Options {
+        /** Convert 16-bit per channel images to 8-bit per channel. */
+        '8bit'?: boolean;
+
+        /**
+         * Remove colors behind alpha channel 0.
+         * No visual difference, removes hidden information.
+         */
+        transparent?: boolean;
+
+        /**
+         * The number of iterations, more iterations makes it slower
+         * but provides slightly better compression.
+         * Default: 15 for small files, 5 for large files.
+         */
+        iterations?: number;
+
+        /**
+         * Compress more: use more iterations (depending on file size).
+         */
+        more?: boolean;
+    }
+}
+
+export = imageminZopfli;

--- a/types/imagemin-zopfli/tsconfig.json
+++ b/types/imagemin-zopfli/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "imagemin-zopfli-tests.ts"
+    ]
+}

--- a/types/imagemin-zopfli/tslint.json
+++ b/types/imagemin-zopfli/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.