### PR TITLE
@mapbox/mapbox-sdk: matrix api annotations should be an array and source destinations can be "all"

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -4,7 +4,6 @@
 //                 Mike O'Meara <https://github.com/mikeomeara1>
 //                 chachan <https://github.com/chachan>
 //                 techieshark <https://github.com/techieshark>
-//                 maribest2 <https://github.com/marisbest2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -4,6 +4,7 @@
 //                 Mike O'Meara <https://github.com/mikeomeara1>
 //                 chachan <https://github.com/chachan>
 //                 techieshark <https://github.com/techieshark>
+//                 maribest2 <https://github.com/marisbest2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -1165,9 +1166,9 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
   interface MatrixRequest {
     points: Point[];
     profile?: DirectionsProfile;
-    sources?: number[];
-    destinations?: number[];
-    annotations?: DirectionsAnnotation;
+    sources?: number[] | 'all';
+    destinations?: number[] | 'all';
+    annotations?: DirectionsAnnotation[];
   }
 
   interface MatrixResponse {


### PR DESCRIPTION
The mapbox sdk Matrix API takes in an array for the `annotations` parameter. Additionally, the `sources` and `destinations` can take in the string value `'all'` See typing here:

https://github.com/mapbox/mapbox-sdk-js/blob/bb84221720f13404a9ae883849b1be1c3e06042f/services/matrix.js#L21-L23

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
