### PR TITLE
[next-auth] fix: improve types and follow behavior of JS implementation

### DIFF
--- a/types/next-auth/_utils.d.ts
+++ b/types/next-auth/_utils.d.ts
@@ -1,32 +1,9 @@
-import { IncomingMessage, ServerResponse } from 'http';
-import { User } from './index';
+export type NonNullParams<T> = {
+    [K in keyof T]: T[K] extends Record<string, unknown> ? NonNullParams<T[K]> : NonNullable<T[K]>;
+};
 
-interface GenericObject {
-    [key: string]: any;
-}
+export type NullableParams<T> = {
+    [K in keyof T]: T[K] | undefined | null
+};
 
-interface NextApiRequest extends IncomingMessage, GenericObject {
-    query: {
-        [key: string]: string | string[];
-    };
-    cookies: {
-        [key: string]: string;
-    };
-    body: any;
-}
-
-interface NextApiResponse<T = any> extends ServerResponse, GenericObject {
-    send: Send<T>;
-    json: Send<T>;
-    status: (statusCode: number) => NextApiResponse<T>;
-}
-
-type Send<T> = (body: T) => void;
-
-interface SessionBase {
-    user: User;
-    accessToken?: string;
-    expires: string;
-}
-
-export { GenericObject, SessionBase, NextApiRequest, NextApiResponse };
+export type WithAdditionalParams<T extends Record<string, any>> = T & Record<string, unknown>;

--- a/types/next-auth/adapters.d.ts
+++ b/types/next-auth/adapters.d.ts
@@ -1,6 +1,7 @@
 import { ConnectionOptions, EntitySchema } from 'typeorm';
+import { PrismaClient } from '@prisma/client';
 import { AppOptions, User } from '.';
-import { SessionProvider } from './client';
+import { AppProvider } from './providers';
 
 export interface Profile {
     id: string;
@@ -27,10 +28,10 @@ export interface SendVerificationRequestParams {
     url: string;
     token: string;
     baseUrl: string;
-    provider: SessionProvider;
+    provider: AppProvider;
 }
 
-export type EmailSessionProvider = SessionProvider & {
+export type EmailAppProvider = AppProvider & {
     sendVerificationRequest: (params: SendVerificationRequestParams) => Promise<void>;
     maxAge: number | undefined;
 };
@@ -59,20 +60,20 @@ export interface AdapterInstance<TUser, TProfile, TSession, TVerificationRequest
         url: string,
         token: string,
         secret: string,
-        provider: EmailSessionProvider,
+        provider: EmailAppProvider,
         options: AppOptions,
     ): Promise<TVerificationRequest>;
     getVerificationRequest?(
         email: string,
         verificationToken: string,
         secret: string,
-        provider: SessionProvider,
+        provider: AppProvider,
     ): Promise<TVerificationRequest | null>;
     deleteVerificationRequest?(
         email: string,
         verificationToken: string,
         secret: string,
-        provider: SessionProvider,
+        provider: AppProvider,
     ): Promise<void>;
 }
 
@@ -143,7 +144,7 @@ interface TypeORMAdapter<
 
 interface PrismaAdapter {
     Adapter(config: {
-        prisma: any;
+        prisma: PrismaClient;
         modelMapping?: {
             User: string;
             Account: string;

--- a/types/next-auth/client.d.ts
+++ b/types/next-auth/client.d.ts
@@ -1,23 +1,11 @@
 import { FC } from 'react';
 import { IncomingMessage } from 'http';
-import { GenericObject, SessionBase  } from './_utils';
-
-type Session = SessionBase & GenericObject;
-
-interface GetProvidersResponse {
-    [provider: string]: SessionProvider;
-}
-
-interface SessionProvider extends GenericObject {
-    id: string;
-    name: string;
-    type: string;
-    signinUrl: string;
-    callbackUrl: string;
-}
+import { WithAdditionalParams } from './_utils';
+import { Session } from '.';
+import { AppProvider, Providers } from './providers';
 
 interface ContextProviderProps {
-    session: Session | null | undefined;
+    session: WithAdditionalParams<Session> | null | undefined;
     options?: SetOptionsParams;
 }
 
@@ -36,7 +24,8 @@ interface NextContext {
 }
 
 declare function useSession(): [Session | null | undefined, boolean];
-declare function providers(): Promise<GetProvidersResponse | null>;
+
+declare function providers(): Promise<Record<keyof Providers, AppProvider> | null>;
 declare const getProviders: typeof providers;
 declare function session(
     context?: NextContext & {
@@ -48,7 +37,7 @@ declare function csrfToken(context?: NextContext): Promise<string | null>;
 declare const getCsrfToken: typeof csrfToken;
 declare function signin(
     provider?: string,
-    data?: GenericObject & {
+    data?: Record<string, unknown> & {
         callbackUrl?: string;
     },
 ): Promise<void>;
@@ -74,6 +63,4 @@ export {
     options,
     setOptions,
     Provider,
-    Session,
-    SessionProvider,
 };

--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -1,58 +1,105 @@
-// Type definitions for next-auth 3.1
+// Type definitions for next-auth 3.5
 // Project: https://github.com/iaincollins/next-auth#readme
 // Definitions by: Lluis <https://github.com/lluia>
 //                 Iain <https://github.com/iaincollins>
 //                 Juan <https://github.com/JuanM04>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="node" />
 
 import { ConnectionOptions } from 'typeorm';
-import { PossibleProviders } from './providers';
+import { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { Adapter } from './adapters';
-import { GenericObject, SessionBase, NextApiRequest, NextApiResponse } from './_utils';
-import { SessionProvider } from './client';
-import { JWTEncodeParams, JWTDecodeParams } from './jwt';
+import { JWTEncodeParams, JWTDecodeParams, JWTOptions, JWT } from './jwt';
+import { AppProvider, Providers } from './providers';
+import { NonNullParams, WithAdditionalParams } from './_utils';
 
-interface InitOptions {
-    providers: ReadonlyArray<ReturnType<PossibleProviders>>;
-    database?: string | ConnectionOptions;
+export interface NextAuthOptions {
+    theme?: 'auto' | 'dark' | 'light';
+    providers: Providers;
+    database?: string | Record<string, any> | ConnectionOptions;
     secret?: string;
-    session?: Session;
+    session?: SessionOptions;
     jwt?: JWTOptions;
-    pages?: PageOptions;
-    callbacks?: Callbacks;
+    pages?: PagesOptions;
+    callbacks?: CallbacksOptions;
     debug?: boolean;
     adapter?: Adapter;
-    events?: Events;
+    events?: EventsOptions;
     useSecureCookies?: boolean;
-    cookies?: Cookies;
+    cookies?: CookiesOptions;
+    logger?: LoggerInstance;
 }
 
-interface AppOptions {
-    debug: boolean;
-    pages: PageOptions;
-    adapter: Adapter;
-    baseUrl: string;
-    basePath: string;
-    action: 'providers' | 'session' | 'csrf' | 'signin' | 'signout' | 'callback' | 'verify-request' | 'error';
-    provider?: string;
-    cookies: Cookies;
-    secret: string;
-    csrfToken: string;
-    providers: {
-        [provider: string]: SessionProvider;
+export interface LoggerInstance {
+    warn: (code?: string, ...message: unknown[]) => void;
+    error: (code?: string, ...message: unknown[]) => void;
+    debug: (code?: string, ...message: unknown[]) => void;
+}
+
+interface InternalOptions extends Omit<NextAuthOptions, 'providers' | 'database' | 'session' | 'useSecureCookie'> {
+    pkce: {
+        code_verifier?: string
+        code_challenge_method?: 'S256'
     };
-    session: Session;
-    jwt: JWTOptions;
-    events: Events;
-    callbacks: Callbacks;
-    callbackUrl: string;
-    // redirect?(redirectUrl: string): any;
+    provider?: string;
+    baseUrl?: string;
+    basePath?: string;
+    action?: 'providers' | 'session' | 'csrf' | 'signin' | 'signout' | 'callback' | 'verify-request' | 'error';
+    csrfToken?: string;
 }
 
-interface PageOptions {
+export interface AppOptions extends Omit<NextApiRequest, 'cookies'>, NonNullParams<InternalOptions> {
+    providers: AppProvider[];
+}
+
+export interface CallbacksOptions {
+    signIn?:
+        | (() => true)
+        | ((user: User, account: Record<string, unknown>, profile: Record<string, unknown>) => Promise<never | string | boolean>);
+    redirect?: ((url: string, baseUrl: string) => Promise<string>);
+    session?:
+        | ((session: Session) => WithAdditionalParams<Session>)
+        | ((session: Session, userOrToken: User | JWT) => Promise<WithAdditionalParams<Session>>);
+    jwt?:
+        | ((token: JWT) => WithAdditionalParams<JWT>)
+        | ((token: JWT, user: User, account: Record<string, unknown>, profile: Record<string, unknown>, isNewUser: boolean) => Promise<WithAdditionalParams<JWT>>);
+}
+
+export interface CookieOption {
+    name: string;
+    options: {
+        httpOnly: boolean;
+        sameSite: true | 'strict' | 'lax' | 'none';
+        path?: string;
+        secure: boolean;
+        maxAge?: number;
+        domain?: string;
+    };
+}
+
+export interface CookiesOptions {
+    sessionToken?: CookieOption;
+    callbackUrl?: CookieOption;
+    csrfToken?: CookieOption;
+    pkceCodeVerifier?: CookieOption;
+}
+
+export type EventType=
+    | 'signIn'
+    | 'signOut'
+    | 'createUser'
+    | 'updateUser'
+    | 'linkAccount'
+    | 'session'
+    | 'error';
+
+export type EventCallback = (message: any) => Promise<void>;
+
+export type EventsOptions = Partial<Record<EventType, EventCallback>>;
+
+export interface PagesOptions {
     signIn?: string;
     signOut?: string;
     error?: string;
@@ -60,70 +107,32 @@ interface PageOptions {
     newUser?: string | null;
 }
 
-interface Cookies {
-    [cookieKey: string]: Cookie;
+export interface Session {
+    user: WithAdditionalParams<User>;
+    accessToken?: string;
+    expires: string;
 }
 
-interface Cookie {
-    name: string;
-    options?: CookieOptions;
-}
-
-interface CookieOptions {
-    httpOnly?: boolean;
-    sameSite?: true | 'strict' | 'lax' | 'none';
-    path?: string;
-    secure?: boolean;
-    maxAge?: number;
-    domain?: string;
-}
-
-interface Events {
-    signIn?(message: any): Promise<void>;
-    signOut?(message: any): Promise<void>;
-    createUser?(message: any): Promise<void>;
-    updateUser?(message: any): Promise<void>;
-    linkAccount?(message: any): Promise<void>;
-    session?(message: any): Promise<void>;
-    error?(message: any): Promise<void>;
-}
-
-interface Session {
+export interface SessionOptions {
     jwt?: boolean;
     maxAge?: number;
     updateAge?: number;
 }
 
-interface User {
+export interface User {
     name?: string | null;
     email?: string | null;
     image?: string | null;
 }
 
-interface JWTOptions {
-    secret?: string;
-    maxAge?: number;
-    encryption?: boolean;
-    signingKey?: string;
-    encryptionKey?: string;
-    encode?(options: JWTEncodeParams): Promise<string>;
-    decode?(options: JWTDecodeParams): Promise<GenericObject>;
+export interface NextAuthRequest extends NextApiRequest {
+  options: InternalOptions;
 }
+export type NextAuthResponse = NextApiResponse;
 
-// TODO: Improve callback typings
-interface Callbacks {
-    signIn?(user: User, account: GenericObject, profile: GenericObject): Promise<boolean>;
-    redirect?(url: string, baseUrl: string): Promise<string>;
-    session?(session: SessionBase, user: User): Promise<GenericObject>;
-    jwt?(
-        token: GenericObject,
-        user: User,
-        account: GenericObject,
-        profile: GenericObject,
-        isNewUser: boolean,
-    ): Promise<GenericObject>;
-}
+declare function NextAuthHandler(req: NextApiRequest, res: NextApiResponse, options?: NextAuthOptions): ReturnType<NextApiHandler>;
+declare function NextAuth(req: NextApiRequest, res: NextApiResponse, options?: NextAuthOptions): ReturnType<NextApiHandler>;
+declare function NextAuth(options: NextAuthOptions): ReturnType<typeof NextAuthHandler>;
 
-declare function NextAuth(req: NextApiRequest, res: NextApiResponse, options?: InitOptions): Promise<void>;
+export { NextAuthHandler, NextAuth };
 export default NextAuth;
-export { InitOptions, AppOptions, PageOptions, Cookies, Events, Session, JWTOptions, User, Callbacks };

--- a/types/next-auth/jwt.d.ts
+++ b/types/next-auth/jwt.d.ts
@@ -1,8 +1,15 @@
 import jose from 'jose';
-import { NextApiRequest } from './_utils';
+import { NextApiRequest } from 'next';
+import { WithAdditionalParams } from './_utils';
+
+export interface JWT extends Record<string, unknown> {
+    name?: string | null;
+    email?: string | null;
+    picture?: string | null;
+}
 
 export interface JWTEncodeParams {
-    token?: object;
+    token?: WithAdditionalParams<JWT>;
     maxAge?: number;
     secret: string | Buffer;
     signingKey?: string;
@@ -25,8 +32,18 @@ export interface JWTDecodeParams {
     encryption?: boolean;
 }
 
+export interface JWTOptions {
+    secret?: string;
+    maxAge?: number;
+    encryption?: boolean;
+    signingKey?: string;
+    encryptionKey?: string;
+    encode?(options: JWTEncodeParams): Promise<string>;
+    decode?(options: JWTDecodeParams): Promise<WithAdditionalParams<JWT>>;
+}
+
 declare function encode(args?: JWTEncodeParams): Promise<string>;
-declare function decode(args?: JWTDecodeParams & { token: string }): Promise<object>;
+declare function decode(args?: JWTDecodeParams & { token: string }): Promise<WithAdditionalParams<JWT>>;
 
 declare function getToken(
     args?: {
@@ -35,7 +52,7 @@ declare function getToken(
         cookieName?: string;
         raw?: string;
     } & JWTDecodeParams,
-): Promise<object>;
+): Promise<WithAdditionalParams<JWT>>;
 declare function getToken(args?: {
     req: NextApiRequest;
     secureCookie?: boolean;

--- a/types/next-auth/next-auth-tests.ts
+++ b/types/next-auth/next-auth-tests.ts
@@ -5,12 +5,12 @@
  * in the sense of typing and call signature consistency. They
  * are not intended as functional tests.
  */
-import Providers from 'next-auth/providers';
-import Adapters, { Adapter, EmailSessionProvider, Profile, Session, VerificationRequest } from 'next-auth/adapters';
+import { NextApiRequest, NextApiResponse } from 'next';
+import Providers, { AppProvider } from 'next-auth/providers';
+import Adapters, { Adapter, EmailAppProvider, Profile, Session, VerificationRequest } from 'next-auth/adapters';
 import * as client from 'next-auth/client';
-import * as JWT from 'next-auth/jwt';
+import * as JWTType from 'next-auth/jwt';
 import NextAuth, * as NextAuthTypes from 'next-auth';
-import { GenericObject, SessionBase, NextApiRequest, NextApiResponse } from 'next-auth/_utils';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Socket } from 'net';
 
@@ -22,12 +22,16 @@ const req: NextApiRequest = Object.assign(new IncomingMessage(new Socket()), {
     query: {},
     cookies: {},
     body: {},
+    env: {},
 });
 
 const res: NextApiResponse = Object.assign(new ServerResponse(req), {
-    send: () => undefined,
-    json: () => undefined,
+    send: (body: string) => undefined,
+    json: (body: string) => undefined,
     status: (code: number) => res,
+    redirect: (statusOrUrl: number | string, url?: string) => res as any,
+    setPreviewData: (data: object | string) => res,
+    clearPreviewData: () => res,
 });
 
 const pageOptions = {
@@ -95,20 +99,20 @@ const adapter: Adapter<NextAuthTypes.User, Profile, Session, VerificationRequest
                 url: string,
                 token: string,
                 secret: string,
-                provider: EmailSessionProvider,
+                provider: EmailAppProvider,
                 options: NextAuthTypes.AppOptions,
             ) => Promise.resolve(exampleVerificatoinRequest),
             getVerificationRequest: (
                 email: string,
                 verificationToken: string,
                 secret: string,
-                provider: client.SessionProvider,
+                provider: AppProvider,
             ) => Promise.resolve(exampleVerificatoinRequest),
             deleteVerificationRequest: (
                 email: string,
                 verificationToken: string,
                 secret: string,
-                provider: client.SessionProvider,
+                provider: AppProvider,
             ) => Promise.resolve(),
         });
     },
@@ -141,14 +145,14 @@ const allConfig = {
     },
     pages: pageOptions,
     callbacks: {
-        signIn: (user: NextAuthTypes.User, account: GenericObject, profile: GenericObject) => Promise.resolve(true),
+        signIn: (user: NextAuthTypes.User, account: Record<string, unknown>, profile: Record<string, unknown>) => Promise.resolve(true),
         redirect: (url: string, baseUrl: string) => Promise.resolve('path/to/foo'),
-        session: (session: SessionBase, user: NextAuthTypes.User) => Promise.resolve<any>(user),
+        session: (session: NextAuthTypes.Session, user: NextAuthTypes.User) => Promise.resolve<any>(user),
         jwt: (
-            token: GenericObject,
+            token: JWTType.JWT,
             user: NextAuthTypes.User,
-            account: GenericObject,
-            profile: GenericObject,
+            account: Record<string, unknown>,
+            profile: Record<string, unknown>,
             isNewUser: boolean,
         ) => Promise.resolve({}),
     },
@@ -243,10 +247,10 @@ client.getSession({ req });
 // $ExpectType Promise<Session | null>
 client.session({ req });
 
-// $ExpectType Promise<GetProvidersResponse | null>
+// $ExpectType Promise<Record<number | keyof Providers, AppProvider> | null>
 client.getProviders();
 
-// $ExpectType Promise<GetProvidersResponse | null>
+// $ExpectType Promise<Record<number | keyof Providers, AppProvider> | null>
 client.providers();
 
 // $ExpectType Promise<string | null>
@@ -300,13 +304,13 @@ client.Provider({
 // Providers
 // --------------------------------------------------------------------------
 
-// $ExpectType GenericReturnConfig
+// $ExpectType NonNullParams<ProviderEmailOptions> & { id: "email"; type: "email"; }
 Providers.Email({
     server: 'path/to/server',
     from: 'path/from',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType NonNullParams<ProviderEmailOptions> & { id: "email"; type: "email"; }
 Providers.Email({
     server: {
         host: 'host',
@@ -319,7 +323,7 @@ Providers.Email({
     from: 'path/from',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType NonNullParams<ProviderCredentialsOptions> & { id: "credentials"; type: "credentials"; }
 Providers.Credentials({
     id: 'login',
     name: 'account',
@@ -341,7 +345,7 @@ Providers.Credentials({
     },
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"apple", "oauth"> & { protection: "none"; }
 Providers.Apple({
     clientId: 'foo123',
     clientSecret: {
@@ -352,64 +356,64 @@ Providers.Apple({
     },
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"twitter", "oauth">
 Providers.Twitter({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"facebook", "oauth">
 Providers.Facebook({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"github", "oauth">
 Providers.GitHub({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"github", "oauth">
 Providers.GitHub({
     clientId: 'foo123',
     clientSecret: 'bar123',
     scope: 'change:thing read:that',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"gitlab", "oauth">
 Providers.GitLab({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"slack", "oauth">
 Providers.Slack({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"google", "oauth">
 Providers.Google({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"google", "oauth">
 Providers.Google({
     clientId: 'foo123',
     clientSecret: 'bar123',
     authorizationUrl: 'https://foo.google.com',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"auth0", "oauth"> & { domain: string; }
 Providers.Auth0({
     clientId: 'foo123',
     clientSecret: 'bar123',
     domain: 'https://foo.auth0.com',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"auth0", "oauth"> & { domain: string; }
 Providers.Auth0({
     clientId: 'foo123',
     clientSecret: 'bar123',
@@ -422,7 +426,7 @@ Providers.Auth0({
     })
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<string, "oauth"> & { domain: string; }
 Providers.IdentityServer4({
     id: 'identity-server4',
     name: 'IdentityServer4',
@@ -432,85 +436,85 @@ Providers.IdentityServer4({
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"discord", "oauth">
 Providers.Discord({
     clientId: 'foo123',
     clientSecret: 'bar123',
-    scope: 'identify', // This tests the `extends GenericObject`
+    scope: 'identify',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"twitch", "oauth">
 Providers.Twitch({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"mixer", "oauth">
 Providers.Mixer({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"okta", "oauth"> & { domain: string; }
 Providers.Okta({
     clientId: 'foo123',
     clientSecret: 'bar123',
     domain: 'https://foo.auth0.com',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"battlenet", "oauth"> & { region: string; }
 Providers.BattleNet({
     clientId: 'foo123',
     clientSecret: 'bar123',
     region: 'europe',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"box", "oauth">
 Providers.Box({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"cognito", "oauth"> & { domain: string; }
 Providers.Cognito({
     clientId: 'foo123',
     clientSecret: 'bar123',
     domain: 'https://foo.auth0.com',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"yandex", "oauth">
 Providers.Yandex({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"linkedin", "oauth">
 Providers.LinkedIn({
     clientId: 'foo123',
     clientSecret: 'bar123',
     scope: 'r_emailaddress r_liteprofile',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"spotify", "oauth">
 Providers.Spotify({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"spotify", "oauth">
 Providers.Spotify({
     clientId: 'foo123',
     clientSecret: 'bar123',
     scope: 'user-read-email',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"basecamp", "oauth">
 Providers.Basecamp({
     clientId: 'foo123',
     clientSecret: 'bar123',
 });
 
-// $ExpectType GenericReturnConfig
+// $ExpectType Provider<"reddit", "oauth">
 Providers.Reddit({
     clientId: 'foo123',
     clientSecret: 'bar123',
@@ -537,25 +541,25 @@ Adapters.TypeORM.Adapter({
 // --------------------------------------------------------------------------
 
 // $ExpectType Promise<string>
-JWT.encode({
+JWTType.encode({
     token: { key: 'value' },
     secret: 'secret',
 });
 
-// $ExpectType Promise<object>
-JWT.decode({
+// $ExpectType Promise<WithAdditionalParams<JWT>>
+JWTType.decode({
     token: 'token',
     secret: 'secret',
 });
 
 // $ExpectType Promise<string>
-JWT.getToken({
+JWTType.getToken({
     req,
     raw: true,
 });
 
-// $ExpectType Promise<object>
-JWT.getToken({
+// $ExpectType Promise<WithAdditionalParams<JWT>>
+JWTType.getToken({
     req,
     secret: 'secret',
 });

--- a/types/next-auth/package.json
+++ b/types/next-auth/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "dependencies": {
+    "@prisma/client": "^2.17.0",
     "jose": "^1.28.0",
+    "next": "^10.0.7",
     "typeorm": "^0.2.24"
   }
 }

--- a/types/next-auth/providers.d.ts
+++ b/types/next-auth/providers.d.ts
@@ -25,27 +25,39 @@ export interface AppProvider extends Pick<Provider, 'id' | 'name' | 'type'> {
 
 export interface DefaultProviders {
     Apple: Apple;
+    Attlassian: Atlassian;
     Auth0: Auth0;
+    AzureADB2C: AzureADB2C;
     Basecamp: Basecamp;
     BattleNet: BattleNet;
     Box: Box;
+    Bungie: Bungie;
     Cognito: Cognito;
     Credentials: Credentials;
     Discord: Discord;
     Email: Email;
+    EVEOnline: EVEOnline;
     Facebook: Facebook;
+    Foursquare: Foursquare;
+    FusionAuth: FusionAuth;
     GitHub: GitHub;
     GitLab: GitLab;
     Google: Google;
     IdentityServer4: IdentityServer4;
+    LINE: LINE;
     LinkedIn: LinkedIn;
-    Mixer: Mixer;
+    MailRu: MailRu;
+    Medium: Medium;
+    Netlify: Netlify;
     Okta: Okta;
     Reddit: Reddit;
+    Salesforce: Salesforce;
     Slack: Slack;
     Spotify: Spotify;
+    Strava: Strava;
     Twitch: Twitch;
     Twitter: Twitter;
+    VK: VK;
     Yandex: Yandex;
 }
 
@@ -212,11 +224,6 @@ type Discord = (options: ProviderCommonOptions) => Provider<'discord'>;
 type Twitch = (options: ProviderCommonOptions) => Provider<'twitch'>;
 
 /**
- * Mixer
- */
-type Mixer = (options: ProviderCommonOptions) => Provider<'mixer'>;
-
-/**
  * Okta
  */
 type Okta = (options: ProviderOktaOptions) => Provider<'okta'> & { domain: string };
@@ -280,3 +287,68 @@ type Basecamp = (options: ProviderCommonOptions) => Provider<'basecamp'>;
  * Reddit
  */
 type Reddit = (options: ProviderCommonOptions) => Provider<'reddit'>;
+
+/**
+ * Atlassian
+ */
+type Atlassian = (options: ProviderCommonOptions) => Provider<'atlassian'>;
+
+/**
+ * AzureADB2C
+ */
+type AzureADB2C = (options: ProviderCommonOptions) => Provider<'azure-ad-b2c'>;
+
+/**
+ * Bungie
+ */
+type Bungie = (options: ProviderCommonOptions) => Provider<'bungie'>;
+
+/**
+ * EVEOnline
+ */
+type EVEOnline = (options: ProviderCommonOptions) => Provider<'eveonline'>;
+
+/**
+ *
+ */
+type Foursquare = (options: ProviderCommonOptions) => Provider<'foursquare'>;
+
+/**
+ * FusionAuth
+ */
+type FusionAuth = (options: ProviderCommonOptions) => Provider<'fusionauth'>;
+
+/**
+ * LINE
+ */
+type LINE = (options: ProviderCommonOptions) => Provider<'line'>;
+
+/**
+ *
+ */
+type MailRu = (options: ProviderCommonOptions) => Provider<'mailru'>;
+
+/**
+ *
+ */
+type Medium = (options: ProviderCommonOptions) => Provider<'medium'>;
+
+/**
+ *
+ */
+type Netlify = (options: ProviderCommonOptions) => Provider<'netlify'>;
+
+/**
+ * Salesforce
+ */
+type Salesforce = (options: ProviderCommonOptions) => Provider<'salesforce'>;
+
+/**
+ * Strava
+ */
+type Strava = (options: ProviderCommonOptions) => Provider<'strava'>;
+
+/**
+ * VK
+ */
+type VK = (options: ProviderCommonOptions) => Provider<'vk'>;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

## !!!Help Needed!!!
When I add Type Definitions of `next` package to dependency (not in DefinitelyTyped, in JS impl lib), it causes error as below.

```
DefinitelyTyped ❯ npm test next-auth

> definitely-typed@0.0.3 test
> dtslint types "next-auth"

Error: At /Users/euxn23/code/DefinitelyTyped/types/next-auth/node_modules/next/types/index.d.ts:{"line":14,"character":6}: 'ts-ignore' is forbidden.
```

But not adding `next` package to dependency, other error of missing `next` occurred as I expect.

```
Error: /Users/euxn23/code/DefinitelyTyped/types/next-auth/index.d.ts:12:65
ERROR: 12:65  expect  TypeScript@4.3 compile error:
Cannot find module 'next' or its corresponding type declarations.
```

I read dtslint impl for banning ts-ignore (https://github.com/microsoft/dtslint/pull/89/files) and it seems to be impossible to turn off `ban-ts-ignore` on dtslint.
Is there any workaround?

---

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/nextauthjs/next-auth/blob/main/src/server/index.js
  - https://next-auth.js.org/getting-started/example
  - https://github.com/nextauthjs/next-auth/blob/main/src/providers/index.js
  - https://next-auth.js.org/configuration/providers
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Related (Dependency)

https://github.com/microsoft/DefinitelyTyped-tools/pull/209