### PR TITLE
opentok: generateToken has an optional options arg

### DIFF
--- a/types/opentok/index.d.ts
+++ b/types/opentok/index.d.ts
@@ -4,6 +4,7 @@
 //                 Anthony Messerschmidt <https://github.com/CatGuardian>
 //                 Andrej Mihajlov <https://github.com/pronebird>
 //                 Victor Alencar <https://github.com/valencar>
+//                 Luis Felipe Zaguini <https://github.com/zaguiini>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'opentok' {
@@ -187,7 +188,7 @@ declare module 'opentok' {
       options: OpenTok.DialOptions,
     ): OpenTok.SipInterconnect;
     public forceDisconnect(sessionId: string, connectionId: string, callback: (error: Error | null) => void): void;
-    public generateToken(sessionId: string, options: OpenTok.TokenOptions): OpenTok.Token;
+    public generateToken(sessionId: string, options?: OpenTok.TokenOptions): OpenTok.Token;
     public getArchive(archiveId: string, callback: (error: Error | null, archive?: OpenTok.Archive) => void): void;
     public getBroadcast(
       broadcastId: string,


### PR DESCRIPTION
The options argument for `generateToken` is optional. Per the source code (line 1196):

![image](https://user-images.githubusercontent.com/76902462/107681715-2d806380-6c7e-11eb-8025-9c62d384480a.png)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.