### PR TITLE
google-apps-script: Added moveTo function to Drive.File interface

### DIFF
--- a/types/google-apps-script/google-apps-script.drive.d.ts
+++ b/types/google-apps-script/google-apps-script.drive.d.ts
@@ -182,6 +182,7 @@ declare namespace GoogleAppsScript {
       makeCopy(destination: Folder): File;
       makeCopy(name: string): File;
       makeCopy(name: string, destination: Folder): File;
+      moveTo(destination: Folder): File;
       removeCommenter(emailAddress: string): File;
       removeCommenter(user: Base.User): File;
       removeEditor(emailAddress: string): File;


### PR DESCRIPTION
Added the moveTo(folder) function definition for the Drive.File interface.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/drive/file#movetodestination
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.