### PR TITLE
Prettier: fix printComment signature in plugin API

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -6,6 +6,7 @@
 //                 Sosuke Suzuki <https://github.com/sosukesuzuki>,
 //                 Christopher Quadflieg <https://github.com/Shinigami92>
 //                 Kevin Deisz <https://github.com/kddeisz>
+//                 Georgii Dolzhykov <https://github.com/thorn0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -207,12 +208,7 @@ export interface Printer<T = any> {
     hasPrettierIgnore?: (path: FastPath<T>) => boolean;
     canAttachComment?: (node: T) => boolean;
     willPrintOwnComments?: (path: FastPath<T>) => boolean;
-    printComments?: (
-        path: FastPath<T>,
-        print: (path: FastPath<T>) => Doc,
-        options: ParserOptions<T>,
-        needsSemi: boolean,
-    ) => Doc;
+    printComment?: (commentPath: FastPath<T>, options: ParserOptions<T>) => Doc;
     handleComments?: {
         ownLine?: (
             commentNode: any,

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -102,7 +102,7 @@ doc.utils.isEmpty;
 doc.debug.printDocToDebug;
 
 interface PluginAST {
-    kind: "line";
+    kind: 'line';
     value: string;
 }
 
@@ -110,18 +110,18 @@ const plugin: prettier.Plugin<PluginAST> = {
     parsers: {
         lines: {
             parse(text, parsers, options) {
-                return { kind: "line", value: "This is a line" };
+                return { kind: 'line', value: 'This is a line' };
             },
-            astFormat: "lines",
-            locStart: (node) => {
+            astFormat: 'lines',
+            locStart: node => {
                 node; // $ExpectType PluginAST
                 return 0;
             },
-            locEnd: (node) => {
+            locEnd: node => {
                 node; // $ExpectType PluginAST
                 return 0;
-            }
-        }
+            },
+        },
     },
     printers: {
         lines: {
@@ -133,9 +133,13 @@ const plugin: prettier.Plugin<PluginAST> = {
                 node; // $ExpectType PluginAST
 
                 return node.value;
-            }
-        }
-    }
+            },
+            printComment(commentPath, options) {
+                const comment = commentPath.getValue();
+                return comment.value;
+            },
+        },
+    },
 };
 
-prettier.format("a line!", { parser: "lines", plugins: [plugin] });
+prettier.format('a line!', { parser: 'lines', plugins: [plugin] });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prettier.io/docs/en/plugins.html#optional-printcomment

