### PR TITLE
[leaflet.markercluster] Add missing `clusterPane` prop to MarkerClusterGroupOptions

### DIFF
--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -107,6 +107,12 @@ declare module 'leaflet' {
         iconCreateFunction?: ((cluster: MarkerCluster) => Icon | DivIcon);
 
         /*
+        * Map pane where the cluster icons will be added.
+        * Defaults to L.Marker's default (currently 'markerPane')
+         */
+        clusterPane?: string;
+
+        /*
         * Boolean to split the addLayers processing in to small intervals so that the page does not freeze.
         */
         chunkedLoading?: boolean;
@@ -137,6 +143,7 @@ declare module 'leaflet' {
         * single versions when doing bulk addition/removal of markers.
         */
         addLayers(layers: Layer[], skipLayerAddEvent?: boolean): this;
+
         removeLayers(layers: Layer[]): this;
 
         clearLayers(): this;
@@ -151,7 +158,7 @@ declare module 'leaflet' {
         * If you have customized the clusters icon to use some data from the contained markers,
         * and later that data changes, use this method to force a refresh of the cluster icons.
         */
-        refreshClusters(clusters?: Marker | Marker[] | LayerGroup | {[index: string]: Layer}): this;
+        refreshClusters(clusters?: Marker | Marker[] | LayerGroup | { [index: string]: Layer }): this;
 
         /*
         * Returns the total number of markers contained within that cluster.

--- a/types/leaflet.markercluster/leaflet.markercluster-tests.ts
+++ b/types/leaflet.markercluster/leaflet.markercluster-tests.ts
@@ -37,6 +37,8 @@ markerClusterGroupOptions.iconCreateFunction = (cluster: L.MarkerCluster) => {
     return L.divIcon();
 };
 
+markerClusterGroupOptions.clusterPane = "foobarPane";
+
 let markerClusterGroup: L.MarkerClusterGroup;
 markerClusterGroup = L.markerClusterGroup();
 markerClusterGroup = L.markerClusterGroup(markerClusterGroupOptions);


### PR DESCRIPTION
Fixes issue #31230

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - `clusterPane` property taken from 'other options' section of marker cluster options [https://github.com/Leaflet/Leaflet.markercluster#other-options](https://github.com/Leaflet/Leaflet.markercluster#other-options)