### PR TITLE
w3c-web-serial: Add type annotations

### DIFF
--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package w3c-web-serial-browser 1.0
+// Type definitions for non-npm package w3c-web-serial 1.0
 // Project: https://wicg.github.io/serial
 // Definitions by: Reilly Grant <https://github.com/reillyeon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for non-npm package w3c-web-serial-browser 1.0
+// Project: https://wicg.github.io/serial
+// Definitions by: Reilly Grant <https://github.com/reillyeon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.5
+
+/*~ https://wicg.github.io/serial/#dom-paritytype */
+type ParityType = 'none' | 'even' | 'odd';
+
+/*~ https://wicg.github.io/serial/#dom-flowcontroltype */
+type FlowControlType = 'none' | 'hardware';
+
+/*~ https://wicg.github.io/serial/#dom-serialoptions */
+interface SerialOptions {
+    baudRate: number;
+    dataBits?: number;
+    stopBits?: number;
+    parity?: ParityType;
+    bufferSize?: number;
+    flowControl?: FlowControlType;
+}
+
+/*~ https://wicg.github.io/serial/#dom-serialoutputsignals */
+interface SerialOutputSignals {
+    dataTerminalReady?: boolean;
+    requestToSend?: boolean;
+    break?: boolean;
+}
+
+/*~ https://wicg.github.io/serial/#dom-serialinputsignals */
+interface SerialInputSignals {
+    dataCarrierDetect: boolean;
+    clearToSend: boolean;
+    ringIndicator: boolean;
+    dataSetReady: boolean;
+}
+
+/*~ https://wicg.github.io/serial/#dom-serialport */
+declare class SerialPort extends EventTarget {
+    onconnect: ((this: this, ev: Event) => any) | null;
+    ondisconnect: ((this: this, ev: Event) => any) | null;
+    readonly readable: ReadableStream<Uint8Array> | null;
+    readonly writable: WritableStream<Uint8Array> | null;
+
+    open(options: SerialOptions): Promise<void>;
+    setSignals(signals: SerialOutputSignals): Promise<void>;
+    getSignals(): Promise<SerialInputSignals>;
+    close(): Promise<void>;
+
+    addEventListener(
+        type: 'connect' | 'disconnect',
+        listener: (this: this, ev: Event) => any,
+        useCapture?: boolean): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(
+        type: 'connect' | 'disconnect',
+        callback: (this: this, ev: Event) => any,
+        useCapture?: boolean): void;
+    removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: EventListenerOptions | boolean): void;
+}
+
+/*~ https://wicg.github.io/serial/#dom-serialportfilter */
+interface SerialPortFilter {
+    usbVendorId?: number;
+    usbProductId?: number;
+}
+
+/*~ https://wicg.github.io/serial/#dom-serialportrequestoptions */
+interface SerialPortRequestOptions {
+    filters?: SerialPortFilter[];
+}
+
+/*~ https://wicg.github.io/serial/#dom-serial */
+declare class Serial extends EventTarget {
+    onconnect: ((this: this, ev: Event) => any) | null;
+    ondisconnect: ((this: this, ev: Event) => any) | null;
+
+    getPorts(): Promise<SerialPort[]>;
+    requestPort(options?: SerialPortRequestOptions): Promise<SerialPort>;
+    addEventListener(
+        type: 'connect' | 'disconnect',
+        listener: (this: this, ev: Event) => any,
+        useCapture?: boolean): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(
+        type: 'connect' | 'disconnect',
+        callback: (this: this, ev: Event) => any,
+        useCapture?: boolean): void;
+    removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: EventListenerOptions | boolean): void;
+}
+
+/*~ https://wicg.github.io/serial/#extensions-to-the-navigator-interface */
+interface Navigator {
+    readonly serial: Serial;
+}
+
+/*~ https://wicg.github.io/serial/#extensions-to-workernavigator-interface */
+interface WorkerNavigator {
+    readonly serial: Serial;
+}

--- a/types/w3c-web-serial/tsconfig.json
+++ b/types/w3c-web-serial/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "w3c-web-serial-tests.ts"
+    ]
+}

--- a/types/w3c-web-serial/tslint.json
+++ b/types/w3c-web-serial/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/w3c-web-serial/w3c-web-serial-tests.ts
+++ b/types/w3c-web-serial/w3c-web-serial-tests.ts
@@ -1,0 +1,187 @@
+/*~ https://wicg.github.io/serial/#example-1 */
+
+async function example_1() {
+    const filter = { usbVendorId: 0x2341 };
+    const port = await navigator.serial.requestPort({ filters: [filter] });
+
+    const connectButton = document.getElementById("connect");
+    if (connectButton) {
+        connectButton.addEventListener('click', async () => {
+            try {
+                const port = await navigator.serial.requestPort();
+                // Continue connecting to the device attached to |port|.
+            } catch (e) {
+                // The prompt has been dismissed without selecting a device.
+            }
+        });
+    }
+}
+
+/*~ https://wicg.github.io/serial/#example-2 */
+
+// Check to see what ports are available when the page loads.
+document.addEventListener('DOMContentLoaded', async () => {
+    const ports = await navigator.serial.getPorts();
+    // Populate the UI with options for the user to select or
+    // automatically connect to devices.
+});
+
+navigator.serial.addEventListener('connect', e => {
+    // Add |e.port| to the UI or automatically connect.
+});
+
+navigator.serial.addEventListener('disconnect', e => {
+    // Remove |e.port| from the UI. If the device was open the
+    // disconnection can also be observed as a stream error.
+});
+
+/*~ https://wicg.github.io/serial/#example-3 */
+
+async function example_3() {
+    const port = await navigator.serial.requestPort();
+    await port.open({ baudRate: 115200 });
+}
+
+/*~ https://wicg.github.io/serial/#readable-example */
+
+async function example_4() {
+    const port = await navigator.serial.requestPort();
+
+    while (port.readable) {
+        const reader = port.readable.getReader();
+        try {
+            while (true) {
+                const { value, done } = await reader.read();
+                if (done) {
+                    // |reader| has been canceled.
+                    break;
+                }
+                // Do something with |value|...
+            }
+        } catch (error) {
+            // Handle |error|...
+        } finally {
+            reader.releaseLock();
+        }
+    }
+}
+
+async function example_4b() {
+    class LineBreakTransformer implements Transformer<string, string> {
+        container: string;
+
+        constructor() {
+            this.container = '';
+        }
+
+        transform(chunk: string, controller: TransformStreamDefaultController<string>) {
+            this.container += chunk;
+            const lines = this.container.split('\r\n');
+            this.container = lines.pop()!;
+            lines.forEach(line => controller.enqueue(line));
+        }
+
+        flush(controller: TransformStreamDefaultController<string>) {
+            controller.enqueue(this.container);
+        }
+    }
+
+    const port = await navigator.serial.requestPort();
+
+    if (port.readable) {
+        const lineReader = port.readable
+            .pipeThrough(new TextDecoderStream())
+            .pipeThrough(new TransformStream(new LineBreakTransformer()))
+            .getReader();
+    }
+}
+
+/*~ https://wicg.github.io/serial/#example-5 */
+
+async function example_5() {
+    const port = await navigator.serial.requestPort();
+
+    if (port.writable) {
+        const encoder = new TextEncoder();
+        const writer = port.writable.getWriter();
+        await writer.write(encoder.encode("PING"));
+        writer.releaseLock();
+    }
+}
+
+/*~ https://wicg.github.io/serial/#example-6 */
+
+async function example_6() {
+    const port = await navigator.serial.requestPort();
+
+    await port.setSignals({ dataTerminalReady: false });
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await port.setSignals({ dataTerminalReady: true });
+}
+
+/*~ https://wicg.github.io/serial/#example-7 */
+
+async function example_7a() {
+    const port = await navigator.serial.requestPort();
+
+    if (port.writable) {
+        const encoder = new TextEncoder();
+        const writer = port.writable.getWriter();
+        writer.write(encoder.encode("A long message that will take..."));
+        await writer.close();
+        await port.close();
+    }
+}
+
+async function example_7b() {
+    const port = await navigator.serial.requestPort();
+
+    if (port.writable) {
+        const encoder = new TextEncoderStream();
+        const writableStreamClosed = encoder.readable.pipeTo(port.writable);
+        const writer = encoder.writable.getWriter();
+        writer.write("A long message that will take...");
+        writer.close();
+        await writableStreamClosed;
+        await port.close();
+    }
+}
+
+async function example_7c() {
+    const port = await navigator.serial.requestPort();
+
+    let keepReading = true;
+    let reader: ReadableStreamDefaultReader | null;
+
+    async function readUntilClosed() {
+        while (port.readable && keepReading) {
+            reader = port.readable.getReader();
+            try {
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) {
+                        // |reader| has been canceled.
+                        break;
+                    }
+                    // Do something with |value|...
+                }
+            } catch (error) {
+                // Handle |error|...
+            } finally {
+                reader.releaseLock();
+            }
+        }
+
+        await port.close();
+    }
+
+    readUntilClosed();
+
+    setTimeout(() => {
+        // Sometime later...
+        keepReading = false;
+        if (reader) {
+            reader.cancel();
+        }
+    }, 1_000);
+}


### PR DESCRIPTION
This new web API is shipping in Chrome 89 based on the draft
specification from the WICG: https://wicg.github.io/serial/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
