### PR TITLE
[react-autosuggest] Correct the types for renderInputComponent

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -74,6 +74,11 @@ declare namespace Autosuggest {
         highlightedSuggestion: TSuggestion;
     }
 
+    interface RenderInputComponentProps extends React.InputHTMLAttributes<any> {
+        value: string;
+        ref?: React.Ref<HTMLInputElement>;
+    }
+
     interface InputProps<TSuggestion>
         extends Omit<React.InputHTMLAttributes<any>, 'onChange' | 'onBlur'> {
         onChange(event: React.FormEvent<any>, params: ChangeEvent): void;
@@ -132,7 +137,7 @@ declare namespace Autosuggest {
         event: React.FormEvent<any>,
         data: SuggestionSelectedEventData<TSuggestion>,
     ) => void;
-    type RenderInputComponent<TSuggestion> = (inputProps: InputProps<TSuggestion>) => React.ReactNode;
+    type RenderInputComponent = (inputProps: RenderInputComponentProps) => React.ReactNode;
     type RenderSuggestionsContainer = (params: RenderSuggestionsContainerParams) => React.ReactNode;
     type RenderSectionTitle = (section: any) => React.ReactNode;
     type RenderSuggestion<TSuggestion> = (
@@ -185,7 +190,7 @@ declare namespace Autosuggest {
         /**
          * Use it only if you need to customize the rendering of the input.
          */
-        renderInputComponent?: RenderInputComponent<TSuggestion>;
+        renderInputComponent?: RenderInputComponent;
         /**
          * Use it if you want to customize things inside the suggestions container beyond rendering the suggestions themselves.
          */

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -388,11 +388,10 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         return <strong>{section.title}</strong>;
     }
 
-    protected renderInputComponent(inputProps: Autosuggest.InputProps<Language>): JSX.Element {
-        const { onChange, onBlur, ...restInputProps } = inputProps;
+    protected renderInputComponent(inputProps: Autosuggest.RenderInputComponentProps): JSX.Element {
         return (
             <div>
-                <input {...restInputProps} />
+                <input {...inputProps} />
             </div>
         );
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moroshko/react-autosuggest/blob/master/src/Autosuggest.js#L624
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
