### PR TITLE
[ramda] adds more control to lensIndex

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -933,6 +933,7 @@ export function lens<S, A>(getter: (s: S) => A, setter: (a: A, s: S) => S): Lens
  * Creates a lens that will focus on index n of the source array.
  */
 export function lensIndex<A>(n: number): Lens<A[], A>;
+export function lensIndex<A extends any[], N extends number>(n: N): Lens<A, A[N]>;
 
 /**
  * Returns a lens whose focus is the specified path.

--- a/types/ramda/test/lensIndex-tests.ts
+++ b/types/ramda/test/lensIndex-tests.ts
@@ -4,3 +4,23 @@ import * as R from 'ramda';
   // $ExpectType Lens<number[], number>
   R.lensIndex<number>(0);
 };
+
+() => {
+  type First = string;
+  type Second = number;
+  type Third = boolean;
+
+  type Line = [First, Second, Third];
+
+  const lines: Line[] = [
+    ['a', 1, true],
+    ['b', 2, false],
+    ['c', 3, true],
+  ];
+
+  // $ExpectType Lens<Line, string>
+  const firstLens = R.lensIndex<Line, 0>(0);
+
+  // $ExpectType (obj: Line) => string
+  const viewFirst = R.view(firstLens);
+};


### PR DESCRIPTION
The current implementation of the `lensIndex` function works great if every element in the array is the same type, but does not work so well for tuples.

Consider the following:
```ts
type First = string;
type Second = number;
type Third = boolean;

type Line = [First, Second, Third];

const lines: Line[] = [
  ['a', 1, true],
  ['b', 2, false],
  ['c', 3, true],
];

const firstLens = lensIndex(0);
const viewFirst = view(firstLens);
```

Today, the only option available is to do `lensIndex<Line>(0)` but this returns a type of `Lens<Line[], Line>` which is wrong and returns the error when we try to use the lens (e.g. `viewFirst(lines[0])`):
```
Type 'string | number | boolean' is not assignable to type 'Line'.
    Type 'string' is not assignable to type '[string, number, boolean]'.
```

And yet, our actual type is `Lens<Line, First>` (or, `Lens<Line, string>`).

If we could specify `lensIndex<Line, 0>(0)` then the problem is solved, because the type of `viewFirst` then becomes `(obj: Line) => string` instead of `(obj: Line[]) => Line` as it was before.  This PR implements that functionality.

