### PR TITLE
[react-select] Allow more types for value prop

### DIFF
--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -188,11 +188,11 @@ export interface NamedProps<
     /** Select the currently focused option when the user presses tab */
     tabSelectsValue?: boolean;
     /** The value of the select; reflected by the selected option */
-    value?: ValueType<OptionType, IsMulti>;
+    value?: readonly OptionType[] | OptionType | null;
 
     defaultInputValue?: string;
     defaultMenuIsOpen?: boolean;
-    defaultValue?: IsMulti extends true ? ValueType<OptionType, boolean> : ValueType<OptionType, false>;
+    defaultValue?: readonly OptionType[] | OptionType | null;
 }
 
 export interface Props<

--- a/types/react-select/src/stateManager.d.ts
+++ b/types/react-select/src/stateManager.d.ts
@@ -6,7 +6,7 @@ import { ActionMeta, GroupTypeBase, InputActionMeta, OptionTypeBase, ValueType }
 export interface DefaultProps {
     defaultInputValue: string;
     defaultMenuIsOpen: boolean;
-    defaultValue: ValueType<OptionTypeBase, boolean>;
+    defaultValue: readonly OptionTypeBase[] | OptionTypeBase | null;
 }
 
 export const defaultProps: DefaultProps;
@@ -18,10 +18,10 @@ export interface Props<
 > {
     defaultInputValue?: string;
     defaultMenuIsOpen?: boolean;
-    defaultValue?: IsMulti extends true ? ValueType<OptionType, boolean> : ValueType<OptionType, false>;
+    defaultValue?: readonly OptionType[] | OptionType | null;
     inputValue?: string;
     menuIsOpen?: boolean;
-    value?: ValueType<OptionType, IsMulti>;
+    value?: readonly OptionType[] | OptionType | null;
     onChange?: (value: ValueType<OptionType, IsMulti>, actionMeta: ActionMeta<OptionType>) => void;
 }
 
@@ -36,7 +36,7 @@ type StateProps<T extends SelectProps<any, boolean, any>> = Pick<
 interface State<OptionType extends OptionTypeBase, IsMulti extends boolean> {
     inputValue: string;
     menuIsOpen: boolean;
-    value: ValueType<OptionType, IsMulti>;
+    value: readonly OptionType[] | OptionType | null;
 }
 
 type GetOptionType<T> = T extends SelectBase<infer OT> ? OT : never;

--- a/types/react-select/test/Tests.tsx
+++ b/types/react-select/test/Tests.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import Select from 'react-select/index';
+import Select from 'react-select';
 import * as animatedComponents from 'react-select/animated';
+import { colourOptions } from './data';
 
 const AnimatedSelect = (props: React.ComponentProps<typeof Select>) => (
     <Select
@@ -11,3 +12,7 @@ const AnimatedSelect = (props: React.ComponentProps<typeof Select>) => (
         }}
     />
 );
+
+const SingleSelectWithValueArray = <Select options={colourOptions} value={[colourOptions[0]]} />;
+const MultiSelectWithSingleValue = <Select options={colourOptions} value={colourOptions[0]} isMulti />;
+const MultiSelectWithNullValue = <Select options={colourOptions} value={null} isMulti />;


### PR DESCRIPTION
Many of the tests in https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/__tests__/Select.test.js assume that the type of the value doesn't have to correspond with `isMulti`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
