### PR TITLE
[Swiper] More accurate event callbacks

### DIFF
--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -228,9 +228,9 @@ export interface SwiperOptions {
      * Register event handlers.
      */
     on?: {
-        [key in Exclude<SwiperEvent, LazyLoadingEvent>]?: (swiper: Swiper) => void;
+        [key in Exclude<SwiperEvent, LazyLoadingEvent>]?: (this: Swiper, swiper: Swiper) => void;
     } & {
-        [key in LazyLoadingEvent]?: (slideEl: HTMLElement, imageEl: HTMLImageElement) => void;
+        [key in LazyLoadingEvent]?: (this: Swiper, slideEl: HTMLElement, imageEl: HTMLImageElement) => void;
     };
 
     // CSS Scroll Snap

--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -227,7 +227,11 @@ export interface SwiperOptions {
     /**
      * Register event handlers.
      */
-    on?: { [key in SwiperEvent]?: () => void };
+    on?: {
+        [key in Exclude<SwiperEvent, LazyLoadingEvent>]?: (swiper: Swiper) => void;
+    } & {
+        [key in LazyLoadingEvent]?: (slideEl: HTMLElement, imageEl: HTMLImageElement) => void;
+    };
 
     // CSS Scroll Snap
 

--- a/types/swiper/swiper-tests.ts
+++ b/types/swiper/swiper-tests.ts
@@ -787,6 +787,9 @@ function slideableNavigation() {
                     menuButton.classList.remove('cross');
                 }
             },
+            lazyImageReady: (slideEl, imageEl) => {
+                // 
+            }
         }
     });
 }

--- a/types/swiper/swiper-tests.ts
+++ b/types/swiper/swiper-tests.ts
@@ -788,7 +788,7 @@ function slideableNavigation() {
                 }
             },
             lazyImageReady: (slideEl, imageEl) => {
-                // 
+                //
             }
         }
     });


### PR DESCRIPTION
This:
- adds `this` arg to callbacks to point to the Swiper instance
- specifies that the lazy image events come with two arguments: slide element and image element

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://web.archive.org/web/20191003204427/http://swiperjs.com/api/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.