### PR TITLE
mongodb: fix overloading with generic find options

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -48,7 +48,6 @@ import { checkServerIdentity } from 'tls';
 
 type FlattenIfArray<T> = T extends ReadonlyArray<infer R> ? R : T;
 type WithoutProjection<T> = T & { fields?: undefined, projection?: undefined };
-type WithProjection<T extends { projection?: any }> = T & { projection: NonNullable<T['projection']> };
 
 export function connect(uri: string, options?: MongoClientOptions): Promise<MongoClient>;
 export function connect(uri: string, callback: MongoCallback<MongoClient>): void;
@@ -1359,7 +1358,7 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     ): Cursor<TSchema>;
     find<T = TSchema>(
         query: FilterQuery<TSchema>,
-        options: WithProjection<FindOneOptions<T extends TSchema ? TSchema : T>>,
+        options: FindOneOptions<T extends TSchema ? TSchema : T>,
     ): Cursor<T>;
     /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne */
     findOne(
@@ -1372,7 +1371,7 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     ): Promise<TSchema | null>;
     findOne<T = TSchema>(
         filter: FilterQuery<TSchema>,
-        options: WithProjection<FindOneOptions<T extends TSchema ? TSchema : T>>,
+        options: FindOneOptions<T extends TSchema ? TSchema : T>,
     ): Promise<T | null>;
     findOne(
         filter: FilterQuery<TSchema>,
@@ -1381,7 +1380,7 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     ): void;
     findOne<T = TSchema>(
         filter: FilterQuery<TSchema>,
-        options: WithProjection<FindOneOptions<T extends TSchema ? TSchema : T>>,
+        options: FindOneOptions<T extends TSchema ? TSchema : T>,
         callback: MongoCallback<T extends TSchema ? TSchema : T | null>,
     ): void;
     /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndDelete */

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -1,4 +1,4 @@
-import { connect, MongoError, Cursor } from 'mongodb';
+import { connect, FindOneOptions, MongoError, Cursor } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.findX tests
@@ -111,4 +111,19 @@ async function testFindReturnValue() {
 
     // $ExpectError
     printHouse(await car.findOne({}));
+}
+
+async function testFindWithGenericOptions() {
+    interface Car { make: string; }
+
+    function printCar(car: Car | null) {
+        console.log(car == null ? 'No car' : `A car of ${car.make} make`);
+    }
+
+    const client = await connect(connectionString);
+    const db = client.db('test');
+    const car = db.collection<Car>('car');
+    const options: FindOneOptions<Car> = {};
+
+    printCar(await car.findOne({}, options));
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

Small follow up to my previous PR #51003. Before this change `FindOneOptions` was always required to either explicitly have a projection, or not. That isn't always the case so this patch loosens the overload to also catch the generic case. See added test case.