### PR TITLE
[ziggy-js]: Fix return type of Router().current()

### DIFF
--- a/types/ziggy-js/index.d.ts
+++ b/types/ziggy-js/index.d.ts
@@ -46,7 +46,8 @@ export class Router extends String {
     hydrateUrl(): string;
     matchUrl(): boolean;
     constructQuery(): string;
-    current(name?: string): Route;
+    current(): string;
+    current(name: string): boolean;
     check(name: string): boolean;
     extractParams(uri: string, template: string, delimiter: string): NormalizedParams;
     get params(): NormalizedParams;

--- a/types/ziggy-js/ziggy-js-tests.ts
+++ b/types/ziggy-js/ziggy-js-tests.ts
@@ -7,3 +7,9 @@ ziggy.default();
 
 // $ExpectType string
 ziggy.default("test");
+
+// $ExpectType boolean
+new ziggy.Router().current("test");
+
+// $ExpectType string
+new ziggy.Router().current();


### PR DESCRIPTION
The `current()` returns either string or boolean based on if the user provided an argument and not an object as it is currently defined.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tighten/ziggy#the-router-class
