### PR TITLE
Add constructor for `BigInteger`

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -33,6 +33,7 @@ declare module "node-forge" {
 
     namespace jsbn {
         class BigInteger {
+            constructor(s: string | null | undefined, t: number | null | undefined)
             data: number[];
             t: number;
             s: number;


### PR DESCRIPTION
Add constructor for `BigInteger` based on https://github.com/digitalbazaar/forge/blob/master/lib/jsbn.js#L61-L68

(Ignore - premature)
