### PR TITLE
Support messageFormat as func into PrettyOptions

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -539,6 +539,8 @@ declare namespace P {
         };
     }
 
+    type MessageFormatFunc = (log: LogDescriptor, messageKey: string, levelLabel: string) => string;
+
     interface PrettyOptions {
         /**
          * Translate the epoch time value into a human readable date and time string.
@@ -561,8 +563,19 @@ declare namespace P {
         timestampKey?: string;
         /**
          * Format output of message, e.g. {level} - {pid} will output message: INFO - 1123 Default: `false`.
+         *
+         * @example
+         * ```typescript
+         * {
+         *   messageFormat: (log, messageKey) => {
+         *     const message = log[messageKey];
+         *     if (log.requestId) return `[${log.requestId}] ${message}`;
+         *     return message;
+         *   }
+         * }
+         * ```
          */
-        messageFormat?: false | string;
+        messageFormat?: false | string | MessageFormatFunc;
         /**
          * If set to true, will add color information to the formatted output message. Default: `false`.
          */

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -182,6 +182,17 @@ const pretty = pino({
     },
 });
 
+const withMessageFormatFunc = pino({
+    prettyPrint: {
+        ignore: 'requestId',
+        messageFormat: (log, messageKey) => {
+            const message = log[messageKey];
+            if (log.requestId) return `[${log.requestId}] ${message}`;
+            return message;
+        },
+    },
+});
+
 const withTimeFn = pino({
     timestamp: pino.stdTimeFunctions.isoTime,
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino-pretty/blob/28ea34be1245122590a978ea233dd9e38d66b695/test/lib/utils.public.test.js#L119-L129
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
