### PR TITLE
uri-templates: fixed fromUri() return type

### DIFF
--- a/types/uri-templates/index.d.ts
+++ b/types/uri-templates/index.d.ts
@@ -11,7 +11,7 @@ declare namespace utpl {
         fillFromObject(vars: { [key: string]: string | { [key: string]: string} }): string;
         fill(callback: (varName: string) => string): string;
         fill(vars: { [key: string]: string | { [key: string]: string } }): string;
-        fromUri(uri: string): { [key: string]: string };
+        fromUri(uri: string): { [key: string]: string } | undefined;
         varNames: string[];
         template: string;
     }


### PR DESCRIPTION
Method fromUri() returns `undefined` for unmatched routes.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/geraintluff/uri-templates/blob/master/uri-templates.js#L362
