### PR TITLE
fix(mixpanel-browser): correct `mixpanel` type

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -178,6 +178,11 @@ export interface Mixpanel {
     people: People;
 }
 
+export interface OverridedMixpanel extends Mixpanel {
+    init(token: string, config: Partial<Config>, name: string): Mixpanel;
+    init(token: string, config?: Partial<Config>): undefined;
+}
+
 export function add_group(group_key: string, group_id: string, callback?: Callback): void;
 export function alias(alias: string, original?: string): void;
 export function clear_opt_in_out_tracking(options?: Partial<ClearOptOutInOutOptions>): void;
@@ -221,5 +226,5 @@ export function track_with_groups(event_name: string, properties: Dict, groups: 
 export function unregister(property: string): void;
 export const people: People;
 
-declare const mixpanel: Mixpanel;
+declare const mixpanel: OverridedMixpanel;
 export default mixpanel;

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -1,4 +1,6 @@
-import mixpanel = require('mixpanel-browser');
+import mixpanel from "mixpanel-browser";
+
+mixpanel; // $ExpectType OverridedMixpanel
 
 const lib = mixpanel.init('new token', { secure_cookie: true }, 'library_name'); // $ExpectType Mixpanel
 lib.track('event name');


### PR DESCRIPTION
This pull request fixes the problem an unexpected break change occurred at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51267. There was an issue that cannot use `mixpanel.init` without `name` argument. You can see the context at [its comment thread](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51267#issuecomment-780349030).

So I introduced new type named `OverridedMixpanel` which having new I did integration test with the below codes:

```
import mixpanel from "mixpanel-browser";

console.log(mixpanel.init("")); // pass
console.log(mixpanel.init("").track("event")); // error
console.log(mixpanel.init("", {}, "name").track("event")); // pass
console.log(mixpanel.init("", {}, "name").init("token")); // error
console.log(mixpanel.init("", {}, "name").init("token", {}, "name")); // pass
```

When review this pull request, please don't feel hard to comment any questions and problems. If you have a idea for naming better than `OverridedMixpanel`, please leave a comment.

------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51267