### PR TITLE
[ember-data] update type for Model.errors

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -327,7 +327,7 @@ export namespace DS {
      * Holds validation errors for a given record, organized by attribute names.
      */
     interface Errors extends Ember.Enumerable<any>, Evented {}
-    class Errors extends Ember.Object {
+    class Errors extends Ember.ArrayProxy<any> {
         /**
          * DEPRECATED:
          * Register with target handler
@@ -474,7 +474,7 @@ export namespace DS {
          * contains keys corresponding to the invalid property names
          * and values which are arrays of Javascript objects with two keys:
          */
-        errors: Ember.ComputedProperty<Errors>;
+        errors: Errors;
         /**
          * This property holds the `DS.AdapterError` object with which
          * last adapter operation was rejected.

--- a/types/ember-data/test/model.ts
+++ b/types/ember-data/test/model.ts
@@ -25,6 +25,9 @@ const person = Person.create();
 assertType<Point>(person.get('point'));
 assertType<Point>(person.get('oldPoint'));
 
+assertType<DS.Errors>(person.get('errors'));
+assertType<DS.Errors>(person.errors);
+
 const User = DS.Model.extend({
     username: DS.attr('string'),
     email: DS.attr('string'),


### PR DESCRIPTION
This updates the type of Model.errors:
- no longer type it as a `ComputedProperty<Errors>` because we no longer need to use `.get()` to access.
- change Errors to extend `Ember.ArrayProxy` since it's a proxy and not just an `Ember.Object`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://api.emberjs.com/ember-data/3.25/classes/Model/properties/errors?anchor=errors
  (the example still uses `.get()`, but it's not necessary. This type change will continue to allow the use of `.get()` while also allowing direct access.
  - https://github.com/emberjs/data/blob/v3.25.0/packages/model/addon/-private/model.js#L496
  - https://github.com/emberjs/data/blob/v3.25.0/packages/model/addon/-private/errors.js#L86
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~