### PR TITLE
[Ember] Allow `onerror` to be `undefined`

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -525,7 +525,8 @@ export namespace Ember {
      * internals encounter an error. This is useful for specialized error handling
      * and reporting code.
      */
-    function onerror(error: Error): void;
+    let onerror: ((error: Error) => void) | undefined;
+
     /**
      * The semantic version
      */

--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -130,6 +130,7 @@ Ember.VERSION; // $ExpectType string
 
 Ember.onerror = (err: Error) => console.error(err);
 Ember.onerror = (num: number, err: Error) => console.error(err); // $ExpectError
+Ember.onerror = undefined;
 
 // Classes
 // TODO ContainerProxyMixin


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
It's poorly documented, but you can see here that the starting value is `undefined`: https://github.com/emberjs/ember.js/blob/17b01c91dc5309639f3e6d961e42858aaaeff3a2/packages/%40ember/-internals/error-handling/index.ts
