### PR TITLE
Fix EvaporateJS typing for customAuthMethod

### DIFF
--- a/types/evaporate/index.d.ts
+++ b/types/evaporate/index.d.ts
@@ -49,8 +49,8 @@ declare namespace Evaporate {
         signParams?: object;
         signHeaders?: object;
         customAuthMethod?: null | ((
-            signParams: string,
-            signHeaders: string,
+            signParams: object,
+            signHeaders: object,
             stringToSign: string,
             signatureDateTime: string,
             canonicalRequest: string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/TTLabs/EvaporateJS/blob/c1f8905d173f07dab1f277b4bd753a2ce2303967/evaporate.js#L1921>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

**Explanation for code change**

Looking at the [source code](https://github.com/TTLabs/EvaporateJS/blob/c1f8905d173f07dab1f277b4bd753a2ce2303967/evaporate.js#L1921), it is quite clear that `customAuthMethod` is called with objects as the first two arguments, generated by `AuthorizationMethod.makeSignParamsObject` ([link](https://github.com/TTLabs/EvaporateJS/blob/c1f8905d173f07dab1f277b4bd753a2ce2303967/evaporate.js#L1847)).


