### PR TITLE
[@types/carbon-components-react] Update types to match 7.28.x (rc0)

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -612,11 +612,22 @@ const tooltipDefHasTriggerClassName = <TooltipDefinition tooltipText="my text" t
 const SliderHasOnChange = <Slider max={0} min={10} value={5} onChange={newValue => newValue.value} />;
 
 // Tag
-const ChipTagFilterUndef = <Tag />;
+{
+    const ChipTagFilterUndef = <Tag />;
 
-const ChipTagFalse = <Tag filter={false} />;
+    const TagCustomComp1: React.FC = () => <div />;
+    const ChipTagIcon1 = <Tag renderIcon={TagCustomComp1} size="sm" />;
 
-const FilterTag = <Tag filter onClose={() => {}} />;
+    const TagCustomComp2: React.FC<{ optionalProp?: string }> = () => <div />;
+    const ChipTagIcon2 = <Tag renderIcon={TagCustomComp2} />;
+
+    class TagCustomComp3 extends React.Component {}
+    const ChipTagIcon3 = <Tag renderIcon={TagCustomComp3} />;
+
+    const ChipTagFalse = <Tag filter={false} />;
+
+    const FilterTag = <Tag filter onClose={() => {}} />;
+}
 
 // TextArea
 const textAreaWithDefaultRef = <TextArea labelText="" />;

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbon-components-react 7.26
+// Type definitions for carbon-components-react 7.28
 // Project: https://github.com/carbon-design-system/carbon/tree/master/packages/react
 // Definitions by: Kyle Albert <https://github.com/kalbert312>
 //                 Sebastien Gregoire <https://github.com/sgregoire>

--- a/types/carbon-components-react/lib/components/CodeSnippet/CodeSnippet.d.ts
+++ b/types/carbon-components-react/lib/components/CodeSnippet/CodeSnippet.d.ts
@@ -1,13 +1,11 @@
 import { ReactDivAttr, FCProps, FCReturn } from "../../../typings/shared";
 import { CopyProps } from "../Copy";
 
-interface InheritedDivProps extends Omit<ReactDivAttr, "children"> { }
-interface InheritedInlineProps extends Omit<CopyProps, "children" | "type"> { }
-
 interface SharedProps {
     children?: string,
     copyLabel?: string,
     copyButtonDescription?: string,
+    disabled?: boolean,
     feedback?: CopyProps["feedback"],
     hideCopyButton?: boolean,
     light?: boolean,
@@ -16,11 +14,11 @@ interface SharedProps {
     wrapText?: boolean,
 }
 
-export interface CodeSnippetDivProps extends SharedProps, InheritedDivProps {
+export interface CodeSnippetDivProps extends SharedProps, Omit<ReactDivAttr, "children"> {
     type?: 'single' | 'multi' | null;
 }
 
-export interface CodeSnippetInlineProps extends SharedProps, InheritedInlineProps {
+export interface CodeSnippetInlineProps extends SharedProps, Omit<CopyProps, "children" | "type"> {
     type: "inline",
 }
 

--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
@@ -23,6 +23,7 @@ export interface DropdownProps<ItemType = string> extends
     inline?: boolean,
     invalid?: boolean;
     invalidText?: React.ReactNode;
+    hideLabel?: boolean;
     helperText?: React.ReactNode,
     items: readonly ItemType[],
     itemToElement?: ItemType extends object ? React.ComponentType<ItemType> : never,

--- a/types/carbon-components-react/lib/components/Tabs/Tabs.d.ts
+++ b/types/carbon-components-react/lib/components/Tabs/Tabs.d.ts
@@ -1,11 +1,15 @@
 import * as React from "react";
-import { ReactDivAttr } from "../../../typings/shared";
+import { ReactDivAttr, ReactButtonAttr } from "../../../typings/shared";
+
+type OverflowButtonProps = Omit<ReactButtonAttr, "ref">;
 
 export interface TabsProps extends Omit<ReactDivAttr, "onScroll"> {
     ariaLabel?: string,
     iconDescription?: string,
+    leftOverflowButtonProps?: ReactButtonAttr,
     light?: boolean,
     onSelectionChange?(index: number): void,
+    rightOverflowButtonProps?: ReactButtonAttr,
     scrollIntoView?: boolean,
     selected?: number,
     selectionMode?: "automatic" | "manual",

--- a/types/carbon-components-react/lib/components/Tag/Tag.d.ts
+++ b/types/carbon-components-react/lib/components/Tag/Tag.d.ts
@@ -16,15 +16,19 @@ export type TagTypeName =
 
 export declare const types: TagTypeName[];
 
-export interface FilterTagProps extends ReactDivAttr {
-    filter: true,
-    onClose?(event: React.MouseEvent<HTMLButtonElement>): void,
+interface SharedProps {
+    size?: "sm";
     type?: TagTypeName,
 }
 
-export interface ChipTagProps extends ReactAttr<HTMLSpanElement> {
+export interface FilterTagProps extends ReactDivAttr, SharedProps {
+    filter: true,
+    onClose?(event: React.MouseEvent<HTMLButtonElement>): void,
+}
+
+export interface ChipTagProps extends ReactAttr<HTMLSpanElement>, SharedProps {
     filter?: false,
-    type?: TagTypeName,
+    renderIcon?: React.ComponentType<any>;
 }
 
 declare function Tag(props: FCProps<FilterTagProps>): FCReturn;

--- a/types/carbon-components-react/lib/components/Tile/Tile.d.ts
+++ b/types/carbon-components-react/lib/components/Tile/Tile.d.ts
@@ -46,7 +46,9 @@ export interface ExpandableTileProps extends Omit<ReactButtonAttr, "onClick"> {
     light?: boolean,
     onBeforeClick?(e: React.MouseEvent<HTMLButtonElement>): void,
     tileCollapsedIconText?: string,
+    tileCollapsedLabel?: string,
     tileExpandedIconText?: string,
+    tileExpandedLabel?: string,
     tileMaxHeight?: number,
     tilePadding?: number,
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/v10.28.0-rc.0/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
