### PR TITLE
hls-parser add types for prefetch segments

### DIFF
--- a/types/hls-parser/hls-parser-tests.ts
+++ b/types/hls-parser/hls-parser-tests.ts
@@ -8,7 +8,7 @@ if (playlist.isMasterPlaylist) {
     // Media playlist
 }
 
-const { MediaPlaylist, MasterPlaylist, Segment } = HLS.types;
+const { MediaPlaylist, MasterPlaylist, Segment, PrefetchSegment } = HLS.types;
 
 new MediaPlaylist({
     targetDuration: 9,
@@ -21,6 +21,13 @@ new MediaPlaylist({
             discontinuitySequence: 0,
         }),
     ],
+    prefetchSegments: [
+        new PrefetchSegment({
+            uri: 'test/1.m3u8',
+            mediaSequenceNumber: 1,
+            discontinuitySequence: 0
+        })
+    ]
 });
 
 new MasterPlaylist({

--- a/types/hls-parser/index.d.ts
+++ b/types/hls-parser/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for hls-parser 0.5
+// Type definitions for hls-parser 0.8
 // Project: https://github.com/kuu/hls-parser#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Christopher Manouvrier <https://github.com/cmanou>
+//                 Joe Flateau <https://github.com/joeflateau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 
@@ -80,6 +81,8 @@ export namespace types {
 
         segments: readonly Segment[];
 
+        prefetchSegments: readonly PrefetchSegment[];
+
         constructor(
             properties: BasePlaylistConstructorProperties & {
                 targetDuration: number;
@@ -89,6 +92,7 @@ export namespace types {
                 playlistType?: 'EVENT' | 'VOD';
                 isIFrame?: boolean;
                 segments?: readonly Segment[];
+                prefetchSegments?: readonly PrefetchSegment[];
                 source?: string;
             },
         );
@@ -226,6 +230,26 @@ export namespace types {
             map?: MediaInitializationSection;
             programDateTime?: Date;
             dateRange?: DateRange;
+        });
+    }
+
+    class PrefetchSegment extends Data {
+        uri: string;
+
+        discontinuity?: boolean;
+
+        mediaSequenceNumber: number;
+
+        discontinuitySequence: number;
+
+        key?: Key;
+
+        constructor(properties: {
+            uri: string;
+            discontinuity?: boolean;
+            mediaSequenceNumber: number;
+            discontinuitySequence: number;
+            key?: Key;
         });
     }
 


### PR DESCRIPTION
hls-parser has added support for prefetchSegments in v0.8 (https://github.com/video-dev/hlsjs-rfcs/blob/lhls-spec/proposals/0001-lhls.md)

https://www.npmjs.com/package/hls-parser
