### PR TITLE
async: fix types for async.retry

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -344,27 +344,32 @@ export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks
 export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, callback?: AsyncResultCallback<R, E>): void;
 export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;
 
-export interface RetryOptions {
+export interface RetryOptions<E> {
     times?: number;
     interval?: number | ((retryCount: number) => number);
-    errorFilter?: (error: Error) => boolean;
+    errorFilter?: (error: E) => boolean;
 }
 export function retry<T, E = Error>(
-    opts?: number | RetryOptions,
-    task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
-): Promise<void>;
+    task: (() => Promise<T>) | ((callback: AsyncResultCallback<T, E>) => void),
+): Promise<T>;
 export function retry<T, E = Error>(
-    opts?: number | RetryOptions,
-    task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
-    callback?: AsyncResultCallback<any, E>,
+    opts: number | RetryOptions<E>,
+    task: (() => Promise<T>) | ((callback: AsyncResultCallback<T, E>) => void),
+): Promise<T>;
+export function retry<T, E = Error>(
+    task: (() => Promise<T>) | ((callback: AsyncResultCallback<T, E>) => void),
+    callback: AsyncResultCallback<T, E>,
+): void;
+export function retry<T, E = Error>(
+    opts: number | RetryOptions<E>,
+    task: (() => Promise<T>) | ((callback: AsyncResultCallback<T, E>) => void),
+    callback: AsyncResultCallback<T, E>,
 ): void;
 
 export function retryable<T, E = Error>(task: AsyncFunction<T, E>): AsyncFunction<T, E>;
 export function retryable<T, E = Error>(
-    opts:
-        | number
-        | RetryOptions & {arity?: number},
-     task: AsyncFunction<T, E>
+    opts: number | (RetryOptions<E> & { arity?: number }),
+    task: AsyncFunction<T, E>,
 ): AsyncFunction<T, E>;
 export function apply<E = Error>(fn: Function, ...args: any[]): AsyncFunction<any, E>;
 export function nextTick(callback: Function, ...args: any[]): void;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -341,31 +341,26 @@ async.auto<A>({
     (err, results) => { console.log('finished auto'); }
 );
 
-async.retry(); // $ExpectType Promise<void>
-async.retry(3); // $ExpectType Promise<void>
-// $ExpectType Promise<void>
-async.retry(
-    3,
-    (callback, results) => {},
-);
-// $ExpectType void
-async.retry(
-    { times: 3, interval: 200 },
-    (callback, results) => {},
-    (err, result) => {},
-);
-// $ExpectType void
-async.retry(
-    { times: 3, interval: retryCount => 200 * retryCount },
-    (callback, results) => {},
-    (err, result) => {},
-);
-// $ExpectType void
-async.retry(
-    { times: 3, interval: 200, errorFilter: err => true },
-    (callback, results) => {},
-    (err, result) => {},
-);
+async.retry(); // $ExpectError
+async.retry(3); // $ExpectError
+
+async.retry(async () => 2); // $ExpectType Promise<number>
+async.retry<number>(async () => 2); // $ExpectType Promise<number>
+
+// dtslint doesn't seem to handle $ExpectType Promise<unknown>, expects Promise<{}>
+const xx: Promise<number> = async.retry(cb => { cb(null, 2); });
+async.retry<number>(cb => { cb(null, 2); }); // $ExpectType Promise<number>
+
+async.retry(1, async () => 2); // $ExpectType Promise<number>
+async.retry<number>(1, async () => 2); // $ExpectType Promise<number>
+
+async.retry<number>(1, cb => { cb(null, 2); }); // $ExpectType Promise<number>
+async.retry<number>({ times: 3, interval: 200 }, cb => { cb(null, 2); }); // $ExpectType Promise<number>
+async.retry<number>(cb => { cb(null, 2); }, (err: Error, r: number) => {}); // $ExpectType void
+async.retry<number>(1, cb => { cb(null, 2); }, (err: Error, r: number) => {}); // $ExpectType void
+async.retry<number>({ times: 3, interval: 200 }, cb => { cb(null, 2); }, (err: Error, r: number) => {}); // $ExpectType void
+async.retry<number>({ interval: rc => 200 * rc }, cb => { cb(null, 2); }, (err: Error, r: number) => {}); // $ExpectType void
+async.retry<number, string>({ errorFilter: (x: string) => true }, cb => { cb("oh no"); }); // $ExpectType Promise<number>
 
 async.retryable(
     (callback) => {},


### PR DESCRIPTION
* Overloads patterns were incorrect, `task` is never optional.
* Return type is that of `task`.
* Error type is also that of `task`.
* `retry()` with no args or just a number is an error (existing tests were wrong)
* The task gets a single argument, no `results` arg.
* Narrow the `any` types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://caolan.github.io/async/v3/docs.html#retry
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - **N/A** the current types are wrong for all recent versions.
