### PR TITLE
[video.js]: Fix overloads for autoplay(), controls(), loop()

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6071,7 +6071,7 @@ export interface VideoJsPlayer extends videojs.Component {
      *
      * @return The current value of autoplay when getting
      */
-    autoplay(value?: boolean | string): void;
+    autoplay(value: boolean | string): void;
 
     autoplay(): boolean | string;
 
@@ -6179,7 +6179,7 @@ export interface VideoJsPlayer extends videojs.Component {
      *
      * @return The current value of controls when getting
      */
-    controls(bool?: boolean): void;
+    controls(bool: boolean): void;
 
     controls(): boolean;
 
@@ -6549,7 +6549,7 @@ export interface VideoJsPlayer extends videojs.Component {
      *
      * @return The current value of loop when getting
      */
-    loop(value?: boolean): void;
+    loop(value: boolean): void;
 
     loop(): boolean;
 

--- a/types/video.js/test/videojs-alt-distributions-tests.ts
+++ b/types/video.js/test/videojs-alt-distributions-tests.ts
@@ -34,6 +34,16 @@ function test(videojs: typeof videojsnovtt | typeof videojscore) {
 
         const howLongIsThis: number = this.duration();
 
+        const autoplay: boolean | string = this.autoplay();
+        this.autoplay(true);
+        this.autoplay("muted");
+
+        const controls: boolean = this.controls();
+        this.controls(true);
+
+        const loop: boolean = this.loop();
+        this.loop(true);
+
         const bufferedTimeRange: TimeRanges = this.buffered();
 
         // Number of different ranges of time have been buffered. Usually 1.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`autoplay`](https://github.com/videojs/video.js/blob/dd0c675f0ffb236f7bce86cc7d2ebb717774430f/src/js/player.js#L3601L3634), [`controls`](https://github.com/videojs/video.js/blob/dd0c675f0ffb236f7bce86cc7d2ebb717774430f/src/js/player.js#L3762L373803), [`loop`](https://github.com/videojs/video.js/blob/dd0c675f0ffb236f7bce86cc7d2ebb717774430f/src/js/player.js#L3671L3678)
