### PR TITLE
[connect-history-api-fallback] Use ReadonlyArray in options.

### DIFF
--- a/types/connect-history-api-fallback/connect-history-api-fallback-tests.ts
+++ b/types/connect-history-api-fallback/connect-history-api-fallback-tests.ts
@@ -26,6 +26,9 @@ historyApiFallback({
     htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
 });
 
+const htmlAcceptHeaders = ['text/html', 'application/xhtml+xml'] as const;
+historyApiFallback({htmlAcceptHeaders});
+
 historyApiFallback({
     rewrites: [
         {
@@ -61,3 +64,13 @@ historyApiFallback({
         }
     ]
 });
+
+const emptyArray = [] as const;
+historyApiFallback({rewrites: emptyArray});
+
+// Unfortunately this won't prevent a regression because of
+// https://github.com/microsoft/TypeScript/issues/13347, however it's the right thing to test.
+const options: {readonly index: string} = {
+    index: 'index.html',
+};
+historyApiFallback(options);

--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -16,22 +16,22 @@ declare function historyApiFallback(options?: historyApiFallback.Options): core.
 
 declare namespace historyApiFallback {
     interface Options {
-        disableDotRule?: true;
-        htmlAcceptHeaders?: string[];
-        index?: string;
-        logger?: typeof console.log;
-        rewrites?: Rewrite[];
-        verbose?: boolean;
+        readonly disableDotRule?: true;
+        readonly htmlAcceptHeaders?: ReadonlyArray<string>;
+        readonly index?: string;
+        readonly logger?: typeof console.log;
+        readonly rewrites?: ReadonlyArray<Rewrite>;
+        readonly verbose?: boolean;
     }
 
     interface Context {
-        match: RegExpMatchArray;
-        parsedUrl: Url;
+        readonly match: RegExpMatchArray;
+        readonly parsedUrl: Url;
     }
     type RewriteTo = (context: Context) => string;
 
     interface Rewrite {
-        from: RegExp;
-        to: string | RegExp | RewriteTo;
+        readonly from: RegExp;
+        readonly to: string | RegExp | RewriteTo;
     }
 }


### PR DESCRIPTION
This is a fix to match with the existing library: options are never modified and as such should accept readonly values. This was somehow saved for fixed property because of https://github.com/microsoft/TypeScript/issues/13347, but fails for ReadonlyArray.

- [X] Test the change in your own code. (Compile and run.)
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/51446)
<!-- Reviewable:end -->
