### PR TITLE
enzyme: update tests for TS 4.3

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -99,7 +99,7 @@ const CommonWrapperHelper = {
         wrapper.invoke('requiredFunctionProp'); // $ExpectType () => void
         wrapper.invoke('singleArg'); // $ExpectType (arg: any) => void
         wrapper.invoke('multipleArg'); // $ExpectType (arg1: number, arg2: string, arg3: boolean) => void
-        wrapper.invoke('multipleReturn'); // $ExpectType () => string | number | boolean | void | null | undefined
+        wrapper.invoke('multipleReturn'); // $ExpectType () => string | number | boolean | void | null | undefined || () => string | number | boolean | void | null
         wrapper.invoke(undefined); // $ExpectError
         wrapper.invoke(null); // $ExpectError
         wrapper.invoke('nonFun'); // $ExpectError


### PR DESCRIPTION
TS 4.3 more aggressively reduces subtypes in unions, including `void | undefined` to just `void`. This PR updates enzyme's tests to work both with 4.3 and 4.2 (and earlier).
