### PR TITLE
ioredis zadd transaction/pipeline signature

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -444,6 +444,10 @@ declare namespace IORedis {
         zrange(key: KeyType, start: number, stop: number, withScores: 'WITHSCORES', callback: Callback<string[]>): void;
         zrange(key: KeyType, start: number, stop: number, withScores?: 'WITHSCORES'): Promise<string[]>;
 
+        zrangeBuffer(key: KeyType, start: number, stop: number, callback: Callback<Buffer[]>): void;
+        zrangeBuffer(key: KeyType, start: number, stop: number, withScores: 'WITHSCORES', callback: Callback<Buffer[]>): void;
+        zrangeBuffer(key: KeyType, start: number, stop: number, withScores?: 'WITHSCORES'): Promise<Buffer[]>;
+
         zrevrange(key: KeyType, start: number, stop: number, callback: Callback<string[]>): void;
         zrevrange(
             key: KeyType,
@@ -453,6 +457,16 @@ declare namespace IORedis {
             callback: Callback<string[]>,
         ): void;
         zrevrange(key: KeyType, start: number, stop: number, withScores?: 'WITHSCORES'): Promise<string[]>;
+
+        zrevrangeBuffer(key: KeyType, start: number, stop: number, callback: Callback<Buffer[]>): void;
+        zrevrangeBuffer(
+            key: KeyType,
+            start: number,
+            stop: number,
+            withScores: 'WITHSCORES',
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrevrangeBuffer(key: KeyType, start: number, stop: number, withScores?: 'WITHSCORES'): Promise<Buffer[]>;
 
         zrangebyscore(
             key: KeyType,
@@ -503,6 +517,57 @@ declare namespace IORedis {
             offset: number,
             count: number,
             callback: Callback<string[]>,
+        ): void;
+
+        zrangebyscoreBuffer(
+            key: KeyType,
+            min: number | string,
+            max: number | string,
+            withScores?: 'WITHSCORES',
+        ): Promise<Buffer[]>;
+        zrangebyscoreBuffer(
+            key: KeyType,
+            min: number | string,
+            max: number | string,
+            withScores: 'WITHSCORES',
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+        ): Promise<Buffer[]>;
+        zrangebyscoreBuffer(
+            key: KeyType,
+            min: number | string,
+            max: number | string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+        ): Promise<Buffer[]>;
+        zrangebyscoreBuffer(key: KeyType, min: number | string, max: number | string, callback: Callback<Buffer[]>): void;
+        zrangebyscoreBuffer(
+            key: KeyType,
+            min: number | string,
+            max: number | string,
+            withScores: 'WITHSCORES',
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrangebyscoreBuffer(
+            key: KeyType,
+            min: number | string,
+            max: number | string,
+            withScores: 'WITHSCORES',
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrangebyscoreBuffer(
+            key: KeyType,
+            min: number | string,
+            max: number | string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+            callback: Callback<Buffer[]>,
         ): void;
 
         zrevrangebyscore(
@@ -556,6 +621,57 @@ declare namespace IORedis {
             callback: Callback<string[]>,
         ): void;
 
+        zrevrangebyscoreBuffer(
+            key: KeyType,
+            max: number | string,
+            min: number | string,
+            withScores?: 'WITHSCORES',
+        ): Promise<Buffer[]>;
+        zrevrangebyscoreBuffer(
+            key: KeyType,
+            max: number | string,
+            min: number | string,
+            withScores: 'WITHSCORES',
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+        ): Promise<Buffer[]>;
+        zrevrangebyscoreBuffer(
+            key: KeyType,
+            max: number | string,
+            min: number | string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+        ): Promise<Buffer[]>;
+        zrevrangebyscoreBuffer(key: KeyType, max: number | string, min: number | string, callback: Callback<Buffer[]>): void;
+        zrevrangebyscoreBuffer(
+            key: KeyType,
+            max: number | string,
+            min: number | string,
+            withScores: 'WITHSCORES',
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrevrangebyscoreBuffer(
+            key: KeyType,
+            max: number | string,
+            min: number | string,
+            withScores: 'WITHSCORES',
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrevrangebyscoreBuffer(
+            key: KeyType,
+            max: number | string,
+            min: number | string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+            callback: Callback<Buffer[]>,
+        ): void;
+
         zrangebylex(
             key: KeyType,
             min: string,
@@ -585,6 +701,35 @@ declare namespace IORedis {
             callback: Callback<string[]>,
         ): void;
 
+        zrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+        ): Promise<Buffer[]>;
+        zrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+        ): Promise<Buffer[]>;
+        zrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+            callback: Callback<Buffer[]>,
+        ): void;
+
         zrevrangebylex(
             key: KeyType,
             min: string,
@@ -612,6 +757,35 @@ declare namespace IORedis {
             offset: number,
             count: number,
             callback: Callback<string[]>,
+        ): void;
+
+        zrevrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+        ): Promise<Buffer[]>;
+        zrevrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+        ): Promise<Buffer[]>;
+        zrevrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+            callback: Callback<Buffer[]>,
+        ): void;
+        zrevrangebylexBuffer(
+            key: KeyType,
+            min: string,
+            max: string,
+            limit: 'LIMIT',
+            offset: number,
+            count: number,
+            callback: Callback<Buffer[]>,
         ): void;
 
         zcount(key: KeyType, min: number | string, max: number | string, callback: Callback<number>): void;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1316,7 +1316,12 @@ declare namespace IORedis {
 
         smembers(key: KeyType, callback?: Callback<string[]>): Pipeline;
 
-        zadd(key: KeyType, ...args: string[]): Pipeline;
+        zadd(key: KeyType, score: number, member: string): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string,): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string, score5: number, member5: string): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string, score5: number, member5: string, score6: number, member6: string): Pipeline;
 
         zincrby(key: KeyType, increment: number, member: string, callback?: Callback<string>): Pipeline;
 

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1317,11 +1317,12 @@ declare namespace IORedis {
         smembers(key: KeyType, callback?: Callback<string[]>): Pipeline;
 
         zadd(key: KeyType, score: number, member: string): Pipeline;
-        zadd(key: KeyType, score: number, member: string, score2: number, member2: string,): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string): Pipeline;
         zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string): Pipeline;
         zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string): Pipeline;
         zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string, score5: number, member5: string): Pipeline;
-        zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string, score5: number, member5: string, score6: number, member6: string): Pipeline;
+        zadd(key: KeyType, score: number, member: string, score2: number, member2: string, score3: number, member3: string, score4: number, member4: string, score5: number, member5: string,
+            score6: number, member6: string): Pipeline;
 
         zincrby(key: KeyType, increment: number, member: string, callback?: Callback<string>): Pipeline;
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -517,6 +517,14 @@ redis.zrangebyscore('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10).then(console.lo
 redis.zrangebyscore('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10, cb);
 redis.zrangebyscore('set', 0, 100, 'LIMIT', 0, 10).then(console.log);
 redis.zrangebyscore('set', 0, 100, 'LIMIT', 0, 10, cb);
+redis.zrangebyscoreBuffer('set', 0, 100).then(console.log);
+redis.zrangebyscoreBuffer('set', 0, 100);
+redis.zrangebyscoreBuffer('set', 0, 100, 'WITHSCORES').then(console.log);
+redis.zrangebyscoreBuffer('set', 0, 100, 'WITHSCORES', cb);
+redis.zrangebyscoreBuffer('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10).then(console.log);
+redis.zrangebyscoreBuffer('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10, cb);
+redis.zrangebyscoreBuffer('set', 0, 100, 'LIMIT', 0, 10).then(console.log);
+redis.zrangebyscoreBuffer('set', 0, 100, 'LIMIT', 0, 10, cb);
 redis.zrevrangebyscore('set', 0, 100).then(console.log);
 redis.zrevrangebyscore('set', 0, 100);
 redis.zrevrangebyscore('set', 0, 100, 'WITHSCORES').then(console.log);
@@ -525,15 +533,31 @@ redis.zrevrangebyscore('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10).then(console
 redis.zrevrangebyscore('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10, cb);
 redis.zrevrangebyscore('set', 0, 100, 'LIMIT', 0, 10).then(console.log);
 redis.zrevrangebyscore('set', 0, 100, 'LIMIT', 0, 10, cb);
+redis.zrevrangebyscoreBuffer('set', 0, 100).then(console.log);
+redis.zrevrangebyscoreBuffer('set', 0, 100);
+redis.zrevrangebyscoreBuffer('set', 0, 100, 'WITHSCORES').then(console.log);
+redis.zrevrangebyscoreBuffer('set', 0, 100, 'WITHSCORES', cb);
+redis.zrevrangebyscoreBuffer('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10).then(console.log);
+redis.zrevrangebyscoreBuffer('set', 0, 100, 'WITHSCORES', 'LIMIT', 0, 10, cb);
+redis.zrevrangebyscoreBuffer('set', 0, 100, 'LIMIT', 0, 10).then(console.log);
+redis.zrevrangebyscoreBuffer('set', 0, 100, 'LIMIT', 0, 10, cb);
 
 redis.zrangebylex('set', '-', '[c').then(console.log);
 redis.zrangebylex('set', '-', '[c');
 redis.zrangebylex('set', '-', '[c', 'LIMIT', 0, 10).then(console.log);
 redis.zrangebylex('set', '-', '[c', 'LIMIT', 0, 10, cb);
+redis.zrangebylexBuffer('set', '-', '[c').then(console.log);
+redis.zrangebylexBuffer('set', '-', '[c');
+redis.zrangebylexBuffer('set', '-', '[c', 'LIMIT', 0, 10).then(console.log);
+redis.zrangebylexBuffer('set', '-', '[c', 'LIMIT', 0, 10, cb);
 redis.zrevrangebylex('set', '-', '[c').then(console.log);
 redis.zrevrangebylex('set', '-', '[c');
 redis.zrevrangebylex('set', '-', '[c', 'LIMIT', 0, 10).then(console.log);
 redis.zrevrangebylex('set', '-', '[c', 'LIMIT', 0, 10, cb);
+redis.zrevrangebylexBuffer('set', '-', '[c').then(console.log);
+redis.zrevrangebylexBuffer('set', '-', '[c');
+redis.zrevrangebylexBuffer('set', '-', '[c', 'LIMIT', 0, 10).then(console.log);
+redis.zrevrangebylexBuffer('set', '-', '[c', 'LIMIT', 0, 10, cb);
 
 // ClusterRetryStrategy can return non-numbers to stop retrying
 new Redis.Cluster([], {

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -431,6 +431,12 @@ redis
     .hscan('hash', '0')
     .zscan('zset', 0)
     .zscan('zset', '0')
+    .zadd('key', 1, 'a')
+    .zadd('key', 1, 'a', 2, 'b')
+    .zadd('key', 1, 'a', 2, 'b', 3, 'c')
+    .zadd('key', 1, 'a', 2, 'b', 3, 'c', 4, 'd')
+    .zadd('key', 1, 'a', 2, 'b', 3, 'c', 4, 'd', 5, 'e')
+    .zadd('key', 1, 'a', 2, 'b', 3, 'c', 4, 'd', 5, 'e', 6, 'f')
     .exec((err, results) => {
         // results = [[null, 'OK'], [null, 'OK'], [null, 'baz']]
     });


### PR DESCRIPTION
The existing pipeline/transaction `zadd` signature forces `score` (2nd argument) to be a string. It is actually a `number`.

The zadd pipeline definition extends up to 6 pairs of {score, member} elements which was also the number used in the OverloadedKeyCommand interface which is used for the normal zadd command.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://npmdoc.github.io/node-npmdoc-ioredis/build/apidoc.html#apidoc.element.ioredis.pipeline.prototype.zadd

