### PR TITLE
[dependency-tree]: allow preloaded config object

### DIFF
--- a/types/dependency-tree/dependency-tree-tests.ts
+++ b/types/dependency-tree/dependency-tree-tests.ts
@@ -30,6 +30,8 @@ dependencyTree({
             strict: true,
             esModuleInterop: true,
             importHelpers: true,
+            module: 'CommonJS',
+            target: 'ES2020',
         },
         extends: '',
         exclude: [''],

--- a/types/dependency-tree/dependency-tree-tests.ts
+++ b/types/dependency-tree/dependency-tree-tests.ts
@@ -1,19 +1,46 @@
 import dependencyTree = require('dependency-tree');
 
 const tree = dependencyTree({
-  filename: 'path/to/a/file',
-  directory: 'path/to/all/files',
-  requireConfig: 'path/to/requirejs/config',
-  webpackConfig: 'path/to/webpack/config',
-  tsConfig: 'path/to/typescript/config',
-  nodeModulesConfig: {
-    entry: 'module'
-  },
-  filter: path => path.indexOf('node_modules') === -1,
-  nonExistent: []
+    filename: 'path/to/a/file',
+    directory: 'path/to/all/files',
+    requireConfig: 'path/to/requirejs/config',
+    webpackConfig: 'path/to/webpack/config',
+    tsConfig: 'path/to/typescript/config',
+    nodeModulesConfig: {
+        entry: 'module',
+    },
+    filter: path => path.indexOf('node_modules') === -1,
+    nonExistent: [],
 });
 
 const list = dependencyTree.toList({
-  filename: 'path/to/a/file',
-  directory: 'path/to/all/files'
+    filename: 'path/to/a/file',
+    directory: 'path/to/all/files',
+});
+
+dependencyTree({
+    filename: 'path/to/a/file',
+    directory: 'path/to/all/files',
+    requireConfig: 'path/to/requirejs/config',
+    webpackConfig: 'path/to/webpack/config',
+    tsConfig: {
+        compilerOptions: {
+            allowJs: true,
+            allowSyntheticDefaultImports: true,
+            strict: true,
+            esModuleInterop: true,
+            importHelpers: true,
+        },
+        extends: '',
+        exclude: [''],
+        include: [''],
+        files: [''],
+        compileOnSave: true,
+        references: [{ path: '' }],
+    },
+    nodeModulesConfig: {
+        entry: 'module',
+    },
+    filter: path => path.indexOf('node_modules') === -1,
+    nonExistent: [],
 });

--- a/types/dependency-tree/index.d.ts
+++ b/types/dependency-tree/index.d.ts
@@ -12,9 +12,14 @@ declare namespace dependencyTree {
         [k: string]: DependencyObj;
     }
 
+    interface TsConfigCompilerOptions extends Omit<CompilerOptions, 'module' | 'target'> {
+        module?: 'None' | 'CommonJS' | 'AMD' | 'System' | 'UMD' | 'ES6' | 'ES2015' | 'ES2020' | 'ESNext';
+        target?: 'ES3' | 'ES5' | 'ES6' | 'ES2015' | 'ES2016' | 'ES2017' | 'ES2018' | 'ES2019' | 'ES2020' | 'ESNext';
+    }
+
     interface TsConfig {
         extends?: string;
-        compilerOptions: CompilerOptions;
+        compilerOptions: TsConfigCompilerOptions;
         exclude?: string[];
         include?: string[];
         files?: string[];

--- a/types/dependency-tree/index.d.ts
+++ b/types/dependency-tree/index.d.ts
@@ -4,28 +4,10 @@
 //                 Alex <https://github.com/adjerbetian>
 //                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.5
-
-import { CompilerOptions } from 'typescript';
 
 declare namespace dependencyTree {
     interface DependencyObj {
         [k: string]: DependencyObj;
-    }
-
-    interface TsConfigCompilerOptions extends Omit<CompilerOptions, 'module' | 'target'> {
-        module?: 'None' | 'CommonJS' | 'AMD' | 'System' | 'UMD' | 'ES6' | 'ES2015' | 'ES2020' | 'ESNext';
-        target?: 'ES3' | 'ES5' | 'ES6' | 'ES2015' | 'ES2016' | 'ES2017' | 'ES2018' | 'ES2019' | 'ES2020' | 'ESNext';
-    }
-
-    interface TsConfig {
-        extends?: string;
-        compilerOptions: TsConfigCompilerOptions;
-        exclude?: string[];
-        include?: string[];
-        files?: string[];
-        compileOnSave?: boolean;
-        references?: Array<{ path: string }>;
     }
 
     interface Options {
@@ -33,7 +15,7 @@ declare namespace dependencyTree {
         directory?: string;
         requireConfig?: string;
         webpackConfig?: string;
-        tsConfig?: string | TsConfig;
+        tsConfig?: string | Record<string, any>;
         nodeModulesConfig?: any;
         detective?: any;
         visited?: DependencyObj;

--- a/types/dependency-tree/index.d.ts
+++ b/types/dependency-tree/index.d.ts
@@ -1,12 +1,25 @@
-// Type definitions for dependency-tree 7.2
+// Type definitions for dependency-tree 8.0
 // Project: https://github.com/mrjoelkemp/node-dependency-tree
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Alex <https://github.com/adjerbetian>
+//                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { CompilerOptions } from 'typescript';
 
 declare namespace dependencyTree {
     interface DependencyObj {
         [k: string]: DependencyObj;
+    }
+
+    interface TsConfig {
+        extends?: string;
+        compilerOptions: CompilerOptions;
+        exclude?: string[];
+        include?: string[];
+        files?: string[];
+        compileOnSave?: boolean;
+        references?: Array<{ path: string }>;
     }
 
     interface Options {
@@ -14,7 +27,7 @@ declare namespace dependencyTree {
         directory?: string;
         requireConfig?: string;
         webpackConfig?: string;
-        tsConfig?: string;
+        tsConfig?: string | TsConfig;
         nodeModulesConfig?: any;
         detective?: any;
         visited?: DependencyObj;

--- a/types/dependency-tree/index.d.ts
+++ b/types/dependency-tree/index.d.ts
@@ -4,6 +4,7 @@
 //                 Alex <https://github.com/adjerbetian>
 //                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.5
 
 import { CompilerOptions } from 'typescript';
 

--- a/types/dependency-tree/package.json
+++ b/types/dependency-tree/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "typescript": "next"
+    }
+}

--- a/types/dependency-tree/package.json
+++ b/types/dependency-tree/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "typescript": "next"
-    }
-}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dependents/node-dependency-tree#options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This pull request enables this feature:

> tsConfig: path to a typescript config (or a preloaded object representing the typescript config)

Unfortunately there is no real working interface for the whole `tsconfig.json` file. (`ParsedCommandLine` and `TypeAcquisition` did not work out as expected)