### PR TITLE
[mysql]: Added missing types to declaration of TypeCast type

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -292,8 +292,8 @@ export type TypeCast =
           field: UntypedFieldInfo & {
               type: string;
               length: number;
-              string(): string;
-              buffer(): Buffer;
+              string(): null | string;
+              buffer(): null | Buffer;
               geometry(): null | GeometryType;
           },
           next: () => void,

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -441,6 +441,20 @@ connection.query({
     }
 });
 
+connection.query({
+    sql: '...',
+    typeCast: (field, next: () => void) => {
+        if (field.type === 'JSON') {
+            const string = field.string();
+            if (string === null) {
+                return null;
+            }
+            return (JSON.parse(string));
+        }
+        next();
+    }
+});
+
 connection.query({ sql: '...', values: ['test'] }, (err: Error, results: any) => {
 });
 


### PR DESCRIPTION
`string()` and `buffer()` methods can return null

see https://github.com/mysqljs/mysql/blob/3430c513d6b0ca279fb7c79b210c9301e9315658/lib/protocol/packets/Field.js and https://github.com/mysqljs/mysql/blob/3430c513d6b0ca279fb7c79b210c9301e9315658/lib/protocol/Parser.js\#L148

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql/blob/3430c513d6b0ca279fb7c79b210c9301e9315658/lib/protocol/packets/Field.js and https://github.com/mysqljs/mysql/blob/3430c513d6b0ca279fb7c79b210c9301e9315658/lib/protocol/Parser.js\#L148
