### PR TITLE
[spotify-api] Add correct typings for PagingObject and CursorPagingObject

### DIFF
--- a/types/spotify-api/index.d.ts
+++ b/types/spotify-api/index.d.ts
@@ -1035,9 +1035,9 @@ declare namespace SpotifyApi {
         href: string;
         items: T[];
         limit: number;
-        next: string;
+        next: string | null;
         offset: number;
-        previous: string;
+        previous: string | null;
         total: number;
     }
 
@@ -1049,7 +1049,7 @@ declare namespace SpotifyApi {
         href: string;
         items: T[];
         limit: number;
-        next: string;
+        next: string | null;
         cursors: CursorObject;
         total?: number;
     }


### PR DESCRIPTION
This PR fixes types for both PagingObject and CursorPagingObject. The properties `next` and `previous` may be `null` if there is no next or previous page, so a type union was added. Tests were not changed and are still passing.

The definitions are listed explicitly in the [objects index reference](https://developer.spotify.com/documentation/web-api/reference/#objects-index).

https://developer.spotify.com/documentation/web-api/reference/#objects-index

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


