### PR TITLE
[object.pick] accept readonly array for keys

### DIFF
--- a/types/object.pick/index.d.ts
+++ b/types/object.pick/index.d.ts
@@ -10,6 +10,6 @@
  * @param object
  * @param keys
  */
-declare function pick<T extends object, U extends keyof T>(object: T, keys: U[]): Pick<T, U>;
+declare function pick<T extends object, U extends keyof T>(object: T, keys: U[] | readonly U[]): Pick<T, U>;
 
 export = pick;

--- a/types/object.pick/object.pick-tests.ts
+++ b/types/object.pick/object.pick-tests.ts
@@ -1,3 +1,6 @@
 import pick = require('object.pick');
 
 pick({a: 'a', b: 'b'}, ['a']);
+
+const keys = ['a'] as const;
+pick({a: 'a', b: 'b'}, keys);


### PR DESCRIPTION
The lodash's `pick` method can accept a readonly array, but object.pick's cannot.
Since object.pick is an alternative to lodash's pick, we should follow the lodash specification.
Thanks.

![image](https://user-images.githubusercontent.com/40315079/108986697-c333de00-76d5-11eb-9432-a052b3bff96f.png)


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jonschlinkert/object.pick>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
