### PR TITLE
types/faker : add the missing declaration for  `faker.unique`

### DIFF
--- a/types/faker/faker-tests.ts
+++ b/types/faker/faker-tests.ts
@@ -294,6 +294,9 @@ resultNum = faker.time.recent('unix');
 resultStr = faker.time.recent('abbr');
 resultStr = faker.time.recent('wide');
 
+resultStr = faker.unique(faker.internet.email);
+resultStr = faker.unique(faker.internet.email, undefined, { maxTime: 10, maxRetries: 1 });
+
 resultStr = faker.vehicle.vehicle();
 resultStr = faker.vehicle.manufacturer();
 resultStr = faker.vehicle.model();

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -264,7 +264,7 @@ declare namespace Faker {
         seed(value: number): void;
         seedValue?: number;
 
-        unique<Fn extends () => any>(method: Fn, args?: Parameters<Fn>, options?: IUniqueOptions): ReturnType<Fn>;
+        unique<Fn extends () => any>(method: Fn, args?: Parameters<Fn>, options?: UniqueOptions): ReturnType<Fn>;
 
         vehicle: {
             vehicle(): string;
@@ -359,7 +359,7 @@ declare namespace Faker {
         account: string;
     }
 
-    interface IUniqueOptions {
+    interface UniqueOptions {
         maxTime: number;
         maxRetries: number;
     }

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -264,6 +264,8 @@ declare namespace Faker {
         seed(value: number): void;
         seedValue?: number;
 
+        unique<Fn extends () => any>(method: Fn, args?: Parameters<Fn>, options?: IUniqueOptions): ReturnType<Fn>;
+
         vehicle: {
             vehicle(): string;
             manufacturer(): string;
@@ -355,6 +357,11 @@ declare namespace Faker {
         name: string;
         type: string;
         account: string;
+    }
+
+    interface IUniqueOptions {
+        maxTime: number;
+        maxRetries: number;
     }
 }
 


### PR DESCRIPTION
Adds the missing declaration for the `faker.unique` function.

The faker source is at https://github.com/Marak/faker.js/blob/master/lib/unique.js

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
