### PR TITLE
[Echarts] fix series custiom renderItem parameter  type is not object & Add type to renderItem return object property `type`

### DIFF
--- a/types/echarts/echarts-tests.ts
+++ b/types/echarts/echarts-tests.ts
@@ -18,10 +18,107 @@ const testChartTitlePadding = (options: echarts.EChartTitleOption) => {
 // id, type, and name are defined for every series type
 const map = option.series!.map(s => [s.id, s.name, s.type]);
 
-const seriesGraph: echarts.EChartOption.SeriesGraph = { };
+const seriesGraph: echarts.EChartOption.SeriesGraph = {};
 // $ExpectType number | number[] | undefined
 seriesGraph.autoCurveness;
 seriesGraph.autoCurveness = 10;
 seriesGraph.autoCurveness = [1, 2, 3, 4];
 // $ExpectError
 seriesGraph.autoCurveness = 'error';
+
+// enumerate render item return type
+type renderItemReturnType = echarts.EChartOption.SeriesCustom.RenderItemReturnGroup
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnPath
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnImage
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnText
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnRect
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnCircle
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnRing
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnSector
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnArc
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnPolygon
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnPolyline
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnLine
+    | echarts.EChartOption.SeriesCustom.RenderItemReturnBezierCurve
+
+
+// test the property `context` of renderItem parameter `param` dynamic type 
+const renderItem: echarts.EChartOption.SeriesCustom.RenderItem = (param) => {
+    const { context } = param;
+
+    type CacheObjType = { customKey: number; custAccessKey: string; };
+
+    const cacheObj:CacheObjType = {
+        customKey: 1,
+        custAccessKey: 'diff CustomParams'
+    };
+
+    // prettier-ignore
+    context.customKey = 'error';    // $ExpectError
+
+    
+
+    if (context) {
+        // $ExpectType { [key: string]: any; } & CacheObjType
+        Object.assign(context,cacheObj)
+    }else{
+        // $ExpectType undefined
+        context
+    }
+
+    const result: renderItemReturnType = {};
+    //$ExpectType 'image' | 'text' | 'circle' | 'sector' | 'ring' | 'polygon' | 'polyline' | 'rect' | 'line' | 'bezierCurve' | 'arc' | 'group'
+    result.type = 'image';
+    result.type = 'text';
+    result.type = 'circle';
+    result.type = 'sector';
+    result.type = 'ring';
+    result.type = 'polygon';
+    result.type = 'polyline';
+    result.type = 'rect';
+    result.type = 'line';
+    result.type = 'bezierCurve';
+    result.type = 'arc';
+    result.type = 'group';
+    return result;
+}
+
+type CustomParams = {
+    customKey: string;
+    customErrorKey?: number;
+}
+
+// test the key `context` of renderItem parameter `param` dynamic type 
+const renderItemWithTypeParams: echarts.EChartOption.SeriesCustom.RenderItem<CustomParams> = (param) => {
+    const { context } = param;
+
+    // $ExpectError
+    context.customKey = 'error';
+
+
+
+    if (context) {
+        // $ExpectType CustomParams
+        Object.assign(context,{
+            customKey: 'cache content'
+        } as CustomParams)
+        // $ExpectError
+        context.customErrorKey = ''
+    }
+
+    const result: renderItemReturnType = {};
+    //$ExpectType 'image' | 'text' | 'circle' | 'sector' | 'ring' | 'polygon' | 'polyline' | 'rect' | 'line' | 'bezierCurve' | 'arc' | 'group'
+    result.type = 'image';
+    result.type = 'text';
+    result.type = 'circle';
+    result.type = 'sector';
+    result.type = 'ring';
+    result.type = 'polygon';
+    result.type = 'polyline';
+    result.type = 'rect';
+    result.type = 'line';
+    result.type = 'bezierCurve';
+    result.type = 'arc';
+    result.type = 'group';
+    return result;
+} 

--- a/types/echarts/options/series/custom.d.ts
+++ b/types/echarts/options/series/custom.d.ts
@@ -1274,8 +1274,8 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-custom.renderItem
              */
-            interface RenderItem {
-                (params: RenderItemParams, api: RenderItemApi):
+            interface RenderItem<CONTEXT = { [key: string]: any }> {
+                (params: RenderItemParams<CONTEXT>, api: RenderItemApi):
                     RenderItemReturnGroup
                     | RenderItemReturnPath
                     | RenderItemReturnImage
@@ -1313,11 +1313,11 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.arguments.params
              */
-            interface RenderItemParams {
+            interface RenderItemParams<CONTEXT> {
                 /**
                  * An object that developers can store something temporarily here. Life cycle: current round of rendering.
                  */
-                context?: string;
+                context?: CONTEXT;
 
                 /**
                  * The id of this series.
@@ -1663,6 +1663,10 @@ declare namespace echarts {
                 dayCount?: number;
             }
 
+            // Renderitem return type range
+
+            type RenderItemReturnType = 'image' | 'text' | 'circle' | 'sector' | 'ring' | 'polygon' | 'polyline' | 'rect' | 'line' | 'bezierCurve' | 'arc' | 'group'
+
             /**
              * `group` is the only type that can contain children, so that
              * a group of elements can be positioned and transformed together.
@@ -1707,7 +1711,7 @@ declare namespace echarts {
                  * "group"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_group.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -2060,7 +2064,7 @@ declare namespace echarts {
                  * "path"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_path.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -2540,7 +2544,7 @@ declare namespace echarts {
                  * "image"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_image.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -2960,7 +2964,7 @@ declare namespace echarts {
                  * "text"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_text.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -3407,7 +3411,7 @@ declare namespace echarts {
                  * "rect"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_rect.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -3841,7 +3845,7 @@ declare namespace echarts {
                  * "circle"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_circle.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -4249,7 +4253,7 @@ declare namespace echarts {
                  * "ring"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_ring.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -4665,7 +4669,7 @@ declare namespace echarts {
                  * "sector"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_sector.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -5109,7 +5113,7 @@ declare namespace echarts {
                  * "arc"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_arc.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -5555,7 +5559,7 @@ declare namespace echarts {
                  * "polygon"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polygon.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -5973,7 +5977,7 @@ declare namespace echarts {
                  * "polyline"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polyline.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -6393,7 +6397,7 @@ declare namespace echarts {
                  * "line"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_line.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update
@@ -6821,7 +6825,7 @@ declare namespace echarts {
                  * "bezierCurve"
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_bezierCurve.type
                  */
-                type?: string;
+                type?: RenderItemReturnType;
 
                 /**
                  * id is used to specifying element when willing to update


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x]  Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ]  If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

