### PR TITLE
[socket.io-redis] Extends SocketIORedisOptions with Redis.ClientOpts

### DIFF
--- a/types/socket.io-redis/index.d.ts
+++ b/types/socket.io-redis/index.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import SocketIO = require("socket.io");
+import Redis = require("redis");
 
 declare const SocketIORedis: SocketIORedisStatic;
 export = SocketIORedis;
@@ -37,7 +38,7 @@ declare namespace SocketIORedis {
     /**
      * Options to pass to the redis server when creating it
      */
-    interface SocketIORedisOptions {
+    interface SocketIORedisOptions extends Redis.ClientOpts {
 
         /**
          * The optional name of the key to pub/sub events on as prefix
@@ -60,7 +61,7 @@ declare namespace SocketIORedis {
         /**
          * The optional password to connect to redis on
          */
-        auth_pass?: number | string;
+        auth_pass?: string;
 
         /**
          * The optional redis client to publish events on

--- a/types/socket.io-redis/socket.io-redis-tests.ts
+++ b/types/socket.io-redis/socket.io-redis-tests.ts
@@ -40,3 +40,11 @@ function testCustomClientAuth() {
     var adapter = ioRedis({ pubClient: pub, subClient: sub });
     io.adapter(adapter);
 }
+
+function testConnectClientWithTls() {
+    var io = socketIO.listen(80);
+    var pub: redis.RedisClient = redis.createClient(8080, 'localhost', { tls: { rejectUnauthorized: false } });
+    var sub: redis.RedisClient = redis.createClient(8081, 'localhost', { tls: { rejectUnauthorized: false } });
+    var adapter = ioRedis({ pubClient: pub, subClient: sub });
+    io.adapter(adapter);
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source Code](https://github.com/socketio/socket.io-redis/blob/master/lib/index.ts#L57)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

When initializing a new RedisAdapter the options object gets passed through to the Redis `createClient` function. This means any option accepted by the Redis client can be used as an option when initializing a new `RedisAdapter` class.

This extends RedisAdapterOptions with the `Redis.ClientOpts` so the linters allow the users to use options like the TLS field.