### PR TITLE
Fix Fragment.findDiffEnd() parameter type

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -5,6 +5,7 @@
 //                 Tim Baumann <https://github.com/timjb>
 //                 Malte Blanken <https://github.com/neknalb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Anthony Weston <https://github.com/AnthonyWeston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -154,7 +155,7 @@ export class Fragment<S extends Schema = any> {
      * same. Since this position will not be the same in both nodes, an
      * object with two separate positions is returned.
      */
-    findDiffEnd(other: ProsemirrorNode<S>): { a: number; b: number } | null | undefined;
+    findDiffEnd(other: Fragment<S>): { a: number; b: number } | null | undefined;
     /**
      * Return a debugging string that describes this fragment.
      */

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -72,7 +72,7 @@ f1.descendants(() => true);
 
 const res2_1: model.Node = f1.maybeChild(0)!;
 const res2_2: number = f1.findDiffStart(f1)!;
-const res2_3: { a: number; b: number } = f1.findDiffEnd({} as any)!;
+const res2_3: { a: number; b: number } = f1.findDiffEnd(f1)!;
 const res2_4: object = f1.toJSON()!;
 
 const res3_1 = new model.ResolvedPos();


### PR DESCRIPTION
See https://prosemirror.net/docs/ref/#model.Fragment.findDiffEnd

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prosemirror.net/docs/ref/#model.Fragment.findDiffEnd
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
