### PR TITLE
fix(passport): done callback arguments

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -83,8 +83,8 @@ declare namespace passport {
         authorize(strategy: string | string[], options: AuthorizeOptions, callback?: (...args: any[]) => any): AuthorizeRet;
         serializeUser<TID>(fn: (user: Express.User, done: (err: any, id?: TID) => void) => void): void;
         serializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, user: Express.User, done: (err: any, id?: TID) => void) => void): void;
-        deserializeUser<TID>(fn: (id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
-        deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
+        deserializeUser<TID>(fn: (id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
+        deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
         transformAuthInfo(fn: (info: any, done: (err: any, info: any) => void) => void): void;
     }
 

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -83,8 +83,8 @@ declare namespace passport {
         authorize(strategy: string | string[], options: AuthorizeOptions, callback?: (...args: any[]) => any): AuthorizeRet;
         serializeUser<TID>(fn: (user: Express.User, done: (err: any, id?: TID) => void) => void): void;
         serializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, user: Express.User, done: (err: any, id?: TID) => void) => void): void;
-        deserializeUser<TID>(fn: (id: TID, done: (err: any, user?: Express.User) => void) => void): void;
-        deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User) => void) => void): void;
+        deserializeUser<TID>(fn: (id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
+        deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
         transformAuthInfo(fn: (info: any, done: (err: any, info: any) => void) => void): void;
     }
 

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -58,8 +58,20 @@ passport.serializeUser<number>((user, done) => {
         done(new Error('user ID is invalid'));
     }
 });
+passport.serializeUser((user, done) => {
+    done(null, { id: user.id });
+});
 passport.deserializeUser((id, done) => {
     done(null, { username: `${id}` });
+});
+passport.deserializeUser((id, done) => {
+    done(null, false);
+});
+passport.deserializeUser((id, done) => {
+    done(null, null);
+});
+passport.deserializeUser((id, done) => {
+    done('Error', false);
 });
 passport.deserializeUser<number>((id, done) => {
     const fetchUser = (id: number): Promise<Express.User> => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Since this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49723
the type is more strict but it's also not entirely accurate.
For example: You can invalidate a session by passing done(null, false); 
 
https://github.com/jaredhanson/passport/blob/1fd591d5cdcf6516d9eb446216843223c0e020c4/lib/authenticator.js#L338-L340
```js
    // a valid user existed when establishing the session, but that user has
    // since been removed
    if (user === null || user === false) { return done(null, false); }
```
