### PR TITLE
feat(node/vm): add cachedDataRejected property

### DIFF
--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -84,3 +84,8 @@ import { inspect } from 'node:util';
       { timeout: 5, microtaskMode: 'afterEvaluate' }
     );
 }
+
+{
+    const script = new Script('foo()', { cachedData: Buffer.from([]) });
+    console.log(script.cachedDataRejected);
+}

--- a/types/node/v10/vm.d.ts
+++ b/types/node/v10/vm.d.ts
@@ -23,6 +23,7 @@ declare module "vm" {
         displayErrors?: boolean;
         timeout?: number;
         cachedData?: Buffer;
+        /** @deprecated in favor of `script.createCachedData()` */
         produceCachedData?: boolean;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -69,6 +70,7 @@ declare module "vm" {
         runInContext(contextifiedSandbox: Context, options?: RunningScriptOptions): any;
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
+        cachedDataRejected?: boolean;
     }
     function createContext(sandbox?: Context): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/v11/vm.d.ts
+++ b/types/node/v11/vm.d.ts
@@ -23,6 +23,7 @@ declare module "vm" {
         displayErrors?: boolean;
         timeout?: number;
         cachedData?: Buffer;
+        /** @deprecated in favor of `script.createCachedData()` */
         produceCachedData?: boolean;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -54,6 +55,7 @@ declare module "vm" {
         runInContext(contextifiedSandbox: Context, options?: RunningScriptOptions): any;
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
+        cachedDataRejected?: boolean;
     }
     function createContext(sandbox?: Context): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/v12/vm.d.ts
+++ b/types/node/v12/vm.d.ts
@@ -27,6 +27,7 @@ declare module 'vm' {
         displayErrors?: boolean;
         timeout?: number;
         cachedData?: Buffer;
+        /** @deprecated in favor of `script.createCachedData()` */
         produceCachedData?: boolean;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -104,6 +105,7 @@ declare module 'vm' {
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
         createCachedData(): Buffer;
+        cachedDataRejected?: boolean;
     }
     function createContext(sandbox?: Context, options?: CreateContextOptions): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/v13/vm.d.ts
+++ b/types/node/v13/vm.d.ts
@@ -21,6 +21,7 @@ declare module "vm" {
         displayErrors?: boolean;
         timeout?: number;
         cachedData?: Buffer;
+        /** @deprecated in favor of `script.createCachedData()` */
         produceCachedData?: boolean;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -115,6 +116,7 @@ declare module "vm" {
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
         createCachedData(): Buffer;
+        cachedDataRejected?: boolean;
     }
     function createContext(sandbox?: Context, options?: CreateContextOptions): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -25,6 +25,7 @@ declare module 'vm' {
         displayErrors?: boolean;
         timeout?: number;
         cachedData?: Buffer;
+        /** @deprecated in favor of `script.createCachedData()` */
         produceCachedData?: boolean;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -123,6 +124,7 @@ declare module 'vm' {
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
         createCachedData(): Buffer;
+        cachedDataRejected?: boolean;
     }
     function createContext(sandbox?: Context, options?: CreateContextOptions): Context;
     function isContext(sandbox: Context): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Mentioned under the `cachedData` property of ScriptOptions here: https://nodejs.org/docs/latest-v10.x/api/vm.html#vm_new_vm_script_code_options , all versions 10-15.

```
> const { Script } = require('vm');
undefined
> new Script('foo()', { cachedData: Buffer.from([]) }).cachedDataRejected
true
> new Script('foo()').cachedDataRejected
undefined
```
