### PR TITLE
[node] - Add query type to URL

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -334,7 +334,7 @@ declare module "http" {
          * Only valid for request obtained from http.Server.
          */
         url?: string;
-        query?: {[key: string]: any}
+        query?: {[key: string]: unknown}
         /**
          * Only valid for response obtained from http.ClientRequest.
          */

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -334,6 +334,7 @@ declare module "http" {
          * Only valid for request obtained from http.Server.
          */
         url?: string;
+        query?: {[key: string]: any}
         /**
          * Only valid for response obtained from http.ClientRequest.
          */


### PR DESCRIPTION
I'm using query property but getting an error telling me it doesn't exist.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http.html#http_class_http_incomingmessage
