### PR TITLE
@types/jest Use Mock in MockedFunction

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1107,7 +1107,7 @@ declare namespace jest {
      *  const mockMyFunction = myFunction as jest.MockedFunction<typeof myFunction>;
      *  expect(mockMyFunction.mock.calls[0][0]).toBe(42);
      */
-    type MockedFunction<T extends (...args: any[]) => any> = MockInstance<ReturnType<T>, ArgsType<T>> & T;
+    type MockedFunction<T extends (...args: any[]) => any> = Mock<ReturnType<T>, ArgsType<T>> & T;
 
     /**
      * Wrap a class with mock definitions

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -617,6 +617,11 @@ if (mockedTestLambdaFunction_0_ret.type === 'return') {
     mockedTestLambdaFunction_0_ret.value; // $ExpectType boolean
 }
 
+// A function that has jest.Mock as a parameter should also take jest.MockedFunction
+const mockedFunctionCompatTest = (mockFn: jest.Mock) => true;
+mockedFunctionCompatTest(mockedTestFunction);
+mockedFunctionCompatTest(mockedTestLambdaFunction);
+
 const MockedTestClass = module.TestClass as jest.MockedClass<typeof module.TestClass>;
 MockedTestClass.prototype.testClassMethod.mock.calls[0][0]; // $ExpectType string
 MockedTestClass.prototype.testClassMethod.mock.calls[0][1]; // $ExpectType number


### PR DESCRIPTION
This change allows `MockedFunction` to be used where `Mock` can be used. I don't think this fundamentally changes `MockedFunction`, just makes it more robust. This would resolve issues where an extended expect method takes a `Mock` type, but the mocking library uses `MockedFunction`.

Related issues:
https://github.com/extend-chrome/jest-chrome/issues/9
https://github.com/jest-community/jest-extended/pull/292

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jest-community/jest-extended/pull/292>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
