### PR TITLE
@types/cytoscape: Fix the type of roots in the BreadthFirstLayoutOptions

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -4820,7 +4820,7 @@ declare namespace cytoscape {
         // put depths in concentric circles if true, put depths top down if false
         circle: boolean;
         // the roots of the trees
-        roots?: string;
+        roots?: string[];
         // how many times to try to position the nodes in a maximal way (i.e. no backtracking)
         maximalAdjustments: number;
     }


### PR DESCRIPTION
BreadthFirstLayoutOptions.roots is an array. Even if you only have one root, unless you wrap it in an array, it won't work.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.

I can't do this, because the code using BreadthFirstLayoutOptions in the test is commented out with a TODO to figure out how to make it work. But I tested in my own code.

- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cytoscape/cytoscape.js/blob/1092b1fb021134ebe89c77ce0875b02cd860561a/src/extensions/layout/breadthfirst.js#L53

That code in theory also allows for a single string, but in reality a single string doesn't work, and since the single string case is well covered with the array case (just wrap the single string in an array), I guess it's better for everyone to not include `|string` here since it would create false expectations.
