### PR TITLE
[react-dom] Add types for ReactDOM.flushSync

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -30,6 +30,9 @@ export const version: string;
 export const render: Renderer;
 export const hydrate: Renderer;
 
+export function flushSync<R>(fn: () => R): R;
+export function flushSync<A, R>(fn: (a: A) => R, a: A): R;
+
 export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
 export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
 export function unstable_batchedUpdates(callback: () => any): void;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -60,6 +60,21 @@ describe('ReactDOM', () => {
 
         ReactDOM.render(<ClassComponent />, rootElement);
     });
+
+    it('flushSync', () => {
+        // $ExpectType void
+        ReactDOM.flushSync(() => {});
+        // $ExpectType number
+        ReactDOM.flushSync(() => 42);
+        // $ExpectType number
+        ReactDOM.flushSync(() => 42, 'not used');
+        // $ExpectType number
+        ReactDOM.flushSync((a: string) => 42, 'not used');
+        // $ExpectError
+        ReactDOM.flushSync((a: string) => 42);
+        // $ExpectError
+        ReactDOM.flushSync((a: string) => 42, 100);
+    });
 });
 
 describe('ReactDOMServer', () => {

--- a/types/react-dom/v16/index.d.ts
+++ b/types/react-dom/v16/index.d.ts
@@ -30,6 +30,9 @@ export const version: string;
 export const render: Renderer;
 export const hydrate: Renderer;
 
+export function flushSync<R>(fn: () => R): R;
+export function flushSync<A, R>(fn: (a: A) => R, a: A): R;
+
 export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
 export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
 export function unstable_batchedUpdates(callback: () => any): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Export available in the ReactDOM: https://github.com/facebook/react/blob/553440bd1578ef71982c4a10e2cc8c462f33d9be/packages/react-dom/index.js#L15
Implementation (which lives in the `react-reconciler`): https://github.com/facebook/react/blob/553440bd1578ef71982c4a10e2cc8c462f33d9be/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L1249
