### PR TITLE
[node] mkdir with recursive: true can have undefined result

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -973,7 +973,7 @@ declare module "fs" {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true }, callback: (err: NodeJS.ErrnoException | null, path: string) => void): void;
+    export function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true }, callback: (err: NodeJS.ErrnoException | null, path?: string) => void): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -989,7 +989,7 @@ declare module "fs" {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdir(path: PathLike, options: Mode | MakeDirectoryOptions | null | undefined, callback: (err: NodeJS.ErrnoException | null, path: string | undefined) => void): void;
+    export function mkdir(path: PathLike, options: Mode | MakeDirectoryOptions | null | undefined, callback: (err: NodeJS.ErrnoException | null, path?: string) => void): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory with a mode of `0o777`.
@@ -1005,7 +1005,7 @@ declare module "fs" {
          * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
          * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
          */
-        function __promisify__(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string>;
+        function __promisify__(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string | undefined>;
 
         /**
          * Asynchronous mkdir(2) - create a directory.
@@ -1030,7 +1030,7 @@ declare module "fs" {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdirSync(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): string;
+    export function mkdirSync(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): string | undefined;
 
     /**
      * Synchronous mkdir(2) - create a directory.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -281,7 +281,7 @@ declare module 'fs/promises' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string>;
+    function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string | undefined>;
 
     /**
      * Asynchronous mkdir(2) - create a directory.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -273,22 +273,22 @@ async function testPromisify() {
         mode: 0o777,
     }, (err, path) => {
         err; // $ExpectType ErrnoException | null
-        path; // $ExpectType string
+        path; // $ExpectType string | undefined
     });
 
-    // $ExpectType string
+    // $ExpectType string | undefined
     fs.mkdirSync('some/test/path', {
         recursive: true,
         mode: 0o777,
     });
 
-    // $ExpectType Promise<string>
+    // $ExpectType Promise<string | undefined>
     util.promisify(fs.mkdir)('some/test/path', {
         recursive: true,
         mode: 0o777,
     });
 
-    // $ExpectType Promise<string>
+    // $ExpectType Promise<string | undefined>
     fs.promises.mkdir('some/test/path', {
         recursive: true,
         mode: 0o777,

--- a/types/node/v13/fs.d.ts
+++ b/types/node/v13/fs.d.ts
@@ -875,7 +875,7 @@ declare module "fs" {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true }, callback: (err: NodeJS.ErrnoException | null, path: string) => void): void;
+    function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true }, callback: (err: NodeJS.ErrnoException | null, path?: string) => void): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -891,7 +891,7 @@ declare module "fs" {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    function mkdir(path: PathLike, options: number | string | MakeDirectoryOptions | null | undefined, callback: (err: NodeJS.ErrnoException | null, path: string | undefined) => void): void;
+    function mkdir(path: PathLike, options: number | string | MakeDirectoryOptions | null | undefined, callback: (err: NodeJS.ErrnoException | null, path?: string) => void): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory with a mode of `0o777`.
@@ -907,7 +907,7 @@ declare module "fs" {
          * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
          * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
          */
-        function __promisify__(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string>;
+        function __promisify__(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string | undefined>;
 
         /**
          * Asynchronous mkdir(2) - create a directory.
@@ -932,7 +932,7 @@ declare module "fs" {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    function mkdirSync(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): string;
+    function mkdirSync(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): string | undefined;
 
     /**
      * Synchronous mkdir(2) - create a directory.
@@ -2382,7 +2382,7 @@ declare module "fs" {
          * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
          * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
          */
-        function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string>;
+        function mkdir(path: PathLike, options: MakeDirectoryOptions & { recursive: true; }): Promise<string | undefined>;
 
         /**
          * Asynchronous mkdir(2) - create a directory.

--- a/types/node/v13/test/fs.ts
+++ b/types/node/v13/test/fs.ts
@@ -282,22 +282,22 @@ async function testPromisify() {
         mode: 0o777,
     }, (err, path) => {
         err; // $ExpectType ErrnoException | null
-        path; // $ExpectType string
+        path; // $ExpectType string | undefined
     });
 
-    // $ExpectType string
+    // $ExpectType string | undefined
     fs.mkdirSync('some/test/path', {
         recursive: true,
         mode: 0o777,
     });
 
-    // $ExpectType Promise<string>
+    // $ExpectType Promise<string | undefined>
     util.promisify(fs.mkdir)('some/test/path', {
         recursive: true,
         mode: 0o777,
     });
 
-    // $ExpectType Promise<string>
+    // $ExpectType Promise<string | undefined>
     fs.promises.mkdir('some/test/path', {
         recursive: true,
         mode: 0o777,


### PR DESCRIPTION
The CI is blocked by https://github.com/microsoft/TypeScript/issues/42337

If all subpaths of the given path already exist, the result is not EEXIST like the non-recursive case, but undefined. The callback is called like `cb(null)`, not `cb(null, undefined)`.

I'm a little concerned this is undefined behavior because [the API documentation](https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback) doesn't say what's supposed to happen if all path components already exist, other than that it isn't considered an error like the non-recursive case. But it would stand to reason that if it's not an error, and no directory was created, then the "first directory created" is literally undefined.

But even though the official API docs don't mention it, you can't in practice rely on the return value to be defined. I believe type definitions shouldn't incorporate implementation bugs, but I also don't believe this is an implementation bug, just a documentation oversight.

This seems like the only reasonable definition given the circumstances; that is, if the Node developers eventually address this edge case, I struggle to see what the alternative would be.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback (kind of)
