### PR TITLE
[jasmine] Fix argument type inference for toHaveBeenCalledOnceWith

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -742,7 +742,17 @@ declare namespace jasmine {
     type MatchableArgs<Fn> = Fn extends (...args: infer P) => any ? { [K in keyof P]: P[K] | AsymmetricMatcher<any> } : never;
 
     interface FunctionMatchers<Fn extends Func> extends Matchers<any> {
+        /**
+         * Expects the actual (a spy) to have been called with the particular arguments at least once
+         * @param params The arguments to look for
+         */
         toHaveBeenCalledWith(...params: MatchableArgs<Fn>): boolean;
+
+        /**
+         * Expects the actual (a spy) to have been called exactly once, and exactly with the particular arguments
+         * @param params The arguments to look for
+         */
+        toHaveBeenCalledOnceWith(...params: MatchableArgs<Fn>): boolean;
 
         /**
          * Add some context for an expect.

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -878,6 +878,39 @@ describe("A spy, when created manually", () => {
     });
 });
 
+describe("a spy on a typed method", () => {
+    class Test {
+        method(arg: number): string { return '42'; }
+    }
+
+    let t: Test;
+
+    beforeEach(() => {
+        t = new Test();
+    });
+
+    it("should match only call arguments with the correct type", () => {
+        const spy = spyOn(t, 'method');
+        t.method(1);
+
+        expect(t.method).toHaveBeenCalledWith(1);
+        expect(t.method).toHaveBeenCalledWith("1"); // $ExpectError
+        expect(t.method).not.toHaveBeenCalledWith("1"); // $ExpectError
+
+        expect(spy).toHaveBeenCalledWith(1);
+        expect(spy).toHaveBeenCalledWith("1"); // $ExpectError
+        expect(spy).not.toHaveBeenCalledWith("1"); // $ExpectError
+
+        expect(t.method).toHaveBeenCalledOnceWith(1);
+        expect(t.method).toHaveBeenCalledOnceWith("1"); // $ExpectError
+        expect(t.method).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+
+        expect(spy).toHaveBeenCalledOnceWith(1);
+        expect(spy).toHaveBeenCalledOnceWith("1"); // $ExpectError
+        expect(spy).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+    });
+});
+
 describe("Spy for generic method", () => {
     interface Test {
         method<T>(): Array<Box<T>>;


### PR DESCRIPTION
Modify the type definition for `toHaveBeenCalledOnceWith` so it infers types of arguments in the same way `toHaveBeenCalledWith` does. As a side-change, add a Minimum TypeScript Version so that npm test runs again without errors when executed locally.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/edge/matchers.html#toHaveBeenCalledOnceWith
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

