### PR TITLE
Add DecoratedText definitions to the Card Service

### DIFF
--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -181,3 +181,19 @@ const createFileAndGetDescription = () => {
   // Get description. Expect 'DESC'.
   Logger.log(file.getDescription().toUpperCase());
 };
+
+CardService.newDecoratedText(); // $ExpectType DecoratedText
+CardService.newDecoratedText().setAuthorizationAction(CardService.newAuthorizationAction()); // $ExpectType DecoratedText
+CardService.newDecoratedText().setBottomLabel(''); // $ExpectType DecoratedText
+CardService.newDecoratedText().setButton(CardService.newTextButton()); // $ExpectType DecoratedText
+CardService.newDecoratedText().setComposeAction(CardService.newAction(), CardService.ComposedEmailType.REPLY_AS_DRAFT); // $ExpectType DecoratedText
+CardService.newDecoratedText().setIcon(CardService.Icon.AIRPLANE); // $ExpectType DecoratedText
+CardService.newDecoratedText().setIconAltText(''); // $ExpectType DecoratedText
+CardService.newDecoratedText().setIconUrl(''); // $ExpectType DecoratedText
+CardService.newDecoratedText().setOnClickAction(CardService.newAction()); // $ExpectType DecoratedText
+CardService.newDecoratedText().setOnClickOpenLinkAction(CardService.newAction()); // $ExpectType DecoratedText
+CardService.newDecoratedText().setOpenLink(CardService.newOpenLink()); // $ExpectType DecoratedText
+CardService.newDecoratedText().setSwitchControl(CardService.newSwitch()); // $ExpectType DecoratedText
+CardService.newDecoratedText().setText(''); // $ExpectType DecoratedText
+CardService.newDecoratedText().setTopLabel(''); // $ExpectType DecoratedText
+CardService.newDecoratedText().setWrapText(true); // $ExpectType DecoratedText

--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Apps Script 2020-01-02
+// Type definitions for Google Apps Script 2021-01-24
 // Project: https://developers.google.com/apps-script/
 // Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
 //                 motemen <https://github.com/motemen/>
@@ -264,6 +264,7 @@ declare namespace GoogleAppsScript {
       newComposeActionResponseBuilder(): ComposeActionResponseBuilder;
       newDatePicker(): DatePicker;
       newDateTimePicker(): DateTimePicker;
+      newDecoratedText(): DecoratedText;
       newDriveItemsSelectedActionResponseBuilder(): DriveItemsSelectedActionResponseBuilder;
       newFixedFooter(): FixedFooter;
       newImage(): Image;
@@ -745,6 +746,29 @@ declare namespace GoogleAppsScript {
       setTitle(title: string): DateTimePicker;
       setValueInMsSinceEpoch(valueMsEpoch: number): DateTimePicker;
       setValueInMsSinceEpoch(valueMsEpoch: string): DateTimePicker;
+    }
+
+    /**
+     * A widget that displays text with optional decorations. Possible keys include an icon, a label
+     * above and a label below. Setting the text content and one of the keys is required using setText(text)
+     * and one of setIcon(icon), setIconUrl(url), setTopLabel(text), or setBottomLabel(text).
+     * This class is intended to replace KeyValue.
+     */
+    interface DecoratedText {
+      setAuthorizationAction(action: AuthorizationAction): DecoratedText;
+      setBottomLabel(text: string): DecoratedText;
+      setButton(button: Button): DecoratedText;
+      setComposeAction(action: Action, composedEmailType: ComposedEmailType): DecoratedText;
+      setIcon(icon: Icon): DecoratedText;
+      setIconAltText(altText: string): DecoratedText;
+      setIconUrl(url: string): DecoratedText;
+      setOnClickAction(action: Action): DecoratedText;
+      setOnClickOpenLinkAction(action: Action): DecoratedText;
+      setOpenLink(openLink: OpenLink): DecoratedText;
+      setSwitchControl(switchToSet: Switch): DecoratedText;
+      setText(text: string): DecoratedText;
+      setTopLabel(text: string): DecoratedText;
+      setWrapText(wrapText: boolean): DecoratedText;
     }
 
     /**


### PR DESCRIPTION
Added missing definitions for [DecoratedText](https://developers.google.com/apps-script/reference/card-service/decorated-text) to the Card Service of the google-apps-script types.

Definitions were pulled using https://github.com/PopGoesTheWza/dts-google-apps-script