### PR TITLE
Update @types/webxr to correctly extend interfaces

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -140,7 +140,7 @@ export interface XRReferenceSpace extends XRSpace {
     onreset: XREventHandler;
 }
 
-export interface XRBoundedReferenceSpace extends XRSpace {
+export interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: DOMPointReadOnly[];
 }
 

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -81,7 +81,7 @@ export interface XRSessionEvent extends Event {
     readonly session: XRSession;
 }
 
-export interface XRSystem {
+export interface XRSystem extends EventTarget {
     isSessionSupported: (sessionMode: XRSessionMode) => Promise<boolean>;
     requestSession: (sessionMode: XRSessionMode, sessionInit?: any) => Promise<XRSession>;
 }

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package webxr 0.1
+// Type definitions for non-npm package webxr 0.2
 // Project: https://www.w3.org/TR/webxr/
 // Definitions by: Rob Rohan <https://github.com/robrohan>
 //                 Raanan Weber <https://github.com/RaananW>

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -37,7 +37,7 @@ xr.requestSession('immersive-vr').then((session: XRSession) => {
         session
             .requestReferenceSpace('local')
             .then(rs => {
-                space = rs as XRReferenceSpace;
+                space = rs;
             })
             .catch(e => {
                 throw Error("Can't get reference space" + e);

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -59,3 +59,8 @@ const renderFrame = (frame: XRFrame) => {
         }
     }
 };
+
+xr.addEventListener('devicechange', (e: Event) => {
+    // Event is a simple event; there is no additional data
+    // XR device availability changed
+});


### PR DESCRIPTION
NOTE: I bumped the version even though this won't break any existing code, since this isn't an NPM package

Made XRSystem extend EventTarget and XRBoundedReferenceSpace extend XRReferenceSpace. Only those interfaces are affected, I haven't checked for any mistakes in other interfaces so there may still be more issues like these.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [XRSystem](https://immersive-web.github.io/webxr/#xrsystem-interface), [XRBoundedReferenceSpace](https://immersive-web.github.io/webxr/#xrboundedreferencespace-interface)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
