### PR TITLE
Only fail when there is truly a fail in the markdown linter

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx remark --use validate-links --frail . .github
+      - run: npx remark --use validate-links . .github


### PR DESCRIPTION
Re: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51051

Stops the markdown linter from failing the build on warnings, I think there's value to the system but the warnings aren't providing much value here.

/cc @jablko in case you have strong opinions