### PR TITLE
Added support for the AcroForm mixin to pdfkit

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Pdfkit v0.10.0
+// Type definitions for Pdfkit v0.11.0
 // Project: http://pdfkit.org
 // Definitions by: Eric Hillah <https://github.com/erichillah>
 //                 Erik Berreßem <https://github.com/she11sh0cked>
@@ -228,6 +228,43 @@ declare namespace PDFKit.Mixins {
         rotate(angle: number, options?: { origin?: number[] }): this;
         scale(xFactor: number, yFactor?: number, options?: { origin?: number[] }): this;
     }
+
+    interface PDFAcroForm {
+        /**
+         * Must call if adding AcroForms to a document. Must also call font() before
+         * this method to set the default font.
+         */
+        initForm(): this;
+
+        /**
+         * Called automatically by document.js
+         */
+        endAcroForm(): this;
+
+        /**
+         * Creates and adds a form field to the document. Form fields are intermediate
+         * nodes in a PDF form that are used to specify form name heirarchy and form
+         * value defaults.
+         * @param name - field name (T attribute in field dictionary)
+         * @param options  - other attributes to include in field dictionary
+         */
+        formField(name: string, options?: Record<string, any>): PDFKitReference;
+
+        /**
+         * Creates and adds a Form Annotation to the document. Form annotations are
+         * called Widget annotations internally within a PDF file.
+         * @param name - form field name (T attribute of widget annotation
+         * dictionary)
+         */
+        formAnnotation(name: string, type: string, x: number, y: number, w: number, h: number, options?: object): this;
+
+        formText(name: string, x: number, y: number, w: number, h: number, options?: object): this;
+        formPushButton(name: string, x: number, y: number, w: number, h: number, options?: object): this;
+        formCombo(name: string, x: number, y: number, w: number, h: number, options?: object): this;
+        formList(name: string, x: number, y: number, w: number, h: number, options?: object): this;
+        formRadioButton(name: string, x: number, y: number, w: number, h: number, options?: object): this;
+        formCheckbox(name: string, x: number, y: number, w: number, h: number, options?: object): this;
+    }
 }
 
 declare namespace PDFKit {
@@ -313,7 +350,8 @@ declare namespace PDFKit {
             Mixins.PDFImage,
             Mixins.PDFText,
             Mixins.PDFVector,
-            Mixins.PDFFont {
+            Mixins.PDFFont,
+            Mixins.PDFAcroForm {
         /**
          * PDF Version
          */

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -204,6 +204,21 @@ doc.image('path/to/image.png', {
 });
 
 
+// AcroForm
+doc.initForm();
+
+doc.endAcroForm();
+
+doc.formField('ZipCode1', { V: 'some-value' });
+
+doc.formAnnotation('ZipCode1', 'text', 0, 0, 10, 10, { V: 'some-value' });
+doc.formText('ZipCode1', 0, 0, 10, 10);
+doc.formPushButton('ZipCode1', 0, 0, 10, 10, { V: 'some-value' });
+doc.formCombo('ZipCode1', 0, 0, 10, 10, { V: 'some-value' });
+doc.formList('ZipCode1', 0, 0, 10, 10, { V: 'some-value' });
+doc.formRadioButton('ZipCode1', 0, 0, 10, 10, { V: 'some-value' });
+doc.formCheckbox('ZipCode1', 0, 0, 10, 10, { V: 'some-value' });
+
 // Subclassing
 class SubPDFDocument extends PDFDocument {
     constructor(options:PDFKit.PDFDocumentOptions) {


### PR DESCRIPTION
I added the AcroForm mixin to the pdfkit typings. This is required for using it to working form elements in generated PDFs.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.