### PR TITLE
@loadable/component: loosened class component Options requirements

### DIFF
--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -88,7 +88,7 @@ declare function loadableFunc<Props>(
 
 declare function loadableFunc<Component extends React.ComponentClass<any>>(
     loadFn: (props: React.ComponentProps<Component>) => Promise<Component | { default: Component }>,
-    options?: OptionsWithResolver<React.ComponentProps<Component>, Component>,
+    options?: Options<React.ComponentProps<Component>, Component>,
 ): LoadableClassComponent<Component>;
 
 declare const loadable: typeof loadableFunc & { lib: typeof lib };

--- a/types/loadable__component/loadable__component-tests.tsx
+++ b/types/loadable__component/loadable__component-tests.tsx
@@ -83,6 +83,16 @@ function importLibLoader() {
         foo=""
     />;
 
+    const LoadableClassDirectOnlyClient = loadable(importClassComponentLoader, {
+        ssr: false,
+    });
+    <LoadableClassDirectOnlyClient
+        ref={ref => {
+            ref && ref.publicMethod();
+        }}
+        foo=""
+    />;
+
     const LoadableClassDefault = loadable(async () => ({
         default: await importClassComponentLoader(),
     }));


### PR DESCRIPTION
Following #50991, I noticed the added `loadableFunc` specifically for class components shouldn't require a `resolveComponent`. I'd erroneously copy & pasted `OptionsWithResolver` instead of `Options`.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<gregberge/loadable-components#108>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
