### PR TITLE
[@styled-system/css] Support vendor-prefixed CSS properties

### DIFF
--- a/types/styled-system__css/index.d.ts
+++ b/types/styled-system__css/index.d.ts
@@ -28,10 +28,10 @@ export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type ResponsiveStyleValue<T> = T | Array<T | null>;
 
 /**
- * All non-vendor-prefixed CSS properties. (Allow `number` to support CSS-in-JS libs,
+ * All CSS properties. (Allow `number` to support CSS-in-JS libs,
  * since they are converted to pixels)
  */
-export interface CSSProperties extends CSS.StandardProperties<number | string>, CSS.SvgProperties<number | string> {}
+export interface CSSProperties extends CSS.StandardProperties<number | string>, CSS.SvgProperties<number | string>, CSS.VendorProperties<number | string> {}
 
 /**
  * Map of all CSS pseudo selectors (`:hover`, `:focus`, ...)

--- a/types/styled-system__css/styled-system__css-tests.ts
+++ b/types/styled-system__css/styled-system__css-tests.ts
@@ -261,4 +261,9 @@ css({
     },
 });
 
+// handles vendor-prefixed css properties
+css({
+    WebkitTouchCallout: 'none'
+});
+
 const result: CssFunctionReturnType = css({});


### PR DESCRIPTION
This PR updates the `@styled-system/css` type definition to support vendor-prefixed CSS properties.

### Before
```js
css({
    WebkitTouchCallout: 'none' // ERROR: Type 'string' is not assignable to type 'SystemStyleObject'.
});
```

### After
```js
css({
    WebkitTouchCallout: 'none' // OK
});
```

cc @jclem

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
