### PR TITLE
InitOptions miss field `theme`

### DIFF
--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -28,6 +28,7 @@ interface InitOptions {
     events?: Events;
     useSecureCookies?: boolean;
     cookies?: Cookies;
+    theme?: string;
 }
 
 interface AppOptions {

--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for next-auth 3.1
+// Type definitions for next-auth 3.5
 // Project: https://github.com/iaincollins/next-auth#readme
 // Definitions by: Lluis <https://github.com/lluia>
 //                 Iain <https://github.com/iaincollins>
 //                 Juan <https://github.com/JuanM04>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.5
 
 /// <reference types="node" />
 

--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -28,7 +28,7 @@ interface InitOptions {
     events?: Events;
     useSecureCookies?: boolean;
     cookies?: Cookies;
-    theme?: string;
+    theme?: 'light' | 'dark' | 'auto';
 }
 
 interface AppOptions {


### PR DESCRIPTION
A quick fix to add field `theme?: string` to `InitOptions `.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
