### PR TITLE
Change CSS modules to default exports

### DIFF
--- a/types/css-modules/css-modules-tests.ts
+++ b/types/css-modules/css-modules-tests.ts
@@ -1,8 +1,8 @@
-import * as css from './styles.css';
-import * as less from './styles.less';
-import * as sass from './styles.sass';
-import * as scss from './styles.scss';
-import * as styl from './styles.styl';
+import css from './styles.css';
+import less from './styles.less';
+import sass from './styles.sass';
+import scss from './styles.scss';
+import styl from './styles.styl';
 
 css; // $ExpectType CSSModule
 

--- a/types/css-modules/index.d.ts
+++ b/types/css-modules/index.d.ts
@@ -17,7 +17,7 @@ declare module '*.css' {
      * A CSS module.
      */
     const styles: CSSModule;
-    export = styles;
+    export default styles;
 }
 
 declare module '*.scss' {
@@ -27,7 +27,7 @@ declare module '*.scss' {
      * https://sass-lang.com
      */
     const styles: CSSModule;
-    export = styles;
+    export default styles;
 }
 
 declare module '*.sass' {
@@ -37,7 +37,7 @@ declare module '*.sass' {
      * https://sass-lang.com
      */
     const styles: CSSModule;
-    export = styles;
+    export default styles;
 }
 
 declare module '*.less' {
@@ -47,7 +47,7 @@ declare module '*.less' {
      * http://lesscss.org
      */
     const styles: CSSModule;
-    export = styles;
+    export default styles;
 }
 
 declare module '*.styl' {
@@ -57,5 +57,5 @@ declare module '*.styl' {
      * https://stylus-lang.com
      */
     const styles: CSSModule;
-    export = styles;
+    export default styles;
 }


### PR DESCRIPTION
This is the default as of `css-loader@4.0.0`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#400-2020-07-25
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.