### PR TITLE
[react-redux]: Move deps [redux] to devDeps

### DIFF
--- a/types/react-redux/package.json
+++ b/types/react-redux/package.json
@@ -1,7 +1,9 @@
 {
     "private": true,
     "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/hoist-non-react-statics": "^3.3.0"
+    },
+    "devDependencies": {
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
     }


### PR DESCRIPTION
My package.json as follows:
```json
{
  "name": "test-types-react-redux",
  "version": "1.0.0",
  "description": "",
  "scripts": {},
  "dependencies": {
    "redux" : "4.0.4",
    "@types/react-redux" : "7.1.16"
  }
}
```

The yarn installation will install two versions of redux 4.04 and 4.05, 
in order to avoid this problem, 
redux should be placed in the dev dependency

------

npm installation is fine,
but yarn installation will install two versions of redux 4.04 and 4.05,
how can i do?

$ yarn -v 
1.22.10

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
