### PR TITLE
[auth0] Fix refreshToken promise response definition and add optional refresh_token to TokenResponse type

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -843,9 +843,21 @@ authentication
         refresh_token: '{YOUR_REFRESH_TOKEN}',
         client_id: '{OPTIONAL_CLIENT_ID}',
     })
-    .then(() => console.log('refreshed'));
-authentication.refreshToken({ refresh_token: '{YOUR_REFRESH_TOKEN}', client_id: '{OPTIONAL_CLIENT_ID}' }, err =>
-    console.log('refreshed'),
+    .then(tokenResponse => {
+        console.log(tokenResponse);
+    })
+    .catch(err => {
+        // Handle the error.
+    });
+
+authentication.refreshToken(
+    { refresh_token: '{YOUR_REFRESH_TOKEN}', client_id: '{OPTIONAL_CLIENT_ID}' },
+    (err, tokenResponse) => {
+        if (err) {
+            // Handle error.
+        }
+        console.log(tokenResponse);
+    },
 );
 
 const oauthAuthenticator = new auth0.OAuthAuthenticator({
@@ -854,8 +866,22 @@ const oauthAuthenticator = new auth0.OAuthAuthenticator({
     clientSecret: '{OPTIONAL_CLIENT_SECRET}',
 });
 
-oauthAuthenticator.refreshToken({ refresh_token: '{YOUR_REFRESH_TOKEN}' }).then(() => console.log('refreshed'));
-oauthAuthenticator.refreshToken({ refresh_token: '{YOUR_REFRESH_TOKEN}' }, err => console.log('refreshed'));
+oauthAuthenticator
+    .refreshToken({
+        refresh_token: '{YOUR_REFRESH_TOKEN}',
+    })
+    .then(tokenResponse => {
+        console.log(tokenResponse);
+    })
+    .catch(err => {
+        // Handle the error.
+    });
+oauthAuthenticator.refreshToken({ refresh_token: '{YOUR_REFRESH_TOKEN}' }, (err, tokenResponse) => {
+    if (err) {
+        // Handle error.
+    }
+    console.log(tokenResponse);
+});
 
 async function signupTest(): Promise<void> {
     const signupResult = await authentication.database.signUp({ email: 'email', password: 'password' });
@@ -895,7 +921,7 @@ tokenManager.revokeRefreshToken(
         client_id: '{OPTIONAL_CLIENT_ID}',
         client_secret: '{OPTIONAL_CLIENT_SECRET}',
     },
-    (err: Error) => {
+    err => {
         if (err) {
             // Handle error.
         }

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1104,7 +1104,7 @@ export class AuthenticationClient {
     passwordGrant(options: PasswordGrantOptions): Promise<TokenResponse>;
     passwordGrant(options: PasswordGrantOptions, cb: (err: Error, response: TokenResponse) => void): void;
 
-    refreshToken(options: AuthenticationClientRefreshTokenOptions): Promise<any>;
+    refreshToken(options: AuthenticationClientRefreshTokenOptions): Promise<TokenResponse>;
     refreshToken(
         options: AuthenticationClientRefreshTokenOptions,
         cb: (err: Error, response: TokenResponse) => void,
@@ -1492,7 +1492,7 @@ export class OAuthAuthenticator {
     authorizationCodeGrant(data: AuthorizationCodeGrantOptions): Promise<SignInToken>;
     authorizationCodeGrant(data: AuthorizationCodeGrantOptions, cb: (err: Error, data: SignInToken) => void): void;
 
-    refreshToken(options: RefreshTokenOptions): Promise<any>;
+    refreshToken(options: RefreshTokenOptions): Promise<TokenResponse>;
     refreshToken(options: RefreshTokenOptions, cb: (err: Error, response: TokenResponse) => void): void;
 }
 

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -688,6 +688,7 @@ export interface TokenResponse {
     expires_in: number;
     scope?: string;
     id_token?: string;
+    refresh_token?: string;
 }
 
 export interface ObjectWithId {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.com/docs/api/authentication#refresh-token
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Basically:

- as soon as `/oauth/token` is called along with the `offline_access` `scope` and in the meanwhile it is enabled in the Auth0 dashboard the `TokenReponse` interface will include the `refresh_token` property which can be used later on in the `refreshToken` method or similar
```
{
    "access_token": "ACCESS_TOKEN",
    "refresh_token": "REFRESH_TOKEN",
    "id_token": "ID_TOKEN",
    "scope": "SOME_SCOPES offline_access",
    "expires_in": EXPIRATION,
    "token_type": "Bearer"
```
- the `refreshToken` was returning the `TokenResponse` in its callback definition but not in its promise definition (I believe it is happening in many other endpoints. It sounds strange to me)
