### PR TITLE
[prettier] Add tests for plugin options, convert oppositeDescription to string

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -393,7 +393,7 @@ export interface BooleanSupportOption extends BaseSupportOption<'boolean'> {
     default: boolean;
     array?: false;
     description: string;
-    oppositeDescription?: boolean;
+    oppositeDescription?: string;
 }
 
 export interface BooleanArraySupportOption extends BaseSupportOption<'boolean'> {

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -140,6 +140,83 @@ const plugin: prettier.Plugin<PluginAST> = {
             },
         },
     },
+    options: {
+        testBoolOption: {
+            since: '1.0.1',
+            type: 'boolean',
+            category: 'Test',
+            default: true,
+            description: 'Move open brace for code blocks onto new line.',
+            oppositeDescription: "Don't move open brace for code blocks onto new line.",
+        },
+        testBoolArrOption: {
+            since: '1.0.1',
+            type: 'boolean',
+            array: true,
+            category: 'Test',
+            default: [{ value: [true, false, true] }],
+            deprecated: true,
+            description: 'Move open brace for code blocks onto new line.',
+        },
+        testIntOption: {
+            since: '1.0.2',
+            type: 'int',
+            category: 'Global',
+            default: 15,
+            range: {
+                start: 5,
+                end: 100,
+                step: 5,
+            },
+            deprecated: 'Deprecated can be a string describing deprecation status.',
+            description: 'This is a number.',
+        },
+        testIntArrOption: {
+            since: 'forever',
+            type: 'int',
+            category: 'Test',
+            default: [{ value: [3, 8, 12] }],
+            array: true,
+            description: 'This is a number.',
+        },
+        testChoiceOption: {
+            since: '1.0.3',
+            type: 'choice',
+            default: 'one',
+            choices: [
+                { value: 'one', description: 'The number one' },
+                { value: 'two', description: 'The number two' },
+                { value: 'three', description: 'The number three' },
+            ],
+            category: 'Test',
+            description: 'Choose one of three.',
+        },
+        testChoiceComplexOption: {
+            since: '1.0.5',
+            type: 'choice',
+            default: [{ since: '1.0.7', value: 'banana' }, { value: 'apple' }],
+            choices: [
+                { value: 'apple', description: 'A fruit.' },
+                { value: 'orange', since: '1.0.6', description: 'A different fruit.' },
+                { value: 'banana', since: '1.0.5', description: 'Added in 1.0.5, made default in 1.0.7.' },
+            ],
+            category: 'Test',
+            description: 'Choose one of three.',
+        },
+        testPathOption: {
+            since: '1.0.0',
+            type: 'path',
+            category: 'Test',
+            default: './path.js',
+        },
+        testPathArrOption: {
+            since: '1.0.0',
+            type: 'path',
+            category: 'Test',
+            array: true,
+            default: [{ value: ['./pathA.js', './pathB.js'] }],
+        },
+    },
 };
 
 prettier.format('a line!', { parser: 'lines', plugins: [plugin] });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/prettier/blob/12bddae20c0bd6c31c53ec44656868f21ec5aca7/src/common/common-options.js#L13