### PR TITLE
add(svg-path-bbox): new definition

### DIFF
--- a/types/svg-path-bbox/index.d.ts
+++ b/types/svg-path-bbox/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.0
+
 export type BoundingBox = [minx: number, miny: number, maxx: number, maxy: number];
 
 /**

--- a/types/svg-path-bbox/index.d.ts
+++ b/types/svg-path-bbox/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for svg-path-bbox 0.2
+// Project: https://github.com/mondeja/svg-path-bbox#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.0
+export type BoundingBox = [minx: number, miny: number, maxx: number, maxy: number];
+
+/**
+ * Computes the bounding box of SVG path following the SVG 1.1 specification.
+ * @param path SVG path.
+ */
+export function svgPathBbox(path: string): BoundingBox;

--- a/types/svg-path-bbox/svg-path-bbox-tests.ts
+++ b/types/svg-path-bbox/svg-path-bbox-tests.ts
@@ -1,0 +1,9 @@
+import { svgPathBbox } from 'svg-path-bbox';
+
+svgPathBbox('M5 10l2 3z'); // $ExpectType BoundingBox
+svgPathBbox('M5 10l2 3z')[0]; // $ExpectType number
+svgPathBbox('M5 10l2 3z')[1]; // $ExpectType number
+svgPathBbox('M5 10l2 3z')[2]; // $ExpectType number
+svgPathBbox('M5 10l2 3z')[3]; // $ExpectType number
+// @ts-expect-error
+svgPathBbox('M5 10l2 3z')[4];

--- a/types/svg-path-bbox/tsconfig.json
+++ b/types/svg-path-bbox/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg-path-bbox-tests.ts"
+    ]
+}

--- a/types/svg-path-bbox/tslint.json
+++ b/types/svg-path-bbox/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- module definition
- tests

https://www.npmjs.com/package/svg-path-bbox
https://www.w3.org/TR/SVG/coords.html#ObjectBoundingBoxUnits

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.