### PR TITLE
fix(tap): Add missing t.fixture() and t.testdir()

### DIFF
--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -352,7 +352,7 @@ interface Mocha {
 
 // Little hack to simulate the Test class on the tap export
 interface TestConstructor {
-    new(options?: Options.Test): Test;
+    new (options?: Options.Test): Test;
     prototype: Test;
 }
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -46,6 +46,12 @@ declare class Test {
     cleanSnapshot: (s: string) => string;
     formatSnapshot: (obj: any) => string;
 
+    fixture(type: 'symlink' | 'link', content: string): Fixture.Instance;
+    fixture(type: 'file', content: string | Buffer): Fixture.Instance;
+    fixture(type: 'dir', content: Fixture.Spec): Fixture.Instance;
+
+    testdir(spec?: Fixture.Spec): string;
+
     context: any;
     name: string;
     runOnly: boolean;
@@ -325,6 +331,17 @@ declare namespace Assertions {
         message?: string,
         extra?: Options.Assert,
     ) => boolean;
+}
+
+declare namespace Fixture {
+    interface Instance {
+        type: 'symlink' | 'link' | 'file' | 'dir';
+        content: string | Buffer | Spec;
+    }
+
+    interface Spec {
+        [pathname: string]: string | Buffer | Instance | Spec;
+    }
 }
 
 interface Mocha {

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -51,6 +51,7 @@ declare class Test {
     fixture(type: 'dir', content: Fixture.Spec): Fixture.Instance;
 
     testdir(spec?: Fixture.Spec): string;
+    readonly testdirName: string;
 
     context: any;
     name: string;

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -249,6 +249,7 @@ tap.test('testdir', t => {
         target: {},
     });
     t.notEqual(cwd, topLevelDir);
+    t.equals(cwd, t.testdirName);
 });
 
 tap.test('fixture', t => {

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -232,3 +232,32 @@ tap.skip('skip', t => {
 tap.test('test with options', { only: true, skip: true, todo: true, timeout: 1000 }, t => {
     t.pass();
 });
+
+const topLevelDir = tap.testdir();
+
+tap.test('testdir', t => {
+    const cwd = t.testdir({
+        'demo.jpg': Buffer.from('a jpg'),
+        'package.json': JSON.stringify({
+            name: 'pj',
+        }),
+        src: {
+            'index.js': 'yay',
+            hardlinked: t.fixture('link', '../target'),
+            softlinked: t.fixture('symlink', '../target'),
+        },
+        target: {},
+    });
+    t.notEqual(cwd, topLevelDir);
+});
+
+tap.test('fixture', t => {
+    // fairly infrequent vs testdir() sugar
+    t.fixture('dir', {});
+    t.fixture('file', 'content');
+    t.fixture('file', Buffer.from('content'));
+
+    // much more common, as sugar does not exist
+    t.fixture('link', 'target');
+    t.fixture('symlink', 'target');
+});


### PR DESCRIPTION
Adding a few missed methods, unfortunately impossible to add via local module extension due to the manner in which the types are defined.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://node-tap.org/docs/api/fixtures/
