### PR TITLE
add mongodb.Timestamp as a valid $currentDate target in mongodb type defs

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1903,7 +1903,7 @@ export type PullAllOperator<TSchema> = ({
 /** @see https://docs.mongodb.com/manual/reference/operator/update */
 export type UpdateQuery<TSchema> = {
     /** @see https://docs.mongodb.com/manual/reference/operator/update-field/ */
-    $currentDate?: OnlyFieldsOfType<TSchema, Date, true | { $type: 'date' | 'timestamp' }>;
+    $currentDate?: OnlyFieldsOfType<TSchema, Date | Timestamp, true | { $type: 'date' | 'timestamp' }>;
     $inc?: OnlyFieldsOfType<TSchema, NumericTypes | undefined>;
     $min?: MatchKeysAndValues<TSchema>;
     $max?: MatchKeysAndValues<TSchema>;

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -1,4 +1,4 @@
-import { connect, Decimal128, Double, Int32, Long, ObjectId, UpdateQuery } from 'mongodb';
+import { connect, Decimal128, Double, Int32, Long, ObjectId, UpdateQuery, Timestamp } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.updateX tests
@@ -31,6 +31,7 @@ async function run() {
         maybeFruitTags?: FruitTypes[];
         subInterfaceField: SubTestModel;
         subInterfaceArray: SubTestModel[];
+        timestampField: Timestamp;
     }
     const collectionTType = db.collection<TestModel>('test.update');
 
@@ -43,6 +44,7 @@ async function run() {
     buildUpdateQuery({ $currentDate: { dateField: true } });
     buildUpdateQuery({ $currentDate: { otherDateField: { $type: 'date' } } });
     buildUpdateQuery({ $currentDate: { otherDateField: { $type: 'timestamp' } } });
+    buildUpdateQuery({ $currentDate: { timestampField: { $type: 'timestamp' } } });
     buildUpdateQuery({ $currentDate: { 'dot.notation': true } });
     buildUpdateQuery({ $currentDate: { 'subInterfaceArray.$': true } });
     buildUpdateQuery({ $currentDate: { 'subInterfaceArray.$[bla]': { $type: 'date' } } });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mongodb.com/manual/reference/operator/update/currentDate/
- NA If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
