### PR TITLE
[nodemailer-ses-transport] Fix version to 1.5

### DIFF
--- a/types/nodemailer-ses-transport/index.d.ts
+++ b/types/nodemailer-ses-transport/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for nodemailer-ses-transport 3.1
-// Project: http://github.com/andris9/nodemailer-ses-transport
+// Type definitions for nodemailer-ses-transport 1.5
+// Project: https://github.com/nodemailer/nodemailer-ses-transport
 // Definitions by: Seth Westphal <https://github.com/westy92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 


### PR DESCRIPTION
Fix wrong version from 3.1 to 1.5.
It was probably updated by mistake when updating node-mailer types to 3.1
https://www.npmjs.com/package/nodemailer-ses-transport

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/nodemailer-ses-transport
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
