### PR TITLE
[lusca] bump to version 1.7 with breaking change

### DIFF
--- a/types/lusca/index.d.ts
+++ b/types/lusca/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for lusca 1.6
+// Type definitions for lusca 1.7
 // Project: https://github.com/krakenjs/lusca#readme
 // Definitions by: Corbin Crutchley <https://github.com/crutchcorn>
 //                 Naoto Yokoyama <https://github.com/builtinnya>
@@ -38,7 +38,7 @@ declare namespace lusca {
         preload?: boolean;
     }
 
-    type csrfOptions = csrfOptionsBase & csrfOptionsAngularOrNonAngular & csrfOptionsBlacklistOrWhitelist;
+    type csrfOptions = csrfOptionsBase & csrfOptionsAngularOrNonAngular & csrfOptionsBlocklistOrAllowlist;
 
     interface csrfOptionsBase {
         /**
@@ -78,17 +78,17 @@ declare namespace lusca {
 
     type csrfOptionsAngularOrNonAngular = csrfOptionsAngular | csrfOptionsNonAngular;
 
-    interface csrfOptionsBlacklist {
-        blacklist?: string[];
-        whitelist?: never;
+    interface csrfOptionsBlocklist {
+        blocklist?: string[];
+        allowlist?: never;
     }
 
-    interface csrfOptionsWhitelist {
-        blacklist?: never;
-        whitelist?: string[];
+    interface csrfOptionsAllowlist {
+        blocklist?: never;
+        allowlist?: string[];
     }
 
-    type csrfOptionsBlacklistOrWhitelist = csrfOptionsBlacklist | csrfOptionsWhitelist;
+    type csrfOptionsBlocklistOrAllowlist = csrfOptionsBlocklist | csrfOptionsAllowlist;
 
     interface xssProtectionOptions {
         enabled?: boolean;

--- a/types/lusca/lusca-tests.ts
+++ b/types/lusca/lusca-tests.ts
@@ -5,21 +5,21 @@ const app = express();
 
 app.use(lusca({
     csrf: true,
-    csp: { policy: "referrer no-referrer"},
+    csp: { policy: "referrer no-referrer" },
     xframe: 'SAMEORIGIN',
     p3p: 'ABCDEF',
-    hsts: {maxAge: 31536000, includeSubDomains: true, preload: true},
+    hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
     xssProtection: true,
     nosniff: true,
     referrerPolicy: 'same-origin'
 }));
 
 app.use(lusca.csrf());
-app.use(lusca.csrf({cookie: {name: 'csrf'}, header: 'x-csrf-token'}));
-app.use(lusca.csrf({cookie: 'csrf', angular: true}));
-app.use(lusca.csrf({blacklist: ['/blacklist']}));
-app.use(lusca.csrf({whitelist: ['/whitelist']}));
-app.use(lusca.csp({policy: [{ "img-src": "'self' http:" }, "block-all-mixed-content"], reportOnly: false}));
+app.use(lusca.csrf({ cookie: { name: 'csrf' }, header: 'x-csrf-token' }));
+app.use(lusca.csrf({ cookie: 'csrf', angular: true }));
+app.use(lusca.csrf({ blocklist: ['/blocklist'] }));
+app.use(lusca.csrf({ allowlist: ['/allowlist'] }));
+app.use(lusca.csp({ policy: [{ "img-src": "'self' http:" }, "block-all-mixed-content"], reportOnly: false }));
 app.use(lusca.xframe('SAMEORIGIN'));
 app.use(lusca.p3p('ABCDEF'));
 app.use(lusca.hsts({ maxAge: 31536000 }));


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test lusca`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/krakenjs/lusca/blob/master/CHANGELOG.md and https://github.com/krakenjs/lusca/blob/master/lib/csrf.js
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Lusca 1.6 -> 1.7 brought a breaking change, where CSRF options changed from `blacklist` to `blocklist` and `whitelist` to `allowlist`.