### PR TITLE
plotly.js: Add separate plot data definition for pie trace

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -27,9 +27,10 @@ import { BoxPlotData, BoxPlotMarker } from './lib/traces/box';
 import { ViolinData } from './lib/traces/violin';
 import { OhclData } from './lib/traces/ohcl';
 import { CandlestickData } from './lib/traces/candlestick';
+import { PieData } from './lib/traces/pie';
 
 export as namespace Plotly;
-export { BoxPlotData, ViolinData, OhclData, CandlestickData };
+export { BoxPlotData, ViolinData, OhclData, CandlestickData, PieData };
 
 export interface StaticPlots {
     resize(root: Root): void;
@@ -1082,7 +1083,8 @@ export type Data =
     | Partial<BoxPlotData>
     | Partial<ViolinData>
     | Partial<OhclData>
-    | Partial<CandlestickData>;
+    | Partial<CandlestickData>
+    | Partial<PieData>;
 
 export type Color =
     | string

--- a/types/plotly.js/lib/traces/pie.d.ts
+++ b/types/plotly.js/lib/traces/pie.d.ts
@@ -1,0 +1,118 @@
+import { PlotData, DataTitle, Datum, HoverLabel } from '../../index';
+
+export type PieColor = string | number;
+export type PieColors = Array<PieColor | null | undefined>;
+
+export interface PieFont {
+    family: string | string[];
+    size: number | number[];
+    color: PieColor | PieColors;
+}
+
+export interface PieDataTitle extends Pick<DataTitle, 'text' | 'position'> {
+    font: Partial<PieFont>;
+}
+
+export type PieTextPosition = 'inside' | 'outside' | 'auto' | 'none';
+
+export type PieHoverInfo =
+    | 'all'
+    | 'none'
+    | 'skip'
+    | 'label'
+    | 'text'
+    | 'value'
+    | 'percent'
+    | 'name'
+    | 'label+text'
+    | 'label+value'
+    | 'label+percent'
+    | 'label+name'
+    | 'text+value'
+    | 'text+percent'
+    | 'text+name'
+    | 'value+percent'
+    | 'value+name'
+    | 'percent+name'
+    | 'label+text+value'
+    | 'label+text+percent'
+    | 'label+text+name'
+    | 'label+value+percent'
+    | 'label+value+name'
+    | 'label+percent+name'
+    | 'text+value+percent'
+    | 'text+value+name'
+    | 'text+percent+name'
+    | 'value+percent+name'
+    | 'label+text+value+percent'
+    | 'label+text+value+name'
+    | 'label+text+percent+name'
+    | 'label+value+percent+name'
+    | 'text+value+percent+name';
+
+export interface PieDomain {
+    x: number[];
+    y: number[];
+    row: number;
+    column: number;
+}
+
+export interface PieLine {
+    color: PieColor | PieColors;
+    width: number | number[];
+}
+
+export interface PieMarker {
+    colors: PieColors;
+    line: Partial<PieLine>;
+}
+
+export interface PieHoverLabel {
+    bgcolor: PieColor | PieColors;
+    bordercolor: PieColor | PieColors;
+    font: PieFont;
+    align: HoverLabel['align'] | Array<HoverLabel['align']>;
+    namelength: number | number[];
+}
+
+export type PieInsideTextOrientation = 'horizontal' | 'radial' | 'tangential' | 'auto';
+
+export interface PieData extends Pick<PlotData,
+    | 'name'
+    | 'visible'
+    | 'showlegend'
+    | 'legendgroup'
+    | 'opacity'
+    | 'ids'
+    | 'labels'
+    | 'hovertext'
+    | 'automargin'
+    | 'textinfo'
+    | 'direction'
+    | 'hole'
+    | 'rotation'
+> {
+    type: 'pie';
+    title: Partial<PieDataTitle>;
+    values: Array<number | string>;
+    dlabel: number;
+    label0: number;
+    pull: number | number[];
+    text: Datum | Datum[];
+    textposition: PieTextPosition | PieTextPosition[];
+    texttemplate: string | string[];
+    hoverinfo: PieHoverInfo;
+    hovertemplate: string | string[];
+    meta: number | string;
+    customdata: Datum[];
+    domain: Partial<PieDomain>;
+    marker: Partial<PieMarker>;
+    textfont: PieFont;
+    hoverlabel: Partial<PieHoverLabel>;
+    insidetextfont: PieFont;
+    insidetextorientation: PieInsideTextOrientation;
+    outsidetextfont: PieFont;
+    scalegroup: string;
+    sort: boolean;
+    uirevision: number | string;
+}

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -1,5 +1,5 @@
 import * as Plotly from 'plotly.js/lib/core';
-import { Datum, ScatterData, Layout, newPlot, PlotData, ViolinData, CandlestickData } from 'plotly.js/lib/core';
+import { Datum, ScatterData, Layout, newPlot, PlotData, ViolinData, CandlestickData, PieData } from 'plotly.js/lib/core';
 
 const graphDiv = '#test';
 
@@ -244,9 +244,9 @@ const graphDiv = '#test';
     Plotly.newPlot(graphDiv, data2, layout2);
 })();
 
-// Plotly.newPlot (bar)
+// Plotly.newPlot (pie)
 (() => {
-    const data: Array<Partial<PlotData>> = [
+    const data: Array<Partial<PieData>> = [
         {
             values: [19, 26, 55],
             labels: ['Residential', 'Non-Residential', 'Utility'],
@@ -258,9 +258,189 @@ const graphDiv = '#test';
         height: 400,
         width: 500,
     };
+    Plotly.newPlot(graphDiv, data, layout);
+})();
+
+(() => {
+    const allLabels = ['1st', '2nd', '3rd', '4th', '5th'];
+
+    const allValues = [
+        [38, 27, 18, 10, 7],
+        [28, 26, 21, 15, 10],
+        [38, 19, 16, 14, 13],
+        [31, 24, 19, 18, 8],
+    ];
+
+    const ultimateColors = [
+        ['rgb(56, 75, 126)', 'rgb(18, 36, 37)', 'rgb(34, 53, 101)', 'rgb(36, 55, 57)', 'rgb(6, 4, 4)'],
+        ['rgb(177, 127, 38)', 'rgb(205, 152, 36)', 'rgb(99, 79, 37)', 'rgb(129, 180, 179)', 'rgb(124, 103, 37)'],
+        ['rgb(33, 75, 99)', 'rgb(79, 129, 102)', 'rgb(151, 179, 100)', 'rgb(175, 49, 35)', 'rgb(36, 73, 147)'],
+        ['rgb(146, 123, 21)', 'rgb(177, 180, 34)', 'rgb(206, 206, 40)', 'rgb(175, 51, 21)', 'rgb(35, 36, 21)'],
+    ];
+
+    const data: Array<Partial<PieData>> = [
+        {
+            values: allValues[0],
+            labels: allLabels,
+            type: 'pie',
+            name: 'Starry Night',
+            marker: {
+                colors: ultimateColors[0],
+            },
+            domain: {
+                row: 0,
+                column: 0,
+            },
+            hoverinfo: 'label+percent+name',
+            textinfo: 'none',
+        },
+        {
+            values: allValues[1],
+            labels: allLabels,
+            type: 'pie',
+            name: 'Sunflowers',
+            marker: {
+                colors: ultimateColors[1],
+            },
+            domain: {
+                row: 1,
+                column: 0,
+            },
+            hoverinfo: 'label+percent+name',
+            textinfo: 'none',
+        },
+        {
+            values: allValues[2],
+            labels: allLabels,
+            type: 'pie',
+            name: 'Irises',
+            marker: {
+                colors: ultimateColors[2],
+            },
+            domain: {
+                row: 0,
+                column: 1,
+            },
+            hoverinfo: 'label+percent+name',
+            textinfo: 'none',
+        },
+        {
+            values: allValues[3],
+            labels: allLabels,
+            type: 'pie',
+            name: 'The Night Cafe',
+            marker: {
+                colors: ultimateColors[3],
+            },
+            domain: {
+                x: [0.52, 1],
+                y: [0, 0.48],
+            },
+            hoverinfo: 'label+percent+name',
+            textinfo: 'none',
+        }
+    ];
+
+    const layout = {
+        height: 400,
+        width: 500,
+        grid: {rows: 2, columns: 2},
+    };
+
+    Plotly.newPlot(graphDiv, data, layout);
+})();
+
+(() => {
+    const data: Array<Partial<PieData>> = [
+        {
+            values: [16, 15, 12, 6, 5, 4, 42],
+            labels: ['US', 'China', 'European Union', 'Russian Federation', 'Brazil', 'India', 'Rest of World'],
+            domain: {column: 0},
+            name: 'GHG Emissions',
+            hoverinfo: 'label+percent+name',
+            hole: .4,
+            type: 'pie',
+        },
+        {
+            values: [27, 11, 25, 8, 1, 3, 25],
+            labels: ['US', 'China', 'European Union', 'Russian Federation', 'Brazil', 'India', 'Rest of World'],
+            text: 'CO2',
+            textposition: 'inside',
+            domain: {column: 1},
+            name: 'CO2 Emissions',
+            hoverinfo: 'label+percent+name',
+            hole: .4,
+            type: 'pie',
+        }
+    ];
+
+    const layout = {
+        title: 'Global Emissions 1990-2011',
+        annotations: [
+            {
+                font: {
+                    size: 20,
+                },
+                showarrow: false,
+                text: 'GHG',
+                x: 0.17,
+                y: 0.5,
+            },
+            {
+                font: {
+                    size: 20,
+                },
+                showarrow: false,
+                text: 'CO2',
+                x: 0.82,
+                y: 0.5,
+            },
+        ],
+        height: 400,
+        width: 600,
+        showlegend: false,
+        grid: {rows: 1, columns: 2},
+    };
+
     Plotly.newPlot('myDiv', data, layout);
 })();
 
+(() => {
+    const data: Array<Partial<PieData>> = [{
+        type: "pie",
+        values: [2, 3, 4, 4],
+        labels: ["Wages", "Operating expenses", "Cost of sales", "Insurance"],
+        textinfo: "label+percent",
+        textposition: "outside",
+        automargin: true,
+    }];
+
+    const layout = {
+        height: 400,
+        width: 400,
+        margin: {t: 0, b: 0, l: 0, r: 0},
+        showlegend: false,
+    };
+
+    Plotly.newPlot('myDiv', data, layout);
+})();
+
+(() => {
+    const data: Array<Partial<PieData>> = [{
+        type: "pie",
+        values: [2, 3, 4, 4],
+        labels: ["Wages", "Operating expenses", "Cost of sales", "Insurance"],
+        textinfo: "label+percent",
+        insidetextorientation: "radial",
+    }];
+
+    const layout = {
+        height: 700,
+        width: 700,
+    };
+
+    Plotly.newPlot('myDiv', data, layout);
+})();
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds a separate plot data interface for the pie trace, which better supports the trace than the generic `PlotData`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://plotly.com/javascript/reference/pie/>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.