### PR TITLE
[email-templates] Mark more arguments as optional

### DIFF
--- a/types/email-templates/email-templates-tests.ts
+++ b/types/email-templates/email-templates-tests.ts
@@ -106,3 +106,27 @@ email = new Email({
         from: 'definitelytyped@example.org'
     }
 });
+
+let emailNoMessage = new Email();
+emailNoMessage = new Email({});
+
+emailNoMessage.send({
+    template: 'sometemplate',
+    message: {
+        from: 'definitelytyped@example.org',
+        to: 'recipient@example.com',
+        subject: 'Test message'
+    }
+});
+
+const emailNoTemplate = new Email({
+    message: {
+        from: 'definitelytyped@example.org',
+        to: 'recipient@example.com',
+        subject: 'Test message',
+        text: 'This is a test message.'
+    }
+});
+
+emailNoTemplate.send();
+emailNoTemplate.send({});

--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -114,7 +114,7 @@ declare namespace Email {
          /**
           * The message <Nodemailer.com/message/>
           */
-         message: Mail.Options;
+         message?: Mail.Options;
          /**
           * The nodemailer Transport created via nodemailer.createTransport
           */
@@ -191,13 +191,13 @@ declare namespace Email {
         /**
          * The template name
          */
-        template: string;
+        template?: string;
         /**
          * Nodemailer Message <Nodemailer.com/message/>
          *
          * Overrides what is given for constructor
          */
-        message: Mail.Options;
+        message?: Mail.Options;
         /**
          * The Template Variables
          */
@@ -239,7 +239,7 @@ declare class Email<T = any> {
     /**
      * Send the Email
      */
-    send(options: Email.EmailOptions<T>): Promise<any>;
+    send(options?: Email.EmailOptions<T>): Promise<any>;
 }
 
 export = Email;


### PR DESCRIPTION
`new Email()` and `Email.send()` have defaults for all of their arguments and have use cases where passing no value can be useful.

- `message` can be omitted from either call, in which case only the options from the other are used.
- Even `template` can be omitted from `send()`, sending a constant message.
- Additionally, `send()`'s argument can be omitted, defaulting to an empty object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    https://github.com/forwardemail/email-templates/blob/master/src/index.js#L71
    constructor() defaults message = {}
    https://github.com/forwardemail/email-templates/blob/master/src/index.js#L307
    send() takes an optional argument and defaults its contents
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
