### PR TITLE
Improve jest types to not rely on user-specified types

### DIFF
--- a/types/jest-in-case/jest-in-case-tests.ts
+++ b/types/jest-in-case/jest-in-case-tests.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 test('array', () => {
     const title = 'add(augend, addend)';
 
-    const tester = jest.fn((opts, cb) => {
+    const tester = jest.fn((opts) => {
         expect(add(opts.augend, opts.addend)).toBe(opts.total);
     });
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -984,7 +984,7 @@ declare namespace jest {
          * expect(desiredHouse).toMatchObject<House>(...standardHouse, kitchen: {area: 20}) // wherein standardHouse is some base object of type House
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toMatchObject<E extends T | any[]>(expected: E): R;
+        toMatchObject<E extends {} | any[]>(expected: E): R;
         /**
          * This ensures that a value matches the most recent snapshot with property matchers.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1032,7 +1032,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toStrictEqual(expected: T): R;
+        toStrictEqual<E extends T>(expected: E): R;
         /**
          * Used to test that a function throws when it is called.
          */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -867,8 +867,26 @@ describe('', () => {
 
         // $ExpectError
         expect(jest.fn()).toBeCalledWith<[string, number]>(1, 'two');
+        const fn: (s: string, n: number) => any = jest.fn();
+        // $ExpectError
+        expect(fn).toBeCalledWith(1, 'two');
         // $ExpectError
         expect({}).toEqual<{ p1: string, p2: number }>({ p1: 'hello' });
+        // $ExpectError
+        expect({p1: 'string', p2: 3}).toEqual({ p1: 'hello' });
+        expect({}).toEqual({ p1: 'hello' });
+        // $ExpectError
+        expect({foo: 3}).toEqual({ p1: 'hello' });
+        // $ExpectError
+        expect('').toEqual(3);
+        expect<string | number>('').toEqual(3);
+
+        expect(Promise.resolve(3)).resolves.toEqual(5);
+        // $ExpectError
+        expect(Promise.resolve(3)).resolves.toEqual('5');
+        // $ExpectError
+        expect(Promise.resolve(3)).toEqual(5);
+        expect(3).resolves.toEqual(5);
 
         expect(0).toBeCloseTo(1);
         expect(0).toBeCloseTo(1, 2);
@@ -903,12 +921,12 @@ describe('', () => {
         expect(NaN).toBeNaN();
         expect(Infinity).toBeNaN();
 
-        expect([]).toContain({});
+        expect([{}]).toContain({});
         expect(['abc']).toContain('abc');
         expect(['abc']).toContain('def');
         expect('abc').toContain('bc');
 
-        expect([]).toContainEqual({});
+        expect([{}]).toContainEqual({});
         expect(['abc']).toContainEqual('def');
 
         expect([]).toEqual([]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
The types were not strong enough (asking users to type instead of using the types that are derived from the "expect" function call
