### PR TITLE
[react-native] Specify valid keys in Animated.ValueXY#getTranslateTransform signature

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -818,10 +818,6 @@ interface MatrixTransform {
     matrix: number[];
 }
 
-type KeysOfUnion<T> = T extends T ? keyof T : never;
-
-type TranslateTransformKeys = KeysOfUnion<TranslateXTransform | TranslateYTransform>;
-
 export interface TransformsStyle {
     transform?: (
         | PerpectiveTransform
@@ -8856,7 +8852,7 @@ export namespace Animated {
          *  }}
          *```
          */
-        getTranslateTransform(): { [key in TranslateTransformKeys]: AnimatedValue }[];
+        getTranslateTransform(): [{ translateX: AnimatedValue }, { translateY: AnimatedValue }];
     }
 
     type EndResult = { finished: boolean };

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -818,6 +818,10 @@ interface MatrixTransform {
     matrix: number[];
 }
 
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+
+type TranslateTransformKeys = KeysOfUnion<TranslateXTransform | TranslateYTransform>;
+
 export interface TransformsStyle {
     transform?: (
         | PerpectiveTransform
@@ -8852,7 +8856,7 @@ export namespace Animated {
          *  }}
          *```
          */
-        getTranslateTransform(): { [key: string]: AnimatedValue }[];
+        getTranslateTransform(): { [key in TranslateTransformKeys]: AnimatedValue }[];
     }
 
     type EndResult = { finished: boolean };

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -165,7 +165,10 @@ function TestAnimatedAPI() {
             <AnimatedComp ref={AnimatedCompRef} width={v1} />
             <ForwardComp ref={ForwardCompRef} width={1} />
             <AnimatedForwardComp ref={AnimatedForwardCompRef} width={10} />
-            <Animated.Image style={position.getTranslateTransform()} source={{ uri: 'https://picsum.photos/200' }} />
+            <Animated.Image
+                style={{ transform: position.getTranslateTransform() }}
+                source={{ uri: 'https://picsum.photos/200' }}
+            />
             <Animated.View
                 testID="expect-type-animated-view"
                 style={{ opacity: v1 }}


### PR DESCRIPTION
We ran into [an issue](https://github.com/5up-okamura/react-native-draggable-gridview/issues/5) using the [`react-native-draggable-gridview`](https://github.com/5up-okamura/react-native-draggable-gridview) library with the `0.63` version of the `react-native` types. This issue did not exist with version `0.62`, and I believe was caused by [this change](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46473/files#diff-e94ad9b79ba4f07235bfefa12c2789cd2d6cb690d9120309555f33ae51295244). Specifically, the move from [this](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46473/files#diff-e94ad9b79ba4f07235bfefa12c2789cd2d6cb690d9120309555f33ae51295244L8945) to [this](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46473/files#diff-e94ad9b79ba4f07235bfefa12c2789cd2d6cb690d9120309555f33ae51295244R8948) where the properties of `withAnimatedObject` are no longer optional. Undoing that change would fix the error we're seeing, but I chose to go a different route as I think the non-optional `withAnimatedObject` properties are technically correct.

My proposed solution provides a more specific return type for `Animated.ValueXY#getTranslateTransform` based on the [actual implementation](https://github.com/facebook/react-native/blob/6e6443afd04a847ef23fb6254a84e48c70b45896/Libraries/Animated/nodes/AnimatedValueXY.js#L222). Note that the existing test for this function was not properly specified according to the [documentation](https://reactnative.dev/docs/animatedvaluexy#gettranslatetransform) for `getTranslateTransform`.



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/facebook/react-native/blob/6e6443afd04a847ef23fb6254a84e48c70b45896/Libraries/Animated/nodes/AnimatedValueXY.js#L222>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
