### PR TITLE
fix: add current property to semaphore.Sempahore

### DIFF
--- a/types/semaphore/index.d.ts
+++ b/types/semaphore/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/abrkn/semaphore.js
 // Definitions by: Matt Frantz <https://github.com/mhfrantz>
 //                 Arturas Molcanovas <https://github.com/Alorel>
+//                 Tanguy Antoine <https://github.com/tanguyantoine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function semaphore(capacity?: number): semaphore.Semaphore;
@@ -14,6 +15,7 @@ declare namespace semaphore {
 
     interface Semaphore {
         capacity: number;
+        current: number;
 
         available(n: number): boolean;
 

--- a/types/semaphore/semaphore-tests.ts
+++ b/types/semaphore/semaphore-tests.ts
@@ -10,5 +10,6 @@ function task() {
 sem.take(task);
 sem.take(2, task);
 sem.leave(2);
+sem.current;
 
 const available: boolean = sem.available(2);


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


## Links
Current is set at this location: https://github.com/abrkn/semaphore.js/blob/master/lib/semaphore.js#L14 and a semaphore object is returned here: https://github.com/abrkn/semaphore.js/blob/master/lib/semaphore.js#L86
The current property is publicly visible



