### PR TITLE
update ackee-tracker to v5 and use-ackee to v2

### DIFF
--- a/types/ackee-tracker/ackee-tracker-tests.ts
+++ b/types/ackee-tracker/ackee-tracker-tests.ts
@@ -8,6 +8,17 @@ const instance1 = ackeeTracker.create('https://example.com');
 const { stop } = instance1.record('hd11f820-68a1-11e6-8047-79c0c2d9bce0');
 stop();
 
+const stop2 = instance1.updateRecord('ID');
+stop2.stop();
+
+instance1.action('ID', { key: "key", value: 0 }, (id: string) => {});
+instance1.action('ID', { key: "key" }, (id: string) => {});
+instance1.action('ID', { key: "key", value: 0 });
+instance1.action('ID', { key: "key" });
+
+instance1.updateAction('ID', { key: "key", value: 0 });
+instance1.updateAction('ID', { key: "key" });
+
 ackeeTracker.detect();
 
 const instance2 = ackeeTracker.create('https://example.com', {

--- a/types/ackee-tracker/ackee-tracker-tests.ts
+++ b/types/ackee-tracker/ackee-tracker-tests.ts
@@ -3,25 +3,18 @@ import * as ackeeTracker from 'ackee-tracker';
 ackeeTracker.attributes();
 ackeeTracker.attributes(true);
 
-const instance1 = ackeeTracker.create({
-    server: 'https://example.com',
-    domainId: 'hd11f820-68a1-11e6-8047-79c0c2d9bce0',
-});
+const instance1 = ackeeTracker.create('https://example.com');
 
-const { stop } = instance1.record();
+const { stop } = instance1.record('hd11f820-68a1-11e6-8047-79c0c2d9bce0');
 stop();
 
 ackeeTracker.detect();
 
-const instance2 = ackeeTracker.create(
-    {
-        server: 'https://example.com',
-        domainId: 'hd11f820-68a1-11e6-8047-79c0c2d9bce0',
-    },
-    {
+const instance2 = ackeeTracker.create('https://example.com', {
         ignoreLocalhost: true,
         detailed: false,
+        ignoreOwnVisits: false
     },
 );
 
-instance2.record(ackeeTracker.attributes(true));
+instance2.record('hd11f820-68a1-11e6-8047-79c0c2d9bce0', ackeeTracker.attributes(true));

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -45,9 +45,6 @@ export interface DetailedData {
     browserHeight: number;
 }
 
-// Fix for useAckee package. (Not updated to Ackee v5)
-export type ServerDetails = string
-
 export function create(server: string, options?: TrackingOptions): AckeeInstance;
 
 export function attributes(detailed?: false): DefaultData;

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -20,8 +20,26 @@ export interface TrackingOptions {
     ignoreOwnVisits?: boolean;
 }
 
+export interface AckeeTrackingReturn {
+    stop: () => void
+}
+
+export interface ActionAttributes {
+    /**
+     * Key that will be used to group similar actions in the Ackee UI.
+     */
+    key: string;
+    /**
+     * Positive float value that is added to all other numerical values of the key.
+     */
+    value?: number;
+}
+
 export interface AckeeInstance {
-    record: (domainId: string, attrs?: ReturnType<typeof attributes>) => { stop: () => void };
+    record: (domainId: string, attrs?: ReturnType<typeof attributes>) => AckeeTrackingReturn;
+    updateRecord: (recordId: string) => AckeeTrackingReturn
+    action: (eventId: string, attributes: ActionAttributes, callback?: (actionId: string) => void) => void
+    updateAction: (actionId: string, attributes: ActionAttributes) => void
 }
 
 export interface DefaultData {

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -45,6 +45,9 @@ export interface DetailedData {
     browserHeight: number;
 }
 
+// Fix for useAckee package. (Not updated to Ackee v5)
+export type ServerDetails = string
+
 export function create(server: string, options?: TrackingOptions): AckeeInstance;
 
 export function attributes(detailed?: false): DefaultData;

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -1,13 +1,9 @@
-// Type definitions for ackee-tracker 4.0
+// Type definitions for ackee-tracker 5.0
 // Project: https://github.com/electerious/ackee-tracker
 // Definitions by: Pablo Sáez <https://github.com/PabloSzx>
 //                 Spencer Elliott <https://github.com/elliottsj>
+//                 Sebastian Krüger <https://github.com/mathe42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-export interface ServerDetails {
-    server: string;
-    domainId: string;
-}
 
 export interface TrackingOptions {
     /**
@@ -18,10 +14,14 @@ export interface TrackingOptions {
      * Defaults to `false`
      */
     detailed?: boolean;
+    /**
+     * Defaults to `true`
+     */
+    ignoreOwnVisits?: boolean;
 }
 
 export interface AckeeInstance {
-    record: (attrs?: ReturnType<typeof attributes>) => { stop: () => void };
+    record: (domainId: string, attrs?: ReturnType<typeof attributes>) => { stop: () => void };
 }
 
 export interface DefaultData {
@@ -45,7 +45,7 @@ export interface DetailedData {
     browserHeight: number;
 }
 
-export function create(server: ServerDetails, options?: TrackingOptions): AckeeInstance;
+export function create(server: string, options?: TrackingOptions): AckeeInstance;
 
 export function attributes(detailed?: false): DefaultData;
 export function attributes(detailed: true): DefaultData & DetailedData;

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -21,7 +21,7 @@ export interface TrackingOptions {
 }
 
 export interface AckeeTrackingReturn {
-    stop: () => void
+    stop: () => void;
 }
 
 export interface ActionAttributes {

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -37,9 +37,9 @@ export interface ActionAttributes {
 
 export interface AckeeInstance {
     record: (domainId: string, attrs?: ReturnType<typeof attributes>) => AckeeTrackingReturn;
-    updateRecord: (recordId: string) => AckeeTrackingReturn
-    action: (eventId: string, attributes: ActionAttributes, callback?: (actionId: string) => void) => void
-    updateAction: (actionId: string, attributes: ActionAttributes) => void
+    updateRecord: (recordId: string) => AckeeTrackingReturn;
+    action: (eventId: string, attributes: ActionAttributes, callback?: (actionId: string) => void) => void;
+    updateAction: (actionId: string, attributes: ActionAttributes) => void;
 }
 
 export interface DefaultData {

--- a/types/use-ackee/index.d.ts
+++ b/types/use-ackee/index.d.ts
@@ -1,10 +1,15 @@
-// Type definitions for use-ackee 1.0
+// Type definitions for use-ackee 2.0
 // Project: https://github.com/electerious/use-ackee
 // Definitions by: Spencer Elliott <https://github.com/elliottsj>
 //                 Pablo Sáez <https://github.com/PabloSzx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ServerDetails, TrackingOptions } from 'ackee-tracker';
+import { TrackingOptions } from 'ackee-tracker';
+
+interface ServerDetails {
+    server: string;
+    domainId: string;
+}
 
 declare function useAckee(pathname: string | null, server: ServerDetails, opts?: TrackingOptions): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Changelog:
https://github.com/electerious/ackee-tracker/blob/master/CHANGELOG.md

The `ignoreOwnVisits` option was added in a version < 5.0 but was not added to the types. Then removed in 5.0.0 but added again in 5.0.1.

### use-ackee
types of use-ackee uses the exported type `ServerDetails` that got changed to `string` in v5 of ackee-tracker so I changed the types there as v2 now uses ackee-tracker v5 but didn't changed the API.
