### PR TITLE
[spotify-web-api-node] Wrong return type in getShowEpisodes method

### DIFF
--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -945,7 +945,7 @@ declare class SpotifyWebApi {
      *                    it contains an error object. Not returned if a callback is given.
      */
     getShowEpisodes(showId: string, options: PaginationMarketOptions, callback: Callback<SpotifyApi.ShowEpisodesResponse>): void;
-    getShowEpisodes(showId: string, options?: PaginationMarketOptions): Promise<SpotifyApi.ShowEpisodesResponse>;
+    getShowEpisodes(showId: string, options?: PaginationMarketOptions): Promise<Response<SpotifyApi.ShowEpisodesResponse>>;
 
     /**
      * Search for a show.

--- a/types/spotify-web-api-node/spotify-web-api-node-tests.ts
+++ b/types/spotify-web-api-node/spotify-web-api-node-tests.ts
@@ -671,3 +671,13 @@ spotifyApi.getMyTopTracks()
   }, (err) => {
     console.log('Something went wrong!', err);
   });
+
+/* Shows */
+
+spotifyApi.getShowEpisodes('53TsTEHBmnGHUNTf5PIuSg')
+  .then((data) => {
+    const episodes = data.body.items;
+    console.log(episodes);
+  }, (err) => {
+    console.log('Something went wrong!', err);
+  });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/thelinmichael/spotify-web-api-node/blob/be15f1c742b35134ce5bd35521d8bf1ab1ba67cf/src/spotify-web-api.js#L1578)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. > no version change, just bugfix