### PR TITLE
[react-select] Make animation props optional on animated components

### DIFF
--- a/types/react-select/src/animated/MultiValue.d.ts
+++ b/types/react-select/src/animated/MultiValue.d.ts
@@ -4,8 +4,8 @@ import { Collapse, fn } from './transitions';
 import { OptionTypeBase } from '../types';
 
 export type AnimatedMultiValueProps<OptionType extends OptionTypeBase> = {
-  in: boolean,
-  onExited: fn,
+  in?: boolean,
+  onExited?: fn,
 } & MultiValueProps<OptionType>;
 
 export function AnimatedMultiValue<OptionType extends OptionTypeBase>(WrappedComponent: ComponentType<MultiValueProps<OptionType>>): ComponentType<AnimatedMultiValueProps<OptionType>>;

--- a/types/react-select/src/animated/transitions.d.ts
+++ b/types/react-select/src/animated/transitions.d.ts
@@ -4,9 +4,9 @@ import { Transition } from 'react-transition-group';
 export type fn = () => void;
 export interface BaseTransition {
   /** Whether we are in a transition. */
-  in: boolean;
+  in?: boolean;
   /** Function to be called once transition finishes. */
-  onExited: fn;
+  onExited?: fn;
 }
 
 // ==============================

--- a/types/react-select/test/Tests.tsx
+++ b/types/react-select/test/Tests.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Select from 'react-select/index';
+import * as animatedComponents from 'react-select/animated';
+
+const AnimatedSelect = (props: React.ComponentProps<typeof Select>) => (
+    <Select
+        {...props}
+        components={{
+            ...animatedComponents,
+            ...props.components,
+        }}
+    />
+);

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -29,6 +29,7 @@
         "test/CustomValueContainer.tsx",
         "test/Header.tsx",
         "test/Placeholder.tsx",
+        "test/Tests.tsx",
         "test/examples/AccessingInternals.tsx",
         "test/examples/AnimatedMulti.tsx",
         "test/examples/AsyncCallbacks.tsx",


### PR DESCRIPTION
The user doesn't have to provide these props and the `Select` component doesn't pass them in.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/master/docs/Tests.js#L25-L33
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
