### PR TITLE
[d3-force] correct type for ForceLink.id

### DIFF
--- a/types/d3-force/d3-force-tests.ts
+++ b/types/d3-force/d3-force-tests.ts
@@ -181,6 +181,15 @@ num = simLink.s;
 
 // id (node id accessor)
 
+// Using id of type number.
+forceLink = forceLink.id((node, index, nodes) => {
+    const n: SimNode = node;
+    const i: number = index;
+    const ns: SimNode[] = nodes;
+    return i;
+});
+
+// Using id of type string.
 forceLink = forceLink.id((node, index, nodes) => {
     const n: SimNode = node;
     const i: number = index;

--- a/types/d3-force/index.d.ts
+++ b/types/d3-force/index.d.ts
@@ -632,10 +632,10 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * as when the nodes or links change, being passed the node, the zero-based index of the node in the node array, and the node array.
      *
      * @param id A node id accessor function which is invoked for each node in the simulation,
-     * being passed the node, the zero-based index of the node in the node array, and the node array. It returns a string to represent the node id which can be used
+     * being passed the node, the zero-based index of the node in the node array, and the node array. It returns a string or number to represent the node id which can be used
      * for matching link source and link target strings during the ForceLink initialization.
      */
-    id(id: (node: NodeDatum, i: number, nodesData: NodeDatum[]) => string): this;
+    id(id: (node: NodeDatum, i: number, nodesData: NodeDatum[]) => (string | number)): this;
 
     /**
      * Return the current distance accessor, which defaults to implying a default distance of 30.


### PR DESCRIPTION
The setter form of ForceLink.id takes a function as its argument. The
type annotations specify the return type of this function as string, but
number is also valid, and used by the default implementation. This
commit changes the return type to (string | number).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-force/blob/523a02d963f7caf28914b3557e28ce707cdd2d87/src/link.js#L15
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.