### PR TITLE
Added types declarations to handlebars-webpack-plugin

### DIFF
--- a/types/handlebars-webpack-plugin/handlebars-webpack-plugin-tests.ts
+++ b/types/handlebars-webpack-plugin/handlebars-webpack-plugin-tests.ts
@@ -1,0 +1,54 @@
+import path = require('path');
+import HandlebarsPlugin = require('handlebars-webpack-plugin');
+import HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    plugins: [
+        new HandlebarsPlugin(),
+        new HandlebarsPlugin({}),
+        new HandlebarsPlugin({
+            htmlWebpackPlugin: {
+                title: 'hey',
+            },
+        }),
+        new HandlebarsPlugin({
+            htmlWebpackPlugin: {
+                title: 'hey',
+                HtmlWebpackPlugin,
+            },
+        }),
+        new HandlebarsPlugin({
+            entry: path.join(process.cwd(), 'app', 'src', '*.hbs'),
+            output: path.join(process.cwd(), 'build', '[name].html'),
+            data: require('package.json'),
+            partials: [path.join(process.cwd(), 'app', 'src', 'components', '*', '*.hbs')],
+            helpers: {
+                hi: (arg1, arg2, options) => {},
+                hey: (arg1, arg2, options) => {},
+            },
+            getTargetFilepath: (filepath, outputTemplate, rootFolder) => {
+                const fileName = path.basename(filepath).replace(path.extname(filepath), '');
+                return outputTemplate.replace('[name]', fileName);
+            },
+            getPartialId: filePath => {
+                return filePath.match(/\/([^/]+\/[^/]+)\.[^.]+$/)?.pop();
+            },
+        }),
+        new HandlebarsPlugin({
+            entry: path.join(process.cwd(), 'app', 'src', '*.hbs'),
+            output: path.join(process.cwd(), 'build', '[name].html'),
+            data: path.join(__dirname, 'app/data/project.json'),
+            partials: [path.join(process.cwd(), 'app', 'src', 'components', '*', '*.hbs')],
+            helpers: {
+                is: (arg1, arg2, options) => {},
+                projectHelpers: path.join(process.cwd(), 'app', 'helpers', '*.helper.js'),
+            },
+            onBeforeSetup: Handlebars => {},
+            onBeforeAddPartials: (Handlebars, partialsMap) => {},
+            onBeforeCompile: (Handlebars, templateContent) => {},
+            onBeforeRender: (Handlebars, data, filename) => {},
+            onBeforeSave: (Handlebars, resultHtml, filename) => {},
+            onDone: (Handlebars, filename) => {},
+        }),
+    ],
+};

--- a/types/handlebars-webpack-plugin/index.d.ts
+++ b/types/handlebars-webpack-plugin/index.d.ts
@@ -10,8 +10,8 @@ import { Options } from 'html-webpack-plugin';
 
 import HtmlWebpackPlugin = require('html-webpack-plugin');
 
-declare class HandlebarsPlugin implements WebpackPluginInstance {
-    constructor(options?: HandlebarsPlugin.PluginOptions);
+declare class HandlebarsWebpackPlugin implements WebpackPluginInstance {
+    constructor(options?: HandlebarsWebpackPlugin.PluginOptions);
 
     /**
      * Apply the plugin
@@ -19,7 +19,7 @@ declare class HandlebarsPlugin implements WebpackPluginInstance {
     apply(compiler: Compiler): void;
 }
 
-declare namespace HandlebarsPlugin {
+declare namespace HandlebarsWebpackPlugin {
     /**
      * Type for the object partials that the plugin creates in other to process all partials
      */
@@ -111,4 +111,4 @@ declare namespace HandlebarsPlugin {
     }
 }
 
-export = HandlebarsPlugin;
+export = HandlebarsWebpackPlugin;

--- a/types/handlebars-webpack-plugin/index.d.ts
+++ b/types/handlebars-webpack-plugin/index.d.ts
@@ -1,0 +1,140 @@
+// Type definitions for handlebars-webpack-plugin 2.2
+// Project: https://github.com/sagold/handlebars-webpack-plugin
+// Definitions by: odas0R <https://github.com/Odas0R>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Compiler, WebpackPluginInstance } from 'webpack';
+import { HelperDeclareSpec } from 'handlebars';
+import { Options } from 'html-webpack-plugin';
+
+import HtmlWebpackPlugin = require('html-webpack-plugin');
+
+declare class HandlebarsPlugin implements WebpackPluginInstance {
+    constructor(options?: HandlebarsPlugin.PluginOptions);
+
+    /**
+     * Apply the plugin
+     */
+    apply(compiler: Compiler): void;
+}
+
+declare namespace HandlebarsPlugin {
+    /**
+     * Type for Handlebars helpers object
+     */
+    type Helpers = HelperDeclareSpec | { projectHelpers: string };
+
+    /**
+     * Type for HtmlWebpackPlugin Options
+     */
+    type HtmlWebpackOptions = Options | HtmlWebpackPlugin;
+
+    /**
+     * Type for the object partials that the plugin creates in other to process all partials
+     */
+    type PartialsMap = { [partial: string]: string };
+
+    /**
+     * Handlebars Webpack Plugin Options
+     */
+    interface PluginOptions {
+        /**
+         * Path to hbs entry file(s).
+         * Also supports nested directories if write
+         * path.join(process.cwd(), "app", "src", "**", "*.hbs"),
+         */
+        entry?: string;
+
+        /**
+         * Output path and filename(s).
+         * This should lie within the webpacks output-folder
+         * if omitted, the input filepath stripped of its extension will be used
+         */
+        output?: string;
+
+        /**
+         * You can also add a [path] variable, which will emit the files with their
+         * relative path, like output:
+         * path.join(process.cwd(), "build", [path], "[name].html
+         *
+         * data passed to main hbs template: `main-template(data)`
+         */
+        data?: object | string;
+
+        /**
+         * globbed path to partials, where folder/filename is unique
+         */
+        partials?: string[];
+
+        /**
+         * Register custom helpers. May be either a function or a glob-pattern
+         */
+        helpers?: Helpers;
+
+        /**
+         * Modify the default output path of each entry-template
+         * @param {String} filepath     - the source of the template
+         * @param {String} outputTemplate - the filepath template defined in `output`
+         * @param {String} rootFolder   - the filepaths rootFolder
+         * @return {String} final path, where the rendered html-file should be saved
+         */
+        getTargetFilepath?: (filepath: string, outputTemplate: string, rootFolder: string) => string | undefined;
+
+        /**
+         * Modify the hbs partial-id created for a loaded partial
+         * @param {String} filePath   - filePath to the loaded partial
+         * @return {String} hbs-partialId, per default folder/partialName is used
+         */
+        getPartialId?: (filePath: string) => string | undefined;
+
+        /**
+         * onBeforeSetup hook, runs before setup of the plugin
+         * @param {RuntimeOptions} Handlebars - runtime handlebar options
+         */
+        onBeforeSetup?: (Handlebars: RuntimeOptions) => any;
+
+        /**
+         * onBeforeAddPartials hook, runs before the partials addition to the .html files
+         * @param {RuntimeOptions} Handlebars - runtime handlebar options
+         * @param {PartialsMap} partialsMap - project partials
+         */
+        onBeforeAddPartials?: (Handlebars: RuntimeOptions, partialsMap: PartialsMap) => any;
+
+        /**
+         * onBeforeCompile hook, runs before the plugin compilation
+         * @param {RuntimeOptions} Handlebars - runtime handlebar options
+         * @param {String} templateContent - html of the template
+         */
+        onBeforeCompile?: (Handlebars: RuntimeOptions, templateContent: string) => any;
+
+        /**
+         * onBeforeRender hook, runs before rendering of the templates
+         * @param {RuntimeOptions} Handlebars - runtime handlebar options
+         * @param {Object} data - data passed to the template
+         * @param {String} filename - name of the file
+         */
+        onBeforeRender?: (Handlebars: RuntimeOptions, data: object, filename: string) => any;
+
+        /**
+         * onBeforeSave hook, runs before saving
+         * @param {RuntimeOptions} Handlebars - runtime handlebar options
+         * @param {String} resultHtml - the result html
+         * @param {String} filename - name of the file
+         */
+        onBeforeSave?: (Handlebars: RuntimeOptions, resultHtml: string, filename: string) => any;
+
+        /**
+         * onDone, runs before the final stages of the plugin
+         * @param {RuntimeOptions} Handlebars - runtime handlebar options
+         * @param {String} filename - name of the file
+         */
+        onDone?: (Handlebars: RuntimeOptions, filename: string) => any;
+
+        /**
+         * HtmlWebpackPlugin additional configurations
+         */
+        htmlWebpackPlugin?: HtmlWebpackOptions;
+    }
+}
+
+export = HandlebarsPlugin;

--- a/types/handlebars-webpack-plugin/index.d.ts
+++ b/types/handlebars-webpack-plugin/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/sagold/handlebars-webpack-plugin
 // Definitions by: odas0R <https://github.com/Odas0R>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
 
 import { Compiler, WebpackPluginInstance } from 'webpack';
 import { HelperDeclareSpec } from 'handlebars';

--- a/types/handlebars-webpack-plugin/index.d.ts
+++ b/types/handlebars-webpack-plugin/index.d.ts
@@ -20,19 +20,11 @@ declare class HandlebarsPlugin implements WebpackPluginInstance {
 
 declare namespace HandlebarsPlugin {
     /**
-     * Type for Handlebars helpers object
-     */
-    type Helpers = HelperDeclareSpec | { projectHelpers: string };
-
-    /**
-     * Type for HtmlWebpackPlugin Options
-     */
-    type HtmlWebpackOptions = Options | HtmlWebpackPlugin;
-
-    /**
      * Type for the object partials that the plugin creates in other to process all partials
      */
-    type PartialsMap = { [partial: string]: string };
+    interface PartialsMap {
+        [partial: string]: string;
+    }
 
     /**
      * Handlebars Webpack Plugin Options
@@ -69,71 +61,52 @@ declare namespace HandlebarsPlugin {
         /**
          * Register custom helpers. May be either a function or a glob-pattern
          */
-        helpers?: Helpers;
+        helpers?: HelperDeclareSpec | { projectHelpers: string };
 
         /**
          * Modify the default output path of each entry-template
-         * @param {String} filepath     - the source of the template
-         * @param {String} outputTemplate - the filepath template defined in `output`
-         * @param {String} rootFolder   - the filepaths rootFolder
-         * @return {String} final path, where the rendered html-file should be saved
          */
         getTargetFilepath?: (filepath: string, outputTemplate: string, rootFolder: string) => string | undefined;
 
         /**
          * Modify the hbs partial-id created for a loaded partial
-         * @param {String} filePath   - filePath to the loaded partial
-         * @return {String} hbs-partialId, per default folder/partialName is used
          */
         getPartialId?: (filePath: string) => string | undefined;
 
         /**
          * onBeforeSetup hook, runs before setup of the plugin
-         * @param {RuntimeOptions} Handlebars - runtime handlebar options
          */
         onBeforeSetup?: (Handlebars: RuntimeOptions) => any;
 
         /**
          * onBeforeAddPartials hook, runs before the partials addition to the .html files
-         * @param {RuntimeOptions} Handlebars - runtime handlebar options
-         * @param {PartialsMap} partialsMap - project partials
          */
         onBeforeAddPartials?: (Handlebars: RuntimeOptions, partialsMap: PartialsMap) => any;
 
         /**
          * onBeforeCompile hook, runs before the plugin compilation
-         * @param {RuntimeOptions} Handlebars - runtime handlebar options
-         * @param {String} templateContent - html of the template
          */
         onBeforeCompile?: (Handlebars: RuntimeOptions, templateContent: string) => any;
 
         /**
          * onBeforeRender hook, runs before rendering of the templates
-         * @param {RuntimeOptions} Handlebars - runtime handlebar options
-         * @param {Object} data - data passed to the template
-         * @param {String} filename - name of the file
          */
         onBeforeRender?: (Handlebars: RuntimeOptions, data: object, filename: string) => any;
 
         /**
          * onBeforeSave hook, runs before saving
-         * @param {RuntimeOptions} Handlebars - runtime handlebar options
-         * @param {String} resultHtml - the result html
-         * @param {String} filename - name of the file
          */
         onBeforeSave?: (Handlebars: RuntimeOptions, resultHtml: string, filename: string) => any;
 
         /**
          * onDone, runs before the final stages of the plugin
-         * @param {RuntimeOptions} Handlebars - runtime handlebar options
-         * @param {String} filename - name of the file
          */
         onDone?: (Handlebars: RuntimeOptions, filename: string) => any;
 
         /**
          * HtmlWebpackPlugin additional configurations
          */
-        htmlWebpackPlugin?: HtmlWebpackOptions;
+        htmlWebpackPlugin?: Options | HtmlWebpackPlugin;
     }
 }
 

--- a/types/handlebars-webpack-plugin/package.json
+++ b/types/handlebars-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "handlebars": ">=4.7.7"
+        "handlebars": ">=4.0.3"
     }
 }

--- a/types/handlebars-webpack-plugin/package.json
+++ b/types/handlebars-webpack-plugin/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": ">=4.7.7"
+    }
+}

--- a/types/handlebars-webpack-plugin/tsconfig.json
+++ b/types/handlebars-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "handlebars-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/handlebars-webpack-plugin/tslint.json
+++ b/types/handlebars-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.