### PR TITLE
Add generic version of RecordSource get method

### DIFF
--- a/types/relay-runtime/lib/store/RelayRecordSource.d.ts
+++ b/types/relay-runtime/lib/store/RelayRecordSource.d.ts
@@ -7,7 +7,7 @@ export class RelayRecordSource implements MutableRecordSource {
 
     static create(records?: RecordMap): MutableRecordSource;
     // tslint:disable-next-line:no-unnecessary-generics
-    get<T = {}>(dataID: DataID): Record<T> | null | undefined;
+    get<T extends object = {}>(dataID: DataID): Record<T> | null | undefined;
     getRecordIDs(): DataID[];
     getStatus(dataID: DataID): RecordState;
     has(dataID: DataID): boolean;

--- a/types/relay-runtime/lib/store/RelayRecordSource.d.ts
+++ b/types/relay-runtime/lib/store/RelayRecordSource.d.ts
@@ -6,8 +6,8 @@ export class RelayRecordSource implements MutableRecordSource {
     constructor(records?: RecordMap);
 
     static create(records?: RecordMap): MutableRecordSource;
-
-    get(dataID: DataID): Record | null | undefined;
+    // tslint:disable-next-line:no-unnecessary-generics
+    get<T = {}>(dataID: DataID): Record<T> | null | undefined;
     getRecordIDs(): DataID[];
     getStatus(dataID: DataID): RecordState;
     has(dataID: DataID): boolean;

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -27,8 +27,8 @@ export type OperationTracker = RelayOperationTracker;
 /*
  * An individual cached graph object.
  */
-export interface Record {
-    [key: string]: unknown;
+export interface Record<T = {}> {
+    [key: string]: T;
 }
 
 /**

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -178,6 +178,8 @@ export interface FragmentSpecResolver {
  */
 export interface RecordSource {
     get(dataID: DataID): Record | null | undefined;
+    // tslint:disable-next-line:no-unnecessary-generics
+    get<T = {}>(dataID: DataID): Record<T> | null | undefined;
     getRecordIDs(): DataID[];
     getStatus(dataID: DataID): RecordState;
     has(dataID: DataID): boolean;

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -178,7 +178,7 @@ export interface FragmentSpecResolver {
  */
 export interface RecordSource {
     // tslint:disable-next-line:no-unnecessary-generics
-    get<T = {}>(dataID: DataID): Record<T> | null | undefined;
+    get<T extends object = {}>(dataID: DataID): Record<T> | null | undefined;
     getRecordIDs(): DataID[];
     getStatus(dataID: DataID): RecordState;
     has(dataID: DataID): boolean;

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -177,7 +177,6 @@ export interface FragmentSpecResolver {
  * A read-only interface for accessing cached graph data.
  */
 export interface RecordSource {
-    get(dataID: DataID): Record | null | undefined;
     // tslint:disable-next-line:no-unnecessary-generics
     get<T = {}>(dataID: DataID): Record<T> | null | undefined;
     getRecordIDs(): DataID[];

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -27,7 +27,7 @@ export type OperationTracker = RelayOperationTracker;
 /*
  * An individual cached graph object.
  */
-export interface Record<T = {}> {
+export interface Record<T extends object = {}> {
     [key: string]: T;
 }
 

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -202,12 +202,9 @@ function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversation
 // Source
 // ~~~~~~~~~~~~~~~~~~~~~
 
-store.publish(source);
-        
+store.publish(source);   
 const get_store_item = store.getSource().get("someDataId");
-
 const get_store_item_typed = store.getSource().get<TConversation>("someDataId");
-
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // commitLocalUpdate

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -203,6 +203,11 @@ function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversation
 // ~~~~~~~~~~~~~~~~~~~~~
 
 store.publish(source);
+        
+const get_store_item = store.getSource().get("someDataId");
+
+const get_store_item_typed = store.getSource().get<TConversation>("someDataId");
+
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // commitLocalUpdate

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -203,8 +203,9 @@ function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversation
 // ~~~~~~~~~~~~~~~~~~~~~
 
 store.publish(source);
-const get_store_item = store.getSource().get("someDataId");
-const get_store_item_typed = store.getSource().get<TConversation>("someDataId");
+const get_store_recorditem = store.getSource().get("someDataId");
+// $ExpectType Record<TConversation> | null | undefined
+const get_store_recorditem_typed = store.getSource().get<TConversation>("someDataId");
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // commitLocalUpdate

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -202,7 +202,7 @@ function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversation
 // Source
 // ~~~~~~~~~~~~~~~~~~~~~
 
-store.publish(source);   
+store.publish(source);
 const get_store_item = store.getSource().get("someDataId");
 const get_store_item_typed = store.getSource().get<TConversation>("someDataId");
 


### PR DESCRIPTION
RecordSource under the hood can support generic but current interface does not have generic method..

Equal is already done for RecordSourceProxy... But this breakes bit generic rule...

**Already in types:**
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b71dc542f83c8c655713a7c9abedcdfb62dfa845/types/relay-runtime/lib/store/RelayStoreTypes.d.ts#L387-L393

**My change:**
I added generic version of get() method.. equaly to RecordSource 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
