### PR TITLE
[videojs-contrib-quality-levels]: Add types

### DIFF
--- a/types/videojs-contrib-quality-levels/index.d.ts
+++ b/types/videojs-contrib-quality-levels/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for videojs-contrib-quality-levels 2.0
+// Project: https://github.com/videojs/videojs-contrib-quality-levels#readme
+// Definitions by: Nathan Hardy <https://github.com/nhardy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+import { VideoJsPlayer } from 'video.js';
+import QualityLevelList from './src/quality-level-list';
+
+declare module 'video.js' {
+    interface VideoJsPlayer {
+        qualityLevels: {
+            VERSION: string;
+            (): QualityLevelList;
+        };
+    }
+}
+
+export interface Representation {
+    id: string;
+    width?: number;
+    height?: number;
+    bandwidth: number;
+    enabled: {
+        (enable: boolean): void;
+        (): boolean;
+    };
+}
+
+export type { default as QualityLevelList } from './src/quality-level-list';
+
+export type { default as QualityLevel } from './src/quality-level';
+
+declare const qualityLevels: {
+    VERSION: string;
+    (this: VideoJsPlayer, options?: {}): void;
+};
+export default qualityLevels;

--- a/types/videojs-contrib-quality-levels/src/quality-level-list.d.ts
+++ b/types/videojs-contrib-quality-levels/src/quality-level-list.d.ts
@@ -1,0 +1,19 @@
+import videojs from 'video.js';
+import { Representation } from '../';
+import QualityLevel from './quality-level';
+
+export default class QualityLevelList extends videojs.EventTarget implements ArrayLike<QualityLevel> {
+    readonly selectedIndex: number;
+
+    readonly length: number;
+
+    readonly [index: number]: QualityLevel;
+
+    addQualityLevel(representation: Representation): QualityLevel;
+
+    removeQualityLevel(representation: Representation): QualityLevel | null;
+
+    getQualityLevelById(id: string): QualityLevel | null;
+
+    dispose(): void;
+}

--- a/types/videojs-contrib-quality-levels/src/quality-level.d.ts
+++ b/types/videojs-contrib-quality-levels/src/quality-level.d.ts
@@ -1,0 +1,17 @@
+import { Representation } from '../';
+
+export default class QualityLevel {
+    readonly id: string;
+
+    readonly label: string;
+
+    readonly width?: number;
+
+    readonly height?: number;
+
+    readonly bitrate: number;
+
+    enabled: boolean;
+
+    constructor(representation: Representation);
+}

--- a/types/videojs-contrib-quality-levels/tsconfig.json
+++ b/types/videojs-contrib-quality-levels/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "videojs-contrib-quality-levels-tests.ts"
+    ]
+}

--- a/types/videojs-contrib-quality-levels/tslint.json
+++ b/types/videojs-contrib-quality-levels/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true, { "mode": "code", "errors": [["NeedsExportEquals", false]] }]
+    }
+}

--- a/types/videojs-contrib-quality-levels/videojs-contrib-quality-levels-tests.ts
+++ b/types/videojs-contrib-quality-levels/videojs-contrib-quality-levels-tests.ts
@@ -1,0 +1,42 @@
+import videojs from 'video.js';
+import qualityLevels, { QualityLevel, QualityLevelList, Representation } from 'videojs-contrib-quality-levels';
+
+const video = videojs('id');
+let VERSION: string = qualityLevels.VERSION;
+
+function getterSetter(value: boolean): void;
+function getterSetter(): boolean;
+function getterSetter(value?: boolean): boolean | void {
+    if (typeof value === 'undefined') return true;
+}
+
+video.ready(function() {
+    qualityLevels.call(this);
+    qualityLevels.call(this, {});
+
+    ({ VERSION } = video.qualityLevels);
+    const list: QualityLevelList = video.qualityLevels();
+    const selectedIndex: number = list.selectedIndex;
+    const length: number = list.length;
+
+    const level: QualityLevel = list[0];
+    const id: string = level.id;
+    const label: string = level.label;
+    const width: number | undefined = level.width;
+    const height: number | undefined = level.height;
+    const bitrate: number = level.bitrate;
+    const enabled: boolean = level.enabled;
+
+    const representation: Representation = {
+        id: 'id',
+        width: 1920,
+        height: 1080,
+        bandwidth: 9999,
+        enabled: getterSetter,
+    };
+    const ql1: QualityLevel = list.addQualityLevel(representation);
+    const ql2: QualityLevel | null = list.removeQualityLevel(representation);
+    const ql3: QualityLevel | null = list.getQualityLevelById('id');
+
+    list.dispose();
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
  `jsnext:main` is defined which does use ES modules, so `NeedsExportEquals` has been overridden.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
  Using `"strict": true` so that `.call()` signature can infer args correctly for tests.
