### PR TITLE
Fix react-redux on TS 4.2

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -303,7 +303,11 @@ export interface Connect<DefaultState = DefaultRootState> {
  */
 export type ConnectedProps<TConnector> =
     TConnector extends InferableComponentEnhancerWithProps<infer TInjectedProps, any>
-        ? TInjectedProps
+        ? unknown extends TInjectedProps
+            ? TConnector extends InferableComponentEnhancer<infer TInjectedProps>
+                ? TInjectedProps
+                : never
+            : TInjectedProps
         : never;
 
 /**


### PR DESCRIPTION
Typescript 4.2 breaks react-redux' types in a subtle way, described at microsoft/typescript#42421. That changes preserves type aliases, but it also treats them more nominally for the purposes of inference.

The result is that ConnectedProps, which normally tries to infer a type argument from InferableComponentEnhancerWithProps, needs to add a fallback inference from InferableComponentEnhancer, *even though* the latter is just a type alias.

This is a non-breaking change; it would be simpler just to remove InferableComponentEnhancer and give InferableComponentEnhancerWithProps a type parameter default, but that would be a breaking change since both types are exported.

You can check this yourself with `typescript@beta` or `typescript@next`.