### PR TITLE
fix(webpack-plugin-serve): adjust `http-proxy-middleware` dependency

### DIFF
--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -5,7 +5,7 @@
 // Minimum TypeScript Version: 3.8
 /// <reference types="node" />
 
-import { Config as HttpProxyMiddlewareConfig, Proxy } from 'http-proxy-middleware';
+import { Options as HttpProxyMiddlewareConfig, RequestHandler as Proxy } from 'http-proxy-middleware';
 import * as Koa from 'koa';
 import { ServerOptions as Http2ServerOptions, SecureServerOptions as Http2SecureServerOptions } from 'http2';
 import { ServerOptions as HttpsServerOptions } from 'https';

--- a/types/webpack-plugin-serve/package.json
+++ b/types/webpack-plugin-serve/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "globby": "^11.0.1"
+        "globby": "^11.0.1",
+        "http-proxy-middleware": "^1.0.0"
     }
 }

--- a/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
+++ b/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
@@ -1,4 +1,12 @@
-import { WebpackPluginServe } from 'webpack-plugin-serve';
+import { Builtins, WebpackPluginServe } from 'webpack-plugin-serve';
+
+const proxy: Builtins['proxy'] = ({ logLevel }) => {
+    if (logLevel === 'debug') {
+        console.debug('debugging logs activated!');
+    }
+
+    return (req, res, next) => next();
+};
 
 interface Configuration {
     entry: string[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #45479
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-------

Fixes #45479 (<--- this has all the details)

~I'm making a PR to `DefinitelyTyped-tools` adding `http-proxy-middleware` to the `allowedPackageJsonDependencies` list.~ https://github.com/microsoft/DefinitelyTyped-tools/pull/201

`http-proxy-middleware` should maybe be removed as it's now shipping its own types? I say "maybe" because the types are for 0.x, and its shipping the types as of 1.x, so maybe it's fine 🤷 