### PR TITLE
[highland] Add Highland.Nil to the value of pull()

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -463,7 +463,7 @@ fooStream.pipe(readwritable);
 // $ExpectType WritableStream
 fooStream.pipe(writable, { end: false });
 
-fooStream.pull((err: Error, x: Foo) => {});
+fooStream.pull((err: Error, x: Foo | Highland.Nil) => {});
 
 fooStream.pull((err, x) => {});
 

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1527,7 +1527,7 @@ declare namespace Highland {
          * @param {Function} f - the function to handle data
          * @api public
          */
-        pull(f: (err: Error, x: R) => void): void;
+        pull(f: (err: Error, x: R | Highland.Nil) => void): void;
 
         /**
          * Collects all values from a Stream into an Array and calls a function with


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://github.com/caolan/highland/blob/18c14bbbc1154ecc9df0115e4e0ecf7d52b25eb3/lib/index.js#L1604
- The code above shows that the value passed to `pull()` should be same as `consume()`. As `consume()`'s type contains `Nil`, we should also add `Nil` to `pull()`.
