### PR TITLE
@types/draftjs: fix return type of `ContentState.getBlockBefore` / `ContentState.getBlockAfter` 

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -144,6 +144,10 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
 
         // Change the new block type to be normal 'unstyled' text,
         const newBlock = contentWithBlock.getBlockAfter(selection.getEndKey());
+        // Return the current EditorState when a block does not exist
+        if (newBlock === undefined) {
+            return editorState
+        }
         const contentWithUnstyledBlock = Modifier.setBlockType(
             contentWithBlock,
             SelectionState.createEmpty(newBlock.getKey()),

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -846,8 +846,8 @@ declare namespace Draft {
 
                 getKeyBefore(key: string): string;
                 getKeyAfter(key: string): string;
-                getBlockAfter(key: string): ContentBlock;
-                getBlockBefore(key: string): ContentBlock;
+                getBlockAfter(key: string): ContentBlock | undefined;
+                getBlockBefore(key: string): ContentBlock | undefined;
 
                 getBlocksAsArray(): Array<ContentBlock>;
                 getFirstBlock(): ContentBlock;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [docs](https://draftjs.org/docs/api-reference-content-state#getblockbefore), [SourceCode](https://github.com/facebook/draft-js/blob/99aeb5c6df087d66f7f9cc2e984585a5672425b3/src/model/immutable/ContentState.js#L122)
