### PR TITLE
[braintree-web] Add some missing types in HostedFields

### DIFF
--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -364,7 +364,7 @@ export interface HostedFields {
      *   if (focusErr) {
      *     console.error(focusErr);
      *   }
-     * }); 
+     * });
      */
     focus(field: HostedFieldsHostedFieldsFieldName, callback?: callback): void;
 }

--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -117,7 +117,8 @@ export type HostedFieldsHostedFieldsFieldName =
     | 'expirationDate'
     | 'expirationMonth'
     | 'expirationYear'
-    | 'postalCode';
+    | 'postalCode'
+    | 'cardholderName';
 
 export type HostedFieldsFieldDataFields = {
     [key in HostedFieldsHostedFieldsFieldName]: HostedFieldsHostedFieldsFieldData;

--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -232,6 +232,7 @@ export interface HostedFields {
     VERSION: string;
 
     on(event: HostedFieldEventType, handler: (event: HostedFieldsStateObject) => void): void;
+    off(event: HostedFieldEventType, handler: (event: HostedFieldsStateObject) => void): void;
 
     teardown(callback?: callback): void;
     teardown(): Promise<void>;

--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -354,4 +354,15 @@ export interface HostedFields {
      * });
      */
     getState(): any;
+
+    /**
+     * Programmatically focus a {@link module:braintree-web/hosted-fields-field field}.     *
+     * @example
+     * hostedFieldsInstance.focus('number', function (focusErr) {
+     *   if (focusErr) {
+     *     console.error(focusErr);
+     *   }
+     * }); 
+     */
+    focus(field: HostedFieldsHostedFieldsFieldName, callback?: callback): void;
 }

--- a/types/braintree-web/test/node.ts
+++ b/types/braintree-web/test/node.ts
@@ -262,6 +262,20 @@ braintree.client.create(
                 const formValid = Object.keys(state.fields).every(key => {
                     return state.fields[key].isValid;
                 });
+
+                hostedFieldsInstance.focus('cardholderName');
+                hostedFieldsInstance.focus('number', (focusErr: braintree.BraintreeError) => {
+                    if (focusErr) {
+                        console.error(focusErr);
+                    }
+                });
+
+                function onValidityChange(fieldState: braintree.HostedFieldsStateObject): void {
+                    console.log(fieldState);
+                }
+
+                hostedFieldsInstance.on('validityChange', onValidityChange);
+                hostedFieldsInstance.off('validityChange', onValidityChange);
             },
         );
 

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -298,6 +298,20 @@ braintree.client.create(
                 const formValid = Object.keys(state.fields).every(key => {
                     return state.fields[key].isValid;
                 });
+
+                hostedFieldsInstance.focus('cardholderName');
+                hostedFieldsInstance.focus('number', (focusErr: braintree.BraintreeError) => {
+                    if (focusErr) {
+                        console.error(focusErr);
+                    }
+                });
+
+                function onValidityChange(fieldState: braintree.HostedFieldsStateObject): void {
+                    console.log(fieldState);
+                }
+
+                hostedFieldsInstance.on('validityChange', onValidityChange);
+                hostedFieldsInstance.off('validityChange', onValidityChange);
             },
         );
 


### PR DESCRIPTION
HostedFields type has some missing methods.
This PR contains types for such methods as .focus and .off.
Also here added cardholderName as possible HostedFieldsName which was update in https://github.com/braintree/braintree-web/blob/master/CHANGELOG.md#3650

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test types/braintree-web`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://braintree.github.io/braintree-web/3.69.0/HostedFields.html#focus
https://braintree.github.io/braintree-web/3.69.0/HostedFields.html#off
https://braintree.github.io/braintree-web/3.69.0/module-braintree-web_hosted-fields.html#~fieldOptions