### PR TITLE
[atlassian-connect-js] Remove enums from definition and replace them with string unions

### DIFF
--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -27,10 +27,10 @@ AP.cookie.read('name', value => console.log(value)); // $ExpectType void
 AP.cookie.erase('name'); // $ExpectType void
 
 const editComponent = AP.customContent.getEditComponent(); // $ExpectType EditComponent
-editComponent.intercept(AP.customContent.InterceptableEvent.Submit); // $ExpectType void
-editComponent.intercept(AP.customContent.InterceptableEvent.SubmitSuccess); // $ExpectType void
-editComponent.intercept(AP.customContent.InterceptableEvent.SubmitError); // $ExpectType void
-editComponent.intercept(AP.customContent.InterceptableEvent.Cancel); // $ExpectType void
+editComponent.intercept('confluence.customcontent.submit'); // $ExpectType void
+editComponent.intercept('confluence.customcontent.submitSuccess'); // $ExpectType void
+editComponent.intercept('confluence.customcontent.submitError'); // $ExpectType void
+editComponent.intercept('confluence.customcontent.cancel'); // $ExpectType void
 editComponent.submitCallback('content'); // $ExpectType void
 editComponent.submitCallback({}); // $ExpectType void
 editComponent.submitCallback(false); // $ExpectType void
@@ -92,8 +92,8 @@ AP.jira.showJQLEditor(obj => console.log(obj.jql), {}); // $ExpectType void
 AP.jira.isNativeApp(isNative => console.log(isNative)); // $ExpectType void
 
 AP.navigator.getLocation(location => console.log(location)); // $ExpectType void
-AP.navigator.go(AP.navigator.NavigatorTargetConfluence.dashboard, {}); // $ExpectType void
-AP.navigator.go(AP.navigator.NavigatorTargetJira.dashboard, {}); // $ExpectType void
+AP.navigator.go('contentview', {}); // $ExpectType void
+AP.navigator.go('issue', {}); // $ExpectType void
 AP.navigator.reload(); // $ExpectType void
 
 AP.user.getUser(user => console.log(user.id, user.key, user.fullName)); // $ExpectType void

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -280,7 +280,7 @@ declare namespace AP {
      * A Confluence specific JavaScript module which provides functions to interact with the custom content.
      */
     namespace customContent {
-        enum InterceptableEvent {
+        type InterceptableEvent =
             /**
              * Add-on **must** intercept this event to provide the content body.
              * The `confluence.customcontent.submit` event will be emitted when user clicks the save button on the custom content edit component.
@@ -315,7 +315,7 @@ declare namespace AP {
              *     // editComponent.submitCallback(false, 'Cannot save the content');
              * });
              */
-            Submit = 'confluence.customcontent.submit',
+            | 'confluence.customcontent.submit'
 
             /**
              * The `confluence.customcontent.submitSuccess` event will be emitted when Confluence successfully saved the content.
@@ -341,7 +341,7 @@ declare namespace AP {
              *     editComponent.submitSuccessCallback(true);
              * });
              */
-            SubmitSuccess = 'confluence.customcontent.submitSuccess',
+            | 'confluence.customcontent.submitSuccess'
 
             /**
              * The `confluence.customcontent.submitError` event will be emitted when Confluence encountered problem when saving the content.
@@ -363,10 +363,10 @@ declare namespace AP {
              *     editComponent.submitErrorCallback(true);
              * });
              */
-            SubmitError = 'confluence.customcontent.submitError',
+            | 'confluence.customcontent.submitError'
 
             /**
-             * The confluence.customcontent.cancel event will be emitted when user clicks close button.
+             * The `confluence.customcontent.cancel` event will be emitted when user clicks close button.
              * If add-on didn't intercept this event, user will be redirected to the custom content list or the container page depending on the content type.
              * You can call cancelCallback function to return the data:
              * @example <caption>**Return false** Return `false` will prevent user being redirected.
@@ -387,52 +387,49 @@ declare namespace AP {
              *     editComponent.cancelCallback(true);
              * });
              */
-            Cancel = 'confluence.customcontent.cancel',
-        }
+            | 'confluence.customcontent.cancel';
+
         interface EditComponent {
             /**
-             * See docs on InterceptableEvent enum
+             * See docs on InterceptableEvent type
              * @param event Event to intercept
-             * @see InterceptableEvent#Submit
-             * @see InterceptableEvent#SubmitSuccess
-             * @see InterceptableEvent#SubmitError
-             * @see InterceptableEvent#Cancel
+             * @see InterceptableEvent
              */
             intercept: (event: InterceptableEvent) => void;
 
             /**
-             * Used inside an event listener for a {@link InterceptableEvent#Submit} event to submit the content of the macro.
+             * Used inside an event listener for a `confluence.customcontent.submit` event to submit the content of the macro.
              * @param contentBody can be either content body string, a complete content object or false (cancels submit action)
-             * @see InterceptableEvent#Submit
+             * @see InterceptableEvent
              */
             submitCallback: (contentBody: string | object | false) => void;
 
             /**
-             * Used inside an event listener for a {@link InterceptableEvent#SubmitSuccess} event to do something before the user is redirected and/or
+             * Used inside an event listener for a `confluence.customcontent.submitSuccess` event to do something before the user is redirected and/or
              * to instruct Confluence on whether to redirect the user to the content page view after the content was saved successfully.
              * If no redirect is desired, an error message can also be shown.
              * @param doRedirect Whether to redirect the user to the content view. If false, an error can be shown.
              * @param error The error to display if no redirect is desired
-             * @see InterceptableEvent#SubmitSuccess
+             * @see InterceptableEvent
              */
             submitSuccessCallback: (doRedirect: boolean, error?: string) => void;
 
             /**
-             * Used inside an event listener for a {@link InterceptableEvent#SubmitError} event to do something before the error is being shown and/or
+             * Used inside an event listener for a `confluence.customcontent.submitError` event to do something before the error is being shown and/or
              * prevent Confluence from showing the default error message and optionally providing a custom one.
              * @param preventDefaultErrorMessage Whether to show the default error message. If false, a custom error can be shown
              * @param customError The error to show instead of the default Confluence one
-             * @see InterceptableEvent#SubmitError
+             * @see InterceptableEvent
              */
             submitErrorCallback: (preventDefaultErrorMessage: boolean, customError?: string) => void;
 
             /**
-             * Used inside an event listener for a {@link InterceptableEvent#Cancel} event to do something before the user is redirected and/or
+             * Used inside an event listener for a `confluence.customcontent.cancel` event to do something before the user is redirected and/or
              * to instruct Confluence on whether to redirect the user to the content page view after the user clicked the "Close" button.
              * If no redirect is desired, an error message can also be shown.
              * @param doRedirect Whether to redirect the user to the content view. If false, an error can be shown.
              * @param error The error to display if no redirect is desired
-             * @see InterceptableEvent#Cancel
+             * @see InterceptableEvent
              */
             cancelCallback: (doRedirect: boolean, error?: string) => void;
         }
@@ -997,89 +994,87 @@ declare namespace AP {
      * The Navigator API allows your add-on to change the current page using JavaScript.
      */
     namespace navigator {
-        enum NavigatorTargetJira {
+        type NavigatorTargetJira =
             /**
              * A specific dashboard in Jira. Takes a `dashboardId` to identify the dashboard.
              */
-            dashboard = 'dashboard',
+            'dashboard' |
 
             /**
              * A specific Issue in Jira. Takes an `issueKey` to identify the issue.
              */
-            issue = 'issue',
+            'issue' |
 
             /**
              * The module page within a specific add-on. Takes an `addonKey` and a `moduleKey` to identify the correct module.
              */
-            addonModule = 'addonModule',
+            'addonModule' |
 
             /**
              * The profile page for a Jira User. Takes a `username` or `userAccountId` to identify the user.
              */
-            userProfile = 'userProfile',
+            'userProfile' |
 
             /**
              * The admin details of a specific Jira Project. Takes a `projectKey` to identify the project. Only accessible to administrators.
              */
-            projectAdminSummary = 'projectAdminSummary',
+            'projectAdminSummary' |
 
             /**
              * The admin panel definted by a connect addon. Takes an `addonKey`, `adminPageKey`, `projectKey` and `projectId`. Only accessible to administrators.
              */
-            projectAdminTabPanel = 'projectAdminTabPanel',
+            'projectAdminTabPanel' |
 
             /**
              * A specific location contained within the site. Takes either a `relativeUrl` or `absoluteUrl` to identify the path.
              */
-            site = 'site',
-        }
+            'site';
 
-        enum NavigatorTargetConfluence {
+        type NavigatorTargetConfluence =
             /**
              * The view page for pages, blogs and custom content. Takes a `contentId` to identify the content.
              */
-            contentview = 'contentview',
+            | 'contentview'
 
             /**
              * The edit page for pages, blogs and custom content. Takes a `contentId` to identify the content.
              */
-            contentedit = 'contentedit',
+            | 'contentedit'
 
             /**
              * The space view page. Takes a `spaceKey` to identify the space.
              */
-            spaceview = 'spaceview',
+            | 'spaceview'
 
             /**
              * The space tools page. Takes a `spaceKey` to identify the space.
              */
-            spacetools = 'spacetools',
+            | 'spacetools'
 
             /**
              * The dashboard of Confluence.
              */
-            dashboard = 'dashboard',
+            | 'dashboard'
 
             /**
              * The profile page for a specific user. Takes a `username` or `userAccountId` to identify the user.
              */
-            userProfile = 'userProfile',
+            | 'userProfile'
 
             /**
              * The module page within a specific add-on. Takes an `addonKey` and a `moduleKey` to identify the correct module.
              */
-            addonModule = 'addonModule',
+            | 'addonModule'
 
             /**
              * The list/collector page for pages, blogs and custom content contained in a space. Takes a `spaceKey` and a `contentType` to identify the content type.
              */
-            contentlist = 'contentlist',
+            | 'contentlist'
 
             /**
              * A specific location contained within a site. Takes a `relativeUrl` to identify the path.
              */
-            site = 'site',
-        }
+            | 'site';
 
         interface NavigatorContext {
             /**


### PR DESCRIPTION
Using any enums caused compiled code to contain references to the enums, but since they don't exist in the actual object, there would be runtime errors.
I would have preferred to use `const enum`s instead, but they don't play nice with the `isolatedModules` flag in `tsc`, so the only option I could think of was to use a string union instead.
I realize this will break existing code using those enums, but I don't think that code worked in the first place anyway.
Am open for other suggestions though.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.atlassian.com/cloud/confluence/jsapi/classes/jira/ https://developer.atlassian.com/cloud/confluence/jsapi/classes/confluence/ https://developer.atlassian.com/cloud/confluence/jsapi/custom-content/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
