### PR TITLE
[react-select] Make Async loadOptions prop optional

### DIFF
--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -18,7 +18,7 @@ export interface AsyncProps<
      * Function that returns a promise, which is the set of options to be used
      * once the promise resolves.
      */
-    loadOptions: (
+    loadOptions?: (
         inputValue: string,
         callback: (options: OptionsType<OptionType> | GroupedOptionsType<OptionType, GroupType>) => void,
     ) => Promise<OptionsType<OptionType> | GroupedOptionsType<OptionType, GroupType>> | void;

--- a/types/react-select/test/Tests.tsx
+++ b/types/react-select/test/Tests.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import Select from 'react-select/index';
 import * as animatedComponents from 'react-select/animated';
+import Async from 'react-select/async';
+import AsyncCreatable from 'react-select/async-creatable';
 
 const AnimatedSelect = (props: React.ComponentProps<typeof Select>) => (
     <Select
@@ -11,3 +13,6 @@ const AnimatedSelect = (props: React.ComponentProps<typeof Select>) => (
         }}
     />
 );
+
+const defaultAsync = <Async />;
+const defaultCreatableAsync = <AsyncCreatable />;


### PR DESCRIPTION
Many of the tests in https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/__tests__/Async.test.js and https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/__tests__/AsyncCreatable.test.js assume that `loadOptions` is optional.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/Async.js#L127
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
