### PR TITLE
redux-promise: allow newer major versions than 3

### DIFF
--- a/types/redux-promise/package.json
+++ b/types/redux-promise/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": ">=3.6.0"
     }
 }


### PR DESCRIPTION
I'm finding in a large legacy-ish Redux app using `@types/redux-promise` that the only reason `redux@3` gets included in the lockfile is from this types package. Amusing.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- ~[ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
