### PR TITLE
[plotly.js] Add missing apis to PlotData, make currentvalue on sliders partial

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -20,6 +20,7 @@
 //                 Jessica Blizzard <https://github.com/blizzardjessica>
 //                 Oleg Shilov <https://github.com/olegshilov>
 //                 Pablo Gracia <https://github.com/PabloGracia>
+//                 Jeffrey van Gogh <https://github.com/jvgogh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as _d3 from 'd3';
@@ -1282,6 +1283,10 @@ export interface PlotData {
     level: string;
     cliponaxis: boolean;
     automargin: boolean;
+    locationmode: 'ISO-3' | 'USA-states' | 'country names' | 'geojson-id';
+    locations: Datum[];
+    reversescale: boolean;
+    colorbar: Partial<ColorBar>;
 }
 
 /**
@@ -2139,33 +2144,7 @@ export interface Slider {
      */
     yanchor: 'auto' | 'top' | 'middle' | 'bottom';
     transition: Transition;
-    currentvalue: {
-        /**
-         * Shows the currently-selected value above the slider.
-         */
-        visible: boolean;
-        /**
-         * The alignment of the value readout relative to the length of the slider.
-         */
-        xanchor: 'left' | 'center' | 'right';
-        /**
-         * The amount of space, in pixels, between the current value label
-         * and the slider.
-         */
-        offset: number;
-        /**
-         * When currentvalue.visible is true, this sets the prefix of the label.
-         */
-        prefix: string;
-        /**
-         * When currentvalue.visible is true, this sets the suffix of the label.
-         */
-        suffix: string;
-        /**
-         * Sets the font of the current value label text.
-         */
-        font: Partial<Font>;
-    };
+    currentvalue: Partial<CurrentValue>;
     /**
      * Sets the font of the slider step labels.
      */
@@ -2203,4 +2182,32 @@ export interface Slider {
      * Sets the length in pixels of minor step tick marks
      */
     minorticklen: number;
+}
+
+export interface CurrentValue {
+  /**
+   * Shows the currently-selected value above the slider.
+   */
+  visible: boolean;
+  /**
+   * The alignment of the value readout relative to the length of the slider.
+   */
+  xanchor: 'left' | 'center' | 'right';
+  /**
+   * The amount of space, in pixels, between the current value label
+   * and the slider.
+   */
+  offset: number;
+  /**
+   * When currentvalue.visible is true, this sets the prefix of the label.
+   */
+  prefix: string;
+  /**
+   * When currentvalue.visible is true, this sets the suffix of the label.
+   */
+  suffix: string;
+  /**
+   * Sets the font of the current value label text.
+   */
+  font: Partial<Font>;
 }

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -315,7 +315,62 @@ const graphDiv = '#test';
 
     Plotly.newPlot('myDiv', data, layout);
 })();
-
+(() => {
+  // Test slider APIs
+  const data: Array<Partial<PlotData>> = [
+      {
+        colorbar: {
+          title: 'Test',
+        },
+        locationmode: 'ISO-3',
+        locations: ['USA', 'NLD'],
+        reversescale: true,
+        type: 'choropleth',
+        z: [1, 2]
+      },
+  ];
+  const layout: Partial<Layout> = {
+    showlegend: true,
+    title: 'World Map',
+    geo: {
+      projection: { type: 'Mercator'},
+      showcoastlines: true,
+      showframe: true,
+    },
+    sliders: [{
+      pad: {t: 30},
+      y: 1.3,
+      x: 0.2,
+      len: 0.8,
+      currentvalue: {
+        visible: true,
+        prefix: 'Date:',
+        xanchor: 'right',
+        font: {size: 20, color: '#666'}
+      },
+      steps: [{
+        method: 'animate',
+        label: '2019-02-04',
+        args: [
+          [
+            '2019-02-04'
+          ],
+          {
+            mode: 'immediate',
+            transition: {
+              duration: 300,
+            },
+            frame: {
+              duration: 300,
+              redraw: false
+            }
+          }
+        ]
+      }]
+    }]
+  };
+  Plotly.newPlot('myDiv', data, layout);
+})();
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add properties to PlotData:
  locationmode: https://plotly.com/javascript/reference/scattergeo/#scattergeo-locationmode
  locations: https://plotly.com/javascript/reference/scattergeo/#scattergeo-locations
  reversescale: https://plotly.com/javascript/reference/#heatmap-reversescale
  colorbar: https://plotly.com/javascript/reference/#heatmapgl-colorbar

Make currentvalue on sliders partial:
  https://plotly.com/javascript/reference/#layout-sliders-items-slider-currentvalue
  'Type: object containing one or more of the keys listed below.'

Includes adding tests for new properties and partial currentvalue

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See commit message for various URLs
