### PR TITLE
[react-native] Add missing `scaleX` and `scaleY` `LayoutAnimationProperties` interface

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -622,6 +622,8 @@ export interface LayoutAnimationTypes {
 
 export interface LayoutAnimationProperties {
     opacity: string;
+    scaleX: string;
+    scaleY: string;
     scaleXY: string;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactnative.dev/docs/layoutanimation#properties-1>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
