### PR TITLE
Fix missing `addDefaultLocale` for `javascript-time-ago`

### DIFF
--- a/types/javascript-time-ago/index.d.ts
+++ b/types/javascript-time-ago/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Erik Burton  <https://github.com/erikburt>
 //                 Henry Nguyen <https://github.com/HenryNguyen5>
 //                 Luis Felipe Zaguini <https://github.com/zaguiini>
+//                 Randy Merrill <https://github.com/Zoramite>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import {
     DefaultFormats,
@@ -27,6 +28,7 @@ declare class TimeAgo {
     getRule(value: Date | number, unit: TimeUnit, localeData: Duration): string;
 
     static addLocale(localeData: Locale): void;
+    static addDefaultLocale(localeData: Locale): void;
     static locale(localeData: Locale): void;
     static getDefaultLocale(): string;
     static intlDateTimeFormatSupported(): boolean;

--- a/types/javascript-time-ago/index.d.ts
+++ b/types/javascript-time-ago/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Erik Burton  <https://github.com/erikburt>
 //                 Henry Nguyen <https://github.com/HenryNguyen5>
 //                 Luis Felipe Zaguini <https://github.com/zaguiini>
-//                 Randy Merrill <https://github.com/Zoramite>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import {
     DefaultFormats,

--- a/types/javascript-time-ago/javascript-time-ago-tests.ts
+++ b/types/javascript-time-ago/javascript-time-ago-tests.ts
@@ -7,6 +7,7 @@ import zhHansHK from "javascript-time-ago/locale/zh-Hant-HK";
 TimeAgo.locale(en);
 TimeAgo.addLocale(to);
 TimeAgo.addLocale(zhHansHK);
+TimeAgo.addDefaultLocale(en);
 
 TimeAgo.intlDateTimeFormatSupportedLocale("en");
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/catamphetamine/javascript-time-ago#use
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.