### PR TITLE
fix(aws-lambda): connect contact flow queue type

### DIFF
--- a/types/aws-lambda/test/connect-contact-flow-tests.ts
+++ b/types/aws-lambda/test/connect-contact-flow-tests.ts
@@ -1,16 +1,18 @@
 import {
-    ConnectContactFlowHandler,
-    ConnectContactFlowResult,
+    ConnectContactFlowChannel,
     ConnectContactFlowEndpoint,
     ConnectContactFlowEvent,
-    ConnectContactFlowChannel,
-    ConnectContactFlowInitiationMethod
+    ConnectContactFlowHandler,
+    ConnectContactFlowInitiationMethod,
+    ConnectContactFlowQueue,
+    ConnectContactFlowResult,
 } from 'aws-lambda';
 
 const contactFlowHandler: ConnectContactFlowHandler = async (event, context, callback) => {
     let endpoint: ConnectContactFlowEndpoint | null;
     let channel: ConnectContactFlowChannel;
     let initiationMethod: ConnectContactFlowInitiationMethod;
+    let queue: ConnectContactFlowQueue | null;
 
     strOrUndefined = event.Details.ContactData.Attributes[num];
     channel = event.Details.ContactData.Channel;
@@ -23,7 +25,7 @@ const contactFlowHandler: ConnectContactFlowHandler = async (event, context, cal
     strOrUndefined = event.Details.ContactData.MediaStreams.Customer.Audio.StartTimestamp;
     strOrUndefined = event.Details.ContactData.MediaStreams.Customer.Audio.StreamARN;
     str = event.Details.ContactData.PreviousContactId;
-    strOrNull = event.Details.ContactData.Queue;
+    queue = event.Details.ContactData.Queue;
     endpoint = event.Details.ContactData.SystemEndpoint;
     strOrUndefined = event.Details.Parameters[num];
     str = event.Name;

--- a/types/aws-lambda/trigger/connect-contact-flow.d.ts
+++ b/types/aws-lambda/trigger/connect-contact-flow.d.ts
@@ -16,7 +16,7 @@ export interface ConnectContactFlowEvent {
             InitiationMethod: ConnectContactFlowInitiationMethod;
             InstanceARN: string;
             PreviousContactId: string;
-            Queue: string | null;
+            Queue: ConnectContactFlowQueue | null;
             SystemEndpoint: ConnectContactFlowEndpoint | null;
             MediaStreams: {
                 Customer: {
@@ -40,6 +40,11 @@ export type ConnectContactFlowInitiationMethod = 'INBOUND' | 'OUTBOUND' | 'TRANS
 export interface ConnectContactFlowEndpoint {
     Address: string;
     Type: 'TELEPHONE_NUMBER';
+}
+
+export interface ConnectContactFlowQueue {
+    ARN: string;
+    Name: string;
 }
 
 export interface ConnectContactFlowResult {


### PR DESCRIPTION
The queue value inside of an ConnectContactFlowEvent is not of type string. This should correct it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test aws-lambda>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html#function-contact-flow
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

