### PR TITLE
[react-native-calendars] add missing key today

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -8,7 +8,11 @@
 
 import * as React from 'react';
 import { StyleProp, TextStyle, ViewStyle } from 'react-native';
-export import LocaleConfig = require('xdate');
+import XDateLocaleConfig = require('xdate');
+
+declare class LocaleConfig extends XDateLocaleConfig {
+    public static locales: { [key: string]: typeof XDateLocaleConfig.locales[string] & { today: string } };
+}
 
 export interface DateObject {
     day: number;

--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -10,8 +10,8 @@ import * as React from 'react';
 import { StyleProp, TextStyle, ViewStyle } from 'react-native';
 import XDateLocaleConfig = require('xdate');
 
-declare class LocaleConfig extends XDateLocaleConfig {
-    public static locales: { [key: string]: typeof XDateLocaleConfig.locales[string] & { today: string } };
+export class LocaleConfig extends XDateLocaleConfig {
+    static locales: { [key: string]: typeof XDateLocaleConfig.locales[string] & { today: string } };
 }
 
 export interface DateObject {

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Text, View } from 'react-native';
-import { Calendar, CalendarList, Agenda } from 'react-native-calendars';
+import { Calendar, CalendarList, Agenda, LocaleConfig } from 'react-native-calendars';
 
 declare const Arrow: React.SFC<unknown>;
 
@@ -427,3 +427,37 @@ const workout = { key: 'workout', color: 'green' };
         </View>
     )}
 />;
+
+LocaleConfig.locales['fr'] = {
+    monthNames: [
+        'Janvier',
+        'Février',
+        'Mars',
+        'Avril',
+        'Mai',
+        'Juin',
+        'Juillet',
+        'Août',
+        'Septembre',
+        'Octobre',
+        'Novembre',
+        'Décembre',
+    ],
+    monthNamesShort: [
+        'Janv.',
+        'Févr.',
+        'Mars',
+        'Avril',
+        'Mai',
+        'Juin',
+        'Juil.',
+        'Août',
+        'Sept.',
+        'Oct.',
+        'Nov.',
+        'Déc.',
+    ],
+    dayNames: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+    dayNamesShort: ['Dim.', 'Lun.', 'Mar.', 'Mer.', 'Jeu.', 'Ven.', 'Sam.'],
+    today: "Aujourd'hui",
+};


### PR DESCRIPTION
In react-native-calendars, there is a key `today` which is not defined in LocaleConfig type exported from XDate

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Locale Config doc](https://github.com/wix/react-native-calendars#usage)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


