### PR TITLE
[arcgis-to-geojson-utils] Updates signature (v1.0->v1.3)

### DIFF
--- a/types/arcgis-to-geojson-utils/arcgis-to-geojson-utils-tests.ts
+++ b/types/arcgis-to-geojson-utils/arcgis-to-geojson-utils-tests.ts
@@ -13,8 +13,16 @@ const geojsonPoint: GeoJSON.Point = {
   coordinates: [45.5165, -122.6764]
 };
 
+const geojsonFeature: GeoJSON.Feature = {
+  type: "Feature",
+  geometry: geojsonPoint,
+  properties: null,
+}
+
 // parse ArcGIS JSON, convert it to GeoJSON
 const geojson = utils.arcgisToGeoJSON(arcgisPoint);
 
 // take GeoJSON and convert it to ArcGIS JSON
 const arcgis = utils.geojsonToArcGIS(geojsonPoint);
+
+const arcgisFeature = utils.geojsonToArcGIS(geojsonFeature);

--- a/types/arcgis-to-geojson-utils/index.d.ts
+++ b/types/arcgis-to-geojson-utils/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for arcgis-to-geojson-utils 1.0
+// Type definitions for arcgis-to-geojson-utils 1.3.0
 // Project: https://github.com/Esri/arcgis-to-geojson-utils
 // Definitions by: Jeff Jacobson <https://github.com/JeffJacobson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,9 +11,9 @@ import * as ArcGis from "arcgis-rest-api";
 /**
  * Converts an ArcGIS geometry into a GeoJSON geometry.
  */
-export function arcgisToGeoJSON<T extends ArcGis.Geometry>(arcgis: T): GeoJSON.GeometryObject;
+export function arcgisToGeoJSON<T extends ArcGis.Geometry>(arcgis: T): GeoJSON.GeoJSON;
 
 /**
  * Converts a GeoJSON geometry into a ArcGIS geometry.
  */
-export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject): ArcGis.Geometry;
+export function geojsonToArcGIS(geojson: GeoJSON.GeoJSON): ArcGis.Geometry;


### PR DESCRIPTION
Updating signature of `arcgisToGeoJSON` and `geojsonToArcGIS` to support new capabilities.

Both functions can now generate full `GeoJSON` types, not just `GeometryObject`.
From `@types/geojson`:
```ts
export type GeoJSON = Geometry | Feature | FeatureCollection;
```

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [in `geojsonToArcGIS`](https://github.com/Esri/arcgis-to-geojson-utils/blob/v1.3.0/index.js#L377) & [in `arcgisToGeoJSON`](https://github.com/Esri/arcgis-to-geojson-utils/blob/v1.3.0/index.js#L266)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
