### PR TITLE
Minor changes in output from TS handling builtin symbols as unique symbols

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5268,8 +5268,8 @@ fp.now(); // $ExpectType number
     _.chain({ a: undefined }).get("a", defaultValue); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
     _.chain({ a: [1] }).get("a", []).map((val) => val.toFixed()); // $ExpectType CollectionChain<string>
 
-    fp.get(Symbol.iterator, []); // $ExpectType any
-    fp.get(Symbol.iterator)([]); // $ExpectType any
+    fp.get(Symbol.iterator, []); // $ExpectType any || () => IterableIterator<never>
+    fp.get(Symbol.iterator)([]); // $ExpectType any || () => IterableIterator<never>
     fp.get([Symbol.iterator], []); // $ExpectType any
     fp.get(1)("abc"); // $ExpectType string
     fp.get("1")("abc"); // $ExpectType any
@@ -6960,7 +6960,7 @@ fp.now(); // $ExpectType number
     _.chain("a.b[0]").property<SampleObject, number>(); // $ExpectType FunctionChain<(obj: SampleObject) => number>
     _.chain(["a", "b", 0]).property<SampleObject, number>(); // $ExpectType FunctionChain<(obj: SampleObject) => number>
     fp.property(Symbol.iterator)([]); // $ExpectType any
-    fp.property([Symbol.iterator], []); // $ExpectType any
+    fp.property([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never>
     fp.property(1)("abc"); // $ExpectType string
 }
 
@@ -6971,7 +6971,7 @@ fp.now(); // $ExpectType number
     _.chain({}).propertyOf() as _.LoDashExplicitWrapper<(path: _.Many<_.PropertyName>) => any>;
 
     fp.propertyOf(Symbol.iterator)([]); // $ExpectType any
-    fp.propertyOf([Symbol.iterator], []); // $ExpectType any
+    fp.propertyOf([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never>
     fp.propertyOf(1)("abc"); // $ExpectType string
 }
 

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -31,7 +31,7 @@ conversions.any(any); // $ExpectType any
 conversions.any(unknown); // $ExpectType unknown
 conversions.any(options); // $ExpectType Options
 conversions.any(RegExp); // $ExpectType RegExpConstructor
-conversions.any(Symbol.toStringTag); // $ExpectType symbol
+conversions.any(Symbol.toStringTag); // $ExpectType symbol || typeof toStringTag
 
 conversions.void(); // $ExpectType void
 conversions.boolean(any, integerOptions); // $ExpectType boolean


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/pull/42543 for more. This probably shouldn't be merged until that is (though, ofc, the `$ExpectType` assertions are backwards compatible), and, in fact, it should _probably_ be merged with DT master have it's CI rerun after it is (and a new TS nightly is out), for good measure.