### PR TITLE
♻️(video.js) fix Middleware.setSource signature

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -3614,7 +3614,7 @@ declare namespace videojs {
          * @param src
          * @param next
          */
-        setSource: (src: Tech.SourceObject, next: (err: any, next: (src: Tech.SourceObject) => void) => void) => void;
+        setSource: (src: Tech.SourceObject, next: (err: any, src: Tech.SourceObject) => void) => void;
     }
 
     /**

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -155,6 +155,8 @@ videojs('example_video_1', playerOptions).ready(function() {
     testPlugin(this, {});
 
     testLogger();
+
+    testMiddleware();
 });
 
 function testEvents(player: videojs.Player) {
@@ -255,4 +257,10 @@ function testLogger() {
 
     const currentLevel = videojs.log.level();
     videojs.log.level(videojs.log.levels.DEFAULT);
+}
+
+function testMiddleware() {
+    videojs.use('*', () => ({
+        setSource: (srcObj, next) => next(null, srcObj),
+    }));
 }


### PR DESCRIPTION
The method Middleware.setSource does not have the good signature for the
`next` argument. This argument is a function taking in first argument an
error and in second a source object. The current signature has an other
callback instead. It's not possible to write a Middleware with this
signature.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/videojs/video.js/blob/v7.3.0/docs/guides/middleware.md
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

