### PR TITLE
add types for wordfilter

### DIFF
--- a/types/wordfilter/index.d.ts
+++ b/types/wordfilter/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for wordfilter 0.2
+// Project: https://github.com/dariusk/wordfilter
+// Definitions by: mike castleman <https://github.com/mlc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function blacklisted(string: string): boolean;
+export function addWords(array: string | readonly string[]): void;
+export function removeWord(word: string): void;
+export function clearList(): void;

--- a/types/wordfilter/tsconfig.json
+++ b/types/wordfilter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wordfilter-tests.ts"
+    ]
+}

--- a/types/wordfilter/tslint.json
+++ b/types/wordfilter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wordfilter/wordfilter-tests.ts
+++ b/types/wordfilter/wordfilter-tests.ts
@@ -1,0 +1,13 @@
+import { blacklisted, addWords, removeWord, clearList } from 'wordfilter';
+
+// $ExpectType boolean
+blacklisted('this is some kind of string');
+
+addWords('foo');
+addWords(['bar', 'baz']);
+// $ExpectError
+addWords(3);
+
+removeWord('foo');
+
+clearList();


### PR DESCRIPTION
[`wordfilter`](https://github.com/dariusk/wordfilter) is a small module to filter strings for "bad words". This PR adds types for that module.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

