### PR TITLE
Add GM.registerMenuCommand to greasemonkey

### DIFF
--- a/types/greasemonkey/greasemonkey-tests.ts
+++ b/types/greasemonkey/greasemonkey-tests.ts
@@ -98,6 +98,11 @@ GM.notification(
 GM.openInTab('https://wiki.greasespot.net/GM.openInTab');
 GM.openInTab('https://wiki.greasespot.net/GM.openInTab', true);
 
+// GM.registerMenuCommand
+
+GM.registerMenuCommand('Do the thing', () => {});
+GM.registerMenuCommand('Do the thing', () => {}, 'd');
+
 // GM.setClipboard
 
 GM.setClipboard('Text from clipboard');

--- a/types/greasemonkey/index.d.ts
+++ b/types/greasemonkey/index.d.ts
@@ -276,6 +276,16 @@ declare var GM: {
     openInTab(url: string, openInBackground?: boolean): void
 
     /**
+     * Adds an item to the User Script Commands menu.
+     * @param caption The caption to display on the menu item.
+     * @param commandFunc The function to call when the menu item is selected.
+     * @param accessKey A single character that can be used to select the
+     * item when the menu is open. It should be a letter in the caption.
+     * @see {@link https://wiki.greasespot.net/GM.registerMenuCommand}
+     */
+    registerMenuCommand(caption: string, commandFunc: () => any, accessKey?: string): void;
+
+    /**
      * Sets the current contents of the operating system's clipboard
      * @see {@link https://wiki.greasespot.net/GM.setClipboard}
      */

--- a/types/greasemonkey/index.d.ts
+++ b/types/greasemonkey/index.d.ts
@@ -283,7 +283,7 @@ declare var GM: {
      * item when the menu is open. It should be a letter in the caption.
      * @see {@link https://wiki.greasespot.net/GM.registerMenuCommand}
      */
-    registerMenuCommand(caption: string, commandFunc: () => any, accessKey?: string): void;
+    registerMenuCommand(caption: string, commandFunc: () => void, accessKey?: string): void;
 
     /**
      * Sets the current contents of the operating system's clipboard


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test greasemonkey`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://wiki.greasespot.net/GM.registerMenuCommand

`GM.registerMenuCommand` is now implemented natively as of Greasemonkey 4.11