### PR TITLE
fix(styled-components): limited use of 'Omit' for strictly types

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -11,6 +11,7 @@
 //                 Yuki Ito <https://github.com/Lazyuki>
 //                 Maciej Goszczycki <https://github.com/mgoszcz2>
 //                 Danilo Fuchs <https://github.com/danilofuchs>
+//                 Junya Kani <https://github.com/ka2jun8>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // forward declarations

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -57,6 +57,9 @@ type Defaultize<P, D> = P extends any
 
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
+// return true if T is never
+type IsExtendsNever<T> = T extends never ? true : false;
+
 export type StyledComponentProps<
     // The Component from whose props are derived
     C extends string | React.ComponentType<any>,
@@ -70,25 +73,33 @@ export type StyledComponentProps<
     // Distribute O if O is a union type
     O extends object
         ? WithOptionalTheme<
-              Omit<
-                  ReactDefaultizedProps<
-                      C,
-                      React.ComponentPropsWithRef<
-                          C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                      >
-                  > &
-                      O,
-                  A
-              > &
-                  Partial<
-                      Pick<
-                          React.ComponentPropsWithRef<
-                              C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                          > &
-                              O,
-                          A
-                      >
-                  >,
+              false extends IsExtendsNever<A>
+                  ? Omit<
+                        ReactDefaultizedProps<
+                            C,
+                            React.ComponentPropsWithRef<
+                                C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                            >
+                        > &
+                            O,
+                        A
+                    >
+                  : ReactDefaultizedProps<
+                        C,
+                        React.ComponentPropsWithRef<
+                            C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                        >
+                    > &
+                        O &
+                        Partial<
+                            Pick<
+                                React.ComponentPropsWithRef<
+                                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                                > &
+                                    O,
+                                A
+                            >
+                        >,
               T
           > &
               WithChildrenIfReactComponentClass<C>
@@ -305,7 +316,7 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmp
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+type WithOptionalTheme<P extends { theme?: T }, T> = P & {
     theme?: T;
 };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -316,9 +316,9 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmp
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = P & {
-    theme?: T;
-};
+type WithOptionalTheme<P extends { theme?: T }, T> = (P extends { theme?: T }
+    ? Omit<P, 'theme'>
+    : { [K in keyof P]: P[K] }) & { theme?: T };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
 export interface ThemedStyledComponentsModule<T extends object, U extends object = T> {

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1162,8 +1162,7 @@ function unionTest() {
         font-size: ${props => (props.kind === 'book' ? 16 : 14)};
     `;
 
-    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
-    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
+    <StyledReadable kind="book" author="Hejlsberg" />;
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }
 


### PR DESCRIPTION
resolved https://github.com/styled-components/styled-components/issues/3385.

I stopped using 'Omit' where I think it is not needed for the types.

The reason why I want to avoid 'Omit'.
refer: https://github.com/microsoft/TypeScript/issues/28339

I think it is better solution for this issue,
but I am concerned about the following historical background,
because I can not perfectly understand difficulty of typescript performance issue.

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33061
- https://github.com/Microsoft/TypeScript/issues/30663
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34499


--

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
