### PR TITLE
[leaflet-editable] Update to version 1.2

### DIFF
--- a/types/leaflet-editable/index.d.ts
+++ b/types/leaflet-editable/index.d.ts
@@ -518,7 +518,7 @@ declare module 'leaflet' {
         /**
          * Fired when a click is issued on a vertex without any special key and without being in drawing mode.
          */
-        'editable:vertex:rawclick'?: CancelableVertexEvent;
+        'editable:vertex:rawclick'?: CancelableVertexEventHandlerFn;
         /**
          * Fired after a vertex has been deleted by user.
          */
@@ -577,5 +577,16 @@ declare module 'leaflet' {
         'editable:shape:deleted'?: ShapeEventHandlerFn;
     }
 
-    // abstract class Evented extends Class {}
+    /*
+     * Extend Evented to add new events.
+     */
+    interface Evented {
+        on(type: 'editable:disable' | 'editable:drag' | 'editable:dragend' | 'editable:dragstart' | 'editable:drawing:cancel' | 'editable:drawing:clicked' | 'editable:drawing:commit' | 'editable:drawing:end' | 'editable:drawing:mousedown' | 'editable:drawing:mouseup' | 'editable:drawing:move' | 'editable:drawing:start' | 'editable:editing' | 'editable:enable', fn: LeafletEventHandlerFn, context?: any): this;
+        on(type: 'editable:drawing:click', fn: CancelableEventHandlerFn, context?: any): this;
+        on(type: 'editable:shape:delete', fn: CancelableShapeEventHandlerFn, context?: any): this;
+        on(type: 'editable:vertex:rawclick' | 'editable:vertex:click', fn: CancelableVertexEventHandlerFn, context?: any): this;
+        on(type: 'editable:created', fn: LayerEventHandlerFn, context?: any): this;
+        on(type: 'editable:shape:deleted' | 'editable:shape:new', fn: ShapeEventHandlerFn, context?: any): this;
+        on(type: 'editable:middlemarker:mousedown' | 'editable:vertex:altclick' | 'editable:vertex:clicked' | 'editable:vertex:contextmenu' | 'editable:vertex:ctrlclick' | 'editable:vertex:deleted' | 'editable:vertex:drag' | 'editable:vertex:dragend' | 'editable:vertex:dragstart' | 'editable:vertex:metakeyclick' | 'editable:vertex:mousedown' | 'editable:vertex:new' | 'editable:vertex:shiftclick', fn: VertexEventHandlerFn, context?: any): this;
+    }
 }

--- a/types/leaflet-editable/index.d.ts
+++ b/types/leaflet-editable/index.d.ts
@@ -1,12 +1,80 @@
-// Type definitions for Leaflet.Editable 0.7
+// Type definitions for Leaflet.Editable 1.2
 // Project: https://github.com/leaflet/leaflet.editable
 // Definitions by: Dominic Alie <https://github.com/dalie>
+//                 Eric Myllyoja <https://github.com/MasterEric>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 import * as Leaflet from 'leaflet';
 
 declare module 'leaflet' {
+    /*
+     * Leaflet.Editable add options and events to the `L.Map` object.
+     * See `Editable` events for the list of events fired on the Map.
+     */
+    interface Map {
+        /**
+         * Whether to create a L.Editable instance at map init or not.
+         */
+        editable: boolean;
+
+        /**
+         * Options to pass to L.Editable when instanciating.
+         */
+        editOptions: EditableOptions;
+
+        /**
+         * Edit tools instance.
+         */
+        editTools: Editable;
+    }
+
+    /**
+     * Add to the MapOptions.
+     */
+    interface MapOptions {
+        /**
+         * Whether to create a L.Editable instance at map init or not.
+         */
+        editable?: boolean;
+
+        /**
+         * Options to pass to L.Editable when instanciating.
+         */
+        editOptions?: EditableOptions;
+
+        /**
+         * Class to be used as vertex, for path editing.
+         */
+        editToolsClass?: object;
+    }
+
+    /**
+     * EditableMixin is included to L.Polyline, L.Polygon, L.Rectangle, L.Circle and L.Marker.
+     * It adds some methods to them.
+     */
+    interface EditableMixin {
+        /**
+         * Enable editing, by creating an editor if not existing, and then calling enable on it.
+         */
+        enableEdit(map?: Map): Editor;
+
+        /**
+         * Disable editing, also remove the editor property reference.
+         */
+        disableEdit(): void;
+
+        /**
+         * Enable or disable editing, according to current status.
+         */
+        toggleEdit(): void;
+
+        /**
+         * Return true if current instance has an editor attached, and this editor is enabled.
+         */
+        editEnabled(): boolean;
+    }
+
     /**
      * Make geometries editable in Leaflet.
      *
@@ -14,17 +82,17 @@ declare module 'leaflet' {
      * control editing of geometries. So you can easily build your own UI with your own needs and choices.
      */
     interface EditableStatic {
-        new (map: Map, options: EditOptions): Editable;
+        new (map: Map, options: EditableOptions): Editable;
     }
 
     /**
      * Options to pass to L.Editable when instanciating.
      */
-    interface EditOptions {
+    interface EditableOptions {
         /**
-         * Class to be used when creating a new Polyline.
+         * The default zIndex of the editing tools.
          */
-        polylineClass?: object;
+        zIndex?: number;
 
         /**
          * Class to be used when creating a new Polygon.
@@ -32,9 +100,24 @@ declare module 'leaflet' {
         polygonClass?: object;
 
         /**
+         * Class to be used when creating a new Polyline.
+         */
+        polylineClass?: object;
+
+        /**
          * Class to be used when creating a new Marker.
          */
         markerClass?: object;
+
+        /**
+         * Class to be used when creating a new Rectangle.
+         */
+        rectangleClass?: object;
+
+        /**
+         * Class to be used when creating a new Circle.
+         */
+        circleClass?: object;
 
         /**
          * CSS class to be added to the map container while drawing.
@@ -42,24 +125,19 @@ declare module 'leaflet' {
         drawingCSSClass?: string;
 
         /**
+         * Cursor mode set to the map while drawing.
+         */
+        drawingCursor?: string;
+
+        /**
          * Layer used to store edit tools (vertex, line guide…).
          */
-        editLayer?: LayerGroup<ILayer>;
+        editLayer?: LayerGroup<Layer>;
 
         /**
          * Default layer used to store drawn features (marker, polyline…).
          */
-        featuresLayer?: LayerGroup<Polyline|Polygon|Marker>;
-
-        /**
-         * Class to be used as vertex, for path editing.
-         */
-        vertexMarkerClass?: object;
-
-        /**
-         * Class to be used as middle vertex, pulled by the user to create a new point in the middle of a path.
-         */
-        middleMarkerClass?: object;
+        featuresLayer?: LayerGroup<Polyline | Polygon | Marker>;
 
         /**
          * Class to be used as Polyline editor.
@@ -75,6 +153,16 @@ declare module 'leaflet' {
          * Class to be used as Marker editor.
          */
         markerEditorClass?: object;
+
+        /**
+         * Class to be used as Rectangle editor.
+         */
+        rectangleEditorClass?: object;
+
+        /**
+         * Class to be used as Circle editor.
+         */
+        circleEditorClass?: object;
 
         /**
          * Options to be passed to the line guides.
@@ -93,13 +181,26 @@ declare module 'leaflet' {
      * This is not a plug and play UI, and will not. This is a minimal, lightweight, and fully extendable API to
      * control editing of geometries. So you can easily build your own UI with your own needs and choices.
      */
-    interface Editable extends Mixin.LeafletMixinEvents {
+    interface Editable extends Evented {
         /**
          * Options to pass to L.Editable when instanciating.
          */
-        options: EditOptions;
+        options: EditableOptions;
 
-        currentPolygon: Polyline|Polygon|Marker;
+        /**
+         * Return true if any drawing action is ongoing.
+         */
+        drawing(): boolean;
+
+        /**
+         * When you need to stop any ongoing drawing, without needing to know which editor is active.
+         */
+        stopDrawing(): void;
+
+        /**
+         * When you need to commit any ongoing drawing, without needing to know which editor is active.
+         */
+        commitDrawing(event: LeafletMouseEvent): void;
 
         /**
          * Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user
@@ -121,141 +222,185 @@ declare module 'leaflet' {
         startMarker(latLng?: LatLng, options?: MarkerOptions): Marker;
 
         /**
-         * When you need to stop any ongoing drawing, without needing to know which editor is active.
+         * Start drawing a Rectangle. If `latlng` is given, the Rectangle anchor will be added. In any case,
+         * continuing on user drag. If `options` is given, it will be passed to the Rectangle class constructor.
          */
-        stopDrawing(): void;
+        startRectangle(latLng?: LatLng, options?: PolylineOptions): Rectangle;
 
         /**
-         * When you need to commit any ongoing drawing, without needing to know which editor is active.
+         * Start drawing a Circle. If `latlng` is given, the Circle anchor will be added. In any case, continuing
+         * on user drag. If `options` is given, it will be passed to the Circle class constructor.
          */
-        commitDrawing(): void;
+        startCircle(latLng?: LatLng, options?: CircleMarkerOptions): Circle;
     }
 
     let Editable: EditableStatic;
 
-    /**
-     * EditableMixin is included to L.Polyline, L.Polygon and L.Marker. It adds the following methods to them.
-     *
-     * When editing is enabled, the editor is accessible on the instance with the editor property.
-     */
-    interface EditableMixin {
-        /**
-         * Enable editing, by creating an editor if not existing, and then calling enable on it.
-         */
-        enableEdit(): any;
-
-        /**
-         * Disable editing, also remove the editor property reference.
-         */
-        disableEdit(): void;
-
-        /**
-         * Enable or disable editing, according to current status.
-         */
-        toggleEdit(): void;
-
-        /**
-         * Return true if current instance has an editor attached, and this editor is enabled.
-         */
-        editEnabled(): boolean;
-    }
-
-    interface Map {
-        /**
-         * Whether to create a L.Editable instance at map init or not.
-         */
-        editable: boolean;
-
-        /**
-         * Options to pass to L.Editable when instanciating.
-         */
-        editOptions: EditOptions;
-
-        /**
-         * L.Editable plugin instance.
-         */
-        editTools: Editable;
-    }
-
-    // tslint:disable-next-line:no-empty-interface
-    interface Polyline extends EditableMixin {}
-
-    namespace Map {
-        interface MapOptions {
-            /**
-             * Whether to create a L.Editable instance at map init or not.
-             */
-            editable?: boolean;
-
-            /**
-             * Options to pass to L.Editable when instanciating.
-             */
-            editOptions?: EditOptions;
-        }
-    }
+    type Editor = MarkerEditor | PolylineEditor | PolygonEditor | RectangleEditor | CircleEditor;
 
     /**
-     * When editing a feature (marker, polyline…), an editor is attached to it. This editor basically knows
-     * how to handle the edition.
+     * When editing a feature (marker, polyline…), an editor is attached to it.
+     * This editor basically knows how to handle the edition.
      */
     interface BaseEditor {
         /**
          * Set up the drawing tools for the feature to be editable.
          */
-        enable(): MarkerEditor|PolylineEditor|PolygonEditor;
+        enable(): Editor;
 
         /**
          * Remove editing tools.
          */
-        disable(): MarkerEditor|PolylineEditor|PolygonEditor;
+        disable(): Editor;
+
+        /**
+         * Return true if any drawing action is ongoing with this editor.
+         */
+        drawing(): boolean;
     }
 
     /**
-     * Inherit from L.Editable.BaseEditor.
-     * Inherited by L.Editable.PolylineEditor and L.Editable.PolygonEditor.
+     * Editor for Marker.
+     */
+    // tslint:disable-next-line:no-empty-interface
+    interface MarkerEditor extends BaseEditor {}
+
+    /**
+     * Base class for all path editors.
      */
     interface PathEditor extends BaseEditor {
         /**
-         * Rebuild edit elements (vertex, middlemarker, etc.).
+         * Rebuild edit elements (Vertex, MiddleMarker, etc.).
          */
         reset(): void;
+
+        /**
+         * Programmatically add a point while drawing.
+         */
+        push(): void;
+
+        /**
+         * Programmatically remove last point (if any) while drawing.
+         */
+        pop(): LatLng | null;
+
+        /**
+         * Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
+         * if optional latlng is given, start a path at this point.
+         */
+        newShape(latLng?: LatLng): void;
+
+        /**
+         * Remove a path shape at the given latlng.
+         */
+        deleteShapeAt(latLng?: LatLng): LatLng[];
+
+        /**
+         * Append a new shape to the Polygon or Polyline.
+         */
+        appendShape(shape: LatLng[]): void;
+
+        /**
+         * Prepend a new shape to the Polygon or Polyline.
+         */
+        prependShape(shape: LatLng[]): void;
+
+        /**
+         * Insert a new shape to the Polygon or Polyline at given index (default is to append).
+         */
+        insertShape(shape: LatLng[], index: number): void;
     }
 
     /**
-     * Inherit from L.Editable.PathEditor.
+     * Editor for Polyline.
      */
     interface PolylineEditor extends PathEditor {
         /**
          * Set up drawing tools to continue the line forward.
          */
-        continueForward(): void;
+        continueForward(latLngs?: LatLng[]): void;
 
         /**
          * Set up drawing tools to continue the line backward.
          */
-        continueBackward(): void;
+        continueBackward(latLngs?: LatLng[]): void;
+
+        /**
+         * Split the given latlngs shape at index index and integrate new shape in instance latlngs.
+         */
+        splitShape(latLngs: LatLng[], index: number): void;
     }
 
     /**
-     * Inherit from L.Editable.PathEditor.
+     * Editor for Polygon.
      */
     interface PolygonEditor extends PathEditor {
         /**
-         * Set up drawing tools for creating a new hole on the polygon. If the latlng param is given, a first
-         * point is created.
+         * Set up drawing tools for creating a new hole on the polygon.
+         * If the latlng param is given, a first point is created.
+         *
+         * Despite being described in the documentation,
+         *   the index parameter is not specified in the method signature.
          */
-        newHole(latlng: LatLng): void;
+        newHole(latlng?: LatLng): void;
     }
 
     /**
-     * Inherit from L.Editable.BaseEditor.
+     * Editor for Rectangle.
      */
     // tslint:disable-next-line:no-empty-interface
-    interface MarkerEditor extends BaseEditor {}
+    interface RectangleEditor extends PathEditor {}
+
+    /**
+     * Editor for Circle.
+     */
+    // tslint:disable-next-line:no-empty-interface
+    interface CircleEditor extends PathEditor {}
+
+    /**
+     * Handler for dragging path vertices.
+     */
+    interface VertexMarker extends Marker {
+        /**
+         * Delete a vertex and the related LatLng.
+         */
+        delete(): void;
+
+        /**
+         * Get the index of the current vertex among others of the same LatLngs group.
+         */
+        getIndex(): number;
+
+        /**
+         * Get last vertex index of the LatLngs group of the current vertex.
+         */
+        getLastIndex(): number;
+
+        /**
+         * Get the previous VertexMarker in the same LatLngs group.
+         */
+        getPrevious(): VertexMarker;
+
+        /**
+         * Get the next VertexMarker in the same LatLngs group.
+         */
+        getNext(): VertexMarker;
+
+        /**
+         * Split the vertex LatLngs group at its index, if possible.
+         */
+        split(): void;
+
+        /**
+         * Continue the vertex LatLngs from this vertex.
+         * Only active for first and last vertices of a Polyline.
+         */
+        continue(): void;
+    }
 
     interface Marker extends EditableMixin, MarkerEditor {}
-
     interface Polyline extends EditableMixin, PolylineEditor {}
-
     interface Polygon extends EditableMixin, PolygonEditor {}
+    interface Rectangle extends EditableMixin, RectangleEditor {}
+    interface Circle extends EditableMixin, CircleEditor {}
 }

--- a/types/leaflet-editable/index.d.ts
+++ b/types/leaflet-editable/index.d.ts
@@ -581,12 +581,51 @@ declare module 'leaflet' {
      * Extend Evented to add new events.
      */
     interface Evented {
-        on(type: 'editable:disable' | 'editable:drag' | 'editable:dragend' | 'editable:dragstart' | 'editable:drawing:cancel' | 'editable:drawing:clicked' | 'editable:drawing:commit' | 'editable:drawing:end' | 'editable:drawing:mousedown' | 'editable:drawing:mouseup' | 'editable:drawing:move' | 'editable:drawing:start' | 'editable:editing' | 'editable:enable', fn: LeafletEventHandlerFn, context?: any): this;
+        on(
+            type:
+                | 'editable:disable'
+                | 'editable:drag'
+                | 'editable:dragend'
+                | 'editable:dragstart'
+                | 'editable:drawing:cancel'
+                | 'editable:drawing:clicked'
+                | 'editable:drawing:commit'
+                | 'editable:drawing:end'
+                | 'editable:drawing:mousedown'
+                | 'editable:drawing:mouseup'
+                | 'editable:drawing:move'
+                | 'editable:drawing:start'
+                | 'editable:editing'
+                | 'editable:enable',
+            fn: LeafletEventHandlerFn,
+            context?: any,
+        ): this;
         on(type: 'editable:drawing:click', fn: CancelableEventHandlerFn, context?: any): this;
         on(type: 'editable:shape:delete', fn: CancelableShapeEventHandlerFn, context?: any): this;
-        on(type: 'editable:vertex:rawclick' | 'editable:vertex:click', fn: CancelableVertexEventHandlerFn, context?: any): this;
+        on(
+            type: 'editable:vertex:rawclick' | 'editable:vertex:click',
+            fn: CancelableVertexEventHandlerFn,
+            context?: any,
+        ): this;
         on(type: 'editable:created', fn: LayerEventHandlerFn, context?: any): this;
         on(type: 'editable:shape:deleted' | 'editable:shape:new', fn: ShapeEventHandlerFn, context?: any): this;
-        on(type: 'editable:middlemarker:mousedown' | 'editable:vertex:altclick' | 'editable:vertex:clicked' | 'editable:vertex:contextmenu' | 'editable:vertex:ctrlclick' | 'editable:vertex:deleted' | 'editable:vertex:drag' | 'editable:vertex:dragend' | 'editable:vertex:dragstart' | 'editable:vertex:metakeyclick' | 'editable:vertex:mousedown' | 'editable:vertex:new' | 'editable:vertex:shiftclick', fn: VertexEventHandlerFn, context?: any): this;
+        on(
+            type:
+                | 'editable:middlemarker:mousedown'
+                | 'editable:vertex:altclick'
+                | 'editable:vertex:clicked'
+                | 'editable:vertex:contextmenu'
+                | 'editable:vertex:ctrlclick'
+                | 'editable:vertex:deleted'
+                | 'editable:vertex:drag'
+                | 'editable:vertex:dragend'
+                | 'editable:vertex:dragstart'
+                | 'editable:vertex:metakeyclick'
+                | 'editable:vertex:mousedown'
+                | 'editable:vertex:new'
+                | 'editable:vertex:shiftclick',
+            fn: VertexEventHandlerFn,
+            context?: any,
+        ): this;
     }
 }

--- a/types/leaflet-editable/index.d.ts
+++ b/types/leaflet-editable/index.d.ts
@@ -403,4 +403,179 @@ declare module 'leaflet' {
     interface Polygon extends EditableMixin, PolygonEditor {}
     interface Rectangle extends EditableMixin, RectangleEditor {}
     interface Circle extends EditableMixin, CircleEditor {}
+
+    interface CancelableEvent extends LeafletEvent {
+        /**
+         * Cancel any subsequent action.
+         */
+        cancel(): void;
+    }
+    interface VertexEvent extends LeafletEvent {
+        /**
+         * The vertex that fired the event.
+         */
+        vertex: VertexMarker;
+    }
+    interface ShapeEvent extends LeafletEvent {
+        /**
+         * The shape (LatLngs array) subject of the action.
+         */
+        shape: LatLng[];
+    }
+    interface CancelableVertexEvent extends CancelableEvent, VertexEvent {}
+    interface CancelableShapeEvent extends CancelableEvent, ShapeEvent {}
+
+    /**
+     * Custom event handler functions.
+     */
+    type VertexEventHandlerFn = (event: VertexEvent) => void;
+    type ShapeEventHandlerFn = (event: ShapeEvent) => void;
+    type CancelableEventHandlerFn = (event: CancelableEvent) => void;
+    type CancelableVertexEventHandlerFn = (event: CancelableVertexEvent) => void;
+    type CancelableShapeEventHandlerFn = (event: CancelableShapeEvent) => void;
+
+    /**
+     * Extend the existing event handler function map,
+     * to include
+     */
+    interface LeafletEventHandlerFnMap {
+        /**
+         * Fired when a new feature (Marker, Polyline…) is created.
+         */
+        'editable:created'?: LayerEventHandlerFn;
+        /**
+         * Fired when an existing feature is ready to be edited.
+         */
+        'editable:enable'?: LeafletEventHandlerFn;
+        /**
+         * Fired when an existing feature is not ready anymore to be edited.
+         */
+        'editable:disable'?: LeafletEventHandlerFn;
+        /**
+         * Fired as soon as any change is made to the feature geometry.
+         */
+        'editable:editing'?: LeafletEventHandlerFn;
+        /**
+         * Fired before a path feature is dragged.
+         */
+        'editable:dragstart'?: LeafletEventHandlerFn;
+        /**
+         * Fired when a path feature is being dragged.
+         */
+        'editable:drag'?: LeafletEventHandlerFn;
+        /**
+         * Fired after a path feature has been dragged.
+         */
+        'editable:dragend'?: LeafletEventHandlerFn;
+        /**
+         * Fired when a feature is to be drawn.
+         */
+        'editable:drawing:start'?: LeafletEventHandlerFn;
+        /**
+         * Fired when a feature is not drawn anymore.
+         */
+        'editable:drawing:end'?: LeafletEventHandlerFn;
+        /**
+         * Fired when user cancel drawing while a feature is being drawn.
+         */
+        'editable:drawing:cancel'?: LeafletEventHandlerFn;
+        /**
+         * Fired when user finish drawing a feature.
+         */
+        'editable:drawing:commit'?: LeafletEventHandlerFn;
+        /**
+         * Fired when user mousedown while drawing.
+         */
+        'editable:drawing:mousedown'?: LeafletEventHandlerFn;
+        /**
+         * Fired when user mouseup while drawing.
+         */
+        'editable:drawing:mouseup'?: LeafletEventHandlerFn;
+        /**
+         * Fired when user click while drawing, before any internal action is being processed.
+         */
+        'editable:drawing:click'?: CancelableEventHandlerFn;
+        /**
+         * Fired when move mouse while drawing, while dragging a marker, and while dragging a vertex.
+         */
+        'editable:drawing:move'?: LeafletEventHandlerFn;
+        /**
+         * Fired when user click while drawing, after all internal actions.
+         */
+        'editable:drawing:clicked'?: LeafletEventHandlerFn;
+        /**
+         * Fired when a new vertex is created.
+         */
+        'editable:vertex:new'?: VertexEventHandlerFn;
+        /**
+         * Fired when a click is issued on a vertex, before any internal action is being processed.
+         */
+        'editable:vertex:click'?: CancelableVertexEventHandlerFn;
+        /**
+         * Fired when a click is issued on a vertex, after all internal actions.
+         */
+        'editable:vertex:clicked'?: VertexEventHandlerFn;
+        /**
+         * Fired when a click is issued on a vertex without any special key and without being in drawing mode.
+         */
+        'editable:vertex:rawclick'?: CancelableVertexEvent;
+        /**
+         * Fired after a vertex has been deleted by user.
+         */
+        'editable:vertex:deleted'?: VertexEventHandlerFn;
+        /**
+         * Fired when a click with ctrlKey is issued on a vertex.
+         */
+        'editable:vertex:ctrlclick'?: VertexEventHandlerFn;
+        /**
+         * Fired when a click with shiftKey is issued on a vertex.
+         */
+        'editable:vertex:shiftclick'?: VertexEventHandlerFn;
+        /**
+         * Fired when a click with metaKey is issued on a vertex.
+         */
+        'editable:vertex:metakeyclick'?: VertexEventHandlerFn;
+        /**
+         * Fired when a click with altKey is issued on a vertex.
+         */
+        'editable:vertex:altclick'?: VertexEventHandlerFn;
+        /**
+         * Fired when a contextmenu is issued on a vertex.
+         */
+        'editable:vertex:contextmenu'?: VertexEventHandlerFn;
+        /**
+         * Fired when user mousedown a vertex.
+         */
+        'editable:vertex:mousedown'?: VertexEventHandlerFn;
+        /**
+         * Fired when a vertex is dragged by user.
+         */
+        'editable:vertex:drag'?: VertexEventHandlerFn;
+        /**
+         * Fired before a vertex is dragged by user.
+         */
+        'editable:vertex:dragstart'?: VertexEventHandlerFn;
+        /**
+         * Fired after a vertex is dragged by user.
+         */
+        'editable:vertex:dragend'?: VertexEventHandlerFn;
+        /**
+         * Fired when user mousedown a middle marker.
+         */
+        'editable:middlemarker:mousedown'?: VertexEventHandlerFn;
+        /**
+         * Fired when a new shape is created in a multi (Polygon or Polyline).
+         */
+        'editable:shape:new'?: ShapeEventHandlerFn;
+        /**
+         * Fired before a new shape is deleted in a multi (Polygon or Polyline).
+         */
+        'editable:shape:delete'?: CancelableShapeEventHandlerFn;
+        /**
+         * Fired after a new shape is deleted in a multi (Polygon or Polyline).
+         */
+        'editable:shape:deleted'?: ShapeEventHandlerFn;
+    }
+
+    // abstract class Evented extends Class {}
 }

--- a/types/leaflet-editable/leaflet-editable-tests.ts
+++ b/types/leaflet-editable/leaflet-editable-tests.ts
@@ -1,59 +1,147 @@
 import * as L from 'leaflet';
 import 'leaflet-editable';
 
-class MarkerClass { }
-class MarkerEditorClass { }
-class MiddleMarkerClass { }
-class PolygonClass { }
-class PolygonEditorClass { }
-class PolylineClass { }
-class PolylineEditorClass { }
-class VertexMarkerClass { }
+class PolygonClass {}
+class PolylineClass {}
+class MarkerClass {}
+class RectangleClass {}
+class CircleClass {}
+class EditToolsClass {}
+class PolygonEditorClass {}
+class PolylineEditorClass {}
+class MarkerEditorClass {}
+class RectangleEditorClass {}
+class CircleEditorClass {}
 
 const map: L.Map = L.map('div', {
     editable: true,
     editOptions: {
-        drawingCSSClass: 'css-class',
-        editLayer: L.layerGroup(),
-        featuresLayer: L.layerGroup<L.Marker|L.Polyline|L.Polygon>(),
-        lineGuideOptions: {},
-        markerClass: MarkerClass,
-        markerEditorClass: MarkerEditorClass,
-        middleMarkerClass: MiddleMarkerClass,
+        zIndex: 1500,
         polygonClass: PolygonClass,
-        polygonEditorClass: PolygonEditorClass,
         polylineClass: PolylineClass,
+        markerClass: MarkerClass,
+        rectangleClass: RectangleClass,
+        circleClass: CircleClass,
+        drawingCSSClass: 'css-class',
+        drawingCursor: 'pointer',
+        editLayer: L.layerGroup(),
+        featuresLayer: L.layerGroup(),
+        polygonEditorClass: PolygonEditorClass,
         polylineEditorClass: PolylineEditorClass,
+        markerEditorClass: MarkerEditorClass,
+        rectangleEditorClass: RectangleEditorClass,
+        circleEditorClass: CircleEditorClass,
+        lineGuideOptions: { option: true },
         skipMiddleMarkers: true,
-        vertexMarkerClass: VertexMarkerClass
-    }
+    },
+    editToolsClass: EditToolsClass,
 });
 
-const currentPoly: L.Polygon|L.Polyline| L.Marker = map.editTools.currentPolygon;
-map.editTools.stopDrawing();
-map.editTools.commitDrawing();
+const line = L.polyline([
+    [43.1292, 1.256],
+    [43.1295, 1.259],
+    [43.1291, 1.261],
+]).addTo(map);
+line.enableEdit();
+line.on('dblclick', L.DomEvent.stop).on('dblclick', line.toggleEdit);
 
-const marker: L.Marker = map.editTools.startMarker(L.latLng(0, 0), { draggable: true });
-marker.disable();
-marker.enable();
-marker.toggleEdit();
-let enabled: boolean = marker.editEnabled();
+const multi = L.polygon([
+    [
+        [
+            [43.1239, 1.244],
+            [43.123, 1.253],
+            [43.1252, 1.255],
+            [43.125, 1.251],
+            [43.1239, 1.244],
+        ],
+        [
+            [43.124, 1.246],
+            [43.1236, 1.248],
+            [43.12475, 1.25],
+        ],
+        [
+            [43.124, 1.251],
+            [43.1236, 1.253],
+            [43.12475, 1.254],
+        ],
+    ],
+    [
+        [
+            [43.1269, 1.246],
+            [43.126, 1.252],
+            [43.1282, 1.255],
+            [43.128, 1.245],
+        ],
+    ],
+]).addTo(map);
+multi.enableEdit();
+multi.on('dblclick', L.DomEvent.stop).on('dblclick', multi.toggleEdit);
+multi.bindPopup('hi!');
 
-const polyline: L.Polyline = map.editTools.startPolyline(L.latLng(0, 0), { noClip: true });
-polyline.continueBackward();
-polyline.continueForward();
-polyline.disable();
-polyline.enable();
-enabled = polyline.editEnabled();
-polyline.reset();
-polyline.toggleEdit();
+const poly = L.polygon([
+    [
+        [43.1239, 1.259],
+        [43.123, 1.263],
+        [43.1252, 1.265],
+        [43.125, 1.261],
+    ],
+    [
+        [43.124, 1.263],
+        [43.1236, 1.261],
+        [43.12475, 1.262],
+    ],
+]).addTo(map);
+poly.enableEdit();
+poly.on('dblclick', L.DomEvent.stop).on('dblclick', poly.toggleEdit);
 
-const polygon: L.Polygon = map.editTools.startPolygon(L.latLng(0, 0), { noClip: true });
-polygon.continueBackward();
-polygon.continueForward();
-polygon.disable();
-polygon.enable();
-enabled = polygon.editEnabled();
-polygon.newHole(L.latLng(0, 0));
-polygon.reset();
-polygon.toggleEdit();
+const rectangle = L.rectangle([
+    [43.1235, 1.255],
+    [43.1215, 1.259],
+]).addTo(map);
+rectangle.enableEdit();
+rectangle.on('dblclick', L.DomEvent.stop).on('dblclick', rectangle.toggleEdit);
+
+const circle = L.circle([43.122, 1.25], { radius: 100 }).addTo(map);
+circle.enableEdit();
+circle.on('dblclick', L.DomEvent.stop).on('dblclick', circle.toggleEdit);
+
+const newMarker = map.editTools.startMarker();
+newMarker.enable();
+newMarker.disable();
+const newMarkerDrawing: boolean = newMarker.drawing();
+
+const newPolyline = map.editTools.startPolyline();
+newPolyline.enable();
+newPolyline.disable();
+const newPolylineDrawing: boolean = newPolyline.drawing();
+newPolyline.continueForward([L.latLng(43.124, 1.263), L.latLng(43.1236, 1.261), L.latLng(43.12475, 1.262)]);
+newPolyline.continueBackward([
+    L.latLng(43.124, 1.263),
+    L.latLng(43.1236, 1.261),
+    L.latLng(43.12475, 1.262),
+]);
+newPolyline.splitShape([L.latLng(43.124, 1.263), L.latLng(43.1236, 1.261), L.latLng(43.12475, 1.262)], 2);
+
+const newPolygon = map.editTools.startPolygon();
+newPolygon.enable();
+newPolygon.disable();
+const newPolygonDrawing: boolean = newPolygon.drawing();
+newPolygon.continueForward([L.latLng(43.124, 1.263), L.latLng(43.1236, 1.261), L.latLng(43.12475, 1.262)]);
+newPolygon.continueBackward([
+    L.latLng(43.124, 1.263),
+    L.latLng(43.1236, 1.261),
+    L.latLng(43.12475, 1.262),
+]);
+newPolygon.splitShape([L.latLng(43.124, 1.263), L.latLng(43.1236, 1.261), L.latLng(43.12475, 1.262)], 2);
+newPolygon.newHole(L.latLng(0, 17));
+
+const newRectangle = map.editTools.startRectangle();
+newRectangle.enable();
+newRectangle.disable();
+const newRectangleDrawing: boolean = newRectangle.drawing();
+newRectangle.splitShape([L.latLng(43.124, 1.263), L.latLng(43.1236, 1.261), L.latLng(43.12475, 1.262)], 2);
+
+const newCircle = map.editTools.startCircle();
+newCircle.enable();
+newCircle.disable();
+const newCircleDrawing: boolean = newCircle.drawing();

--- a/types/leaflet-editable/v0/index.d.ts
+++ b/types/leaflet-editable/v0/index.d.ts
@@ -1,0 +1,261 @@
+// Type definitions for Leaflet.Editable 0.7
+// Project: https://github.com/leaflet/leaflet.editable
+// Definitions by: Dominic Alie <https://github.com/dalie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as Leaflet from 'leaflet';
+
+declare module 'leaflet' {
+    /**
+     * Make geometries editable in Leaflet.
+     *
+     * This is not a plug and play UI, and will not. This is a minimal, lightweight, and fully extendable API to
+     * control editing of geometries. So you can easily build your own UI with your own needs and choices.
+     */
+    interface EditableStatic {
+        new (map: Map, options: EditOptions): Editable;
+    }
+
+    /**
+     * Options to pass to L.Editable when instanciating.
+     */
+    interface EditOptions {
+        /**
+         * Class to be used when creating a new Polyline.
+         */
+        polylineClass?: object;
+
+        /**
+         * Class to be used when creating a new Polygon.
+         */
+        polygonClass?: object;
+
+        /**
+         * Class to be used when creating a new Marker.
+         */
+        markerClass?: object;
+
+        /**
+         * CSS class to be added to the map container while drawing.
+         */
+        drawingCSSClass?: string;
+
+        /**
+         * Layer used to store edit tools (vertex, line guide…).
+         */
+        editLayer?: LayerGroup<ILayer>;
+
+        /**
+         * Default layer used to store drawn features (marker, polyline…).
+         */
+        featuresLayer?: LayerGroup<Polyline|Polygon|Marker>;
+
+        /**
+         * Class to be used as vertex, for path editing.
+         */
+        vertexMarkerClass?: object;
+
+        /**
+         * Class to be used as middle vertex, pulled by the user to create a new point in the middle of a path.
+         */
+        middleMarkerClass?: object;
+
+        /**
+         * Class to be used as Polyline editor.
+         */
+        polylineEditorClass?: object;
+
+        /**
+         * Class to be used as Polygon editor.
+         */
+        polygonEditorClass?: object;
+
+        /**
+         * Class to be used as Marker editor.
+         */
+        markerEditorClass?: object;
+
+        /**
+         * Options to be passed to the line guides.
+         */
+        lineGuideOptions?: object;
+
+        /**
+         * Set this to true if you don't want middle markers.
+         */
+        skipMiddleMarkers?: boolean;
+    }
+
+    /**
+     * Make geometries editable in Leaflet.
+     *
+     * This is not a plug and play UI, and will not. This is a minimal, lightweight, and fully extendable API to
+     * control editing of geometries. So you can easily build your own UI with your own needs and choices.
+     */
+    interface Editable extends Mixin.LeafletMixinEvents {
+        /**
+         * Options to pass to L.Editable when instanciating.
+         */
+        options: EditOptions;
+
+        currentPolygon: Polyline|Polygon|Marker;
+
+        /**
+         * Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user
+         * click. If options is given, it will be passed to the polyline class constructor.
+         */
+        startPolyline(latLng?: LatLng, options?: PolylineOptions): Polyline;
+
+        /**
+         * Start drawing a polygon. If latlng is given, a first point will be added. In any case, continuing on user
+         * click. If options is given, it will be passed to the polygon class constructor.
+         */
+        startPolygon(latLng?: LatLng, options?: PolylineOptions): Polygon;
+
+        /**
+         * Start adding a marker. If latlng is given, the marker will be shown first at this point. In any case, it
+         * will follow the user mouse, and will have a final latlng on next click (or touch). If options is given,
+         * it will be passed to the marker class constructor.
+         */
+        startMarker(latLng?: LatLng, options?: MarkerOptions): Marker;
+
+        /**
+         * When you need to stop any ongoing drawing, without needing to know which editor is active.
+         */
+        stopDrawing(): void;
+
+        /**
+         * When you need to commit any ongoing drawing, without needing to know which editor is active.
+         */
+        commitDrawing(): void;
+    }
+
+    let Editable: EditableStatic;
+
+    /**
+     * EditableMixin is included to L.Polyline, L.Polygon and L.Marker. It adds the following methods to them.
+     *
+     * When editing is enabled, the editor is accessible on the instance with the editor property.
+     */
+    interface EditableMixin {
+        /**
+         * Enable editing, by creating an editor if not existing, and then calling enable on it.
+         */
+        enableEdit(): any;
+
+        /**
+         * Disable editing, also remove the editor property reference.
+         */
+        disableEdit(): void;
+
+        /**
+         * Enable or disable editing, according to current status.
+         */
+        toggleEdit(): void;
+
+        /**
+         * Return true if current instance has an editor attached, and this editor is enabled.
+         */
+        editEnabled(): boolean;
+    }
+
+    interface Map {
+        /**
+         * Whether to create a L.Editable instance at map init or not.
+         */
+        editable: boolean;
+
+        /**
+         * Options to pass to L.Editable when instanciating.
+         */
+        editOptions: EditOptions;
+
+        /**
+         * L.Editable plugin instance.
+         */
+        editTools: Editable;
+    }
+
+    // tslint:disable-next-line:no-empty-interface
+    interface Polyline extends EditableMixin {}
+
+    namespace Map {
+        interface MapOptions {
+            /**
+             * Whether to create a L.Editable instance at map init or not.
+             */
+            editable?: boolean;
+
+            /**
+             * Options to pass to L.Editable when instanciating.
+             */
+            editOptions?: EditOptions;
+        }
+    }
+
+    /**
+     * When editing a feature (marker, polyline…), an editor is attached to it. This editor basically knows
+     * how to handle the edition.
+     */
+    interface BaseEditor {
+        /**
+         * Set up the drawing tools for the feature to be editable.
+         */
+        enable(): MarkerEditor|PolylineEditor|PolygonEditor;
+
+        /**
+         * Remove editing tools.
+         */
+        disable(): MarkerEditor|PolylineEditor|PolygonEditor;
+    }
+
+    /**
+     * Inherit from L.Editable.BaseEditor.
+     * Inherited by L.Editable.PolylineEditor and L.Editable.PolygonEditor.
+     */
+    interface PathEditor extends BaseEditor {
+        /**
+         * Rebuild edit elements (vertex, middlemarker, etc.).
+         */
+        reset(): void;
+    }
+
+    /**
+     * Inherit from L.Editable.PathEditor.
+     */
+    interface PolylineEditor extends PathEditor {
+        /**
+         * Set up drawing tools to continue the line forward.
+         */
+        continueForward(): void;
+
+        /**
+         * Set up drawing tools to continue the line backward.
+         */
+        continueBackward(): void;
+    }
+
+    /**
+     * Inherit from L.Editable.PathEditor.
+     */
+    interface PolygonEditor extends PathEditor {
+        /**
+         * Set up drawing tools for creating a new hole on the polygon. If the latlng param is given, a first
+         * point is created.
+         */
+        newHole(latlng: LatLng): void;
+    }
+
+    /**
+     * Inherit from L.Editable.BaseEditor.
+     */
+    // tslint:disable-next-line:no-empty-interface
+    interface MarkerEditor extends BaseEditor {}
+
+    interface Marker extends EditableMixin, MarkerEditor {}
+
+    interface Polyline extends EditableMixin, PolylineEditor {}
+
+    interface Polygon extends EditableMixin, PolygonEditor {}
+}

--- a/types/leaflet-editable/v0/index.d.ts
+++ b/types/leaflet-editable/v0/index.d.ts
@@ -49,7 +49,7 @@ declare module 'leaflet' {
         /**
          * Default layer used to store drawn features (marker, polyline…).
          */
-        featuresLayer?: LayerGroup<Polyline|Polygon|Marker>;
+        featuresLayer?: LayerGroup<Polyline | Polygon | Marker>;
 
         /**
          * Class to be used as vertex, for path editing.
@@ -99,7 +99,7 @@ declare module 'leaflet' {
          */
         options: EditOptions;
 
-        currentPolygon: Polyline|Polygon|Marker;
+        currentPolygon: Polyline | Polygon | Marker;
 
         /**
          * Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user
@@ -202,12 +202,12 @@ declare module 'leaflet' {
         /**
          * Set up the drawing tools for the feature to be editable.
          */
-        enable(): MarkerEditor|PolylineEditor|PolygonEditor;
+        enable(): MarkerEditor | PolylineEditor | PolygonEditor;
 
         /**
          * Remove editing tools.
          */
-        disable(): MarkerEditor|PolylineEditor|PolygonEditor;
+        disable(): MarkerEditor | PolylineEditor | PolygonEditor;
     }
 
     /**

--- a/types/leaflet-editable/v0/leaflet-editable-tests.ts
+++ b/types/leaflet-editable/v0/leaflet-editable-tests.ts
@@ -1,0 +1,59 @@
+import * as L from 'leaflet';
+import 'leaflet-editable';
+
+class MarkerClass { }
+class MarkerEditorClass { }
+class MiddleMarkerClass { }
+class PolygonClass { }
+class PolygonEditorClass { }
+class PolylineClass { }
+class PolylineEditorClass { }
+class VertexMarkerClass { }
+
+const map: L.Map = L.map('div', {
+    editable: true,
+    editOptions: {
+        drawingCSSClass: 'css-class',
+        editLayer: L.layerGroup(),
+        featuresLayer: L.layerGroup<L.Marker|L.Polyline|L.Polygon>(),
+        lineGuideOptions: {},
+        markerClass: MarkerClass,
+        markerEditorClass: MarkerEditorClass,
+        middleMarkerClass: MiddleMarkerClass,
+        polygonClass: PolygonClass,
+        polygonEditorClass: PolygonEditorClass,
+        polylineClass: PolylineClass,
+        polylineEditorClass: PolylineEditorClass,
+        skipMiddleMarkers: true,
+        vertexMarkerClass: VertexMarkerClass
+    }
+});
+
+const currentPoly: L.Polygon|L.Polyline| L.Marker = map.editTools.currentPolygon;
+map.editTools.stopDrawing();
+map.editTools.commitDrawing();
+
+const marker: L.Marker = map.editTools.startMarker(L.latLng(0, 0), { draggable: true });
+marker.disable();
+marker.enable();
+marker.toggleEdit();
+let enabled: boolean = marker.editEnabled();
+
+const polyline: L.Polyline = map.editTools.startPolyline(L.latLng(0, 0), { noClip: true });
+polyline.continueBackward();
+polyline.continueForward();
+polyline.disable();
+polyline.enable();
+enabled = polyline.editEnabled();
+polyline.reset();
+polyline.toggleEdit();
+
+const polygon: L.Polygon = map.editTools.startPolygon(L.latLng(0, 0), { noClip: true });
+polygon.continueBackward();
+polygon.continueForward();
+polygon.disable();
+polygon.enable();
+enabled = polygon.editEnabled();
+polygon.newHole(L.latLng(0, 0));
+polygon.reset();
+polygon.toggleEdit();

--- a/types/leaflet-editable/v0/leaflet-editable-tests.ts
+++ b/types/leaflet-editable/v0/leaflet-editable-tests.ts
@@ -1,21 +1,21 @@
 import * as L from 'leaflet';
 import 'leaflet-editable';
 
-class MarkerClass { }
-class MarkerEditorClass { }
-class MiddleMarkerClass { }
-class PolygonClass { }
-class PolygonEditorClass { }
-class PolylineClass { }
-class PolylineEditorClass { }
-class VertexMarkerClass { }
+class MarkerClass {}
+class MarkerEditorClass {}
+class MiddleMarkerClass {}
+class PolygonClass {}
+class PolygonEditorClass {}
+class PolylineClass {}
+class PolylineEditorClass {}
+class VertexMarkerClass {}
 
 const map: L.Map = L.map('div', {
     editable: true,
     editOptions: {
         drawingCSSClass: 'css-class',
         editLayer: L.layerGroup(),
-        featuresLayer: L.layerGroup<L.Marker|L.Polyline|L.Polygon>(),
+        featuresLayer: L.layerGroup<L.Marker | L.Polyline | L.Polygon>(),
         lineGuideOptions: {},
         markerClass: MarkerClass,
         markerEditorClass: MarkerEditorClass,
@@ -25,11 +25,11 @@ const map: L.Map = L.map('div', {
         polylineClass: PolylineClass,
         polylineEditorClass: PolylineEditorClass,
         skipMiddleMarkers: true,
-        vertexMarkerClass: VertexMarkerClass
-    }
+        vertexMarkerClass: VertexMarkerClass,
+    },
 });
 
-const currentPoly: L.Polygon|L.Polyline| L.Marker = map.editTools.currentPolygon;
+const currentPoly: L.Polygon | L.Polyline | L.Marker = map.editTools.currentPolygon;
 map.editTools.stopDrawing();
 map.editTools.commitDrawing();
 

--- a/types/leaflet-editable/v0/tsconfig.json
+++ b/types/leaflet-editable/v0/tsconfig.json
@@ -9,11 +9,16 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
         "types": [],
+        "paths": {
+            "leaflet": [
+                "leaflet/v0"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/leaflet-editable/v0/tsconfig.json
+++ b/types/leaflet-editable/v0/tsconfig.json
@@ -17,6 +17,9 @@
         "paths": {
             "leaflet": [
                 "leaflet/v0"
+            ],
+            "leaflet-editable": [
+                "leaflet-editable/v0"
             ]
         },
         "noEmit": true,

--- a/types/leaflet-editable/v0/tslint.json
+++ b/types/leaflet-editable/v0/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://leaflet.github.io/Leaflet.Editable/doc/api.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

This PR updates the leaflet-editable type interfaces to match the API of version 1.2. As this reflects a new major version for the library, the old API will be maintained in the `v0` directory.

Tests have been developed to match, and I have tested the type definitions on my own code (which was having issues due to the old definitions).

I am also adding myself as a definition owner. The main repo has not seen changes in about 18 months, but in the event that the repo has further changes, or in the event that the types I specify here have issues, I will look to help resolve them.

EDIT: No other DefinitelyTyped packages utilize these definitions, so other packages do not need updates.