### PR TITLE
[cometd] Fix: Adds missing shorthand property for websocket transport

### DIFF
--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -555,4 +555,11 @@ export class CometD {
         isListener: boolean,
         message: string,
     ) => void;
+
+    /**
+     * Shorthand property to enable or disable websocket transport.
+     * Must be set before performing the initial CometD handshake.
+     * Functionally equivelant to cometd.unregisterTransport('websocket');
+     */
+    websocketEnabled: boolean;
 }


### PR DESCRIPTION
As per docs at https://docs.cometd.org/2.9.1/reference/#d0e2770 (7.7.3. The websocket Transport)

This is a shorthand property that is missing. This adds in that property.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


**If changing an existing definition:**
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.cometd.org/2.9.1/reference/#d0e2770>>

