### PR TITLE
[@types/exress-serve-static-core]According to express doc, NextFunction takes "route" as its arg, not "router". 

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -82,9 +82,9 @@ app.get('/nexterr', (req, res, next) => {
     next(new Error('dummy')); // $ExpectType void
 });
 
-// Next can receive a 'router' parameter to fall back to next router
+// Next can receive a 'route' parameter to fall back to next route
 app.get('/nextrouter', (req, res, next) => {
-    next('router'); // $ExpectType void
+    next('route'); // $ExpectType void
 });
 
 // Default types

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -34,10 +34,10 @@ export type Query = ParsedQs;
 export interface NextFunction {
     (err?: any): void;
     /**
-     * "Break-out" of a router by calling {next('router')};
+     * "Break-out" of a router by calling {next('route')};
      * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.router}
      */
-    (deferToNext: 'router'): void;
+    (deferToNext: 'route'): void;
 }
 
 export interface Dictionary<T> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/guide/using-middleware.html#middleware.router
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
