### PR TITLE
Revert "Use NoticeMessage type for pg.Client 'notice' event."

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -9,7 +9,6 @@
 import events = require('events');
 import stream = require('stream');
 import pgTypes = require('pg-types');
-import { NoticeMessage } from 'pg-protocol/dist/messages';
 
 import { ConnectionOptions } from 'tls';
 
@@ -249,8 +248,7 @@ export class ClientBase extends events.EventEmitter {
     escapeLiteral(str: string): string;
 
     on(event: 'drain', listener: () => void): this;
-    on(event: 'error', listener: (err: Error) => void): this;
-    on(event: 'notice', listener: (notice: NoticeMessage) => void): this;
+    on(event: 'error' | 'notice', listener: (err: Error) => void): this;
     on(event: 'notification', listener: (message: Notification) => void): this;
     // tslint:disable-next-line unified-signatures
     on(event: 'end', listener: () => void): this;

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "pg-types": "^2.2.0",
-        "pg-protocol": "^1.2.0"
+        "pg-types": "^2.2.0"
     }
 }

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -1,6 +1,5 @@
 import { types, Client, CustomTypesConfig, QueryArrayConfig, Pool } from 'pg';
 import TypeOverrides = require('pg/lib/type-overrides');
-import { NoticeMessage } from 'pg-protocol/dist/messages';
 
 // https://github.com/brianc/node-pg-types
 // tslint:disable-next-line no-unnecessary-callback-wrapper
@@ -22,7 +21,6 @@ const host: string = client.host;
 const password: string | undefined = client.password;
 const ssl: boolean = client.ssl;
 
-client.on('notice', (notice: NoticeMessage) => console.warn(`${notice.severity}: ${notice.message}`));
 client.connect(err => {
     if (err) {
         console.error('Could not connect to postgres', err);


### PR DESCRIPTION
Reverts #51183, which has caused problems for multiple users using `isolatedModules: true`, due to the const enum in `pg-protocol/lib/messages`.

Hopefully this can be revisited in the future, if `pg-protocol` can be changed to expose the message interfaces without breaking isolated module builds.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51183#issuecomment-781695508
https://github.com/brianc/node-postgres/pull/2473
