### PR TITLE
[node] feat(node): aded generics for custom req, res

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -123,7 +123,7 @@ declare module 'http' {
         insecureHTTPParser?: boolean;
     }
 
-    type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
+    type RequestListener<Request extends IncomingMessage = IncomingMessage, Response extends ServerResponse = ServerResponse> = (req: Request, res: Response) => void;
 
     interface HttpBase {
         setTimeout(msecs?: number, callback?: () => void): this;
@@ -151,9 +151,9 @@ declare module 'http' {
     }
 
     interface Server extends HttpBase {}
-    class Server extends NetServer {
-        constructor(requestListener?: RequestListener);
-        constructor(options: ServerOptions, requestListener?: RequestListener);
+    class Server<Request extends IncomingMessage = IncomingMessage, Response extends ServerResponse = ServerResponse> extends NetServer {
+        constructor(requestListener?: RequestListener<Request, Response>);
+        constructor(options: ServerOptions, requestListener?: RequestListener<Request, Response>);
     }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js
@@ -407,8 +407,12 @@ declare module 'http' {
         [errorCode: string]: string | undefined;
     };
 
-    function createServer(requestListener?: RequestListener): Server;
-    function createServer(options: ServerOptions, requestListener?: RequestListener): Server;
+    function createServer<Request extends IncomingMessage = IncomingMessage, Response extends ServerResponse = ServerResponse>(
+        requestListener?: RequestListener<Request, Response>
+    ): Server<Request, Response>;
+    function createServer<Request extends IncomingMessage = IncomingMessage, Response extends ServerResponse = ServerResponse>(
+        options: ServerOptions, requestListener?: RequestListener<Request, Response>
+    ): Server<Request, Response>;
 
     // although RequestOptions are passed as ClientRequestArgs to ClientRequest directly,
     // create interface RequestOptions would make the naming more clear to developers

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -470,49 +470,49 @@ declare module 'http2' {
         origins?: string[];
     }
 
-    export interface Http2Server extends net.Server {
-        addListener(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        addListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+    export interface Http2Server<Request extends Http2ServerRequest = Http2ServerRequest, Response extends Http2ServerResponse = Http2ServerResponse> extends net.Server {
+        addListener(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        addListener(event: "request", listener: (request: Request, response: Response) => void): this;
         addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
+        emit(event: "checkContinue", request: Request, response: Response): boolean;
+        emit(event: "request", request: Request, response: Response): boolean;
         emit(event: "session", session: ServerHttp2Session): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
 
-        on(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        on(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        on(event: "request", listener: (request: Request, response: Response) => void): this;
         on(event: "session", listener: (session: ServerHttp2Session) => void): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         on(event: "timeout", listener: () => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        once(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        once(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        once(event: "request", listener: (request: Request, response: Response) => void): this;
         once(event: "session", listener: (session: ServerHttp2Session) => void): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         once(event: "timeout", listener: () => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependListener(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        prependListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependListener(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        prependListener(event: "request", listener: (request: Request, response: Response) => void): this;
         prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependOnceListener(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        prependOnceListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependOnceListener(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        prependOnceListener(event: "request", listener: (request: Request, response: Response) => void): this;
         prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
@@ -522,9 +522,9 @@ declare module 'http2' {
         setTimeout(msec?: number, callback?: () => void): this;
     }
 
-    export interface Http2SecureServer extends tls.Server {
-        addListener(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        addListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+    export interface Http2SecureServer<Request extends Http2ServerRequest = Http2ServerRequest, Response extends Http2ServerResponse = Http2ServerResponse> extends tls.Server {
+        addListener(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        addListener(event: "request", listener: (request: Request, response: Response) => void): this;
         addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
@@ -532,8 +532,8 @@ declare module 'http2' {
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
+        emit(event: "checkContinue", request: Request, response: Response): boolean;
+        emit(event: "request", request: Request, response: Response): boolean;
         emit(event: "session", session: ServerHttp2Session): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
@@ -541,8 +541,8 @@ declare module 'http2' {
         emit(event: "unknownProtocol", socket: tls.TLSSocket): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
 
-        on(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        on(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        on(event: "request", listener: (request: Request, response: Response) => void): this;
         on(event: "session", listener: (session: ServerHttp2Session) => void): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
@@ -550,8 +550,8 @@ declare module 'http2' {
         on(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        once(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        once(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        once(event: "request", listener: (request: Request, response: Response) => void): this;
         once(event: "session", listener: (session: ServerHttp2Session) => void): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
@@ -559,8 +559,8 @@ declare module 'http2' {
         once(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependListener(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        prependListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependListener(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        prependListener(event: "request", listener: (request: Request, response: Response) => void): this;
         prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
@@ -568,8 +568,8 @@ declare module 'http2' {
         prependListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependOnceListener(event: "checkContinue", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        prependOnceListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependOnceListener(event: "checkContinue", listener: (request: Request, response: Response) => void): this;
+        prependOnceListener(event: "request", listener: (request: Request, response: Response) => void): this;
         prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
@@ -947,11 +947,19 @@ declare module 'http2' {
     export function getPackedSettings(settings: Settings): Buffer;
     export function getUnpackedSettings(buf: Uint8Array): Settings;
 
-    export function createServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
-    export function createServer(options: ServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
+    export function createServer<Request extends Http2ServerRequest = Http2ServerRequest, Response extends Http2ServerResponse = Http2ServerResponse>(
+        onRequestHandler?: (request: Request, response: Response) => void
+    ): Http2Server<Request, Response>;
+    export function createServer<Request extends Http2ServerRequest = Http2ServerRequest, Response extends Http2ServerResponse = Http2ServerResponse>(
+        options: ServerOptions, onRequestHandler?: (request: Request, response: Response) => void
+    ): Http2Server<Request, Response>;
 
-    export function createSecureServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2SecureServer;
-    export function createSecureServer(options: SecureServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2SecureServer;
+    export function createSecureServer<Request extends Http2ServerRequest = Http2ServerRequest, Response extends Http2ServerResponse = Http2ServerResponse>(
+        onRequestHandler?: (request: Request, response: Response) => void
+    ): Http2SecureServer<Request, Response>;
+    export function createSecureServer<Request extends Http2ServerRequest = Http2ServerRequest, Response extends Http2ServerResponse = Http2ServerResponse>(
+        options: SecureServerOptions, onRequestHandler?: (request: Request, response: Response) => void
+    ): Http2SecureServer<Request, Response>;
 
     export function connect(authority: string | url.URL, listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
     export function connect(

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -25,13 +25,17 @@ declare module 'https' {
     }
 
     interface Server extends http.HttpBase {}
-    class Server extends tls.Server {
-        constructor(requestListener?: http.RequestListener);
-        constructor(options: ServerOptions, requestListener?: http.RequestListener);
+    class Server<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> extends tls.Server {
+        constructor(requestListener?: http.RequestListener<Request, Response>);
+        constructor(options: ServerOptions, requestListener?: http.RequestListener<Request, Response>);
     }
 
-    function createServer(requestListener?: http.RequestListener): Server;
-    function createServer(options: ServerOptions, requestListener?: http.RequestListener): Server;
+    function createServer<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+        requestListener?: http.RequestListener<Request, Response>
+    ): Server<Request, Response>;
+    function createServer<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+        options: ServerOptions, requestListener?: http.RequestListener<Request, Response>
+    ): Server<Request, Response>;
     function request(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
     function request(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
     function get(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -2,30 +2,16 @@ import * as http from 'node:http';
 import * as url from 'node:url';
 import * as net from 'node:net';
 
-// http Server
+// test default http Server
 {
+    let server: http.Server = new http.Server();
     function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}
 
-    let server: http.Server = new http.Server();
-
-    class MyIncomingMessage extends http.IncomingMessage {
-        foo: number;
-    }
-
-    class MyServerResponse extends http.ServerResponse {
-        foo: string;
-    }
-
-    server = new http.Server({ IncomingMessage: MyIncomingMessage});
-
-    server = new http.Server({
-        IncomingMessage: MyIncomingMessage,
-        ServerResponse: MyServerResponse
-    }, reqListener);
+    server = new http.Server();
 
     server = http.createServer(reqListener);
-    server = http.createServer({ IncomingMessage: MyIncomingMessage });
-    server = http.createServer({ ServerResponse: MyServerResponse }, reqListener);
+    server = http.createServer();
+    server = http.createServer({}, reqListener);
     server = http.createServer({ insecureHTTPParser: true }, reqListener);
 
     // test public props
@@ -36,6 +22,43 @@ import * as net from 'node:net';
     const keepAliveTimeout: number = server.keepAliveTimeout;
     const requestTimeout: number = server.requestTimeout;
     server.setTimeout().setTimeout(1000).setTimeout(() => {}).setTimeout(100, () => {});
+}
+// test custom req, res
+{
+    class MyIncomingMessage extends http.IncomingMessage {
+        foo: number;
+    }
+
+    class MyServerResponse extends http.ServerResponse {
+        bar: string;
+    }
+
+    function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}
+    function reqListener2(req: MyIncomingMessage, res: http.ServerResponse): void {}
+    function reqListener3(req: http.IncomingMessage, res: MyServerResponse): void {}
+
+    const server1 = new http.Server<MyIncomingMessage, MyServerResponse>();
+    const server2 = new http.Server<MyIncomingMessage>({
+        IncomingMessage: MyIncomingMessage
+    });
+    const server3 = new http.Server<MyIncomingMessage>({
+        IncomingMessage: MyIncomingMessage
+    }, reqListener2);
+    const server4 = new http.Server<MyIncomingMessage, MyServerResponse>({
+        IncomingMessage: MyIncomingMessage,
+        ServerResponse: MyServerResponse
+    }, reqListener);
+
+    const server5 = http.createServer(reqListener);
+    const server6 = http.createServer<MyIncomingMessage>({
+        IncomingMessage: MyIncomingMessage
+    });
+    const server7 = http.createServer<http.IncomingMessage, MyServerResponse>({
+        ServerResponse: MyServerResponse
+    }, reqListener3);
+    const server8 = http.createServer({
+        insecureHTTPParser: true
+    }, reqListener);
 }
 
 // http IncomingMessage

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -396,32 +396,30 @@ import { URL } from 'node:url';
         bar: string;
     }
 
-    function reqListener(req: Http2ServerRequest, res: Http2ServerResponse): void {}
+    function reqListener(req: MyHttp2ServerRequest, res: MyHttp2ServerResponse): void {}
+    function reqListener2(req: MyHttp2ServerRequest, res: Http2ServerResponse): void {}
+    function reqListener3(req: Http2ServerRequest, res: MyHttp2ServerResponse): void {}
 
-    let server: Http2Server;
-
-    server = createServer({
+    const server1 = createServer<MyHttp2ServerRequest, MyHttp2ServerResponse>({
         Http2ServerRequest: MyHttp2ServerRequest,
         Http2ServerResponse: MyHttp2ServerResponse
     });
-    server = createServer({
-        Http2ServerRequest: MyHttp2ServerRequest,
-        Http2ServerResponse: MyHttp2ServerResponse
-    }, reqListener);
+    const server2 = createServer<MyHttp2ServerRequest>({ Http2ServerRequest: MyHttp2ServerRequest});
+    const server3 = createServer<MyHttp2ServerRequest>({ Http2ServerRequest: MyHttp2ServerRequest }, reqListener2);
+    const server4 = createServer<Http2ServerRequest, MyHttp2ServerResponse>({ Http2ServerResponse: MyHttp2ServerResponse });
+    const server5 = createServer<Http2ServerRequest, MyHttp2ServerResponse>({ Http2ServerResponse: MyHttp2ServerResponse }, reqListener3);
 
-    server = createServer({ Http2ServerRequest: MyHttp2ServerRequest });
-    server = createServer({ Http2ServerResponse: MyHttp2ServerResponse }, reqListener);
-
-    server = createSecureServer({
+    const server6 = createSecureServer<MyHttp2ServerRequest, MyHttp2ServerResponse>({
         Http2ServerRequest: MyHttp2ServerRequest,
         Http2ServerResponse: MyHttp2ServerResponse
     });
-    server = createSecureServer({
+    const server7 = createSecureServer<MyHttp2ServerRequest, MyHttp2ServerResponse>({
         Http2ServerRequest: MyHttp2ServerRequest,
         Http2ServerResponse: MyHttp2ServerResponse
     }, reqListener);
-    server = createSecureServer({ Http2ServerRequest: MyHttp2ServerRequest });
-    server = createSecureServer({ Http2ServerResponse: MyHttp2ServerResponse }, reqListener);
+    const server8 = createSecureServer<MyHttp2ServerRequest>({ Http2ServerRequest: MyHttp2ServerRequest });
+    const server9 = createSecureServer<MyHttp2ServerRequest>({ Http2ServerRequest: MyHttp2ServerRequest }, reqListener2);
+    const server10 = createSecureServer<Http2ServerRequest, MyHttp2ServerResponse>({ Http2ServerResponse: MyHttp2ServerResponse }, reqListener3);
 }
 
 // constants


### PR DESCRIPTION
This continuation of work to support custom req,res classes. Initial support was already there, This just add generics for createServer* and HttpServer*.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
[http2 createServer](https://nodejs.org/api/http2.html#http2_http2_createserver_options_onrequesthandler)
[http1 createServer](https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener)

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

