### PR TITLE
fix(next-auth): jwt.decode option should return object

### DIFF
--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -107,7 +107,7 @@ interface JWTOptions {
     signingKey?: string;
     encryptionKey?: string;
     encode?(options: JWTEncodeParams): Promise<string>;
-    decode?(options: JWTDecodeParams): Promise<string>;
+    decode?(options: JWTDecodeParams): Promise<GenericObject>;
 }
 
 // TODO: Improve callback typings

--- a/types/next-auth/next-auth-tests.ts
+++ b/types/next-auth/next-auth-tests.ts
@@ -137,7 +137,7 @@ const allConfig = {
         signingKey: 'some-key',
         encryptionKey: 'some-key',
         encode: () => Promise.resolve('foo'),
-        decode: () => Promise.resolve('foo'),
+        decode: () => Promise.resolve({}),
     },
     pages: pageOptions,
     callbacks: {


### PR DESCRIPTION
The decode option at `jwt.decode` currently expects a return of `Promise<string>`, which I think is wrong. It should be an object, so I set it to `GenericObject`... Maybe it should be even more strict and be a `User`?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://next-auth.js.org/configuration/options#jwt
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

