### PR TITLE
[sharedb] Less strict typings on ops and source

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -295,6 +295,9 @@ interface SubmitRequest {
     op: sharedb.CreateOp | sharedb.DeleteOp | sharedb.EditOp;
     options: any;
     start: number;
+    extra: {
+        source?: any;
+    };
 
     saveMilestoneSnapshot: boolean | null;
     suppressPublish: boolean | null;

--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -105,7 +105,7 @@ declare namespace sharedb {
         projectsSnapshots: boolean;
         disableSubscribe: boolean;
         close(callback?: BasicCallback): void;
-        commit(collection: string, id: string, op: Op, snapshot: any, options: any, callback: (...args: any[]) => any): void;
+        commit(collection: string, id: string, op: any, snapshot: any, options: any, callback: (...args: any[]) => any): void;
         getSnapshot(collection: string, id: string, fields: any, options: any, callback: (...args: any[]) => any): void;
         getSnapshotBulk(collection: string, ids: string[], fields: any, options: any, callback: (...args: any[]) => any): void;
         getOps(collection: string, id: string, from: number | null, to: number | null, options: any, callback: (...args: any[]) => any): void;
@@ -174,7 +174,7 @@ declare namespace sharedb {
     type Doc = ShareDB.Doc;
     type Query = ShareDB.Query;
     type Error = ShareDB.Error;
-    type Op = ShareDB.Op;
+    type Json0Op = ShareDB.Json0Op;
     type CreateOp = ShareDB.CreateOp;
     type DeleteOp = ShareDB.DeleteOp;
     type EditOp = ShareDB.EditOp;
@@ -241,7 +241,7 @@ declare namespace sharedb {
         interface OpContext extends BaseContext {
             collection: string;
             id: string;
-            op: ShareDB.Op;
+            op: any;
         }
 
         interface QueryContext extends BaseContext {
@@ -305,7 +305,7 @@ interface SubmitRequest {
     retries: number;
 
     snapshot: ShareDB.Snapshot | null;
-    ops: ShareDB.Op[];
+    ops: any[];
     channels: string[] | null;
 }
 

--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -174,7 +174,7 @@ declare namespace sharedb {
     type Doc = ShareDB.Doc;
     type Query = ShareDB.Query;
     type Error = ShareDB.Error;
-    type Json0Op = ShareDB.Json0Op;
+    type Op = ShareDB.Op;
     type CreateOp = ShareDB.CreateOp;
     type DeleteOp = ShareDB.DeleteOp;
     type EditOp = ShareDB.EditOp;

--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -166,7 +166,7 @@ declare namespace sharedb {
      *   lives in the actual source code.
      */
     class Connection {
-        constructor(ws: WebSocket);
+        constructor(socket: ShareDB.Socket);
         get(collectionName: string, documentID: string): ShareDB.Doc;
         createFetchQuery(collectionName: string, query: string, options: {results?: ShareDB.Query[]}, callback: (err: Error, results: any) => any): ShareDB.Query;
         createSubscribeQuery(collectionName: string, query: string, options: {results?: ShareDB.Query[]}, callback: (err: Error, results: any) => any): ShareDB.Query;

--- a/types/sharedb/lib/agent.d.ts
+++ b/types/sharedb/lib/agent.d.ts
@@ -30,7 +30,7 @@ declare class Agent {
      * given client session. It is in memory only as long as the session is
      * active, and it is passed to each middleware call.
      */
-    custom: Agent.Custom;
+    custom: any;
 
     /**
      * Sends a JSON-compatible message to the client for this agent.
@@ -38,10 +38,4 @@ declare class Agent {
      * @param message
      */
     send(message: JSONObject): void;
-}
-
-declare namespace Agent {
-    interface Custom {
-        [key: string]: unknown;
-    }
 }

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -1,10 +1,9 @@
 /// <reference path="sharedb.d.ts" />
-import * as WS from 'ws';
 import * as ShareDB from './sharedb';
 import Agent = require('./agent');
 
 export class Connection {
-    constructor(ws: WebSocket | WS);
+    constructor(ws: ShareDB.Socket);
 
     // This direct reference from connection to agent is not used internal to
     // ShareDB, but it is handy for server-side only user code that may cache

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -22,7 +22,7 @@ export type Doc<T = any> = ShareDB.Doc<T>;
 export type Query = ShareDB.Query;
 export type Presence<T = any> = ShareDB.Presence<T>;
 export type Error = ShareDB.Error;
-export type Json0Op = ShareDB.Json0Op;
+export type Op = ShareDB.Op;
 export type AddNumOp = ShareDB.AddNumOp;
 export type ListMoveOp = ShareDB.ListMoveOp;
 export type ListInsertOp = ShareDB.ListInsertOp;

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -23,7 +23,7 @@ export type Doc<T = any> = ShareDB.Doc<T>;
 export type Query = ShareDB.Query;
 export type Presence<T = any> = ShareDB.Presence<T>;
 export type Error = ShareDB.Error;
-export type Op = ShareDB.Op;
+export type Json0Op = ShareDB.Json0Op;
 export type AddNumOp = ShareDB.AddNumOp;
 export type ListMoveOp = ShareDB.ListMoveOp;
 export type ListInsertOp = ShareDB.ListInsertOp;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -40,7 +40,7 @@ export interface StringDeleteOp { p: Path; sd: string; }
 
 export interface SubtypeOp { p: Path; t: string; o: any; }
 
-export type Json0Op = AddNumOp | ListInsertOp | ListDeleteOp | ListReplaceOp | ListMoveOp | ObjectInsertOp | ObjectDeleteOp | ObjectReplaceOp | StringInsertOp | StringDeleteOp | SubtypeOp;
+export type Op = AddNumOp | ListInsertOp | ListDeleteOp | ListReplaceOp | ListMoveOp | ObjectInsertOp | ObjectDeleteOp | ObjectReplaceOp | StringInsertOp | StringDeleteOp | SubtypeOp;
 
 export interface RawOp {
     src: string;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -109,6 +109,7 @@ export class Doc<T = any> extends EventEmitter {
     subscribed: boolean;
     preventCompose: boolean;
     paused: boolean;
+    submitSource: boolean;
 
     fetch: (callback?: (err: Error) => void) => void;
     subscribe: (callback?: (err: Error) => void) => void;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -188,3 +188,15 @@ export interface ClientRequest {
 
     [propertyName: string]: any;
 }
+
+export interface Socket {
+    readyState: number;
+
+    close(reason?: number): void;
+    send(data: any): void;
+
+    onmessage: (event: any) => void;
+    onclose: (event: any) => void;
+    onerror: (event: any) => void;
+    onopen: (event: any) => void;
+}

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -40,7 +40,7 @@ export interface StringDeleteOp { p: Path; sd: string; }
 
 export interface SubtypeOp { p: Path; t: string; o: any; }
 
-export type Op = AddNumOp | ListInsertOp | ListDeleteOp | ListReplaceOp | ListMoveOp | ObjectInsertOp | ObjectDeleteOp | ObjectReplaceOp | StringInsertOp | StringDeleteOp | SubtypeOp;
+export type Json0Op = AddNumOp | ListInsertOp | ListDeleteOp | ListReplaceOp | ListMoveOp | ObjectInsertOp | ObjectDeleteOp | ObjectReplaceOp | StringInsertOp | StringDeleteOp | SubtypeOp;
 
 export interface RawOp {
     src: string;
@@ -53,7 +53,7 @@ export interface RawOp {
 
 export type CreateOp = RawOp & { create: { type: string; data: any }; del: undefined; op: undefined; };
 export type DeleteOp = RawOp & { del: boolean; create: undefined; op: undefined; };
-export type EditOp = RawOp & { op: Op[]; create: undefined; del: undefined; };
+export type EditOp = RawOp & { op: any[]; create: undefined; del: undefined; };
 
 export type OTType = 'ot-text' | 'ot-json0' | 'ot-json1' | 'ot-text-tp2' | 'rich-text';
 
@@ -90,7 +90,7 @@ export interface Error {
     code: number;
     message: string;
 }
-export interface ShareDBSourceOptions { source?: boolean; }
+export interface ShareDBSourceOptions { source?: any; }
 // interface ShareDBCreateOptions extends ShareDBSourceOptions {}
 // interface ShareDBDelOptions extends ShareDBSourceOptions {}
 // interface ShareDBSubmitOpOptions extends ShareDBSourceOptions {}
@@ -116,15 +116,15 @@ export class Doc<T = any> extends EventEmitter {
     unsubscribe: (callback?: (err: Error) => void) => void;
 
     on(event: 'load' | 'no write pending' | 'nothing pending', callback: () => void): this;
-    on(event: 'create', callback: (source: boolean) => void): this;
-    on(event: 'op' | 'before op', callback: (ops: Op[], source: boolean) => void): this;
-    on(event: 'del', callback: (data: any, source: boolean) => void): this;
+    on(event: 'create', callback: (source: any) => void): this;
+    on(event: 'op' | 'before op', callback: (ops: any[], source: any) => void): this;
+    on(event: 'del', callback: (data: any, source: any) => void): this;
     on(event: 'error', callback: (err: Error) => void): this;
 
     addListener(event: 'load' | 'no write pending' | 'nothing pending', callback: () => void): this;
-    addListener(event: 'create', callback: (source: boolean) => void): this;
-    addListener(event: 'op' | 'before op', callback: (ops: Op[], source: boolean) => void): this;
-    addListener(event: 'del', callback: (data: any, source: boolean) => void): this;
+    addListener(event: 'create', callback: (source: any) => void): this;
+    addListener(event: 'op' | 'before op', callback: (ops: any[], source: any) => void): this;
+    addListener(event: 'del', callback: (data: any, source: any) => void): this;
     addListener(event: 'error', callback: (err: Error) => void): this;
 
     ingestSnapshot(snapshot: Snapshot<T>, callback?: Callback): void;
@@ -132,7 +132,7 @@ export class Doc<T = any> extends EventEmitter {
     create(data: any, callback?: Callback): void;
     create(data: any, type?: OTType, callback?: Callback): void;
     create(data: any, type?: OTType, options?: ShareDBSourceOptions, callback?: Callback): void;
-    submitOp(data: ReadonlyArray<Op>, options?: ShareDBSourceOptions, callback?: Callback): void;
+    submitOp(data: any, options?: ShareDBSourceOptions, callback?: Callback): void;
     del(options: ShareDBSourceOptions, callback?: (err: Error) => void): void;
     whenNothingPending(callback: () => void): void;
     hasPending(): boolean;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -88,6 +88,7 @@ for (const action of submitRelatedActions) {
             request.op.op,
             request.op.create,
             request.op.del,
+            request.extra.source,
         );
         callback();
     });

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -285,6 +285,8 @@ function startClient(callback) {
         if (doc.hasWritePending()) throw new Error();
     });
 
+    doc.submitOp([{insert: 'foo', attributes: {bold: true}}], {source: {deep: true}});
+
     connection.fetchSnapshot('examples', 'foo', 123, (error, snapshot) => {
         if (error) throw error;
         console.log(snapshot.data);

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -57,13 +57,6 @@ console.log(backend.extraDbs);
 
 backend.addProjection('notes_minimal', 'notes', {title: true, creator: true, lastUpdateTime: true});
 
-// Test module augmentation to attach custom typed properties to `agent.custom`.
-import _ShareDbAgent = require('sharedb/lib/agent');
-declare module 'sharedb/lib/agent' {
-    interface Custom {
-        user?: {id: string};
-    }
-}
 // Exercise middleware (backend.use)
 type SubmitRelatedActions = 'afterWrite' | 'apply' | 'commit' | 'submit';
 const submitRelatedActions: SubmitRelatedActions[] = ['afterWrite', 'apply', 'commit', 'submit'];

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -308,3 +308,18 @@ function startClient(callback) {
 
     connection.close();
 }
+
+class SocketLike {
+    readyState = 1;
+
+    close(reason?: number): void {}
+    send(data: any): void {}
+
+    onmessage: (event: any) => void;
+    onclose: (event: any) => void;
+    onerror: (event: any) => void;
+    onopen: (event: any) => void;
+}
+
+const socketLike = new SocketLike();
+new ShareDBClient.Connection(socketLike);


### PR DESCRIPTION
# Submit source support

ShareDB recently added the ability to send an op's `source` to the
server in https://github.com/share/sharedb/pull/426

This change adds the corresponding flag to `Doc`, and updates the
structure of the `SubmitRequest`.

# `agent.custom`

`Agent.custom` is normally just an [empty anonymous object](https://github.com/share/sharedb/blob/0986b1bff5f2fb557f33c5e584ef2a68f206c255/lib/agent.js#L55-L58), which is
meant to hold arbitrary information that consumers wish to store.

Typing this as `Record<string, unknown>` is quite an aggressive typing,
and essentially _forces_ consumers to declare their own overriding type
definition file, which is quite unusual for a type definition.

This change moves us from `Record<string, unknown>` to simply declaring
it as `any`, because the type is completely consumer-defined.

If consumers want stricter typing, they're free to:

 - cast `agent.custom`
 - `extend` the `Agent` class
 - declare their own type definition (as they are currently forced to do
   anyway)

# Op and Source typing

 - The `source` may take [any truthy value](https://github.com/share/sharedb/blob/0986b1bff5f2fb557f33c5e584ef2a68f206c255/lib/client/doc.js#L729-L730), so `boolean` is too
   strict
 - We also remove internal references that assume ops are `json0`;
   documents may use any arbitrary type, including `rich-text`, for
   example

# Remove WebSocket references

ShareDB can be run in a purely Node.js environment, where it doesn't
have access to DOM types, such as `WebSocket`. In these cases, the
TypeScript compilation errors.

ShareDB doesn't actually rely on a full `WebSocket` implementation, its
required properties are listed [here](https://github.com/share/sharedb/blob/0986b1bff5f2fb557f33c5e584ef2a68f206c255/lib/client/connection.js#L88-L95).

Internally, ShareDB doesn't even use a `WebSocket` on server-side
connections. It has a [`StreamSocket`](https://github.com/share/sharedb/blob/0986b1bff5f2fb557f33c5e584ef2a68f206c255/lib/stream-socket.js#L6), which implements the bare
minimum.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.