### PR TITLE
[rebass] Fix typography and flexbox props of base Box component

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -8,6 +8,7 @@
 //                 orzarchi <https://github.com/orzarchi>
 //                 ilaiwi <https://github.com/ilaiwi>
 //                 mrkosima <https://github.com/mrkosima>
+//                 rafaelalmeidatk <https://github.com/rafaelalmeidatk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -50,11 +51,9 @@ interface BoxKnownProps
     extends BaseProps,
         StyledSystem.SpaceProps,
         StyledSystem.LayoutProps,
-        StyledSystem.FontSizeProps,
+        StyledSystem.TypographyProps,
         StyledSystem.ColorProps,
-        StyledSystem.FlexProps,
-        StyledSystem.OrderProps,
-        StyledSystem.AlignSelfProps,
+        StyledSystem.FlexboxProps,
         SxProps {
     variant?: StyledSystem.ResponsiveValue<string>;
     tx?: string;
@@ -71,18 +70,8 @@ export const Button: React.FunctionComponent<ButtonProps>;
 export interface CardProps extends BoxKnownProps, Omit<React.HTMLProps<HTMLDivElement>, keyof BoxKnownProps> {}
 export const Card: React.FunctionComponent<BoxKnownProps>;
 
-interface FlexKnownProps
-    extends BoxKnownProps,
-        StyledSystem.FlexGrowProps,
-        StyledSystem.FlexShrinkProps,
-        StyledSystem.FlexWrapProps,
-        StyledSystem.FlexDirectionProps,
-        StyledSystem.AlignItemsProps,
-        StyledSystem.AlignContentProps,
-        StyledSystem.AlignSelfProps,
-        StyledSystem.JustifyItemsProps,
-        StyledSystem.JustifyContentProps,
-        StyledSystem.JustifySelfProps {}
+// tslint:disable-next-line no-empty-interface
+interface FlexKnownProps extends BoxKnownProps {}
 export interface FlexProps extends FlexKnownProps, Omit<React.HTMLProps<HTMLDivElement>, keyof FlexKnownProps> {}
 export const Flex: React.FunctionComponent<FlexProps>;
 
@@ -94,14 +83,8 @@ interface LinkKnownProps extends BoxKnownProps {}
 export interface LinkProps extends LinkKnownProps, Omit<React.HTMLProps<HTMLAnchorElement>, keyof LinkKnownProps> {}
 export const Link: React.FunctionComponent<LinkProps>;
 
-interface TextKnownProps
-    extends BoxKnownProps,
-        StyledSystem.FontFamilyProps,
-        StyledSystem.FontWeightProps,
-        StyledSystem.FontStyleProps,
-        StyledSystem.TextAlignProps,
-        StyledSystem.LineHeightProps,
-        StyledSystem.LetterSpacingProps {}
+// tslint:disable-next-line no-empty-interface
+interface TextKnownProps extends BoxKnownProps {}
 export interface TextProps extends TextKnownProps, Omit<React.HTMLProps<HTMLDivElement>, keyof TextKnownProps> {}
 export const Text: React.FunctionComponent<TextProps>;
 

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -30,7 +30,15 @@ const CssBox = () => <Box css={boxCss} />;
 const VariantBox = () => <Box tx="specialBoxes" />;
 
 export default () => (
-    <Box width={1} css={{ height: '100vh' }} py={[1, 2, 3]} ml="1em" display="block">
+    <Box
+        width={1}
+        css={{ height: '100vh' }}
+        py={[1, 2, 3]}
+        ml="1em"
+        display="block"
+        fontFamily="monospace"
+        flexShrink={1}
+    >
         <Flex
             width={1}
             flexGrow={1}
@@ -41,11 +49,11 @@ export default () => (
             justifyItems="center"
             justifyContent="start"
             justifySelf="stretch"
-            >
-            <Heading fontSize={5} fontWeight="bold">
+        >
+            <Heading fontSize={5} fontWeight="bold" flexShrink={1}>
                 Hi, I'm a heading.
             </Heading>
-            <Text as="p" fontSize={3} lineHeight="1em" letterSpacing="1rem" fontStyle="italic">
+            <Text as="p" fontSize={3} lineHeight="1em" letterSpacing="1rem" fontStyle="italic" order={1}>
                 Hi, I'm text.
             </Text>
             <Card


### PR DESCRIPTION
The `Box` component from `rebass` is [exported](https://github.com/rebassjs/rebass/blob/ec9bda64f5e9f33931ef297a64cc46cc62fe4c8f/packages/rebass/src/index.js#L2-L4) from `reflexbox` where it is a div that composes all the [styled-system props](https://rebassjs.org/reflexbox/#styled-system-props):

https://github.com/rebassjs/rebass/blob/ec9bda64f5e9f33931ef297a64cc46cc62fe4c8f/packages/reflexbox/src/index.js#L39-L43

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rebassjs.org/reflexbox/#styled-system-props
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
