### PR TITLE
Deprecate moo's lexer has function

### DIFF
--- a/types/moo/index.d.ts
+++ b/types/moo/index.d.ts
@@ -79,7 +79,7 @@ export interface Lexer {
      */
     formatError(token: Token, message?: string): string;
     /**
-     * Can be used by parsers like nearley to check whether a given token type can be parsed by this lexer.
+     * @deprecated since 0.5.0. Now just returns true
      */
     has(tokenType: string): boolean;
     /**


### PR DESCRIPTION
Moo's lexer has function is deprecated now and just returns `true` after a type transform was added.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/no-context/moo/pull/85
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (The version is accurate since this was effective on version 0.5.0)