### PR TITLE
[cheerio] Add comment element type

### DIFF
--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -355,8 +355,8 @@ const doSomething = (element: cheerio.Element): void => {
     let a = element.firstChild;
     // $ExpectError
     let b = element.lastChild;
-    // $ExpectType TextElement | TagElement | null
+    // $ExpectType TextElement | TagElement | CommentElement | null
     let c = element.next;
-    // $ExpectType TextElement | TagElement | null
+    // $ExpectType TextElement | TagElement | CommentElement | null
     let d = element.prev;
 };

--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -344,7 +344,7 @@ cheerio.html($el);
 cheerio.version;
 
 const doSomething = (element: cheerio.Element): void => {
-    if (element.type !== 'text') {
+    if (element.type !== 'text' && element.type !== 'comment') {
         // $ExpectType { [attr: string]: string; }
         element.attribs;
         // $ExpectType Element[]

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -16,7 +16,7 @@
 interface Document {}
 
 declare namespace cheerio {
-    type Element = TextElement | TagElement;
+    type Element = TextElement | TagElement | CommentElement;
 
     interface TextElement {
         type: 'text';
@@ -44,6 +44,14 @@ declare namespace cheerio {
         nodeValue: string;
         data?: string;
         startIndex?: number;
+    }
+
+    interface CommentElement {
+        type: 'comment';
+        next: Element | null;
+        prev: Element | null;
+        parent: Element;
+        data?: string;
     }
 
     type AttrFunction = (el: Element, i: number, currentValue: string) => any;


### PR DESCRIPTION
Adds the missing `comment` type for `cheerio.contents()`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://cheerio.js.org/Cheerio.html#contents>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
