### PR TITLE
[graphql-relay] Add ArrayConnection

### DIFF
--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -5,27 +5,23 @@
 // TypeScript Version: 2.6
 
 import {
-    GraphQLBoolean,
-    GraphQLInt,
-    GraphQLNonNull,
-    GraphQLList,
-    GraphQLObjectType,
-    GraphQLString,
+    GraphQLEnumType,
     GraphQLFieldConfig,
-    GraphQLInputFieldConfigMap,
-    GraphQLFieldConfigMap,
     GraphQLFieldConfigArgumentMap,
-    GraphQLResolveInfo,
-    GraphQLInterfaceType,
-    GraphQLInputType,
-    GraphQLOutputType,
+    GraphQLFieldConfigMap,
     GraphQLFieldResolver,
+    GraphQLInputFieldConfigMap,
+    GraphQLInputType,
+    GraphQLInterfaceType,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLOutputType,
+    GraphQLResolveInfo,
+    GraphQLScalarType,
     GraphQLTypeResolver,
     GraphQLUnionType,
-    GraphQLEnumType,
-    GraphQLScalarType,
-    Thunk
-} from "graphql";
+    Thunk,
+} from 'graphql';
 
 // connection/connection.js
 
@@ -83,9 +79,7 @@ export interface GraphQLConnectionDefinitions {
  * Returns a GraphQLObjectType for a connection with the given name,
  * and whose nodes are of the specified type.
  */
-export function connectionDefinitions(
-    config: ConnectionConfig
-): GraphQLConnectionDefinitions;
+export function connectionDefinitions(config: ConnectionConfig): GraphQLConnectionDefinitions;
 
 // connection/connectiontypes.js
 
@@ -104,12 +98,24 @@ export interface PageInfo {
     hasNextPage?: boolean | null;
 }
 
+export interface ArrayConnectionPageInfo {
+    startCursor?: ConnectionCursor | null;
+    endCursor?: ConnectionCursor | null;
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+}
+
 /**
  * A flow type designed to be exposed as a `Connection` over GraphQL.
  */
 export interface Connection<T> {
     edges: Array<Edge<T>>;
     pageInfo: PageInfo;
+}
+
+export interface ArrayConnection<T> {
+    edges: Array<Edge<T>>;
+    pageInfo: ArrayConnectionPageInfo;
 }
 
 /**
@@ -142,10 +148,7 @@ export interface ArraySliceMetaInfo {
  * a connection object for use in GraphQL. It uses array offsets as pagination,
  * so pagination will only work if the array is static.
  */
-export function connectionFromArray<T>(
-    data: T[],
-    args: ConnectionArguments
-): Connection<T>;
+export function connectionFromArray<T>(data: T[], args: ConnectionArguments): ArrayConnection<T>;
 
 /**
  * A version of `connectionFromArray` that takes a promised array, and returns a
@@ -153,8 +156,8 @@ export function connectionFromArray<T>(
  */
 export function connectionFromPromisedArray<T>(
     dataPromise: Promise<T[]>,
-    args: ConnectionArguments
-): Promise<Connection<T>>;
+    args: ConnectionArguments,
+): Promise<ArrayConnection<T>>;
 
 /**
  * Given a slice (subset) of an array, returns a connection object for use in
@@ -168,8 +171,8 @@ export function connectionFromPromisedArray<T>(
 export function connectionFromArraySlice<T>(
     arraySlice: T[],
     args: ConnectionArguments,
-    meta: ArraySliceMetaInfo
-): Connection<T>;
+    meta: ArraySliceMetaInfo,
+): ArrayConnection<T>;
 
 /**
  * A version of `connectionFromArraySlice` that takes a promised array slice,
@@ -178,8 +181,8 @@ export function connectionFromArraySlice<T>(
 export function connectionFromPromisedArraySlice<T>(
     dataPromise: Promise<T[]>,
     args: ConnectionArguments,
-    arrayInfo: ArraySliceMetaInfo
-): Promise<Connection<T>>;
+    arrayInfo: ArraySliceMetaInfo,
+): Promise<ArrayConnection<T>>;
 
 /**
  * Creates the cursor string from an offset.
@@ -194,28 +197,18 @@ export function cursorToOffset(cursor: ConnectionCursor): number;
 /**
  * Return the cursor associated with an object in an array.
  */
-export function cursorForObjectInConnection<T>(
-    data: T[],
-    object: T
-): ConnectionCursor;
+export function cursorForObjectInConnection<T>(data: T[], object: T): ConnectionCursor;
 
 /**
  * Given an optional cursor and a default offset, returns the offset
  * to use; if the cursor contains a valid offset, that will be used,
  * otherwise it will be the default.
  */
-export function getOffsetWithDefault(
-    cursor?: ConnectionCursor | null,
-    defaultOffset?: number | null
-): number;
+export function getOffsetWithDefault(cursor?: ConnectionCursor | null, defaultOffset?: number | null): number;
 
 // mutation/mutation.js
 
-export type mutationFn = (
-    object: any,
-    ctx: any,
-    info: GraphQLResolveInfo
-) => Promise<any> | any;
+export type mutationFn = (object: any, ctx: any, info: GraphQLResolveInfo) => Promise<any> | any;
 
 /**
  * A description of a mutation consumable by mutationWithClientMutationId
@@ -244,9 +237,7 @@ export interface MutationConfig {
  * Returns a GraphQLFieldConfig for the mutation described by the
  * provided MutationConfig.
  */
-export function mutationWithClientMutationId(
-    config: MutationConfig
-): GraphQLFieldConfig<any, any>;
+export function mutationWithClientMutationId(config: MutationConfig): GraphQLFieldConfig<any, any>;
 
 // node/node.js
 
@@ -256,8 +247,7 @@ export interface GraphQLNodeDefinitions {
     nodesField: GraphQLFieldConfig<any, any>;
 }
 
-export type typeResolverFn = ((any: any) => GraphQLObjectType) |
-    ((any: any) => Promise<GraphQLObjectType>);
+export type typeResolverFn = ((any: any) => GraphQLObjectType) | ((any: any) => Promise<GraphQLObjectType>);
 
 /**
  * Given a function to map from an ID to an underlying object, and a function
@@ -270,8 +260,8 @@ export type typeResolverFn = ((any: any) => GraphQLObjectType) |
  * interface without a provided `resolveType` method.
  */
 export function nodeDefinitions<TContext>(
-    idFetcher: ((id: string, context: TContext, info: GraphQLResolveInfo) => any),
-    typeResolver?: GraphQLTypeResolver<any, TContext>
+    idFetcher: (id: string, context: TContext, info: GraphQLResolveInfo) => any,
+    typeResolver?: GraphQLTypeResolver<any, TContext>,
 ): GraphQLNodeDefinitions;
 
 export interface ResolvedGlobalId {
@@ -299,7 +289,7 @@ export function fromGlobalId(globalId: string): ResolvedGlobalId;
  */
 export function globalIdField(
     typeName?: string,
-    idFetcher?: (object: any, context: any, info: GraphQLResolveInfo) => string
+    idFetcher?: (object: any, context: any, info: GraphQLResolveInfo) => string,
 ): GraphQLFieldConfig<any, any>;
 
 // node/plural.js
@@ -312,6 +302,4 @@ export interface PluralIdentifyingRootFieldConfig {
     description?: string;
 }
 
-export function pluralIdentifyingRootField(
-    config: PluralIdentifyingRootFieldConfig
-): GraphQLFieldConfig<any, any>;
+export function pluralIdentifyingRootField(config: PluralIdentifyingRootFieldConfig): GraphQLFieldConfig<any, any>;

--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -98,9 +98,7 @@ export interface PageInfo {
     hasNextPage?: boolean | null;
 }
 
-export interface ArrayConnectionPageInfo {
-    startCursor?: ConnectionCursor | null;
-    endCursor?: ConnectionCursor | null;
+export interface ArrayConnectionPageInfo extends PageInfo {
     hasPreviousPage: boolean;
     hasNextPage: boolean;
 }
@@ -113,8 +111,7 @@ export interface Connection<T> {
     pageInfo: PageInfo;
 }
 
-export interface ArrayConnection<T> {
-    edges: Array<Edge<T>>;
+export interface ArrayConnection<T> extends Connection<T> {
     pageInfo: ArrayConnectionPageInfo;
 }
 


### PR DESCRIPTION
Add ArrayConnection. a more narrow version of Connection for connections created by connectionFromArray. In the [source code](https://github.com/graphql/graphql-relay-js/blob/master/src/connection/arrayconnection.js), all versions of `connectionFromArray` provide non-null values for `pageInfo.hasPreviousPage` and `pageInfo.hasNextPage`.

The formatting changes are a result of running prettier.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-relay-js/blob/master/src/connection/arrayconnection.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
