### PR TITLE
luxon: Fix DateTimeFormatOptions to be compatible with ES2020.Intl

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -376,7 +376,7 @@ export class Duration {
 // @deprecated
 export type EraLength = StringUnitLength;
 
-export type NumberingSystem =
+export type NumberingSystem = Intl.DateTimeFormatOptions extends { numberingSystem?: infer T } ? T :
     | 'arab'
     | 'arabext'
     | 'bali'
@@ -400,7 +400,7 @@ export type NumberingSystem =
     | 'thai'
     | 'tibt';
 
-export type CalendarSystem =
+export type CalendarSystem = Intl.DateTimeFormatOptions extends { calendar?: infer T } ? T :
     | 'buddhist'
     | 'chinese'
     | 'coptic'

--- a/types/luxon/tsconfig.json
+++ b/types/luxon/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6", "ES2020"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.  -- *Adding `ES2020.Intl` to `tsconfig.json` causes tests to fail on ts4.2 with current definitions.*
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

TL;DR [This definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/187d62800d9e1f033841d022e37f44e3cff358a9/types/luxon/index.d.ts#L379-L417) is not compatible with [ES2020.Intl](https://github.com/microsoft/TypeScript/blob/290b0ea94d540bb451880cc598a7f1fbf93c848e/src/lib/es2020.intl.d.ts#L64-L288)

You can see change on [Playground](https://www.typescriptlang.org/play?target=7&module=0&ts=4.2.0-beta#code/JYWwDg9gTgLgBAbzgEQIYwKYBVQbgXzgDMoIQ4ByACxhjAGcAuAemalQHcA6Ac2BioBXAEaD6GKAGMIAO0xyu0kM2QYiwGfwwAbAJ5ZdYDABMVajVr0GjpgIwAOAOzGAbACZ7ABk-GAnBlsiTwBmYPsAFltjTzc3DGDHInDw+MkiImCAVntUX2YYQwx6Zm1BAA9ZZg1jDDKuYy4YegoAbgBYAChQSFhEFHRsXDhUen7MHBAMADFgMoJiUnJqWgYWNk5efiFRcSlZeRhFMmYAaVQwflQZAHlJAC9dDmB6ArN1TUwrQtNSipkAWia4S4bnyhWKv0q1Vq9UazXaHU6CE6cFRcGkMhecGM8AAvGNBpMuNoIJJUNoABQASgRKLROMaEAAMqTyRgAMowKAaHgUtDjXBcZAAQSwAFEsABJACyYoA+uyABLXABKWDlAHVJVhFQqxQBha4AOWQ7JpnXwSLpqIxWJxcHx-MJ01mxNZlPNiI6aOxhxgzPdHK5PL5AwmLrqIvFUtlCuVas12t17INxtNnvwQA)

Fixes #50392 