### PR TITLE
[nodegit] Change Remote#defaultBranch return type to string

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -100,3 +100,8 @@ revwalk.push(id);
 const commitList: Promise<Git.Commit[]> = revwalk.getCommitsUntil((commit: Git.Commit) => {
     return true;
 });
+
+Git.Remote.create(repo, 'test-repository', 'https://github.com/test-repository/test-repository').then((remote) => {
+    remote.connect(Git.Enums.DIRECTION.FETCH, {});
+    remote.defaultBranch(); // $ExpectType Promise<string>
+});

--- a/types/nodegit/remote.d.ts
+++ b/types/nodegit/remote.d.ts
@@ -42,7 +42,7 @@ export class Remote {
     autotag(): number;
     connect(direction: Enums.DIRECTION, callbacks: RemoteCallbacks, callback?: Function): Promise<number>;
     connected(): number;
-    defaultBranch(): Promise<Buf>;
+    defaultBranch(): Promise<string>;
     disconnect(): Promise<void>;
     download(refSpecs: any[], opts?: FetchOptions, callback?: Function): Promise<number>;
     dup(): Promise<Remote>;


### PR DESCRIPTION
**Commits**

- Change Remote#defaultBranch return type to string
  This is inconsistent with [the documentation](https://www.nodegit.org/api/remote/#defaultBranch), but appears to be the
  actual return type of the function based on [the
  tests](https://github.com/nodegit/nodegit/blob/7df154a5eb9e93ad933f0a9864f06e2395d32d21/test/tests/remote.js#L254-L257).