### PR TITLE
redux-sentry-middleware: Support @sentry/browser 6.x in typings

### DIFF
--- a/types/redux-sentry-middleware/index.d.ts
+++ b/types/redux-sentry-middleware/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for redux-sentry-middleware 0.1
+// Type definitions for redux-sentry-middleware 0.2
 // Project: https://github.com/vidit-sh/redux-sentry-middleware#readme, https://github.com/viditisonline/redux-sentry-middleware
 // Definitions by: Jan Dolezel <https://github.com/dolezel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.5
 
 import { Action, Middleware } from "redux";
 import * as Sentry from "@sentry/browser";

--- a/types/redux-sentry-middleware/package.json
+++ b/types/redux-sentry-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@sentry/browser": "^5.0.0",
+    "@sentry/browser": "^5.0.0 || ^6.0.0",
     "redux": "^4.0.0"
   }
 }


### PR DESCRIPTION
Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/43709#issuecomment-789104574

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/43709#issuecomment-789104574
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Error being fixed:

```
Issues checking in progress...
ERROR in app.tsx:24:41
TS2345: Argument of type 'typeof import("js/node_modules/@sentry/browser/dist/index")' is not assignable to parameter of type 'typeof import("js/node_modules/@types/redux-sentry-middleware/node_modules/@sentry/browser/dist/index")'.
  The types of 'Integrations.GlobalHandlers' are incompatible between these types.
    Types of construct signatures are incompatible.
      Type 'new (options?: GlobalHandlersIntegrations | undefined) => GlobalHandlers' is not assignable to type 'new (options?: GlobalHandlersIntegrations | undefined) => GlobalHandlers'.
        Type 'import("js/node_modules/@sentry/browser/dist/integrations/globalhandlers").GlobalHandlers' is not assignable to type 'import("js/node_modules/@types/redux-sentry-middleware/node_modules/@sentry/browser/dist/integrations/globalhandlers").GlobalHandlers'.
          Types have separate declarations of a private property '_options'.
    22 |     (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
    23 |
  > 24 |   const sentryMiddleware = createSentryMiddleware(Sentry, {
       |                                                   ^^^^^^
    25 |     stateTransformer: (state: any) => state,
    26 |   })
    27 |   const middleware = [thunkMiddleware, sentryMiddleware]
```