### PR TITLE
@types/googlemaps: Add 'className' to MarkerLabel interface

### DIFF
--- a/types/googlemaps/reference/marker.d.ts
+++ b/types/googlemaps/reference/marker.d.ts
@@ -463,10 +463,9 @@ declare namespace google.maps {
          * Multiple space-separated CSS classes can be added. Default is no CSS class (an empty string).
          * The font color, size, weight, and family can only be set via the other properties of {@link MarkerLabel}.
          * CSS classes should not be used to change the position nor
-         * orientation of the label (e.g. using translations and rotations) if also using marker collision management.
+         * orientation of the label (e.g. using translations and rotations) if also using {@link https://developers.google.com/maps/documentation/javascript/examples/marker-collision-management marker collision management}.
          * @default ''
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerLabel.className Maps JavaScript API}
-         * @see {@link https://developers.google.com/maps/documentation/javascript/examples/marker-collision-management marker collision management}
          */
         className?: string;
         /**

--- a/types/googlemaps/reference/marker.d.ts
+++ b/types/googlemaps/reference/marker.d.ts
@@ -459,6 +459,17 @@ declare namespace google.maps {
      */
     interface MarkerLabel {
         /**
+         * The className property of the label's element (equivalent to the element's class attribute).
+         * Multiple space-separated CSS classes can be added. Default is no CSS class (an empty string).
+         * The font color, size, weight, and family can only be set via the other properties of MarkerLabel.
+         * CSS classes should not be used to change the position nor
+         * orientation of the label (e.g. using translations and rotations) if also using marker collision management.
+         * @default ''
+         * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerLabel.className Maps JavaScript API}
+         * @see {@link https://developers.google.com/maps/documentation/javascript/examples/marker-collision-management marker collision management}
+         */
+        className?: string;
+        /**
          * The color of the label text.
          * @default 'black'
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerLabel.color Maps JavaScript API}
@@ -493,6 +504,8 @@ declare namespace google.maps {
 
     /** @see {@link MarkerLabel} */
     interface ReadonlyMarkerLabel {
+        /** @see {@link MarkerLabel#className} */
+        className?: string;
         /** @see {@link MarkerLabel#color} */
         color?: string;
         /** @see {@link MarkerLabel#fontFamily} */

--- a/types/googlemaps/reference/marker.d.ts
+++ b/types/googlemaps/reference/marker.d.ts
@@ -461,7 +461,7 @@ declare namespace google.maps {
         /**
          * The className property of the label's element (equivalent to the element's class attribute).
          * Multiple space-separated CSS classes can be added. Default is no CSS class (an empty string).
-         * The font color, size, weight, and family can only be set via the other properties of MarkerLabel.
+         * The font color, size, weight, and family can only be set via the other properties of {@link MarkerLabel}.
          * CSS classes should not be used to change the position nor
          * orientation of the label (e.g. using translations and rotations) if also using marker collision management.
          * @default ''

--- a/types/googlemaps/reference/marker.d.ts
+++ b/types/googlemaps/reference/marker.d.ts
@@ -463,7 +463,8 @@ declare namespace google.maps {
          * Multiple space-separated CSS classes can be added. Default is no CSS class (an empty string).
          * The font color, size, weight, and family can only be set via the other properties of {@link MarkerLabel}.
          * CSS classes should not be used to change the position nor
-         * orientation of the label (e.g. using translations and rotations) if also using {@link https://developers.google.com/maps/documentation/javascript/examples/marker-collision-management marker collision management}.
+         * orientation of the label (e.g. using translations and rotations) if also using
+         * {@link https://developers.google.com/maps/documentation/javascript/examples/marker-collision-management marker collision management}.
          * @default ''
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerLabel.className Maps JavaScript API}
          */

--- a/types/googlemaps/test/reference/marker-tests.ts
+++ b/types/googlemaps/test/reference/marker-tests.ts
@@ -96,6 +96,7 @@ marker.setIcon(null);
 
 marker.setLabel({
     text: 'test',
+    className: 'test',
     color: 'test',
     fontFamily: 'test',
     fontSize: 'test',


### PR DESCRIPTION
This is my first time submitting a PR to this repo, so hopefully I'm doing this correctly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerLabel.className>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Header already indicates 3.4.3, which is where this prop was added)
