### PR TITLE
Definitions for node-siege

### DIFF
--- a/types/node-siege/index.d.ts
+++ b/types/node-siege/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for node-siege 0.0
+// Project: https://github.com/npr/node-siege
+// Definitions by: Zlatko Andonovski <https://github.com/Goldsmith42>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+
+declare class Siege extends EventEmitter {
+    args(args: string): Siege;
+    run(): Siege;
+    validateArgs(): void;
+    error(err: any): void;
+
+    readonly running: boolean;
+}
+
+declare function siege(): Siege;
+
+export = siege;

--- a/types/node-siege/node-siege-tests.ts
+++ b/types/node-siege/node-siege-tests.ts
@@ -1,0 +1,13 @@
+import siege = require('node-siege');
+
+const attack = siege()
+    .args('-t5s -c 10 -b -f./urls.txt')
+    .on('stdout', (data) => {})
+    .on('stderr', (data) => {})
+    .on('error', (err) => {})
+    .on('exit', () => {
+        if (attack.running) {
+            throw new Error('Exit received but still marked as running');
+        }
+    })
+    .run();

--- a/types/node-siege/tsconfig.json
+++ b/types/node-siege/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-siege-tests.ts"
+    ]
+}

--- a/types/node-siege/tslint.json
+++ b/types/node-siege/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.