### PR TITLE
Improve react's no-return hack for TS 4.3

### DIFF
--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -7,6 +7,8 @@ import {
 
 import * as ReactTestUtils from ".";
 
+export {};
+
 export interface OptionalEventProperties {
     bubbles?: boolean;
     cancelable?: boolean;
@@ -288,12 +290,14 @@ export function createRenderer(): ShallowRenderer;
  */
 // NOTES
 // - the order of these signatures matters - typescript will check the signatures in source order.
-//   If the `() => void` signature is first, it'll erroneously match a Promise returning function for users with
+//   If the `() => VoidOrUndefinedOnly` signature is first, it'll erroneously match a Promise returning function for users with
 //   `strictNullChecks: false`.
-// - the "void/brand type union" is there to forbid any non-void return values for users with `strictNullChecks: true`
+// - VoidOrUndefinedOnly is there to forbid any non-void return values for users with `strictNullChecks: true`
+declare const UNDEFINED_VOID_ONLY: unique symbol;
 // tslint:disable-next-line: void-return
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 export function act(callback: () => Promise<void>): Promise<undefined>;
-export function act(callback: () => void | { __undefined_and_void_return_only: never }): void;
+export function act(callback: () => VoidOrUndefinedOnly): void;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -290,10 +290,10 @@ export function createRenderer(): ShallowRenderer;
 // - the order of these signatures matters - typescript will check the signatures in source order.
 //   If the `() => void` signature is first, it'll erroneously match a Promise returning function for users with
 //   `strictNullChecks: false`.
-// - the "void | undefined" types are there to forbid any non-void return values for users with `strictNullChecks: true`
+// - the "void/brand type union" is there to forbid any non-void return values for users with `strictNullChecks: true`
 // tslint:disable-next-line: void-return
-export function act(callback: () => Promise<void | undefined>): Promise<undefined>;
-export function act(callback: () => void | undefined): void;
+export function act(callback: () => Promise<void>): Promise<undefined>;
+export function act(callback: () => void | { __undefined_and_void_return_only: never }): void;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-dom/v16/test-utils/index.d.ts
+++ b/types/react-dom/v16/test-utils/index.d.ts
@@ -7,6 +7,7 @@ import {
 
 import * as ReactTestUtils from ".";
 
+export {};
 export interface OptionalEventProperties {
     bubbles?: boolean;
     cancelable?: boolean;
@@ -288,12 +289,14 @@ export function createRenderer(): ShallowRenderer;
  */
 // NOTES
 // - the order of these signatures matters - typescript will check the signatures in source order.
-//   If the `() => void` signature is first, it'll erroneously match a Promise returning function for users with
+//   If the `() => VoidOrUndefinedOnly` signature is first, it'll erroneously match a Promise returning function for users with
 //   `strictNullChecks: false`.
-// - the "void/brand type union" is there to forbid any non-void return values for users with `strictNullChecks: true`
+// - VoidOrUndefinedOnly is there to forbid any non-void return values for users with `strictNullChecks: true`
+declare const UNDEFINED_VOID_ONLY: unique symbol;
 // tslint:disable-next-line: void-return
-export function act(callback: () => Promise<void | undefined>): Promise<undefined>;
-export function act(callback: () => void | { __undefined_and_void_return_only: never }): void;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+export function act(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>;
+export function act(callback: () => VoidOrUndefinedOnly): void;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-dom/v16/test-utils/index.d.ts
+++ b/types/react-dom/v16/test-utils/index.d.ts
@@ -290,10 +290,10 @@ export function createRenderer(): ShallowRenderer;
 // - the order of these signatures matters - typescript will check the signatures in source order.
 //   If the `() => void` signature is first, it'll erroneously match a Promise returning function for users with
 //   `strictNullChecks: false`.
-// - the "void | undefined" types are there to forbid any non-void return values for users with `strictNullChecks: true`
+// - the "void/brand type union" is there to forbid any non-void return values for users with `strictNullChecks: true`
 // tslint:disable-next-line: void-return
 export function act(callback: () => Promise<void | undefined>): Promise<undefined>;
-export function act(callback: () => void | undefined): void;
+export function act(callback: () => void | { __undefined_and_void_return_only: never }): void;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -10,6 +10,7 @@
 // TypeScript Version: 2.8
 
 import { ReactElement, ElementType } from 'react';
+export {};
 
 // extracted from:
 // - https://github.com/facebook/react/blob/v16.0.0/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -54,6 +55,11 @@ export interface TestRendererOptions {
 }
 export function create(nextElement: ReactElement, options?: TestRendererOptions): ReactTestRenderer;
 
+// VoidOrUndefinedOnly is here to forbid any sneaky "Promise" returns.
+// the actual return value is always a "DebugPromiseLike".
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// tslint:disable-next-line: void-return
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 /**
  * Wrap any code rendering and triggering updates to your components into `act()` calls.
  *
@@ -65,9 +71,8 @@ export function create(nextElement: ReactElement, options?: TestRendererOptions)
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void | undefined" is here to forbid any sneaky return values
-// tslint:disable-next-line: void-return
-export function act(callback: () => Promise<void | undefined>): Promise<undefined>;
+// VoidOrUndefinedOnly is here to forbid any sneaky return values
+export function act(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>;
 /**
  * Wrap any code rendering and triggering updates to your components into `act()` calls.
  *
@@ -79,9 +84,7 @@ export function act(callback: () => Promise<void | undefined>): Promise<undefine
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void/brand type union" is here to forbid any sneaky "Promise" returns.
-// the actual return value is always a "DebugPromiseLike".
-export function act(callback: () => void | { __undefined_and_void_return_only: never }): DebugPromiseLike;
+export function act(callback: () => VoidOrUndefinedOnly): DebugPromiseLike;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -79,9 +79,9 @@ export function act(callback: () => Promise<void | undefined>): Promise<undefine
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void | undefined" is here to forbid any sneaky "Promise" returns.
+// the "void/brand type union" is here to forbid any sneaky "Promise" returns.
 // the actual return value is always a "DebugPromiseLike".
-export function act(callback: () => void | undefined): DebugPromiseLike;
+export function act(callback: () => void | { __undefined_and_void_return_only: never }): DebugPromiseLike;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-test-renderer/v16/index.d.ts
+++ b/types/react-test-renderer/v16/index.d.ts
@@ -10,6 +10,7 @@
 // TypeScript Version: 2.8
 
 import { ReactElement, ElementType } from 'react';
+export {};
 
 // extracted from:
 // - https://github.com/facebook/react/blob/v16.0.0/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -54,6 +55,11 @@ export interface TestRendererOptions {
 }
 export function create(nextElement: ReactElement, options?: TestRendererOptions): ReactTestRenderer;
 
+// VoidOrUndefinedOnly is here to forbid any sneaky "Promise" returns.
+// the actual return value is always a "DebugPromiseLike".
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// tslint:disable-next-line: void-return
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 /**
  * Wrap any code rendering and triggering updates to your components into `act()` calls.
  *
@@ -65,9 +71,8 @@ export function create(nextElement: ReactElement, options?: TestRendererOptions)
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void | undefined" is here to forbid any sneaky return values
-// tslint:disable-next-line: void-return
-export function act(callback: () => Promise<void | undefined>): Promise<undefined>;
+// VoidOrUndefinedOnly is here to forbid any sneaky return values
+export function act(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>;
 /**
  * Wrap any code rendering and triggering updates to your components into `act()` calls.
  *
@@ -79,9 +84,7 @@ export function act(callback: () => Promise<void | undefined>): Promise<undefine
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void/brand type union" is here to forbid any sneaky "Promise" returns.
-// the actual return value is always a "DebugPromiseLike".
-export function act(callback: () => void | { __undefined_and_void_return_only: never }): DebugPromiseLike;
+export function act(callback: () => VoidOrUndefinedOnly): DebugPromiseLike;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-test-renderer/v16/index.d.ts
+++ b/types/react-test-renderer/v16/index.d.ts
@@ -79,9 +79,9 @@ export function act(callback: () => Promise<void | undefined>): Promise<undefine
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void | undefined" is here to forbid any sneaky "Promise" returns.
+// the "void/brand type union" is here to forbid any sneaky "Promise" returns.
 // the actual return value is always a "DebugPromiseLike".
-export function act(callback: () => void | undefined): DebugPromiseLike;
+export function act(callback: () => void | { __undefined_and_void_return_only: never }): DebugPromiseLike;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -38,6 +38,9 @@ import React = require('.');
 
 export {};
 
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
 declare module '.' {
     export interface SuspenseProps {
         /**
@@ -110,12 +113,12 @@ declare module '.' {
 
     // undocumented, considered for removal
     export function unstable_withSuspenseConfig(
-        scope: () => void | { __undefined_and_void_return_only: never },
+        scope: () => VoidOrUndefinedOnly,
         config: SuspenseConfig | null | undefined,
     ): void;
 
     // must be synchronous
-    export type TransitionFunction = () => void | { __undefined_and_void_return_only: never };
+    export type TransitionFunction = () => VoidOrUndefinedOnly;
     // strange definition to allow vscode to show documentation on the invocation
     export interface TransitionStartFunction {
         /**

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -110,12 +110,12 @@ declare module '.' {
 
     // undocumented, considered for removal
     export function unstable_withSuspenseConfig(
-        scope: () => void | undefined,
+        scope: () => void | { __undefined_and_void_return_only: never },
         config: SuspenseConfig | null | undefined,
     ): void;
 
     // must be synchronous
-    export type TransitionFunction = () => void | undefined;
+    export type TransitionFunction = () => void | { __undefined_and_void_return_only: never };
     // strange definition to allow vscode to show documentation on the invocation
     export interface TransitionStartFunction {
         /**

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -61,6 +61,10 @@ interface SchedulerInteraction {
     timestamp: number;
 }
 
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// Destructors are only allowed to return void.
+type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
+
 // tslint:disable-next-line:export-just-namespace
 export = React;
 export as namespace React;
@@ -891,8 +895,7 @@ declare namespace React {
     type DependencyList = ReadonlyArray<any>;
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
-    // The destructor is itself only allowed to return void.
-    type EffectCallback = () => (void | (() => void | { __undefined_and_void_return_only: never }));
+    type EffectCallback = () => (void | Destructor);
 
     interface MutableRefObject<T> {
         current: T;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -892,7 +892,7 @@ declare namespace React {
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
     // The destructor is itself only allowed to return void.
-    type EffectCallback = () => (void | (() => void | undefined));
+    type EffectCallback = () => (void | (() => void | { __undefined_and_void_return_only: never }));
 
     interface MutableRefObject<T> {
         current: T;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -893,7 +893,7 @@ declare namespace React {
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
     // The destructor is itself only allowed to return void.
-    type EffectCallback = () => (void | (() => void | undefined));
+    type EffectCallback = () => (void | (() => void | { __undefined_and_void_return_only: never }));
 
     interface MutableRefObject<T> {
         current: T;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -61,6 +61,10 @@ interface SchedulerInteraction {
     timestamp: number;
 }
 
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// Destructors are only allowed to return void.
+type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
+
 // tslint:disable-next-line:export-just-namespace
 export = React;
 export as namespace React;
@@ -892,8 +896,7 @@ declare namespace React {
     type DependencyList = ReadonlyArray<any>;
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
-    // The destructor is itself only allowed to return void.
-    type EffectCallback = () => (void | (() => void | { __undefined_and_void_return_only: never }));
+    type EffectCallback = () => (void | Destructor);
 
     interface MutableRefObject<T> {
         current: T;


### PR DESCRIPTION
React, along with react-dom and react-test-renderer, have a few return types that are intended to disallow returning anything except `undefined`. Previously, the union type `void | undefined` worked for this purpose, but with TS 4.3's new, more aggressive subtype reduction, this is treated as just `void`. And `void`-returning signatures allow *anything* to be returned.

The solution is to use a brand with void, like `void | { _a: never}`. This allows functions that don't have a return statement to infer `void`, which is assignable to `void`. Any functions with a return statement will infer from the return statement, and that type will not be assignable to `{ _a: never }`. 

Thanks to @tjjfvi for suggesting this solution.

Exceptions are

1. returning expressions of type `undefined`
2. returning expressions of type `void`
3. ~casting to the brand type~.

The first should be fine, the second should rarely happen by mistake, and the third should only happen as an intentional workaround.
Update: @rbuckton suggested using `unique symbol` for the brand, which removes exception (3), as well as using a type alias to make the solution display better in quick info.

I'm opening this PR in order to maintain backward compatibility. It's entirely possible that trying to restrict the return type of callbacks is pointless, and that it's fine for callbacks to actually return anything. If that's the case, it would be fine to simplify the return type to just `void`.