### PR TITLE
[mailparser] Fix type of ParsedMail.references

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -213,11 +213,11 @@ export interface ParsedMail {
      */
     subject?: string;
     /**
-     * An array of referenced Message-ID values.
+     * Either an array of two or more referenced Message-ID values or a single Message-ID value.
      *
      * Not set if no reference values present.
      */
-    references?: string[];
+    references?: string[] | string;
     /**
      * A Date object for the `Date:` header.
      */

--- a/types/mailparser/mailparser-tests.ts
+++ b/types/mailparser/mailparser-tests.ts
@@ -56,4 +56,8 @@ simpleParser(sourceString, (err, mail) => {
     console.log(mail.text);
     console.log(mail.html);
     console.log(mail.textAsHtml);
+
+    // References are either arrays or strings
+    if (mail.references && !Array.isArray(mail.references))
+        mail.references.toLowerCase();
 });


### PR DESCRIPTION
Mailparser will return a string (as opposed to an array) where the
'references' header of a parsed mail is a single value:

See the 'array unwrapping' logic in the original mailparser source:
https://github.com/nodemailer/mailparser/blob/a80fcbf62c7433069319df1ef4c58a798a38049c/lib/mail-parser.js#L410-L412

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/mailparser/blob/a80fcbf62c7433069319df1ef4c58a798a38049c/lib/mail-parser.js#L410-L412
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. Not applicable: this behavior has been in the source code for mail-parser for 4 years.
