### PR TITLE
[sharedb] Support backend.on('submitRequestEnd')

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -91,9 +91,11 @@ declare class sharedb extends EventEmitter {
     ): void;
 
     on(event: 'timing', callback: (type: string, time: number, request: any) => void): this;
+    on(event: 'submitRequestEnd', callback: (error: Error, request: SubmitRequest) => void): this;
     on(event: 'error', callback: (err: Error) => void): this;
 
     addListener(event: 'timing', callback: (type: string, time: number, request: any) => void): this;
+    addListener(event: 'submitRequestEnd', callback: (error: Error, request: SubmitRequest) => void): this;
     addListener(event: 'error', callback: (err: Error) => void): this;
 
     static types: ShareDB.Types;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -168,6 +168,10 @@ backend.use('readSnapshots', (context, callback) => {
     callback();
 });
 
+backend.on('submitRequestEnd', (error, request) => {
+    console.log(request.op);
+});
+
 const connection = backend.connect();
 const netRequest = {};  // Passed through to 'connect' middleware, not used by sharedb itself
 const connectionWithReq = backend.connect(null, netRequest);


### PR DESCRIPTION
ShareDB added a new `submitRequestEnd` event to `Backend` in:
https://github.com/share/sharedb/pull/429

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
