### PR TITLE
mongodb: fix findOne<T> options to be optional again

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1371,7 +1371,7 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     ): Promise<TSchema | null>;
     findOne<T = TSchema>(
         filter: FilterQuery<TSchema>,
-        options: FindOneOptions<T extends TSchema ? TSchema : T>,
+        options?: FindOneOptions<T extends TSchema ? TSchema : T>,
     ): Promise<T | null>;
     findOne(
         filter: FilterQuery<TSchema>,

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -81,7 +81,7 @@ async function run() {
         b; // $ExpectType Bag | null
     });
     collectionBag
-        .findOne({ color: 'white' })
+        .findOne<{ cost: number }>({ color: 'white' })
         .then(b => {
             if (b) {
                 b.cost; // $ExpectType number


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Previous PR #51003  broke the optional definition of `options`, so that if users are trying to use `findOne` with a generic and no options, they get type errors even if they were previously doing so with no type or runtime errors.

![image](https://user-images.githubusercontent.com/10067791/107079576-e63d3300-67a4-11eb-8449-0ac310992736.png)

Fixing the definition of `options` back to optional for `findOne` with a defined generic.
