### PR TITLE
Added type definitions for set-accurate-timeout

### DIFF
--- a/types/set-accurate-timeout/index.d.ts
+++ b/types/set-accurate-timeout/index.d.ts
@@ -7,6 +7,6 @@
  * @param callback This callback is called when the specified delay is passed
  * @param delay The time (in milliseconds) to wait, before calling the callback
  */
-declare function setAccurateTimeout(callback: () => void, delay: number): void;
+declare function setAccurateTimeout(callback: (...args: any[]) => void, delay: number): void;
 
 export = setAccurateTimeout;

--- a/types/set-accurate-timeout/index.d.ts
+++ b/types/set-accurate-timeout/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for set-accurate-timeout 1.0
+// Project: https://gitlab.com/notacircle/set-accurate-timeout
+// Definitions by: Priyanshu Rav <https://github.com/pr357>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function setAccurateTimeout(callback: () => void, delay: number): void;
+
+export = setAccurateTimeout;

--- a/types/set-accurate-timeout/index.d.ts
+++ b/types/set-accurate-timeout/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: Priyanshu Rav <https://github.com/pr357>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/**
+ * @param callback This callback is called when the specified delay is passed
+ * @param delay The time (in milliseconds) to wait, before calling the callback
+ */
 declare function setAccurateTimeout(callback: () => void, delay: number): void;
 
 export = setAccurateTimeout;

--- a/types/set-accurate-timeout/set-accurate-timeout-tests.ts
+++ b/types/set-accurate-timeout/set-accurate-timeout-tests.ts
@@ -1,0 +1,3 @@
+import setAccurateTimeout = require('set-accurate-timeout');
+
+setAccurateTimeout(() => {}, 3000);

--- a/types/set-accurate-timeout/tsconfig.json
+++ b/types/set-accurate-timeout/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "set-accurate-timeout-tests.ts"
+    ]
+}

--- a/types/set-accurate-timeout/tslint.json
+++ b/types/set-accurate-timeout/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds the type definitions for [set-accurate-timeout](https://www.npmjs.com/package/set-accurate-timeout)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
