### PR TITLE
mongodb: fix typings related to projection

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -47,6 +47,8 @@ import { Readable, Writable } from 'stream';
 import { checkServerIdentity } from 'tls';
 
 type FlattenIfArray<T> = T extends ReadonlyArray<infer R> ? R : T;
+type WithoutProjection<T> = T & { fields?: undefined, projection?: undefined };
+type WithProjection<T extends { projection?: any }> = T & { projection: NonNullable<T['projection']> };
 
 export function connect(uri: string, options?: MongoClientOptions): Promise<MongoClient>;
 export function connect(uri: string, callback: MongoCallback<MongoClient>): void;
@@ -1345,23 +1347,36 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
         callback: MongoCallback<number>,
     ): void;
     /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#find */
-    find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<T>;
+    find(query?: FilterQuery<TSchema>): Cursor<TSchema>;
+    find(
+        query: FilterQuery<TSchema>,
+        options?: WithoutProjection<FindOneOptions<TSchema>>,
+    ): Cursor<TSchema>;
     find<T = TSchema>(
         query: FilterQuery<TSchema>,
-        options?: FindOneOptions<T extends TSchema ? TSchema : T>,
+        options: WithProjection<FindOneOptions<T extends TSchema ? TSchema : T>>,
     ): Cursor<T>;
     /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne */
+    findOne(
+        filter: FilterQuery<TSchema>,
+        callback: MongoCallback<TSchema>,
+    ): void;
+    findOne(
+        filter: FilterQuery<TSchema>,
+        options?: WithoutProjection<FindOneOptions<TSchema>>,
+    ): Promise<TSchema | null>;
     findOne<T = TSchema>(
         filter: FilterQuery<TSchema>,
-        callback: MongoCallback<T extends TSchema ? TSchema : T | null>,
+        options: WithProjection<FindOneOptions<T extends TSchema ? TSchema : T>>,
+    ): Promise<T | null>;
+    findOne(
+        filter: FilterQuery<TSchema>,
+        options: WithoutProjection<FindOneOptions<TSchema>>,
+        callback: MongoCallback<TSchema | null>,
     ): void;
     findOne<T = TSchema>(
         filter: FilterQuery<TSchema>,
-        options?: FindOneOptions<T extends TSchema ? TSchema : T>,
-    ): Promise<T | null>;
-    findOne<T = TSchema>(
-        filter: FilterQuery<TSchema>,
-        options: FindOneOptions<T extends TSchema ? TSchema : T>,
+        options: WithProjection<FindOneOptions<T extends TSchema ? TSchema : T>>,
         callback: MongoCallback<T extends TSchema ? TSchema : T | null>,
     ): void;
     /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndDelete */
@@ -2737,7 +2752,7 @@ export class Cursor<T = Default> extends Readable {
     next(): Promise<T | null>;
     next(callback: MongoCallback<T | null>): void;
     /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#project */
-    project(value: SchemaMember<T, ProjectionOperators | number | boolean | any>): Cursor<T>;
+    project<U = T>(value: SchemaMember<T, ProjectionOperators | number | boolean | any>): Cursor<U>;
     /** @see https://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#read */
     read(size: number): string | Buffer | void;
     /** @see https://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#returnKey */

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -66,7 +66,8 @@ async function run() {
         cost: number;
         color: string;
     }
-    const cursor: Cursor<Bag> = collection.find<Bag>({ color: 'black' });
+    const collectionBag = db.collection<Bag>('bag');
+    const cursor: Cursor<Bag> = collectionBag.find({ color: 'black' });
     cursor.toArray((err, r) => {
         r[0].cost; // $ExpectType number
     });
@@ -76,14 +77,38 @@ async function run() {
         },
         () => {},
     );
-    collection.findOne({ color: 'white' }).then(b => {
-        const _b: Bag = b; // b is larger than bag and may contain extra properties
+    collectionBag.findOne({ color: 'white' }).then(b => {
+        b; // $ExpectType Bag | null
     });
-    collection
-        .findOne<Bag>({ color: 'white' })
+    collectionBag
+        .findOne({ color: 'white' })
         .then(b => {
             if (b) {
                 b.cost; // $ExpectType number
             }
         });
+    collectionBag
+        .findOne<{ cost: number }>({ color: 'red' }, { projection: { cost: 1 } })
+        .then(b => {
+            if (b) {
+                b.color; // $ExpectError
+                b.cost; // $ExpectType number
+            }
+        });
+}
+
+async function testFindReturnValue() {
+    interface Car { make: string; }
+    interface House { windows: number; }
+
+    function printHouse(house: House | null) {
+        console.log(house == null ? 'No house' : `A house with ${house.windows} windows`);
+    }
+
+    const client = await connect(connectionString);
+    const db = client.db('test');
+    const car = db.collection<Car>('car');
+
+    // $ExpectError
+    printHouse(await car.findOne({}));
 }

--- a/types/mongodb/test/cursor.ts
+++ b/types/mongodb/test/cursor.ts
@@ -4,10 +4,10 @@ import { connectionString } from './index';
 async function run() {
     const client = await connect(connectionString);
     const db = client.db('test');
-    const collection = db.collection('test.find');
+    const collection = db.collection<{ age: number }>('test.find');
 
     const cursor = collection // $ExpectType Cursor<{ foo: number; }>
-        .find<{ age: number }>()
+        .find()
         .addCursorFlag('', true)
         .addQueryModifier('', true)
         .batchSize(1)
@@ -70,6 +70,9 @@ async function run() {
     typedCollection.find().project({ name: 1 });
     typedCollection.find().project({ notExistingField: 1 });
     typedCollection.find().project({ max: { $max: [] } });
+
+    // $ExpectType Cursor<{ name: string; }>
+    typedCollection.find().project<{ name: string; }>({ name: 1 });
 
     for await (const item of cursor) {
         item.foo; // $ExpectType number


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

This PR starts to improve the typings related to projecting the objects from a collection. Right now it fixes a few annoyances that I've encountered while using these typings:

- When running `project` on a cursor there was no way to tell TypeScript how the resulting objects would look
- When running `find` or `findOne` without a projection, and passing the result directly to something else TypeScript would "helpfully" infer the `T` type to be whatever it needed to be to pass there.
  - This can be seen in the new test `testFindReturnValue` which *did not* error previously
  - another example is when using with `unwrap`, here `foo` was `null | undefined` instead of `DBUser`:
    <img width="566" alt="Screenshot 2021-02-03 at 13 22 55" src="https://user-images.githubusercontent.com/189580/106760731-62fccf80-6634-11eb-92c6-cbeccf471d76.png">

Possible future improvements:

- Change ` = T` to ` = DeepPartial<T>` on `project` to not accidentally use a non-projected value
- Change ` = TSchema` to ` = DeepPartial<TSchema>` on `find`/`findOne` for the same reason as last point
- Remove ` = T` from `project` since I don't see any use case where you would project without changing the underlying type
- Remove ` = TSchema` from `find`/`findOne` with `projection` specified for the same reason as last point
- Enable inference of the `T` type by looking at what shallow properties are passed to `projection: ...`
  - e.g. `db.collection<{ a: number, b: number }>('foo').find({}).project({ b: 1 })` should infer `{ b: number }`
- Enable inference of the `T` type by parsing `dot.prop` style properties with the TypeScript type system
  - e.g. `db.collection<{ test: { a: number, b: number } }>('foo').find({}).project({ 'test.b': 1 })` should infer `{ test: { b: number } }`