### PR TITLE
nodegit: add HistoryEntry type to revwalk

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -108,10 +108,10 @@ historyEntries.then((entries: Git.Revwalk.HistoryEntry[]) => {
         const status: Git.Diff.DELTA = entry.status;
         const newName: string = entry.newName;
         const oldName: string = entry.oldName;
-        entry; // $ExpectType Git.Revwalk.HistoryEntry
-        commit; // $ExpectType Git.Commit
-        status; // $ExpectType Git.Diff.DELTA
+        entry; // $ExpectType HistoryEntry
+        commit; // $ExpectType Commit
+        status; // $ExpectType DELTA
         newName; // $ExpectType string
         oldName; // $ExpectType string
     }
-})
+});

--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -100,3 +100,18 @@ revwalk.push(id);
 const commitList: Promise<Git.Commit[]> = revwalk.getCommitsUntil((commit: Git.Commit) => {
     return true;
 });
+const historyEntries: Promise<Git.Revwalk.HistoryEntry[]> = revwalk.fileHistoryWalk('path', 100);
+historyEntries.then((entries: Git.Revwalk.HistoryEntry[]) => {
+    if (entries.length > 0) {
+        const entry = entries[0];
+        const commit: Git.Commit = entry.commit;
+        const status: Git.Diff.DELTA = entry.status;
+        const newName: string = entry.newName;
+        const oldName: string = entry.oldName;
+        entry; // $ExpectType Git.Revwalk.HistoryEntry
+        commit; // $ExpectType Git.Commit
+        status; // $ExpectType Git.Diff.DELTA
+        newName; // $ExpectType string
+        oldName; // $ExpectType string
+    }
+})

--- a/types/nodegit/rev-walk.d.ts
+++ b/types/nodegit/rev-walk.d.ts
@@ -1,6 +1,7 @@
 import { Repository } from './repository';
 import { Oid } from './oid';
 import { Commit } from './commit';
+import { Diff } from './diff';
 
 export namespace Revwalk {
     const enum SORT {
@@ -8,6 +9,12 @@ export namespace Revwalk {
         TOPOLOGICAL = 1,
         TIME = 2,
         REVERSE = 4
+    }
+    interface HistoryEntry {
+        commit: Commit;
+        status: Diff.DELTA;
+        newName: string;
+        oldName: string;
     }
 }
 
@@ -34,7 +41,7 @@ export class Revwalk {
      */
     sorting(...sort: number[]): void;
     fastWalk(maxCount: number): Promise<any>;
-    fileHistoryWalk(filePath: string, maxCount: number): Promise<any[]>;
+    fileHistoryWalk(filePath: string, maxCount: number): Promise<Revwalk.HistoryEntry[]>;
     /**
      * Walk the history from the given oid. The callback is invoked for each commit; When the walk is over, the callback is invoked with (null, null).
      */


### PR DESCRIPTION
This PR adds a definition for the `HistoryEntry` type & uses it instead of previously `any` in the return type of `Revwalk#fileHistoryWalk`.

- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `HistoryEntry` mostly taken from JSDoc declarations: 
    https://github.com/nodegit/nodegit/blob/7df154a5eb9e93ad933f0a9864f06e2395d32d21/lib/revwalk.js#L10-L27
  - `HistoryEntry.status` property deduced as `Git.Diff.DELTA` enum type (instead of plain `number` as indicated by the JSDoc) according to C++ bindings source code for `fileHistoryWalk`: 
    https://github.com/nodegit/nodegit/blob/7df154a5eb9e93ad933f0a9864f06e2395d32d21/generate/templates/manual/revwalk/file_history_walk.cc#L96
