### PR TITLE
fix(node): Backport #38480 to node 10 and node 11 declarations: replace reserved identifier in a function parameter

### DIFF
--- a/types/node/v10/readline.d.ts
+++ b/types/node/v10/readline.d.ts
@@ -136,7 +136,7 @@ declare module "readline" {
     function createInterface(options: ReadLineOptions): Interface;
 
     function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
-    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: Interface): void;
+    function emitKeypressEvents(stream: NodeJS.ReadableStream, readlineInterface?: Interface): void;
     function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
     function clearLine(stream: NodeJS.WritableStream, dir: number): void;
     function clearScreenDown(stream: NodeJS.WritableStream): void;

--- a/types/node/v11/readline.d.ts
+++ b/types/node/v11/readline.d.ts
@@ -130,7 +130,7 @@ declare module "readline" {
     function createInterface(options: ReadLineOptions): Interface;
 
     function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
-    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: Interface): void;
+    function emitKeypressEvents(stream: NodeJS.ReadableStream, readlineInterface?: Interface): void;
     function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
     function clearLine(stream: NodeJS.WritableStream, dir: number): void;
     function clearScreenDown(stream: NodeJS.WritableStream): void;


### PR DESCRIPTION
Backport of #38480 into the node 10 and 11 declarations.  The same motivation applies.  In my case, `swc`'s parser was throwing an error when attempting to parse the file.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: #38480
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.