### PR TITLE
fix(tv4): addFormat() and defineKeyword() validator functions return nullable string

### DIFF
--- a/types/tv4/index.d.ts
+++ b/types/tv4/index.d.ts
@@ -4,12 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace tv4 {
-
     // Note that every top-level property is optional in json-schema
     export interface JsonSchema {
         [key: string]: any;
-        title?: string;          // used for humans only, and not used for computation
-        description?: string;    // used for humans only, and not used for computation
+        title?: string; // used for humans only, and not used for computation
+        description?: string; // used for humans only, and not used for computation
         id?: string;
         $schema?: string;
         type?: string | string[];
@@ -22,19 +21,18 @@ declare namespace tv4 {
         default?: any;
     }
 
-    export type SchemaMap = {[uri: string]: JsonSchema;};
+    export type SchemaMap = { [uri: string]: JsonSchema };
     // maps error codes/names to human readable error description for a single language
-    export type ErrorMap  = {[errorCode: string]: string;};
-
+    export type ErrorMap = { [errorCode: string]: string };
 
     export interface ErrorCodes {
-        [key:string]:number;
+        [key: string]: number;
     }
     export interface ValidationError {
-        code:number;
-        message:any;
-        dataPath?:string;
-        schemaPath?:string;
+        code: number;
+        message: any;
+        dataPath?: string;
+        schemaPath?: string;
         subErrors?: ValidationError[];
     }
     export interface ErrorVar extends ValidationError {
@@ -43,18 +41,23 @@ declare namespace tv4 {
         stack: string;
     }
     export interface BaseResult {
-        missing:string[];
-        valid:boolean;
+        missing: string[];
+        valid: boolean;
     }
     export interface SingleResult extends BaseResult {
-        error:ValidationError;
+        error: ValidationError;
     }
     export interface MultiResult extends BaseResult {
-        errors:ValidationError[];
+        errors: ValidationError[];
     }
     export type FormatValidationFunction = (data: any, schema: JsonSchema) => string;
     // documentation doesnt agree with code in tv4, this type agrees with code
-    export type KeywordValidationFunction = (data: any, value: any, schema: JsonSchema, dataPointerPath: string) => string | ValidationError;
+    export type KeywordValidationFunction = (
+        data: any,
+        value: any,
+        schema: JsonSchema,
+        dataPointerPath: string,
+    ) => string | ValidationError;
     export type AsyncValidationCallback = (isValid: boolean, error: ValidationError) => void;
     export interface TV4 {
         error: ErrorVar;
@@ -63,17 +66,33 @@ declare namespace tv4 {
         validate(data: any, schema: JsonSchema, checkRecursive?: boolean): boolean;
         validate(data: any, schema: JsonSchema, checkRecursive: boolean, banUnknownProperties: boolean): boolean;
         validateResult(data: any, schema: JsonSchema, checkRecursive?: boolean): SingleResult;
-        validateResult(data: any, schema: JsonSchema, checkRecursive: boolean, banUnknownProperties: boolean): SingleResult;
+        validateResult(
+            data: any,
+            schema: JsonSchema,
+            checkRecursive: boolean,
+            banUnknownProperties: boolean,
+        ): SingleResult;
         validateMultiple(data: any, schema: JsonSchema, checkRecursive?: boolean): MultiResult;
-        validateMultiple(data: any, schema: JsonSchema, checkRecursive: boolean, banUnknownProperties: boolean): MultiResult;
+        validateMultiple(
+            data: any,
+            schema: JsonSchema,
+            checkRecursive: boolean,
+            banUnknownProperties: boolean,
+        ): MultiResult;
         // from including: tv4.async-jquery.js
         validate(data: any, schema: JsonSchema, callback: AsyncValidationCallback, checkRecursive?: boolean): void;
-        validate(data: any, schema: JsonSchema, callback: AsyncValidationCallback, checkRecursive: boolean, banUnknownProperties: boolean): void;
+        validate(
+            data: any,
+            schema: JsonSchema,
+            callback: AsyncValidationCallback,
+            checkRecursive: boolean,
+            banUnknownProperties: boolean,
+        ): void;
 
         // additional API for more complex cases
         addSchema(schema: JsonSchema): void;
-        addSchema(uri:string, schema: JsonSchema): void;
-        getSchema(uri:string): JsonSchema;
+        addSchema(uri: string, schema: JsonSchema): void;
+        getSchema(uri: string): JsonSchema;
         getSchemaMap(): SchemaMap;
         getSchemaUris(filter?: RegExp): string[];
         getMissingUris(filter?: RegExp): string[];
@@ -85,15 +104,15 @@ declare namespace tv4 {
         language(code: string): void;
         addLanguage(code: string, map: ErrorMap): void;
         addFormat(format: string, validationFunction: FormatValidationFunction): void;
-        addFormat(formats: {[formatName: string]: FormatValidationFunction;}): void;
+        addFormat(formats: { [formatName: string]: FormatValidationFunction }): void;
         defineKeyword(keyword: string, validationFunction: KeywordValidationFunction): void;
         defineError(codeName: string, codeNumber: number, defaultMessage: string): void;
 
         // not documented
-        normSchema(schema: JsonSchema, baseUri:string):any;
-        resolveUrl(base:string, href:string):string;
+        normSchema(schema: JsonSchema, baseUri: string): any;
+        resolveUrl(base: string, href: string): string;
 
-        errorCodes:ErrorCodes;
+        errorCodes: ErrorCodes;
     }
 }
 

--- a/types/tv4/index.d.ts
+++ b/types/tv4/index.d.ts
@@ -50,14 +50,14 @@ declare namespace tv4 {
     export interface MultiResult extends BaseResult {
         errors: ValidationError[];
     }
-    export type FormatValidationFunction = (data: any, schema: JsonSchema) => string;
+    export type FormatValidationFunction = (data: any, schema: JsonSchema) => null | string;
     // documentation doesnt agree with code in tv4, this type agrees with code
     export type KeywordValidationFunction = (
         data: any,
         value: any,
         schema: JsonSchema,
         dataPointerPath: string,
-    ) => string | ValidationError;
+    ) => null | string | ValidationError;
     export type AsyncValidationCallback = (isValid: boolean, error: ValidationError) => void;
     export interface TV4 {
         error: ErrorVar;

--- a/types/tv4/tsconfig.json
+++ b/types/tv4/tsconfig.json
@@ -11,7 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/tv4/tv4-tests.ts
+++ b/types/tv4/tv4-tests.ts
@@ -1,14 +1,14 @@
-import tv4 = require("tv4");
-var str:string;
-var strArr:string[];
-var bool:boolean;
-var num:number;
-var obj:any;
+import tv4 = require('tv4');
+var str: string;
+var strArr: string[];
+var bool: boolean;
+var num: number;
+var obj: any;
 var validator: tv4.TV4;
-var err:tv4.ValidationError;
-var errs:tv4.ValidationError[];
-var single:tv4.SingleResult;
-var multi:tv4.MultiResult;
+var err: tv4.ValidationError;
+var errs: tv4.ValidationError[];
+var single: tv4.SingleResult;
+var multi: tv4.MultiResult;
 
 single = validator.validateResult(obj, obj);
 bool = single.valid;
@@ -40,10 +40,9 @@ num = validator.errorCodes['bla'];
 
 num = validator.errorCodes['MY_NAME'];
 
-
 // Here are all the examples from the v1.2.3 documentation at https://www.npmjs.com/package/validator
 var data = '';
-var schema : tv4.JsonSchema = {type: "string"}
+var schema: tv4.JsonSchema = { type: 'string' };
 var valid = validator.validate(data, schema);
 var url = 'http://example.com/schema';
 validator.addSchema(url, schema);
@@ -53,17 +52,16 @@ var multiErrorResult = validator.validateMultiple(data, schema);
 validator.validate(data, schema, function (isValid, validationError) {});
 
 // checkRecursive
-var a : tv4.JsonSchema = {};
+var a: tv4.JsonSchema = {};
 var b = { a: a };
 a['b'] = b;
-var aSchema : tv4.JsonSchema = { properties: { b: { $ref: 'bSchema' }}};
-var bSchema : tv4.JsonSchema = { properties: { a: { $ref: 'aSchema' }}};
+var aSchema: tv4.JsonSchema = { properties: { b: { $ref: 'bSchema' } } };
+var bSchema: tv4.JsonSchema = { properties: { a: { $ref: 'aSchema' } } };
 validator.addSchema('aSchema', aSchema);
 validator.addSchema('bSchema', bSchema);
 validator.validate(a, aSchema, true);
 validator.validateResult(data, aSchema, true);
 validator.validateMultiple(data, aSchema, true);
-
 
 // banUnknownProperties
 var checkRecursive = true;
@@ -87,87 +85,91 @@ validator.dropSchemas();
 var other_tv4 = validator.freshApi();
 validator.reset();
 validator.setErrorReporter(function (error, data, schema) {
-    return "Error code: " + error.code;
+    return 'Error code: ' + error.code;
 });
 validator.language('en-gb');
 validator.addLanguage('fr', {});
-validator.language('fr')
+validator.language('fr');
 validator.addFormat('decimal-digits', function (data, schema) {
     if (typeof data === 'string' && !/^[0-9]+$/.test(data)) {
         return null;
     }
-    return "must be string of decimal digits";
+    return 'must be string of decimal digits';
 });
 validator.addFormat({
-    'my-format': function (data: any, schema: any): string {return null;},
-    'other-format': function (data: any, schema: any): string {return 'oops';}
+    'my-format': function (data: any, schema: any): string {
+        return null;
+    },
+    'other-format': function (data: any, schema: any): string {
+        return 'oops';
+    },
 });
-function simpleFailure() {return true;}
-function detailedFailure() {return true;}
+function simpleFailure() {
+    return true;
+}
+function detailedFailure() {
+    return true;
+}
 validator.defineKeyword('my-custom-keyword', function (data, value, schema) {
     if (simpleFailure()) {
-        return "Failure";
+        return 'Failure';
     } else if (detailedFailure()) {
-        return {code: validator.errorCodes['MY_CUSTOM_CODE'], message: {param1: 'a', param2: 'b'}};
+        return { code: validator.errorCodes['MY_CUSTOM_CODE'], message: { param1: 'a', param2: 'b' } };
     } else {
         return null;
     }
 });
 
-
 // Demos
 schema = {
-    "items": {
-        "type": "boolean"
-    }
+    items: {
+        type: 'boolean',
+    },
 };
 {
     let data1 = [true, false];
     let data2 = [true, 123];
-    alert("data 1: " + validator.validate(data1, schema)); // true
-    alert("data 2: " + validator.validate(data2, schema)); // false
-    alert("data 2 error: " + JSON.stringify(validator.error, null, 4));
+    alert('data 1: ' + validator.validate(data1, schema)); // true
+    alert('data 2: ' + validator.validate(data2, schema)); // false
+    alert('data 2 error: ' + JSON.stringify(validator.error, null, 4));
 
     schema = {
-        "type": ["array"],
-        "items": {"$ref": "#"}
+        type: ['array'],
+        items: { $ref: '#' },
     };
 }
 {
-let data1 : any = [[], [[]]];
-let data2 : any = [[], [true, []]];
-alert("data 1: " + validator.validate(data1, schema)); // true
-alert("data 2: " + validator.validate(data2, schema)); // false
+    let data1: any = [[], [[]]];
+    let data2: any = [[], [true, []]];
+    alert('data 1: ' + validator.validate(data1, schema)); // true
+    alert('data 2: ' + validator.validate(data2, schema)); // false
 }
 
 {
     schema = {
-        "type": "array",
-        "items": {"$ref": "http://example.com/schema" }
+        type: 'array',
+        items: { $ref: 'http://example.com/schema' },
     };
     let data = [1, 2, 3];
-    alert("Valid: " + validator.validate(data, schema)); // true
-    alert("Missing schemas: " + JSON.stringify(validator.missing));
+    alert('Valid: ' + validator.validate(data, schema)); // true
+    alert('Missing schemas: ' + JSON.stringify(validator.missing));
 }
 {
-    validator.addSchema("http://example.com/schema", {
-        "definitions": {
-            "arrayItem": {"type": "boolean"}
-        }
+    validator.addSchema('http://example.com/schema', {
+        definitions: {
+            arrayItem: { type: 'boolean' },
+        },
     });
-    let schema : tv4.JsonSchema = {
-        "type": "array",
-        "items": {"$ref": "http://example.com/schema#/definitions/arrayItem" }
+    let schema: tv4.JsonSchema = {
+        type: 'array',
+        items: { $ref: 'http://example.com/schema#/definitions/arrayItem' },
     };
-    let data1 : any = [true, false, true];
-    let data2 : any = [1, 2, 3];
-    alert("data 1: " + validator.validate(data1, schema)); // true
-    alert("data 2: " + validator.validate(data2, schema)); // false
+    let data1: any = [true, false, true];
+    let data2: any = [1, 2, 3];
+    alert('data 1: ' + validator.validate(data1, schema)); // true
+    alert('data 2: ' + validator.validate(data2, schema)); // false
 }
 
 // undocumented functions
 var uri = '';
 obj = validator.normSchema(schema, uri);
-
-
-

--- a/types/tv4/tv4-tests.ts
+++ b/types/tv4/tv4-tests.ts
@@ -1,14 +1,18 @@
 import tv4 = require('tv4');
-var str: string;
-var strArr: string[];
+var str = '';
+var nullableStr: null | string = '';
+var optionalStr: undefined | string = '';
+var strArr: string[] = [];
 var bool: boolean;
 var num: number;
 var obj: any;
-var validator: tv4.TV4;
+var validator: tv4.TV4 = tv4;
 var err: tv4.ValidationError;
 var errs: tv4.ValidationError[];
 var single: tv4.SingleResult;
 var multi: tv4.MultiResult;
+var validator: tv4.TV4 = tv4;
+var uri = '';
 
 single = validator.validateResult(obj, obj);
 bool = single.valid;
@@ -16,9 +20,9 @@ strArr = single.missing;
 err = single.error;
 
 num = err.code;
-str = err.message;
-str = err.dataPath;
-str = err.schemaPath;
+nullableStr = err.message;
+optionalStr = err.dataPath;
+optionalStr = err.schemaPath;
 
 multi = validator.validateMultiple(obj, obj);
 bool = multi.valid;
@@ -97,7 +101,7 @@ validator.addFormat('decimal-digits', function (data, schema) {
     return 'must be string of decimal digits';
 });
 validator.addFormat({
-    'my-format': function (data: any, schema: any): string {
+    'my-format': function (data: any, schema: any): null | string {
         return null;
     },
     'other-format': function (data: any, schema: any): string {
@@ -171,5 +175,4 @@ schema = {
 }
 
 // undocumented functions
-var uri = '';
 obj = validator.normSchema(schema, uri);


### PR DESCRIPTION
# Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

# Description

 ### aee9b06 refactor(tv4): reformat tv4 directory with prettier

The README says to use prettier but it wasn't formatted 🤷🏼‍♂️. I made this a separate commit for easier reviewing.

 ### 9ef59c4 fix(tv4): enable `strictNullChecks` and fix incorrect types

- `addFormat()` takes in a validation function that returns a nullable string
  - This is the whole point of this function: to return `null` if the data is valid and a string error message otherwise. See documentation here: https://github.com/geraintluff/tv4#addformatformat-validationfunction.
- `defineKeyword()` takes in a validation function that returns a nullable string
  - This is the whole point of this function: to return `null` if the data is valid and a string error message otherwise. See documentation here: https://github.com/geraintluff/tv4#definekeywordkeyword-validationfunction.
- I noticed the tests were already covering these behaviors but obviously should have been failing previously. This was because `strictNullChecks` was disabled, so I enabled it and fixed all resulting type errors.

Thanks!