### PR TITLE
Update simpl-schema SimpleSchema objectKeys definition to specify parameter `keyPrefix` as optional

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -172,7 +172,7 @@ export class SimpleSchema {
   messageForError(type: any, key: any, def: any, value: any): string;
   allowsKey(key: any): string;
   newContext(): ValidationContext;
-  objectKeys(keyPrefix: any): any[];
+  objectKeys(keyPrefix?: any): any[];
   validate(obj: any, options?: ValidationOption): void;
   validator(options?: ValidationOption): (obj: any) => boolean;
   extend(otherSchema: SimpleSchema | SimpleSchemaDefinition): SimpleSchema;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -129,3 +129,13 @@ StringSchema.extend({
 });
 
 SimpleSchema.extendOptions(['autoform']);
+
+const objectKeysTestSchema = new SimpleSchema({});
+
+// No prefix passed
+// $ExpectType any[]
+objectKeysTestSchema.objectKeys();
+
+// Prefix passed
+// $ExpectType any[]
+objectKeysTestSchema.objectKeys("_prefix");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/aldeed/simpl-schema/blob/43dd168a71591a1b26e412bbd3577a0c00db9780/lib/SimpleSchema.js#L316>>

The linked file is the earliest published version of `simpl-schema@0.0.4` which has the `SimpleSchema.objectKeys` defined with the optional parameter