### PR TITLE
Added Types for node-livereload (livereload server implementation)

### DIFF
--- a/types/livereload/index.d.ts
+++ b/types/livereload/index.d.ts
@@ -1,0 +1,70 @@
+// Type definitions for node-livereload 0.9
+// Project: https://github.com/napcs/node-livereload
+// Definitions by: Hector Osuna <https://github.com/FanGoH/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Server as WebSocketServer } from 'ws';
+import { Server as httpServer } from 'http';
+import { Server as httpsServer, ServerOptions } from 'https';
+import { EventEmitter } from 'events';
+import { FSWatcher } from 'fs';
+
+interface ServerConfig {
+    /** Protocol Version defaults to "7" */
+    version?: string;
+    /** Sets server port number: Defaults to 35729 */
+    port?: number;
+
+    /** File Extensions to watch */
+    exts?: string[];
+
+    extraExts?: string[];
+
+    /** Extensions to not watch */
+    exclusions?: RegExp[];
+    applyCSSLive?: boolean;
+    applyImgLive?: boolean;
+    originalPath?: string;
+    overrideURL?: string;
+    usePolling?: boolean;
+    server?: httpServer | httpsServer;
+
+    /** ms to delay browser refresh */
+    delay?: number;
+
+    /** Logs debug messages to console */
+    debug?: boolean;
+}
+
+/** Create Server Parameters */
+interface CreateServerConfig extends ServerConfig {
+    https?: ServerOptions;
+    server?: httpServer | httpsServer;
+    noListen?: boolean;
+}
+
+/** Live Reload Server object, provides main functionality */
+declare class LiveReloadServer extends EventEmitter {
+    config: ServerConfig;
+    watcher: FSWatcher;
+    server: WebSocketServer;
+    constructor(config?: ServerConfig);
+
+    listen(callback?: () => void): void;
+    onError(err: Error): void;
+    onConnection(socket?: WebSocket): void;
+    onClose(socket?: WebSocket): void;
+
+    /** Specify path(s) to watch */
+    watch(paths: string | string[]): void;
+    filterRefresh(filepath: string): void;
+    refresh(filepath: string): void;
+    alert(message: string): void;
+    sendAllClients(data: string): void;
+    close(): void;
+    debug(message: string): void;
+}
+
+export {};
+
+export function createServer(config?: CreateServerConfig, callback?: () => void): LiveReloadServer;

--- a/types/livereload/livereload-tests.ts
+++ b/types/livereload/livereload-tests.ts
@@ -1,0 +1,19 @@
+import { createServer } from 'livereload';
+
+const extensionsToWatch = ['md', 'text'];
+
+const liveReloadServer = createServer({
+    port: 35729,
+    debug: true,
+    exts: extensionsToWatch,
+});
+
+// Listen for errors
+liveReloadServer.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+        console.log('The port LiveReload wants to use is used by something else.');
+        process.exit(1);
+    }
+});
+
+liveReloadServer.watch(__dirname);

--- a/types/livereload/tsconfig.json
+++ b/types/livereload/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "livereload-tests.ts"]
+}

--- a/types/livereload/tslint.json
+++ b/types/livereload/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

