### PR TITLE
fixing mailparser to, cc, bcc types

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -223,21 +223,22 @@ export interface ParsedMail {
      */
     date?: Date;
     /**
-     * An address object for the `To:` header.
+     * An address object or array of address objects for the `To:` header.
      */
-    to?: AddressObject;
+    to?: AddressObject | AddressObject[];
     /**
      * An address object for the `From:` header.
      */
     from?: AddressObject;
     /**
-     * An address object for the `Cc:` header.
+     * An address object or array of address objects for the `Cc:` header.
      */
-    cc?: AddressObject;
+    cc?: AddressObject | AddressObject[];
     /**
-     * An address object for the `Bcc:` header (usually not present).
+     * An address object or array of address objects for the `Bcc:` header.
+     * (usually not present)
      */
-    bcc?: AddressObject;
+    bcc?: AddressObject | AddressObject[];
     /**
      * An address object for the `Reply-To:` header.
      */

--- a/types/mailparser/mailparser-tests.ts
+++ b/types/mailparser/mailparser-tests.ts
@@ -52,7 +52,14 @@ simpleParser(sourceString, (err, mail) => {
     // Attachments
     mail.attachments.forEach(attachment => console.log(attachment.filename));
 
-    // Text
+    // TO Recipieints
+    if (Array.isArray(mail.to)) {
+        mail.to.forEach(recipient => console.log(recipient));
+    } else {
+        console.log(mail.to);
+    }
+
+    // Texte
     console.log(mail.text);
     console.log(mail.html);
     console.log(mail.textAsHtml);


### PR DESCRIPTION
While working on email parsing failures recently, one of the problems uncovered was that the mailparser typings are inaccurate.

Specifically, the `to`, `cc`, and `bcc` fields are typed as optional `AddressObject`, but at run time they are actually optional `AddressObject | AddressObject[]`.

source code:
```
import { simpleParser } from 'mailparser';
import * as fs from 'fs';
import * as process from 'process';
import * as util from 'util';
const readFileAsync = util.promisify(fs.readFile);
const testFilename = `${process.cwd()}/test/fixtures/testFile.txt`;

      it(`simple test`, async () => {
        const content = (await readFileAsync(testFilename)).toString();
        const parsedMail = await simpleParser(content);
        if (Array.isArray(parsedMail.to)) {
          parsedMail.to.map((a, idx) => {
            console.log(`Object at index ${idx}:\n ${JSON.stringify(a)} \n\n`);
          });
        };
      })
```
console:
```
    Object at index 0:
     {"value":[{"address":"tenders@automail.x.com","name":""}],"html":"<span class=\"mp_address_group\"><a href=\"mailto:tenders@automail.x.com\" class=\"mp_address_email\">tenders@automail.x.com</a></span>","text":"tenders@automail.x.com"}

    Object at index 1:
     {"value":[{"address":"anotheraddress@automail.x.com","name":""}],"html":"<span class=\"mp_address_group\"><a href=\"mailto:anotheraddress@automail.x.com\" class=\"mp_address_email\">anotheraddress@automail.x.com</a></span>","text":"anotheraddress@automail.x.com"}

    Object at index 2:
     {"value":[{"address":"thirdaddress@automail.x.com","name":""}],"html":"<span class=\"mp_address_group\"><a href=\"mailto:thirdaddress@automail.x.com\" class=\"mp_address_email\">thirdaddress@automail.x.com</a></span>","text":"thirdaddress@automail.x.com"}
```

Incrementing major version of mailparser typings since consuming new typings may result in initial compile errors.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Example at top
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
