### PR TITLE
feat(aws-lambda): add IoT PreProvisioningHook types

### DIFF
--- a/types/aws-lambda/test/iot-tests.ts
+++ b/types/aws-lambda/test/iot-tests.ts
@@ -1,4 +1,10 @@
-import { IoTEvent, IoTHandler } from "aws-lambda";
+import {
+    IoTEvent,
+    IoTHandler,
+    IoTPreProvisioningHookEvent,
+    IoTPreProvisioningHookHandler,
+    IoTPreProvisioningHookResult,
+} from 'aws-lambda';
 
 const handler: IoTHandler = async (event, context, callback) => { };
 
@@ -15,3 +21,27 @@ const eventString: IoTEvent = "AWS Lambda IoT Event";
 const eventNumber: IoTEvent = 100;
 
 const eventArray: IoTEvent<any[]> = [eventObject, eventString, eventNumber];
+
+// PreProvisioningHook
+// https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html
+
+const preProvisioningHookEvent: IoTPreProvisioningHookEvent = {
+    claimCertificateId: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    certificateId: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    certificatePem: "-----BEGIN CERTIFICATE-----\nXXXXXXXXXXXXXXXXXXXXX\n-----END CERTIFICATE-----\n",
+    templateArn: "arn:aws:iot:region:11111111111:provisioningtemplate/PreProvisioningHookIotTemplate",
+    clientId: "test-13534135",
+    parameters: {
+        key: "value"
+    }
+};
+
+const preProvisioningHookResult: IoTPreProvisioningHookResult = {
+    allowProvisioning: true,
+    parameterOverrides: {
+        key: "new value"
+    }
+};
+const preProvisioningHookHandler: IoTPreProvisioningHookHandler = async (event, context, callback) => {
+    return preProvisioningHookResult;
+};

--- a/types/aws-lambda/trigger/iot.d.ts
+++ b/types/aws-lambda/trigger/iot.d.ts
@@ -7,3 +7,22 @@ export type IoTHandler = Handler<IoTEvent, void>;
 // IoT payload is not restriced to JSON, but JSON is highly recommended. Types as string, number or array are possible to use.
 
 export type IoTEvent<T = never> = string | number | T;
+
+// PreProvisioningHook
+// https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html
+// When using AWS IoT fleet provisioning, you can set up a Lambda function to validate parameters passed from the device before allowing the device to be provisioned.
+export type IoTPreProvisioningHookHandler = Handler<IoTPreProvisioningHookEvent, IoTPreProvisioningHookResult>;
+
+export interface IoTPreProvisioningHookEvent {
+    claimCertificateId: string;
+    certificateId: string;
+    certificatePem: string;
+    templateArn: string;
+    clientId: string;
+    parameters: Record<string, string>;
+}
+
+export interface IoTPreProvisioningHookResult {
+    allowProvisioning: boolean;
+    parameterOverrides: Record<string, string>;
+}


### PR DESCRIPTION
### [Iot PreProvisioningHook Types](https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html)

When using AWS IoT fleet provisioning, you can set up a Lambda function to validate parameters passed from the device before allowing the device to be provisioned.

AWS doc that describes the types: https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


