### PR TITLE
update(imagemin-svgo): v9

### DIFF
--- a/types/imagemin-svgo/imagemin-svgo-tests.ts
+++ b/types/imagemin-svgo/imagemin-svgo-tests.ts
@@ -12,6 +12,7 @@ imagemin(['*.svg'], {
                     removeViewBox: false,
                 },
             ],
+            multipass: false,
         }),
     ],
 });

--- a/types/imagemin-svgo/index.d.ts
+++ b/types/imagemin-svgo/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for imagemin-svgo 8.0
+// Type definitions for imagemin-svgo 9.0
 // Project: https://github.com/imagemin/imagemin-svgo#readme
 // Definitions by: Romain Faust <https://github.com/romain-faust>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -13,7 +13,13 @@ import { Options as SvgoOptions } from 'svgo';
 declare function imageminSvgo(options?: imageminSvgo.Options): Plugin;
 
 declare namespace imageminSvgo {
-    type Options = SvgoOptions;
+    type Options = SvgoOptions & {
+        /**
+         * Pass over SVGs multiple times to ensure all optimizations are applied
+         * @default true
+         */
+        multipass?: boolean;
+    };
 }
 
 export = imageminSvgo;


### PR DESCRIPTION
This is non-breaking change (see release link). However I've made a
change in default value hint for this package `multipass`, as it is
different from SVGO defaults (`false` in original, `true` in
`imagemin-svgo`):
https://github.com/imagemin/imagemin-svgo/blob/master/index.js#L6

This does not break existing code, just exposes better
documentation hints.

- version bump
- test updated

https://github.com/imagemin/imagemin-svgo/compare/v8.0.0...v9.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.