### PR TITLE
[numeral, papaparse, sanitize-html, sqlite3, xml2js] Remove Behindthemath from definition owners

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Numeral.js
 // Project: https://github.com/adamwdraper/Numeral-js
 // Definitions by: Vincent Bortone <https://github.com/vbortone>
-//                 Behind The Math <https://github.com/BehindTheMath>
 //                 Kenneth Luján <https://github.com/klujanrosas>
 //                   Carlos Quiroga <https://github.com/KarlosQ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -5,7 +5,6 @@
 //                 João Loff <https://github.com/jfloff>
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Alberto Restifo <https://github.com/albertorestifo>
-//                 Behind The Math <https://github.com/BehindTheMath>
 //                 Janne Liuhtonen <https://github.com/jliuhtonen>
 //                 Raphaël Barbazza <https://github.com/rbarbazz>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>

--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/punkave/sanitize-html
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Afshin Darian <https://github.com/afshin>
-//                 BehindTheMath <https://github.com/BehindTheMath>
 //                 Rinze de Laat <https://github.com/biermeester>
 //                 Will Gibson <https://github.com/WillGibson>
 //                 A penguin <https://github.com/sirMerr>

--- a/types/sqlite3/index.d.ts
+++ b/types/sqlite3/index.d.ts
@@ -2,7 +2,6 @@
 // Project: http://github.com/mapbox/node-sqlite3
 // Definitions by: Nick Malaguti <https://github.com/nmalaguti>
 //                 Sumant Manne <https://github.com/dpyro>
-//                 Behind The Math <https://github.com/BehindTheMath>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -4,7 +4,6 @@
 //                 Jason McNeil <https://github.com/jasonrm>
 //                 Christopher Currens <https://github.com/ccurrens>
 //                 Edward Hinkle <https://github.com/edwardhinkle>
-//                 Behind The Math <https://github.com/BehindTheMath>
 //                 Claas Ahlrichs <https://github.com/claasahl>
 //                 Grzegorz Redlicki <https://github.com/redlickigrzegorz>
 //                 Ryan Ling <https://github.com/72636c>


### PR DESCRIPTION
I no longer have time to be a maintainer for these definitions.