### PR TITLE
[w3c-web-hid] Add w3c webhid type definitions

### DIFF
--- a/types/w3c-web-hid/index.d.ts
+++ b/types/w3c-web-hid/index.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for non-npm package w3c-web-hid 1.0
 // Project: https://wicg.github.io/webhid
+// Definitions by: Kouhei Kiyama <https://github.com/kkiyama117>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/w3c-web-hid/index.d.ts
+++ b/types/w3c-web-hid/index.d.ts
@@ -1,0 +1,177 @@
+// Type definitions for non-npm package w3c-web-hid 1.0
+// Project: https://wicg.github.io/webhid
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+/*~ https://wicg.github.io/webhid/#enumeration */
+interface HIDDeviceFilter {
+    vendorId?: number;
+    productId?: number;
+    usagePage?: number;
+    usage?: number;
+}
+
+/*~ https://wicg.github.io/webhid/#enumeration */
+interface HIDDeviceRequestOptions {
+    filters: HIDDeviceFilter[];
+}
+
+/*~ https://wicg.github.io/webhid/#enumeration */
+declare class HID extends EventTarget {
+    onconnect: ((this: this, ev: Event) => any) | null;
+    ondisconnect: ((this: this, ev: Event) => any) | null;
+
+    getDevices(): Promise<HIDDevice[]>;
+
+    requestDevice(options?: HIDDeviceRequestOptions): Promise<HIDDevice[]>;
+
+    addEventListener(
+        type: 'connect' | 'disconnect',
+        listener: (this: this, ev: HIDConnectionEvent) => any,
+        useCapture?: boolean,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+
+    removeEventListener(
+        type: 'connect' | 'disconnect',
+        callback: (this: this, ev: HIDConnectionEvent) => any,
+        useCapture?: boolean,
+    ): void;
+    removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: EventListenerOptions | boolean,
+    ): void;
+}
+
+/*~ https://wicg.github.io/webhid/#enumeration */
+interface Navigator {
+    readonly hid: HID;
+}
+
+/*~ https://wicg.github.io/webhid/#events */
+interface HIDConnectionEventInit {
+    device: HIDDevice;
+}
+
+/*~ https://wicg.github.io/webhid/#events */
+declare class HIDConnectionEvent extends Event {
+    constructor(type: string, eventInitDict: HIDConnectionEventInit);
+
+    readonly device: HIDDevice;
+    readonly reportId: number;
+    readonly data: DataView;
+}
+
+/*~ https://wicg.github.io/webhid/#events */
+interface HIDInputReportEventInit extends EventInit {
+    device: HIDDevice;
+    reportId: number;
+    data: DataView;
+}
+
+/*~ https://wicg.github.io/webhid/#events */
+declare class HIDInputReportEvent extends Event {
+    constructor(type: string, eventInitDict: HIDInputReportEventInit);
+
+    readonly device: HIDDevice;
+    readonly reportId: number;
+    readonly data: DataView;
+}
+
+/*~ https://wicg.github.io/webhid/#report-descriptor */
+type HIDUnitSystem =
+    | 'none'
+    | 'si-linear'
+    | 'si-rotation'
+    | 'english-linear'
+    | 'english-rotation'
+    | 'vendor-defined'
+    | 'reserved';
+
+/*~ https://wicg.github.io/webhid/#report-descriptor */
+interface HIDReportItem {
+    isAbsolute?: boolean;
+    isArray?: boolean;
+    isBufferedBytes?: boolean;
+    isConstant?: boolean;
+    isLinear?: boolean;
+    isRange?: boolean;
+    isVolatile?: boolean;
+    hasNull?: boolean;
+    hasPreferredState?: boolean;
+    wrap?: boolean;
+    usages?: number[];
+    usageMinimum?: number;
+    usageMaximum?: number;
+    reportSize?: number;
+    reportCount?: number;
+    unitExponent?: number;
+    unitSystem?: HIDUnitSystem;
+    unitFactorLengthExponent?: number;
+    unitFactorMassExponent?: number;
+    unitFactorTimeExponent?: number;
+    unitFactorTemperatureExponent?: number;
+    unitFactorCurrentExponent?: number;
+    unitFactorLuminousIntensityExponent?: number;
+    logicalMinimum?: number;
+    logicalMaximum?: number;
+    physicalMinimum?: number;
+    physicalMaximum?: number;
+    strings?: string[];
+}
+
+/*~ https://wicg.github.io/webhid/#report-descriptor */
+interface HIDReportInfo {
+    reportId?: number;
+    items?: HIDReportItem[];
+}
+
+/*~ https://wicg.github.io/webhid/#report-descriptor */
+interface HIDCollectionInfo {
+    usagePage?: number;
+    usage?: number;
+    type?: number;
+    children?: HIDCollectionInfo[];
+    inputReports?: HIDReportInfo[];
+    outputReports?: HIDReportInfo[];
+    featureReports?: HIDReportInfo[];
+}
+
+/*~ https://wicg.github.io/webhid/#device-usage */
+declare class HIDDevice extends EventTarget {
+    oninputreport: ((this: this, ev: HIDInputReportEvent) => any) | null;
+    readonly opened?: boolean;
+    readonly vendorId?: number;
+    readonly productId?: number;
+    readonly productName?: string;
+    readonly collections?: HIDCollectionInfo[];
+
+    open(): Promise<void>;
+
+    close(): Promise<void>;
+
+    sendReport(reportId: number, data: BufferSource): Promise<void>;
+
+    sendFeatureReport(reportId: number, data: BufferSource): Promise<void>;
+
+    receiveFeatureReport(reportId: number): Promise<DataView>;
+
+    addEventListener(type: 'inputreport', listener: (this: this, ev: HIDInputReportEvent) => any): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+
+    removeEventListener(type: 'inputreport', callback: (this: this, ev: HIDInputReportEvent) => any): void;
+    removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: EventListenerOptions | boolean,
+    ): void;
+}

--- a/types/w3c-web-hid/tsconfig.json
+++ b/types/w3c-web-hid/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "w3c-web-hid-tests.ts"
+    ]
+}

--- a/types/w3c-web-hid/tslint.json
+++ b/types/w3c-web-hid/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/w3c-web-hid/w3c-web-hid-tests.ts
+++ b/types/w3c-web-hid/w3c-web-hid-tests.ts
@@ -1,0 +1,51 @@
+// NOTE: Code kept as close to spec examples as possible but avoid compile errors.
+
+/*~ https://wicg.github.io/webhid/#example-1 */
+async function example_1() {
+    // Retrieve devices and log the device names to the console.
+
+    document.addEventListener('DOMContentLoaded', async () => {
+        const devices = await navigator.hid.getDevices();
+        devices.forEach(device => {
+            console.log(`HID: ${device.productName}`);
+        });
+    });
+    // Register event listeners for connection and disconnection of HID devices.
+
+    navigator.hid.addEventListener('connect', ({ device }) => {
+        console.log(`HID connected: ${device.productName}`);
+    });
+
+    navigator.hid.addEventListener('disconnect', ({ device }) => {
+        console.log(`HID disconnected: ${device.productName}`);
+    });
+
+    // Devices are not accessible through getDevices() and will not generate connection events until permission has been granted to access the device.
+    // The page may request permission using requestDevice(). In this example, the page requests access to a device with vendor ID 0xABCD, product ID 0x1234.
+    // The device must also have a collection with usage page Consumer (0x0C) and usage ID Consumer Control (0x01).
+    const requestButton = document.getElementById('request-hid-device');
+    requestButton?.addEventListener('click', async () => {
+        let device;
+        try {
+            const devices = await navigator.hid.requestDevice({
+                filters: [
+                    {
+                        vendorId: 0xabcd,
+                        productId: 0x1234,
+                        usagePage: 0x0c,
+                        usage: 0x01,
+                    },
+                ],
+            });
+            device = devices[0];
+        } catch (error) {
+            console.log('An error occurred.');
+        }
+
+        if (!device) {
+            console.log('No device was selected.');
+        } else {
+            console.log(`HID: ${device.productName}`);
+        }
+    });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

## Question & Offer

I've made this type definitions for my needs and shere deliverables, but I'd like to give the code owner to proper one since I'm not a member of WICG nor developer of `google chrome`. Please tell me whether to be it and what I should do for finding new owners if not.
