### PR TITLE
fix(ejs): add missing Options.views param

### DIFF
--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -169,7 +169,7 @@ export namespace Template {
         ESCAPED = 'escaped',
         RAW = 'raw',
         COMMENT = 'comment',
-        LITERAL = 'literal'
+        LITERAL = 'literal',
     }
 }
 
@@ -430,6 +430,11 @@ export interface Options {
 
     /** Set to a string (e.g., 'echo' or 'print') for a function to print output inside scriptlet tags. */
     outputFunctionName?: string;
+
+    /**
+     * An array of paths to use when resolving includes with relative paths
+     */
+    views?: string[];
 }
 
 export interface Cache {

--- a/types/ejs/test/ejs.cjs.test.ts
+++ b/types/ejs/test/ejs.cjs.test.ts
@@ -27,7 +27,7 @@ ejs.name; // $ExpectType "ejs"
 result = ejs.render(template);
 result = ejs.render(template, data);
 result = ejs.render(template, data, options);
-ejs.render('<% echo(\'foo\'); %>', {}, { outputFunctionName: 'echo' });
+ejs.render("<% echo('foo'); %>", {}, { outputFunctionName: 'echo' });
 
 result = ejs.renderFile(fileName, SimpleCallback);
 result = ejs.renderFile(fileName, data, SimpleCallback);
@@ -76,8 +76,9 @@ ejs.cache = LRU(100);
 ejs.delimiter; // $ExpectType string | undefined
 ejs.delimiter = '%';
 
-// https://github.com/mde/ejs#options
+/** @see https://github.com/mde/ejs#options */
 const renderOptions: ejs.Options = {
     beautify: true,
     filename: fileName,
+    views: ['dir1', 'dir2'],
 };

--- a/types/ejs/test/ejs.umd.test.ts
+++ b/types/ejs/test/ejs.umd.test.ts
@@ -43,8 +43,9 @@ expectType<{
     (path: string, data?: ejs.Data, opts?: ejs.Options): Promise<string>;
 }>(ejs.renderFile);
 
-// https://github.com/mde/ejs#options
+/** @see https://github.com/mde/ejs#options */
 const renderOptions: ejs.Options = {
     beautify: true,
     filename: './index.ejs',
+    views: ['dir1', 'dir2'],
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mde/ejs#options
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
