### PR TITLE
amplitude-js: add type for AmplitudeClient.groupIdentify

### DIFF
--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -84,6 +84,9 @@ import amplitude = require('amplitude-js');
     client.regenerateDeviceId();
     client.clearUserProperties();
     client.identify(identify);
+    client.groupIdentify('type', 'name', identify);
+    client.groupIdentify('type', ['name', 'name2'], identify);
+    client.groupIdentify('type', 'name', identify, (httpCode, response, details) => {});
     client.logRevenue(3.99, 1, 'product_1234');
     client.logRevenueV2(revenue);
     identify = new amplitude.Identify()

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -103,7 +103,8 @@ export class AmplitudeClient {
     setDeviceId(id: string): void;
     regenerateDeviceId(): void;
 
-    identify(identify_obj: Identify, opt_callback?: Callback): void;
+    identify(identify: Identify, callback?: Callback): void;
+    groupIdentify(groupType: string, groupName: string | string[], identify: Identify, callback?: Callback): void;
 
     setUserProperties(properties: any): void;
     setGlobalUserProperties(properties: any): void;


### PR DESCRIPTION
The types for amplitude-js were missing a type for the groupIndentify method on the AmplitudeClient https://github.com/amplitude/Amplitude-JavaScript/blob/main/src/amplitude-client.js#L1173. This PR adds a type definition for that method.

There was some inconsistent casing of parameter names throughout the file (some camelCase some snake_case). I opted to copy the [groupType/groupName properties in the setGroup definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/amplitude-js/index.d.ts#L114) and the [identify/callback properties from the main identify definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/amplitude-js/index.d.ts#L166). updated the identify/callback param names in the AmplitudeClient.identify type as well for consistency. happy to update those if people prefer something different 👍 

checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

