### PR TITLE
update(numeral): `value()` method returns union type

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -70,7 +70,7 @@ declare namespace numeral {
         prototype: Numeral;
         clone(): Numeral;
         format(inputString?: string, roundingFunction?: RoundingFunction): string;
-        value(): number;
+        value(): number | null;
         input(): any;
         set(value: any): Numeral;
         add(value: any): Numeral;

--- a/types/numeral/test/numeral-tests-cjs.ts
+++ b/types/numeral/test/numeral-tests-cjs.ts
@@ -14,12 +14,12 @@ const added: Numeral = value3.add(10);
 const value4: Numeral = numeral(1000);
 const formatValue4a: string = value4.format('0,0');
 // '1,000'
-const formatValue4b: number = value4.value();
+const formatValue4b: number | null = value4.value();
 // 1000
 
 const value5: Numeral = numeral();
 value5.set(1000);
-const value5Num: number = value5.value();
+const value5Num: number | null = value5.value();
 // 1000
 
 const value6: Numeral = numeral(1000);
@@ -36,11 +36,11 @@ const a: Numeral = numeral(1000);
 const b: Numeral = numeral(a);
 const c: Numeral = a.clone();
 
-const aVal: number = a.set(2000).value();
+const aVal: number | null = a.set(2000).value();
 // 2000
-const bVal: number = b.value();
+const bVal: number | null = b.value();
 // 1000
-const cVal: number = c.add(10).value();
+const cVal: number | null = c.add(10).value();
 // 1010
 
 // Formats
@@ -107,3 +107,6 @@ numeral(50).format('0%');
 // test isNumeral
 numeral.isNumeral(numeral(1000));
 numeral.isNumeral(1000);
+
+numeral(null).value(); // $ExpectType number | null
+numeral(null).value() || 0; // $ExpectType number

--- a/types/numeral/test/numeral-tests-global.ts
+++ b/types/numeral/test/numeral-tests-global.ts
@@ -11,12 +11,12 @@ const added: numeral.Numeral = value3.add(10);
 const value4: numeral.Numeral = numeral(1000);
 const formatValue4a: string = value4.format('0,0');
 // '1,000'
-const formatValue4b: number = value4.value();
+const formatValue4b: number | null = value4.value();
 // 1000
 
 const value5: numeral.Numeral = numeral();
 value5.set(1000);
-const value5Num: number = value5.value();
+const value5Num: number | null = value5.value();
 // 1000
 
 const value6: numeral.Numeral = numeral(1000);
@@ -33,11 +33,11 @@ const a: numeral.Numeral = numeral(1000);
 const b: numeral.Numeral = numeral(a);
 const c: numeral.Numeral = a.clone();
 
-const aVal: number = a.set(2000).value();
+const aVal: number | null = a.set(2000).value();
 // 2000
-const bVal: number = b.value();
+const bVal: number | null = b.value();
 // 1000
-const cVal: number = c.add(10).value();
+const cVal: number | null = c.add(10).value();
 // 1010
 
 // Formats
@@ -104,3 +104,6 @@ numeral(50).format('0%');
 // test isNumeral
 numeral.isNumeral(numeral(1000));
 numeral.isNumeral(1000);
+
+numeral(null).value(); // $ExpectType number | null
+numeral(null).value() || 0; // $ExpectType number


### PR DESCRIPTION
```ts
numeral(null).value(); // $ExpectType number | null
numeral(null).value() ?? 0; // $ExpectType number
```

https://github.com/adamwdraper/Numeral-js/blob/master/src/numeral.js#L60-L88

I've got this error when used Numeral types in @ts-check context in
plain js today. The return type `number` is wrong, and leads to runtime
errors.
I know this can potentially require rewrite when someone is using
numeral in plain JS/TS code, without using other numeral methods.

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).