### PR TITLE
update(svg-spritemap-webpack-plugin): v3.9 (webpack 5)

### DIFF
--- a/types/svg-spritemap-webpack-plugin/index.d.ts
+++ b/types/svg-spritemap-webpack-plugin/index.d.ts
@@ -1,11 +1,8 @@
-// Type definitions for svg-spritemap-webpack-plugin 3.7
+// Type definitions for svg-spritemap-webpack-plugin 3.9
 // Project: https://github.com/cascornelissen/svg-spritemap-webpack-plugin
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-import { Compiler } from 'webpack';
-
-export = SVGSpritemapPlugin;
+import { Compiler, WebpackPluginInstance } from 'webpack';
 
 declare namespace SVGSpritemapPlugin {
     /**
@@ -56,7 +53,15 @@ declare namespace SVGSpritemapPlugin {
          * The sprite object contains the configuration for the generated sprites in the output spritemap.
          */
         sprite?: {
+            /**
+             * @default 'sprite-'
+             */
             prefix?: string | ((file: string) => string) | false;
+            /**
+             * Whether to also prefix any selectors that are generated in the styles file, if enabled.
+             * @default false
+             */
+            prefixStylesSelectors?: boolean;
             /**
              * Function that will be used to transform the filename of each sprite into a valid HTML id
              */
@@ -93,14 +98,16 @@ declare namespace SVGSpritemapPlugin {
                       mixin?: string;
                   };
                   /** @default undefined */
-                  callback?: (content: string) => string
+                  callback?: (content: string) => string;
               };
     }
 }
-declare class SVGSpritemapPlugin {
+declare class SVGSpritemapPlugin implements WebpackPluginInstance {
     readonly directories: string[];
 
     constructor(pattern?: string | string[], options?: SVGSpritemapPlugin.Options);
+
+    apply(compiler: Compiler): void;
 
     private updateDependencies(): void;
     private getStylesType(styles: object, filename?: string): 'asset' | 'dir' | 'module' | undefined;
@@ -117,6 +124,6 @@ declare class SVGSpritemapPlugin {
     private getSpritemapHashes(compilation: any): string[];
     private getStylesHashes(compilation: any): string[];
     private getContentHash(source: string): string;
-
-    apply(compiler: Compiler): void;
 }
+
+export = SVGSpritemapPlugin;

--- a/types/svg-spritemap-webpack-plugin/package.json
+++ b/types/svg-spritemap-webpack-plugin/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "webpack": "^5.3.0"
+    }
+}

--- a/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
+++ b/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
@@ -1,7 +1,5 @@
-/// <reference types="node" />
 import SVGSpritemapPlugin = require('svg-spritemap-webpack-plugin');
 import { Configuration } from 'webpack';
-import path = require('path');
 
 (config: Configuration) => {
     // tests
@@ -10,7 +8,7 @@ import path = require('path');
         new SVGSpritemapPlugin('images/sprites/**/*.svg'),
         new SVGSpritemapPlugin(['images/logos/**/*.svg', 'images/icons/**/*.svg']),
         new SVGSpritemapPlugin('src/**/*.svg', {
-            styles: path.join(__dirname, 'src/scss/_sprites.scss'),
+            styles: 'src/scss/_sprites.scss',
         }),
         new SVGSpritemapPlugin('src/**/*.svg', {
             output: {
@@ -24,12 +22,14 @@ import path = require('path');
                     view: '-fragment',
                     symbol: true,
                 },
+                prefix: 'sprie-prefix-',
+                prefixStylesSelectors: true,
             },
             styles: {
                 format: 'fragment',
                 keepAttributes: true,
-                filename: path.join(__dirname, 'src/scss/_sprites.scss'),
-                callback: (content) => `[class*="sprite-"] { background-size: cover; } ${content}`,
+                filename: 'src/scss/_sprites.scss',
+                callback: content => `[class*="sprite-"] { background-size: cover; } ${content}`,
             },
         }),
     ];


### PR DESCRIPTION
- v3.9 bump
- webpack 5 (5.3)
- `node` types removed from tests to speed ci

https://github.com/cascornelissen/svg-spritemap-webpack-plugin/compare/v3.8.3...v3.9.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).