### PR TITLE
[spectrum] Cleanup, improve typings and docs, update for 1.8.1

### DIFF
--- a/types/spectrum/index.d.ts
+++ b/types/spectrum/index.d.ts
@@ -1,212 +1,631 @@
-// Type definitions for spectrum 1.5.1
+// Type definitions for spectrum 1.8
 // Project: https://github.com/bgrins/spectrum/
 // Definitions by: Mordechai Zuber <https://github.com/M-Zuber>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.4
 
 /// <reference types="jquery"/>
 /// <reference types="tinycolor2"/>
 
+// tslint:disable:unified-signatures self-documenting code and JSDoc require non-unified signatures
 interface JQuery {
-
     /**
-     * Shows the colorpicker.
+     * Shows the color picker.
+     *
+     * @param methodName Name of the method to call, i.e. `show`.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "show"): JQuery;
 
     /**
-     * Hides the colorpicker.
+     * Hides the color picker.
+     *
+     * @param methodName Name of the method to call, i.e. `hide`.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "hide"): JQuery;
 
     /**
-    * Toggles the colorpicker.
-    *
-    * Warning: If you are calling toggle from a click handler,
-    *   make sure you return false to prevent the colorpicker from immediately hiding after it is toggled.
-    */
+     * Toggles the color picker.
+     *
+     * Warning: If you are calling toggle from a click handler, make sure you
+     * return `false` to prevent the color picker from immediately hiding after
+     * it is toggled.
+     *
+     * ```javascript
+     * $("#btn-toggle").click(function() {
+     *   $("#toggle").spectrum("toggle");
+     *   return false;
+     * });
+     * ```
+     *
+     * @param methodName Name of the method to call, i.e. `toggle`.
+     * @return This JQuery instance for chaining method calls.
+     */
     spectrum(methodName: "toggle"): JQuery;
 
     /**
-     * Gets the current value from the colorpicker.
+     * Gets the current value from the color picker.
+     *
+     * @param methodName Name of the method to call, i.e. `get`.
+     * @return The currently selected color.
      */
     spectrum(methodName: "get"): tinycolor.Instance;
 
     /**
-     * Sets the colorpickers value to update the original input.
-     * Note: this will not fire the `change` event, to prevent infinite loops
-     *  from calling `set` from within `change`.
+     * Sets the color picker's value to update the original input.
      *
-     * @param colorString- the new color for the colorpicker.
+     * Note: This will not fire the `change` event, to prevent infinite loops
+     * from calling `set` from within `change`.
+     *
+     * ```html
+     * <input type='text' value='blanchedalmond' name='triggerSet' id='triggerSet' />
+     * <input type='text' placeholder='Enter A Color' id='enterAColor' />
+     * <button id='btnEnterAColor'>Trigger Set</button>
+     * <script>
+     *   $("#triggerSet").spectrum();
+     *
+     * // Show the original input to demonstrate the
+     *   // value changing when calling `set`
+     *   $("#triggerSet").show();
+     *
+     *   $("#btnEnterAColor").click(function() {
+     *     $("#triggerSet").spectrum("set", $("#enterAColor").val());
+     *   });
+     * </script>
+     * ```
+     *
+     * @param methodName Name of the method to call, i.e. `set`.
+     * @param colorString The new color for the color picker. When not given,
+     * resets the color to the default color.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "set", colorString?: string): JQuery;
 
     /**
-     * Retrieves the container element of the colorpicker,
-     * in case you want to manaully position it or do other things.
+     * Retrieves the container element of the color picker, in case you want to
+     * manually position it or do other things.
+     *
+     * @param methodName Name of the method to call, i.e. `container`.
+     * @return The JQuery element representing the container DOM element of the
+     * color picker.
      */
     spectrum(methodName: "container"): JQuery;
 
     /**
      * Resets the positioning of the container element.
-     * This could be used if the colorpicker was hidden when initialized,
-     * or if the colorpicker is inside of a moving area.
+     *
+     * This could be used if the color picker was hidden when initialized, or if
+     * the color picker is inside of a moving area.
+     *
+     * @param methodName Name of the method to call, i.e. `reflow`.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "reflow"): JQuery;
 
     /**
-     * Removes the colorpicker functionality and restores the element to its original state.
+     * Removes the color picker functionality and restores the element to its
+     * original state.
+     *
+     * @param methodName Name of the method to call, i.e. `destroy`.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "destroy"): JQuery;
 
     /**
-     * Allows selection of the colorpicker component. if it is already enabled, this method does nothing.
-     * Additionally, this will cause the original (now hidden) input to be set as disabled.
+     * Allows selection of the color picker component. if it is already enabled,
+     * this method does nothing.
+     *
+     * Additionally, this will cause the original (now hidden) input to be set
+     * as disabled.
+     *
+     * @param methodName Name of the method to call, i.e. `enable`.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "enable"): JQuery;
 
     /**
-     * Disables selection of the colorpicker component. adds the sp-disabled class onto the replacer element.
-     * If it is already disabled, this method does nothing.
-     * Additionally, this will remove the disabled property on the original (now hidden).
+     * Disables selection of the color picker component. Adds the `sp-disabled`
+     * class to the replacer element. If it is already disabled, this method
+     * does nothing.
+     *
+     * Additionally, this will remove the `disabled` property on the original
+     * now hidden).
+     *
+     * @param methodName Name of the method to call, i.e. `disable`.
+     * @return This JQuery instance for chaining method calls.
      */
     spectrum(methodName: "disable"): JQuery;
 
     /**
-     * Retrieves the current value for the option name.
+     * Retrieves the set of options currently set on the color picker.
      *
-     * @param optionName- the option to retrieve the value for.
+     * @param methodName Name of the method to call, i.e. `option`.
+     * @return An object with all options currently set on the color picker.
      */
-    spectrum(methodName: "option", optionName?: string): JQuery;
+    spectrum(methodName: "option"): Spectrum.Options;
 
     /**
-     * Sets the value of the option name with the value passed in.
+     * Retrieves the current value for the option with the given name.
      *
-     * @param optionName- the option to set.
-     * @param newOptionvalue- the new value for the option.
+     * ```javascript
+     * $("input").spectrum({
+     *   showInput: true
+     * });
+     * $("input").spectrum("option", "showInput"); // true
+     * ```
+     *
+     * @param methodName Name of the method to call, i.e. `option`.
+     * @param optionName Name of the option for which to retrieve the value.
+     * @return The current value for the given option.
      */
-    spectrum(methodName: "option", optionName?: string, newOptionValue?: any): JQuery;
+    spectrum<K extends keyof Spectrum.Options>(
+        methodName: "option",
+        optionName: K
+    ): Spectrum.Options[K];
 
     /**
-     * Calls the method.
+     * Sets the value of the option with the given name to the given value.
+     *
+     * ```javascript
+     * $("input").spectrum({
+     *   showInput: true
+     * });
+     * $("input").spectrum("option", "showInput", false);
+     * $("input").spectrum("option", "showInput"); // false
+     * ```
+     *
+     * @param optionName Name of the option to set.
+     * @param newOptionValue the new value for the option. This must not be
+     * `undefined`, or the current value of the option will be returned.
+     * @return This JQuery instance for chaining method calls.
      */
-    spectrum(methodName: string): any; // in most cases this is JQuery except for the get method which returns a tinycolorInstance
+    spectrum<K extends keyof Spectrum.Options>(
+        methodName: "option",
+        optionName: K,
+        newOptionValue: NonNullable<Spectrum.Options[K]>
+    ): JQuery;
 
     /**
-     * Initializes the input element that it is called on
-     * as a spectrum colorpicker instance.
+     * Initializes the input element that it is called on as a spectrum color
+     * picker instance.
+     *
+     * Just create a normal input and initialize it as a normal jQuery plugin.
+     * You can set a lot of options when initializing the color picker.
+     *
+     * ```html
+     * <input type='text' id="custom" />
+     *
+     * <script>
+     * $("#custom").spectrum({
+     *   color: "#f00"
+     * });
+     * </script>
+     * ```
      */
     spectrum(options?: Spectrum.Options): JQuery;
+}
 
-    /**
-     * Called at the beginning of a drag event on either hue slider, alpha slider, or main color picker areas.
-     */
-    on(events: "dragstart.spectrum", handler: (eventObject: JQueryEventObject, color: tinycolor.Instance) => any): JQuery;
+declare namespace JQuery {
+    interface TypeToTriggeredEventMap<
+        TDelegateTarget,
+        TData,
+        TCurrentTarget,
+        TTarget
+    > {
+        /**
+         * Called as the original input changes. Only happens when the input is
+         * closed or the 'Choose' button is clicked.
+         *
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   change: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         */
+        "change.spectrum": ChangeEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
 
-    /**
-     * Called at the end of a drag event on either hue slider, alpha slider, or main color picker areas.
-     */
-    on(events: "dragstop.spectrum", handler: (eventObject: JQueryEventObject, color: tinycolor.Instance) => any): JQuery;
+        /**
+         * Called as the user moves around within the color picker.
+         *
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   move: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         */
+        "move.spectrum": Spectrum.MoveEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        /**
+         * Called after the color picker is opened. This is ignored on a flat
+         * color picker.
+         *
+         * Note: When any color picker on the page is shown, it will hide all
+         * other color pickers that are already open.
+         *
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   show: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         */
+        "show.spectrum": Spectrum.ShowEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        /**
+         * Called after the color picker is hidden.
+         *
+         * This happens when clicking outside of the picker while it is open.
+         *
+         * Note: When any color picker on the page is shown, it will hide all
+         * other color picker that are already open.
+         *
+         * This event is ignored on a flat color picker, i.e. when `flat` is
+         * set to `true`.
+         *
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   hide: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         */
+        "hide.spectrum": Spectrum.HideEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        /**
+         * You can prevent the color picker from showing up if you return
+         * `false` in the `beforeShow` event.
+         *
+         * This event is ignored on a flat color picker.
+         *
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   beforeShow: function(color) {
+         *     color.toHexString(); // #ff0000
+         *     return false; // Will never show up
+         *   }
+         * }
+         * ```
+         */
+        "beforeShow.spectrum": Spectrum.BeforeShowEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        /**
+         * Called at the beginning of a drag event on either hue slider, alpha
+         * slider, or main color picker areas.
+         *
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $(element).on("dragstart.spectrum", function(e, color) {
+         *  color.toHexString(); // #ff0000
+         * });
+         * ```
+         */
+        "dragstart.spectrum": Spectrum.DragstartEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        /**
+         * Called at the end of a drag event on either hue slider, alpha slider, or
+         * main color picker areas.
+         * The callback will receive an additional argument of type
+         * `tinycolor.Instance` with the currently selected color.
+         *
+         * ```javascript
+         * $(element).on("dragstop.spectrum", function(e, color) {
+         *  color.toHexString(); // #ff0000
+         * });
+         * ```
+         */
+        "dragstop.spectrum": Spectrum.DragstopEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+    }
 }
 
 declare namespace Spectrum {
-
     interface Options {
-
         /**
-         * The initial color can be set with the color option.
-         * if you don't pass in a color, Spectrum will use the value attribute on the input.
-         * The input is a string that is parsed using https://github.com/bgrins/TinyColor
+         * The initial color can be set with the color option. This may be
+         * `false` when no value has been set explicitly.
+         *
+         * If you do not pass in a color, spectrum will use the value attribute
+         * on the input. The input is a string that is parsed using
+         * [TinyColor](https://github.com/bgrins/TinyColor).
+         *
+         * ```html
+         * <input type='text' class='basic' value='red' />
+         * <input type='text' class='basic' value='#0f0' />
+         * <input type='text' class='basic' value='blue' />
+         * <br />
+         * <input type='text' class='override' />
+         * <br />
+         * <input type='text' class='startEmpty' value='' />
+         *
+         * <script>
+         * $(".basic").spectrum();
+         * $(".override").spectrum({
+         *   color: "yellow"
+         * });
+         * $(".startEmpty").spectrum({
+         *   allowEmpty: true
+         * });
+         * </script>
+         * ```
          */
-        color?: string;
+        color?: string | false;
 
         /**
-         * The colorpicker will always show up at full size, and be positioned as an inline-block element.
+         * The color picker will always show up at full size, and be positioned
+         * as an `inline-block` element.
+         *
+         * ```html
+         * <input type='text' id="flat" />
+         * <br/>
+         * <input type='text' id="flat" />
+         * ```
+         *
+         * ```javascript
+         * $("#flat").spectrum({
+         *   flat: true,
+         *   showInput: true
+         * });
+         * $("#flatClearable").spectrum({
+         *   flat: true,
+         *   showInput: true,
+         *   allowEmpty:true
+         * });
+         * ```
          */
         flat?: boolean;
 
         /**
-         * Adds an input to allow for free form typing.
+         * Adds an input to allow for free form typing. The color parsing is
+         * very permissive in the allowed strings. See
+         * [TinyColor](https://github.com/bgrins/TinyColor) for more details.
+         *
+         * ```javascript
+         * $("#showInput").spectrum({
+         *   showInput: true
+         * });
+         * $("#showInputWithClear").spectrum({
+         *   showInput: true,
+         *   allowEmpty:true
+         * });
+         * ```
          */
         showInput?: boolean;
 
         /**
-         * Shows the color that was initially set when opening.
-         * This provides an easy way to click back to what was set when opened.
+         * Shows the color that was initially set when opening. This provides an
+         * easy way to click back to what was set when opened.
+         *
+         * ```javascript
+         * $("#showInitial").spectrum({
+         *   showInitial: true
+         * });
+         * ```
          */
         showInitial?: boolean;
 
         /**
-         * Allows the colorpicker to have no color as a value.
-         * Will display a button to set selection to 'no color'.
+         * Allows the color picker to have no color as a value. This will
+         * display a button to set selection to 'no color'.
          */
         allowEmpty?: boolean;
 
         /**
-         * Allows alpha transparency selection
+         * Allows alpha transparency selection.
+         *
+         * ```javascript
+         * $("#showAlpha").spectrum({
+         *   showAlpha: true
+         * });
+         * ```
          */
         showAlpha?: boolean;
 
         /**
-         * Automatically disables the colorpicker.
-         * Additionally, if the input that you initialize spectrum on is disabled, this will be the default value.
-         * Note: you cannot enable spectrum if the input is disabled
+         * Spectrum can be automatically disabled if you pass in the `disabled`
+         * flag.
+         *
+         * Additionally, if the input that you initialize spectrum on is
+         * disabled, this will be the default value.
+         *
+         * Note: You cannot enable spectrum if the input is disabled.
+         *
+         * ```javascript
+         * $("#disabled").spectrum({
+         *   disabled: true
+         * });
+         * $("input:disabled").spectrum({
+         * });
+         * ```
          */
         disabled?: boolean;
 
         /**
-         * Sets a palette below the colorpicker to make it convenient for users to choose from
-         *  frequently or recently used colors.
-         * Default value:  [["#ffffff", "#000000", "#ff0000", "#ff8000", "#ffff00", "#008000", "#0000ff", "#4b0082", "#9400d3"]]
+         * Sets a palette below the color picker to make it convenient for users
+         * to choose from frequently or recently used colors.
+         *
+         * Default value:
+         *
+         * ```javascript
+         * [[
+         *     "#ffffff", "#000000", "#ff0000",
+         *     "#ff8000", "#ffff00", "#008000",
+         *     "#0000ff", "#4b0082", "#9400d3"
+         * ]]
+         * ```
          */
         palette?: string[][];
 
         /**
-         * When the colorpicker is closed, the current color will be added to the palette if it isn't there already.
+         * Spectrum can show a palette below the color picker to make it
+         * convenient for users to choose from frequently or recently used colors.
+         *
+         * When the color picker is closed, the current color will be added to
+         * the palette if it is not there already.
+         *
+         * ```javascript
+         * $("#showPalette").spectrum({
+         *   showPalette: true,
+         *   palette: [
+         *     ['black', 'white', 'blanchedalmond'],
+         *     ['rgb(255, 128, 0);', 'hsv 100 70 50', 'lightyellow']
+         *   ]
+         * });
+         * ```
          */
         showPalette?: boolean;
 
         /**
-         * Shows only the colors specified in the palette
+         * Shows only the colors specified in the palette.
+         *
+         * ```javascript
+         * $("#showPaletteOnly").spectrum({
+         *   showPaletteOnly: true,
+         *   showPalette:true,
+         *   color: 'blanchedalmond',
+         *   palette: [
+         *     ['black', 'white', 'blanchedalmond',
+         *     'rgb(255, 128, 0);', 'hsv 100 70 50'],
+         *     ['red', 'yellow', 'green', 'blue', 'violet']
+         *   ]
+         * });
+         * ```
          */
         showPaletteOnly?: boolean;
 
         /**
-         * Shows a button to toggle the colorpicker next to the palette.
-         * This way, the user can choose from a limited number of colors in the palette,
-         * but still be able to pick a color that's not in the palette.
+         * Shows a button to toggle the color picker next to the palette.
+         *
+         * This way, the user can choose from a limited number of colors in the
+         * palette, but still be able to pick a color that's not in the palette.
+         *
+         * The default value for `togglePaletteOnly` is `false`. Set it to
+         * `true` to enable the toggle button.
+         *
+         * You can also change the text on the toggle button with the options
+         * `togglePaletteMoreText` (default is `more`) and
+         * `togglePaletteLessText` (default is `less`).
+         *
+         * ```javascript
+         * $("#togglePaletteOnly").spectrum({
+         *   showPaletteOnly: true,
+         *   togglePaletteOnly: true,
+         *   togglePaletteMoreText: 'more',
+         *   togglePaletteLessText: 'less',
+         *   color: 'blanchedalmond',
+         *   palette: [
+         *     ["#000","#444","#666","#999","#ccc","#eee","#f3f3f3","#fff"],
+         *     ["#f00","#f90","#ff0","#0f0","#0ff","#00f","#90f","#f0f"],
+         *     ["#f4cccc","#fce5cd","#fff2cc","#d9ead3","#d0e0e3","#cfe2f3","#d9d2e9","#ead1dc"],
+         *     ["#ea9999","#f9cb9c","#ffe599","#b6d7a8","#a2c4c9","#9fc5e8","#b4a7d6","#d5a6bd"],
+         *     ["#e06666","#f6b26b","#ffd966","#93c47d","#76a5af","#6fa8dc","#8e7cc3","#c27ba0"],
+         *     ["#c00","#e69138","#f1c232","#6aa84f","#45818e","#3d85c6","#674ea7","#a64d79"],
+         *     ["#900","#b45f06","#bf9000","#38761d","#134f5c","#0b5394","#351c75","#741b47"],
+         *     ["#600","#783f04","#7f6000","#274e13","#0c343d","#073763","#20124d","#4c1130"]
+         *   ]
+         * });
+         * ```
          */
         togglePaletteOnly?: boolean;
 
         /**
-         * Changes the text on the open-toggle colorpicker button.
+         * Changes the text on the open-toggle color picker button.
          */
         togglePaletteMoreText?: string;
 
         /**
-         * Changes the text on the close-toggle colorpicker button.
+         * Changes the text on the close-toggle color picker button.
          */
         togglePaletteLessText?: string;
 
         /**
-         * Automatically hides the colorpicker after a palette color is selected.
+         * Automatically hides the color picker after a palette color is
+         * selected.
+         *
+         * ```javascript
+         * $("#hideAfterPaletteSelect").spectrum({
+         *   showPaletteOnly: true,
+         *   showPalette:true,
+         *   hideAfterPaletteSelect:true,
+         *   color: 'blanchedalmond',
+         *   palette: [
+         *     ['black', 'white', 'blanchedalmond',
+         *     'rgb(255, 128, 0);', 'hsv 100 70 50'],
+         *     ['red', 'yellow', 'green', 'blue', 'violet']
+         *   ]
+         * });
+         * ```
          */
         hideAfterPaletteSelect?: boolean;
 
         /**
          * Keeps track of what has been selected by the user.
+         *
+         * Spectrum can keep track of what has been selected by the user with
+         * the `showSelectionPalette` option.
+         *
+         * If the `localStorageKey` option is defined, the selection will be
+         * saved in the browser's `localStorage` object.
+         *
+         * ```javascript
+         * $("#showSelectionPalette").spectrum({
+         *   showPalette: true,
+         *   showSelectionPalette: true, // true by default
+         *   palette: [ ]
+         * });
+         * $("#showSelectionPaletteStorage").spectrum({
+         *   showPalette: true,
+         *   showSelectionPalette: true,
+         *   palette: [ ],
+         *   localStorageKey: "spectrum.homepage", // Any Spectrum with the same string will share selection
+         * });
+         * ```
          */
         showSelectionPalette?: boolean;
 
         /**
-         * The users selection will be saved in the browser's localStorage object.
-         * Any Spectrum with the same string will share the selection.
+         * The users selection will be saved in the browser's `localStorage`
+         * object. Any spectrum with the same string will share the selection.
+         *
+         * May be `false` when no value has been set explicitly.
          */
-        localStorageKey?: string;
+        localStorageKey?: string | false;
 
         /**
-         * When clicking outside of the colorpicker,
-         *  force it to fire a change event rather than having it revert the change.
+         * When clicking outside of the color picker, you can force it to fire a
+         * `change` event rather than having it revert the change. This is
+         * `true` by default.
+         *
+         * ```javascript
+         * $("#clickoutFiresChange").spectrum({
+         *   clickoutFiresChange: true
+         * });
+         * $("#clickoutDoesntChange").spectrum({
+         *   clickoutFiresChange: false
+         * });
+         * ```
          */
         clickoutFiresChange?: boolean;
 
@@ -222,72 +641,403 @@ declare namespace Spectrum {
 
         /**
          * Adds an additional class name to the just the container element.
+         *
+         * ```javascript
+         * $("#containerClassName").spectrum({
+         *   containerClassName: 'awesome'
+         * });
+         * ```
+         *
+         * ```css
+         * .awesome {
+         *   background: purple;
+         * }
+         * ```
          */
         containerClassName?: string;
 
         /**
          * Adds an additional class name to just the replacer element.
+         *
+         * ```javascript
+         * $("#replacerClassName").spectrum({
+         *   replacerClassName: 'awesome'
+         * });
+         * ```
+         *
+         * ```css
+         * .awesome {
+         *   background: purple;
+         * }
+         * ```
          */
         replacerClassName?: string;
 
         /**
-         * Sets the format that is displayed in the text box.
-         * This will also change the format that is displayed in the titles from the palette swatches.
-         * Possible values: "hex", "hex3", "hsl", "rgb", "name"
+         * Sets the format that is displayed in the text box. This may be
+         * `false` when not set explicitly.
+         *
+         * This will also change the format that is displayed in the titles from
+         * the palette swatches.
+         *
+         * ```javascript
+         * $("#preferredHex").spectrum({
+         *   preferredFormat: "hex",
+         *   showInput: true,
+         *   showPalette: true,
+         *   palette: [["red", "rgba(0, 255, 0, .5)", "rgb(0, 0, 255)"]]
+         * });
+         * $("#preferredHex3").spectrum({
+         *   preferredFormat: "hex3",
+         *   showInput: true,
+         *   showPalette: true,
+         *   palette: [["red", "rgba(0, 255, 0, .5)", "rgb(0, 0, 255)"]]
+         * });
+         * $("#preferredHsl").spectrum({
+         *   preferredFormat: "hsl",
+         *   showInput: true,
+         *   showPalette: true,
+         *   palette: [["red", "rgba(0, 255, 0, .5)", "rgb(0, 0, 255)"]]
+         * });
+         * $("#preferredRgb").spectrum({
+         *   preferredFormat: "rgb",
+         *   showInput: true,
+         *   showPalette: true,
+         *   palette: [["red", "rgba(0, 255, 0, .5)", "rgb(0, 0, 255)"]]
+         * });
+         * $("#preferredName").spectrum({
+         *   preferredFormat: "name",
+         *   showInput: true,
+         *   showPalette: true,
+         *   palette: [["red", "rgba(0, 255, 0, .5)", "rgb(0, 0, 255)"]]
+         * });
+         * $("#preferredNone").spectrum({
+         *   showInput: true,
+         *   showPalette: true,
+         *   palette: [["red", "rgba(0, 255, 0, .5)", "rgb(0, 0, 255)"]]
+         * });
+         * ```
          */
-        preferredFormat?: string;
+        preferredFormat?: ColorFormatName | false;
 
         /**
-         * Toggles the choose/cancel buttons.
-         * If there are no buttons, the behavior will be to fire the `change` event (and update the original input) when the picker is closed.
+         * Toggles the choose / cancel buttons.
+         *
+         * If there are no buttons, the behavior will be to fire the `change`
+         * event (and update the original input) when the picker is closed.
+         *
+         * ```javascript
+         * $("#hideButtons").spectrum({
+         *   showButtons: false
+         * });
+         * ```
          */
         showButtons?: boolean;
 
         /**
-         * Sets which element the colorpicker container is appended to (default is "body").
-         * This can be any valid object taken into the jQuery appendTo function.
-         * Changing this can help resolve issues with opening the colorpicker in a modal dialog
-         * or fixed position container, for instance.
+         * Sets which element the color picker container is appended to (default
+         * is `body`).
+         *
+         * Changing this can help resolve issues with opening the color picker
+         * in a modal dialog or fixed position container, for instance.
          */
-        appendTo?: any //same as JQuery appendTo : JQuery| any[] | Element| string
+        appendTo?: Parameters<JQuery["appendTo"]>[0];
 
         /**
          * Sets the max size for the palette.
+         *
+         * This is how many elements are allowed in the selection palette at
+         * once.
+         *
+         * Elements will be removed from the palette in first in - first out
+         * order if this limit is reached.
+         *
+         * ```javascript
+         * $("#maxSelectionSize").spectrum({
+         *   showPalette: true,
+         *   palette: [ ],
+         *   showSelectionPalette: true, // true by default
+         *   selectionPalette: ["red", "green", "blue"],
+         *   maxSelectionSize: 2
+         * });
+         * ```
          */
         maxSelectionSize?: number;
 
         /**
+         * The default values inside of the selection palette. Make sure that
+         * `showSelectionPalette` and `showPalette` are both enabled.
+         *
+         * If a `localStorageKey` is defined, then this value will be
+         * overwritten by it.
+         *
+         * The following example shows a color picker with red, green, and blue
+         * available in the selection palette by default:
+         *
+         * ```javascript
+         * $("#selectionPalette").spectrum({
+         *     showPalette: true,
+         *     palette: [ ],
+         *     showSelectionPalette: true, // true by default
+         *     selectionPalette: ["red", "green", "blue"]
+         * });
+         * ```
          */
         selectionPalette?: string[];
 
         /**
-         * Called as the original input changes. Only happens when the input is closed or the 'Choose' button is clicked.
+         * Additional offset to apply as a CSS unit to the container.
+         */
+        offset?: JQuery.CoordinatesPartial | null;
+
+        /**
+         * Called as the original input changes. Only happens when the input is
+         * closed or the 'Choose' button is clicked.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   change: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         *
+         * @param color The currently selected color of the color picker.
          */
         change?: (color: tinycolor.Instance) => void;
 
         /**
-         * Called as the user moves around within the colorpicker.
+         * Called as the user moves around within the color picker.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   move: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         *
+         * @param color The currently selected color of the color picker.
          */
         move?: (color: tinycolor.Instance) => void;
 
         /**
-         * Called after the colorpicker is opened. This is ignored on a flat colorpicker.
-         * Note, when any colorpicker on the page is shown it will hide any that are already open.
+         * Called after the color picker is opened. This is ignored on a flat
+         * color picker.
+         *
+         * Note: When any color picker on the page is shown, it will hide all
+         * other color pickers that are already open.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   show: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         *
+         * @param color The currently selected color of the color picker.
          */
         show?: (color: tinycolor.Instance) => void;
 
         /**
-         * Called after the colorpicker is hidden.
+         * Called after the color picker is hidden.
+         *
          * This happens when clicking outside of the picker while it is open.
-         * Note, when any colorpicker on the page is shown it will hide any that are already open.
-         * This event is ignored on a flat colorpicker.
+         *
+         * Note: When any color picker on the page is shown, it will hide all
+         * other color picker that are already open.
+         *
+         * This event is ignored on a flat color picker, i.e. when `flat` is
+         * set to `true`.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   hide: function(color) {
+         *     color.toHexString(); // #ff0000
+         *   }
+         * }
+         * ```
+         *
+         * @param color The currently selected color of the color picker.
          */
         hide?: (color: tinycolor.Instance) => void;
 
         /**
-         * You can prevent the colorpicker from showing up if you return false in the beforeShow event.
-         * This event is ignored on a flat colorpicker.
+         * You can prevent the color picker from showing up if you return
+         * `false` in the `beforeShow` event.
+         *
+         * This event is ignored on a flat color picker.
+         *
+         * ```javascript
+         * $("#picker").spectrum({
+         *   beforeShow: function(color) {
+         *     color.toHexString(); // #ff0000
+         *     return false; // Will never show up
+         *   }
+         * }
+         * ```
+         *
+         * @param color The currently selected color of the color picker.
+         * @return `false` to prevent the color picker from showing up.
          */
-        beforeShow?: (color: tinycolor.Instance) => void;
+        beforeShow?: (color: tinycolor.Instance) => boolean | void;
+    }
+
+    /**
+     * Possible values for the `preferredFormat` option.
+     */
+    type ColorFormatName = "hex" | "hex3" | "hsl" | "rgb" | "name";
+
+    /**
+     * You can prevent the color picker from showing up if you return `false` in
+     * the `beforeShow` event.
+     *
+     * This event is ignored on a flat color picker.
+     *
+     * The callback will receive an additional argument of type
+     * `tinycolor.Instance` with the currently selected color.
+     *
+     * ```javascript
+     * $("#picker").spectrum({
+     *   beforeShow: function(color) {
+     *     color.toHexString(); // #ff0000
+     *     return false; // Will never show up
+     *   }
+     * }
+     * ```
+     */
+    interface BeforeShowEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends JQuery.EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: "beforeShow";
+    }
+
+    /**
+     * Called after the color picker is opened. This is ignored on a flat color
+     * picker.
+     *
+     * Note: When any color picker on the page is shown, it will hide all other
+     * color pickers that are already open.
+     *
+     * The callback will receive an additional argument of type
+     * `tinycolor.Instance` with the currently selected color.
+     *
+     * ```javascript
+     * $("#picker").spectrum({
+     *   show: function(color) {
+     *     color.toHexString(); // #ff0000
+     *   }
+     * }
+     * ```
+     */
+    interface ShowEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends JQuery.EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: "show";
+    }
+
+    /**
+     * Called after the color picker is hidden.
+     *
+     * This happens when clicking outside of the picker while it is open.
+     *
+     * Note: When any color picker on the page is shown, it will hide all other
+     * color picker that are already open.
+     *
+     * This event is ignored on a flat color picker, i.e. when `flat` is set to
+     * `true`.
+     *
+     * The callback will receive an additional argument of type
+     * `tinycolor.Instance` with the currently selected color.
+     *
+     * ```javascript
+     * $("#picker").spectrum({
+     *   hide: function(color) {
+     *     color.toHexString(); // #ff0000
+     *   }
+     * }
+     * ```
+     */
+    interface HideEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends JQuery.EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: "hide";
+    }
+
+    /**
+     * Called as the user moves around within the color picker.
+     *
+     * The callback will receive an additional argument of type
+     * `tinycolor.Instance` with the currently selected color.
+     *
+     * ```javascript
+     * $("#picker").spectrum({
+     *   move: function(color) {
+     *     color.toHexString(); // #ff0000
+     *   }
+     * }
+     * ```
+     */
+    interface MoveEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends JQuery.EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: "move";
+    }
+
+    /**
+     * Called at the beginning of a drag event on either hue slider, alpha
+     * slider, or main color picker areas.
+     *
+     * The callback will receive an additional argument of type
+     * `tinycolor.Instance` with the currently selected color.
+     *
+     * ```javascript
+     * $(element).on("dragstart.spectrum", function(e, color) {
+     *  color.toHexString(); // #ff0000
+     * });
+     * ```
+     */
+    interface DragstartEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends JQuery.EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: "dragstart";
+    }
+
+    /**
+     * Called at the end of a drag event on either hue slider, alpha slider, or
+     * main color picker areas.
+     *
+     * The callback will receive an additional argument of type
+     * `tinycolor.Instance` with the currently selected color.
+     *
+     * ```javascript
+     * $(element).on("dragstop.spectrum", function(e, color) {
+     *  color.toHexString(); // #ff0000
+     * });
+     * ```
+     */
+    interface DragstopEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends JQuery.EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: "dragstop";
     }
 }

--- a/types/spectrum/spectrum-tests.ts
+++ b/types/spectrum/spectrum-tests.ts
@@ -1,5 +1,7 @@
+// No-arg initializer
 $("#picker").spectrum();
 
+// Initializer with options
 $("#picker").spectrum({
     color: "yellow"
 });
@@ -85,40 +87,86 @@ $("#picker").spectrum({
     preferredFormat: "hex"
 });
 
+$("#picker").spectrum(
+    // Invalid format name raises a type error
+    // $ExpectError
+    { preferredFormat: "lol" }
+);
+
 $("#picker").spectrum({
     appendTo: "body"
 });
 $("#picker").spectrum({
+    appendTo: document.createDocumentFragment()
+});
+$("#picker").spectrum({
+    appendTo: [document.createDocumentFragment()]
+});
+$("#picker").spectrum({
+    appendTo: document.createElement("input")
+});
+$("#picker").spectrum({
+    appendTo: [document.createElement("input")]
+});
+$("#picker").spectrum({
     appendTo: $("#otherPicker")
 });
+$("#picker").spectrum(
+    // Cannot use values not allowed by JQuery#appendTo
+    // $ExpectError
+    { appendTo: [$("#otherPicker")] }
+);
 
 $("#picker").spectrum({
-    change: function (color) {
-        console.log(color);
-    }
-});
-
-$("#picker").spectrum({
-    move: function (color) {
-        console.log(color);
+    offset: {
+        left: 0,
+        top: 0,
     }
 });
 $("#picker").spectrum({
-    hide: function (color) {
-        console.log(color);
-    }
-});
-$("#picker").spectrum({
-    show: function (color) {
-        console.log(color);
-    }
-});
-$("#picker").spectrum({
-    beforeShow: function (color) {
-        console.log(color);
+    offset: {
+        left: 0,
     }
 });
 
+$("#picker").spectrum({
+    change(color) {
+        console.log(color);
+    }
+});
+$("#picker").spectrum({
+    move(color) {
+        // $ExpectType string
+        color.toHexString();
+    }
+});
+$("#picker").spectrum({
+    hide(color) {
+        // $ExpectType string
+        color.toHexString();
+    }
+});
+$("#picker").spectrum({
+    show(color) {
+        // $ExpectType string
+        color.toHexString();
+    }
+});
+$("#picker").spectrum({
+    beforeShow(color) {
+        // $ExpectType string
+        color.toHexString();
+    }
+});
+$("#picker").spectrum({
+    beforeShow(color) {
+        // $ExpectType string
+        color.toHexString();
+        return false;
+    }
+});
+
+// JQuery instance method
 $("#picker").spectrum("show");
 $("#picker").spectrum("hide");
 $("#picker").spectrum("toggle");
@@ -129,5 +177,92 @@ $("#picker").spectrum("reflow");
 $("#picker").spectrum("destroy");
 $("#picker").spectrum("enable");
 $("#picker").spectrum("disable");
+
+// $ExpectType Options
+$("#picker").spectrum("option");
+
 $("#picker").spectrum("option", "show");
+// $ExpectType string | undefined
+$("#picker").spectrum("option", "cancelText");
+// These options may return false when not set explicitly
+// $ExpectType string | false | undefined
+$("#picker").spectrum("option", "color");
+// $ExpectType string | false | undefined
+$("#picker").spectrum("option", "localStorageKey");
+// $ExpectType false | "hex" | "hex3" | "hsl" | "rgb" | "name" | undefined || false | ColorFormatName | undefined
+$("#picker").spectrum("option", "preferredFormat");
+// $ExpectType boolean | undefined
+$("#picker").spectrum("option", "disabled");
+// Invalid option name raises a type error
+// $ExpectError
+$("#picker").spectrum("option", "foobar");
+
 $("#picker").spectrum("option", "color", "#ededed");
+$("#picker").spectrum("option", "disabled", true);
+// Invalid option name raises a type error
+// $ExpectError
+$("#picker").spectrum("option", "foobar", "#ededed");
+// Invalid option value raises a type error
+// $ExpectError
+$("#picker").spectrum("option", "disabled", "true");
+// Passing undefined would be interpreted as the getter, not the setter, so this is disallowed
+// $ExpectError
+$("#picker").spectrum("option", "disabled", undefined);
+
+// Event handling
+$("#picker").on("change.spectrum", (e) => {
+    // $ExpectType "change"
+    e.type;
+});
+$("#picker").on("move.spectrum", (e) => {
+    // $ExpectType "move"
+    e.type;
+});
+$("#picker").on("show.spectrum", (e) => {
+    // $ExpectType "show"
+    e.type;
+});
+$("#picker").on("hide.spectrum", (e) => {
+    // $ExpectType "hide"
+    e.type;
+});
+$("#picker").on("beforeShow.spectrum", (e) => {
+    // $ExpectType "beforeShow"
+    e.type;
+});
+$("#picker").on("dragstart.spectrum", (e) => {
+    // $ExpectType "dragstart"
+    e.type;
+});
+$("#picker").on("dragstop.spectrum", (e) => {
+    // $ExpectType "dragstop"
+    e.type;
+});
+$("#picker").off("change.spectrum", (e) => {
+    // $ExpectType "change"
+    e.type;
+});
+$("#picker").off("move.spectrum", (e) => {
+    // $ExpectType "move"
+    e.type;
+});
+$("#picker").off("show.spectrum", (e) => {
+    // $ExpectType "show"
+    e.type;
+});
+$("#picker").off("hide.spectrum", (e) => {
+    // $ExpectType "hide"
+    e.type;
+});
+$("#picker").off("beforeShow.spectrum", (e) => {
+    // $ExpectType "beforeShow"
+    e.type;
+});
+$("#picker").off("dragstart.spectrum", (e) => {
+    // $ExpectType "dragstart"
+    e.type;
+});
+$("#picker").off("dragstop.spectrum", (e) => {
+    // $ExpectType "dragstop"
+    e.type;
+});

--- a/types/spectrum/tslint.json
+++ b/types/spectrum/tslint.json
@@ -1,16 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "comment-format": false,
-        "dt-header": false,
-        "jsdoc-format": false,
-        "no-padding": false,
-        "no-redundant-jsdoc-2": false,
-        "npm-naming": false,
-        "object-literal-shorthand": false,
-        "only-arrow-functions": false,
-        "semicolon": false,
-        "space-before-function-paren": false,
-        "unified-signatures": false
+        "npm-naming": false
     }
 }


### PR DESCRIPTION
* Increment TS version to latest tested version (3.4)
* Check against the latest version of the library (1.8.1) and add / cleanup tests
* Remove disabled options in tslint.json and adjust typings accordingly
* Clean-up doc comments, fix some spelling mistakes
* Add `@param` / `@return` where it was missing.
* Add example code from documentation.
* Replace all remaining `any` types with more specific types.
* Fix `options` JQuery instance method.
    * When called with no option name, it returns the entire options object.
    * Use `K extends keyof Spectrum.Options` instead of string type
    * Make the option value a required argument for the setter. Passing no argument or undefined would be
      interpreted as the getter method.
    * Remove generic `spectrum(methodName: string)` as we are already covering all available methods.
* Fix types of some Spectrum.Options (tested against the current version on the demo page,
  see also https://github.com/bgrins/spectrum/blob/master/spectrum.js#L21)
    * Option `color` is `false` when not set explicitly
    * Option `preferredFormat` is `false` when not set explicitly
    * Option `localStorageKey` is `false` when not set explicitly
* Remove `on` method overloads and extend JQuery.TypeToTriggeredEventMap instead. This has the benefit
  of allowing the event to be recognized in the `off`, `one` etc. methods as well. This also brings it
  in line with how JQuery typings handle different event types. This removes the ability to specifiy
  type of the additional arguments passed to the handler, but this may be considered a feature as users
  can invoke the event handler with different types via the `trigger` method.
* Use a string union instead of just the string type for `preferredFormat`
* `beforeShow` callback can return a `boolean`
* Added `offset` option that was added in 1.6.0. Not mentioned in the docs yet, see
  https://github.com/bgrins/spectrum/releases and https://github.com/bgrins/spectrum/pull/179

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://bgrins.github.io/spectrum https://github.com/bgrins/spectrum/releases
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.