### PR TITLE
[office-js] [office-js-preview] Clean up deprecated tags

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1169,10 +1169,12 @@ declare namespace Office {
 
        /**
         * Check if the specified requirement set is supported by the host Office application.
+        *
+        * **Warning**: This overload of `isSetSupported` (where `minVersionNumber` is a number) has been deprecated. Use the string overload of `isSetSupported` instead.
+        *
         * @deprecated Use the string overload of `isSetSupported` instead.
         * @param name - The requirement set name (e.g., "ExcelApi").
         * @param minVersionNumber - The minimum required version (e.g., 1.4). 
-        * **Warning**: This overload of `isSetSupported` (where `minVersionNumber` is a number) is deprecated. Use the string overload of `isSetSupported` instead.
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;
     }
@@ -1218,10 +1220,12 @@ declare namespace Office {
          * Server-side code can use this token to access Microsoft Graph for the add-in's web application by using the
          * {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | "on behalf of" OAuth flow}.
          *
-         * @deprecated Use Office.auth.getAccessToken instead.
-         * 
          * **Important**: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
-         * 
+         *
+         * **Warning**: `getAccessTokenAsync` has been deprecated. Use `Office.auth.getAccessToken` instead.
+         *
+         * @deprecated Use `Office.auth.getAccessToken` instead.
+         *
          * @remarks
          *
          * **Hosts**: Excel, OneNote, Outlook, PowerPoint, Word
@@ -1241,9 +1245,11 @@ declare namespace Office {
          * Server-side code can use this token to access Microsoft Graph for the add-in's web application by using the
          * {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | "on behalf of" OAuth flow}.
          *
-         * @deprecated Use `Office.auth.getAccessToken` instead.
-         * 
          * **Important**: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+         *
+         * **Warning**: `getAccessTokenAsync` has been deprecated. Use `Office.auth.getAccessToken` instead.
+         *
+         * @deprecated Use `Office.auth.getAccessToken` instead.
          *
          * @remarks
          *
@@ -1298,12 +1304,16 @@ declare namespace Office {
         /**
          * Prompts the user to add their Office account (or to switch to it, if it is already added). Default value is `false`.
          *
+         * **Warning**: `forceAddAccount` has been deprecated. Use `allowSignInPrompt` instead.
+         *
          * @deprecated Use `allowSignInPrompt` instead.
          */
         forceAddAccount?: boolean;
         /**
          * Causes Office to display the add-in consent experience. Useful if the add-in's Azure permissions have changed or if the user's consent has
          * been revoked. Default value is `false`.
+         *
+         * **Warning**: `forceConsent` has been deprecated. Use `allowConsentPrompt` instead.
          *
          * @deprecated Use `allowConsentPrompt` instead.
          */
@@ -1674,9 +1684,9 @@ declare namespace Office {
      */
     interface SaveSettingsOptions {
         /**
-         * **Warning**: This setting is deprecated and should not be used. It has no effect on most platforms and will cause errors if set to `false` in Excel on the web.
+         * **Warning**: This setting has been deprecated and should not be used. It has no effect on most platforms and will cause errors if set to `false` in Excel on the web.
          * 
-         * @deprecated
+         * @deprecated `overwriteIfStale` is no longer supported.
          */
         overwriteIfStale?: boolean
         /**
@@ -71025,11 +71035,15 @@ declare namespace Word {
          */
         none = "None",
         /**
-         * @deprecated Hidden is no longer supported.
+         * **Warning**: `hidden` has been deprecated.
+         *
+         * @deprecated `hidden` is no longer supported.
          */
         hidden = "Hidden",
         /**
-         * @deprecated DotLine is no longer supported.
+         * **Warning**: `dotLine` has been deprecated.
+         *
+         * @deprecated `dotLine` is no longer supported.
          */
         dotLine = "DotLine",
         /**
@@ -71099,6 +71113,8 @@ declare namespace Word {
          */
         page = "Page",
         /**
+         * **Warning**: `next` has been deprecated. Use `sectionNext` instead.
+         *
          * @deprecated Use sectionNext instead.
          */
         next = "Next",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

**Review site pages (office-js-preview)**:
[Office.Auth](https://review.docs.microsoft.com/en-us/javascript/api/office/office.auth?view=word-js-preview&branch=elizs-test)
[Office.AuthOptions](https://review.docs.microsoft.com/en-us/javascript/api/office/office.authoptions?view=word-js-preview&branch=elizs-test)
[Office.RequirementSetSupport](https://review.docs.microsoft.com/en-us/javascript/api/office/office.requirementsetsupport?view=word-js-preview&branch=elizs-test)
[Office.SaveSettingsOptions](https://review.docs.microsoft.com/en-us/javascript/api/office/office.savesettingsoptions?view=word-js-preview&branch=elizs-test)
[Word.BreakType](https://review.docs.microsoft.com/en-us/javascript/api/word/word.breaktype?view=word-js-preview&branch=elizs-test)
[Word.UnderlineType](https://review.docs.microsoft.com/en-us/javascript/api/word/word.underlinetype?view=word-js-preview&branch=elizs-test)