### PR TITLE
Fix type definition for `Dygraph.yAxisExtremes()` method

### DIFF
--- a/types/dygraphs/dygraphs-tests.ts
+++ b/types/dygraphs/dygraphs-tests.ts
@@ -228,6 +228,9 @@ d.setAnnotations([
 // $ExpectType Annotation[]
 d.annotations();
 
+// $ExpectType [number, number][]
+d.yAxisExtremes();
+
 // $ExpectType void
 d.updateOptions({
     fillGraph: true,

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1238,7 +1238,7 @@ export default class Dygraph {
      * high] tuples, one for each y-axis.
      * {@link https://dygraphs.com/jsdoc/symbols/Dygraph.html#yAxisExtremes}
      */
-    yAxisExtremes(): [number, number];
+    yAxisExtremes(): Array<[number, number]>;
 
     /**
      * Convert from data coordinates to canvas/div X/Y coordinates.


### PR DESCRIPTION
It should be an array of the tuple. See docs: https://dygraphs.com/jsdoc/symbols/Dygraph.html#yAxisExtremes