### PR TITLE
fix(cheerio): support passing an array of elements to `load`

### DIFF
--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -18,6 +18,8 @@ cheerio(html);
 cheerio('ul', html);
 cheerio('li', 'ul', html);
 
+cheerio.load([$('ul').get(0)]);
+
 const $fromElement = cheerio.load($('ul').get(0));
 
 if ($fromElement('ul > li').length !== 3) {

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -313,7 +313,7 @@ declare namespace cheerio {
     interface CheerioAPI extends Root {
         version: string;
         load(html: string | Buffer, options?: CheerioParserOptions): Root;
-        load(element: Element, options?: CheerioParserOptions): Root;
+        load(element: Element | Element[], options?: CheerioParserOptions): Root;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://npmfs.com/package/cheerio/1.0.0-rc.5/lib/parse.js#L38
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

Really it should be `Root | Element[]`, but I don't think `Root` currently reflects actual root elements, so this'll do for now.