### PR TITLE
update(dotenv-webpack): v6 update

### DIFF
--- a/types/dotenv-webpack/dotenv-webpack-tests.ts
+++ b/types/dotenv-webpack/dotenv-webpack-tests.ts
@@ -1,4 +1,3 @@
-import webpack = require('webpack');
 import Dotenv = require('dotenv-webpack');
 import { Options } from 'dotenv-webpack';
 import { Configuration } from 'webpack';

--- a/types/dotenv-webpack/index.d.ts
+++ b/types/dotenv-webpack/index.d.ts
@@ -1,17 +1,17 @@
-// Type definitions for dotenv-webpack 5.0
+// Type definitions for dotenv-webpack 6.0
 // Project: https://github.com/mrsteele/dotenv-webpack
 // Definitions by: Karol Majewski <https://github.com/karol-majewski>
 //                 Dave Cardwell <https://github.com/davecardwell>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Compiler, WebpackPluginInstance } from 'webpack';
+import { Compiler } from 'webpack';
 
 /**
  * A secure webpack plugin that supports dotenv and other environment variables
  * and only exposes what you choose and use.
  */
-declare class DotenvWebpackPlugin implements WebpackPluginInstance {
+declare class DotenvWebpackPlugin {
     constructor(options?: DotenvWebpackPlugin.Options);
     apply(compiler: Compiler): void;
 }


### PR DESCRIPTION
v6 update is non-breaking, but here is an attemtp to simplify package
dependency on custom types, simplifyng compatilbity between v4 and v5 fo
webacpk (hopefully).

https://github.com/mrsteele/dotenv-webpack/compare/v5.1.0...v6.0.4

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.