### PR TITLE
use-double-click: add types

### DIFF
--- a/types/use-double-click/index.d.ts
+++ b/types/use-double-click/index.d.ts
@@ -5,7 +5,7 @@
 
 import { RefObject, MutableRefObject, MouseEvent } from 'react';
 
-export default function useDoubleClick<T = unknown>(options: {
+declare function useDoubleClick<T = unknown>(options: {
   /** Dom node to watch for double clicks */
   ref: RefObject<T> | MutableRefObject<T>;
   /** The amount of time (in milliseconds) to wait before differentiating a single from a double click. Defaults to 300. */
@@ -15,3 +15,5 @@ export default function useDoubleClick<T = unknown>(options: {
   /** A callback function for double click events */
   onDoubleClick?: (e: MouseEvent) => void;
 }): void;
+
+export = useDoubleClick;

--- a/types/use-double-click/index.d.ts
+++ b/types/use-double-click/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for use-double-click 1.0
+// Project: https://github.com/tim-soft/use-double-click
+// Definitions by: Matthew Peveler <https://github.com/MasterOdin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { RefObject, MutableRefObject, MouseEvent } from 'react';
+
+export default function useDoubleClick<T = unknown>(options: {
+  /** Dom node to watch for double clicks */
+  ref: RefObject<T> | MutableRefObject<T>;
+  /** The amount of time (in milliseconds) to wait before differentiating a single from a double click. Defaults to 300. */
+  latency?: number;
+  /** A callback function for single click events */
+  onSingleClick?: (e: MouseEvent) => void;
+  /** A callback function for double click events */
+  onDoubleClick?: (e: MouseEvent) => void;
+}): void;

--- a/types/use-double-click/tsconfig.json
+++ b/types/use-double-click/tsconfig.json
@@ -16,7 +16,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/use-double-click/tsconfig.json
+++ b/types/use-double-click/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "use-double-click-tests.tsx"
+    ]
+}

--- a/types/use-double-click/tslint.json
+++ b/types/use-double-click/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/use-double-click/use-double-click-tests.tsx
+++ b/types/use-double-click/use-double-click-tests.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import useDoubleClick from 'use-double-click';
+
+const Button = () => {
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  useDoubleClick({
+    onSingleClick: e => {
+      console.log(e, 'single click');
+    },
+    onDoubleClick: e => {
+      console.log(e, 'double click');
+    },
+    ref: buttonRef,
+    latency: 250
+  });
+
+  return <button ref={buttonRef}>Click Me</button>;
+};


### PR DESCRIPTION
Adds a types file for [use-double-click](https://npmjs.com/package/use-double-click) package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.