### PR TITLE
[@types/ffmpeg] fix type property name for "keepAspectRatio"

### DIFF
--- a/types/ffmpeg/index.d.ts
+++ b/types/ffmpeg/index.d.ts
@@ -22,7 +22,7 @@ type FrameToJPGSettings = Partial<{
     every_n_seconds: number;
     every_n_percentage: number;
     keep_pixel_aspect_ratio: boolean;
-    keep_aspect_ration: boolean;
+    keep_aspect_ratio: boolean;
     padding_color: string;
     file_name: string;
 }>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/damianociarla/node-ffmpeg/blob/master/lib/video.js#L655
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
