### PR TITLE
simpl-schema: Fix support for oneOf, add support for simple array forms, add static validate function

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -148,13 +148,21 @@ interface SimpleSchemaValidationError {
 type IntegerSchema = "SimpleSchema.Integer";
 
 export type SimpleSchemaDefinition = {
-    [key: string]: SchemaDefinition
-      | BooleanConstructor | StringConstructor | NumberConstructor | DateConstructor
+    [key: string]:
+      | SchemaDefinition
+      | BooleanConstructor
+      | StringConstructor
+      | NumberConstructor
+      | DateConstructor
       | ArrayConstructor
       | IntegerSchema
-      | StringConstructor[] | NumberConstructor[] | IntegerSchema[]
-      | string | RegExp
-      | SimpleSchema
+      | [StringConstructor]
+      | [NumberConstructor]
+      | [IntegerSchema]
+      | [SimpleSchema]
+      | string
+      | RegExp
+      | SimpleSchema;
   } | any[];
 
 type SimpleSchemaCreateFunc = (options: { label: string; regExp: string }) => string;

--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -145,10 +145,14 @@ interface SimpleSchemaValidationError {
   [key: string]: number | string;
 }
 
+type IntegerSchema = "SimpleSchema.Integer";
+
 export type SimpleSchemaDefinition = {
     [key: string]: SchemaDefinition
       | BooleanConstructor | StringConstructor | NumberConstructor | DateConstructor
       | ArrayConstructor
+      | IntegerSchema
+      | StringConstructor[] | NumberConstructor[] | IntegerSchema[]
       | string | RegExp
       | SimpleSchema
   } | any[];
@@ -169,7 +173,7 @@ export class SimpleSchema {
   addValidator(validator: Validator): void;
   pick(...fields: string[]): SimpleSchema;
   omit(...fields: string[]): SimpleSchema;
-  oneOf(...types: Array<(SchemaDefinition | BooleanConstructor | StringConstructor | NumberConstructor | DateConstructor | ArrayConstructor)>): SimpleSchema;
+  static oneOf(...types: Array<(RegExp | SchemaDefinition | BooleanConstructor | StringConstructor | NumberConstructor | DateConstructor | ArrayConstructor | IntegerSchema)>): SimpleSchema;
   clean(doc: any, options?: CleanOption): any;
   schema(key: string): SchemaDefinition;
   schema(): SchemaDefinition[];
@@ -178,13 +182,14 @@ export class SimpleSchema {
   keyIsInBlackBox(key: string): boolean;
   labels(labels: { [key: string]: string }): void;
   label(key: any): any;
-  static Integer: RegExp;
+  static Integer: IntegerSchema;
   messages(messages: any): any;
   messageForError(type: any, key: any, def: any, value: any): string;
   allowsKey(key: any): string;
   newContext(): ValidationContext;
   objectKeys(keyPrefix?: any): any[];
   validate(obj: any, options?: ValidationOption): void;
+  static validate(obj: any, schema: SimpleSchema, options?: ValidationOption): void;
   validator(options?: ValidationOption): (obj: any) => boolean;
   extend(otherSchema: SimpleSchema | SimpleSchemaDefinition): SimpleSchema;
   static extendOptions(options: ReadonlyArray<string>): void;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -132,6 +132,7 @@ new SimpleSchema({
     arrayOfString: [String],
     arrayOfNumber: [Number],
     arrayOfInteger: [SimpleSchema.Integer],
+    arrayOfSchema: [StringSchema],
     oneOfTest: SimpleSchema.oneOf(String, SimpleSchema.Integer, Number, Boolean, /regextest/),
     subSchema: StringSchemaWithOptions
 });

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -67,11 +67,22 @@ const schema: SimpleSchemaDefinition = {
 
 const StringSchema = new SimpleSchema(schema);
 
-StringSchema.validate({
+const testData = {
     basicString: 'Test',
     limitedString: 'pro',
     regExpString: 'id',
-}, {keys: ['basicString']});
+};
+
+const testOptions = {keys: ['basicString']};
+
+StringSchema.validate(testData);
+
+StringSchema.validate(testData, testOptions);
+
+// Static versions
+SimpleSchema.validate(testData, StringSchema);
+
+SimpleSchema.validate(testData, StringSchema, testOptions);
 
 StringSchema.validator();
 
@@ -118,6 +129,10 @@ new SimpleSchema({
     shortInteger: SimpleSchema.Integer,
     shortDate: Date,
     shortArray: Array,
+    arrayOfString: [String],
+    arrayOfNumber: [Number],
+    arrayOfInteger: [SimpleSchema.Integer],
+    oneOfTest: SimpleSchema.oneOf(String, SimpleSchema.Integer, Number, Boolean, /regextest/),
     subSchema: StringSchemaWithOptions
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
oneOf is static: https://github.com/longshotlabs/simpl-schema#multiple-definitions-for-one-key
shorthand array forms: https://github.com/longshotlabs/simpl-schema#more-shorthand
static version of validate function: https://github.com/longshotlabs/simpl-schema#validating-and-throwing-validationerrors

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
