### PR TITLE
[@types/formidable] Adding Constructor options

### DIFF
--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -12,9 +12,8 @@ import events = require("events");
 import crypto = require("crypto");
 
 export declare class IncomingForm extends events.EventEmitter {
-    
     constructor({ ...options }?: IncomingFormOptions);
-    
+
     encoding: string;
     uploadDir: string;
     keepExtensions: boolean;

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -13,7 +13,7 @@ import crypto = require("crypto");
 
 export declare class IncomingForm extends events.EventEmitter {
     
-    constructor({ ...options }?: FormidableOptions);
+    constructor({ ...options }?: IncomingFormOptions);
     
     encoding: string;
     uploadDir: string;

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -9,8 +9,12 @@
 import http = require("http");
 import stream = require("stream");
 import events = require("events");
+import crypto = require("crypto");
 
 export declare class IncomingForm extends events.EventEmitter {
+    
+    constructor({ ...options }?: FormidableOptions);
+    
     encoding: string;
     uploadDir: string;
     keepExtensions: boolean;
@@ -27,6 +31,20 @@ export declare class IncomingForm extends events.EventEmitter {
 
     handlePart(part: Part): void;
     parse(req: http.IncomingMessage, callback?: (err: any, fields: Fields, files: Files) => any): void;
+}
+
+export declare interface IncomingFormOptions {
+    encoding?: string;
+    uploadDir?: string;
+    keepExtensions?: boolean;
+    allowEmptyFiles?: boolean;
+    minFileSize?: number;
+    maxFileSize?: number;
+    maxFields?: number;
+    maxFieldsSize?: number;
+    hash?: crypto.Encoding | boolean;
+    fileWriteStreamHandler?: () => stream.Writable;
+    multiples?: boolean;
 }
 
 export interface Fields {

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -12,7 +12,7 @@ import events = require("events");
 import crypto = require("crypto");
 
 export declare class IncomingForm extends events.EventEmitter {
-    constructor({ ...options }?: IncomingFormOptions);
+    constructor(options?: IncomingFormOptions);
 
     encoding: string;
     uploadDir: string;


### PR DESCRIPTION
According to https://github.com/node-formidable/formidable#options constructor had some options, but typing is given wrong options from events.EventEmitter.
Fixed with adding Interface to constructor options.
- Tested in VSCode@latest

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).