### PR TITLE
Replaced "@types/webpack" dependency with "webpack"

### DIFF
--- a/types/webpack-dev-server/package.json
+++ b/types/webpack-dev-server/package.json
@@ -1,0 +1,10 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/connect-history-api-fallback": "*",
+        "@types/express": "*",
+        "@types/http-proxy-middleware": "*",
+        "@types/serve-static": "*",
+        "webpack": "*"
+    }
+}


### PR DESCRIPTION
Replaced `@types/webpack` dependency with `webpack`, because webpack 5 now provides it's own dependencies:
https://github.com/webpack/webpack/blob/v5.0.0/declarations.d.ts