### PR TITLE
[react-select] Make ActionMeta a type union to allow for type narrowing

### DIFF
--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -23,6 +23,7 @@ import {
     ValueType,
     GroupedOptionsType,
     OptionTypeBase,
+    SetValueActionType,
 } from './types';
 
 export type MouseOrTouchEvent = React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>;
@@ -285,11 +286,7 @@ export default class Select<
     focusValue(direction: 'previous' | 'next'): void;
 
     focusOption(direction: FocusDirection): void;
-    setValue: (
-        newValue: ValueType<OptionType, IsMulti>,
-        action: 'select-option' | 'deselect-option',
-        option?: OptionType,
-    ) => void;
+    setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueActionType, option?: OptionType) => void;
     selectOption: (newValue: OptionType) => void;
     removeValue: (removedValue: OptionType) => void;
     clearValue: () => void;
@@ -309,11 +306,7 @@ export default class Select<
         isRtl: boolean;
         options: OptionsType<any>;
         selectOption: (newValue: OptionType) => void;
-        setValue: (
-            newValue: ValueType<OptionType, IsMulti>,
-            action: 'select-option' | 'deselect-option',
-            option?: OptionType,
-        ) => void;
+        setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueActionType, option?: OptionType) => void;
         selectProps: Readonly<{
             children?: React.ReactNode;
         }> &

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -12,7 +12,6 @@ import { StylesConfig } from './styles';
 import { ThemeConfig } from './theme';
 import {
     ActionMeta,
-    ActionTypes,
     FocusDirection,
     FocusEventHandler,
     GroupTypeBase,
@@ -286,7 +285,11 @@ export default class Select<
     focusValue(direction: 'previous' | 'next'): void;
 
     focusOption(direction: FocusDirection): void;
-    setValue: (newValue: ValueType<OptionType, IsMulti>, action: ActionTypes, option?: OptionType) => void;
+    setValue: (
+        newValue: ValueType<OptionType, IsMulti>,
+        action: 'select-option' | 'deselect-option',
+        option?: OptionType,
+    ) => void;
     selectOption: (newValue: OptionType) => void;
     removeValue: (removedValue: OptionType) => void;
     clearValue: () => void;
@@ -306,7 +309,11 @@ export default class Select<
         isRtl: boolean;
         options: OptionsType<any>;
         selectOption: (newValue: OptionType) => void;
-        setValue: (newValue: ValueType<OptionType, IsMulti>, action: ActionTypes, option?: OptionType) => void;
+        setValue: (
+            newValue: ValueType<OptionType, IsMulti>,
+            action: 'select-option' | 'deselect-option',
+            option?: OptionType,
+        ) => void;
         selectProps: Readonly<{
             children?: React.ReactNode;
         }> &

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -23,7 +23,7 @@ import {
     ValueType,
     GroupedOptionsType,
     OptionTypeBase,
-    SetValueActionType,
+    SetValueAction,
 } from './types';
 
 export type MouseOrTouchEvent = React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>;
@@ -286,7 +286,7 @@ export default class Select<
     focusValue(direction: 'previous' | 'next'): void;
 
     focusOption(direction: FocusDirection): void;
-    setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueActionType, option?: OptionType) => void;
+    setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueAction, option?: OptionType) => void;
     selectOption: (newValue: OptionType) => void;
     removeValue: (removedValue: OptionType) => void;
     clearValue: () => void;
@@ -306,7 +306,7 @@ export default class Select<
         isRtl: boolean;
         options: OptionsType<any>;
         selectOption: (newValue: OptionType) => void;
-        setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueActionType, option?: OptionType) => void;
+        setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueAction, option?: OptionType) => void;
         selectProps: Readonly<{
             children?: React.ReactNode;
         }> &

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -109,8 +109,8 @@ export type ActionMeta<OptionType extends OptionTypeBase> =
     | ClearActionMeta
     | CreateOptionActionMeta;
 
-export type ActionType = ActionMeta<OptionTypeBase>['action'];
-export type SetValueActionType = 'select-option' | 'deselect-option';
+export type Action = ActionMeta<OptionTypeBase>['action'];
+export type SetValueAction = 'select-option' | 'deselect-option';
 
 export type InputActionTypes = 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
 

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -64,24 +64,54 @@ export interface CommonProps<
     options: OptionsType<OptionType>;
     selectOption: (option: OptionType) => void;
     selectProps: SelectProps<OptionType, IsMulti, GroupType>;
-    setValue: (value: ValueType<OptionType, IsMulti>, action: ActionTypes) => void;
+    setValue: (
+        newValue: ValueType<OptionType, IsMulti>,
+        action: 'select-option' | 'deselect-option',
+        option: OptionType,
+    ) => void;
 }
 
-export type ActionTypes =
-    | 'select-option'
-    | 'deselect-option'
-    | 'remove-value'
-    | 'pop-value'
-    | 'set-value'
-    | 'clear'
-    | 'create-option';
-
-export interface ActionMeta<OptionType extends OptionTypeBase> {
-    action: ActionTypes;
+export interface SelectOptionActionMeta<OptionType extends OptionTypeBase> {
+    action: 'select-option';
+    option: OptionType;
     name?: string;
-    option?: OptionType;
-    removedValue?: OptionType;
 }
+
+export interface DeselectOptionActionMeta<OptionType extends OptionTypeBase> {
+    action: 'deselect-option';
+    option: OptionType;
+    name?: string;
+}
+
+export interface RemoveValueActionMeta<OptionType extends OptionTypeBase> {
+    action: 'remove-value';
+    removedValue: OptionType;
+    name?: string;
+}
+
+export interface PopValueActionMeta<OptionType extends OptionTypeBase> {
+    action: 'pop-value';
+    removedValue: OptionType;
+    name?: string;
+}
+
+export interface ClearActionMeta {
+    action: 'clear';
+    name?: string;
+}
+
+export interface CreateOptionActionMeta {
+    action: 'create-option';
+    name?: string;
+}
+
+export type ActionMeta<OptionType extends OptionTypeBase> =
+    | SelectOptionActionMeta<OptionType>
+    | DeselectOptionActionMeta<OptionType>
+    | RemoveValueActionMeta<OptionType>
+    | PopValueActionMeta<OptionType>
+    | ClearActionMeta
+    | CreateOptionActionMeta;
 
 export type InputActionTypes = 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
 

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -64,7 +64,7 @@ export interface CommonProps<
     options: OptionsType<OptionType>;
     selectOption: (option: OptionType) => void;
     selectProps: SelectProps<OptionType, IsMulti, GroupType>;
-    setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueActionType, option: OptionType) => void;
+    setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueAction, option: OptionType) => void;
 }
 
 export interface SelectOptionActionMeta<OptionType extends OptionTypeBase> {

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -64,11 +64,7 @@ export interface CommonProps<
     options: OptionsType<OptionType>;
     selectOption: (option: OptionType) => void;
     selectProps: SelectProps<OptionType, IsMulti, GroupType>;
-    setValue: (
-        newValue: ValueType<OptionType, IsMulti>,
-        action: 'select-option' | 'deselect-option',
-        option: OptionType,
-    ) => void;
+    setValue: (newValue: ValueType<OptionType, IsMulti>, action: SetValueActionType, option: OptionType) => void;
 }
 
 export interface SelectOptionActionMeta<OptionType extends OptionTypeBase> {
@@ -112,6 +108,9 @@ export type ActionMeta<OptionType extends OptionTypeBase> =
     | PopValueActionMeta<OptionType>
     | ClearActionMeta
     | CreateOptionActionMeta;
+
+export type ActionType = ActionMeta<OptionTypeBase>['action'];
+export type SetValueActionType = 'select-option' | 'deselect-option';
 
 export type InputActionTypes = 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
 

--- a/types/react-select/test/data.ts
+++ b/types/react-select/test/data.ts
@@ -4,14 +4,15 @@ export interface ColourOption {
     value: string;
     label: string;
     color: string;
-    disabled?: boolean;
+    isFixed?: boolean;
+    isDisabled?: boolean;
 }
 
-export const colourOptions: ReadonlyArray<ColourOption> = [
-    { value: 'ocean', label: 'Ocean', color: '#00B8D9' },
-    { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
+export const colourOptions: readonly ColourOption[] = [
+    { value: 'ocean', label: 'Ocean', color: '#00B8D9', isFixed: true },
+    { value: 'blue', label: 'Blue', color: '#0052CC', isDisabled: true },
     { value: 'purple', label: 'Purple', color: '#5243AA' },
-    { value: 'red', label: 'Red', color: '#FF5630' },
+    { value: 'red', label: 'Red', color: '#FF5630', isFixed: true },
     { value: 'orange', label: 'Orange', color: '#FF8B00' },
     { value: 'yellow', label: 'Yellow', color: '#FFC400' },
     { value: 'green', label: 'Green', color: '#36B37E' },

--- a/types/react-select/test/examples/FixedOptions.tsx
+++ b/types/react-select/test/examples/FixedOptions.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import Select, { ActionMeta, StylesConfig, ValueType } from 'react-select';
+import { ColourOption, colourOptions } from '../data';
+
+interface State {
+    readonly value: readonly ColourOption[];
+}
+
+const styles: StylesConfig<ColourOption, true> = {
+    multiValue: (base, state) => {
+        return state.data.isFixed ? { ...base, backgroundColor: 'gray' } : base;
+    },
+    multiValueLabel: (base, state) => {
+        return state.data.isFixed ? { ...base, fontWeight: 'bold', color: 'white', paddingRight: 6 } : base;
+    },
+    multiValueRemove: (base, state) => {
+        return state.data.isFixed ? { ...base, display: 'none' } : base;
+    },
+};
+
+const orderOptions = (values: readonly ColourOption[]) => {
+    return values.filter(v => v.isFixed).concat(values.filter(v => !v.isFixed));
+};
+
+export default class FixedOptions extends React.Component<{}, State> {
+    state = {
+        value: orderOptions([colourOptions[0], colourOptions[1], colourOptions[3]]),
+    };
+
+    constructor(props: {}) {
+        super(props);
+
+        this.onChange = this.onChange.bind(this);
+    }
+
+    onChange(value: ValueType<ColourOption, true>, actionMeta: ActionMeta<ColourOption>) {
+        switch (actionMeta.action) {
+            case 'remove-value':
+            case 'pop-value':
+                if (actionMeta.removedValue.isFixed) {
+                    return;
+                }
+                break;
+            case 'clear':
+                value = colourOptions.filter(v => v.isFixed);
+                break;
+        }
+
+        value = orderOptions(value);
+        this.setState({ value });
+    }
+
+    render() {
+        return (
+            <Select
+                value={this.state.value}
+                isMulti
+                styles={styles}
+                isClearable={this.state.value.some(v => !v.isFixed)}
+                name="colors"
+                className="basic-multi-select"
+                classNamePrefix="select"
+                onChange={this.onChange}
+                options={colourOptions}
+            />
+        );
+    }
+}

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -71,6 +71,7 @@
         "test/examples/CustomSingleValue.tsx",
         "test/examples/CustomValueContainer.tsx",
         "test/examples/Experimental.tsx",
+        "test/examples/FixedOptions.tsx",
         "test/examples/MenuPortal.tsx",
         "test/examples/OnMenuOpen.tsx",
         "test/examples/OnSelectResetsInput.tsx",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/c3faa4031d56918a1c9da9ebc3e687446ddcfa7a/docs/examples/FixedOptions.tsx#L44-L49
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
