### PR TITLE
ws: use numeric literals for readyState types

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -7,6 +7,7 @@
 //                 reduckted <https://github.com/reduckted>
 //                 teidesu <https://github.com/teidesu>
 //                 Bartosz Wojtkowiak <https://github.com/wojtkowiak>
+//                 Kyle Hensel <https://github.com/k-yle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -22,27 +23,35 @@ import { SecureContextOptions } from 'tls';
 
 // WebSocket socket.
 declare class WebSocket extends events.EventEmitter {
-    static CONNECTING: number;
-    static OPEN: number;
-    static CLOSING: number;
-    static CLOSED: number;
+    /** The connection is not yet open. */
+    static CONNECTING: 0;
+    /** The connection is open and ready to communicate. */
+    static OPEN: 1;
+    /** The connection is in the process of closing. */
+    static CLOSING: 2;
+    /** The connection is closed. */
+    static CLOSED: 3;
 
     binaryType: string;
     bufferedAmount: number;
     extensions: string;
     protocol: string;
     /** The current state of the connection */
-    readyState: WebSocket.ReadyState;
+    readyState:
+        | typeof WebSocket.CONNECTING
+        | typeof WebSocket.OPEN
+        | typeof WebSocket.CLOSING
+        | typeof WebSocket.CLOSED;
     url: string;
 
     /** The connection is not yet open. */
-    CONNECTING: WebSocket.ReadyState.CONNECTING;
+    CONNECTING: 0;
     /** The connection is open and ready to communicate. */
-    OPEN: WebSocket.ReadyState.OPEN;
+    OPEN: 1;
     /** The connection is in the process of closing. */
-    CLOSING: WebSocket.ReadyState.CLOSING;
+    CLOSING: 2;
     /** The connection is closed. */
-    CLOSED: WebSocket.ReadyState.CLOSED;
+    CLOSED: 3;
 
     onopen: (event: WebSocket.OpenEvent) => void;
     onerror: (event: WebSocket.ErrorEvent) => void;
@@ -121,14 +130,6 @@ declare namespace WebSocket {
      * Data represents the message payload received over the WebSocket.
      */
     type Data = string | Buffer | ArrayBuffer | Buffer[];
-
-    /** The current state of the connection */
-    enum ReadyState {
-        CONNECTING = 0,
-        OPEN = 1,
-        CLOSING = 2,
-        CLOSED = 3,
-    }
 
     /**
      * CertMeta represents the accepted types for certificate & key data.

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -31,13 +31,18 @@ declare class WebSocket extends events.EventEmitter {
     bufferedAmount: number;
     extensions: string;
     protocol: string;
-    readyState: number;
+    /** The current state of the connection */
+    readyState: WebSocket.ReadyState;
     url: string;
 
-    CONNECTING: number;
-    OPEN: number;
-    CLOSING: number;
-    CLOSED: number;
+    /** The connection is not yet open. */
+    CONNECTING: WebSocket.ReadyState.CONNECTING;
+    /** The connection is open and ready to communicate. */
+    OPEN: WebSocket.ReadyState.OPEN;
+    /** The connection is in the process of closing. */
+    CLOSING: WebSocket.ReadyState.CLOSING;
+    /** The connection is closed. */
+    CLOSED: WebSocket.ReadyState.CLOSED;
 
     onopen: (event: WebSocket.OpenEvent) => void;
     onerror: (event: WebSocket.ErrorEvent) => void;
@@ -116,6 +121,14 @@ declare namespace WebSocket {
      * Data represents the message payload received over the WebSocket.
      */
     type Data = string | Buffer | ArrayBuffer | Buffer[];
+
+    /** The current state of the connection */
+    enum ReadyState {
+        CONNECTING = 0,
+        OPEN = 1,
+        CLOSING = 2,
+        CLOSED = 3,
+    }
 
     /**
      * CertMeta represents the accepted types for certificate & key data.

--- a/types/ws/tsconfig.json
+++ b/types/ws/tsconfig.json
@@ -1,23 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "ws-tests.ts"
-    ]
+    "files": ["index.d.ts", "ws-tests.ts"]
 }

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -169,6 +169,35 @@ import * as url from 'url';
 {
     const ws = new WebSocket('ws://www.host.com/path');
     ws.addEventListener('message', (event: WebSocket.MessageEvent) => {
-        console.log(event.data, event.target, event.type);
+            console.log(event.data, event.target, event.type);
     }, { once: true });
+}
+
+function f() {
+    const ws = new WebSocket('ws://www.host.com/path');
+
+    // $ExpectError
+    const a: 5 = ws.readyState;
+
+    if (ws.readyState === ws.OPEN) {
+        // $ExpectError
+        const a: 2 = ws.readyState;
+        const x: 1 = ws.readyState;
+        return;
+    }
+    if (ws.readyState === ws.CONNECTING) {
+        const x: 0 = ws.readyState;
+        return;
+    }
+    if (ws.readyState === ws.CLOSING) {
+        const x: 2 = ws.readyState;
+        return;
+    }
+    if (ws.readyState === ws.CLOSED) {
+        const x: 3 = ws.readyState;
+        return;
+    }
+
+    // $ExpectType never
+    const x: never = ws.readyState;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

ictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/master/doc/ws.md#ready-state-constants
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
