### PR TITLE
[yaireo__tagify] Fix types, add missing types, add missing docs, cleanup

### DIFF
--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -26,7 +26,7 @@ declare namespace Tagify {
      * Settings for the autocomplete feature that can be configured via the
      * `autocomplete` option of the settings that are passed to tagify.
      */
-    interface AutocompleteSettings {
+    interface AutoCompleteSettings {
         /**
          * Tries to suggest the input's value while typing (match from
          * whitelist) by adding the rest of term as grayed-out text.
@@ -521,7 +521,7 @@ declare namespace Tagify {
         /**
          * Options for offering autocomplete suggestions as the user types.
          */
-        autocomplete?: AutocompleteSettings;
+        autoComplete?: AutoCompleteSettings;
 
         /**
          * An array of allowed tags.

--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -1,291 +1,1091 @@
 // Type definitions for @yaireo/tagify 3.22
 // Project: https://github.com/yairEO/tagify
 // Definitions by: Brakebein <https://github.com/Brakebein>
+//                 Andre Wachsmuth <https://github.com/blutorange>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Tagify {
-    interface TagifySettings {
+    /**
+     * Mode for how tags are displayed and how they can be edited:
+     * - `select`: Single-value dropdown-like select box.
+     * - `mix`: Allow mixed-content. Requires the `pattern` setting to be set.
+     */
+    type Mode = 'select' | 'mix';
+
+    /**
+     * Where the dropdown menu will appear:
+     * - `manual` - will not render the dropdown, and you would need to do
+     * it yourself.
+     * - `text` - will place the dropdown next to the caret
+     * - `input` - will place the dropdown next to the input
+     * - `all` - normal, full-width design
+     */
+    type DropDownPosition = 'manual' | 'text' | 'input' | 'all';
+
+    /**
+     * Settings for the autocomplete feature that can be configured via the
+     * `autocomplete` option of the settings that are passed to tagify.
+     */
+    interface AutocompleteSettings {
+        /**
+         * Tries to suggest the input's value while typing (match from
+         * whitelist) by adding the rest of term as grayed-out text.
+         * @default true
+         */
+        enabled?: boolean;
+
+        /**
+         * If `true`, when the right arrow key is pressed, use the suggested
+         * value to create a tag, else just auto-completes the input. In mixed
+         * mode this is ignored and treated as `true`.
+         * @default false
+         */
+        rightKey?: boolean;
+    }
+
+    /**
+     * Settings for the dropdown feature that can be configured via the
+     * `dropdown` option of the settings that are passed to tagify.
+     */
+    interface DropDownSettings<T extends BaseTagData = TagData> {
+        /**
+         * Minimum characters input for showing a suggestions list.
+         * `false` will not render a suggestions list.
+         * @default 2
+         */
+        enabled?: number | false;
+
+        /**
+         * If `true`, match exact item when a suggestion is selected (from the
+         * dropdown) and also more strict matching for duplicate items.
+         * Ensure `fuzzySearch` is `false` for this to work.
+         * @default false
+         */
+        caseSensitive?: boolean;
+
+        /**
+         * Maximum items to show in the suggestions list.
+         * @default 10
+         */
+        maxItems?: number;
+
+        /**
+         * Custom class name for the dropdown suggestions select box.
+         * @default Empty string.
+         */
+        classname?: string;
+
+        /**
+         * Enables filtering dropdown items values by string _containing_ and not only _beginning_.
+         * @default true
+         */
+        fuzzySearch?: boolean;
+
+        /**
+         * Enable searching for accented items in the whitelist without typing exact match.
+         * @default true
+         */
+        accentedSearch?: boolean;
+
+        /**
+         * Controls where the dropdown menu is positioned.
+         * @default all
+         */
+        position?: DropDownPosition;
+
+        /**
+         * When a suggestions list is shown, highlight the first item,
+         * and also suggest it in the input (The suggestion can be accepted with → key).
+         * @default false
+         */
+        highlightFirst?: boolean;
+
+        /**
+         * Close the dropdown after selecting an item, if `enabled: 0` is set
+         * (which means always show dropdown on focus).
+         * @default true
+         */
+        closeOnSelect?: boolean;
+
+        /**
+         * if `false`, keep typed text after selecting a suggestion.
+         * @default true
+         */
+        clearOnSelect?: boolean;
+
+        /**
+         * If whitelist is an array of tag objects, this setting controls which
+         * data key will be printed in the dropdown.
+         * @default undefined
+         */
+        mapValueTo?: string |
+        /**
+         * @param data The tag data to map.
+         * @return The value that will be shown in the dropdown menu.
+         */
+        ((data: T) => string);
+
+        /**
+         * When a user types something and trying to match the whitelist items
+         * for suggestions, this setting allows matching other keys of a
+         * whitelist objects.
+         * @default ['value', 'searchBy']
+         */
+        searchKeys?: string[];
+
+        /**
+         * Target node to which the suggestions dropdown is appended (only when
+         * rendered). When `null`, appends to `document.body`.
+         * @default null
+         */
+        appendTarget?: HTMLElement | null;
+
+        /**
+         * If defined, will force the placement of the dropdown:
+         * - `true` - always show the suggestions dropdown above the input field
+         * - `false` - always show the suggestions dropdown below the input field
+         *
+         * By default this setting it not defined and the placement of the
+         * dropdown is automatically decided according to the space available,
+         * where opening it below the input is preferred.
+         * @default undefined
+         */
+        placeAbove?: boolean;
+    }
+
+    /**
+     * Options for the mix mode feature that can be activated via the `mode`
+     * option of the settings that are passed to tagify.
+     */
+    interface MixModeSettings {
+        /**
+         * Add after the added tag.
+         * @default '\u00A0'
+         */
+        insertAfterTag?: string | HTMLElement;
+    }
+
+    /**
+     * Options for the edit tags feature that can be activated via the
+     * `editTags` option of the settings that are passed to tagify.
+     */
+    interface EditTagsSettings {
+        /**
+         * Number of clicks to enter `edit` mode: `1` for single click. Any
+         * other value is considered as double-click
+         * @default 2
+         */
+        clicks: 1 | 2;
+
+        /**
+         * When `true`, keeps invalid edits as-is until the escape key is
+         * pressed while in focus.
+         * @default true
+         */
+        keepInvalid: boolean;
+    }
+
+    /**
+     * Optional class names that can be used to add additional class names to
+     * the corresponding DOM elements.
+     */
+    interface ClassNameSettings {
+        /**
+         * @default 'tagify'
+         */
+        namespace: string;
+
+        /**
+         * @default 'tagify--mix'
+         */
+        mixMode: string;
+
+        /**
+         * @default 'tagify--select'
+         */
+        selectMode: string;
+
+        /**
+         * @default 'tagify__input'
+         */
+        input: string;
+
+        /**
+         * @default 'tagify--focus'
+         */
+        focus: string;
+
+        /**
+         * @default 'tagify__tag'
+         */
+        tag: string;
+
+        /**
+         * @default 'tagify--noAnim'
+         */
+        tagNoAnimation: string;
+
+        /**
+         * @default 'tagify--invalid'
+         */
+        tagInvalid: string;
+
+        /**
+         * @default 'tagify--notAllowed'
+         */
+        tagNotAllowed: string;
+
+        /**
+         * @default 'tagify__input--invalid'
+         */
+        inputInvalid: string;
+
+        /**
+         * @default 'tagify__tag__removeBtn'
+         */
+        tagX: string;
+
+        /**
+         * @default 'tagify__tag-text'
+         */
+        tagText: string;
+
+        /**
+         * @default 'tagify__dropdown'
+         */
+        dropdown: string;
+
+        /**
+         * @default 'tagify__dropdown__wrapper'
+         */
+        dropdownWrapper: string;
+
+        /**
+         * @default 'tagify__dropdown__item'
+         */
+        dropdownItem: string;
+
+        /**
+         * @default 'tagify__dropdown__item--active'
+         */
+        dropdownItemActive: string;
+
+        /**
+         * Initial class for the dropdown menu.
+         *
+         * Note: This is __not a typo__, this is the name as used by the tagify
+         * library.
+         * @default 'tagify__dropdown--initial'
+         */
+        dropdownInital: string;
+
+        /**
+         * @default 'tagify--loading'
+         */
+        scopeLoading: string;
+
+        /**
+         * @default 'tagify__tag--loading'
+         */
+        tagLoading: string;
+
+        /**
+         * @default 'tagify__tag--editable'
+         */
+        tagEditing: string;
+
+        /**
+         * @default 'tagify__tag--flash'
+         */
+        tagFlash: string;
+
+        /**
+         * @default 'tagify__tag--hide'
+         */
+        tagHide: string;
+
+        /**
+         * @default 'tagify--hasMaxTags'
+         */
+        hasMaxTags: string;
+
+        /**
+         * @default 'tagify--noTags'
+         */
+        hasNoTags: string;
+
+        /**
+         * @default 'tagify--empty'
+         */
+        empty: string;
+    }
+
+    /**
+     * Render functions for the template feature that can be configured via the
+     * `templates` option of the settings that are passed to tagify.
+     */
+    interface Templates<T extends BaseTagData = TagData> {
+        /**
+         * Template for wrapper element for the tags.
+         */
+        wrapper?:
+        /**
+         * @param input Original input DOM element.
+         * @param settings Tagify instance settings object.
+         * @returns HTML string with the wrapper for the tags. Defaults to a
+         * `TAGS` DOM element.
+         */
+        (this: Tagify<T>, input: HTMLInputElement | HTMLTextAreaElement, settings: TagifySettings<T>) => string;
+
+        /**
+         * Template for the rendered tags.
+         */
+        tag?:
+        /**
+         * @param tagData Data of the tag to render.
+         * @returns HTML string with the rendered tag. Defaults to a `TAG` DOM
+         * element.
+         */
+        (this: Tagify<T>, tagData: T) => string;
+
+        /**
+         * This callback is called when the dropdown menu is about to be shown.
+         * It receives the current settings and should return the HTML for the
+         * dropdown menu container.
+         */
+        dropdown?:
+        /**
+         * @param Current settings for the dropdown instance.
+         * @returns HTML string with the dropdown menu container to use for the
+         * dropdown menu.
+         */
+        (this: Tagify<T>, settings: TagifySettings<T>) => string;
+
+        /**
+         * This callback is called once for each item in the dropdown list. It
+         * is given an item and should return the HTML markup for that item.
+         */
+        dropdownItem?:
+        /**
+         * @param Data of the item to render in the dropdown menu.
+         * @returns HTML string with the rendered dropdown item that will be
+         * shown in the dropdown menu.
+         */
+        (this: Tagify<T>, item: T) => string;
+
+        /**
+         * Callback invoked when no matching dropdown item was found. If there
+         * is no match for the typed text, a special dropdown item will be
+         * rendered using the value returned by this callback.
+         */
+        dropdownItemNoMatch?:
+        /**
+         * @param data Dropdown request data. The `value` is the value by
+         * which the whitelist should be filtered.
+         * @returns HTML string that is displayed in the dropdown suggestions
+         * list when no matching suggestions are found.
+         */
+        (this: Tagify<T>, data: { value: string }) => string;
+    }
+
+    /**
+     * Promise-based hooks for async program flow scenarios. Allows to "hook"
+     * (intervene) at certain points of the program, which were selected as a
+     * suitable place to pause the program flow and wait for further
+     * instructions on how / if to proceed.
+     *
+     * See also the `hooks` option of the settings that are passed to tagify.
+     */
+    interface Hooks<T extends BaseTagData = TagData> {
+        /**
+         * Hook invoked before a tag is removed. Can be used to perform a custom
+         * action. The tag is removed only when the promise is fulfilled. When
+         * the promise is rejected, the tag is not removed.
+         */
+        beforeRemoveTag?:
+        /**
+         * @param tags Tag or tags that are schedule to be removed.
+         * @return Promise that controls whether the tags are removed. When the
+         * promise resolves, the tags are removed if the promise was fulfilled,
+         * or kept when the promise was rejected.
+         */
+        (tags: T[]) => Promise<void>;
+
+        /**
+         * Hook invoked when the user clicks on a suggestion in the dropdown
+         * menu. Can be used to perform custom actions, such as removing a
+         * suggestion from the dropdown menu via a custom remove button. The
+         * suggestion is accepted and a new tag is added only when the promise
+         * is fulfilled. When the promise is rejected, the suggestion is not
+         * accepted and no tag is added.
+         */
+        suggestionClick?:
+        /**
+         * @param event Click event that occurred on a suggestion item.
+         * @return Promise that controls whether the suggestion is accepted.
+         * When the promise resolves, the suggestion is accepted if the promise
+         * was fulfilled, and declined when the promise was rejected.
+         */
+        (event: MouseEvent) => Promise<void>;
+    }
+
+    /**
+     * Settings that are available after the tagify instance was created.
+     * Includes a few extra properties that are not available when creating a
+     * new instance. These are also passed to several callback methods.
+     */
+    interface TagifySettings<T extends BaseTagData = TagData> extends TagifyConstructorSettings<T> {
+        /**
+         * Adds a required attribute to the Tagify wrapper element. Does nothing
+         * more.
+         */
+        required?: boolean;
+        /**
+         * No user-interaction (add / remove / edit) is allowed when `true`.
+         */
+        readonly?: boolean;
+    }
+
+    /**
+     * Optional settings for creating a new tagify instance. These can be used
+     * to modify how the tagify component behaves.
+     */
+    interface TagifyConstructorSettings<T extends BaseTagData = TagData> {
         /**
          * `TagData` property which will be displayed as the tag's text.
          * Remember to keep `value` property unique.
          * @default 'value'
          */
         tagTextProp?: string;
+
         /**
-         * Placeholder text. If this attribute is set on an input/textarea element it will override this setting.
+         * Placeholder text. If this attribute is set on an input / textarea
+         * element it will override this setting.
+         * @default Unset (no placeholder)
          */
         placeholder?: string;
+
         /**
          * RegEx string. Split tags by any of these delimiters.
          * Example delimiters: ",|.| " (comma, dot, or whitespace)
          * @default ','
          */
         delimiters?: string | RegExp;
+
         /**
          * Validate input by RegEx pattern (can also be applied on the input itself as an attribute).
-         * Example: `/[1-9]/`
+         * Example: /[1-9]/
          */
-        pattern?: string | RegExp;
+        pattern?: string | RegExp | null;
+
         /**
          * Use `select` for single-value dropdown-like select box.
          * See `mix` as value to allow mixed-content. The `pattern` setting must be set to some character.
          * @default null
          */
-        mode?: 'select' | 'mix' | null;
+        mode?: Mode | null;
+
         /**
-         * Interpolation for mix mode. Everything between these will become a tag.
+         * Interpolation for mix mode. Everything between these will become a
+         * tag.
          * @default ['[[', ']]']
          */
-        mixTagsInterpolator?: string[];
+        mixTagsInterpolator?: [string, string];
+
         /**
-         * Define conditions in which typed mix-tags content is allowing a tag to be created after.
+         * Define conditions in which typed mix-tags content is allowing a tag
+         * to be created after.
          * @default /,|\.|\:|\s/
          */
         mixTagsAllowedAfter?: RegExp;
+
         /**
          * Should duplicate tags be allowed or not?
          * @default false
          */
         duplicates?: boolean;
+
         /**
-         * If `true` trim the tag's value (remove before/after whitespaces).
+         * If `true` trim the tag's value (remove before / after white spaces).
          * @default true
          */
         trim?: boolean;
+
         /**
          * Should ONLY use tags allowed in whitelist.
          * In `mix` mode, setting it to `false` will not allow creating new tags.
          * @default false
          */
         enforceWhitelist?: boolean;
-        autocomplete?: {
-            /**
-             * Tries to suggest the input's value while typing (match from whitelist)
-             * by adding the rest of term as grayed-out text.
-             * @default true
-             */
-            enabled?: boolean;
-            /**
-             * If `true`, when → is pressed, use the suggested value to create a tag,
-             * else just auto-completes the input. In mixed-mode this is ignored and treated as `true`.
-             * @default false
-             */
-            rightKey?: boolean;
-        };
+
+        /**
+         * Options for offering autocomplete suggestions as the user types.
+         */
+        autocomplete?: AutocompleteSettings;
+
         /**
          * An array of allowed tags.
-         * Also used for auto-completion when `autoComplete.enabled` is `true`.
+         *
+         * Also used for auto-completion when `autocomplete.enabled` is `true`.
+         * @default Empty array.
          */
-        whitelist?: string[] | TagData[];
+        whitelist?: string[] | T[];
+
         /**
          * An array of tags which aren't allowed.
+         * @default Empty array.
          */
         blacklist?: string[];
+
         /**
-         * Automatically adds the text which was inputed as a tag when blur event happens.
+         * Automatically adds the text which was entered as a tag when a blur
+         * event happens.
          * @default true
          */
         addTagOnBlur?: boolean;
+
         /**
-         * Exposed callbacks object to be triggered on events.
+         * Callbacks that are invoked when the event specified by the key
+         * occurs.
          */
-        callbacks?: { [key: string]: (...args: any[]) => void };
+        callbacks?: {
+            [K in keyof EventDataMap]?: (event: CustomEvent<EventDataMap[K]>) => void;
+        };
+
         /**
          * Maximum number of allowed tags.
+         *
          * When reached, adds a class `tagify--hasMaxTags` to `<tags>`.
          * @default Infinity
          */
         maxTags?: number;
+
         /**
-         * Number of clicks to enter `edit` mode.
+         * Number of clicks to enter `edit` mode: 1 for single click, `2` for a
+         * double-click.
+         *
          * `false` or `null` will disallow editing.
-         * @default 2
+         * @default {clicks: 2, keepInvalid: true}
          */
-        editTags?: 2 | 1 | false | null | { clicks: 2 | 1, keepInvalid: boolean };
+        editTags?: 1 | 2 | false | null | EditTagsSettings;
+
         /**
-         * Functions that return template strings.
+         * Functions that return template strings. Can be used to customize how
+         * tags, drop down menus etc. are rendered.
          */
-        templates?: {
-            wrapper?: (input: HTMLInputElement | HTMLTextAreaElement, settings: TagifySettings) => string;
-            tag?: (tagData: TagData) => string;
-            dropdown?: (settings: TagifySettings) => string;
-            dropdownItem?: (item: TagData) => string;
-            dropdownItemNoMatch?: () => string;
-        };
+        templates?: Templates<T>;
+
         /**
-         * If the `pattern` setting does not meet your needs, use this function,
-         * which receives tag data object as an argument and should return `true`
-         * if validaton passed or `false`/`string` if not. A string may be returned
-         * as the reason of the validation failure.
+         * If the `pattern` setting does not meet your needs, use this function
+         * to implement a custom validation.
          */
-        validate?: (tagData: TagData) => boolean | string;
+        validate?:
         /**
-         * Takes a tag data as argument and allows mutating it before a tag is created or edited.
+         * @param tagData The tag to validate.
+         * @returns `true` if the tag is valid. `false` if the tag is invalid.
+         * When a string is returned, the tag is considered invalid and the
+         * string will be used as an error message.
+         */
+        (tagData: T) => boolean | string;
+
+        /**
+         * Takes a tag data as an argument and allows mutating it before a tag
+         * is created or edited.
+         *
          * Should not return anything, only mutate.
          */
-        transformTag?: (tagData: TagData) => void;
+        transformTag?:
+        /**
+         * @param tagData The tag to transform. May be mutated by this method.
+         */
+        (tagData: T) => void;
+
         /**
          * If `true`, do not remove tags which did not pass validation.
          * @default false
          */
         keepInvalidTags?: boolean;
+
         /**
-         * If `true`, do not add invalid, temporary tags before automatically removing them.
+         * If `true`, do not add invalid, temporary tags before automatically
+         * removing them.
          * @default false
          */
         skipInvalid?: boolean;
+
         /**
-         * On pressing backspace key:
-         * `true` - remove last tag,
-         * `edit` - edit last tag.
+         * When the backspace key is pressed:
+         * `true` - remove last tag
+         * `edit` - edit last tag
          * @default true
          */
         backspace?: boolean | 'edit';
+
         /**
-         * If you wish your original input/textarea `value` property format to other than the default
-         * (which I recommend keeping) you may use this and make sure it returns a string.
+         * If you wish your original input / textarea `value` property format to
+         * be anything other than the default (which I recommend keeping), you
+         * may use this and make sure it returns a string.
          */
-        originalInputValueFormat?: (value: TagData[]) => string;
-        mixMode?: {
-            /**
-             * Add after the added tag.
-             * @default '\u00A0'
-             */
-            insertAfterTag?: string | HTMLElement;
-        };
-        dropdown?: {
-            /**
-             * Minimum characters input for showing a suggestions list.
-             * `false` will not render a suggestions list.
-             * @default 2
-             */
-            enabled?: number | false;
-            /**
-             * If `true`, match exact item when a suggestion is selected (from the dropdown)
-             * and also more strict matching for dulpicate items.
-             * Ensure `fuzzySearch` is `false` for this to work.
-             * @default false
-             */
-            caseSensitive?: boolean;
-            /**
-             * Maximum items to show in the suggestions list.
-             * @default 10
-             */
-            maxItems?: number;
-            /**
-             * Custom class name for the dropdown suggestions selectbox.
-             */
-            classname?: string;
-            /**
-             * Enables filtering dropdown items values by string _containing_ and not only _beginning_.
-             * @default true
-             */
-            fuzzySearch?: boolean;
-            /**
-             * Enable searching for accented items in the whitelist without typing exact match.
-             * @default true
-             */
-            accentedSearch?: boolean;
-            /**
-             * - `manual` - will not render the dropdown, and you would need to do it yourself.
-             * - `text` - will place the dropdown next to the caret
-             * - `input` - will place the dropdown next to the input
-             * - `all` - normal, full-width design
-             * @default null
-             */
-            position?: 'manual' | 'text' | 'input' | 'all' | null;
-            /**
-             * When a suggestions list is shown, highlight the first item,
-             * and also suggest it in the input (The suggestion can be accepted with → key).
-             * @default null
-             */
-            highlightFirst?: boolean;
-            /**
-             * Close the dropdown after selecting an item, if `enabled: 0` is set
-             * (which means always show dropdown on focus).
-             * @default true
-             */
-            closeOnSelect?: boolean;
-            /**
-             * if `false`, keep typed text after selecting a suggestion.
-             * @default true
-             */
-            clearOnSelect?: boolean;
-            /**
-             * If whitelist is an Array of Objects,
-             * this setting controlls which data key will be printed in the dropdown.
-             */
-            mapValueTo?: string | ((data: TagData) => string);
-            /**
-             * When a user types something and trying to match the whitelist items for suggestions,
-             * this setting allows matching other keys of a whitelist objects.
-             * @default ['value', 'searchBy']
-             */
-            searchKeys?: string[];
-            /**
-             * Target node which the suggestions dropdown is appended to (only when rendered).
-             */
-            appendTarget?: HTMLElement;
-        };
+        originalInputValueFormat?:
+        /**
+         * @param value Currently selected tags.
+         * @returns The stringified value representing all tags. This value is
+         * set on the hidden input or textarea element.
+         */
+        (value: T[]) => string;
+
+        /**
+         * Optional settings to configure how mixed mode behaves, see also the
+         * `mode` setting.
+         */
+        mixMode?: MixModeSettings;
+
+        /**
+         * Optional class names that are added to the corresponding elements.
+         */
+        classNames?: ClassNameSettings;
+
+        /**
+         * Options for offering a dropdown menu with available tags.
+         */
+        dropdown?: DropDownSettings<T>;
+
+        /**
+         * Promise-based hooks for async program flow scenarios. Allows to
+         * "hook" (intervene) at certain points of the program, which were
+         * selected as a suitable place to pause the program flow and wait for
+         * further instructions on how / if to proceed.
+         */
+        hooks?: Hooks<T>;
     }
 
     /**
-     * Default tag format. `value` property must be unique.
+     * Generic tag format that requires only a value and allows other
+     * properties.
+     *
+     * `value` property must be unique, i.e. no two different tags may share the
+     * same value.
+     *
+     * Note to TypeScript users: you can parametrize the tagify instance with a
+     * type parameter that extends from `BaseTagData` instead for additional
+     * type safety.
      */
-    interface TagData {
-        value: string;
+    interface TagData extends BaseTagData {
         [key: string]: any;
+    }
+
+    /**
+     * Base interface for tag data. A tag always requires a value, but may have
+     * more custom properties.
+     *
+     * `value` property must be unique, i.e. no two different tags may share the
+     * same value.
+     *
+     * Note to TypeScript users: you can parametrize the tagify instance with a
+     * type parameter that extends this interface for additional type safety.
+     */
+    interface BaseTagData {
+        value: string;
+    }
+
+    /**
+     * Base event data common to all events.
+     */
+    interface EventData<T extends BaseTagData = TagData> {
+        /**
+         * The tagify instance which triggered the event.
+         */
+        tagify: Tagify<T>;
+    }
+
+    /**
+     * Event data with a single parameter. When a non-object value is passed to
+     * trigger, it is wrapped in this object.
+     */
+    interface SingleEventData<T extends BaseTagData = TagData, S = unknown> extends EventData<T> {
+        value: S;
+    }
+
+    /**
+     * Event data relating to a single tag.
+     */
+    interface TagEventData<T extends BaseTagData = TagData> extends EventData<T> {
+        data?: T;
+        index?: number;
+        tag: HTMLElement;
+    }
+
+    /**
+     * Event data for events triggered by DOM events.
+     */
+    interface DomEventData<T extends BaseTagData = TagData, E extends Event = Event> extends EventData<T> {
+        originalEvent: E;
+    }
+
+    /**
+     * Event data for keyboard related events.
+     */
+    interface KeyboardEventData<T extends BaseTagData = TagData> extends DomEventData<T, KeyboardEvent> { }
+
+    /**
+     * Event data for when the element receives or loses focus.
+     */
+    interface FocusChangeEventData<T extends BaseTagData = TagData> extends EventData<T> {
+        relatedTarget: Element;
+    }
+
+    /**
+     * Event data for events related to the dropdown feature.
+     */
+    interface DropDownEventData<T extends BaseTagData = TagData> extends EventData<T> {
+        dropdown: HTMLElement;
+    }
+
+    /**
+     * A tag has been added.
+     */
+    interface AddEventData<T extends BaseTagData = TagData> extends TagEventData<T> { }
+
+    /**
+     * The component lost focus.
+     */
+    interface BlurEventData<T extends BaseTagData = TagData> extends FocusChangeEventData<T> { }
+
+    /**
+     * Any change to the value has occurred.
+     */
+    interface ChangeEventData<T extends BaseTagData = TagData> extends SingleEventData<T, string> { }
+
+    /**
+     * Clicking a tag.
+     */
+    interface ClickEventData<T extends BaseTagData = TagData> extends DomEventData<T, MouseEvent>, TagEventData<T> {
+        data: T;
+        index: number;
+    }
+
+    /**
+     * Double-clicking a tag.
+     */
+    interface DoubleClickEventData<T extends BaseTagData = TagData> extends TagEventData<T> { }
+
+    /**
+     * Suggestions dropdown has been removed from the DOM.
+     */
+    interface DropDownHideEventData<T extends BaseTagData = TagData> extends DropDownEventData<T> { }
+
+    /**
+     * Suggestions dropdown is to be rendered. The dropdown DOM node is
+     * passed in the callback.
+     */
+    interface DropDownShowEventData<T extends BaseTagData = TagData> extends DropDownEventData<T> { }
+
+    /**
+     * When the dropdown menu is open and its items were recomputed via
+     * `Tagify.refilter`.
+     */
+    interface DropDownUpdatedEventData<T extends BaseTagData = TagData> extends DropDownEventData<T> { }
+
+    /**
+     * No whitelist suggestion item matched for the the typed input. At this
+     * point it is possible to manually set `suggestedListItems` to any
+     * possible custom value, for example: `[{ value:"default" }]`.
+     */
+    interface DropDownNoMatchEventData<T extends BaseTagData = TagData> extends SingleEventData<T, string> { }
+
+    /**
+     * Suggestions dropdown item selected (by mouse / keyboard/ touch).
+     */
+    interface DropDownSelectEventData<T extends BaseTagData = TagData> extends SingleEventData<T, string> { }
+
+    /**
+     * Tells the percentage scrolled. (`event.detail.percentage`).
+     */
+    interface DropDownScrollEventData<T extends BaseTagData = TagData> extends EventData<T> {
+        percentage: number;
+    }
+
+    /**
+     * Just before a tag has been updated, while still in "edit" mode.
+     */
+    interface EditBeforeUpdateEventData<T extends BaseTagData = TagData> extends TagEventData<T> { }
+
+    /**
+     * Typing inside an edited tag.
+     */
+    interface EditInputEventData<T extends BaseTagData = TagData> extends TagEventData<T> {
+        data: T & { newValue: string };
+        index: number;
+        originalEvent: Event;
+    }
+
+    /**
+     * Keydown event while an edited tag is in focus
+     */
+    interface EditKeydownEventData<T extends BaseTagData = TagData> extends KeyboardEventData<T> { }
+
+    /**
+     * A tag is now in "edit mode".
+     */
+    interface EditStartEventData<T extends BaseTagData = TagData> extends TagEventData<T> {
+        data: T;
+        index: number;
+        isValid: boolean;
+    }
+
+    /**
+     * A tag as been updated (changed view editing or by directly calling
+     * the `replaceTag` method).
+     */
+    interface EditUpdatedEventData<T extends BaseTagData = TagData> extends TagEventData<T> { }
+
+    /**
+     * The component has received focus.
+     */
+    interface FocusEventData<T extends BaseTagData = TagData> extends FocusChangeEventData<T> { }
+
+    /**
+     * A tag has been added but did not pass validation.
+     */
+    interface InvalidTagEventData<T extends BaseTagData = TagData> extends TagEventData<T> {
+        data: T;
+        message: boolean;
+    }
+
+    /**
+     * Input event, when a tag is being typed / edited.
+     */
+    interface InputEventData<T extends BaseTagData = TagData> extends EventData<T> {
+        inputElm: HTMLInputElement | HTMLTextAreaElement;
+        value: string;
+    }
+
+    /**
+     * When tagify input has focus and a key was pressed.
+     */
+    interface KeydownEventData<T extends BaseTagData = TagData> extends KeyboardEventData<T> { }
+
+    /**
+     * A tag has been removed (use `removeTag` instead with jQuery).
+     */
+    interface RemoveEventData<T extends BaseTagData = TagData> extends TagEventData<T> { }
+
+    /**
+     * Map between the events that are triggered by tagify and the data provided
+     * for each event.
+     */
+    interface EventDataMap<T extends BaseTagData = TagData> {
+        /**
+         * A tag has been added.
+         */
+        'add': AddEventData<T>;
+
+        /**
+         * The component lost focus.
+         */
+        'blur': BlurEventData<T>;
+
+        /**
+         * Any change to the value has occurred.
+         */
+        'change': ChangeEventData<T>;
+
+        /**
+         * Clicking a tag.
+         */
+        'click': ClickEventData<T>;
+
+        /**
+         * Double-clicking a tag.
+         */
+        'dblclick': DoubleClickEventData<T>;
+
+        /**
+         * Suggestions dropdown item selected (by mouse / keyboard/ touch).
+         */
+        'dropdown:select': DropDownSelectEventData<T>;
+
+        /**
+         * Tells the percentage scrolled. (`event.detail.percentage`).
+         */
+        'dropdown:scroll': DropDownScrollEventData<T>;
+
+        /**
+         * Suggestions dropdown is to be rendered. The dropdown DOM node is
+         * passed in the callback.
+         */
+        'dropdown:show': DropDownShowEventData<T>;
+
+        /**
+         * Suggestions dropdown has been removed from the DOM.
+         */
+        'dropdown:hide': DropDownHideEventData<T>;
+
+        /**
+         * No whitelist suggestion item matched for the the typed input. At this
+         * point it is possible to manually set `suggestedListItems` to any
+         * possible custom value, for example: `[{ value:"default" }]`.
+         */
+        'dropdown:noMatch': DropDownNoMatchEventData<T>;
+
+        /**
+         * When the dropdown menu is open and its items were recomputed via
+         * `Tagify.refilter`.
+         */
+        'dropdown:updated': DropDownUpdatedEventData<T>;
+
+        /**
+         * Just before a tag has been updated, while still in "edit" mode.
+         */
+        'edit:beforeUpdate': EditBeforeUpdateEventData<T>;
+
+        /**
+         * Typing inside an edited tag.
+         */
+        'edit:input': EditInputEventData<T>;
+
+        /**
+         * Keydown event while an edited tag is in focus
+         */
+        'edit:keydown': EditKeydownEventData<T>;
+
+        /**
+         * A tag is now in "edit mode".
+         */
+        'edit:start': EditStartEventData<T>;
+
+        /**
+         * A tag as been updated (changed view editing or by directly calling
+         * the `replaceTag` method).
+         */
+        'edit:updated': EditUpdatedEventData<T>;
+
+        /**
+         * The component has received focus.
+         */
+        'focus': FocusEventData<T>;
+
+        /**
+         * Input event, when a tag is being typed / edited.
+         */
+        'input': InputEventData<T>;
+
+        /**
+         * A tag has been added but did not pass validation.
+         */
+        'invalid': InvalidTagEventData<T>;
+
+        /**
+         * When tagify input has focus and a key was pressed.
+         */
+        'keydown': KeydownEventData<T>;
+
+        /**
+         * A tag has been removed (use `removeTag` instead with jQuery).
+         */
+        'remove': RemoveEventData<T>;
+    }
+
+    /**
+     * References to DOM elements used by an active tagify instance.
+     */
+    interface Dom {
+        /**
+         * The dropdown container with the `tagify__dropdown` class.
+         */
+        dropdown: HTMLDivElement;
+
+        /**
+         * The SPAN element representing the visible tag input area with the
+         * `tagify__input` class.
+         */
+        input: HTMLSpanElement;
+
+        /**
+         * The original hidden INPUT or TEXTAREA element that stores the value.
+         */
+        originalInput: HTMLInputElement | HTMLTextAreaElement;
+
+        /**
+         * The tagify container with the `tagify` class.
+         */
+        scope: HTMLElement;
     }
 }
 
 /**
  * Tagify class
  */
-declare class Tagify {
+declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
     /**
-     * Settings.
+     * The current settings of this tagify instance.
      */
-    settings: Tagify.TagifySettings;
-    /**
-     * Array with tag data.
-     */
-    value: Tagify.TagData[];
+    settings: Tagify.TagifySettings<T>;
 
     /**
-     * References to elements.
+     * Array with tag data of the currently selected tags.
      */
-    DOM: {
-        dropdown: HTMLDivElement,
-        input: HTMLSpanElement,
-        originalInput: HTMLInputElement | HTMLTextAreaElement,
-        scope: HTMLElement
-    };
+    value: T[];
+
+    /**
+     * References to DOM elements used by this tagify instance.
+     */
+    DOM: Tagify.Dom;
 
     /**
      * Dropdown specific methods.
      */
     dropdown: {
         /**
-         * Shows the suggestions select box.
-         * @param value - Filter the whitelist by this value (optional)
+         * Refilters the list of items in the dropdown.
+         *
+         * Note that this must be called with the this context set to the tagify
+         * instance, use `call` or `apply` for that.
+         *
+         * @param filterValue Filter the whitelist by this value (optional).
          */
-        show(value?: string): void;
+        refilter(this: Tagify<T>, filterValue?: string): void;
+
+        /**
+         * Shows the suggestions select box.
+         *
+         * Note that this must be called with the this context set to the tagify
+         * instance, use `call` or `apply` for that.
+         *
+         * @param filterValue Filter the whitelist by this value (optional).
+         */
+        show(this: Tagify<T>, filterValue?: string): void;
+
         /**
          * Hide the suggestions select box.
+         *
+         * Note that this must be called with the this context set to the tagify
+         * instance, use `call` or `apply` for that.
+         *
+         * @param force Whether the dropdown menu should be hidden even when it
+         * would need to be prevented.
          */
-        hide(force?: boolean): void;
+        hide(this: Tagify<T>, force?: boolean): void;
+
         /**
          * Add all whitelist items as tags and close the suggestion dropdown.
+         *
+         * Note that this must be called with the this context set to the tagify
+         * instance, use `call` or `apply` for that.
          */
-        selectAll(): void;
+        selectAll(this: Tagify<T>): void;
     };
 
-    constructor(inputElement: HTMLInputElement | HTMLTextAreaElement, settings?: Tagify.TagifySettings);
+    constructor(
+        inputElement: HTMLInputElement | HTMLTextAreaElement,
+        settings?: Tagify.TagifyConstructorSettings<T>
+    );
 
     /**
-     * Returns a string of HTML element attributes.
+     * @param tagData Tag for which to retrieve its HTML attributes.
+     * @returns A string of HTML element attributes for the given tag.
      */
-    getAttributes(tagData: Tagify.TagData): string;
+    getAttributes(tagData: T): string;
 
     /**
      * Reverts the input element back as it was before Tagify was applied.
@@ -299,177 +1099,274 @@ declare class Tagify {
 
     /**
      * Parse and add tags.
-     * @param tags - Accepts a String (word, single or multiple with a delimiter), an Array of Objects or Strings
-     * @param clearInput - If true, the input's value gets cleared after adding tags
-     * @param skipInvalid - If true, do not add, mark & remove invalid tags (defaults to Tagify settings)
+     * @param tags Tags to add. When a string, it can be either a single word or
+     * multiple words separated with a delimiter.
+     * @param clearInput If `true`, the input's value gets cleared after
+     * adding tags.
+     * @param skipInvalid If `true`, do not add, mark & remove invalid tags
+     * (defaults to Tagify settings).
+     * @return List of HTML elements representing the tags that were added.
      */
-    addTags(tags: string, clearInput?: boolean, skipInvalid?: boolean): HTMLElement;
-    addTags(tags: string[] | Tagify.TagData[], clearInput?: boolean, skipInvalid?: boolean): HTMLElement[];
+    addTags(tags: string | string[] | T[], clearInput?: boolean, skipInvalid?: boolean): HTMLElement[];
 
     /**
-     * Bypasses the normalization process in `addTags`, forcefully adding tags at the last caret
-     * location or at the end, if there's no last caret location saved (at `tagify.state.selection`).
-     * @param tags - Accepts a String (word, single or multiple with a delimiter), an Array of Objects or Strings
+     * Bypasses the normalization process in `addTags`, forcefully adding tags
+     * at the last caret location or at the end, if there's no last caret
+     * location saved (at `tagify.state.selection`).
+     * @param tags Tags to add. When a string, it can be either a single word or
+     * multiple words separated with a delimiter.
      */
-    addMixTags(tags: string | string[] | Tagify.TagData[]): void;
+    addMixTags(tags: string | string[] | T[]): void;
 
     /**
-     * Remove single/multiple tags. When nothing passed, removes last tag.
-     * @param tagElms - DOM element(s) or a String value
-     * @param silent - A flag, which when turned on, does not remove any value and does not update
-     * the original input value but simply removes the tag from tagify
-     * @param tranDuration - Delay for animation, after which the tag will be removed from the DOM
+     * Remove single/multiple tags. When nothing is passed, removes the last
+     * tag.
+     * @param tagElms DOM element(s) or a String value
+     * @param silent A flag, which when turned on, does not remove any value and
+     * does not update the original input value but simply removes the tag from
+     * tagify.
+     * @param tranDuration - Delay for animation in milliseconds, after which
+     * the tag will be removed from the DOM.
      */
     removeTags(tagElms?: HTMLElement[] | HTMLElement | string, silent?: boolean, tranDuration?: number): void;
 
     /**
-     * Create an empty tag (optionally with predefined data) and enters "edit" mode directly.
+     * Create an empty tag (optionally with predefined data) and enters edit
+     * mode directly.
+     * @param initialData Optional initial data for the new tag.
      */
-    addEmptyTag(initialData?: {[key: string]: any}): void;
+    addEmptyTag(initialData?: Partial<T>): void;
 
     /**
-     * Converts the input's value into tags. This method gets called automatically when instantiating Tagify.
-     * Also works for mixed-tags.
+     * Converts the given value into tags. This method gets called
+     * automatically when instantiating Tagify. Also works for mixed tags.
+     * @param value Value to convert to tags. When not given, the value of
+     * the hidden INPUT or TEXTAREA element is used.
      */
     loadOriginalValues(value: string | string[]): void;
 
     /**
-     * Return an array of found matching items (case-insensitive).
+     * @param value Value to search for.
+     * @param property Optional property whose value is used for the search.
+     * Defaults to `value` when not given. The property will be converted to a
+     * string and compared to the search value.
+     * @param whitelist List of tag in which to search. When no given, uses the
+     * current whitelist setting of this tagify instance.
+     * @returns An array of found matching items (case-insensitive).
      */
-    getWhitelistItem(value: Tagify.TagData): Tagify.TagData[];
+    getWhitelistItem(value: string, property?: keyof T, whitelist?: string[] | T[]): T[];
 
     /**
-     * Returns how many tags already exists with specific value.
+     * @param value Value to search for in the `value` property` of the
+     * existing tags.
+     * @param caseSensitive Whether the search for tags should be
+     * case-sensitive.
+     * @returns When the `mode` is set to `select`, this returns `false`.
+     * Otherwise, this returns how many tags with the given value already exist.
      */
-    isTagDuplicate(value: string | Tagify.TagData, caseSensitive?: boolean): number;
+    isTagDuplicate(value: string | T, caseSensitive?: boolean): number | false;
 
     /**
-     * Converts a string argument (`[[foo]] and [[bar]] are...`) into HTML with mixed tags & texts.
+     * Converts a string argument (such as `[[foo]] and [[bar]] are...`) into
+     * HTML with mixed tags & texts.
+     * @param value A value with tags to parse.
+     * @return The parsed HTML with mixed tags & texts.
      */
     parseMixTags(value: string): string;
 
     /**
-     * Return a DOM nodes list of all the tags.
      * @param classes - Filter by set of class names
+     * @return A list of DOM nodes of all the tags, optionally filtered by the
+     * given class names. Empty array when there are no tags.
      */
     getTagElms(...classes: string[]): HTMLElement[];
 
     /**
-     * Return a specific tag DOM node by value.
+     * @param value Value to search for in the text content of the current tags.
+     * @returns The DOM node for the first matching tag. `undefined` when no
+     * matching tag was found.
      */
-    getTagElmByValue(value: string): HTMLElement;
+    getTagElmByValue(value: string): HTMLElement | undefined;
 
     /**
-     * Return the indices of tags by value.
+     * @param value Value to search for in the text content of the current tags.
+     * @returns The 0-based indices of the matching tags. Empty array when no
+     * matching tag was found.
      */
     getTagIndexByValue(value: string): number[];
 
     /**
-     * Set/get tag data on a tag element
+     * Gets the tag data of the given tag element.
+     * @param tagElm A tag HTML element (by default those with the `tagify__tag`
+     * class).
+     * @return The data for the tag. `undefined` when no tag data was found or
+     * the element is not an existing tag.
      */
-    tagData(tagElm: HTMLElement, data?: Tagify.TagData): Tagify.TagData;
+    tagData(tagElm: HTMLElement): T | undefined;
 
     /**
-     * Enters a tag into "edit" mode.
-     * @param tagElm - The tag element to edit. If nothing specified, use the last one.
+     * Sets the data of the given tag element to the given value.
+     * @param tagElm A tag HTML element (by default those with the `tagify__tag`
+     * class).
+     * @param data New data to set on the tag. Replaces the values for the given
+     * properties. Properties not given remain unchanged.
+     * @param override `undefined` or `false` to assign the given data to the
+     * tag's data and keep other properties.
+     * @return The new tag data for the tag, or the given data when the element
+     * is not an existing tag.
      */
-    editTag(tagElm?: HTMLElement): void;
+    tagData<P extends Partial<T>>(tagElm: HTMLElement, data: P, override?: false): P | T;
+
+    /**
+     * Sets the data of the given tag element to the given value.
+     * @param tagElm A tag HTML element (by default those with the `tagify__tag`
+     * class).
+     * @param data New data to set on the tag. Replaces the values for the given
+     * properties. Properties not given remain unchanged.
+     * @param override `true` to replace all the entire tag data with the given
+     * data.
+     * @return The new tag data for the tag, or the given data when the element
+     * is not an existing tag.
+     */
+    tagData(tagElm: HTMLElement, data: T, override: true): T;
+
+    /**
+     * Switches a tag into edit mode so that it can be edited by the user.
+     * @param tagElm The tag element to edit. If none is given, use the last
+     * tag.
+     * @return This tagify instance for chaining methods.
+     */
+    editTag(tagElm?: HTMLElement): this;
 
     /**
      * Replaces an existing tag with a new one. Used for updating a tag's data.
+     * Also exits the tag's edit mode.
+     * @param tagElm A tag HTML element (by default those with the `tagify__tag`
+     * class).
+     * @param tagData The new tag data for the tag.
      */
-    replaceTag(tagElm: HTMLElement, tagData: Tagify.TagData): void;
+    replaceTag(tagElm: HTMLElement, tagData: T): void;
 
     /**
      * Toggle loading state on/off (e.g. for AJAX whitelist pulling)
+     * @param loading `true` to switch to the loading state, `false` to switch out of
+     * the loading state.
+     * @return This tagify instance for chaining methods.
      */
-    loading(isLoading: boolean): this;
+    loading(loading: boolean): this;
 
     /**
-     * Toggle specific tag loading state on/off.
+     * Toggle specific tag loading state on or off.
+     * @param tagElm A tag HTML element (by default those with the `tagify__tag`
+     * class).
+     * @param loading `true` to switch the tag to the loading state, `false` to
+     * switch it out of the loading state.
+     * @return This tagify instance for chaining methods.
      */
-    tagLoading(tagElm: HTMLElement, isLoading: boolean): this;
+    tagLoading(tagElm: HTMLElement, loading: boolean): this;
 
     /**
-     * Return a tag element from the supplied tag data.
+     * Creates a new tag DOM element with the given data.
+     * @param Data to use for creating the tag.
+     * @returns A new tag element from the supplied tag data.
      */
-    createTagElem(tagData: Tagify.TagData): HTMLElement;
+    createTagElem(tagData: T): HTMLElement;
 
     /**
      * Injects text or HTML node at last caret position,
      * which is saved on the "state" when "blur" event gets triggered.
-     * @param injectedNode - The node to inject at the caret position
-     * @param range - Optional range object, must have `anchorNode` and  `anchorOffset`
+     * @param injectedNode The text content or node to inject at the current
+     * caret position.
+     * @param range Optional range object, must have `anchorNode` and
+     * `anchorOffset` set.
+     * @return This tagify instance for chaining methods.
      */
-    injectAtCaret(injectedNode: string | HTMLElement, range?: Selection): void;
+    injectAtCaret(injectedNode: string | HTMLElement, range?: Selection): this;
 
     /**
      * Places the caret after a given node.
+     * @param Node after which to place the caret.
      */
     placeCaretAfterNode(node: HTMLElement): void;
 
+    /**
+     * Inserts text or a node after the given tag.
+     * @param tagElm A tag HTML element (by default those with the `tagify__tag`
+     * class).
+     * @param newNode Text content or node to insert.
+     * @return The newly inserted node. A new node is created when a string is
+     * given.
+     */
     insertAfterTag(tagElm: HTMLElement, newNode: string | HTMLElement): HTMLElement;
 
     /**
-     * Toggles class on the man tagify container (`scope`).
+     * Toggles the given class on the main tagify container (`scope`).
+     * @param className Name of the class to toggle.
+     * @param force If not given, adds the class to the element if not present
+     * and removes it when present. If `true`, adds the class to the element.
+     * If `false`, removes the class from the element.
      */
-    toggleClass(className: string, on: boolean): void;
+    toggleClass(className: string, force?: boolean): void;
 
     /**
-     * Update `value` (array of objects) by traversing all valid tags.
+     * Update `value` (array of tag data) by traversing all valid tags.
+     *
+     * Iterates all tag DOM nodes and rebuilds the `value` array. Call this if
+     * tags get sorted manually)
      */
     updateValueByDOMTags(): void;
 
     /**
      * Converts a template string into a DOM node.
-     * @param template - Select a template from the `settings.templates` by name or supply a template function which returns a string
-     * @param data - Arguments passed to the template function
+     * @template K The name of a template from `settings.templates`.
+     * @param template The name of a template from `settings.templates`.
+     * @param data Arguments passed to the template function.
+     * @returns The rendered HTML string.
      */
-    parseTemplate(template: 'wrapper', data: [HTMLInputElement | HTMLTextAreaElement, Tagify.TagifySettings]): HTMLElement;
-    parseTemplate(template: 'tag' | 'dropdownItem', data: [Tagify.TagData]): HTMLElement;
-    parseTemplate(template: 'dropdown', data: [Tagify.TagifySettings]): HTMLElement;
-    parseTemplate(template: 'dropdownItemNoMatch', data: []): HTMLElement;
-    parseTemplate(template: ((...args: any) => string), data: any[]): HTMLElement;
+    parseTemplate<K extends keyof Tagify.Templates>(
+        template: K,
+        data: Parameters<Exclude<Tagify.Templates[K], undefined>>
+    ): HTMLElement;
 
     /**
-     * Toggles "readonly" mode on/off.
+     * Converts a template string into a DOM node.
+     * @template Args Arguments passed to the template function.
+     * @param template A template function which returns a string.
+     * @param data Arguments passed to the template function.
+     * @returns The rendered HTML string.
      */
-    setReadonly(isReadonly: boolean): void;
+    parseTemplate<Args extends any[]>(template: ((...args: Args) => string), data: Args): HTMLElement;
 
     /**
-     * Add event listener
+     * Switches read-only mode on or off.
+     * @param readonly `true` to switch the tagify instance to read-only mode,
+     * `false` to switch off read-only mode.
      */
-    on(event: 'add' | 'remove' | 'dblclick' | 'edit:beforeUpdate' | 'edit:updated', cb: (e: CustomEvent<{
-        tagify: Tagify, tag: HTMLElement, index?: number, data?: Tagify.TagData
-    }>) => void): this;
-    on(event: 'invalid', cb: (e: CustomEvent<{
-        tagify: Tagify, tag: HTMLElement, index?: number, data: Tagify.TagData, message: boolean
-    }>) => void): this;
-    on(event: 'input', cb: (e: CustomEvent<{
-        tagify: Tagify, value: string, inputElm: HTMLInputElement | HTMLTextAreaElement
-    }>) => void): this;
-    on(event: 'click', cb: (e: CustomEvent<{
-        tagify: Tagify, tag: HTMLElement, index: number, data: Tagify.TagData, originalEvent: MouseEvent
-    }>) => void): this;
-    on(event: 'keydown' | 'edit:keydown', cb: (e: CustomEvent<{ tagify: Tagify, originalEvent: KeyboardEvent }>) => void): this;
-    on(event: 'focus' | 'blur', cb: (e: CustomEvent<{
-        tagify: Tagify, relatedTarget: Element
-    }>) => void): this;
-    on(event: 'edit:start', cb: (e: CustomEvent<{
-        tagify: Tagify, tag: HTMLElement, index: number, data: Tagify.TagData, isValid: boolean
-    }>) => void): this;
-    on(event: 'edit:input', cb: (e: CustomEvent<{
-        tagify: Tagify, tag: HTMLElement, index: number, data: Tagify.TagData & { newValue: string }, originalEvent: Event
-    }>) => void): this;
-    on(event: 'dropdown:show' | 'dropdown:hide' | 'dropdown:updated', cb: (e: CustomEvent<{
-        tagify: Tagify, dropdown: HTMLElement
-    }>) => void): this;
-    on(event: 'dropdown:scroll', cb: (e: CustomEvent<{
-        tagify: Tagify, percentage: number
-    }>) => void): this;
-    on(event: 'dropdown:select', cb: (e: CustomEvent<{
-        tagify: Tagify, value: string;
-    }>) => void): this;
+    setReadonly(readonly: boolean): void;
+
+    /**
+     * Removes a listener previously added via `on`.
+     * @template K Name of the event.
+     * @param event Name of the event.
+     * @param callback Callback listener to remove.
+     * @returns This tagify instance for chaining method calls.
+     */
+    off<K extends keyof Tagify.EventDataMap>(
+        event: K,
+        callback: (event: CustomEvent<Tagify.EventDataMap[K]>) => void
+    ): this;
+
+    /**
+     * Adds a listener for the given event to this tagify instance.
+     * @template K Name of the event to which to listen.
+     * @param event Name of the event to which to listen.
+     * @param callback Callback listener invoked when the event occurs.
+     * @returns This tagify instance for chaining method calls.
+     */
+    on<K extends keyof Tagify.EventDataMap>(
+        event: K,
+        callback: (event: CustomEvent<Tagify.EventDataMap[K]>) => void
+    ): this;
 }
 
 export = Tagify;

--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -1128,8 +1128,8 @@ declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
      * Creates a string representing the current value entered in the tagify
      * input field. In mixed mode, both tags and plain text content may be
      * entered. The string that is returned will have tags enclosed in the
-     * delimiters as specified by `mixTagsInterpolator`. For example, when is
-     * ``mixTagsInterpolator` was not changed from its default:
+     * delimiters as specified by `mixTagsInterpolator`. For example, when
+     * `mixTagsInterpolator` was not changed from its default:
      *
      * ```text
      * [[{"id":101,"value":"cartman","title":"Eric Cartman"}]] does not know [[{"value":"homer simpson","readonly":true}]] because he's a relic.

--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -10,7 +10,7 @@ declare namespace Tagify {
      * - `select`: Single-value dropdown-like select box.
      * - `mix`: Allow mixed-content. Requires the `pattern` setting to be set.
      */
-    type Mode = 'select' | 'mix';
+    type TagifyMode = 'select' | 'mix';
 
     /**
      * Where the dropdown menu will appear:
@@ -483,7 +483,7 @@ declare namespace Tagify {
          * See `mix` as value to allow mixed-content. The `pattern` setting must be set to some character.
          * @default null
          */
-        mode?: Mode | null;
+        mode?: TagifyMode | null;
 
         /**
          * Interpolation for mix mode. Everything between these will become a
@@ -986,10 +986,12 @@ declare namespace Tagify {
         'remove': RemoveEventData<T>;
     }
 
+    // types for the tagify instance
+
     /**
      * References to DOM elements used by an active tagify instance.
      */
-    interface Dom {
+    interface DomReference {
         /**
          * The dropdown container with the `tagify__dropdown` class.
          */
@@ -1011,6 +1013,21 @@ declare namespace Tagify {
          */
         scope: HTMLElement;
     }
+
+    /**
+     * Optional settings that can be passed to {@link Tagify.update}.
+     */
+    interface UpdateOptions {
+        /**
+         * When `true`, no change is event triggered and the change is applied
+         * silently. When `false` or not given, a change event is triggered
+         * normally as if the user had made the change. Note that no event is
+         * triggered when the value of the INPUT or TEXTAREA element did not
+         * change.
+         * @default false
+         */
+        withoutChangeEvent?: boolean;
+    }
 }
 
 /**
@@ -1030,7 +1047,7 @@ declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
     /**
      * References to DOM elements used by this tagify instance.
      */
-    DOM: Tagify.Dom;
+    DOM: Tagify.DomReference;
 
     /**
      * Dropdown specific methods.
@@ -1098,13 +1115,41 @@ declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
     removeAllTags(): void;
 
     /**
+     * Update the value of the original (hidden) INPUT or TEXTAREA field so that
+     * it reflects the currently selected tags.
+     * @param opts Optional settings that affect how the update is performed.
+     * Can be used to suppress the change event.
+     */
+    update(opts?: Tagify.UpdateOptions): void;
+
+    /**
+     * Should only be used when in mixed mode.
+     *
+     * Creates a string representing the current value entered in the tagify
+     * input field. In mixed mode, both tags and plain text content may be
+     * entered. The string that is returned will have tags enclosed in the
+     * delimiters as specified by `mixTagsInterpolator`. For example, when is
+     * ``mixTagsInterpolator` was not changed from its default:
+     *
+     * ```text
+     * [[{"id":101,"value":"cartman","title":"Eric Cartman"}]] does not know [[{"value":"homer simpson","readonly":true}]] because he's a relic.
+     * ```
+     *
+     * @return When not in mixed mode: the empty string. When in mixed mode: a
+     * string with the entire content currently entered in the tagify input
+     * fields, with tags enclosed in the delimiters as specified by the
+     * `mixTagsInterpolator` setting.
+     */
+    getMixedTagsAsString(): string;
+
+    /**
      * Parse and add tags.
      * @param tags Tags to add. When a string, it can be either a single word or
      * multiple words separated with a delimiter.
      * @param clearInput If `true`, the input's value gets cleared after
      * adding tags.
      * @param skipInvalid If `true`, do not add, mark & remove invalid tags
-     * (defaults to Tagify settings).
+     * (defaults to the current tagify settings).
      * @return List of HTML elements representing the tags that were added.
      */
     addTags(tags: string | string[] | T[], clearInput?: boolean, skipInvalid?: boolean): HTMLElement[];

--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @yaireo/tagify 3.22
+// Type definitions for @yaireo/tagify 3.23
 // Project: https://github.com/yairEO/tagify
 // Definitions by: Brakebein <https://github.com/Brakebein>
 //                 Andre Wachsmuth <https://github.com/blutorange>

--- a/types/yaireo__tagify/yaireo__tagify-tests.ts
+++ b/types/yaireo__tagify/yaireo__tagify-tests.ts
@@ -779,37 +779,50 @@ typedTagify.addEmptyTag({ active: false });
 typedTagify.addEmptyTag({ label: "Apple" });
 tagify.loadOriginalValues('banana');
 tagify.loadOriginalValues(['banana', 'orange']);
+// $ExpectType TagData[]
 tagify.getWhitelistItem("foo");
+// $ExpectType TagData[]
 tagify.getWhitelistItem("foo", 'banana');
+// $ExpectType TagData[]
 tagify.getWhitelistItem("foo", 'banana', [{ value: "boo" }]);
+// $ExpectType MyTagData[]
 typedTagify.getWhitelistItem("foo");
+// $ExpectType MyTagData[]
 typedTagify.getWhitelistItem("foo", "title");
+// $ExpectType MyTagData[]
 typedTagify.getWhitelistItem("foo", "title", [{ value: 'foo', active: false, name: "", title: "" }]);
 // $ExpectError
 typedTagify.getWhitelistItem("foo", "banana");
+// $ExpectType number[]
 tagify.getTagIndexByValue('foo');
 // $ExpectType number | false
 tagify.isTagDuplicate('foo');
 // $ExpectType number | false
 tagify.isTagDuplicate('foo', true);
+// $ExpectType string
 tagify.parseMixTags('[[foo]] and [[bar]] are...');
+// $ExpectType HTMLElement[]
 tagify.getTagElms();
+// $ExpectType HTMLElement[]
 tagify.getTagElms('blue', 'green');
+
+// $ExpectType string
+tagify.getMixedTagsAsString();
 
 // $ExpectType HTMLElement | undefined
 const tagElement = tagify.getTagElmByValue('foo');
 if (tagElement !== undefined) {
+    // $ExpectType TagData | undefined
     tagify.tagData(tagElement);
     tagify.tagData(tagElement, { value: 'bar' });
     tagify.tagData(tagElement, { value: 'bar' }, false);
     tagify.tagData(tagElement, { value: 'bar' }, true);
     // $ExpectType Tagify<TagData>
     tagify.editTag();
+    // $ExpectType Tagify<TagData>
     tagify.editTag(tagElement);
     tagify.replaceTag(tagElement, { value: 'bar' });
-    // $ExpectError
-    typedTagify.replaceTag(tagElement, { value: 'bar' });
-    typedTagify.replaceTag(tagElement, { value: 'bar', title: "", name: "", active: false });
+    // $ExpectType Tagify<TagData>
     tagify.tagLoading(tagElement, true);
 }
 tagify.loading(true);
@@ -828,6 +841,9 @@ if (typedTagElement !== undefined) {
     typedTagify.tagData(typedTagElement, { active: true, name: '', title: '', value: '' }, true);
     // $ExpectError
     typedTagify.tagData(typedTagElement, { active: true }, true);
+    // $ExpectError
+    typedTagify.replaceTag(typedTagElement, { value: 'bar' });
+    typedTagify.replaceTag(typedTagElement, { value: 'bar', title: "", name: "", active: false });
 }
 
 const newTag = tagify.createTagElem({ value: 'hello' });
@@ -876,4 +892,7 @@ tagify.dropdown.refilter.call(this);
 tagify.dropdown.refilter.call(this, "filter value");
 
 tagify.removeAllTags();
+tagify.update();
+tagify.update({});
+tagify.update({withoutChangeEvent: true});
 tagify.destroy();

--- a/types/yaireo__tagify/yaireo__tagify-tests.ts
+++ b/types/yaireo__tagify/yaireo__tagify-tests.ts
@@ -1,4 +1,4 @@
-import Tagify, { TagData, TagifySettings } from '@yaireo/tagify';
+import Tagify, { BaseTagData, TagData, TagifyConstructorSettings, TagifySettings } from '@yaireo/tagify';
 
 export function tagTemplate(this: Tagify, tagData: TagData): string {
     return `
@@ -8,7 +8,7 @@ export function tagTemplate(this: Tagify, tagData: TagData): string {
     </tag>`;
 }
 
-const settings: TagifySettings = {
+const settings: TagifyConstructorSettings = {
     tagTextProp: 'value',
     placeholder: 'Start typing...',
     delimiters: ',| ',
@@ -28,17 +28,220 @@ const settings: TagifySettings = {
     addTagOnBlur: false,
     callbacks: {
         add: (event) => {
-            console.log(event);
-        }
+            // $ExpectType TagData | undefined
+            event.detail.data;
+            // $ExpectType number | undefined
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        blur: event => {
+            // $ExpectType Element
+            event.detail.relatedTarget;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        change: event => {
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType string
+            event.detail.value;
+        },
+        click: event => {
+            // $ExpectType TagData
+            event.detail.data;
+            // $ExpectType number
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType MouseEvent
+            event.detail.originalEvent;
+        },
+        dblclick: event => {
+            // $ExpectType TagData | undefined
+            event.detail.data;
+            // $ExpectType number | undefined
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        focus: event => {
+            // $ExpectType Element
+            event.detail.relatedTarget;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        input: event => {
+            // $ExpectType HTMLInputElement | HTMLTextAreaElement
+            event.detail.inputElm;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType string
+            event.detail.value;
+        },
+        invalid: event => {
+            // $ExpectType TagData
+            event.detail.data;
+            // $ExpectType number | undefined
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType boolean
+            event.detail.message;
+        },
+        keydown: event => {
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType KeyboardEvent
+            event.detail.originalEvent;
+        },
+        remove: event => {
+            // $ExpectType TagData | undefined
+            event.detail.data;
+            // $ExpectType number | undefined
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        "dropdown:hide": event => {
+            // $ExpectType HTMLElement
+            event.detail.dropdown;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        "dropdown:scroll": event => {
+            // $ExpectType number
+            event.detail.percentage;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        "dropdown:noMatch": event => {
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType string
+            event.detail.value;
+        },
+        "dropdown:select": event => {
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType string
+            event.detail.value;
+        },
+        "dropdown:show": event => {
+            // $ExpectType HTMLElement
+            event.detail.dropdown;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        "dropdown:updated": event => {
+            // $ExpectType HTMLElement
+            event.detail.dropdown;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        "edit:beforeUpdate": event => {
+            // $ExpectType TagData | undefined
+            event.detail.data;
+            // $ExpectType number | undefined
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
+        "edit:input": event => {
+            // $ExpectType TagData & { newValue: string; }
+            event.detail.data;
+            // $ExpectType number
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType Event
+            event.detail.originalEvent;
+        },
+        "edit:keydown": event => {
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType KeyboardEvent
+            event.detail.originalEvent;
+        },
+        "edit:start": event => {
+            // $ExpectType TagData
+            event.detail.data;
+            // $ExpectType number
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+            // $ExpectType boolean
+            event.detail.isValid;
+        },
+        "edit:updated": event => {
+            event.detail.data;
+            // $ExpectType number | undefined
+            event.detail.index;
+            // $ExpectType HTMLElement
+            event.detail.tag;
+            // $ExpectType Tagify<TagData>
+            event.detail.tagify;
+        },
     },
     maxTags: 10,
     editTags: { clicks: 1, keepInvalid: false },
     templates: {
-        wrapper: (input, settings) => '<div></div>',
+        wrapper: (input, settings) => {
+            // Can use "as const" in later TS versions
+            if (settings.classNames) {
+                const className = settings.mode === "mix" ? settings.classNames.mixMode : settings.classNames.selectMode;
+                return `<tags class="${settings.classNames.namespace} ${settings.mode ? `${className}` : ""} ${input.className}"
+                        ${settings.readonly ? 'readonly' : ''}
+                        ${settings.required ? 'required' : ''}
+                        tabIndex="-1">
+                <span ${!settings.readonly || settings.mode !== 'mix' ? 'contenteditable' : ''} data-placeholder="${settings.placeholder || '&#8203;'}" aria-placeholder="${settings.placeholder || ''}"
+                    class="${settings.classNames.input}"
+                    role="textbox"
+                    aria-autocomplete="both"
+                    aria-multiline="${settings.mode === 'mix' ? true : false}"></span>
+            </tags>`;
+            }
+            return "";
+        },
         tag: tagTemplate,
-        dropdown: (settings) => '<select></select>',
-        dropdownItem: (item) => `<li>${item.value}</li>`,
-        dropdownItemNoMatch: () => '<span>No match</span>'
+        dropdown(settings) {
+            const _sd = settings.dropdown;
+            if (settings.classNames && _sd) {
+                const isManual = _sd.position === 'manual';
+                const className = `${settings.classNames.dropdown}`;
+
+                return `<div class="${isManual ? "" : className} ${_sd.classname}" role="listbox" aria-labelledby="dropdown">
+                            <div class="${settings.classNames.dropdownWrapper}"></div>
+                </div>`;
+            }
+            return "";
+        },
+        dropdownItem(item) {
+            if (this.settings.classNames) {
+                return `<div ${this.getAttributes(item)}
+            class='${this.settings.classNames.dropdownItem} ${item.class ? item.class : ""}'
+            tabindex="0"
+            role="option">${item.value}</div>`;
+            }
+            return "";
+        },
+        dropdownItemNoMatch: (data) => `No suggestion found for: ${data.value}`,
     },
     validate: (tagData) => /^starts-with/.test(tagData.value),
     transformTag: (tagData) => { tagData.active = true; },
@@ -47,7 +250,34 @@ const settings: TagifySettings = {
     backspace: 'edit',
     originalInputValueFormat: (data) => JSON.stringify(data),
     mixMode: {
-      insertAfterTag: '\u00A0'
+        insertAfterTag: '\u00A0'
+    },
+    classNames: {
+        namespace: 'tagify',
+        mixMode: 'tagify--mix',
+        selectMode: 'tagify--select',
+        input: 'tagify__input',
+        focus: 'tagify--focus',
+        tag: 'tagify__tag',
+        tagNoAnimation: 'tagify--noAnim',
+        tagInvalid: 'tagify--invalid',
+        tagNotAllowed: 'tagify--notAllowed',
+        inputInvalid: 'tagify__input--invalid',
+        tagX: 'tagify__tag__removeBtn',
+        tagText: 'tagify__tag-text',
+        dropdown: 'tagify__dropdown',
+        dropdownWrapper: 'tagify__dropdown__wrapper',
+        dropdownItem: 'tagify__dropdown__item',
+        dropdownItemActive: 'tagify__dropdown__item--active',
+        dropdownInital: 'tagify__dropdown--initial',
+        scopeLoading: 'tagify--loading',
+        tagLoading: 'tagify__tag--loading',
+        tagEditing: 'tagify__tag--editable',
+        tagFlash: 'tagify__tag--flash',
+        tagHide: 'tagify__tag--hide',
+        hasMaxTags: 'tagify--hasMaxTags',
+        hasNoTags: 'tagify--noTags',
+        empty: 'tagify--empty',
     },
     dropdown: {
         enabled: 3,
@@ -62,8 +292,62 @@ const settings: TagifySettings = {
         clearOnSelect: false,
         mapValueTo: 'place',
         searchKeys: ['value', 'color'],
-        appendTarget: document.body
-    }
+        appendTarget: document.body,
+        placeAbove: false,
+    },
+    hooks: {
+        beforeRemoveTag: tags => {
+            tags[0].node.classList.add('tagify__tag--loading');
+            return new Promise((resolve, reject) => {
+                if (confirm(`Remove ${tags[0].data.value} ?`)) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
+        },
+        suggestionClick: e => {
+            if (e.target instanceof HTMLElement) {
+                const isAction = e.target.classList.contains('removeBtn');
+                const suggestionElm = e.target.closest('.tagify__dropdown__item');
+                const value = suggestionElm ? suggestionElm.getAttribute('value') : "";
+                return new Promise((resolve, reject) => {
+                    if (isAction) {
+                        tagify.dropdown.refilter.call(tagify);
+                        reject();
+                    }
+                    resolve();
+                });
+            } else {
+                return Promise.resolve();
+            }
+        },
+    },
+};
+
+interface MyTagData extends BaseTagData {
+    title: string;
+    active: boolean;
+    name: string;
+}
+
+const typedSettings: TagifyConstructorSettings<MyTagData> = {
+    templates: {
+        tag: (tagData) => `${tagData.name} ${tagData.title.substring(0)}`,
+        dropdownItem: item => `${item.active}`,
+    },
+    validate: (tagData) => /^starts-with/.test(tagData.title.substring(0)),
+    transformTag: (tagData) => { tagData.active = true; },
+    originalInputValueFormat: (data) => JSON.stringify(data.map(d => d.title.substring(0))),
+    hooks: {
+        beforeRemoveTag: async tags => { tags.map(t => t.name.substring(0)); },
+    },
+};
+
+const instanceSettings: TagifySettings = {
+    ...settings,
+    readonly: true,
+    required: false,
 };
 
 settings.delimiters = /,|"/;
@@ -85,10 +369,27 @@ settings.dropdown = {
     mapValueTo: (data) => 'To:' + data.email
 };
 
+typedSettings.dropdown = {
+    mapValueTo: (data) => 'To:' + data.title.substring(0),
+};
+
 const inputElement = document.createElement('input');
 const textAreaElement = document.createElement('textarea');
 const tagify = new Tagify(inputElement, settings);
+const typedTagify = new Tagify(inputElement, typedSettings);
 const tagifyArea = new Tagify(textAreaElement);
+const tagifyOneArg = new Tagify(inputElement);
+const tagifyEmptySettings = new Tagify(inputElement, {});
+new Tagify(inputElement, { dropdown: { appendTarget: null } });
+new Tagify(inputElement, { pattern: null });
+// $ExpectError
+new Tagify(inputElement, { required: false });
+// $ExpectError
+new Tagify(inputElement, { readonly: false });
+// $ExpectError
+new Tagify(inputElement, { mixTagsInterpolator: ["", "", ""] });
+// $ExpectError
+new Tagify(inputElement, { mixTagsInterpolator: [""] });
 
 const tagArray: TagData[] = tagify.value;
 const scopeEl: HTMLElement = tagify.DOM.scope;
@@ -96,33 +397,361 @@ const spanEl: HTMLSpanElement = tagify.DOM.input;
 const dropdownEl: HTMLDivElement = tagify.DOM.dropdown;
 const inputEl: HTMLInputElement | HTMLTextAreaElement = tagify.DOM.originalInput;
 
-tagify.on('invalid', (event) => {
-    const data: TagData = event.detail.data;
+// $ExpectType Tagify<TagData>
+tagify.on('add', (event) => { });
+// $ExpectType Tagify<TagData>
+tagify.off('add', (event) => { });
+
+// $ExpectError
+tagify.on('foobar', (event) => { });
+// $ExpectError
+tagify.off('foobar', (event) => { });
+
+tagify.on('change', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
 });
-tagify.on('add', (event) => {});
-tagify.on('remove', (event) => {});
-tagify.on('dblclick', (event) => {});
-tagify.on('edit:beforeUpdate', (event) => {});
-tagify.on('edit:updated', (event) => {});
-tagify.on('input', (event) => {});
+tagify.on('dropdown:noMatch', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
+tagify.on('invalid', (event) => {
+    // $ExpectType TagData
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType boolean
+    event.detail.message;
+});
+tagify.on('add', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('remove', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('dblclick', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('edit:beforeUpdate', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('edit:updated', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('input', (event) => {
+    // $ExpectType HTMLInputElement | HTMLTextAreaElement
+    event.detail.inputElm;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
 tagify.on('click', (event) => {
-    const ev: MouseEvent = event.detail.originalEvent;
+    // $ExpectType TagData
+    event.detail.data;
+    // $ExpectType number
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType MouseEvent
+    event.detail.originalEvent;
 });
 tagify.on('keydown', (event) => {
-    const ev: KeyboardEvent = event.detail.originalEvent;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType KeyboardEvent
+    event.detail.originalEvent;
 });
-tagify.on('edit:keydown', (event) => {});
-tagify.on('focus', (event) => {});
-tagify.on('blur', (event) => {});
-tagify.on('edit:start', (event) => {});
+tagify.on('edit:keydown', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType KeyboardEvent
+    event.detail.originalEvent;
+});
+tagify.on('focus', (event) => {
+    // $ExpectType Element
+    event.detail.relatedTarget;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('blur', (event) => {
+    // $ExpectType Element
+    event.detail.relatedTarget;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('edit:start', (event) => {
+    // $ExpectType TagData
+    event.detail.data;
+    // $ExpectType number
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType boolean
+    event.detail.isValid;
+});
 tagify.on('edit:input', (event) => {
-    const newValue: string = event.detail.data.newValue;
+    // $ExpectType TagData & { newValue: string; }
+    event.detail.data;
+    // $ExpectType number
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType Event
+    event.detail.originalEvent;
 });
-tagify.on('dropdown:show', (event) => {});
-tagify.on('dropdown:hide', (event) => {});
-tagify.on('dropdown:updated', (event) => {});
-tagify.on('dropdown:scroll', (event) => {});
-tagify.on('dropdown:select', (event) => {});
+tagify.on('dropdown:show', (event) => {
+    // $ExpectType HTMLElement
+    event.detail.dropdown;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('dropdown:hide', (event) => {
+    // $ExpectType HTMLElement
+    event.detail.dropdown;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('dropdown:updated', (event) => {
+    // $ExpectType HTMLElement
+    event.detail.dropdown;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('dropdown:scroll', (event) => {
+    // $ExpectType number
+    event.detail.percentage;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.on('dropdown:select', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
+
+tagify.off('change', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
+tagify.off('dropdown:noMatch', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
+tagify.off('invalid', (event) => {
+    // $ExpectType TagData
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType boolean
+    event.detail.message;
+});
+tagify.off('add', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('remove', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('dblclick', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('edit:beforeUpdate', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('edit:updated', (event) => {
+    // $ExpectType TagData | undefined
+    event.detail.data;
+    // $ExpectType number | undefined
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('input', (event) => {
+    // $ExpectType HTMLInputElement | HTMLTextAreaElement
+    event.detail.inputElm;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
+tagify.off('click', (event) => {
+    // $ExpectType TagData
+    event.detail.data;
+    // $ExpectType number
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType MouseEvent
+    event.detail.originalEvent;
+});
+tagify.off('keydown', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType KeyboardEvent
+    event.detail.originalEvent;
+});
+tagify.off('edit:keydown', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType KeyboardEvent
+    event.detail.originalEvent;
+});
+tagify.off('focus', (event) => {
+    // $ExpectType Element
+    event.detail.relatedTarget;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('blur', (event) => {
+    // $ExpectType Element
+    event.detail.relatedTarget;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('edit:start', (event) => {
+    // $ExpectType TagData
+    event.detail.data;
+    // $ExpectType number
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType boolean
+    event.detail.isValid;
+});
+tagify.off('edit:input', (event) => {
+    // $ExpectType TagData & { newValue: string; }
+    event.detail.data;
+    // $ExpectType number
+    event.detail.index;
+    // $ExpectType HTMLElement
+    event.detail.tag;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType Event
+    event.detail.originalEvent;
+});
+tagify.off('dropdown:show', (event) => {
+    // $ExpectType HTMLElement
+    event.detail.dropdown;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('dropdown:hide', (event) => {
+    // $ExpectType HTMLElement
+    event.detail.dropdown;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('dropdown:updated', (event) => {
+    // $ExpectType HTMLElement
+    event.detail.dropdown;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('dropdown:scroll', (event) => {
+    // $ExpectType number
+    event.detail.percentage;
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+});
+tagify.off('dropdown:select', (event) => {
+    // $ExpectType Tagify<TagData>
+    event.detail.tagify;
+    // $ExpectType string
+    event.detail.value;
+});
 
 const tags: TagData[] = [
     { value: 'banana', color: 'yellow' },
@@ -132,40 +761,86 @@ const tags: TagData[] = [
 tagify.addTags('foo');
 tagify.addTags(tags);
 const addedElements = tagify.addTags(['banana', 'orange', 'apple'], true, true);
+typedTagify.addTags([{ active: false, name: "", title: "", value: "" }]);
 
 tagify.addMixTags('[[foo]] and [[bar]]');
 tagify.addMixTags(['[[foo]] and', '[[bar]]...']);
 tagify.addMixTags(tags);
+typedTagify.addMixTags([{ active: false, name: "", title: "", value: "" }]);
 
 tagify.removeTags();
 tagify.removeTags(addedElements, true, 100);
 
 tagify.addEmptyTag();
 tagify.addEmptyTag({ label: 'Apple' });
+typedTagify.addEmptyTag();
+typedTagify.addEmptyTag({ active: false });
+// $ExpectError
+typedTagify.addEmptyTag({ label: "Apple" });
 tagify.loadOriginalValues('banana');
 tagify.loadOriginalValues(['banana', 'orange']);
-tagify.getWhitelistItem({ value: 'foo' });
+tagify.getWhitelistItem("foo");
+tagify.getWhitelistItem("foo", 'banana');
+tagify.getWhitelistItem("foo", 'banana', [{ value: "boo" }]);
+typedTagify.getWhitelistItem("foo");
+typedTagify.getWhitelistItem("foo", "title");
+typedTagify.getWhitelistItem("foo", "title", [{ value: 'foo', active: false, name: "", title: "" }]);
+// $ExpectError
+typedTagify.getWhitelistItem("foo", "banana");
 tagify.getTagIndexByValue('foo');
+// $ExpectType number | false
+tagify.isTagDuplicate('foo');
+// $ExpectType number | false
 tagify.isTagDuplicate('foo', true);
 tagify.parseMixTags('[[foo]] and [[bar]] are...');
 tagify.getTagElms();
 tagify.getTagElms('blue', 'green');
 
+// $ExpectType HTMLElement | undefined
 const tagElement = tagify.getTagElmByValue('foo');
-tagify.tagData(tagElement);
-tagify.tagData(tagElement, { value: 'bar' });
-tagify.editTag();
-tagify.editTag(tagElement);
-tagify.replaceTag(tagElement, { value: 'bar' });
-tagify.tagLoading(tagElement, true);
+if (tagElement !== undefined) {
+    tagify.tagData(tagElement);
+    tagify.tagData(tagElement, { value: 'bar' });
+    tagify.tagData(tagElement, { value: 'bar' }, false);
+    tagify.tagData(tagElement, { value: 'bar' }, true);
+    // $ExpectType Tagify<TagData>
+    tagify.editTag();
+    tagify.editTag(tagElement);
+    tagify.replaceTag(tagElement, { value: 'bar' });
+    // $ExpectError
+    typedTagify.replaceTag(tagElement, { value: 'bar' });
+    typedTagify.replaceTag(tagElement, { value: 'bar', title: "", name: "", active: false });
+    tagify.tagLoading(tagElement, true);
+}
 tagify.loading(true);
 
+const typedTagElement = typedTagify.getTagElmByValue('foo');
+if (typedTagElement !== undefined) {
+    // $ExpectType MyTagData | undefined
+    typedTagify.tagData(typedTagElement);
+    // $ExpectType MyTagData | { active: true; }
+    typedTagify.tagData(typedTagElement, { active: true });
+    // $ExpectType MyTagData | { active: true; }
+    typedTagify.tagData(typedTagElement, { active: true }, false);
+    // $ExpectType MyTagData | { active: true; }
+    typedTagify.tagData(typedTagElement, { active: true }, undefined);
+    // $ExpectType MyTagData
+    typedTagify.tagData(typedTagElement, { active: true, name: '', title: '', value: '' }, true);
+    // $ExpectError
+    typedTagify.tagData(typedTagElement, { active: true }, true);
+}
+
 const newTag = tagify.createTagElem({ value: 'hello' });
+// $ExpectError
+typedTagify.createTagElem({ value: 'hello' });
+typedTagify.createTagElem({ value: 'hello', title: "", name: "", active: false });
+// $ExpectType Tagify<TagData>
 tagify.injectAtCaret(newTag);
 tagify.placeCaretAfterNode(newTag);
 tagify.insertAfterTag(newTag, 'world');
 tagify.insertAfterTag(newTag, document.createElement('span'));
 
+tagify.toggleClass('active');
 tagify.toggleClass('active', true);
 
 tagify.updateValueByDOMTags();
@@ -173,15 +848,32 @@ tagify.parseTemplate('wrapper', [inputElement, settings]);
 tagify.parseTemplate('tag', [tags[0]]);
 tagify.parseTemplate('dropdownItem', [tags[0]]);
 tagify.parseTemplate('dropdown', [settings]);
-tagify.parseTemplate('dropdownItemNoMatch', []);
+tagify.parseTemplate('dropdownItemNoMatch', [{ value: "" }]);
 tagify.parseTemplate((data) => `<span>${data.value}</span>`, [tags[0]]);
+// $ExpectError
+tagify.parseTemplate((data) => `<span>${data.value}</span>`, [tags]);
 tagify.setReadonly(false);
 
+// $ExpectError
 tagify.dropdown.show();
+// $ExpectError
 tagify.dropdown.show('foo');
+// $ExpectError
 tagify.dropdown.selectAll();
+// $ExpectError
 tagify.dropdown.hide();
+// $ExpectError
 tagify.dropdown.hide(true);
+// $ExpectError
+tagify.dropdown.refilter();
+
+tagify.dropdown.show.call(this);
+tagify.dropdown.show.call(this, 'foo');
+tagify.dropdown.selectAll.call(tagify);
+tagify.dropdown.hide.call(this);
+tagify.dropdown.hide.call(this, true);
+tagify.dropdown.refilter.call(this);
+tagify.dropdown.refilter.call(this, "filter value");
 
 tagify.removeAllTags();
 tagify.destroy();

--- a/types/yaireo__tagify/yaireo__tagify-tests.ts
+++ b/types/yaireo__tagify/yaireo__tagify-tests.ts
@@ -19,7 +19,7 @@ const settings: TagifyConstructorSettings = {
     duplicates: false,
     trim: false,
     enforceWhitelist: true,
-    autocomplete: {
+    autoComplete: {
         enabled: true,
         rightKey: true
     },


### PR DESCRIPTION
Woah, the devil is in the details once you actually start to compare the docs, the source code and how the program behaves in practice. The hardest part is deciding which differences / omissions in the docs are intentional... I hope I didn't make any mistakes, but if anyone could review, that would be great.

* Extracted nested objects into their own interfaces (e.g. `Tagify.TagifySettings.autocomplete` > `Tagify.AutocompleteSettings`). Personally I find it very helpful to have these types available for refactoring your code, e.g. when you want to create a `function createAutocompleteSettings` or `const autocompleteSettings = ...`
* Refactored the events and their data into an EventDataMap interface. This also allows us to reuse that event data map for typing the `off` method and the `callbacks` setting.
    * I also added the events `change` and `dropdown:noMatch`, see https://github.com/yairEO/tagify#events
* Also, I edited the docs a little, correcting some typos, adding docs where it was missing, and added `@param` / `@returns` tags.
* Added an optional type parameter `T` to the Tagify class that encodes the type of the tag data. It must extend `BaseTagData`, which is `{value: string}` and defaults to `TagData`, which is `{value: string, [key: string]: any}`. This ensures compatibility but allows people to be more strict if they wish.
    * This also allows us to type the parameter of `addEmptyTag` as `Partial<T>`
* Adjusted the types of a few settings and added missing settings:
    * Added the `hooks` option to `TagifySettings.hooks`, see https://github.com/yairEO/tagify#hooks
    * `pattern` can be `null`
    * `dropdown.appendTarget` can be `null` (which results in the dropdown being appended to `document.body`)
    * `dropdown.position` defaults to `all`, not `null`
    * `dropdown.highlightFirst` defaults to `false`, not `null`
    * Added the `dropdown.placeAbove` option to the `TagifySettings`, see https://github.com/yairEO/tagify#settings
    * Added the `data: {value: string}` parameter to `dropdownItemNoMatch` callback, see e.g. https://yaireo.github.io/tagify/#section-advance-options and https://github.com/yairEO/tagify/blob/master/src/parts/dropdown.js#L44
    * `mixTagsInterpolator` is not a string array, but a tuple of two elements,  so I changed the type to `[string, string]`
* Adjusted the types of a few methods:
    * `Tagify.addTags` always seems returns an array of added tags, even when passed a single string. I tried it out and this also seems to match the source code https://github.com/yairEO/tagify/blob/master/src/tagify.js#L1196
    * First parameter of `Tagify.getWhitelistItem` must be a string, not `TagData` (despite the documentation indicating otherwise), see https://github.com/yairEO/tagify/blob/master/src/tagify.js#L814
    * Added parameters `property` and `whitelist` to `Tagify.getWhitelistItem`
    * `Tagify.getTagElmByValue` returns `undefined` when it does not find a tag.
    * `Tagify.isTagDuplicate` does not alway return a number, but sometimes also `false`, see https://github.com/yairEO/tagify/blob/master/src/tagify.js#L752
    * Split `Tagify.tagData` into two method signatures, one for the getter and one for the setter.
    * For the setter, the second argument is a `Partial<TagData>` -- it assigns the given properties and keeps the properties that are not given.
    * Added a third method signature for the third optional parameters `override` (completely replace the tag data).
    * Tagify.editTag` and `Tagify.injectAtCaret` return `this`, not `void`
    * Second argument `force` of `Tagify.toggleClass` is optional.
    * Refactored the `parseTemplate` type signature so that (a) it just reads the available methods from `Tagify.TagifySettings` and (b) uses a type parameter for the arguments of the custom template function to get rid of `any`.
* Replaced the tests for the `templates` callback methods with the defaults from https://github.com/yairEO/tagify/blob/master/src/parts/templates.js. These should pass the type check, but I found a few missing types
   * These `templates` callback methods are invoked with the this context set to the tagify instance. Since the this context is used even in the defaults, I added `this: Tagify` to the callback type signatures.
   * There's apparently a property `TagifySettings#classNames`, which I added. See https://github.com/yairEO/tagify#drag--sort and https://github.com/yairEO/tagify/blob/master/src/parts/defaults.js#L33
   * `required` and `readonly` can be set via HTML attributes, but are also available in the `TagifySettings`. It's a bit hidden, but can be found here in the docs: https://github.com/yairEO/tagify#html-input--textarea-attributes However, even though the docs suggest you can set these options by passing them to the constructor, that is not actually the case if you try it out / read the code. These two options are added to the `TagifySettings` when the tagify instance is created. So I split the settings into `TagifySettings` and `TagifyConstructorSettings`. The latter are used in the constructor, the former everywhere else.
* This is missing in the docs, but when we actually try to use the `tagify.dropdown.*` methods (such as `selectAll`), we notice they won't work. This is because they have to be called with the tagify instance as the this context. Just calling `tagify.dropdown.selectAll()` will result in an error. I added the this context in the method signature and adjusted the tests.
    * I also added the `refilter` method to the dropdown methods.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yairEO/tagify and https://yaireo.github.io/tagify
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.