### PR TITLE
Update aframe for r125 of three.js

### DIFF
--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -11,6 +11,7 @@
  */
 
 import * as three from 'three';
+import * as threeDeprecated from 'three/examples/jsm/deprecated/Geometry';
 import * as tween from '@tweenjs/tween.js';
 
 export type ThreeLib = typeof three;
@@ -201,7 +202,7 @@ export interface EntityEventMap {
 export interface Geometry<T = any> {
     data: T;
     name: string;
-    geometry: THREE.Geometry;
+    geometry: threeDeprecated.Geometry;
     schema: Schema<any>;
 
     init(data: any): void;

--- a/types/aframe/test/aframe-io-tests.ts
+++ b/types/aframe/test/aframe-io-tests.ts
@@ -465,7 +465,6 @@ AFRAME.registerComponent('audioanalyser-waveform', {
         // Create ring geometries.
         loopShape = new THREE.Shape();
         loopShape.absarc(0, 0, data.radius, 0, Math.PI * 2, false);
-        this.geometry = loopShape.createPointsGeometry(SEGMENTS / 2);
         this.geometry.dynamic = true;
 
         // Create container object.

--- a/types/aframe/test/aframe-tests.ts
+++ b/types/aframe/test/aframe-tests.ts
@@ -9,6 +9,7 @@ import {
     registerComponent,
     Scene
 } from 'aframe';
+import * as threeDeprecated from 'three/examples/jsm/deprecated/Geometry';
 
 // Global
 const threeCamera = new AFRAME.THREE.Camera();
@@ -122,7 +123,7 @@ AFRAME.registerGeometry('a-test-geometry', {
         groupIndex: { default: 0 }
     },
     init(data) {
-        this.geometry = new THREE.Geometry();
+        this.geometry = new threeDeprecated.Geometry();
         const temp = data.groupIndex;
         temp;
     }


### PR DESCRIPTION
three.js' r125 release deprecates support for `Geometry`. See discussion at https://discourse.threejs.org/t/three-geometry-will-be-removed-from-core-with-r125/22401/5

I just moved the references to the deprecated location, since I don't actually know anything about aframe. And `createPointsGeometry` seems to be gone entirely so I just deleted it. Probably the right long-term solution is to switch to one of the newer *-Geometry types.