### PR TITLE
fix(mixpanel-browser): correct return types of `init` functions

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -154,7 +154,8 @@ export interface Mixpanel {
     has_opted_in_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
     has_opted_out_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
     identify(unique_id?: string): any;
-    init(token: string, config?: Partial<Config>, name?: string): Mixpanel;
+    init(token: string, config: Partial<Config>, name: string): Mixpanel;
+    init(token: string, config?: Partial<Config>): undefined;
     opt_in_tracking(options?: Partial<InTrackingOptions>): void;
     opt_out_tracking(options?: Partial<OutTrackingOptions>): void;
     push(item: PushItem): void;

--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -155,7 +155,6 @@ export interface Mixpanel {
     has_opted_out_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
     identify(unique_id?: string): any;
     init(token: string, config: Partial<Config>, name: string): Mixpanel;
-    init(token: string, config?: Partial<Config>): undefined;
     opt_in_tracking(options?: Partial<InTrackingOptions>): void;
     opt_out_tracking(options?: Partial<OutTrackingOptions>): void;
     push(item: PushItem): void;

--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -4,6 +4,7 @@
 //                 Ricardo Rodrigues <https://github.com/RicardoRodrigues>
 //                 Kristian Randall <https://github.com/randak>
 //                 Dan Wilt <https://github.com/dwilt>
+//                 Lee Dogeon <https://github.com/moreal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -188,7 +189,8 @@ export function get_property(property_name: string): any;
 export function has_opted_in_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
 export function has_opted_out_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
 export function identify(unique_id?: string): any;
-export function init(token: string, config?: Partial<Config>, name?: string): Mixpanel;
+export function init(token: string, config: Partial<Config>, name: string): Mixpanel;
+export function init(token: string, config?: Partial<Config>): undefined;
 export function opt_in_tracking(options?: Partial<InTrackingOptions>): void;
 export function opt_out_tracking(options?: Partial<OutTrackingOptions>): void;
 export function push(item: PushItem): void;

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -2,8 +2,6 @@ import mixpanel = require('mixpanel-browser');
 
 const lib = mixpanel.init('new token', { secure_cookie: true }, 'library_name'); // $ExpectType Mixpanel
 lib.track('event name');
-lib.init('token');  // $ExpectType undefined
-lib.init('token', {});  // $ExpectType undefined
 lib.init('token', {}, "name");  // $ExpectType Mixpanel
 mixpanel.init("token");  // $ExpectType undefined
 mixpanel.init("token", {});  // $ExpectType undefined

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -1,7 +1,9 @@
 import mixpanel = require('mixpanel-browser');
 
-const lib = mixpanel.init('new token', { secure_cookie: true }, 'library_name');
+const lib = mixpanel.init('new token', { secure_cookie: true }, 'library_name'); // $ExpectType Mixpanel
 lib.track('event name');
+mixpanel.init("token");  // $ExpectType undefined
+mixpanel.init("token", {});  // $ExpectType undefined
 mixpanel.push(['register', { a: 'b' }]);
 mixpanel.disable();
 mixpanel.track('Registered', { Gender: 'Male', Age: 21 });

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -2,6 +2,9 @@ import mixpanel = require('mixpanel-browser');
 
 const lib = mixpanel.init('new token', { secure_cookie: true }, 'library_name'); // $ExpectType Mixpanel
 lib.track('event name');
+lib.init('token');  // $ExpectType undefined
+lib.init('token', {});  // $ExpectType undefined
+lib.init('token', {}, "name");  // $ExpectType Mixpanel
 mixpanel.init("token");  // $ExpectType undefined
 mixpanel.init("token", {});  // $ExpectType undefined
 mixpanel.push(['register', { a: 'b' }]);


### PR DESCRIPTION
This corrects the return types of `init` functions (i.e. `mixpanel.init`, `MixpanelLib.prototype.init`).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/mixpanel/mixpanel-js/blob/f94759c57367b65c81e84780d7d47a48e3e33028/src/mixpanel-core.js#L208-L211
  - https://github.com/mixpanel/mixpanel-js/blob/f94759c57367b65c81e84780d7d47a48e3e33028/src/mixpanel-core.js#L1668-L1674
