### PR TITLE
Create a types package for dns2

### DIFF
--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -1,0 +1,33 @@
+// Examples taken from the package readme for 1.4.2:
+// https://github.com/song940/node-dns/tree/6c2041b82ba2109fbb95bc529572404508787337#dns2
+
+import DNS = require('dns2');
+
+const dns = new DNS();
+
+(async () => {
+  const result = await dns.resolveA('google.com');
+  console.log(result.answers);
+})();
+
+const { Packet } = DNS;
+
+const server = DNS.createServer((request, send, rinfo) => {
+  const response = Packet.createResponseFromRequest(request);
+  const [ question ] = request.questions;
+  const { name } = question;
+  response.answers.push({
+    name,
+    type: Packet.TYPE.A,
+    class: Packet.CLASS.IN,
+    ttl: 300,
+    address: '8.8.8.8'
+  });
+  send(response);
+});
+
+server.on('request', (request, response, rinfo) => {
+  console.log(request.header.id, request.questions[0]);
+});
+
+server.listen(5333);

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -8,27 +8,6 @@
 import * as net from 'net';
 import * as udp from 'dgram';
 
-interface DnsRequest {
-    header: { id: string };
-    questions: DnsQuestion[];
-}
-
-interface DnsQuestion {
-    name: string;
-}
-
-interface DnsResponse {
-    answers: DnsAnswer[];
-}
-
-interface DnsAnswer {
-    name: string;
-    type: number;
-    class: number;
-    ttl: number;
-    address: string;
-}
-
 declare class Packet {
     static TYPE: {
         A: 0x01;
@@ -66,26 +45,49 @@ declare class Packet {
         ANY: 0xff;
     };
 
-    static createResponseFromRequest(request: DnsRequest): DnsResponse;
+    static createResponseFromRequest(request: DNS.DnsRequest): DNS.DnsResponse;
 
     toBuffer(): Buffer;
+}
+
+declare namespace DNS {
+    interface DnsRequest {
+        header: { id: string };
+        questions: DnsQuestion[];
+    }
+
+    interface DnsQuestion {
+        name: string;
+    }
+
+    interface DnsResponse {
+        answers: DnsAnswer[];
+    }
+
+    interface DnsAnswer {
+        name: string;
+        type: number;
+        class: number;
+        ttl: number;
+        address: string;
+    }
 }
 
 declare class DNS {
     static createServer(
         callback: (
-            request: DnsRequest,
-            sendResponse: (response: DnsResponse) => void,
+            request: DNS.DnsRequest,
+            sendResponse: (response: DNS.DnsResponse) => void,
             remoteInfo: udp.RemoteInfo,
         ) => void,
     ): net.Server;
 
     static Packet: typeof Packet;
 
-    resolveA(domain: string, clientIp?: string): Promise<DnsResponse>;
-    resolveAAAA(domain: string): Promise<DnsResponse>;
-    resolveMX(domain: string): Promise<DnsResponse>;
-    resolveCNAME(domain: string): Promise<DnsResponse>;
+    resolveA(domain: string, clientIp?: string): Promise<DNS.DnsResponse>;
+    resolveAAAA(domain: string): Promise<DNS.DnsResponse>;
+    resolveMX(domain: string): Promise<DNS.DnsResponse>;
+    resolveCNAME(domain: string): Promise<DNS.DnsResponse>;
 }
 
 export = DNS;

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -1,0 +1,91 @@
+// Type definitions for dns2 1.4
+// Project: https://github.com/song940/node-dns#readme
+// Definitions by: Tim Perry <https://github.com/pimterry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import * as net from 'net';
+import * as udp from 'dgram';
+
+interface DnsRequest {
+    header: { id: string };
+    questions: DnsQuestion[];
+}
+
+interface DnsQuestion {
+    name: string;
+}
+
+interface DnsResponse {
+    answers: DnsAnswer[];
+}
+
+interface DnsAnswer {
+    name: string;
+    type: number;
+    class: number;
+    ttl: number;
+    address: string;
+}
+
+declare class Packet {
+    static TYPE: {
+        A: 0x01;
+        NS: 0x02;
+        MD: 0x03;
+        MF: 0x04;
+        CNAME: 0x05;
+        SOA: 0x06;
+        MB: 0x07;
+        MG: 0x08;
+        MR: 0x09;
+        NULL: 0x0a;
+        WKS: 0x0b;
+        PTR: 0x0c;
+        HINFO: 0x0d;
+        MINFO: 0x0e;
+        MX: 0x0f;
+        TXT: 0x10;
+        AAAA: 0x1c;
+        SRV: 0x21;
+        EDNS: 0x29;
+        SPF: 0x63;
+        AXFR: 0xfc;
+        MAILB: 0xfd;
+        MAILA: 0xfe;
+        ANY: 0xff;
+        CAA: 0x101;
+    };
+
+    static CLASS: {
+        IN: 0x01;
+        CS: 0x02;
+        CH: 0x03;
+        HS: 0x04;
+        ANY: 0xff;
+    };
+
+    static createResponseFromRequest(request: DnsRequest): DnsResponse;
+
+    toBuffer(): Buffer;
+}
+
+declare class DNS {
+    static createServer(
+        callback: (
+            request: DnsRequest,
+            sendResponse: (response: DnsResponse) => void,
+            remoteInfo: udp.RemoteInfo,
+        ) => void,
+    ): net.Server;
+
+    static Packet: typeof Packet;
+
+    resolveA(domain: string, clientIp?: string): Promise<DnsResponse>;
+    resolveAAAA(domain: string): Promise<DnsResponse>;
+    resolveMX(domain: string): Promise<DnsResponse>;
+    resolveCNAME(domain: string): Promise<DnsResponse>;
+}
+
+export = DNS;

--- a/types/dns2/tsconfig.json
+++ b/types/dns2/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dns2-tests.ts"
+    ]
+}

--- a/types/dns2/tslint.json
+++ b/types/dns2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This is based on the latest release of https://www.npmjs.com/package/dns2. Note that the package source itself is changing rapidly as we speak, so the npm docs or the code at https://github.com/song940/node-dns/tree/6c2041b82ba2109fbb95bc529572404508787337 should be used for reference instead of `master`.

It's a kind of weird package in that it exports a class that can be instantiated but also has the rest of the package attached as static members. I think this is the right way to represent that, but alternative suggestions are very welcome.