### PR TITLE
[schwifty] update types for version 5, add interface for augmenting

### DIFF
--- a/types/schwifty/index.d.ts
+++ b/types/schwifty/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for schwifty 4.0
+// Type definitions for schwifty 5.0
 // Project: https://github.com/hapipal/schwifty
 // Definitions by: ozum <https://github.com/ozum>
+//                 timcosta <https://github.com/timcosta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -9,14 +10,15 @@
 
 import * as Objection from "objection";
 import * as Joi from "joi";
-import { Server, Request, ResponseToolkit, Plugin } from "hapi";
+import { Server, Request, ResponseToolkit, Plugin } from "@hapi/hapi";
 import * as Knex from "knex";
 
 export type ModelClass = typeof Model | typeof Objection.Model;
 
 export class Model extends Objection.Model {
     static getJoiSchema(patch?: boolean): Joi.Schema;
-    joiSchema: Joi.Schema;
+    static field(name: string): Joi.Schema;
+    static joiSchema: Joi.Schema;
 }
 
 export interface RegistrationOptions {
@@ -35,6 +37,10 @@ export function assertCompatible(
 
 export const plugin: Plugin<RegistrationOptions>;
 
+export interface RegisteredModels {
+    [key: string]: ModelClass;
+}
+
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                      Hapi Decorations                                     +
  + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + */
@@ -42,7 +48,7 @@ export const plugin: Plugin<RegistrationOptions>;
 /**
  * Merge decorations into hapi objects.
  */
-declare module "hapi" {
+declare module "@hapi/hapi" {
     interface Server {
         schwifty: (
             config:
@@ -55,16 +61,16 @@ declare module "hapi" {
                   }
         ) => void;
         knex: () => Knex;
-        models: (all?: boolean) => { [key: string]: typeof Model };
+        models: (all?: boolean) => RegisteredModels;
     }
 
     interface Request {
         knex: () => Knex;
-        models: (all?: boolean) => { [key: string]: typeof Model };
+        models: (all?: boolean) => RegisteredModels;
     }
 
     interface ResponseToolkit {
         knex: () => Knex;
-        models: (all?: boolean) => { [key: string]: typeof Model };
+        models: (all?: boolean) => RegisteredModels;
     }
 }

--- a/types/schwifty/package.json
+++ b/types/schwifty/package.json
@@ -1,8 +1,8 @@
 {
     "private": true,
     "dependencies": {
+        "joi": "^17.3.0",
         "knex": "^0.16.1",
-        "objection": "^1.1.9",
-        "joi": "^17.3.0"
+        "objection": "^1.1.9"
     }
 }

--- a/types/schwifty/schwifty-tests.ts
+++ b/types/schwifty/schwifty-tests.ts
@@ -1,4 +1,4 @@
-import * as Hapi from "hapi";
+import * as Hapi from "@hapi/hapi";
 import * as Joi from "joi";
 import * as Schwifty from "schwifty";
 import DogModel from "./test/dog";
@@ -26,7 +26,7 @@ import DogModel from "./test/dog";
     server.schwifty(DogModel);
 
     await server.initialize();
-    const Dog: typeof DogModel = server.models().Dog;
+    const { Dog } = server.models();
 
     await Dog.query().insert({ name: "Guinness" });
 

--- a/types/schwifty/test/dog.ts
+++ b/types/schwifty/test/dog.ts
@@ -1,10 +1,16 @@
 import * as Joi from "joi";
 import * as Schwifty from "schwifty";
 
+declare module 'schwifty' {
+    interface RegisteredModels {
+        Dog: typeof Dog;
+    }
+}
+
 export default class Dog extends Schwifty.Model {
     static tableName = "Dog";
 
-    joiSchema: Joi.Schema = Joi.object({
+    static joiSchema: Joi.Schema = Joi.object({
         id: Joi.number(),
         name: Joi.string()
     });

--- a/types/schwifty/test/plugin.ts
+++ b/types/schwifty/test/plugin.ts
@@ -1,4 +1,4 @@
-import * as Hapi from "hapi";
+import * as Hapi from "@hapi/hapi";
 import * as Schwifty from "schwifty";
 import DogModel from "./dog";
 

--- a/types/schwifty/tsconfig.json
+++ b/types/schwifty/tsconfig.json
@@ -11,7 +11,10 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "target": "es6",
-        "strictFunctionTypes": true
+        "strictFunctionTypes": true,
+        "paths": {
+            "@hapi/*": [ "hapi__*" ]
+        }
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapipal/schwifty/blob/master/lib/model.js#L85
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Additional context: Currently the definitions aren't super typescript friendly as the types are dynamic and the existing definition requires you to set the type every time you call `server.models` or one of the other decorations. This PR adds an interface that can be used to strongly type the return value of `server.models()` so that you don't have to set the type every usage.

This does not provide a way for handing realms and the `all` boolean, however I believe this to be a marked improvement from the current implementation and the realms implementation is likely incompatible with TS. 
