### PR TITLE
[react-select] Remove defaultProps from Creatable

### DIFF
--- a/types/react-select/src/Creatable.d.ts
+++ b/types/react-select/src/Creatable.d.ts
@@ -50,8 +50,6 @@ export type Props<
     GroupType extends GroupTypeBase<OptionType> = GroupTypeBase<OptionType>
 > = SelectProps<OptionType, IsMulti, GroupType> & CreatableProps<OptionType, IsMulti, GroupType>;
 
-export const defaultProps: Props<any, boolean>;
-
 export interface State<OptionType extends OptionTypeBase> {
     newOption: OptionType | undefined;
     options: OptionsType<OptionType>;
@@ -61,7 +59,6 @@ export class Creatable<OptionType extends OptionTypeBase, IsMulti extends boolea
     Props<OptionType, IsMulti>,
     State<OptionType>
 > {
-    static defaultProps: Props<any, boolean>;
     select: React.Ref<any>;
 
     onChange: (newValue: ValueType<OptionType, IsMulti>, actionMeta: ActionMeta<OptionType>) => void;


### PR DESCRIPTION
I'm decorating Creatable. It looks like this:

```ts
interface CreatableSelectProps extends Props<{label: string, value: string}, true>
{}

function makeDecoratable<P extends CreatableSelectProps>(Creatable: React.ComponentType<P>): React.ComponentType<P & CreatableSelectProps>
{
	return ({...props}) =>
	{
		return (
			<Creatable
				{...props as P}
			/>
		);
	};
}

let Select = makeDecoratable(Creatable);
Select = decorateWithSomething1(Select);
Select = decorateWithSomething2(Select);
render(<Select options=[...] ... />, el);
```

Error given:

![image](https://user-images.githubusercontent.com/9862581/109983348-052ad880-7d03-11eb-820e-992b0b6ea215.png)

`defaultProps: <any, boolean>` conflicts with type counted from Props.

This PR is not solution, just raising awareness of the problem. I'm not sure what removing `defaultProps` can cause.

@Methuselah96 @kylemh 