### PR TITLE
[node] child_process.execFile causes SystemError on ENOENT

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -338,6 +338,7 @@ declare module "child_process" {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
+    type ExecFileException = ExecException & NodeJS.ErrnoException;
 
     function execFile(file: string): ChildProcess;
     function execFile(file: string, options: (BaseEncodingOptions & ExecFileOptions) | undefined | null): ChildProcess;
@@ -345,25 +346,25 @@ declare module "child_process" {
     function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: (BaseEncodingOptions & ExecFileOptions) | undefined | null): ChildProcess;
 
     // no `options` definitely means stdout/stderr are `string`.
-    function execFile(file: string, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, callback: (error: ExecFileException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: ExecFileException | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
-    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
 
     // `options` with well known `encoding` means stdout/stderr are definitely `string`.
-    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: ExecFileException | null, stdout: string, stderr: string) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecException | null, stdout: string, stderr: string) => void,
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
 
     // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
@@ -371,35 +372,35 @@ declare module "child_process" {
     function execFile(
         file: string,
         options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
 
     // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(file: string, options: ExecFileOptions, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptions, callback: (error: ExecFileException | null, stdout: string, stderr: string) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptions,
-        callback: (error: ExecException | null, stdout: string, stderr: string) => void
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void
     ): ChildProcess;
 
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
         options: (BaseEncodingOptions & ExecFileOptions) | undefined | null,
-        callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+        callback: ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: (BaseEncodingOptions & ExecFileOptions) | undefined | null,
-        callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+        callback: ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -37,6 +37,9 @@ import { Writable, Readable, Pipe } from 'stream';
     childProcess.execFile("npm", ["-v"] as ReadonlyArray<string>, { windowsHide: true, encoding: 'buffer' }, (stdout, stderr) => { assert(stdout instanceof Buffer); });
     childProcess.execFile("npm", { encoding: 'utf-8' }, (stdout, stderr) => { assert(stdout instanceof String); });
     childProcess.execFile("npm", { encoding: 'buffer' }, (stdout, stderr) => { assert(stdout instanceof Buffer); });
+    childProcess.execFile("npm", (err) => {
+        if (err && err.errno) assert(err.code === 'ENOENT');
+    });
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

`child_process.execFile` causes [`SystemError`](https://nodejs.org/api/errors.html#errors_class_systemerror) when given file does not exist.

```
> require('child_process').execFile('blahblahblah',[],e => console.log(e))
Error: spawn blahblahblah ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:281:19)
    at onErrorNT (node:internal/child_process:481:16)
    at processTicksAndRejections (node:internal/process/task_queues:81:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn blahblahblah',
  path: 'blahblahblah',
  spawnargs: [],
  cmd: 'blahblahblah'
}
```

But current node.d.ts does not consider the case. This PR fixes the point.