### PR TITLE
react-native-calendars: replace React.SFC -> React.FC 

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -190,7 +190,7 @@ export interface CalendarBaseProps {
     /**
      *  Provide custom day rendering component.
      */
-    dayComponent?: React.Component<DayComponentProps> | React.SFC<DayComponentProps>;
+    dayComponent?: React.Component<DayComponentProps> | React.FC<DayComponentProps>;
 
     /**
      *  Disable days by default. Default = false

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Text, View } from 'react-native';
 import { Calendar, CalendarList, Agenda } from 'react-native-calendars';
 
-declare const Arrow: React.SFC<unknown>;
+declare const Arrow: React.FC<unknown>;
 
 // this is copied directly from the documentation at https://github.com/wix/react-native-calendars#basic-parameters
 // and then linting errors are addressed which is why formatting is slightly inconsistent


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactjs.org/docs/hooks-intro.html>

Because React.SFC is deprecated, React.FC replace React.SFC.

