### PR TITLE
[@types/tpdirect] Fix wrong typing in get prime result when using token pay

### DIFF
--- a/types/tpdirect/google-pay.d.ts
+++ b/types/tpdirect/google-pay.d.ts
@@ -37,7 +37,7 @@ interface GooglePay {
             },
             prime: Pick<BaseResult, "prime">,
             result: Pick<BaseResult, "client_ip"> & MerchantReferenceInfo & {
-                card_info: CardInfoV2;
+                card_info: CardInfoV1;
             }
         ) => void;
     }): void;
@@ -58,7 +58,7 @@ interface GooglePay {
             },
             prime: Pick<BaseResult, "prime">,
             result: Pick<BaseResult, "client_ip"> & {
-                card_info: CardInfoV2;
+                card_info: CardInfoV1;
                 merchant_reference_info: {
                     affiliate_codes: string[];
                 };

--- a/types/tpdirect/payment-request-api.d.ts
+++ b/types/tpdirect/payment-request-api.d.ts
@@ -67,7 +67,7 @@ interface PaymentRequestApi {
         shippingOption: string;
         methodName: string;
         requestId: string;
-        card_info: CardInfoV2;
+        card_info: CardInfoV1;
         /**
          * Real Card Info
          */

--- a/types/tpdirect/samsung-pay.d.ts
+++ b/types/tpdirect/samsung-pay.d.ts
@@ -21,7 +21,7 @@ interface SamsungPay {
 
     getPrime(callback: (
         result: BaseResult & MerchantReferenceInfo & {
-            card_info: CardInfoV2;
+            card_info: CardInfoV1;
             card: Card;
             total_amount: string;
         }

--- a/types/tpdirect/tpdirect-tests.ts
+++ b/types/tpdirect/tpdirect-tests.ts
@@ -110,8 +110,8 @@ TPDirect.paymentRequestApi.getPrime((result) => {
      * Only test different field with other payment response
      */
     result.client_ip; // $ExpectType string
-    result.card_info.country_code; // $ExpectType string
-    result.card_info.last_four; // $ExpectType string
+    result.card_info.countrycode; // $ExpectType string
+    result.card_info.lastfour; // $ExpectType string
     result.card.lastfour; // $ExpectType string
 });
 
@@ -128,8 +128,8 @@ TPDirect.googlePay.getPrime((error, prime, result) => {
      * Only test different field with other payment response
      */
     result.client_ip; // $ExpectType string
-    result.card_info.country_code; // $ExpectType string
-    result.card_info.last_four; // $ExpectType string
+    result.card_info.countrycode; // $ExpectType string
+    result.card_info.lastfour; // $ExpectType string
 });
 
 // $ExpectType void
@@ -160,8 +160,8 @@ TPDirect.googlePay.setupGooglePayButton({
          * Only test different field with other payment response
          */
         result.client_ip; // $ExpectType string
-        result.card_info.country_code; // $ExpectType string
-        result.card_info.last_four; // $ExpectType string
+        result.card_info.countrycode; // $ExpectType string
+        result.card_info.lastfour; // $ExpectType string
     }
 });
 
@@ -180,8 +180,8 @@ TPDirect.googlePay.getPrime((error, prime, result) => {
      * Only test different field with other payment response
      */
     result.client_ip; // $ExpectType string
-    result.card_info.country_code; // $ExpectType string
-    result.card_info.last_four; // $ExpectType string
+    result.card_info.countrycode; // $ExpectType string
+    result.card_info.lastfour; // $ExpectType string
 });
 
 /**
@@ -199,8 +199,8 @@ TPDirect.samsungPay.getPrime((result) => {
      * Only test different field with other payment response
      */
     result.client_ip; // $ExpectType string
-    result.card_info.country_code; // $ExpectType string
-    result.card_info.last_four; // $ExpectType string
+    result.card_info.countrycode; // $ExpectType string
+    result.card_info.lastfour; // $ExpectType string
 });
 
 // $ExpectType void


### PR DESCRIPTION
According to the [Apple Pay](https://docs.tappaysdk.com/apple-pay/zh/front.html#get-prime-result), [Google Pay](https://docs.tappaysdk.com/google-pay/zh/front.html#get-prime19), and [Samsung Pay](https://docs.tappaysdk.com/samsung-pay/zh/front.html#get-prime-result) in TapPay Docs, fix the wrong type in get prime result.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
