### PR TITLE
Nightwatch.js: Fix executeAsync type

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -2534,7 +2534,7 @@ export interface WebDriverProtocolDocumentHandling {
      *    });
      * }
      */
-    executeAsync<T>(script: ((this: undefined, ...data: any[]) => any) | string, args?: any[], callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<T>) => void): this;
+    executeAsync(script: ((this: undefined, ...data: any[]) => any) | string, args?: any[], callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<any>) => void): this;
 }
 
 export interface WebDriverProtocolCookies {

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -2534,7 +2534,7 @@ export interface WebDriverProtocolDocumentHandling {
      *    });
      * }
      */
-    executeAsync<T>(script: ((this: undefined, ...data: any[]) => T) | string, args?: any[], callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<T>) => void): this;
+    executeAsync<T>(script: ((this: undefined, ...data: any[]) => any) | string, args?: any[], callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<T>) => void): this;
 }
 
 export interface WebDriverProtocolCookies {

--- a/types/nightwatch/nightwatch-tests.ts
+++ b/types/nightwatch/nightwatch-tests.ts
@@ -180,6 +180,32 @@ const testPage = {
 };
 
 //
+// ./tests/specific-commands.ts
+//
+
+const testSpecificCommands: NightwatchTests = {
+  executeAsync: (browser: NightwatchBrowser) => {
+    browser.executeAsync((done) => {
+      setTimeout(() => {
+        done(true);
+      }, 500);
+    }, [], (result) => {
+      browser.assert.equal(result.value, true);
+    });
+
+    browser.executeAsync((arg1, arg2, done) => {
+      setTimeout(() => {
+        done(true);
+      }, 500);
+    }, [1, 2], (result) => {
+      browser.assert.equal(result.value, true);
+    });
+
+    browser.end();
+  }
+};
+
+//
 // ./commands/localStorageValue.ts
 // - function based command
 //


### PR DESCRIPTION
The return value of the callback function passed to executeAsync is not used, so the type does not matter. Since the callback is async, normally there is not a value of type `T` available to return synchronously. Therefore this commit changes the callback's return type to `any`. You can see even in the docblock above the type definition that the example usage of `executeAsync` would fail a type check before this PR, and will not afterwards.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [link](https://github.com/nightwatchjs/nightwatch/blob/master/lib/api/protocol/executeAsync.js)
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.