### PR TITLE
feat(react-router): add params inference to Route

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -135,7 +135,7 @@ export interface match<Params extends { [K in keyof Params]?: string } = {}> {
 export type Omit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
 // Newer Omit type: as the previous one is being exported, removing it would be a breaking change
-export type OmitNative<T, K extends string | number | symbol> = { [P in Exclude<keyof T, K>]: T[P]; };
+export type OmitNative<T, K extends string | number | symbol> = { [P in Exclude<keyof T, K>]: T[P] };
 
 export function matchPath<Params extends { [K in keyof Params]?: string }>(
     pathname: string,
@@ -155,10 +155,7 @@ export type ExtractRouteParams<T extends string, U = string | number | boolean> 
     ? ExtractRouteOptionalParam<Param, U>
     : {};
 
-export function generatePath<S extends string>(
-    path: S,
-    params?: ExtractRouteParams<S>,
-): string;
+export function generatePath<S extends string>(path: S, params?: ExtractRouteParams<S>): string;
 
 export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass
     ? { wrappedComponentRef?: React.Ref<InstanceType<C>> }

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -83,17 +83,23 @@ export interface RouteChildrenProps<Params extends { [K in keyof Params]?: strin
     match: match<Params> | null;
 }
 
-export interface RouteProps {
+export interface RouteProps<
+    Path extends string = string,
+    Params extends { [K: string]: string | undefined } = ExtractRouteParams<Path, string>
+> {
     location?: H.Location;
     component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
-    render?: (props: RouteComponentProps<any>) => React.ReactNode;
-    children?: ((props: RouteChildrenProps<any>) => React.ReactNode) | React.ReactNode;
-    path?: string | string[];
+    render?: (props: RouteComponentProps<Params>) => React.ReactNode;
+    children?: ((props: RouteChildrenProps<Params>) => React.ReactNode) | React.ReactNode;
+    path?: Path | Path[];
     exact?: boolean;
     sensitive?: boolean;
     strict?: boolean;
 }
-export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> {}
+export class Route<T extends {} = {}, Path extends string = string> extends React.Component<
+    RouteProps<Path> & OmitNative<T, keyof RouteProps>,
+    any
+> {}
 
 export interface RouterProps {
     history: H.History;
@@ -128,25 +134,31 @@ export interface match<Params extends { [K in keyof Params]?: string } = {}> {
 // Omit taken from https://github.com/Microsoft/TypeScript/issues/28339#issuecomment-467220238
 export type Omit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
+// Newer Omit type: as the previous one is being exported, removing it would be a breaking change
+export type OmitNative<T, K extends string | number | symbol> = { [P in Exclude<keyof T, K>]: T[P]; };
+
 export function matchPath<Params extends { [K in keyof Params]?: string }>(
     pathname: string,
     props: string | string[] | RouteProps,
     parent?: match<Params> | null,
 ): match<Params> | null;
 
-export type ExtractRouteOptionalParam<T extends string> = T extends `${infer Param}?`
-    ? { [k in Param]?: string | number | boolean }
-    : { [k in T]: string | number | boolean };
+export type ExtractRouteOptionalParam<T extends string, U> = T extends `${infer Param}?`
+    ? { [k in Param]?: U }
+    : { [k in T]: U };
 
-export type ExtractRouteParams<T extends string> = string extends T
-    ? { [k in string]?: string | number | boolean }
+export type ExtractRouteParams<T extends string, U> = string extends T
+    ? { [k in string]?: U }
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
-    ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
+    ? ExtractRouteOptionalParam<Param, U> & ExtractRouteParams<Rest, U>
     : T extends `${infer _Start}:${infer Param}`
-    ? ExtractRouteOptionalParam<Param>
+    ? ExtractRouteOptionalParam<Param, U>
     : {};
 
-export function generatePath<S extends string>(path: S, params?: ExtractRouteParams<S>): string;
+export function generatePath<S extends string>(
+    path: S,
+    params?: ExtractRouteParams<S, string | number | boolean>,
+): string;
 
 export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass
     ? { wrappedComponentRef?: React.Ref<InstanceType<C>> }

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -143,7 +143,7 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
     parent?: match<Params> | null,
 ): match<Params> | null;
 
-export type ExtractRouteOptionalParam<T extends string, U> = T extends `${infer Param}?`
+export type ExtractRouteOptionalParam<T extends string, U = string | number | boolean> = T extends `${infer Param}?`
     ? { [k in Param]?: U }
     : { [k in T]: U };
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -147,7 +147,7 @@ export type ExtractRouteOptionalParam<T extends string, U = string | number | bo
     ? { [k in Param]?: U }
     : { [k in T]: U };
 
-export type ExtractRouteParams<T extends string, U> = string extends T
+export type ExtractRouteParams<T extends string, U = string | number | boolean> = string extends T
     ? { [k in string]?: U }
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
     ? ExtractRouteOptionalParam<Param, U> & ExtractRouteParams<Rest, U>
@@ -157,7 +157,7 @@ export type ExtractRouteParams<T extends string, U> = string extends T
 
 export function generatePath<S extends string>(
     path: S,
-    params?: ExtractRouteParams<S, string | number | boolean>,
+    params?: ExtractRouteParams<S>,
 ): string;
 
 export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass

--- a/types/react-router/test/InheritingRoute.tsx
+++ b/types/react-router/test/InheritingRoute.tsx
@@ -13,6 +13,9 @@ export default class CustomRoute extends Route<CustomRouteInterface> {
     // react-fiber's render function can also return an array of elements,
     // but in this case it's assumed that a JSX.Element is returned.
     const maybeElement = super.render() as JSX.Element;
+    const aProperty: string = this.props.aProperty;
+    const anotherOne: boolean = this.props.anotherOne;
+    const willItEnd: number | undefined = this.props.willItEnd;
     return maybeElement && <div className="meaningfulClass">{React.cloneElement(maybeElement, this.props)}</div>;
   }
 }

--- a/types/react-router/test/Route.tsx
+++ b/types/react-router/test/Route.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+const exhausted = (_: never): never => {
+    throw new Error('unreachable');
+};
+
+const RouteExample = () => (
+    <Switch>
+        <Route
+            path={'test-for-non-static-string' as string}
+            render={route => {
+                const { params } = route.match;
+                const __shrug__: string | undefined = params.__shrug__;
+                return <>{__shrug__}</>;
+            }}
+        />
+        <Route
+            path="/single/:id"
+            render={route => {
+                const { params } = route.match;
+                const notDefined = params.notDefined; // $ExpectError
+                const id: string = params.id;
+                return <>{id}</>;
+            }}
+        />
+        <Route
+            path="/optional/:id?"
+            render={route => {
+                const { params } = route.match;
+                const notDefined = params.notDefined; // $ExpectError
+                const id: string | undefined = params.id;
+                return <>{id}</>;
+            }}
+        />
+        <Route
+            path={['/abc/:id', '/xyz/:name']}
+            render={route => {
+                const { params } = route.match;
+
+                const notDefined = params.notDefined; // $ExpectError
+                const unionParams = params.id; // $ExpectError
+
+                if ('id' in params) {
+                    const id: string = params.id;
+                    return <>{id}</>;
+                }
+
+                if ('name' in params) {
+                    const name: string = params.name;
+                    return <>{name}</>;
+                }
+
+                return exhausted(params);
+            }}
+        />
+        <Route
+            path="/single/:id"
+            children={route => {
+                if (!route.match) return null;
+                const { params } = route.match;
+                const notDefined = params.notDefined; // $ExpectError
+                const id: string = params.id;
+                return <>{id}</>;
+            }}
+        />
+        <Route
+            path={['/abc/:id', '/xyz/:name']}
+            children={route => {
+                if (!route.match) return null;
+                const { params } = route.match;
+
+                const notDefined = params.notDefined; // $ExpectError
+                const unionParams = params.id; // $ExpectError
+
+                if ('id' in params) {
+                    const id: string = params.id;
+                    return <>{id}</>;
+                }
+
+                if ('name' in params) {
+                    const name: string = params.name;
+                    return <>{name}</>;
+                }
+
+                return exhausted(params);
+            }}
+        />
+    </Switch>
+);
+
+// $ExpectType { batman: string; }
+type signature = Parameters<NonNullable<Route<{}, '/:batman'>['props']['render']>>[0]['match']['params'];
+
+export default RouteExample;

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -2,7 +2,7 @@ import { generatePath } from 'react-router';
 
 declare const unknownPath: string;
 
-// inncorect usage, type errors
+// incorrect usage, type errors
 generatePath('/posts/:postId', {}); // $ExpectError
 generatePath('/posts/:postId/comments/:commentId', { postId: '1' }); // $ExpectError
 generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -39,6 +39,7 @@
         "test/NavigateWithContext.tsx",
         "test/MemoryRouter.tsx",
         "test/Prompt.tsx",
+        "test/Route.tsx",
         "test/Switch.tsx",
         "test/InheritingRoute.tsx",
         "test/WithRouter.tsx",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

Reued the recent work done for `generatePath` to support also inferring the params in `render={}` and `children={}` props when using static paths. (for non-static paths it fallsback to the previous `Record<string, string | undefined>`)