### PR TITLE
Remove missed package.json from bell

### DIFF
--- a/types/bell/package.json
+++ b/types/bell/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "joi": "^17.3.0"
-    }
-}


### PR DESCRIPTION
Follow up to #50516. I'm not sure why tests didn't fail on that PR.