### PR TITLE
Narrow down types for Koa negotiation methods

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -180,7 +180,7 @@ declare interface ContextDelegatedRequest {
 
     /**
      * Check if the given `type(s)` is acceptable, returning
-     * the best match when true, otherwise `undefined`, in which
+     * the best match when true, otherwise `false`, in which
      * case you should respond with 406 "Not Acceptable".
      *
      * The `type` value may be a single mime type string
@@ -214,9 +214,9 @@ declare interface ContextDelegatedRequest {
      *     this.accepts('html', 'json');
      *     // => "json"
      */
-    accepts(): string[] | boolean;
-    accepts(...types: string[]): string | boolean;
-    accepts(types: string[]): string | boolean;
+    accepts(): string[];
+    accepts(...types: string[]): string | false;
+    accepts(types: string[]): string | false;
 
     /**
      * Return accepted encodings or best fit based on `encodings`.
@@ -226,9 +226,9 @@ declare interface ContextDelegatedRequest {
      *
      *     ['gzip', 'deflate']
      */
-    acceptsEncodings(): string[] | boolean;
-    acceptsEncodings(...encodings: string[]): string | boolean;
-    acceptsEncodings(encodings: string[]): string | boolean;
+    acceptsEncodings(): string[];
+    acceptsEncodings(...encodings: string[]): string | false;
+    acceptsEncodings(encodings: string[]): string | false;
 
     /**
      * Return accepted charsets or best fit based on `charsets`.
@@ -238,9 +238,9 @@ declare interface ContextDelegatedRequest {
      *
      *     ['utf-8', 'utf-7', 'iso-8859-1']
      */
-    acceptsCharsets(): string[] | boolean;
-    acceptsCharsets(...charsets: string[]): string | boolean;
-    acceptsCharsets(charsets: string[]): string | boolean;
+    acceptsCharsets(): string[];
+    acceptsCharsets(...charsets: string[]): string | false;
+    acceptsCharsets(charsets: string[]): string | false;
 
     /**
      * Return accepted languages or best fit based on `langs`.
@@ -250,9 +250,9 @@ declare interface ContextDelegatedRequest {
      *
      *     ['es', 'pt', 'en']
      */
-    acceptsLanguages(): string[] | boolean;
-    acceptsLanguages(...langs: string[]): string | boolean;
-    acceptsLanguages(langs: string[]): string | boolean;
+    acceptsLanguages(): string[];
+    acceptsLanguages(...langs: string[]): string | false;
+    acceptsLanguages(langs: string[]): string | false;
 
     /**
      * Check if the incoming request contains the "Content-Type"
@@ -276,8 +276,8 @@ declare interface ContextDelegatedRequest {
      *     this.is('html'); // => false
      */
     // is(): string | boolean;
-    is(...types: string[]): string | boolean;
-    is(types: string[]): string | boolean;
+    is(...types: string[]): string | false | null;
+    is(types: string[]): string | false | null;
 
     /**
      * Return request header. If the header is not set, will return an empty
@@ -593,8 +593,8 @@ declare namespace Application {
          * @api public
          */
         // is(): string;
-        is(...types: string[]): string;
-        is(types: string[]): string;
+        is(...types: string[]): string | false | null;
+        is(types: string[]): string | false | null;
 
         /**
          * Return response header. If the header is not set, will return an empty

--- a/types/koa/test/index.ts
+++ b/types/koa/test/index.ts
@@ -47,6 +47,23 @@ app.use((ctx, next) => {
     });
 });
 
+app.use(ctx => {
+    ctx.accepts(); // $ExpectType string[]
+    ctx.accepts(''); // $ExpectType string | false
+    ctx.accepts(['']); // $ExpectType string | false
+    ctx.acceptsEncodings(); // $ExpectType string[]
+    ctx.acceptsEncodings(''); // $ExpectType string | false
+    ctx.acceptsEncodings(['']); // $ExpectType string | false
+    ctx.acceptsCharsets(); // $ExpectType string[]
+    ctx.acceptsCharsets(''); // $ExpectType string | false
+    ctx.acceptsCharsets(['']); // $ExpectType string | false
+    ctx.acceptsLanguages(); // $ExpectType string[]
+    ctx.acceptsLanguages(''); // $ExpectType string | false
+    ctx.acceptsLanguages(['']); // $ExpectType string | false
+    ctx.is(''); // $ExpectType string | false | null
+    ctx.is(['']); // $ExpectType string | false | null
+});
+
 // response
 app.use(ctx => {
     ctx.body = 'Hello World';


### PR DESCRIPTION
These methods return `string[]` if no arguments are passed, or `string | false` one or more arguments are passed.

This allows to use code such as:

```ts
const accepts = ctx.accepts();
if(!accepts) {
  return ctx.throw(415);
}
// accepts is a string here
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://koajs.com (it’s in the documentation, also I verified this in actual code, and this matches types of the underlying library `accepts`)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.