### PR TITLE
Improve Jasmine CustomReporterResult type

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -858,14 +858,60 @@ declare namespace jasmine {
     interface PassedExpectation extends CustomReportExpectation {
     }
 
+    interface DeprecatedExpectation {
+        message: string;
+    }
+
     interface CustomReporterResult {
-        description: string;
-        failedExpectations?: FailedExpectation[];
-        fullName: string;
+        /**
+         * The unique id of this spec.
+         */
         id: string;
+
+        /**
+         * The description passed to the {@link it} that created this spec.
+         */
+        description: string;
+
+        /**
+         * The full description including all ancestors of this spec.
+         */
+        fullName: string;
+
+        /**
+         * The list of expectations that failed during execution of this spec.
+         */
+        failedExpectations?: FailedExpectation[];
+
+        /**
+         * The list of expectations that passed during execution of this spec.
+         */
         passedExpectations?: PassedExpectation[];
+
+        /**
+         * The list of deprecation warnings that occurred during execution this spec.
+         */
+        deprecationWarnings?: DeprecatedExpectation[];
+
+        /**
+         * If the spec is pending, this will be the reason.
+         */
         pendingReason?: string;
+
+        /**
+         * Once the spec has completed, this string represents the pass/fail status of this spec.
+         */
         status?: string;
+
+        /**
+         * The time in ms used by the spec execution, including any before/afterEach.
+         */
+        duration: number | null;
+
+        /**
+         * User-supplied properties, if any, that were set using {@link Env.setSpecProperty}
+         */
+        properties: { [key: string]: unknown } | null;
     }
 
     interface RunDetails {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1711,7 +1711,11 @@ var myReporter: jasmine.CustomReporter = {
     },
 
     suiteDone: (result: jasmine.CustomReporterResult) => {
-        console.log(`Suite: ${result.description} was ${result.status}`);
+        console.log(`Suite: ${result.description} was ${result.status} (${result.duration})`);
+        console.log(`Suite has properties: ${Object.keys(result.properties || {})}`);
+        if (result.deprecationWarnings) {
+            console.log(`Suite has deprecations: ${result.deprecationWarnings.map(w => w.message)}`);
+        }
         for (var i = 0; result.failedExpectations && i < result.failedExpectations.length; i += 1) {
             console.log('AfterAll ' + result.failedExpectations[i].message);
             console.log(result.failedExpectations[i].stack);


### PR DESCRIPTION
Updated the CustomReporterResult interface to match Jasmine's
[SpecResult](https://github.com/jasmine/jasmine/blob/9ab039e3302f4e97fd27d4997e36a300627a850a/lib/jasmine-core/jasmine.js#L722-L734)/[SuiteResult](https://github.com/jasmine/jasmine/blob/9ab039e3302f4e97fd27d4997e36a300627a850a/lib/jasmine-core/jasmine.js#L8996-L9006).

Only made changes that should be safe:
  - copied over doc strings
  - rearranged fields to match Jasmine's doc comments
  - added fields

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [SpecResult](https://github.com/jasmine/jasmine/blob/9ab039e3302f4e97fd27d4997e36a300627a850a/lib/jasmine-core/jasmine.js#L722-L734)/[SuiteResult](https://github.com/jasmine/jasmine/blob/9ab039e3302f4e97fd27d4997e36a300627a850a/lib/jasmine-core/jasmine.js#L8996-L9006)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

