### PR TITLE
[sharedb] Make Agent.Custom less strict

### DIFF
--- a/types/sharedb/lib/agent.d.ts
+++ b/types/sharedb/lib/agent.d.ts
@@ -30,7 +30,7 @@ declare class Agent {
      * given client session. It is in memory only as long as the session is
      * active, and it is passed to each middleware call.
      */
-    custom: Agent.Custom;
+    custom: any;
 
     /**
      * Sends a JSON-compatible message to the client for this agent.
@@ -38,10 +38,4 @@ declare class Agent {
      * @param message
      */
     send(message: JSONObject): void;
-}
-
-declare namespace Agent {
-    interface Custom {
-        [key: string]: unknown;
-    }
 }

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -57,13 +57,6 @@ console.log(backend.extraDbs);
 
 backend.addProjection('notes_minimal', 'notes', {title: true, creator: true, lastUpdateTime: true});
 
-// Test module augmentation to attach custom typed properties to `agent.custom`.
-import _ShareDbAgent = require('sharedb/lib/agent');
-declare module 'sharedb/lib/agent' {
-    interface Custom {
-        user?: {id: string};
-    }
-}
 // Exercise middleware (backend.use)
 type SubmitRelatedActions = 'afterWrite' | 'apply' | 'commit' | 'submit';
 const submitRelatedActions: SubmitRelatedActions[] = ['afterWrite', 'apply', 'commit', 'submit'];


### PR DESCRIPTION
`Agent.custom` is normally just an [empty anonymous object][1], which is
meant to hold arbitrary information that consumers wish to store.

Typing this as `Record<string, unknown>` is quite an aggressive typing,
and essentially _forces_ consumers to declare their own overriding type
definition file, which is quite unusual for a type definition.

This change moves us from `Record<string, unknown>` to simply declaring
it as `any`, because the type is completely consumer-defined.

If consumers want stricter typing, they're free to:

 - cast `agent.custom`
 - `extend` the `Agent` class
 - declare their own type definition (as they are currently forced to do
   anyway)


[1]: https://github.com/share/sharedb/blob/0986b1bff5f2fb557f33c5e584ef2a68f206c255/lib/agent.js#L55-L58

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

