### PR TITLE
cypress-image-snapshot: do not require cypress dependency

### DIFF
--- a/types/cypress-image-snapshot/cypress-image-snapshot-tests.ts
+++ b/types/cypress-image-snapshot/cypress-image-snapshot-tests.ts
@@ -7,6 +7,17 @@ command.addMatchImageSnapshotCommand({
     scale: true,
 });
 
-function pluginSetup(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void {
+type Task = (value: any) => any;
+
+interface Tasks {
+    [key: string]: Task;
+}
+
+interface PluginEvents {
+    (action: 'after:screenshot', fn: (details: {path: string}) => void): void;
+    (action: 'task', tasks: Tasks): void;
+}
+
+function pluginSetup(on: PluginEvents, config: {}): void {
     addMatchImageSnapshotPlugin(on, config); // $ExpectType void
 }

--- a/types/cypress-image-snapshot/package.json
+++ b/types/cypress-image-snapshot/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "cypress": "*"
-    }
-}

--- a/types/cypress-image-snapshot/plugin.d.ts
+++ b/types/cypress-image-snapshot/plugin.d.ts
@@ -1,5 +1,28 @@
-/// <reference types="Cypress" />
+/* Definitions extracted from Cypress 4.5, which is the minimum
+ * version required by the cypress-image-snapshot.
+ * https://github.com/cypress-io/cypress/blob/v4.5.0/cli/types/index.d.ts#L4513-L4524
+ *
+ * The definitions have been copied in, as DefinitelyTyped does not (yet) support
+ * peerDependencies. This is causing with npms version resolution for consumers.
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20290#issuecomment-589738371
+ * this has been addressed before on these definitions here
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41921
+ *
+ * The Cypress interfaces have been stripped down, according to consumed fields
+ * in https://github.com/jaredpalmer/cypress-image-snapshot/blob/master/src/plugin.js
+ */
+type Task = (value: any) => any;
 
-declare function addMatchImageSnapshotPlugin(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void;
+interface Tasks {
+    [key: string]: Task;
+}
+
+interface PluginEvents {
+    (action: 'after:screenshot', fn: (details: {path: string}) => void): void;
+    (action: 'task', tasks: Tasks): void;
+}
+/* Cypress definitions - end */
+
+declare function addMatchImageSnapshotPlugin(on: PluginEvents, config: {}): void;
 
 export { addMatchImageSnapshotPlugin };


### PR DESCRIPTION
hey @Keysox,

I came to the realisation that the solution i provided yesterday is less then ideal, as it depends on cypress. which unfortunately resolves badly in npm, as we can not specify it in `peerDependencies`.

The issue if well described here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20290#issuecomment-589738371 and i believe you addressed exactly the same problem before on this definition here https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41921

Thefore I have followed your lead and done the same again.

Sorry for the inconveniences. I am hoping you agree this is the better solution.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cypress-io/cypress/blob/v4.5.0/cli/types/index.d.ts#L4513-L4524
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
