### PR TITLE
[@types/react-leaflet] Update types for v2.8.0.

### DIFF
--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-leaflet 2.5
+// Type definitions for react-leaflet 2.8
 // Project: https://github.com/PaulLeCam/react-leaflet
 // Definitions by: Dave Leaver <https://github.com/danzel>
 //                 David Schneider <https://github.com/davschne>

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -285,6 +285,8 @@ export class ImageOverlay<P extends ImageOverlayProps = ImageOverlayProps, E ext
 
 export interface SVGOverlayProps extends Leaflet.ImageOverlayOptions, MapComponentProps {
     children?: Children;
+    preserveAspectRatio?: string;
+    viewBox?: string;
 }
 export class SVGOverlay<P extends SVGOverlayProps = SVGOverlayProps, E extends Leaflet.SVGOverlay = Leaflet.SVGOverlay> extends MapComponent<P, E> {
     createLeafletElement(props: P): E;
@@ -349,6 +351,7 @@ export class FeatureGroup<P extends FeatureGroupProps = FeatureGroupProps, E ext
 
 export interface GeoJSONProps extends PathProps, FeatureGroupEvents, Leaflet.GeoJSONOptions {
     data: GeoJSON.GeoJsonObject | GeoJSON.GeoJsonObject[];
+    markersInheritOptions?: boolean;
 }
 export class GeoJSON<P extends GeoJSONProps = GeoJSONProps, E extends Leaflet.GeoJSON = Leaflet.GeoJSON> extends FeatureGroup<P, E> {
     createLeafletElement(props: P): E;

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -513,7 +513,7 @@ export default class SVGOverlayExample extends Component {
   render() {
     return (
       <Map center={[51.505, -0.09]} zoom={13}>
-        <SVGOverlay bounds={[[51.49, -0.08], [51.5, -0.06]]}>
+        <SVGOverlay bounds={[[51.49, -0.08], [51.5, -0.06]]} preserveAspectRatio={"xMidYMid meet"} viewBox={"0 0 1080 1080"}>
           <rect x="0" y="0" width="100%" height="100%" fill="blue" />
           <circle r="5" cx="10" cy="10" fill="red" />
           <text x="50%" y="50%" fill="white">
@@ -883,7 +883,7 @@ export class GeoJSONExample extends Component<undefined, undefined> {
                 url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
                 attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
             />
-            <GeoJSON data={this.polygons} />
+            <GeoJSON data={this.polygons} markersInheritOptions={false} />
         </Map>);
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/PaulLeCam/react-leaflet/blob/v2/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

===

This PR updates the typings for `react-leaflet` to v2.8.0, the latest version on the v2 branch.

The following entries from the `react-leaflet` changelog have been implemented, chronologically, into this PR:

* **v2.6.0 (2019-11-18)**
  * Added `markersInheritOptions` prop to `GeoJSON` component.
* **v2.7.0 (2020-05-06)**
  * Added `viewBox` and `preserveAspectRatio` props to `SVGOverlay` component (PR #704 by spectras).

The package's tests have been updated to reflect these changes as well.

Note that `react-leaflet` is currently at v3.1.0, however this version includes a full API rework, and thus applications which rely on v2 still use v2.8.0 (and thus may need DefinitelyTyped's typings). The v3 project now uses TypeScript, so I considered removing `@types/react-leaflet` altogether, but there are still projects using v2.