### PR TITLE
[prosemirror-schema-list] Append to nodes type

### DIFF
--- a/types/prosemirror-schema-list/index.d.ts
+++ b/types/prosemirror-schema-list/index.d.ts
@@ -40,11 +40,11 @@ export let listItem: NodeSpec;
  * given to assign a group name to the list node types, for example
  * `"block"`.
  */
-export function addListNodes(
-    nodes: OrderedMap<NodeSpec>,
+export function addListNodes<N extends string = any>(
+    nodes: { [name in N]: NodeSpec } | OrderedMap<NodeSpec>,
     itemContent: string,
     listGroup?: string,
-): OrderedMap<NodeSpec>;
+): { [name in (N | "ordered_list" | "bullet_list" | "list_item")]: NodeSpec } | OrderedMap<NodeSpec>;
 /**
  * Returns a command function that wraps the selection in a list with
  * the given type an attributes. If `dispatch` is null, only return a

--- a/types/prosemirror-schema-list/prosemirror-schema-list-tests.ts
+++ b/types/prosemirror-schema-list/prosemirror-schema-list-tests.ts
@@ -1,3 +1,4 @@
+import { schema } from 'prosemirror-schema-basic';
 import {
     orderedList,
     bulletList,
@@ -8,3 +9,6 @@ import {
     liftListItem,
     sinkListItem,
 } from 'prosemirror-schema-list';
+
+// Add the listNodes to the schema from prosemirror-schema-basic
+const listNodes = addListNodes(schema.spec.nodes, "paragraph block*", "block");


### PR DESCRIPTION
Makes `addListNodes` accept the same type as nodes in a `Schema` defined in `prosemirror-model`. This way if `N` is not a string, but a union of specific strings `addListNodes` will add the specific nodes to the definition.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d5e336820531f28dcf3ca1f056b6695105dbc875/types/prosemirror-model/index.d.ts#L1110-L1119

The test is from the example on https://prosemirror.net/examples/basic/, this test fails on the previous version of these types.