### PR TITLE
[spectrum] Add missing i18n settings, use readonly array for parameters

### DIFF
--- a/types/spectrum/index.d.ts
+++ b/types/spectrum/index.d.ts
@@ -476,7 +476,7 @@ declare namespace Spectrum {
          * ]]
          * ```
          */
-        palette?: string[][];
+        palette?: ReadonlyArray<ReadonlyArray<string>>;
 
         /**
          * Spectrum can show a palette below the color picker to make it
@@ -551,12 +551,14 @@ declare namespace Spectrum {
         togglePaletteOnly?: boolean;
 
         /**
-         * Changes the text on the open-toggle color picker button.
+         * Changes the text on the open-toggle color picker button. Defaults to
+         * `more`.
          */
         togglePaletteMoreText?: string;
 
         /**
-         * Changes the text on the close-toggle color picker button.
+         * Changes the text on the close-toggle color picker button. Defaults to
+         * `less`.
          */
         togglePaletteLessText?: string;
 
@@ -630,14 +632,26 @@ declare namespace Spectrum {
         clickoutFiresChange?: boolean;
 
         /**
-         * Sets the text on the cancel button.
+         * Sets the text on the cancel button. Defaults to `cancel`.
          */
         cancelText?: string;
 
         /**
-         * Sets the text on the choose button.
+         * Sets the text on the choose button. Defaults to `choose`.
          */
         chooseText?: string;
+
+        /**
+         * Sets the text on the clear button. Defaults to
+         * `Clear Color Selection`.
+         */
+        clearText?: string;
+
+        /**
+         * Sets the text for when no color has been selected. Defaults to
+         * `No Color Selected`.
+         */
+        noColorSelectedText?: string;
 
         /**
          * Adds an additional class name to the just the container element.
@@ -741,7 +755,7 @@ declare namespace Spectrum {
          * Changing this can help resolve issues with opening the color picker
          * in a modal dialog or fixed position container, for instance.
          */
-        appendTo?: Parameters<JQuery["appendTo"]>[0];
+        appendTo?: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element | DocumentFragment> | JQuery;
 
         /**
          * Sets the max size for the palette.
@@ -783,7 +797,7 @@ declare namespace Spectrum {
          * });
          * ```
          */
-        selectionPalette?: string[];
+        selectionPalette?: ReadonlyArray<string>;
 
         /**
          * Additional offset to apply as a CSS unit to the container.

--- a/types/spectrum/spectrum-tests.ts
+++ b/types/spectrum/spectrum-tests.ts
@@ -48,10 +48,49 @@ $("#picker").spectrum({
     ]
 });
 
+const paletteModMod: string[][] = [["#000"]];
+const paletteUnmodMod: ReadonlyArray<string[]> = [["#000"]];
+const paletteModUnmod: Array<ReadonlyArray<string>> = [["#000"]];
+const paletteUnmodUnmod: ReadonlyArray<ReadonlyArray<string>> = [["#000"]];
+$("#picker").spectrum({
+    palette: paletteModMod,
+});
+$("#picker").spectrum({
+    palette: paletteModUnmod,
+});
+$("#picker").spectrum({
+    palette: paletteUnmodMod,
+});
+$("#picker").spectrum({
+    palette: paletteUnmodUnmod,
+});
+$("#picker").spectrum("option", "palette", paletteModMod);
+$("#picker").spectrum("option", "palette", paletteModUnmod);
+$("#picker").spectrum("option", "palette", paletteUnmodMod);
+$("#picker").spectrum("option", "palette", paletteUnmodUnmod);
+const palette = $("#picker").spectrum("option", "palette");
+if (palette) {
+    // Disallowed, must use "option" method to apply settings
+    // $ExpectError
+    palette[0][0] = "";
+    // $ExpectError
+    palette[0] = [""];
+}
+
 $("#picker").spectrum({
     showPalette: true,
     showSelectionPalette: true,
+    selectionPalette: ["red", "green", "blue"],
     localStorageKey: "spectrum.homepage",
+});
+
+const selectionPaletteMod: string[] = ["red", "green", "blue"];
+const selectionPaletteUnmod: ReadonlyArray<string> = ["red", "green", "blue"];
+$("#picker").spectrum({
+    selectionPalette: selectionPaletteMod,
+});
+$("#picker").spectrum({
+    selectionPalette: selectionPaletteUnmod,
 });
 
 $("#picker").spectrum({
@@ -61,6 +100,14 @@ $("#picker").spectrum({
 $("#picker").spectrum({
     clickoutFiresChange: true
 });
+$("#picker").spectrum("option", "selectionPalette", selectionPaletteMod);
+$("#picker").spectrum("option", "selectionPalette", selectionPaletteUnmod);
+const selectionPalette = $("#picker").spectrum("option", "selectionPalette");
+if (selectionPalette) {
+    // Disallowed, must use "option" method to apply settings
+    // $ExpectError
+    selectionPaletteUnmod[0] = "red";
+}
 
 $("#picker").spectrum({
     showInitial: true,
@@ -68,7 +115,9 @@ $("#picker").spectrum({
 });
 $("#picker").spectrum({
     chooseText: "Alright",
-    cancelText: "No way"
+    cancelText: "No way",
+    clearText: "Start over",
+    noColorSelectedText: "A world of gray",
 });
 
 $("#picker").spectrum({


### PR DESCRIPTION
* I added two missing localization options that weren't explicitly mentioned in the docs but are definitely there and usable, see e.g. https://github.com/bgrins/spectrum/blob/master/spectrum.js#L50
* I also changed the few array setting to readonly arrays so they can accept both mutable and immutable arrays
* Finally I changed the type for `appendTo` to its more resolved version which should hopefully improve the perf stats
  
---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bgrins/spectrum/blob/master/spectrum.js#L50 https://github.com/bgrins/spectrum/blob/master/spectrum.js#L51
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

