### PR TITLE
Add public methods to react-bootstrap-typeahead.

### DIFF
--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -281,7 +281,14 @@ export interface TypeaheadProps<T extends TypeaheadModel> {
 }
 
 export type AllTypeaheadOwnAndInjectedProps<T extends TypeaheadModel> = TypeaheadProps<T> & TypeaheadContainerProps<T>;
-export class Typeahead<T extends TypeaheadModel> extends React.Component<TypeaheadProps<T>> {}
+export class Typeahead<T extends TypeaheadModel> extends React.Component<TypeaheadProps<T>> {
+    blur: () => void;
+    clear: () => void;
+    focus: () => void;
+    getInput: () => HTMLInputElement;
+    hideMenu: () => void;
+    toggleMenu: () => void;
+}
 
 /* ---------------------------------------------------------------------------
                     AsyncTypeahead Props and Component

--- a/types/react-bootstrap-typeahead/react-bootstrap-typeahead-tests.tsx
+++ b/types/react-bootstrap-typeahead/react-bootstrap-typeahead-tests.tsx
@@ -72,6 +72,7 @@ class BasicExample extends React.Component {
 
     render() {
         const { multiple } = this.state;
+        const typeaheadRef = React.createRef<Typeahead<State>>();
 
         return (
             <div>
@@ -166,6 +167,48 @@ class BasicExample extends React.Component {
                     placeholder="Choose a state..."
                     renderInput={inputProps => <TypeaheadInputSingle {...inputProps} />}
                 />
+                <Typeahead
+                    labelKey="name"
+                    options={options}
+                    placeholder="Choose a state..."
+                    ref={typeaheadRef}
+                />
+                <button onClick={(e) => {
+                    typeaheadRef.current &&
+                    typeaheadRef.current.blur(); }}
+                >
+                    Hide
+                </button>
+                <button onClick={(e) => {
+                    typeaheadRef.current &&
+                    typeaheadRef.current.clear(); }}
+                >
+                    Toggle
+                </button>
+                <button onClick={(e) => {
+                    typeaheadRef.current &&
+                    typeaheadRef.current.focus(); }}
+                >
+                    Toggle
+                </button>
+                <button onClick={(e) => {
+                    typeaheadRef.current &&
+                    typeaheadRef.current.hideMenu(); }}
+                >
+                    Hide
+                </button>
+                <button onClick={(e) => {
+                    typeaheadRef.current &&
+                    typeaheadRef.current.toggleMenu(); }}
+                >
+                    Toggle
+                </button>
+                <button onClick={(e) => {
+                    typeaheadRef.current &&
+                    typeaheadRef.current.getInput().select(); }}
+                >
+                    Toggle
+                </button>
             </div>
         );
     }


### PR DESCRIPTION
See https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Methods.md

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Methods.md>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
    * https://github.com/ericgio/react-bootstrap-typeahead/commit/2a700993cbaf8aa82a5e84bb797371cd78ad71b2#diff-46b42b4229cd7a39c564e780bb665a8bde4fdf722007e8473f167fe53ed4b995 suggests that getInput() and friends have been present since at least react-bootstrap-typeahead 3.4.3 and the existing type definitions are for 5.1.
