### PR TITLE
Fix @types/scheduler wrapCallback type

### DIFF
--- a/types/scheduler/index.d.ts
+++ b/types/scheduler/index.d.ts
@@ -23,7 +23,7 @@ export function unstable_runWithPriority<T>(priorityLevel: number, eventHandler:
 export function unstable_scheduleCallback(priorityLevel: number, callback: FrameCallbackType, options?: { delay?: number, timeout?: number}): CallbackNode;
 export function unstable_next<T>(eventHandler: () => T): T;
 export function unstable_cancelCallback(callbackNode: CallbackNode): void;
-export function unstable_wrapCallback(callback: FrameCallbackType): () => FrameCallbackType;
+export function unstable_wrapCallback(callback: () => void): () => void;
 export function unstable_getCurrentPriorityLevel(): number;
 export function unstable_shouldYield(): boolean;
 export function unstable_continueExecution(): void;

--- a/types/scheduler/index.d.ts
+++ b/types/scheduler/index.d.ts
@@ -23,7 +23,7 @@ export function unstable_runWithPriority<T>(priorityLevel: number, eventHandler:
 export function unstable_scheduleCallback(priorityLevel: number, callback: FrameCallbackType, options?: { delay?: number, timeout?: number}): CallbackNode;
 export function unstable_next<T>(eventHandler: () => T): T;
 export function unstable_cancelCallback(callbackNode: CallbackNode): void;
-export function unstable_wrapCallback(callback: () => void): () => void;
+export function unstable_wrapCallback<I extends Array<any>, O>(callback: (...args: I) => O): (...args: I) => O;
 export function unstable_getCurrentPriorityLevel(): number;
 export function unstable_shouldYield(): boolean;
 export function unstable_continueExecution(): void;


### PR DESCRIPTION
The intention of the `unstable_wrapCallback()` function is to take a function of any arguments/returns and when that callback is called to execute it at the priority level in which wrap callback was called.

https://github.com/facebook/react/blob/8af27aeedbc6b00bc2ef49729fc84f116c70a27c/packages/scheduler/src/forks/SchedulerDOM.js#L305-L318