### PR TITLE
[@types/chrome] Add Chrome 88 scripting API definitions

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -86,6 +86,156 @@ declare namespace chrome.accessibilityFeatures {
 }
 
 ////////////////////
+// Action
+////////////////////
+/**
+ * Use the chrome.action API to control the extension's icon in the Google Chrome toolbar.
+ * Availability: Since Chrome 88. Manifest v3.
+ * Manifest:  "action": {...}
+ */
+declare namespace chrome.action {
+    export interface BadgeBackgroundColorDetails {
+        /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is [255, 0, 0, 255]. Can also be a string with a CSS value, with opaque red being #FF0000 or #F00. */
+        color: string | ColorArray;
+        /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
+        tabId?: number;
+    }
+
+    export interface BadgeTextDetails {
+        /** Any number of characters can be passed, but only about four can fit in the space. */
+        text: string;
+        /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
+        tabId?: number;
+    }
+
+    export type ColorArray = [number, number, number, number];
+
+    export interface TitleDetails {
+        /** The string the action should display when moused over. */
+        title: string;
+        /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
+        tabId?: number;
+    }
+
+    export interface PopupDetails {
+        /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
+        tabId?: number;
+        /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
+        popup: string;
+    }
+
+    export interface BrowserClickedEvent extends chrome.events.Event<(tab: chrome.tabs.Tab) => void> {}
+
+    export interface TabIconDetails {
+        /** Optional. Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'  */
+        path?: string | { [index: number]: string };
+        /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
+        tabId?: number;
+        /** Optional. Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'  */
+        imageData?: ImageData | { [index: number]: ImageData };
+    }
+
+    export interface TabDetails {
+        /** Optional. The ID of the tab to query state for. If no tab is specified, the non-tab-specific state is returned.  */
+        tabId?: number;
+    }
+
+    /**
+     * Since Chrome 88.
+     * Disables the action for a tab.
+     * @param tabId The id of the tab for which you want to modify the action.
+     * @param callback
+     */
+    export function disable(tabId: number, callback: () => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Enables the action for a tab. By default, actions are enabled.
+     * @param tabId The id of the tab for which you want to modify the action.
+     * @param callback
+     */
+    export function enable(tabId: number, callback: () => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Gets the background color of the action.
+     * @param callback The callback parameter should be a function that looks like this:
+     * (result: ColorArray) => {...}
+     */
+    export function getBadgeBackgroundColor(details: TabDetails, callback: (result: ColorArray) => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Gets the badge text of the action. If no tab is specified, the non-tab-specific badge text is returned.
+     * If displayActionCountAsBadgeText is enabled, a placeholder text will be returned unless the
+     * declarativeNetRequestFeedback permission is present or tab-specific badge text was provided.
+     * @param callback The callback parameter should be a function that looks like this:
+     * (result: string) => {...}
+     */
+    export function getBadgeText(details: TabDetails, callback: (result: string) => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Gets the html document set as the popup for this action.
+     * @param callback The callback parameter should be a function that looks like this:
+     * (result: string) => {...}
+     */
+    export function getPopup(details: TabDetails, callback: (result: string) => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Gets the title of the action.
+     * @param callback The callback parameter should be a function that looks like this:
+     * (result: string) => {...}
+     */
+    export function getTitle(details: TabDetails, callback: (result: string) => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Sets the background color for the badge.
+     * @param callback The callback parameter should be a function that looks like this:
+     * () => {...}
+     */
+    export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails, callback?: () => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Sets the badge text for the action. The badge is displayed on top of the icon.
+     * @param callback The callback parameter should be a function that looks like this:
+     * () => {...}
+     */
+    export function setBadgeText(details: BadgeTextDetails, callback: () => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Sets the icon for the action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element,
+     * or as dictionary of either one of those. Either the path or the imageData property must be specified.
+     * @param callback The callback parameter should be a function that looks like this:
+     * () => {...}
+     */
+    export function setIcon(details: TabIconDetails, callback?: Function): void;
+
+    /**
+     * Since Chrome 88.
+     * Sets the html document to be opened as a popup when the user clicks on the action's icon.
+     * @param callback The callback parameter should be a function that looks like this:
+     * () => {...}
+     */
+    export function setPopup(details: PopupDetails, callback: () => void): void;
+
+    /**
+     * Since Chrome 88.
+     * Sets the title of the action. This shows up in the tooltip.
+     * @param callback The callback parameter should be a function that looks like this:
+     * () => {...}
+     */
+    export function setTitle(details: TitleDetails, callback?: () => void): void;
+
+    /** Fired when an action icon is clicked. This event will not fire if the action has a popup. */
+    export var onClicked: BrowserClickedEvent;
+}
+
+////////////////////
 // Alarms
 ////////////////////
 /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -12,6 +12,7 @@
 //                 Sebastiaan Pasma <https://github.com/spasma>
 //                 bdbai <https://github.com/bdbai>
 //                 pokutuna <https://github.com/pokutuna>
+//                 Jason Xian <https://github.com/JasonXian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -146,7 +147,7 @@ declare namespace chrome.action {
      * @param tabId The id of the tab for which you want to modify the action.
      * @param callback
      */
-    export function disable(tabId: number, callback: () => void): void;
+    export function disable(tabId: number, callback?: () => void): void;
 
     /**
      * Since Chrome 88.
@@ -154,7 +155,7 @@ declare namespace chrome.action {
      * @param tabId The id of the tab for which you want to modify the action.
      * @param callback
      */
-    export function enable(tabId: number, callback: () => void): void;
+    export function enable(tabId: number, callback?: () => void): void;
 
     /**
      * Since Chrome 88.
@@ -204,7 +205,7 @@ declare namespace chrome.action {
      * @param callback The callback parameter should be a function that looks like this:
      * () => {...}
      */
-    export function setBadgeText(details: BadgeTextDetails, callback: () => void): void;
+    export function setBadgeText(details: BadgeTextDetails, callback?: () => void): void;
 
     /**
      * Since Chrome 88.
@@ -213,7 +214,7 @@ declare namespace chrome.action {
      * @param callback The callback parameter should be a function that looks like this:
      * () => {...}
      */
-    export function setIcon(details: TabIconDetails, callback?: Function): void;
+    export function setIcon(details: TabIconDetails, callback?: () => void): void;
 
     /**
      * Since Chrome 88.
@@ -221,7 +222,7 @@ declare namespace chrome.action {
      * @param callback The callback parameter should be a function that looks like this:
      * () => {...}
      */
-    export function setPopup(details: PopupDetails, callback: () => void): void;
+    export function setPopup(details: PopupDetails, callback?: () => void): void;
 
     /**
      * Since Chrome 88.
@@ -6556,6 +6557,74 @@ declare namespace chrome.runtime {
      * Fired when a Chrome update is available, but isn't installed immediately because a browser restart is required.
      */
     export var onBrowserUpdateAvailable: RuntimeEvent;
+}
+
+////////////////////
+// Scripting
+////////////////////
+/**
+ * Use the chrome.scripting API to execute script in different contexts.
+ * Permissions: "scripting", Manifest v3+
+ * @since Chrome 88.
+ */
+declare namespace chrome.scripting {
+
+    /* The CSS style origin for a style change. */
+    export type StyleOrigin = "AUTHOR" | "USER";
+
+    export interface InjectionResult {
+        /* The frame associated with the injection. */
+        frameId: number;
+        /* The result of the script execution. */
+        result?: any;
+    }
+
+    export interface InjectionTarget {
+        /* Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if frameIds is specified. */
+        allFrames?: boolean;
+        /* The IDs of specific frames to inject into. */
+        frameIds?: number[];
+        /* The ID of the tab into which to inject. */
+        tabId: number;
+    }
+
+    export interface CSSInjection {
+        /* A string containing the CSS to inject. Exactly one of files and css must be specified. */
+        css?: string;
+        /* The path of the CSS files to inject, relative to the extension's root directory. NOTE: Currently a maximum of one file is supported. Exactly one of files and css must be specified. */
+        files?: string[];
+        /* The style origin for the injection. Defaults to 'AUTHOR'. */
+        origin?: StyleOrigin;
+        /* Details specifying the target into which to insert the CSS. */
+        target: InjectionTarget;
+    }
+
+    export interface ScriptInjection {
+        /* The path of the JS files to inject, relative to the extension's root directory. NOTE: Currently a maximum of one file is supported. Exactly one of files and function must be specified. */
+        files?: string[];
+        /* A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of files and function must be specified. */
+        function?: () => void;
+        /* Details specifying the target into which to inject the script. */
+        target: InjectionTarget;
+    }
+
+    /**
+     * Injects a script into a target context. The script will be run at document_end.
+     * @param injection
+     * The details of the script which to inject.
+     * @param callback
+     * Invoked upon completion of the injection. The resulting array contains the result of execution for each frame where the injection succeeded.
+     */
+    export function executeScript(injection: ScriptInjection, callback?: (results: InjectionResult[]) => void);
+
+    /**
+     * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.
+     * @param injection
+     * The details of the styles to insert.
+     * @param callback
+     * Invoked upon completion of the injection.
+     */
+    export function insertCSS(injection: CSSInjection, callback?: () => void);
 }
 
 ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -6615,7 +6615,7 @@ declare namespace chrome.scripting {
      * @param callback
      * Invoked upon completion of the injection. The resulting array contains the result of execution for each frame where the injection succeeded.
      */
-    export function executeScript(injection: ScriptInjection, callback?: (results: InjectionResult[]) => void);
+    export function executeScript(injection: ScriptInjection, callback?: (results: InjectionResult[]) => void): void;
 
     /**
      * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.
@@ -6624,7 +6624,7 @@ declare namespace chrome.scripting {
      * @param callback
      * Invoked upon completion of the injection.
      */
-    export function insertCSS(injection: CSSInjection, callback?: () => void);
+    export function insertCSS(injection: CSSInjection, callback?: () => void): void;
 }
 
 ////////////////////


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.chrome.com/docs/extensions/reference/scripting/>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Additional Changes:
- Make callbacks for setters in action API optional, which was a mistake I made in previous [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51137)
- Add myself to definition owners
