### PR TITLE
[hammerjs] Use literal types for `eventType`

### DIFF
--- a/types/hammerjs/hammerjs-tests.ts
+++ b/types/hammerjs/hammerjs-tests.ts
@@ -49,6 +49,12 @@
   // listen to events...
   mc.on( "panleft panright panup pandown tap press", function ( ev:HammerInput )
   {
+    type EventType = 
+        | HammerStatic["INPUT_START"]
+        | HammerStatic["INPUT_MOVE"]
+        | HammerStatic["INPUT_END"]
+        | HammerStatic["INPUT_CANCEL"];
+    const eventType: EventType = ev.eventType;
     myElement.textContent = ev.type + " gesture detected.";
   } );
 })();

--- a/types/hammerjs/hammerjs-tests.ts
+++ b/types/hammerjs/hammerjs-tests.ts
@@ -49,7 +49,7 @@
   // listen to events...
   mc.on( "panleft panright panup pandown tap press", function ( ev:HammerInput )
   {
-    type EventType = 
+    type EventType =
         | HammerStatic["INPUT_START"]
         | HammerStatic["INPUT_MOVE"]
         | HammerStatic["INPUT_END"]

--- a/types/hammerjs/index.d.ts
+++ b/types/hammerjs/index.d.ts
@@ -202,7 +202,10 @@ declare class HammerInput
   pointerType:string;
 
   /** Event type, matches the INPUT constants. */
-  eventType:number;
+  eventType: HammerStatic['INPUT_START'] |
+             HammerStatic['INPUT_MOVE'] |
+             HammerStatic['INPUT_END'] |
+             HammerStatic['INPUT_CANCEL'];
 
   /** true when the first input. */
   isFirst:boolean;


### PR DESCRIPTION
## Description

Follow up to #50433, restricting the type of `eventType` property.

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A, see comment above this property and linked PR.**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.