### PR TITLE
react-hooks-helper: Fixed error in useStep definitions

### DIFF
--- a/types/react-hooks-helper/index.d.ts
+++ b/types/react-hooks-helper/index.d.ts
@@ -16,17 +16,21 @@ export interface NavigationProps {
     pause?: () => void;
 }
 
+export interface Step {
+    id: string;
+}
+
 export interface UseStepParams {
     initialStep?: number;
     autoAdvanceDuration?: number;
-    steps: string[] | number;
+    steps: Step[] | number;
 }
 
 export interface UseStepResponse {
     autoAdvanceDuration: number;
     isPaused: boolean;
     index: number;
-    step: number;
+    step: Step | number;
     navigation: NavigationProps;
 }
 
@@ -34,17 +38,15 @@ export function useStep(params: UseStepParams): UseStepResponse;
 
 export interface FormTarget {
     target: {
-        name: string, // object property name or Dot separated when hierarchical
-        value: any,
-        type?: string,
-        checked?: boolean,
+        name: string; // object property name or Dot separated when hierarchical
+        value: any;
+        type?: string;
+        checked?: boolean;
     };
 }
 
-export type SetForm = (event:
-    | React.SyntheticEvent<HTMLInputElement>
-    | React.ChangeEvent<HTMLInputElement>
-    | FormTarget
+export type SetForm = (
+    event: React.SyntheticEvent<HTMLInputElement> | React.ChangeEvent<HTMLInputElement> | FormTarget,
 ) => void;
 
 export function useForm<T>(defaultFormConfig: T): [T, SetForm];

--- a/types/react-hooks-helper/react-hooks-helper-tests.tsx
+++ b/types/react-hooks-helper/react-hooks-helper-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useStep, useForm } from 'react-hooks-helper';
+import { useStep, useForm, Step } from 'react-hooks-helper';
 
 export const ReactHooksHelperTest: React.FunctionComponent = () => {
     const { index, navigation } = useStep({ steps: 3 });
@@ -20,4 +20,21 @@ export const ReactHooksHelperTest: React.FunctionComponent = () => {
             {JSON.stringify(formData)}
         </>
     );
+};
+
+// $ExpectedType number
+export const UseStepReturnNumber = (): number => {
+    const { step, navigation } = useStep({ steps: 3 });
+    const [formData, setForm] = useForm({ name: '', city: '' });
+
+    return step as number;
+};
+
+// $ExpectedType string
+export const UseStepReturnObject = (): string => {
+    const { step, navigation } = useStep({ steps: [{ id: 'Step1' }, { id: 'Step2' }, { id: 'Step3' }] });
+    const [formData, setForm] = useForm({ name: '', city: '' });
+    const { id } = step as Step;
+
+    return id;
 };


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/revelcw/react-hooks-helper#config
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
