### PR TITLE
[bintrees] add null as possible return type to relevant interfaces

### DIFF
--- a/types/bintrees/bintrees-tests.ts
+++ b/types/bintrees/bintrees-tests.ts
@@ -49,5 +49,13 @@ describe('bintrees', () => {
 
         assert.deepEqual(ids, [100, 105, 110]);
     });
-});
 
+    it('has null as a possible max return type', () => {
+        let treeA = new RBTree((a: number, b: number) => a - b);
+
+        const max = treeA.max();
+
+        const foo: Exclude<typeof max, number> = null;
+        assert(foo === null);
+    })
+});

--- a/types/bintrees/index.d.ts
+++ b/types/bintrees/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bintrees 1.0.1
+// Type definitions for bintrees 1.0.2
 // Project: https://github.com/vadimg/js_bintrees
 // Definitions by: Cayle Sharrock <https://github.com/CjS77>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,11 +11,11 @@ declare module 'bintrees' {
     class Iterator<T> {
         constructor(tree: TreeBase<T>);
 
-        data(): T;
+        data(): T | null;
 
-        next(): T;
+        next(): T | null;
 
-        prev(): T;
+        prev(): T | null;
     }
 
     class TreeBase<T> {
@@ -23,17 +23,17 @@ declare module 'bintrees' {
 
         clear(): void;
 
-        find(data: T): T;
+        find(data: T): T | null;
 
-        findIter(data: T): Iterator<T>;
+        findIter(data: T): Iterator<T> | null;
 
         lowerBound(item: T): Iterator<T>;
 
         upperBound(item: T): Iterator<T>;
 
-        min(): T;
+        min(): T | null;
 
-        max(): T;
+        max(): T | null;
 
         iterator(): Iterator<T>;
 


### PR DESCRIPTION
As [per the documentation](https://github.com/vadimg/js_bintrees#readme), all of the `Iterator` methods, as well as `find`, `findIter`, `min`, and `max`, can possibly return `null`. This adds `null` to the possible return types for those interfaces.

Also adds a test which fails to typecheck using the old definition, and does typecheck with the new definition.

Finally, bumps the version number of the definitions to the current version of the library (`1.0.2`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vadimg/js_bintrees#readme
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.