### PR TITLE
react-custom-scroll: fix `onScoll` typo

### DIFF
--- a/types/react-custom-scroll/index.d.ts
+++ b/types/react-custom-scroll/index.d.ts
@@ -14,7 +14,7 @@ export interface CustomScrollProps {
     allowOuterScroll?: boolean;
     heightRelativeToParent?: string;
     flex?: number | string;
-    onScoll?: (e?: any) => any;
+    onScroll?: (e?: any) => any;
     addScrolledClass?: boolean;
     freezePosition?: boolean;
     minScrollHandleHeight?: number;

--- a/types/react-custom-scroll/react-custom-scroll-tests.tsx
+++ b/types/react-custom-scroll/react-custom-scroll-tests.tsx
@@ -13,7 +13,7 @@ export const _ = () => (
             heightRelativeToParent="50%"
             allowOuterScroll={false}
             flex={2}
-            onScoll={onScrollStub}
+            onScroll={onScrollStub}
             addScrolledClass={true}
             freezePosition={false}
             minScrollHandleHeight={50}


### PR DESCRIPTION
`react-custom-scroll` does not have prop named `onScoll`

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rommguy/react-custom-scroll/blob/gh-pages/src/main/customScroll.js#L408
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.