### PR TITLE
[calendar] Fix @types/calendar typings

### DIFF
--- a/types/calendar/calendar-tests.ts
+++ b/types/calendar/calendar-tests.ts
@@ -8,14 +8,16 @@ const now = new Date();
 const year = now.getFullYear();
 const month = now.getMonth();
 
+// $ExpectType Date[][]
 cal.monthDates(
     year,
     month,
     date => date.getMonth() === month ? date.getDate().toString() : '&nbsp;',
     week => week.join('</td><td>'),
-); // $ExpectType Date[][]
+);
 
+// $ExpectType number[][]
 cal.monthDays(
     year,
     month,
-); // $ExpectType number[][]
+);

--- a/types/calendar/calendar-tests.ts
+++ b/types/calendar/calendar-tests.ts
@@ -14,3 +14,8 @@ cal.monthDates(
     date => date.getMonth() === month ? date.getDate().toString() : '&nbsp;',
     week => week.join('</td><td>'),
 ); // $ExpectType Date[][]
+
+cal.monthDays(
+    year,
+    month,
+); // $ExpectType number[][]

--- a/types/calendar/calendar-tests.ts
+++ b/types/calendar/calendar-tests.ts
@@ -13,4 +13,4 @@ cal.monthDates(
     month,
     date => date.getMonth() === month ? date.getDate().toString() : '&nbsp;',
     week => week.join('</td><td>'),
-);
+); // $ExpectType Date[][]

--- a/types/calendar/index.d.ts
+++ b/types/calendar/index.d.ts
@@ -15,7 +15,7 @@ export class Calendar {
     constructor(firstWeekDay?: number);
 
     monthDates(year: number, month: number, dayFormatter?: DayFormatter, weekFormatter?: WeekFormatter): Date[][];
-    monthDays(year: number, month: number): Date[][];
+    monthDays(year: number, month: number): number[][];
     monthText(): string;
     monthText(year: number, month: number): string;
     weekStartDate(date: Date): Date;

--- a/types/calendar/index.d.ts
+++ b/types/calendar/index.d.ts
@@ -14,8 +14,8 @@ export class Calendar {
      */
     constructor(firstWeekDay?: number);
 
-    monthDates(year: number, month: number, dayFormatter?: DayFormatter, weekFormatter?: WeekFormatter): Date[];
-    monthDays(year: number, month: number): Date[];
+    monthDates(year: number, month: number, dayFormatter?: DayFormatter, weekFormatter?: WeekFormatter): Date[][];
+    monthDays(year: number, month: number): Date[][];
     monthText(): string;
     monthText(year: number, month: number): string;
     weekStartDate(date: Date): Date;


### PR DESCRIPTION
monthDates and monthDays does not return array of Dates. First returns arrays of weeks of Dates. Second returns arrays of weeks of days.

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
