### PR TITLE
Allow using Uint8Arrays with varint

### DIFF
--- a/types/varint/index.d.ts
+++ b/types/varint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for varint 5.0
+// Type definitions for varint 6.0
 // Project: https://github.com/chrisdickinson/varint#readme
 // Definitions by: David Brockman Smoliansky <https://github.com/dbrockman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,6 +11,12 @@ export const encode: {
      * `varint.encode.bytes` will now be set to the number of bytes modified.
      */
     (num: number, buffer: Buffer, offset?: number): Buffer;
+
+    /**
+     * Encodes `num` into `bytes` starting at `offset`. returns `bytes`, with the encoded varint written into it.
+     * `varint.encode.bytes` will now be set to the number of bytes modified.
+     */
+    (num: number, bytes: Uint8Array, offset?: number): Uint8Array;
 
     /**
      * Encodes `num` into `array` starting at `offset`. returns `array`, with the encoded varint written into it.
@@ -31,7 +37,7 @@ export const decode: {
      * Decodes `data`, which can be either a buffer or array of integers, from position `offset` or default 0 and returns the decoded original integer.
      * Throws a `RangeError` when `data` does not represent a valid encoding.
      */
-    (buf: Buffer | number[], offset?: number): number;
+    (buf: Uint8Array | number[], offset?: number): number;
 
     /**
      * If you also require the length (number of bytes) that were required to decode the integer you can access it via `varint.decode.bytes`.

--- a/types/varint/varint-tests.ts
+++ b/types/varint/varint-tests.ts
@@ -7,10 +7,16 @@ encode(0, [], 0); // $ExpectType number[]
 encode(0, Buffer.alloc(1)); // $ExpectType Buffer
 encode(0, Buffer.alloc(1), 0); // $ExpectType Buffer
 
+encode(0, new Uint8Array(1)); // $ExpectType Uint8Array
+encode(0, new Uint8Array(1), 0); // $ExpectType Uint8Array
+
 encode.bytes; // $ExpectType number
 
 decode(Buffer.alloc(1)); // $ExpectType number
 decode(Buffer.alloc(1), 0); // $ExpectType number
+
+decode(new Uint8Array(1)); // $ExpectType number
+decode(new Uint8Array(1), 0); // $ExpectType number
 
 decode.bytes; // $ExpectType number
 


### PR DESCRIPTION
The varint module doesn't use any node-Buffer-specific properties
and also uses Uint8Arrays in its tests, so add an additional signature
that allows you to pass Uint8Arrays into `encode`.

Also changes the `decode` argument type as Buffers are Uint8Arrays so
you can use them there too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chrisdickinson/varint/blob/master/test.js#L23
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - sort of, I don't think Buffers have been explicitly required for years - at least, the commit that added Uint8Arrays to the tests was in [2013](https://github.com/chrisdickinson/varint/commit/8c42c841d69be835a1697946a1800ed9fe64b698)

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
