### PR TITLE
[babel-plugin-tester] Fix wrong types

### DIFF
--- a/types/babel-plugin-tester/babel-plugin-tester-tests.ts
+++ b/types/babel-plugin-tester/babel-plugin-tester-tests.ts
@@ -1,9 +1,10 @@
-import pluginTester from 'babel-plugin-tester';
+import pluginTester, { prettierFormatter } from 'babel-plugin-tester';
 import purePluginTester from 'babel-plugin-tester/pure';
 
 pluginTester({
     plugin: () => {},
     pluginName: 'my-babel-plugin',
+    formatResult: code => prettierFormatter(code, { config: { printWidth: 500 } }),
     snapshot: true,
     babelOptions: {
         filename: '/path/to/file',
@@ -17,6 +18,9 @@ pluginTester({
       const globTest = awesome();
     `,
             only: true,
+            pluginOptions: {
+                foo: 'bar',
+            },
         },
     },
 });

--- a/types/babel-plugin-tester/index.d.ts
+++ b/types/babel-plugin-tester/index.d.ts
@@ -153,7 +153,7 @@ export interface TestObject {
      *
      */
     babelOptions?: Babel.TransformOptions;
-    
+
     /**
      * This can be used to pass options into your plugin at transform time.
      *
@@ -290,7 +290,10 @@ export default function pluginTester(options: PluginTesterOptions): void;
 /**
  * Formatter used for the snapshots.
  */
-export function prettierFormatter(code: string, options: Options): string;
+export function prettierFormatter(
+    code: string,
+    options?: { cwd?: string; filename?: string; config?: Options },
+): string;
 
 export const unstringSnapshotSerializer: {
     test(value: unknown): value is string;

--- a/types/babel-plugin-tester/index.d.ts
+++ b/types/babel-plugin-tester/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for babel-plugin-tester 9.0
 // Project: https://github.com/babel-utils/babel-plugin-tester#readme
 // Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
+//                 Mathieu TUDISCO <https://github.com/mathieutu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
 
@@ -152,6 +153,12 @@ export interface TestObject {
      *
      */
     babelOptions?: Babel.TransformOptions;
+    
+    /**
+     * This can be used to pass options into your plugin at transform time.
+     *
+     */
+    pluginOptions?: Babel.PluginOptions;
 }
 
 export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
Hi @ifiokjr!
I've updated wrong types in the package:
- As said in [the doc](https://github.com/babel-utils/babel-plugin-tester#pluginoptions), the `pluginOptions` entry can be used in TestObject
- The `prettierFormatter` options type was wrong, the prettier config should be wrapped in `config`. See [the code](https://github.com/babel-utils/babel-plugin-tester/blob/master/src/formatters/prettier.js), 


Thanks for your work!
Mathieu.

------

DT stuffs:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.