### PR TITLE
[vuelidate] Added missing separator parameter

### DIFF
--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -49,7 +49,7 @@ export function integer(): ValidationRule
 export function decimal(): ValidationRule
 export function email(): ValidationRule
 export function ipAddress(): ValidationRule
-export function macAddress(): ValidationRule
+export function macAddress(separator: string): ValidationRule
 export function sameAs(field: string | ((vm: any, parentVm?: Vue) => any)): ValidationRule
 export function url(): ValidationRule
 export function not(validator: ValidationRule | CustomRule): ValidationRule


### PR DESCRIPTION
Added a missing parameter in the macAddress type for the `separator` as detailed in the documentation linked below

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://vuelidate.js.org/#sub-builtin-validators](https://vuelidate.js.org/#sub-builtin-validators)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
