### PR TITLE
[websocket] move disableNagleAlgorithm to IConfig

### DIFF
--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -63,6 +63,14 @@ export interface IConfig {
      * @default 5000
      */
     closeTimeout?: number;
+
+    /**
+     * The Nagle Algorithm makes more efficient use of network resources by introducing a
+     * small delay before sending small packets so that multiple messages can be batched
+     * together before going onto the wire. This however comes at the cost of latency.
+     * @default true
+     */
+    disableNagleAlgorithm?: boolean;
 }
 
 export interface IServerConfig extends IConfig {
@@ -144,14 +152,6 @@ export interface IServerConfig extends IConfig {
      * @default false
      */
     ignoreXForwardedFor?: boolean;
-
-    /**
-     * The Nagle Algorithm makes more efficient use of network resources by introducing a
-     * small delay before sending small packets so that multiple messages can be batched
-     * together before going onto the wire. This however comes at the cost of latency.
-     * @default true
-     */
-    disableNagleAlgorithm?: boolean;
 }
 
 export class server extends events.EventEmitter {


### PR DESCRIPTION
disableNagleAlgorithm is a config option for both a server or client and has been an option since v1.0.0 of the module at least.

https://github.com/theturtle32/WebSocket-Node/blob/master/lib/WebSocketClient.js#L81

https://github.com/theturtle32/WebSocket-Node/blob/master/lib/WebSocketServer.js#L131

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
