### PR TITLE
Nodejs: Use https for project link (minor)

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for non-npm package Node.js 14.14
-// Project: http://nodejs.org/
+// Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Alberto Schiabel <https://github.com/jkomyno>


### PR DESCRIPTION
I noticed the summary on npm is using `http` for nodejs. I'm not aware which of the occurrences are generated. So there might be the need to change more or other places.

https://www.npmjs.com/package/@types/node

![image](https://user-images.githubusercontent.com/13085980/109397652-0c836800-7938-11eb-81e6-1f8d69e10327.png)

