### PR TITLE
Use NoticeMessage type for pg.Client 'notice' event.

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -9,6 +9,7 @@
 import events = require('events');
 import stream = require('stream');
 import pgTypes = require('pg-types');
+import { NoticeMessage } from 'pg-protocol/dist/messages';
 
 import { ConnectionOptions } from 'tls';
 
@@ -248,7 +249,8 @@ export class ClientBase extends events.EventEmitter {
     escapeLiteral(str: string): string;
 
     on(event: 'drain', listener: () => void): this;
-    on(event: 'error' | 'notice', listener: (err: Error) => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'notice', listener: (notice: NoticeMessage) => void): this;
     on(event: 'notification', listener: (message: Notification) => void): this;
     // tslint:disable-next-line unified-signatures
     on(event: 'end', listener: () => void): this;

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "pg-types": "^2.2.0"
+        "pg-types": "^2.2.0",
+        "pg-protocol": "^1.2.0"
     }
 }

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -1,4 +1,5 @@
 import { types, Client, CustomTypesConfig, QueryArrayConfig, Pool } from 'pg';
+import { NoticeMessage } from 'pg-protocol/dist/messages';
 
 // https://github.com/brianc/node-pg-types
 // tslint:disable-next-line no-unnecessary-callback-wrapper
@@ -20,6 +21,7 @@ const host: string = client.host;
 const password: string | undefined = client.password;
 const ssl: boolean = client.ssl;
 
+client.on('notice', (notice: NoticeMessage) => console.warn(`${notice.severity}: ${notice.message}`));
 client.connect(err => {
     if (err) {
         console.error('Could not connect to postgres', err);


### PR DESCRIPTION
This PR updates the `pg.Client` `'notice'` event to use uses the `NoticeMessage` type from `pg-protocol`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/25f658f227a1bcbe759423678a7ab4ba8e067994/packages/pg-protocol/src/messages.ts#L203-L222
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This type first appears in pg-protocol 1.2.0, which was released with pg 8.0.1. I don't think the additional pg-protocol dependency will cause any conflicts because previous releases used a different name (pg-packet-stream). 