### PR TITLE
add(gravatar-favicons): new definition

### DIFF
--- a/types/gravatar-favicons/gravatar-favicons-tests.ts
+++ b/types/gravatar-favicons/gravatar-favicons-tests.ts
@@ -1,0 +1,39 @@
+import gravatarFavicons = require('gravatar-favicons');
+import { Options } from 'gravatar-favicons';
+
+const logger = (message: string) => {
+    // no-op
+};
+
+const config: Options = {
+    email: 'joe@example.com',
+    dest: './out',
+    faviconConfig: {
+        path: '/',
+        appName: 'bret.io',
+        appDescription: "Bret Comnes's website",
+        developerName: 'Bret Comnes',
+        developerURL: 'https://bret.io',
+        dir: 'auto',
+        lang: 'en-US',
+        background: '#232830',
+        theme_color: '#232830',
+        display: 'standalone',
+        orientation: 'any',
+        start_url: '/?homescreen=1',
+        version: '1.0',
+        logging: true,
+        icons: {
+            android: false,
+            appleIcon: true,
+            appleStartup: false,
+            coast: false,
+            favicons: true,
+            firefox: false,
+            windows: true,
+            yandex: false,
+        },
+    },
+};
+
+gravatarFavicons(config, logger, (err, results) => {});

--- a/types/gravatar-favicons/index.d.ts
+++ b/types/gravatar-favicons/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for gravatar-favicons 2.0
+// Project: https://github.com/bcomnes/gravatar-favicons#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { FaviconOptions } from 'favicons';
+
+/**
+ * Generate favicons from a gravatar email.
+ */
+declare function gravatarFavicons(
+    config?: gravatarFavicons.Options,
+    logger?: gravatarFavicons.Logger,
+    cb?: gravatarFavicons.Callback,
+): void;
+
+declare namespace gravatarFavicons {
+    // console.log compatible contract
+    type Logger = (message?: any, ...optionalParams: any[]) => void;
+
+    type Callback = (err: Error | null, files: string[]) => void;
+
+    interface Options {
+        email: string;
+        dest: string;
+        /**
+         * The `faviconConfig` field is the same options that can be passed to `favicons`.
+         */
+        faviconConfig: Partial<FaviconOptions>;
+    }
+}
+
+export = gravatarFavicons;

--- a/types/gravatar-favicons/tsconfig.json
+++ b/types/gravatar-favicons/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gravatar-favicons-tests.ts"
+    ]
+}

--- a/types/gravatar-favicons/tslint.json
+++ b/types/gravatar-favicons/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition module
- tests

https://github.com/bcomnes/gravatar-favicons

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.