### PR TITLE
[nunjucks] Fix incorrect loader extend type in type definition

### DIFF
--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -104,7 +104,6 @@ export interface ILoader {
     async?: boolean;
     getSource(name: string): LoaderSource;
     getSource(name: string, callback: Callback<Error, LoaderSource>): void;
-    extend?(extender: ILoader): ILoader;
 }
 
 // Needs both Loader and ILoader since nunjucks uses a custom object system
@@ -114,7 +113,7 @@ export class Loader {
     emit(name: string, ...args: any[]): void;
     resolve(from: string, to: string): string;
     isRelative(filename: string): boolean;
-    extend(toExtend: ILoader): ILoader;
+    static extend<LoaderClass extends typeof Loader>(this: LoaderClass, toExtend: ILoader): LoaderClass;
 }
 
 export interface LoaderSource {

--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -104,7 +104,6 @@ export interface ILoader {
     async?: boolean;
     getSource(name: string): LoaderSource;
     getSource(name: string, callback: Callback<Error, LoaderSource>): void;
-    extend?(extender: ILoader): ILoader;
 }
 
 // Needs both Loader and ILoader since nunjucks uses a custom object system
@@ -114,7 +113,6 @@ export class Loader {
     emit(name: string, ...args: any[]): void;
     resolve(from: string, to: string): string;
     isRelative(filename: string): boolean;
-    extend(extender: ILoader): ILoader;
     static extend<LoaderClass extends typeof Loader>(this: LoaderClass, toExtend: ILoader): LoaderClass;
 }
 

--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -104,6 +104,7 @@ export interface ILoader {
     async?: boolean;
     getSource(name: string): LoaderSource;
     getSource(name: string, callback: Callback<Error, LoaderSource>): void;
+    extend?(extender: ILoader): ILoader;
 }
 
 // Needs both Loader and ILoader since nunjucks uses a custom object system
@@ -113,6 +114,7 @@ export class Loader {
     emit(name: string, ...args: any[]): void;
     resolve(from: string, to: string): string;
     isRelative(filename: string): boolean;
+    extend(extender: ILoader): ILoader;
     static extend<LoaderClass extends typeof Loader>(this: LoaderClass, toExtend: ILoader): LoaderClass;
 }
 

--- a/types/nunjucks/nunjucks-tests.ts
+++ b/types/nunjucks/nunjucks-tests.ts
@@ -66,4 +66,17 @@ class MyLoader extends nunjucks.Loader implements nunjucks.ILoader {
 
 env = new nunjucks.Environment(new MyLoader());
 
+// $ExpectType typeof FileSystemLoader
+const MyOtherLoader = nunjucks.FileSystemLoader.extend({
+    getSource(name: string): nunjucks.LoaderSource {
+        return {
+            src: "Amadala",
+            path: "The Right One",
+            noCache: false
+        };
+    }
+});
+
+env = new nunjucks.Environment(new MyOtherLoader());
+
 new nunjucks.runtime.SafeString("an unsafe string");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mozilla.github.io/nunjucks/api.html#writing-a-loader https://github.com/mozilla/nunjucks/blob/d34fdbff8509327db7ab15b3672b3005b89a229a/nunjucks/src/object.js#L76 https://github.com/mozilla/nunjucks/blob/d34fdbff8509327db7ab15b3672b3005b89a229a/nunjucks/src/loader.js#L6
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Regarding the last checkbox above: There are additional types added in the newer version of nunjucks which i haven't added here, so i suppose this change doesn't bring it up to date with the newest version? 

But further than this i have a bigger concern about the versioning here. There are also the previously defined extend types which are incorrect:
https://github.com/JemarJones/DefinitelyTyped/blob/fb86becaa2f362b8380f7139c3cb0830c5bd8c59/types/nunjucks/index.d.ts#L117
https://github.com/JemarJones/DefinitelyTyped/blob/fb86becaa2f362b8380f7139c3cb0830c5bd8c59/types/nunjucks/index.d.ts#L107

^ These are definitions for an instance method which does not exist (its static, as my new types show). As such if you try to call `extend` on an instance of the Loader class as the existing type definition defines it, you will just get a runtime error because `extend` is not defined. I think it would be best to remove those incorrect types, but i'm not quite sure what the procedure would be in terms of versioning. Removing those would technically be a breaking change, but the code that it breaks would just be failing at runtime currently. I hope someone can advise what i should do if i am to remove the incorrect type. The DefinetelyTyped [documentation](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library) on versioning is mum on the issue of a breaking change that doesn't correspond to a new major version for the typed package. For now i haven't removed the incorrect type from the loader class, i've only added the correct type for the static version of the method that actually does exist.