### PR TITLE
[luxon] Add DATETIME_MED_WITH_WEEKDAY preset

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -175,12 +175,12 @@ export class DateTime {
     static readonly DATETIME_HUGE_WITH_SECONDS: DateTimeFormatOptions;
     static readonly DATETIME_MED: DateTimeFormatOptions;
     static readonly DATETIME_MED_WITH_SECONDS: DateTimeFormatOptions;
+    static readonly DATETIME_MED_WITH_WEEKDAY: DateTimeFormatOptions;
     static readonly DATETIME_SHORT: DateTimeFormatOptions;
     static readonly DATETIME_SHORT_WITH_SECONDS: DateTimeFormatOptions;
     static readonly DATE_FULL: DateTimeFormatOptions;
     static readonly DATE_HUGE: DateTimeFormatOptions;
     static readonly DATE_MED: DateTimeFormatOptions;
-    /** abbreviated date with weekday */
     static readonly DATE_MED_WITH_WEEKDAY: DateTimeFormatOptions;
     static readonly DATE_SHORT: DateTimeFormatOptions;
     static readonly TIME_24_SIMPLE: DateTimeFormatOptions;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -196,8 +196,6 @@ if (Interval.isInterval(anything)) {
 
 /* Info */
 Info.months();
-// // $ExpectError
-// Info.months('2-digit', { outputCalendar: 'unknown' });
 Info.weekdays('long');
 // $ExpectError
 Info.weekdays('2-digit');

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -12,6 +12,8 @@ import {
 } from 'luxon';
 
 /* DateTime */
+DateTime.DATETIME_MED; // $ExpectType DateTimeFormatOptions
+DateTime.DATETIME_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
 DateTime.DATE_MED; // $ExpectType DateTimeFormatOptions
 DateTime.DATE_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -196,8 +196,8 @@ if (Interval.isInterval(anything)) {
 
 /* Info */
 Info.months();
-// $ExpectError
-Info.months('2-digit', { outputCalendar: 'unknown' });
+// // $ExpectError
+// Info.months('2-digit', { outputCalendar: 'unknown' });
 Info.weekdays('long');
 // $ExpectError
 Info.weekdays('2-digit');


### PR DESCRIPTION
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/pull/716 

This change was released in luxon 1.17.0.
