### PR TITLE
Add npm-naming exceptions

### DIFF
--- a/types/radium/tslint.json
+++ b/types/radium/tslint.json
@@ -9,6 +9,7 @@
         "no-var-keyword": false,
         "semicolon": false,
         "strict-export-declare-modifiers": false,
-        "void-return": false
+        "void-return": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/rbac-a/tslint.json
+++ b/types/rbac-a/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
In one case, npm-naming isn't smart enough to detect the re-export of
`default`, and in the other, it's fine not to expose the `default`
property that's exported in the d.ts.
