### PR TITLE
Luxon 1.26.0

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.25
+// Type definitions for luxon 1.26
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
@@ -67,7 +67,11 @@ export interface ToSQLOptions {
 
 export type ToISOFormat = 'basic' | 'extended';
 
-export interface ToISOTimeOptions {
+export interface ToISOTimeDurationOptions {
+    /**
+     * @default false
+     */
+    includePrefix?: boolean;
     /**
      * @default false
      */
@@ -77,9 +81,25 @@ export interface ToISOTimeOptions {
      */
     suppressSeconds?: boolean;
     /**
+     * choose between the basic and extended format
+     * @default 'extended'
+     */
+    format?: ToISOFormat;
+}
+
+export interface ToISOTimeOptions {
+    /**
      * @default true
      */
     includeOffset?: boolean;
+    /**
+     * @default false
+     */
+    suppressMilliseconds?: boolean;
+    /**
+     * @default false
+     */
+    suppressSeconds?: boolean;
     /**
      * choose between the basic and extended format
      * @default 'extended'
@@ -336,6 +356,7 @@ export interface DurationToFormatOptions extends DateTimeFormatOptions {
 
 export class Duration {
     static fromISO(text: string, options?: DurationOptions): Duration;
+    static fromISOTime(text: string, options?: DurationOptions): Duration;
     static fromMillis(count: number, options?: DurationOptions): Duration;
     static fromObject(Object: DurationObject): Duration;
     static invalid(reason?: string): Duration;
@@ -367,7 +388,9 @@ export class Duration {
     mapUnits(fn: (x: number, u: DurationUnit) => number): Duration;
     toFormat(format: string, options?: DurationToFormatOptions): string;
     toISO(): string;
+    toISOTime(options?: ToISOTimeDurationOptions): string;
     toJSON(): string;
+    toMillis(): number;
     toObject(options?: { includeConfig?: boolean }): DurationObject;
     toString(): string;
     valueOf(): number;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -162,7 +162,9 @@ dur.seconds; // $ExpectType number
 dur.as('seconds'); // $ExpectType number
 dur.toObject();
 dur.toISO(); // $ExpectType string
+dur.toISOTime(); // $ExpectType string
 dur.normalize(); // $ExpectType Duration
+dur.toMillis(); // $ExpectType number
 dur.mapUnits((x, u) => u === 'hours' ? x * 2 : x); // $ExpectType Duration
 
 if (Duration.isDuration(anything)) {
@@ -334,6 +336,8 @@ dur.shiftTo('week', 'hours').toObject().weeks; // $ExpectType number | undefined
 DateTime.local().plus(dur.shiftTo('milliseconds')).year; // $ExpectType number
 
 Duration.fromISO('PY23', { conversionAccuracy: 'longterm' }); // $ExpectType Duration
+Duration.fromISOTime('21:37.000', { conversionAccuracy: 'longterm' }); // $ExpectType Duration
+
 end.diff(start, 'hours', { conversionAccuracy: 'longterm' }); // $ExpectType Duration
 end.diff(start, ['months', 'days', 'hours']); // $ExpectType Duration
 dur.reconfigure({ conversionAccuracy: 'longterm' }); // $ExpectType Duration


### PR DESCRIPTION
- [x] Luxon 1.26.0
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/master/CHANGELOG.md#1260
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
