### PR TITLE
Catch up assert typesVersions <= 3.6

### DIFF
--- a/types/assert/ts3.6/index.d.ts
+++ b/types/assert/ts3.6/index.d.ts
@@ -1,9 +1,7 @@
 /** An alias of `assert.ok()`. */
 declare function assert(value: any, message?: string | Error): void;
 declare namespace assert {
-    class AssertionError implements Error {
-        name: string;
-        message: string;
+    class AssertionError extends Error {
         actual: any;
         expected: any;
         operator: string;

--- a/types/node/ts3.4/assert.d.ts
+++ b/types/node/ts3.4/assert.d.ts
@@ -2,9 +2,7 @@ declare module 'assert' {
     /** An alias of `assert.ok()`. */
     function assert(value: any, message?: string | Error): void;
     namespace assert {
-        class AssertionError implements Error {
-            name: string;
-            message: string;
+        class AssertionError extends Error {
             actual: any;
             expected: any;
             operator: string;


### PR DESCRIPTION
#49363 and #49462 for #50311. Incorporate #50311 into typesVersions <= 3.6 and into `types/assert`.