### PR TITLE
fs-extra: Define missing fs.realpath.native

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -281,3 +281,13 @@ const openDirTest = async (path: string, opts: fs.OpenDirOptions) => {
 fs.readdir("src").then((files: string[]) => {});
 fs.readdir("src", "buffer").then((files: Buffer[]) => {});
 fs.readdir("src", {withFileTypes: true}).then((files: fs.Dirent[]) => {});
+
+// $ExpectType void
+fs.realpath('src', (err, resolved) => {
+    // $ExpectType string
+    resolved;
+});
+// $ExpectType Promise<string>
+fs.realpath.native('src');
+// $ExpectType Promise<Buffer>
+fs.realpath.native('src', 'buffer');

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -225,6 +225,17 @@ export function realpath(path: PathLike, callback: (err: NodeJS.ErrnoException, 
 export function realpath(path: PathLike, cache: { [path: string]: string }, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
 export function realpath(path: PathLike, cache?: { [path: string]: string }): Promise<string>;
 
+/* tslint:disable:unified-signatures */
+export namespace realpath {
+    const native: {
+        (path: PathLike, options: fs.BaseEncodingOptions | BufferEncoding | undefined | null): Promise<string>;
+        (path: PathLike, options: fs.BufferEncodingOption): Promise<Buffer>;
+        (path: PathLike, options: fs.BaseEncodingOptions | string | undefined | null): Promise<string | Buffer>;
+        (path: PathLike): Promise<string>;
+    } & typeof fs.realpath.native;
+}
+/* tslint:enable:unified-signatures */
+
 export function rename(oldPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 export function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---
Based on:
https://github.com/jprichardson/node-fs-extra/blob/1625838cdfc65a1bbf28ab5fa962a75805629b9c/lib/fs/index.js#L127-L129
and
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dcc9ee498a7d211350b9c618a7f836b0f001e340/types/node/fs.d.ts#L797-L804
This exists since `fs-extra@8.1.0`:
https://github.com/jprichardson/node-fs-extra/commit/fa661f366407c1115e123b29c9ae21f3383e6a50