### PR TITLE
Fix THREE `MTLLoader.getIndex` return type error

### DIFF
--- a/types/three/examples/jsm/loaders/MTLLoader.d.ts
+++ b/types/three/examples/jsm/loaders/MTLLoader.d.ts
@@ -96,7 +96,7 @@ export namespace MTLLoader {
         setMaterials(materialsInfo: { [key: string]: MaterialInfo }): void;
         convert(materialsInfo: { [key: string]: MaterialInfo }): { [key: string]: MaterialInfo };
         preload(): void;
-        getIndex(materialName: string): Material;
+        getIndex(materialName: string): number;
         getAsArray(): Material[];
         create(materialName: string): Material;
         createMaterial_(materialName: string): Material;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As follows:


```typescript
    getIndex(materialName: string): number /* <- I fixed this */ {
      return this.nameLookup[materialName]; // `nameLookup` is type of `{[key: string]: number;}`, so the return value should be a `number`
    };
    getAsArray(): Material[] {
      let index = 0; // the `index` is a `number`

      for (const mn in this.materialsInfo) {
        if (!this.materialsInfo.hasOwnProperty(mn)) {
          continue;
        }
        this.materialsArray[index] = this.create(mn);
        this.nameLookup[mn] = index; // `index` in this array `nameLookup`, so `nameLookup` is a `{[key: string]: number;}`
        index++;
      }

      return this.materialsArray;
    };

```