### PR TITLE
[ramda] fix: ifElse types

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -745,8 +745,8 @@ export function identity<T>(a: T): T;
  * Creates a function that will process either the onTrue or the onFalse function depending upon the result
  * of the condition predicate.
  */
-export function ifElse(fn: Pred, onTrue: Arity1Fn, onFalse: Arity1Fn): Arity1Fn;
-export function ifElse(fn: Pred, onTrue: Arity2Fn, onFalse: Arity2Fn): Arity2Fn;
+export function ifElse<K, T, U>(fn: (a: K) => boolean, onTrue: (a: K) => T, onFalse: (a: K) => U): (a: K) => T | U
+export function ifElse<K, L, T, U>(fn: (a: K, b: L) => boolean, onTrue: (a: K, b: L) => T, onFalse: (a: K, b: L) => U): (a: K, b: L) => T | U;
 
 /**
  * Increments its argument.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

## Description

This MR replaces `ifElse` typings to be more specific. Currently `Arity1Fn` and `Arity2Fn` are used that basically lose types because they operate on `any`. 

Tests pass but TS version 4.2 must be added manually because for some reason it's not installed automatically. Has it been added to `shipped` versions?

`compile-scripts` fails but is seems to be unrelated to the change in any way therefore I wanted to submit this PR for someone to see anyway.



```
error TS5055: Cannot write file '/Users/[username]/projects/DefinitelyTyped/scripts/not-needed.js' because it would overwrite input file.
error TS5055: Cannot write file '/Users/[username]/projects/DefinitelyTyped/scripts/update-codeowners.js' because it would overwrite input file.
```

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- `https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ramda/index.d.ts:748-749`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header
