### PR TITLE
[react-select] Add group generic

### DIFF
--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -2,23 +2,23 @@ import * as React from 'react';
 import Select, { Props as SelectProps } from './Select';
 import { handleInputChange } from './utils';
 import manageState from './stateManager';
-import { GroupedOptionsType, OptionsType, InputActionMeta, OptionTypeBase } from './types';
+import { GroupedOptionsType, OptionsType, InputActionMeta, OptionTypeBase, GroupTypeBase } from './types';
 
-export interface AsyncProps<OptionType extends OptionTypeBase> {
+export interface AsyncProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
     /**
      * The default set of options to show before the user starts searching. When
      * set to `true`, the results for loadOptions('') will be autoloaded.
      * @default false
      */
-    defaultOptions?: GroupedOptionsType<OptionType> | OptionsType<OptionType> | boolean;
+    defaultOptions?: GroupedOptionsType<OptionType, GroupType> | OptionsType<OptionType> | boolean;
     /**
      * Function that returns a promise, which is the set of options to be used
      * once the promise resolves.
      */
     loadOptions: (
         inputValue: string,
-        callback: (options: OptionsType<OptionType> | GroupedOptionsType<OptionType>) => void,
-    ) => Promise<OptionsType<OptionType> | GroupedOptionsType<OptionType>> | void;
+        callback: (options: OptionsType<OptionType> | GroupedOptionsType<OptionType, GroupType>) => void,
+    ) => Promise<OptionsType<OptionType> | GroupedOptionsType<OptionType, GroupType>> | void;
     /**
      * If cacheOptions is truthy, then the loaded data will be cached. The cache
      * will remain until `cacheOptions` changes value.
@@ -27,8 +27,8 @@ export interface AsyncProps<OptionType extends OptionTypeBase> {
     cacheOptions?: any;
 }
 
-export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean> = SelectProps<OptionType, IsMulti> &
-    AsyncProps<OptionType>;
+export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = SelectProps<OptionType, IsMulti, GroupType> &
+    AsyncProps<OptionType, GroupType>;
 
 export const defaultProps: Props<any, boolean>;
 
@@ -41,8 +41,8 @@ export interface State<OptionType extends OptionTypeBase> {
     passEmptyOptions: boolean;
 }
 
-export class Async<OptionType extends OptionTypeBase, IsMulti extends boolean = false> extends React.Component<
-    Props<OptionType, IsMulti>,
+export class Async<OptionType extends OptionTypeBase, IsMulti extends boolean = false, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends React.Component<
+    Props<OptionType, IsMulti, GroupType>,
     State<OptionType>
 > {
     static defaultProps: Props<any, boolean>;

--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -4,7 +4,10 @@ import { handleInputChange } from './utils';
 import manageState from './stateManager';
 import { GroupedOptionsType, OptionsType, InputActionMeta, OptionTypeBase, GroupTypeBase } from './types';
 
-export interface AsyncProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface AsyncProps<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     /**
      * The default set of options to show before the user starts searching. When
      * set to `true`, the results for loadOptions('') will be autoloaded.
@@ -27,8 +30,11 @@ export interface AsyncProps<OptionType extends OptionTypeBase, GroupType extends
     cacheOptions?: any;
 }
 
-export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = SelectProps<OptionType, IsMulti, GroupType> &
-    AsyncProps<OptionType, GroupType>;
+export type Props<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = SelectProps<OptionType, IsMulti, GroupType> & AsyncProps<OptionType, GroupType>;
 
 export const defaultProps: Props<any, boolean>;
 
@@ -41,10 +47,11 @@ export interface State<OptionType extends OptionTypeBase> {
     passEmptyOptions: boolean;
 }
 
-export class Async<OptionType extends OptionTypeBase, IsMulti extends boolean = false, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends React.Component<
-    Props<OptionType, IsMulti, GroupType>,
-    State<OptionType>
-> {
+export class Async<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean = false,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends React.Component<Props<OptionType, IsMulti, GroupType>, State<OptionType>> {
     static defaultProps: Props<any, boolean>;
     select: React.Ref<any>;
     lastRequest: {};

--- a/types/react-select/src/AsyncCreatable.d.ts
+++ b/types/react-select/src/AsyncCreatable.d.ts
@@ -4,15 +4,19 @@ import { Props as CreatableProps, State as CreatableState } from './Creatable';
 import { OptionsType, ValueType, ActionMeta, InputActionMeta, OptionTypeBase, GroupTypeBase } from './types';
 import { cleanValue } from './utils';
 
-export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = AsyncProps<OptionType, IsMulti, GroupType> &
-    CreatableProps<OptionType, IsMulti, GroupType>;
+export type Props<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = AsyncProps<OptionType, IsMulti, GroupType> & CreatableProps<OptionType, IsMulti, GroupType>;
 
 export type State<OptionType extends OptionTypeBase> = AsyncState<OptionType> & CreatableState<OptionType>;
 
-export class AsyncCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<
-    Props<OptionType, IsMulti, GroupType>,
-    State<OptionType>
-> {
+export class AsyncCreatable<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends Component<Props<OptionType, IsMulti, GroupType>, State<OptionType>> {
     static defaultProps: Props<any, boolean>;
     select: ElementRef<any>;
     lastRequest: {};

--- a/types/react-select/src/AsyncCreatable.d.ts
+++ b/types/react-select/src/AsyncCreatable.d.ts
@@ -1,16 +1,16 @@
 import { Component, Ref as ElementRef } from 'react';
 import { Props as AsyncProps, State as AsyncState } from './Async';
 import { Props as CreatableProps, State as CreatableState } from './Creatable';
-import { OptionsType, ValueType, ActionMeta, InputActionMeta, OptionTypeBase } from './types';
+import { OptionsType, ValueType, ActionMeta, InputActionMeta, OptionTypeBase, GroupTypeBase } from './types';
 import { cleanValue } from './utils';
 
-export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean> = AsyncProps<OptionType, IsMulti> &
-    CreatableProps<OptionType, IsMulti>;
+export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = AsyncProps<OptionType, IsMulti, GroupType> &
+    CreatableProps<OptionType, IsMulti, GroupType>;
 
 export type State<OptionType extends OptionTypeBase> = AsyncState<OptionType> & CreatableState<OptionType>;
 
-export class AsyncCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean> extends Component<
-    Props<OptionType, IsMulti>,
+export class AsyncCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<
+    Props<OptionType, IsMulti, GroupType>,
     State<OptionType>
 > {
     static defaultProps: Props<any, boolean>;

--- a/types/react-select/src/Creatable.d.ts
+++ b/types/react-select/src/Creatable.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import Select, { Props as SelectProps } from './Select';
-import { OptionsType, GroupedOptionsType, ValueType, ActionMeta, OptionTypeBase } from './types';
+import { OptionsType, GroupedOptionsType, ValueType, ActionMeta, OptionTypeBase, GroupTypeBase } from './types';
 import { cleanValue } from './utils';
 import manageState from './stateManager';
 
-export interface CreatableProps<OptionType extends OptionTypeBase, IsMulti extends boolean> {
+export interface CreatableProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
     /**
      * Allow options to be created while the `isLoading` prop is true. Useful to
      * prevent the "create new ..." option being displayed while async results are
@@ -23,7 +23,7 @@ export interface CreatableProps<OptionType extends OptionTypeBase, IsMulti exten
     isValidNewOption?: (
         inputValue: string,
         value: ValueType<OptionType, IsMulti>,
-        options: OptionsType<OptionType> | GroupedOptionsType<OptionType>,
+        options: OptionsType<OptionType> | GroupedOptionsType<OptionType, GroupType>,
     ) => boolean;
     /**
      * Returns the data for the new option when it is created. Used to display the
@@ -40,8 +40,8 @@ export interface CreatableProps<OptionType extends OptionTypeBase, IsMulti exten
     createOptionPosition?: 'first' | 'last';
 }
 
-export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean> = SelectProps<OptionType, IsMulti> &
-    CreatableProps<OptionType, IsMulti>;
+export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = SelectProps<OptionType, IsMulti, GroupType> &
+    CreatableProps<OptionType, IsMulti, GroupType>;
 
 export const defaultProps: Props<any, boolean>;
 

--- a/types/react-select/src/Creatable.d.ts
+++ b/types/react-select/src/Creatable.d.ts
@@ -4,7 +4,11 @@ import { OptionsType, GroupedOptionsType, ValueType, ActionMeta, OptionTypeBase,
 import { cleanValue } from './utils';
 import manageState from './stateManager';
 
-export interface CreatableProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface CreatableProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     /**
      * Allow options to be created while the `isLoading` prop is true. Useful to
      * prevent the "create new ..." option being displayed while async results are
@@ -40,8 +44,11 @@ export interface CreatableProps<OptionType extends OptionTypeBase, IsMulti exten
     createOptionPosition?: 'first' | 'last';
 }
 
-export type Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = SelectProps<OptionType, IsMulti, GroupType> &
-    CreatableProps<OptionType, IsMulti, GroupType>;
+export type Props<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = SelectProps<OptionType, IsMulti, GroupType> & CreatableProps<OptionType, IsMulti, GroupType>;
 
 export const defaultProps: Props<any, boolean>;
 

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -223,10 +223,11 @@ export interface State<OptionType extends OptionTypeBase> {
 
 export type ElRef = React.Ref<any>;
 
-export default class Select<OptionType extends OptionTypeBase, IsMulti extends boolean = false, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends React.Component<
-    Props<OptionType, IsMulti, GroupType>,
-    State<OptionType>
-> {
+export default class Select<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean = false,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends React.Component<Props<OptionType, IsMulti, GroupType>, State<OptionType>> {
     static defaultProps: Props<any>;
 
     // Misc. Instance Properties
@@ -390,7 +391,10 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
     // Menu Options
     // ==============================
 
-    buildMenuOptions(props: Props<OptionType, IsMulti, GroupType>, selectValue: OptionsType<OptionType>): MenuOptions<OptionType>;
+    buildMenuOptions(
+        props: Props<OptionType, IsMulti, GroupType>,
+        selectValue: OptionsType<OptionType>,
+    ): MenuOptions<OptionType>;
 
     // ==============================
     // Renderers

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -15,7 +15,7 @@ import {
     ActionTypes,
     FocusDirection,
     FocusEventHandler,
-    GroupType,
+    GroupTypeBase,
     InputActionMeta,
     KeyboardEventHandler,
     MenuPlacement,
@@ -38,7 +38,8 @@ export type SelectComponentsProps = { [key in string]: any };
 
 export interface NamedProps<
     OptionType extends OptionTypeBase = { label: string; value: string },
-    IsMulti extends boolean = false
+    IsMulti extends boolean = false,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
 > {
     /** Aria label (for assistive tech) */
     'aria-label'?: string;
@@ -80,7 +81,7 @@ export interface NamedProps<
      * instead. For a list of the components that can be passed in, and the shape
      * that will be passed to them, see [the components docs](/api#components)
      */
-    components?: SelectComponentsConfig<OptionType, IsMulti>;
+    components?: SelectComponentsConfig<OptionType, IsMulti, GroupType>;
     /** Whether the value of the select, e.g. SingleValue, should be displayed in the control. */
     controlShouldRenderValue?: boolean;
     /** Delimiter used to join multiple values into a single HTML Input value */
@@ -90,7 +91,7 @@ export interface NamedProps<
     /** Custom method to filter whether an option should be displayed in the menu */
     filterOption?: ((option: Option, rawInput: string) => boolean) | null;
     /** Formats group labels in the menu as React components */
-    formatGroupLabel?: formatGroupLabel<OptionType>;
+    formatGroupLabel?: formatGroupLabel<OptionType, GroupType>;
     /** Formats option labels in the menu and control as React components */
     formatOptionLabel?: (option: OptionType, labelMeta: FormatOptionLabelMeta<OptionType, IsMulti>) => React.ReactNode;
     /** Resolves option data to a string to be displayed as the label by components */
@@ -171,7 +172,7 @@ export interface NamedProps<
     /** Allows control of whether the menu is opened when the Select is clicked */
     openMenuOnClick?: boolean;
     /** Array of options that populate the select menu */
-    options?: GroupedOptionsType<OptionType> | OptionsType<OptionType>;
+    options?: GroupedOptionsType<OptionType, GroupType> | OptionsType<OptionType>;
     /** Number of options to jump in menu when page{up|down} keys are used */
     pageSize?: number;
     /** Placeholder text for the select value */
@@ -179,7 +180,7 @@ export interface NamedProps<
     /** Status to relay to screen readers */
     screenReaderStatus?: (obj: { count: number }) => string;
     /** Style modifier methods */
-    styles?: StylesConfig<OptionType, IsMulti>;
+    styles?: StylesConfig<OptionType, IsMulti, GroupType>;
     /** Theme modifier method */
     theme?: ThemeConfig;
     /** Sets the tabIndex attribute on the input */
@@ -196,8 +197,9 @@ export interface NamedProps<
 
 export interface Props<
     OptionType extends OptionTypeBase = { label: string; value: string },
-    IsMulti extends boolean = false
-> extends NamedProps<OptionType, IsMulti>,
+    IsMulti extends boolean = false,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends NamedProps<OptionType, IsMulti, GroupType>,
         SelectComponentsProps {}
 
 export const defaultProps: Props<any>;
@@ -221,8 +223,8 @@ export interface State<OptionType extends OptionTypeBase> {
 
 export type ElRef = React.Ref<any>;
 
-export default class Select<OptionType extends OptionTypeBase, IsMulti extends boolean = false> extends React.Component<
-    Props<OptionType, IsMulti>,
+export default class Select<OptionType extends OptionTypeBase, IsMulti extends boolean = false, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends React.Component<
+    Props<OptionType, IsMulti, GroupType>,
     State<OptionType>
 > {
     static defaultProps: Props<any>;
@@ -233,7 +235,7 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
     blockOptionHover: boolean;
     clearFocusValueOnUpdate: boolean;
     commonProps: any; // TODO
-    components: SelectComponents<OptionType, IsMulti>;
+    components: SelectComponents<OptionType, IsMulti, GroupType>;
     hasGroups: boolean;
     initialTouchX: number;
     initialTouchY: number;
@@ -258,7 +260,7 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
     // Lifecycle
     // ------------------------------
 
-    cacheComponents: (components: SelectComponents<OptionType, IsMulti>) => void;
+    cacheComponents: (components: SelectComponents<OptionType, IsMulti, GroupType>) => void;
 
     // ==============================
     // Consumer Handlers
@@ -307,7 +309,7 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
         selectProps: Readonly<{
             children?: React.ReactNode;
         }> &
-            Readonly<Props<OptionType>>;
+            Readonly<Props<OptionType, IsMulti, GroupType>>;
     };
 
     getNextFocusedValue(nextSelectValue: OptionsType<OptionType>): OptionType;
@@ -333,7 +335,7 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
     isOptionSelected(option: OptionType, selectValue: OptionsType<OptionType>): boolean;
     filterOption(option: {}, inputValue: string): boolean;
     formatOptionLabel(data: OptionType, context: FormatOptionLabelContext): React.ReactNode;
-    formatGroupLabel: formatGroupLabel<OptionType>;
+    formatGroupLabel: formatGroupLabel<OptionType, GroupType>;
 
     // ==============================
     // Mouse Handlers
@@ -388,7 +390,7 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
     // Menu Options
     // ==============================
 
-    buildMenuOptions(props: Props<OptionType>, selectValue: OptionsType<OptionType>): MenuOptions<OptionType>;
+    buildMenuOptions(props: Props<OptionType, IsMulti, GroupType>, selectValue: OptionsType<OptionType>): MenuOptions<OptionType>;
 
     // ==============================
     // Renderers
@@ -396,7 +398,7 @@ export default class Select<OptionType extends OptionTypeBase, IsMulti extends b
     constructAriaLiveMessage(): string;
 
     renderInput(): React.ReactNode;
-    renderPlaceholderOrValue(): PlaceholderOrValue<OptionType, IsMulti> | null;
+    renderPlaceholderOrValue(): PlaceholderOrValue<OptionType, IsMulti, GroupType> | null;
     renderClearIndicator(): React.ReactNode;
     renderLoadingIndicator(): React.ReactNode;
     renderIndicatorSeparator(): React.ReactNode;

--- a/types/react-select/src/animated/MultiValue.d.ts
+++ b/types/react-select/src/animated/MultiValue.d.ts
@@ -3,12 +3,18 @@ import { MultiValueProps } from '../components/MultiValue';
 import { Collapse, fn } from './transitions';
 import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type AnimatedMultiValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = {
+export type AnimatedMultiValueProps<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = {
     in?: boolean;
     onExited?: fn;
 } & MultiValueProps<OptionType, GroupType>;
 
-export function AnimatedMultiValue<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+export function AnimatedMultiValue<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(
     WrappedComponent: ComponentType<MultiValueProps<OptionType, GroupType>>,
 ): ComponentType<AnimatedMultiValueProps<OptionType, GroupType>>;
 

--- a/types/react-select/src/animated/MultiValue.d.ts
+++ b/types/react-select/src/animated/MultiValue.d.ts
@@ -1,15 +1,15 @@
 import { ComponentType } from 'react';
 import { MultiValueProps } from '../components/MultiValue';
 import { Collapse, fn } from './transitions';
-import { OptionTypeBase } from '../types';
+import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type AnimatedMultiValueProps<OptionType extends OptionTypeBase> = {
+export type AnimatedMultiValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = {
     in?: boolean;
     onExited?: fn;
-} & MultiValueProps<OptionType>;
+} & MultiValueProps<OptionType, GroupType>;
 
-export function AnimatedMultiValue<OptionType extends OptionTypeBase>(
-    WrappedComponent: ComponentType<MultiValueProps<OptionType>>,
-): ComponentType<AnimatedMultiValueProps<OptionType>>;
+export function AnimatedMultiValue<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    WrappedComponent: ComponentType<MultiValueProps<OptionType, GroupType>>,
+): ComponentType<AnimatedMultiValueProps<OptionType, GroupType>>;
 
 export default AnimatedMultiValue;

--- a/types/react-select/src/animated/Placeholder.d.ts
+++ b/types/react-select/src/animated/Placeholder.d.ts
@@ -1,15 +1,16 @@
 import { ComponentType } from 'react';
 import { PlaceholderProps } from '../components/Placeholder';
 import { Fade, collapseDuration } from './transitions';
-import { OptionTypeBase } from '../types';
+import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type AnimatedPlaceholderProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = PlaceholderProps<
+export type AnimatedPlaceholderProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = PlaceholderProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 >;
 
-export function AnimatedPlaceholder<OptionType extends OptionTypeBase, IsMulti extends boolean>(
-    WrappedComponent: ComponentType<PlaceholderProps<OptionType, IsMulti>>,
-): ComponentType<AnimatedPlaceholderProps<OptionType, IsMulti>>;
+export function AnimatedPlaceholder<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    WrappedComponent: ComponentType<PlaceholderProps<OptionType, IsMulti, GroupType>>,
+): ComponentType<AnimatedPlaceholderProps<OptionType, IsMulti, GroupType>>;
 
 export default AnimatedPlaceholder;

--- a/types/react-select/src/animated/Placeholder.d.ts
+++ b/types/react-select/src/animated/Placeholder.d.ts
@@ -3,13 +3,17 @@ import { PlaceholderProps } from '../components/Placeholder';
 import { Fade, collapseDuration } from './transitions';
 import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type AnimatedPlaceholderProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = PlaceholderProps<
-    OptionType,
-    IsMulti,
-    GroupType
->;
+export type AnimatedPlaceholderProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = PlaceholderProps<OptionType, IsMulti, GroupType>;
 
-export function AnimatedPlaceholder<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+export function AnimatedPlaceholder<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(
     WrappedComponent: ComponentType<PlaceholderProps<OptionType, IsMulti, GroupType>>,
 ): ComponentType<AnimatedPlaceholderProps<OptionType, IsMulti, GroupType>>;
 

--- a/types/react-select/src/animated/SingleValue.d.ts
+++ b/types/react-select/src/animated/SingleValue.d.ts
@@ -1,12 +1,12 @@
 import { ComponentType } from 'react';
 import { SingleValueProps } from '../components/SingleValue';
 import { Fade } from './transitions';
-import { OptionTypeBase } from '../types';
+import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type AnimatedSingleValueProps<OptionType extends OptionTypeBase> = SingleValueProps<OptionType>;
+export type AnimatedSingleValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = SingleValueProps<OptionType, GroupType>;
 
-export function AnimatedSingleValue<OptionType extends OptionTypeBase>(
-    WrappedComponent: ComponentType<SingleValueProps<OptionType>>,
-): ComponentType<AnimatedSingleValueProps<OptionType>>;
+export function AnimatedSingleValue<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    WrappedComponent: ComponentType<SingleValueProps<OptionType, GroupType>>,
+): ComponentType<AnimatedSingleValueProps<OptionType, GroupType>>;
 
 export default AnimatedSingleValue;

--- a/types/react-select/src/animated/SingleValue.d.ts
+++ b/types/react-select/src/animated/SingleValue.d.ts
@@ -3,9 +3,15 @@ import { SingleValueProps } from '../components/SingleValue';
 import { Fade } from './transitions';
 import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type AnimatedSingleValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = SingleValueProps<OptionType, GroupType>;
+export type AnimatedSingleValueProps<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = SingleValueProps<OptionType, GroupType>;
 
-export function AnimatedSingleValue<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+export function AnimatedSingleValue<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(
     WrappedComponent: ComponentType<SingleValueProps<OptionType, GroupType>>,
 ): ComponentType<AnimatedSingleValueProps<OptionType, GroupType>>;
 

--- a/types/react-select/src/animated/ValueContainer.d.ts
+++ b/types/react-select/src/animated/ValueContainer.d.ts
@@ -1,15 +1,16 @@
 import { ComponentType } from 'react';
 import { TransitionGroup } from 'react-transition-group';
 import { ValueContainerProps } from '../components/containers';
-import { OptionTypeBase } from '../types';
+import { GroupTypeBase, OptionTypeBase } from '../types';
 
 export type AnimatedValueContainerProps<
     OptionType extends OptionTypeBase,
-    IsMulti extends boolean
-> = ValueContainerProps<OptionType, IsMulti>;
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = ValueContainerProps<OptionType, IsMulti, GroupType>;
 
-export function AnimatedValueContainer<OptionType extends OptionTypeBase, IsMulti extends boolean>(
-    WrappedComponent: ComponentType<ValueContainerProps<OptionType, IsMulti>>,
-): ComponentType<AnimatedValueContainerProps<OptionType, IsMulti>>;
+export function AnimatedValueContainer<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    WrappedComponent: ComponentType<ValueContainerProps<OptionType, IsMulti, GroupType>>,
+): ComponentType<AnimatedValueContainerProps<OptionType, IsMulti, GroupType>>;
 
 export default AnimatedValueContainer;

--- a/types/react-select/src/animated/ValueContainer.d.ts
+++ b/types/react-select/src/animated/ValueContainer.d.ts
@@ -9,7 +9,11 @@ export type AnimatedValueContainerProps<
     GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
 > = ValueContainerProps<OptionType, IsMulti, GroupType>;
 
-export function AnimatedValueContainer<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+export function AnimatedValueContainer<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(
     WrappedComponent: ComponentType<ValueContainerProps<OptionType, IsMulti, GroupType>>,
 ): ComponentType<AnimatedValueContainerProps<OptionType, IsMulti, GroupType>>;
 

--- a/types/react-select/src/animated/index.d.ts
+++ b/types/react-select/src/animated/index.d.ts
@@ -7,7 +7,11 @@ import { default as AnimatedSingleValue, AnimatedSingleValueProps } from './Sing
 import { default as AnimatedValueContainer, AnimatedValueContainerProps } from './ValueContainer';
 import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export function makeAnimated<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+export function makeAnimated<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(
     externalComponents?: SelectComponentsConfig<OptionType, IsMulti, GroupType>,
 ): SelectComponents<OptionType, IsMulti, GroupType>;
 

--- a/types/react-select/src/animated/index.d.ts
+++ b/types/react-select/src/animated/index.d.ts
@@ -5,11 +5,11 @@ import { default as AnimatedMultiValue, AnimatedMultiValueProps } from './MultiV
 import { default as AnimatedPlaceholder, AnimatedPlaceholderProps } from './Placeholder';
 import { default as AnimatedSingleValue, AnimatedSingleValueProps } from './SingleValue';
 import { default as AnimatedValueContainer, AnimatedValueContainerProps } from './ValueContainer';
-import { OptionTypeBase } from '../types';
+import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export function makeAnimated<OptionType extends OptionTypeBase, IsMulti extends boolean>(
-    externalComponents?: SelectComponentsConfig<OptionType, IsMulti>,
-): SelectComponents<OptionType, IsMulti>;
+export function makeAnimated<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    externalComponents?: SelectComponentsConfig<OptionType, IsMulti, GroupType>,
+): SelectComponents<OptionType, IsMulti, GroupType>;
 
 export const Input: ComponentType<AnimatedInputProps>;
 export const MultiValue: ComponentType<AnimatedMultiValueProps<any>>;

--- a/types/react-select/src/builtins.d.ts
+++ b/types/react-select/src/builtins.d.ts
@@ -1,7 +1,10 @@
 import { ReactNode } from 'react';
 import { GroupTypeBase, OptionTypeBase } from './types';
 
-export type formatGroupLabel<OptionType extends OptionTypeBase = any, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = (group: GroupType) => ReactNode;
+export type formatGroupLabel<
+    OptionType extends OptionTypeBase = any,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = (group: GroupType) => ReactNode;
 export function formatGroupLabel(group: GroupTypeBase<any>): ReactNode;
 
 export type getOptionLabel<OptionType extends OptionTypeBase = any> = (option: OptionType) => string;

--- a/types/react-select/src/builtins.d.ts
+++ b/types/react-select/src/builtins.d.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
-import { GroupType, OptionTypeBase } from './types';
+import { GroupTypeBase, OptionTypeBase } from './types';
 
-export type formatGroupLabel<OptionType extends OptionTypeBase = any> = (group: GroupType<OptionType>) => ReactNode;
-export function formatGroupLabel(group: GroupType<any>): ReactNode;
+export type formatGroupLabel<OptionType extends OptionTypeBase = any, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = (group: GroupType) => ReactNode;
+export function formatGroupLabel(group: GroupTypeBase<any>): ReactNode;
 
 export type getOptionLabel<OptionType extends OptionTypeBase = any> = (option: OptionType) => string;
 export function getOptionLabel(option: any): string;

--- a/types/react-select/src/components/Control.d.ts
+++ b/types/react-select/src/components/Control.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType, ReactNode, Ref as ElementRef } from 'react';
 
 import { borderRadius, colors, spacing } from '../theme';
-import { CommonProps, OptionTypeBase, PropsWithStyles } from '../types';
+import { CommonProps, GroupTypeBase, OptionTypeBase, PropsWithStyles } from '../types';
 
 interface State {
     /** Whether the select is disabled. */
@@ -12,9 +12,10 @@ interface State {
     menuIsOpen: boolean;
 }
 
-export type ControlProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type ControlProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > &
     PropsWithStyles &
     State & {

--- a/types/react-select/src/components/Control.d.ts
+++ b/types/react-select/src/components/Control.d.ts
@@ -12,11 +12,11 @@ interface State {
     menuIsOpen: boolean;
 }
 
-export type ControlProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> &
+export type ControlProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> &
     PropsWithStyles &
     State & {
         /** Children to render. */

--- a/types/react-select/src/components/Group.d.ts
+++ b/types/react-select/src/components/Group.d.ts
@@ -1,7 +1,7 @@
 import { ReactNode, ComponentType } from 'react';
 
 import { spacing } from '../theme';
-import { CommonProps, OptionTypeBase } from '../types';
+import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
 interface ComponentProps {
     /** The children to be rendered. */
@@ -13,16 +13,17 @@ interface ComponentProps {
     /** Label to be displayed in the heading component. */
     label: ReactNode;
 }
-export type GroupProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<OptionType, IsMulti> &
+export type GroupProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, IsMulti, GroupType> &
     ComponentProps;
 
 export function groupCSS(): React.CSSProperties;
 
 export const Group: ComponentType<GroupProps<any, boolean>>;
 
-export type GroupHeadingProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type GroupHeadingProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > &
     Pick<ComponentProps, 'children'>;
 

--- a/types/react-select/src/components/Group.d.ts
+++ b/types/react-select/src/components/Group.d.ts
@@ -13,19 +13,21 @@ interface ComponentProps {
     /** Label to be displayed in the heading component. */
     label: ReactNode;
 }
-export type GroupProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, IsMulti, GroupType> &
-    ComponentProps;
+export type GroupProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & ComponentProps;
 
 export function groupCSS(): React.CSSProperties;
 
 export const Group: ComponentType<GroupProps<any, boolean>>;
 
-export type GroupHeadingProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> &
-    Pick<ComponentProps, 'children'>;
+export type GroupHeadingProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & Pick<ComponentProps, 'children'>;
 
 export function groupHeadingCSS(): React.CSSProperties;
 

--- a/types/react-select/src/components/Menu.d.ts
+++ b/types/react-select/src/components/Menu.d.ts
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 
 import { animatedScrollTo, getBoundingClientObj, RectType, getScrollParent, getScrollTop, scrollTo } from '../utils';
 import { borderRadius, colors, spacing } from '../theme';
-import { InnerRef, MenuPlacement, MenuPosition, CommonProps, OptionTypeBase } from '../types';
+import { InnerRef, MenuPlacement, MenuPosition, CommonProps, OptionTypeBase, GroupTypeBase } from '../types';
 
 // ==============================
 // Menu
@@ -30,7 +30,7 @@ export function getMenuPlacement(args: PlacementArgs): MenuState;
 // Menu Component
 // ------------------------------
 
-export type MenuProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<OptionType, IsMulti> & {
+export type MenuProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, IsMulti, GroupType> & {
     /** The children to be rendered. */
     children: ReactElement;
     /** Callback to update the portal after possible flip. */
@@ -53,15 +53,15 @@ export type MenuProps<OptionType extends OptionTypeBase, IsMulti extends boolean
 
 export function menuCSS(state: MenuState): React.CSSProperties;
 
-export class Menu<OptionType extends OptionTypeBase, IsMulti extends boolean> extends Component<
-    MenuProps<OptionType, IsMulti>,
+export class Menu<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<
+    MenuProps<OptionType, IsMulti, GroupType>,
     MenuState
 > {
     static contextTypes: {
         getPortalPlacement: (state: MenuState) => void;
     };
     getPlacement: (ref: ElementRef<any>) => void;
-    getState: () => MenuProps<OptionType, IsMulti> & MenuState;
+    getState: () => MenuProps<OptionType, IsMulti, GroupType> & MenuState;
 }
 
 export default Menu;
@@ -85,9 +85,10 @@ export interface MenuListProps {
 }
 
 // TODO: Remove this and merge it into `MenuListProps` so that naming pattern is adhered to.
-export type MenuListComponentProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type MenuListComponentProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > &
     MenuListProps &
     MenuListState;
@@ -102,9 +103,10 @@ export const MenuList: ComponentType<MenuListComponentProps<any, boolean>>;
 export function noOptionsMessageCSS(): React.CSSProperties;
 export function loadingMessageCSS(): React.CSSProperties;
 
-export type NoticeProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type NoticeProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > & {
     /** The children to be rendered. */
     children: ReactNode;
@@ -126,9 +128,10 @@ export const LoadingMessage: ComponentType<NoticeProps<any, boolean>>;
 // Menu Portal
 // ==============================
 
-export type MenuPortalProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type MenuPortalProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > & {
     appendTo: HTMLElement;
     children: ReactNode; // ideally Menu<MenuProps>
@@ -147,8 +150,8 @@ interface PortalStyleArgs {
 
 export function menuPortalCSS(args: PortalStyleArgs): React.CSSProperties;
 
-export class MenuPortal<OptionType extends OptionTypeBase, IsMulti extends boolean> extends Component<
-    MenuPortalProps<OptionType, IsMulti>,
+export class MenuPortal<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<
+    MenuPortalProps<OptionType, IsMulti, GroupType>,
     MenuPortalState
 > {
     static childContextTypes: {

--- a/types/react-select/src/components/Menu.d.ts
+++ b/types/react-select/src/components/Menu.d.ts
@@ -30,7 +30,11 @@ export function getMenuPlacement(args: PlacementArgs): MenuState;
 // Menu Component
 // ------------------------------
 
-export type MenuProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, IsMulti, GroupType> & {
+export type MenuProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & {
     /** The children to be rendered. */
     children: ReactElement;
     /** Callback to update the portal after possible flip. */
@@ -53,10 +57,11 @@ export type MenuProps<OptionType extends OptionTypeBase, IsMulti extends boolean
 
 export function menuCSS(state: MenuState): React.CSSProperties;
 
-export class Menu<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<
-    MenuProps<OptionType, IsMulti, GroupType>,
-    MenuState
-> {
+export class Menu<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends Component<MenuProps<OptionType, IsMulti, GroupType>, MenuState> {
     static contextTypes: {
         getPortalPlacement: (state: MenuState) => void;
     };
@@ -85,13 +90,11 @@ export interface MenuListProps {
 }
 
 // TODO: Remove this and merge it into `MenuListProps` so that naming pattern is adhered to.
-export type MenuListComponentProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> &
-    MenuListProps &
-    MenuListState;
+export type MenuListComponentProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & MenuListProps & MenuListState;
 
 export function menuListCSS(state: MenuState): React.CSSProperties;
 export const MenuList: ComponentType<MenuListComponentProps<any, boolean>>;
@@ -103,11 +106,11 @@ export const MenuList: ComponentType<MenuListComponentProps<any, boolean>>;
 export function noOptionsMessageCSS(): React.CSSProperties;
 export function loadingMessageCSS(): React.CSSProperties;
 
-export type NoticeProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> & {
+export type NoticeProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & {
     /** The children to be rendered. */
     children: ReactNode;
     /** Props to be passed on to the wrapper. */
@@ -128,11 +131,11 @@ export const LoadingMessage: ComponentType<NoticeProps<any, boolean>>;
 // Menu Portal
 // ==============================
 
-export type MenuPortalProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> & {
+export type MenuPortalProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & {
     appendTo: HTMLElement;
     children: ReactNode; // ideally Menu<MenuProps>
     controlElement: HTMLElement;
@@ -150,10 +153,11 @@ interface PortalStyleArgs {
 
 export function menuPortalCSS(args: PortalStyleArgs): React.CSSProperties;
 
-export class MenuPortal<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<
-    MenuPortalProps<OptionType, IsMulti, GroupType>,
-    MenuPortalState
-> {
+export class MenuPortal<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends Component<MenuPortalProps<OptionType, IsMulti, GroupType>, MenuPortalState> {
     static childContextTypes: {
         getPortalPlacement: (state: MenuState) => void;
     };

--- a/types/react-select/src/components/MultiValue.d.ts
+++ b/types/react-select/src/components/MultiValue.d.ts
@@ -3,7 +3,10 @@ import { ComponentType, Component, ReactNode } from 'react';
 import { borderRadius, colors, spacing } from '../theme';
 import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
-export type MultiValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, true, GroupType> & {
+export type MultiValueProps<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, true, GroupType> & {
     children: ReactNode;
     components: any;
     cropWithEllipsis: boolean;
@@ -32,7 +35,10 @@ export const MultiValueGeneric: ComponentType<MultiValueGenericProps<any>>;
 
 export const MultiValueContainer: typeof MultiValueGeneric;
 export const MultiValueLabel: typeof MultiValueGeneric;
-export type MultiValueRemoveProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, true, GroupType> & {
+export type MultiValueRemoveProps<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, true, GroupType> & {
     children: ReactNode;
     data: OptionType;
     innerProps: {
@@ -43,13 +49,19 @@ export type MultiValueRemoveProps<OptionType extends OptionTypeBase, GroupType e
     };
     selectProps: any;
 };
-export class MultiValueRemove<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<MultiValueRemoveProps<OptionType, GroupType>> {
+export class MultiValueRemove<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends Component<MultiValueRemoveProps<OptionType, GroupType>> {
     static defaultProps: {
         children: ReactNode;
     };
 }
 
-export class MultiValue<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<MultiValueProps<OptionType, GroupType>> {
+export class MultiValue<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends Component<MultiValueProps<OptionType, GroupType>> {
     static defaultProps: {
         cropWithEllipsis: boolean;
     };

--- a/types/react-select/src/components/MultiValue.d.ts
+++ b/types/react-select/src/components/MultiValue.d.ts
@@ -1,9 +1,9 @@
 import { ComponentType, Component, ReactNode } from 'react';
 
 import { borderRadius, colors, spacing } from '../theme';
-import { CommonProps, OptionTypeBase } from '../types';
+import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
-export type MultiValueProps<OptionType extends OptionTypeBase> = CommonProps<OptionType, true> & {
+export type MultiValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, true, GroupType> & {
     children: ReactNode;
     components: any;
     cropWithEllipsis: boolean;
@@ -32,7 +32,7 @@ export const MultiValueGeneric: ComponentType<MultiValueGenericProps<any>>;
 
 export const MultiValueContainer: typeof MultiValueGeneric;
 export const MultiValueLabel: typeof MultiValueGeneric;
-export type MultiValueRemoveProps<OptionType extends OptionTypeBase> = CommonProps<OptionType, true> & {
+export type MultiValueRemoveProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, true, GroupType> & {
     children: ReactNode;
     data: OptionType;
     innerProps: {
@@ -43,13 +43,13 @@ export type MultiValueRemoveProps<OptionType extends OptionTypeBase> = CommonPro
     };
     selectProps: any;
 };
-export class MultiValueRemove<OptionType extends OptionTypeBase> extends Component<MultiValueRemoveProps<OptionType>> {
+export class MultiValueRemove<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<MultiValueRemoveProps<OptionType, GroupType>> {
     static defaultProps: {
         children: ReactNode;
     };
 }
 
-export class MultiValue<OptionType extends OptionTypeBase> extends Component<MultiValueProps<OptionType>> {
+export class MultiValue<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> extends Component<MultiValueProps<OptionType, GroupType>> {
     static defaultProps: {
         cropWithEllipsis: boolean;
     };

--- a/types/react-select/src/components/Option.d.ts
+++ b/types/react-select/src/components/Option.d.ts
@@ -19,7 +19,11 @@ interface InnerProps {
     onMouseOver: MouseEventHandler<HTMLDivElement>;
     tabIndex: number;
 }
-export type OptionProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = PropsWithStyles &
+export type OptionProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = PropsWithStyles &
     CommonProps<OptionType, IsMulti, GroupType> &
     State & {
         /** The children to be rendered. */

--- a/types/react-select/src/components/Option.d.ts
+++ b/types/react-select/src/components/Option.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType, ReactNode, MouseEventHandler } from 'react';
 
 import { colors, spacing } from '../theme';
-import { CommonProps, PropsWithStyles, InnerRef, OptionTypeBase } from '../types';
+import { CommonProps, PropsWithStyles, InnerRef, OptionTypeBase, GroupTypeBase } from '../types';
 
 interface State {
     /** Whether the option is disabled. */
@@ -19,8 +19,8 @@ interface InnerProps {
     onMouseOver: MouseEventHandler<HTMLDivElement>;
     tabIndex: number;
 }
-export type OptionProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = PropsWithStyles &
-    CommonProps<OptionType, IsMulti> &
+export type OptionProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = PropsWithStyles &
+    CommonProps<OptionType, IsMulti, GroupType> &
     State & {
         /** The children to be rendered. */
         children: ReactNode;

--- a/types/react-select/src/components/Placeholder.d.ts
+++ b/types/react-select/src/components/Placeholder.d.ts
@@ -1,9 +1,9 @@
 import { ComponentType, CSSProperties, ReactNode } from 'react';
 
-import { CommonProps, OptionTypeBase } from '../types';
+import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
-export interface PlaceholderProps<OptionType extends OptionTypeBase, IsMulti extends boolean>
-    extends CommonProps<OptionType, IsMulti> {
+export interface PlaceholderProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>
+    extends CommonProps<OptionType, IsMulti, GroupType> {
     className?: string;
     /** The children to be rendered. */
     children: ReactNode;

--- a/types/react-select/src/components/Placeholder.d.ts
+++ b/types/react-select/src/components/Placeholder.d.ts
@@ -2,8 +2,11 @@ import { ComponentType, CSSProperties, ReactNode } from 'react';
 
 import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
-export interface PlaceholderProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>
-    extends CommonProps<OptionType, IsMulti, GroupType> {
+export interface PlaceholderProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> extends CommonProps<OptionType, IsMulti, GroupType> {
     className?: string;
     /** The children to be rendered. */
     children: ReactNode;

--- a/types/react-select/src/components/SingleValue.d.ts
+++ b/types/react-select/src/components/SingleValue.d.ts
@@ -1,6 +1,6 @@
 import { ComponentType, ReactNode } from 'react';
 import { colors, spacing } from '../theme';
-import { CommonProps, OptionTypeBase } from '../types';
+import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
 interface State {
     /** Whether this is disabled */
@@ -14,7 +14,7 @@ interface ValueProps<OptionType extends OptionTypeBase> {
     /** Props passed to the wrapping element for the group. */
     innerProps: any;
 }
-export type SingleValueProps<OptionType extends OptionTypeBase> = CommonProps<OptionType, false> &
+export type SingleValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, false, GroupType> &
     ValueProps<OptionType> &
     State;
 

--- a/types/react-select/src/components/SingleValue.d.ts
+++ b/types/react-select/src/components/SingleValue.d.ts
@@ -14,9 +14,10 @@ interface ValueProps<OptionType extends OptionTypeBase> {
     /** Props passed to the wrapping element for the group. */
     innerProps: any;
 }
-export type SingleValueProps<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<OptionType, false, GroupType> &
-    ValueProps<OptionType> &
-    State;
+export type SingleValueProps<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, false, GroupType> & ValueProps<OptionType> & State;
 
 export function css(props: SingleValueProps<any>): React.CSSProperties;
 

--- a/types/react-select/src/components/containers.d.ts
+++ b/types/react-select/src/components/containers.d.ts
@@ -1,6 +1,6 @@
 import { Component, ReactNode, ComponentType } from 'react';
 import { spacing } from '../theme';
-import { CommonProps, KeyboardEventHandler, OptionTypeBase } from '../types';
+import { CommonProps, GroupTypeBase, KeyboardEventHandler, OptionTypeBase } from '../types';
 
 // ==============================
 // Root Container
@@ -13,9 +13,10 @@ export interface ContainerState {
     isRtl: boolean;
 }
 
-export type ContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type ContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > &
     ContainerState & {
         /** The children to be rendered. */
@@ -30,9 +31,10 @@ export const SelectContainer: ComponentType<ContainerProps<any, boolean>>;
 // Value Container
 // ==============================
 
-export type ValueContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type ValueContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > & {
     /** Set when the value container should hold multiple values */
     isMulti: boolean;
@@ -55,9 +57,10 @@ export interface IndicatorsState {
     isDisabled: boolean;
 }
 
-export type IndicatorContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type IndicatorContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > &
     IndicatorsState & {
         /** The children to be rendered. */

--- a/types/react-select/src/components/containers.d.ts
+++ b/types/react-select/src/components/containers.d.ts
@@ -13,11 +13,11 @@ export interface ContainerState {
     isRtl: boolean;
 }
 
-export type ContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> &
+export type ContainerProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> &
     ContainerState & {
         /** The children to be rendered. */
         children: ReactNode;
@@ -31,11 +31,11 @@ export const SelectContainer: ComponentType<ContainerProps<any, boolean>>;
 // Value Container
 // ==============================
 
-export type ValueContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> & {
+export type ValueContainerProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & {
     /** Set when the value container should hold multiple values */
     isMulti: boolean;
     /** Whether the value container currently holds a value. */
@@ -57,11 +57,11 @@ export interface IndicatorsState {
     isDisabled: boolean;
 }
 
-export type IndicatorContainerProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> &
+export type IndicatorContainerProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> &
     IndicatorsState & {
         /** The children to be rendered. */
         children: ReactNode;

--- a/types/react-select/src/components/index.d.ts
+++ b/types/react-select/src/components/index.d.ts
@@ -37,16 +37,26 @@ import Placeholder, { PlaceholderProps } from './Placeholder';
 import SingleValue, { SingleValueProps } from './SingleValue';
 import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type PlaceholderOrValue<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> =
+export type PlaceholderOrValue<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> =
     | Element<ComponentType<PlaceholderProps<OptionType, IsMulti, GroupType>>>
     | Element<ComponentType<SingleValueProps<OptionType, GroupType>>>
     | Array<Element<ComponentType<MultiValueProps<OptionType, GroupType>>>>;
 
-export type IndicatorComponentType<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = ComponentType<
-    IndicatorProps<OptionType, IsMulti, GroupType>
->;
+export type IndicatorComponentType<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = ComponentType<IndicatorProps<OptionType, IsMulti, GroupType>>;
 
-export interface SelectComponents<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface SelectComponents<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     ClearIndicator: IndicatorComponentType<OptionType, IsMulti, GroupType> | null;
     Control: ComponentType<ControlProps<OptionType, IsMulti, GroupType>>;
     DropdownIndicator: IndicatorComponentType<OptionType, IsMulti, GroupType> | null;
@@ -74,9 +84,11 @@ export interface SelectComponents<OptionType extends OptionTypeBase, IsMulti ext
     ValueContainer: ComponentType<ValueContainerProps<OptionType, IsMulti, GroupType>>;
 }
 
-export type SelectComponentsConfig<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = Partial<
-    SelectComponents<OptionType, IsMulti, GroupType>
->;
+export type SelectComponentsConfig<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = Partial<SelectComponents<OptionType, IsMulti, GroupType>>;
 
 export type DeepNonNullable<T> = {
     [P in keyof T]-?: NonNullable<T[P]>;
@@ -84,10 +96,16 @@ export type DeepNonNullable<T> = {
 
 export const components: Required<DeepNonNullable<SelectComponents<any, boolean>>>;
 
-export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface Props<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     components: SelectComponentsConfig<OptionType, IsMulti, GroupType>;
 }
 
-export function defaultComponents<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
-    props: Props<OptionType, IsMulti, GroupType>,
-): SelectComponents<OptionType, IsMulti, GroupType>;
+export function defaultComponents<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(props: Props<OptionType, IsMulti, GroupType>): SelectComponents<OptionType, IsMulti, GroupType>;

--- a/types/react-select/src/components/index.d.ts
+++ b/types/react-select/src/components/index.d.ts
@@ -35,47 +35,47 @@ import MultiValue, { MultiValueProps, MultiValueContainer, MultiValueLabel, Mult
 import Option, { OptionProps } from './Option';
 import Placeholder, { PlaceholderProps } from './Placeholder';
 import SingleValue, { SingleValueProps } from './SingleValue';
-import { OptionTypeBase } from '../types';
+import { GroupTypeBase, OptionTypeBase } from '../types';
 
-export type PlaceholderOrValue<OptionType extends OptionTypeBase, IsMulti extends boolean> =
-    | Element<ComponentType<PlaceholderProps<OptionType, IsMulti>>>
-    | Element<ComponentType<SingleValueProps<OptionType>>>
-    | Array<Element<ComponentType<MultiValueProps<OptionType>>>>;
+export type PlaceholderOrValue<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> =
+    | Element<ComponentType<PlaceholderProps<OptionType, IsMulti, GroupType>>>
+    | Element<ComponentType<SingleValueProps<OptionType, GroupType>>>
+    | Array<Element<ComponentType<MultiValueProps<OptionType, GroupType>>>>;
 
-export type IndicatorComponentType<OptionType extends OptionTypeBase, IsMulti extends boolean> = ComponentType<
-    IndicatorProps<OptionType, IsMulti>
+export type IndicatorComponentType<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = ComponentType<
+    IndicatorProps<OptionType, IsMulti, GroupType>
 >;
 
-export interface SelectComponents<OptionType extends OptionTypeBase, IsMulti extends boolean> {
-    ClearIndicator: IndicatorComponentType<OptionType, IsMulti> | null;
-    Control: ComponentType<ControlProps<OptionType, IsMulti>>;
-    DropdownIndicator: IndicatorComponentType<OptionType, IsMulti> | null;
+export interface SelectComponents<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+    ClearIndicator: IndicatorComponentType<OptionType, IsMulti, GroupType> | null;
+    Control: ComponentType<ControlProps<OptionType, IsMulti, GroupType>>;
+    DropdownIndicator: IndicatorComponentType<OptionType, IsMulti, GroupType> | null;
     DownChevron: ComponentType<any>;
     CrossIcon: ComponentType<any>;
-    Group: ComponentType<GroupProps<OptionType, IsMulti>>;
+    Group: ComponentType<GroupProps<OptionType, IsMulti, GroupType>>;
     GroupHeading: ComponentType<any>;
-    IndicatorsContainer: ComponentType<IndicatorContainerProps<OptionType, IsMulti>>;
-    IndicatorSeparator: IndicatorComponentType<OptionType, IsMulti> | null;
+    IndicatorsContainer: ComponentType<IndicatorContainerProps<OptionType, IsMulti, GroupType>>;
+    IndicatorSeparator: IndicatorComponentType<OptionType, IsMulti, GroupType> | null;
     Input: ComponentType<InputProps>;
-    LoadingIndicator: ComponentType<LoadingIconProps<OptionType, IsMulti>> | null;
-    Menu: ComponentType<MenuProps<OptionType, IsMulti>>;
-    MenuList: ComponentType<MenuListComponentProps<OptionType, IsMulti>>;
-    MenuPortal: ComponentType<MenuPortalProps<OptionType, IsMulti>>;
-    LoadingMessage: ComponentType<NoticeProps<OptionType, IsMulti>>;
-    NoOptionsMessage: ComponentType<NoticeProps<OptionType, IsMulti>>;
-    MultiValue: ComponentType<MultiValueProps<OptionType>>;
+    LoadingIndicator: ComponentType<LoadingIconProps<OptionType, IsMulti, GroupType>> | null;
+    Menu: ComponentType<MenuProps<OptionType, IsMulti, GroupType>>;
+    MenuList: ComponentType<MenuListComponentProps<OptionType, IsMulti, GroupType>>;
+    MenuPortal: ComponentType<MenuPortalProps<OptionType, IsMulti, GroupType>>;
+    LoadingMessage: ComponentType<NoticeProps<OptionType, IsMulti, GroupType>>;
+    NoOptionsMessage: ComponentType<NoticeProps<OptionType, IsMulti, GroupType>>;
+    MultiValue: ComponentType<MultiValueProps<OptionType, GroupType>>;
     MultiValueContainer: ComponentType<any>;
     MultiValueLabel: ComponentType<any>;
     MultiValueRemove: ComponentType<any>;
-    Option: ComponentType<OptionProps<OptionType, IsMulti>>;
-    Placeholder: ComponentType<PlaceholderProps<OptionType, IsMulti>>;
-    SelectContainer: ComponentType<ContainerProps<OptionType, IsMulti>>;
-    SingleValue: ComponentType<SingleValueProps<OptionType>>;
-    ValueContainer: ComponentType<ValueContainerProps<OptionType, IsMulti>>;
+    Option: ComponentType<OptionProps<OptionType, IsMulti, GroupType>>;
+    Placeholder: ComponentType<PlaceholderProps<OptionType, IsMulti, GroupType>>;
+    SelectContainer: ComponentType<ContainerProps<OptionType, IsMulti, GroupType>>;
+    SingleValue: ComponentType<SingleValueProps<OptionType, GroupType>>;
+    ValueContainer: ComponentType<ValueContainerProps<OptionType, IsMulti, GroupType>>;
 }
 
-export type SelectComponentsConfig<OptionType extends OptionTypeBase, IsMulti extends boolean> = Partial<
-    SelectComponents<OptionType, IsMulti>
+export type SelectComponentsConfig<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = Partial<
+    SelectComponents<OptionType, IsMulti, GroupType>
 >;
 
 export type DeepNonNullable<T> = {
@@ -84,10 +84,10 @@ export type DeepNonNullable<T> = {
 
 export const components: Required<DeepNonNullable<SelectComponents<any, boolean>>>;
 
-export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean> {
-    components: SelectComponentsConfig<OptionType, IsMulti>;
+export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+    components: SelectComponentsConfig<OptionType, IsMulti, GroupType>;
 }
 
-export function defaultComponents<OptionType extends OptionTypeBase, IsMulti extends boolean>(
-    props: Props<OptionType, IsMulti>,
-): SelectComponents<OptionType, IsMulti>;
+export function defaultComponents<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    props: Props<OptionType, IsMulti, GroupType>,
+): SelectComponents<OptionType, IsMulti, GroupType>;

--- a/types/react-select/src/components/indicators.d.ts
+++ b/types/react-select/src/components/indicators.d.ts
@@ -14,11 +14,11 @@ export function DownChevron(props?: SVGProps<SVGElement>): ReactSVGElement;
 // Dropdown & Clear Buttons
 // ==============================
 
-export type IndicatorProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
-    OptionType,
-    IsMulti,
-    GroupType
-> & {
+export type IndicatorProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = CommonProps<OptionType, IsMulti, GroupType> & {
     /** The children to be rendered inside the indicator. */
     children: ElementType;
     /** Props that will be passed on to the children. */
@@ -58,7 +58,11 @@ export const IndicatorSeparator: ComponentType<IndicatorProps<any, boolean>>;
 export function loadingIndicatorCSS(state: { isFocused: boolean; size: number }): React.CSSProperties;
 
 /** @deprecated Use `LoadingIndicatorProps` instead. */
-export type LoadingIconProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = {
+export type LoadingIconProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = {
     /** Props that will be passed on to the children. */
     innerProps: any;
     /** The focused state of the select. */
@@ -70,7 +74,11 @@ export type LoadingIconProps<OptionType extends OptionTypeBase, IsMulti extends 
         size: number;
     };
 
-export type LoadingIndicatorProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = {
+export type LoadingIndicatorProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = {
     /** Props that will be passed on to the children. */
     innerProps: any;
     /** The focused state of the select. */

--- a/types/react-select/src/components/indicators.d.ts
+++ b/types/react-select/src/components/indicators.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType, ReactElement as ElementType, SVGProps, ReactSVGElement } from 'react';
 
 import { colors, spacing } from '../theme';
-import { CommonProps, OptionTypeBase } from '../types';
+import { CommonProps, GroupTypeBase, OptionTypeBase } from '../types';
 
 // ==============================
 // Dropdown & Clear Icons
@@ -14,9 +14,10 @@ export function DownChevron(props?: SVGProps<SVGElement>): ReactSVGElement;
 // Dropdown & Clear Buttons
 // ==============================
 
-export type IndicatorProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = CommonProps<
+export type IndicatorProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = CommonProps<
     OptionType,
-    IsMulti
+    IsMulti,
+    GroupType
 > & {
     /** The children to be rendered inside the indicator. */
     children: ElementType;
@@ -57,26 +58,26 @@ export const IndicatorSeparator: ComponentType<IndicatorProps<any, boolean>>;
 export function loadingIndicatorCSS(state: { isFocused: boolean; size: number }): React.CSSProperties;
 
 /** @deprecated Use `LoadingIndicatorProps` instead. */
-export type LoadingIconProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = {
+export type LoadingIconProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = {
     /** Props that will be passed on to the children. */
     innerProps: any;
     /** The focused state of the select. */
     isFocused: boolean;
     /** Whether the text is right to left */
     isRtl: boolean;
-} & CommonProps<OptionType, IsMulti> & {
+} & CommonProps<OptionType, IsMulti, GroupType> & {
         /** Set size of the container. */
         size: number;
     };
 
-export type LoadingIndicatorProps<OptionType extends OptionTypeBase, IsMulti extends boolean> = {
+export type LoadingIndicatorProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = {
     /** Props that will be passed on to the children. */
     innerProps: any;
     /** The focused state of the select. */
     isFocused: boolean;
     /** Whether the text is right to left */
     isRtl: boolean;
-} & CommonProps<OptionType, IsMulti> & {
+} & CommonProps<OptionType, IsMulti, GroupType> & {
         /** Set size of the container. */
         size: number;
     };

--- a/types/react-select/src/stateManager.d.ts
+++ b/types/react-select/src/stateManager.d.ts
@@ -1,7 +1,7 @@
 import { Component, ComponentType, Ref as ElementRef } from 'react';
 
 import SelectBase, { Props as SelectProps } from './Select';
-import { ActionMeta, InputActionMeta, OptionTypeBase, ValueType } from './types';
+import { ActionMeta, GroupTypeBase, InputActionMeta, OptionTypeBase, ValueType } from './types';
 
 export interface DefaultProps {
     defaultInputValue: string;
@@ -11,7 +11,7 @@ export interface DefaultProps {
 
 export const defaultProps: DefaultProps;
 
-export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean> {
+export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
     defaultInputValue?: string;
     defaultMenuIsOpen?: boolean;
     defaultValue?: IsMulti extends true ? ValueType<OptionType, boolean> : ValueType<OptionType, false>;
@@ -21,7 +21,7 @@ export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolea
     onChange?: (value: ValueType<OptionType, IsMulti>, actionMeta: ActionMeta<OptionType>) => void;
 }
 
-type StateProps<T extends SelectProps<any, boolean>> = Pick<
+type StateProps<T extends SelectProps<any, boolean, any>> = Pick<
     T,
     Exclude<
         keyof T,
@@ -40,9 +40,10 @@ type GetOptionType<T> = T extends SelectBase<infer OT> ? OT : never;
 export class StateManager<
     OptionType extends OptionTypeBase = { label: string; value: string },
     IsMulti extends boolean = false,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>,
     T extends SelectBase<OptionType, IsMulti> = SelectBase<OptionType, IsMulti>
 > extends Component<
-    StateProps<SelectProps<OptionType, IsMulti>> & Props<OptionType, IsMulti> & SelectProps<OptionType, IsMulti>,
+    StateProps<SelectProps<OptionType, IsMulti, GroupType>> & Props<OptionType, IsMulti, GroupType> & SelectProps<OptionType, IsMulti, GroupType>,
     State<OptionType, IsMulti>
 > {
     static defaultProps: DefaultProps;
@@ -61,6 +62,6 @@ export class StateManager<
 
 export function manageState<T extends SelectBase<any, boolean>>(
     SelectComponent: T,
-): StateManager<GetOptionType<T>, boolean, T>;
+): StateManager<GetOptionType<T>, boolean, GroupTypeBase<GetOptionType<T>>, T>;
 
 export default manageState;

--- a/types/react-select/src/stateManager.d.ts
+++ b/types/react-select/src/stateManager.d.ts
@@ -11,7 +11,11 @@ export interface DefaultProps {
 
 export const defaultProps: DefaultProps;
 
-export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface Props<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     defaultInputValue?: string;
     defaultMenuIsOpen?: boolean;
     defaultValue?: IsMulti extends true ? ValueType<OptionType, boolean> : ValueType<OptionType, false>;
@@ -43,7 +47,9 @@ export class StateManager<
     GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>,
     T extends SelectBase<OptionType, IsMulti> = SelectBase<OptionType, IsMulti>
 > extends Component<
-    StateProps<SelectProps<OptionType, IsMulti, GroupType>> & Props<OptionType, IsMulti, GroupType> & SelectProps<OptionType, IsMulti, GroupType>,
+    StateProps<SelectProps<OptionType, IsMulti, GroupType>> &
+        Props<OptionType, IsMulti, GroupType> &
+        SelectProps<OptionType, IsMulti, GroupType>,
     State<OptionType, IsMulti>
 > {
     static defaultProps: DefaultProps;

--- a/types/react-select/src/styles.d.ts
+++ b/types/react-select/src/styles.d.ts
@@ -19,14 +19,21 @@ export interface Props {
 /** @deprecated - Unused and will not be exported in next major version */
 export type StylesConfigFunction<Props = any> = (base: CSSProperties, props: Props) => CSSProperties;
 
-export interface Styles<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface Styles<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     clearIndicator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
     container?(base: CSSProperties, props: ContainerProps<OptionType, IsMulti, GroupType>): CSSProperties;
     control?(base: CSSProperties, props: ControlProps<OptionType, IsMulti, GroupType>): CSSProperties;
     dropdownIndicator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
     group?(base: CSSProperties, props: GroupProps<OptionType, IsMulti, GroupType>): CSSProperties;
     groupHeading?(base: CSSProperties, props: GroupHeadingProps<OptionType, IsMulti, GroupType>): CSSProperties;
-    indicatorsContainer?(base: CSSProperties, props: IndicatorContainerProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    indicatorsContainer?(
+        base: CSSProperties,
+        props: IndicatorContainerProps<OptionType, IsMulti, GroupType>,
+    ): CSSProperties;
     indicatorSeparator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
     input?: (base: CSSProperties, props: InputProps) => CSSProperties;
     loadingIndicator?(base: CSSProperties, props: LoadingIndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
@@ -44,9 +51,11 @@ export interface Styles<OptionType extends OptionTypeBase, IsMulti extends boole
     valueContainer?(base: CSSProperties, props: ValueContainerProps<OptionType, IsMulti, GroupType>): CSSProperties;
 }
 
-export type StylesConfig<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = Partial<
-    Styles<OptionType, IsMulti, GroupType>
->;
+export type StylesConfig<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = Partial<Styles<OptionType, IsMulti, GroupType>>;
 export type GetStyles = (a: string, b: Props) => CSSProperties;
 
 export const defaultStyles: Styles<any, false>;
@@ -54,7 +63,11 @@ export const defaultStyles: Styles<any, false>;
 /**
  * Merge Utility - Allows consumers to extend a base Select with additional styles
  */
-export function mergeStyles<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+export function mergeStyles<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+>(
     source: StylesConfig<OptionType, IsMulti, GroupType>,
     target: StylesConfig<OptionType, IsMulti, GroupType>,
 ): StylesConfig<OptionType, IsMulti, GroupType>;

--- a/types/react-select/src/styles.d.ts
+++ b/types/react-select/src/styles.d.ts
@@ -9,7 +9,7 @@ import { MenuProps, MenuListComponentProps, MenuPortalProps, NoticeProps } from 
 import { OptionProps } from './components/Option';
 import { PlaceholderProps } from './components/Placeholder';
 import { SingleValueProps } from './components/SingleValue';
-import { OptionTypeBase } from './types';
+import { GroupTypeBase, OptionTypeBase } from './types';
 
 /** @deprecated - Used internally, but will not be exported in next major version */
 export interface Props {
@@ -19,33 +19,33 @@ export interface Props {
 /** @deprecated - Unused and will not be exported in next major version */
 export type StylesConfigFunction<Props = any> = (base: CSSProperties, props: Props) => CSSProperties;
 
-export interface Styles<OptionType extends OptionTypeBase, IsMulti extends boolean> {
-    clearIndicator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti>): CSSProperties;
-    container?(base: CSSProperties, props: ContainerProps<OptionType, IsMulti>): CSSProperties;
-    control?(base: CSSProperties, props: ControlProps<OptionType, IsMulti>): CSSProperties;
-    dropdownIndicator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti>): CSSProperties;
-    group?(base: CSSProperties, props: GroupProps<OptionType, IsMulti>): CSSProperties;
-    groupHeading?(base: CSSProperties, props: GroupHeadingProps<OptionType, IsMulti>): CSSProperties;
-    indicatorsContainer?(base: CSSProperties, props: IndicatorContainerProps<OptionType, IsMulti>): CSSProperties;
-    indicatorSeparator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti>): CSSProperties;
+export interface Styles<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+    clearIndicator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    container?(base: CSSProperties, props: ContainerProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    control?(base: CSSProperties, props: ControlProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    dropdownIndicator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    group?(base: CSSProperties, props: GroupProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    groupHeading?(base: CSSProperties, props: GroupHeadingProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    indicatorsContainer?(base: CSSProperties, props: IndicatorContainerProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    indicatorSeparator?(base: CSSProperties, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
     input?: (base: CSSProperties, props: InputProps) => CSSProperties;
-    loadingIndicator?(base: CSSProperties, props: LoadingIndicatorProps<OptionType, IsMulti>): CSSProperties;
-    loadingMessage?(base: CSSProperties, props: NoticeProps<OptionType, IsMulti>): CSSProperties;
-    menu?(base: CSSProperties, props: MenuProps<OptionType, IsMulti>): CSSProperties;
-    menuList?(base: CSSProperties, props: MenuListComponentProps<OptionType, IsMulti>): CSSProperties;
-    menuPortal?(base: CSSProperties, props: MenuPortalProps<OptionType, IsMulti>): CSSProperties;
-    multiValue?(base: CSSProperties, props: MultiValueProps<OptionType>): CSSProperties;
-    multiValueLabel?(base: CSSProperties, props: MultiValueProps<OptionType>): CSSProperties;
-    multiValueRemove?(base: CSSProperties, props: MultiValueRemoveProps<OptionType>): CSSProperties;
-    noOptionsMessage?(base: CSSProperties, props: NoticeProps<OptionType, IsMulti>): CSSProperties;
-    option?(base: CSSProperties, props: OptionProps<OptionType, IsMulti>): CSSProperties;
-    placeholder?(base: CSSProperties, props: PlaceholderProps<OptionType, IsMulti>): CSSProperties;
-    singleValue?(base: CSSProperties, props: SingleValueProps<OptionType>): CSSProperties;
-    valueContainer?(base: CSSProperties, props: ValueContainerProps<OptionType, IsMulti>): CSSProperties;
+    loadingIndicator?(base: CSSProperties, props: LoadingIndicatorProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    loadingMessage?(base: CSSProperties, props: NoticeProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    menu?(base: CSSProperties, props: MenuProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    menuList?(base: CSSProperties, props: MenuListComponentProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    menuPortal?(base: CSSProperties, props: MenuPortalProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    multiValue?(base: CSSProperties, props: MultiValueProps<OptionType, GroupType>): CSSProperties;
+    multiValueLabel?(base: CSSProperties, props: MultiValueProps<OptionType, GroupType>): CSSProperties;
+    multiValueRemove?(base: CSSProperties, props: MultiValueRemoveProps<OptionType, GroupType>): CSSProperties;
+    noOptionsMessage?(base: CSSProperties, props: NoticeProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    option?(base: CSSProperties, props: OptionProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    placeholder?(base: CSSProperties, props: PlaceholderProps<OptionType, IsMulti, GroupType>): CSSProperties;
+    singleValue?(base: CSSProperties, props: SingleValueProps<OptionType, GroupType>): CSSProperties;
+    valueContainer?(base: CSSProperties, props: ValueContainerProps<OptionType, IsMulti, GroupType>): CSSProperties;
 }
 
-export type StylesConfig<OptionType extends OptionTypeBase, IsMulti extends boolean> = Partial<
-    Styles<OptionType, IsMulti>
+export type StylesConfig<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = Partial<
+    Styles<OptionType, IsMulti, GroupType>
 >;
 export type GetStyles = (a: string, b: Props) => CSSProperties;
 
@@ -54,7 +54,7 @@ export const defaultStyles: Styles<any, false>;
 /**
  * Merge Utility - Allows consumers to extend a base Select with additional styles
  */
-export function mergeStyles<OptionType extends OptionTypeBase, IsMulti extends boolean>(
-    source: StylesConfig<OptionType, IsMulti>,
-    target: StylesConfig<OptionType, IsMulti>,
-): StylesConfig<OptionType, IsMulti>;
+export function mergeStyles<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>>(
+    source: StylesConfig<OptionType, IsMulti, GroupType>,
+    target: StylesConfig<OptionType, IsMulti, GroupType>,
+): StylesConfig<OptionType, IsMulti, GroupType>;

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -12,7 +12,10 @@ export interface GroupTypeBase<OptionType extends OptionTypeBase> {
     [key: string]: any;
 }
 
-export type GroupedOptionsType<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = ReadonlyArray<GroupType>;
+export type GroupedOptionsType<
+    OptionType extends OptionTypeBase,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> = ReadonlyArray<GroupType>;
 
 export type ValueType<OptionType extends OptionTypeBase, IsMulti extends boolean> = IsMulti extends true
     ? OptionsType<OptionType>
@@ -41,7 +44,11 @@ export interface PropsWithStyles {
 export type ClassNameList = string[];
 export type ClassNamesState = { [key: string]: boolean } | undefined;
 
-export interface CommonProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
+export interface CommonProps<
+    OptionType extends OptionTypeBase,
+    IsMulti extends boolean,
+    GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
+> {
     clearValue: () => void;
     className?: string;
     cx: (state: ClassNamesState | undefined, className: string | undefined) => string;

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -7,12 +7,12 @@ export interface OptionTypeBase {
 
 export type OptionsType<OptionType extends OptionTypeBase> = ReadonlyArray<OptionType>;
 
-export interface GroupType<OptionType extends OptionTypeBase> {
+export interface GroupTypeBase<OptionType extends OptionTypeBase> {
     options: OptionsType<OptionType>;
     [key: string]: any;
 }
 
-export type GroupedOptionsType<OptionType extends OptionTypeBase> = ReadonlyArray<GroupType<OptionType>>;
+export type GroupedOptionsType<OptionType extends OptionTypeBase, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> = ReadonlyArray<GroupType>;
 
 export type ValueType<OptionType extends OptionTypeBase, IsMulti extends boolean> = IsMulti extends true
     ? OptionsType<OptionType>
@@ -41,7 +41,7 @@ export interface PropsWithStyles {
 export type ClassNameList = string[];
 export type ClassNamesState = { [key: string]: boolean } | undefined;
 
-export interface CommonProps<OptionType extends OptionTypeBase, IsMulti extends boolean> {
+export interface CommonProps<OptionType extends OptionTypeBase, IsMulti extends boolean, GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>> {
     clearValue: () => void;
     className?: string;
     cx: (state: ClassNamesState | undefined, className: string | undefined) => string;
@@ -56,7 +56,7 @@ export interface CommonProps<OptionType extends OptionTypeBase, IsMulti extends 
     isMulti: boolean;
     options: OptionsType<OptionType>;
     selectOption: (option: OptionType) => void;
-    selectProps: SelectProps<OptionType>;
+    selectProps: SelectProps<OptionType, IsMulti, GroupType>;
     setValue: (value: ValueType<OptionType, IsMulti>, action: ActionTypes) => void;
 }
 

--- a/types/react-select/test/data.ts
+++ b/types/react-select/test/data.ts
@@ -1,4 +1,4 @@
-import { GroupedOptionsType, GroupType } from 'react-select/src/types';
+import { GroupedOptionsType, GroupTypeBase } from 'react-select/src/types';
 
 export interface ColourOption {
     value: string;
@@ -119,13 +119,18 @@ export const optionLength = [
 //     bigOptions = bigOptions.concat(colourOptions);
 // }
 
-const colourGroup: GroupType<ColourOption> = {
-    label: 'Colours',
-    options: colourOptions,
-};
-const flavourGroup: GroupType<FlavourOption> = {
-    label: 'Flavours',
-    options: flavourOptions,
-};
+export interface GroupedOption {
+    label: string;
+    options: readonly ColourOption[] | readonly FlavourOption[];
+}
 
-export const groupedOptions: GroupedOptionsType<ColourOption | FlavourOption> = [colourGroup, flavourGroup];
+export const groupedOptions = [
+    {
+        label: 'Colours',
+        options: colourOptions,
+    },
+    {
+        label: 'Flavours',
+        options: flavourOptions,
+    },
+];

--- a/types/react-select/test/examples/BasicGrouped.tsx
+++ b/types/react-select/test/examples/BasicGrouped.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Select from 'react-select';
-import { ColourOption, colourOptions, FlavourOption, groupedOptions } from '../data';
+import { ColourOption, colourOptions, FlavourOption, GroupedOption, groupedOptions } from '../data';
 
 const groupStyles = {
     display: 'flex',
@@ -21,7 +21,7 @@ const groupBadgeStyles = {
     textAlign: 'center' as 'center',
 };
 
-const formatGroupLabel = (data: any) => (
+const formatGroupLabel = (data: GroupedOption) => (
     <div style={groupStyles}>
         <span>{data.label}</span>
         <span style={groupBadgeStyles}>{data.options.length}</span>
@@ -29,7 +29,7 @@ const formatGroupLabel = (data: any) => (
 );
 
 export default () => (
-    <Select<ColourOption | FlavourOption>
+    <Select<ColourOption | FlavourOption, false, GroupedOption>
         defaultValue={colourOptions[1]}
         options={groupedOptions}
         formatGroupLabel={formatGroupLabel}

--- a/types/react-select/v1/react-select-tests.tsx
+++ b/types/react-select/v1/react-select-tests.tsx
@@ -120,7 +120,7 @@ describe('react-select', () => {
         class Component extends React.PureComponent {
             private readonly selectRef = (component: ReactSelect) => {
                 component.focus();
-            };
+            }
 
             render() {
                 return <ReactSelect ref={this.selectRef} />;
@@ -134,7 +134,7 @@ describe('react-select', () => {
                 component.setValue({
                     value: 'value',
                 });
-            };
+            }
 
             render() {
                 return <ReactSelect ref={this.selectRef} />;
@@ -193,7 +193,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
-            };
+            }
 
             render() {
                 return <ReactSelect name="select" value="one" options={EXAMPLE_OPTIONS} />;
@@ -205,7 +205,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onValueClick: ReactSelectModule.OnValueClickHandler<number> = option => {
                 const optionValue: number = option.value;
-            };
+            }
 
             render() {
                 const options = [
@@ -222,7 +222,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onValueClick: ReactSelectModule.OnValueClickHandler<CustomValueType> = option => {
                 const optionValue: CustomValueType = option.value;
-            };
+            }
 
             render() {
                 return (
@@ -240,7 +240,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<CustomValueType> = option => {
                 const optionValue: CustomValueType = option.value;
-            };
+            }
 
             render() {
                 return (
@@ -258,7 +258,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
-            };
+            }
 
             private readonly menuRenderer: ReactSelectModule.MenuRendererHandler = props => {
                 const options = props.options.map(option => {
@@ -272,7 +272,7 @@ describe('Examples', () => {
                 });
 
                 return <div className="menu">{options}</div>;
-            };
+            }
 
             render() {
                 return (
@@ -299,7 +299,7 @@ describe('Examples', () => {
                 });
 
                 return <div className="menu">{options}</div>;
-            };
+            }
 
             render() {
                 return (
@@ -318,7 +318,7 @@ describe('Examples', () => {
         return class Component extends React.Component {
             private readonly menuRenderer: ReactSelectModule.MenuRendererHandler = props => {
                 return <div className="menu">defaultMenuRenderer(props)</div>;
-            };
+            }
 
             render() {
                 return <ReactSelect menuRenderer={this.menuRenderer} />;
@@ -347,11 +347,11 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
-            };
+            }
 
             private readonly inputRenderer: ReactSelectModule.InputRendererHandler = props => {
                 return <input {...props} />;
-            };
+            }
 
             render() {
                 return (

--- a/types/react-select/v1/react-select-tests.tsx
+++ b/types/react-select/v1/react-select-tests.tsx
@@ -120,7 +120,7 @@ describe('react-select', () => {
         class Component extends React.PureComponent {
             private readonly selectRef = (component: ReactSelect) => {
                 component.focus();
-            }
+            };
 
             render() {
                 return <ReactSelect ref={this.selectRef} />;
@@ -134,7 +134,7 @@ describe('react-select', () => {
                 component.setValue({
                     value: 'value',
                 });
-            }
+            };
 
             render() {
                 return <ReactSelect ref={this.selectRef} />;
@@ -193,7 +193,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
-            }
+            };
 
             render() {
                 return <ReactSelect name="select" value="one" options={EXAMPLE_OPTIONS} />;
@@ -205,7 +205,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onValueClick: ReactSelectModule.OnValueClickHandler<number> = option => {
                 const optionValue: number = option.value;
-            }
+            };
 
             render() {
                 const options = [
@@ -222,7 +222,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onValueClick: ReactSelectModule.OnValueClickHandler<CustomValueType> = option => {
                 const optionValue: CustomValueType = option.value;
-            }
+            };
 
             render() {
                 return (
@@ -240,7 +240,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<CustomValueType> = option => {
                 const optionValue: CustomValueType = option.value;
-            }
+            };
 
             render() {
                 return (
@@ -258,7 +258,7 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
-            }
+            };
 
             private readonly menuRenderer: ReactSelectModule.MenuRendererHandler = props => {
                 const options = props.options.map(option => {
@@ -272,7 +272,7 @@ describe('Examples', () => {
                 });
 
                 return <div className="menu">{options}</div>;
-            }
+            };
 
             render() {
                 return (
@@ -299,7 +299,7 @@ describe('Examples', () => {
                 });
 
                 return <div className="menu">{options}</div>;
-            }
+            };
 
             render() {
                 return (
@@ -318,7 +318,7 @@ describe('Examples', () => {
         return class Component extends React.Component {
             private readonly menuRenderer: ReactSelectModule.MenuRendererHandler = props => {
                 return <div className="menu">defaultMenuRenderer(props)</div>;
-            }
+            };
 
             render() {
                 return <ReactSelect menuRenderer={this.menuRenderer} />;
@@ -347,11 +347,11 @@ describe('Examples', () => {
         class Component extends React.Component {
             private readonly onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
-            }
+            };
 
             private readonly inputRenderer: ReactSelectModule.InputRendererHandler = props => {
                 return <input {...props} />;
-            }
+            };
 
             render() {
                 return (


### PR DESCRIPTION
This PR makes it possible to generically define a group which is necessary when defining `formatGroupLabel` (see [this example](https://github.com/JedWatson/react-select/blob/master/docs/examples/BasicGrouped.js)). This should be a minimal breaking change since we're defaulting the generic.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/master/docs/examples/BasicGrouped.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
