### PR TITLE
[@types/node] Wrong type for ProcessEnv

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -84,7 +84,7 @@ declare module 'process' {
             }
 
             // Alias for compatibility
-            interface ProcessEnv extends Dict<string> {}
+            interface ProcessEnv extends Dict<string | number | boolean> {}
 
             interface HRTime {
                 (time?: [number, number]): [number, number];

--- a/types/node/test/path.ts
+++ b/types/node/test/path.ts
@@ -85,7 +85,7 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+process.env["PATH"]; // $ExpectType string | number | boolean | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -679,7 +679,7 @@ declare namespace NodeJS {
     }
 
     interface ProcessEnv {
-        [key: string]: string | undefined;
+        [key: string]: string | number | boolean | undefined;
     }
 
     interface WriteStream extends Socket {

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -718,7 +718,7 @@ declare namespace NodeJS {
     }
 
     interface ProcessEnv {
-        [key: string]: string | undefined;
+        [key: string]: string | number | boolean | undefined;
     }
 
     interface WriteStream extends Socket {

--- a/types/node/v11/test/path.ts
+++ b/types/node/v11/test/path.ts
@@ -85,7 +85,7 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+process.env["PATH"]; // $ExpectType string | number | boolean | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -758,7 +758,7 @@ declare namespace NodeJS {
     }
 
     interface ProcessEnv {
-        [key: string]: string | undefined;
+        [key: string]: string | number | boolean | undefined;
     }
 
     interface HRTime {

--- a/types/node/v12/test/path.ts
+++ b/types/node/v12/test/path.ts
@@ -85,7 +85,7 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+process.env["PATH"]; // $ExpectType string | number | boolean | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v13/globals.d.ts
+++ b/types/node/v13/globals.d.ts
@@ -692,7 +692,7 @@ declare namespace NodeJS {
     }
 
     // Alias for compatibility
-    interface ProcessEnv extends Dict<string> {}
+    interface ProcessEnv extends Dict<string | number | boolean> {}
 
     interface HRTime {
         (time?: [number, number]): [number, number];

--- a/types/node/v13/test/path.ts
+++ b/types/node/v13/test/path.ts
@@ -85,7 +85,7 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+process.env["PATH"]; // $ExpectType string | number | boolean | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v13/worker_threads.d.ts
+++ b/types/node/v13/worker_threads.d.ts
@@ -66,7 +66,7 @@ declare module "worker_threads" {
          * were passed as CLI options to the script.
          */
         argv?: any[];
-        env?: NodeJS.Dict<string> | typeof SHARE_ENV;
+        env?: NodeJS.ProcessEnv | typeof SHARE_ENV;
         eval?: boolean;
         workerData?: any;
         stdin?: boolean;

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -79,7 +79,7 @@ declare module 'worker_threads' {
          * were passed as CLI options to the script.
          */
         argv?: any[];
-        env?: NodeJS.Dict<string> | typeof SHARE_ENV;
+        env?: NodeJS.ProcessEnv | typeof SHARE_ENV;
         eval?: boolean;
         workerData?: any;
         stdin?: boolean;


### PR DESCRIPTION
The type for `ProcessEnv` is incorrect. It states it must be a `string` or `undefined`, but [according to the Node documentation](https://nodejs.org/api/process.html#process_process_env), the value can be a `string`, `number`, or `boolean`.

> Assigning a property on process.env will implicitly convert the value to a string. This behavior is deprecated. Future versions of Node.js may throw an error when the value is not a string, number, or boolean.

While the deprecated behavior _converts_ the value to a `string`, that  does not mean you can’t assign a `number` or `boolean`. 

It is clear from the documentation and examples in the docs that you can assign a `string`, `number`, or `boolean`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/process.html#process_process_env
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.