### PR TITLE
[pino-http] Add new res parameter to reqCustomProps

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -35,7 +35,7 @@ declare namespace PinoHttp {
         customErrorMessage?: (error: Error, res: ServerResponse) => string;
         customAttributeKeys?: CustomAttributeKeys;
         wrapSerializers?: boolean;
-        reqCustomProps?: (req: IncomingMessage) => object;
+        reqCustomProps?: (req: IncomingMessage, res: ServerResponse) => object;
     }
 
     interface GenReqId {

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-http 5.0
+// Type definitions for pino-http 5.4
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -1,7 +1,6 @@
 import http = require('http');
 import pino = require('pino');
 import pinoHttp = require('pino-http');
-
 import { Writable } from 'stream';
 
 const logger = pino();

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -1,6 +1,7 @@
 import http = require('http');
 import pino = require('pino');
 import pinoHttp = require('pino-http');
+
 import { Writable } from 'stream';
 
 const logger = pino();
@@ -37,6 +38,6 @@ pinoHttp({ customAttributeKeys: { err: 'err' } });
 pinoHttp({ customAttributeKeys: { responseTime: 'responseTime' } });
 pinoHttp({ customAttributeKeys: { req: 'req', res: 'res', err: 'err', responseTime: 'responseTime' } });
 pinoHttp({ customLogLevel: (req, res) => 'info' });
-pinoHttp({ reqCustomProps: req => ({ key1: 'value1', 'x-key-2': 'value2' }) });
+pinoHttp({ reqCustomProps: (req, res) => ({ key1: 'value1', 'x-key-2': 'value2' }) });
 pinoHttp({ wrapSerializers: false });
 pinoHttp(new Writable());


### PR DESCRIPTION
Add support for the new 5.4 version of pino-http where res is now a parameter for reqCustomProps.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

