### PR TITLE
(fix)[w3c-web-serial] Add missing getInfo and SerialPortInfo

### DIFF
--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -35,6 +35,12 @@ interface SerialInputSignals {
     dataSetReady: boolean;
 }
 
+/*~ https://wicg.github.io/serial/#serialportinfo-dictionary */
+interface SerialPortInfo {
+    usbVendorId?: number;
+    usbProductId?: number;
+}
+
 /*~ https://wicg.github.io/serial/#dom-serialport */
 declare class SerialPort extends EventTarget {
     onconnect: ((this: this, ev: Event) => any) | null;
@@ -45,6 +51,7 @@ declare class SerialPort extends EventTarget {
     open(options: SerialOptions): Promise<void>;
     setSignals(signals: SerialOutputSignals): Promise<void>;
     getSignals(): Promise<SerialInputSignals>;
+    getInfo(): SerialPortInfo;
     close(): Promise<void>;
 
     addEventListener(

--- a/types/w3c-web-serial/w3c-web-serial-tests.ts
+++ b/types/w3c-web-serial/w3c-web-serial-tests.ts
@@ -42,6 +42,11 @@ async function example_3() {
     await port.open({ baudRate: 115200 });
 }
 
+async function example_3b() {
+    const port = await navigator.serial.requestPort();
+    const info = port.getInfo();
+}
+
 /*~ https://wicg.github.io/serial/#readable-example */
 
 async function example_4() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Add's the missing getInfo and SerialPortInfo types from the API