### PR TITLE
[datatables.net-buttons] Fix JQuery type

### DIFF
--- a/types/datatables.net-buttons/index.d.ts
+++ b/types/datatables.net-buttons/index.d.ts
@@ -445,7 +445,7 @@ declare namespace DataTables {
         //#endregion ColVis
     }
 
-    type ButtonSelectorTypes = string | number | JQuery<any>;
+    type ButtonSelectorTypes = string | number | JQuery;
     interface ButtonExportOptions {
         columns?: ButtonSelectorTypes | ButtonSelectorTypes[];
     }


### PR DESCRIPTION
the exported JQuery object does not use generics, fixing
usage in datatables.net-buttons.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. NOTE: existing tests cover this scenario already, just changing type signature
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/JQuery.d.ts#L5
