### PR TITLE
[@types/next-auth] Update JWTOptions interface

### DIFF
--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -104,6 +104,8 @@ interface JWTOptions {
     secret?: string;
     maxAge?: number;
     encryption?: boolean;
+    signingKey?: string;
+    encryptionKey?: string;
     encode?(options: JWTEncodeParams): Promise<string>;
     decode?(options: JWTDecodeParams): Promise<string>;
 }

--- a/types/next-auth/next-auth-tests.ts
+++ b/types/next-auth/next-auth-tests.ts
@@ -134,6 +134,8 @@ const allConfig = {
         secret: 'secret-thing',
         maxAge: 365,
         encryption: true,
+        signingKey: 'some-key',
+        encryptionKey: 'some-key',
         encode: () => Promise.resolve('foo'),
         decode: () => Promise.resolve('foo'),
     },


### PR DESCRIPTION
Based on https://github.com/nextauthjs/next-auth/issues/484 the warn `[warn][jwt_auto_generated_signing_key]` is resolved by passing `signingKey` and `encryptionKey`.
