### PR TITLE
Allowed class refs in @loadable/component

### DIFF
--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -47,12 +47,20 @@ export interface LoadableComponentMethods<Props> {
     load(props?: Props): Promise<React.ComponentType<Props>>;
 }
 
-export interface ExtraComponentProps<Component> {
+export interface ExtraComponentProps {
     fallback?: JSX.Element;
-    ref?: Component extends new (...args: any[]) => any ? React.LegacyRef<InstanceType<Component>> : never;
 }
 
-export type LoadableComponent<Props, Component = never> = React.ComponentType<Props & ExtraComponentProps<Component>> &
+export type LoadableComponent<Props> = React.ComponentType<Props & ExtraComponentProps> &
+    LoadableComponentMethods<Props>;
+
+export interface ExtraClassComponentProps<Component extends React.ComponentClass> extends ExtraComponentProps {
+    ref?: React.LegacyRef<InstanceType<Component>>;
+}
+
+export type LoadableClassComponent<Props, Component extends React.ComponentClass> = React.ComponentType<
+    Props & ExtraClassComponentProps<Component>
+> &
     LoadableComponentMethods<Props>;
 
 export type LoadableLibrary<Module> = React.ComponentType<{
@@ -79,12 +87,12 @@ declare function loadableFunc<Props>(
 ): LoadableComponent<Props>;
 
 declare function loadableFunc<
-    Component extends React.ComponentType<any>,
-    Props extends React.ComponentProps<Component>,
+    Component extends React.ComponentClass<any>,
+    Props extends React.ComponentProps<Component>
 >(
     loadFn: (props: Props) => Promise<Component | { default: Component }>,
     options?: OptionsWithResolver<Props, Component>,
-): LoadableComponent<Props, Component>;
+): LoadableClassComponent<Props, Component>;
 
 declare const loadable: typeof loadableFunc & { lib: typeof lib };
 

--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -58,10 +58,10 @@ export interface ExtraClassComponentProps<Component extends React.ComponentClass
     ref?: React.LegacyRef<InstanceType<Component>>;
 }
 
-export type LoadableClassComponent<Props, Component extends React.ComponentClass> = React.ComponentType<
-    Props & ExtraClassComponentProps<Component>
+export type LoadableClassComponent<Component extends React.ComponentClass> = React.ComponentType<
+    React.ComponentProps<Component> & ExtraClassComponentProps<Component>
 > &
-    LoadableComponentMethods<Props>;
+    LoadableComponentMethods<React.ComponentProps<Component>>;
 
 export type LoadableLibrary<Module> = React.ComponentType<{
     fallback?: JSX.Element;
@@ -86,13 +86,10 @@ declare function loadableFunc<Props>(
     options?: OptionsWithoutResolver<Props>,
 ): LoadableComponent<Props>;
 
-declare function loadableFunc<
-    Component extends React.ComponentClass<any>,
-    Props extends React.ComponentProps<Component>
->(
-    loadFn: (props: Props) => Promise<Component | { default: Component }>,
-    options?: OptionsWithResolver<Props, Component>,
-): LoadableClassComponent<Props, Component>;
+declare function loadableFunc<Component extends React.ComponentClass<any>>(
+    loadFn: (props: React.ComponentProps<Component>) => Promise<Component | { default: Component }>,
+    options?: OptionsWithResolver<React.ComponentProps<Component>, Component>,
+): LoadableClassComponent<Component>;
 
 declare const loadable: typeof loadableFunc & { lib: typeof lib };
 

--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -47,7 +47,12 @@ export interface LoadableComponentMethods<Props> {
     load(props?: Props): Promise<React.ComponentType<Props>>;
 }
 
-export type LoadableComponent<Props> = React.ComponentType<Props & { fallback?: JSX.Element }> &
+export interface ExtraComponentProps<Component> {
+    fallback?: JSX.Element;
+    ref?: Component extends new (...args: any[]) => any ? React.LegacyRef<InstanceType<Component>> : never;
+}
+
+export type LoadableComponent<Props, Component = never> = React.ComponentType<Props & ExtraComponentProps<Component>> &
     LoadableComponentMethods<Props>;
 
 export type LoadableLibrary<Module> = React.ComponentType<{
@@ -72,6 +77,14 @@ declare function loadableFunc<Props>(
     loadFn: (props: Props) => Promise<DefaultComponent<Props>>,
     options?: OptionsWithoutResolver<Props>,
 ): LoadableComponent<Props>;
+
+declare function loadableFunc<
+    Component extends React.ComponentType<any>,
+    Props extends React.ComponentProps<Component>,
+>(
+    loadFn: (props: Props) => Promise<Component | { default: Component }>,
+    options?: OptionsWithResolver<Props, Component>,
+): LoadableComponent<Props, Component>;
 
 declare const loadable: typeof loadableFunc & { lib: typeof lib };
 

--- a/types/loadable__component/loadable__component-tests.tsx
+++ b/types/loadable__component/loadable__component-tests.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import loadable, { lazy, loadableReady } from '@loadable/component';
 
-const TestComponent: React.SFC<{ foo: string }> = () => <>test</>;
+type TestProps = { foo: string };
+
+const TestComponent: React.FC<TestProps> = () => <>test</>;
 
 function defaultImportComponentLoader() {
     return new Promise<{ default: typeof TestComponent }>(resolve => resolve({ default: TestComponent }));
@@ -13,6 +15,16 @@ function namedImportComponentLoader() {
 
 function importComponentLoader() {
     return new Promise<typeof TestComponent>(resolve => resolve(TestComponent));
+}
+
+async function importClassComponentLoader() {
+    return class TestClassComponent extends React.Component<TestProps> {
+        publicMethod() {}
+
+        render() {
+            return <div>{this.props.foo}</div>;
+        }
+    };
 }
 
 const lib = {
@@ -59,6 +71,25 @@ function importLibLoader() {
         resolveComponent: mod => mod.name,
         cacheKey: (props: { foo: string }) => props.foo, // Annotation needed here for some reason?
     });
+
+    // Should allow ref on a class component
+    const LoadableClassDirect = loadable(importClassComponentLoader);
+    <LoadableClassDirect
+        ref={ref => {
+            ref?.publicMethod();
+        }}
+        foo=""
+    />;
+
+    const LoadableClassDefault = loadable(async () => ({
+        default: await importClassComponentLoader(),
+    }));
+    <LoadableClassDefault
+        ref={ref => {
+            ref?.publicMethod();
+        }}
+        foo=""
+    />;
 
     // Should allow passing `fallback` prop to loadable component
     <LoadableComponent foo="test" fallback={<div>loading...</div>} />;

--- a/types/loadable__component/loadable__component-tests.tsx
+++ b/types/loadable__component/loadable__component-tests.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import loadable, { lazy, loadableReady } from '@loadable/component';
 
-type TestProps = { foo: string };
+interface TestProps {
+    foo: string;
+}
 
 const TestComponent: React.FC<TestProps> = () => <>test</>;
 
@@ -76,7 +78,7 @@ function importLibLoader() {
     const LoadableClassDirect = loadable(importClassComponentLoader);
     <LoadableClassDirect
         ref={ref => {
-            ref?.publicMethod();
+            ref && ref.publicMethod();
         }}
         foo=""
     />;
@@ -86,7 +88,7 @@ function importLibLoader() {
     }));
     <LoadableClassDefault
         ref={ref => {
-            ref?.publicMethod();
+            ref && ref.publicMethod();
         }}
         foo=""
     />;


### PR DESCRIPTION
Class components should be able to give `ref`s when loaded by `loadable()`. This adds a specific overload for components that match `React.ComponentClass` so they can be given a `ref`.

In theory this could also expand to `React.forwardRef` FCs, but I didn't want to spend the time wrestling with it, as I don't have that need. 😄 

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I set up a standalone example here: https://github.com/JoshuaKGoldberg/loadable-test

Issue reference: https://github.com/gregberge/loadable-components/issues/108