### PR TITLE
[react-table]: mark column parent optional

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -282,7 +282,7 @@ export interface UseTableHeaderGroupProps<D extends object> {
 
 export interface UseTableColumnProps<D extends object> {
     id: IdType<D>;
-    columns: Array<ColumnInstance<D>>;
+    columns?: Array<ColumnInstance<D>>;
     isVisible: boolean;
     render: (type: 'Header' | 'Footer' | string, props?: object) => ReactNode;
     totalLeft: number;
@@ -293,7 +293,6 @@ export interface UseTableColumnProps<D extends object> {
     parent?: ColumnInstance<D>; // not documented
     getToggleHiddenProps: (userProps?: any) => any;
     depth: number; // not documented
-    index: number; // not documented
     placeholderOf?: ColumnInstance;
 }
 

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -290,7 +290,7 @@ export interface UseTableColumnProps<D extends object> {
     getHeaderProps: (propGetter?: HeaderPropGetter<D>) => TableHeaderProps;
     getFooterProps: (propGetter?: FooterPropGetter<D>) => TableFooterProps;
     toggleHidden: (value?: boolean) => void;
-    parent: ColumnInstance<D>; // not documented
+    parent?: ColumnInstance<D>; // not documented
     getToggleHiddenProps: (userProps?: any) => any;
     depth: number; // not documented
     index: number; // not documented

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -172,8 +172,10 @@ const EditableCell = ({
 };
 
 // Define a default UI for filtering
-function DefaultColumnFilter({ column: { filterValue, preFilteredRows, setFilter } }: FilterProps<Data>) {
+function DefaultColumnFilter({ column: { filterValue, preFilteredRows, setFilter, parent } }: FilterProps<Data>) {
     const count = preFilteredRows.length;
+
+    const foo = parent;  // $ExpectType ColumnInstance<Data> | undefined
 
     return (
         <input


### PR DESCRIPTION
This isn't a change in behavior so much as just discovering that parent always was optional and I missed it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
 - no documentation since it's undocumented.
