### PR TITLE
fix node-zopfli *Sync methods

### DIFF
--- a/types/node-zopfli/index.d.ts
+++ b/types/node-zopfli/index.d.ts
@@ -15,9 +15,9 @@ declare class Zopfli extends Transform {
     static createDeflate(options?: Zopfli.Options): Zopfli;
     static createZlib(options?: Zopfli.Options): Zopfli;
 
-    static gzipSync(options?: Zopfli.Options): Buffer;
-    static deflateSync(options?: Zopfli.Options): Buffer;
-    static zlibSync(options?: Zopfli.Options): Buffer;
+    static gzipSync(input: Buffer, options: Zopfli.Options): Buffer;
+    static deflateSync(input: Buffer, options: Zopfli.Options): Buffer;
+    static zlibSync(input: Buffer, options: Zopfli.Options): Buffer;
 
     static deflate(input: Buffer, options: Zopfli.Options, cb: (err: Error, out: Buffer) => void): void;
     static deflate(input: Buffer, cb: (err: Error, out: Buffer) => void): void;

--- a/types/node-zopfli/node-zopfli-tests.ts
+++ b/types/node-zopfli/node-zopfli-tests.ts
@@ -5,7 +5,7 @@ const opts: Zopfli.Options = {
     verbose: true,
     numiterations: 1
 };
-let input: Buffer = Buffer.from('foo');
+const input: Buffer = Buffer.from('foo');
 const read = fs.createReadStream('foo');
 const write = fs.createWriteStream('foo');
 
@@ -32,14 +32,14 @@ Zopfli.compress(input, 'zlib', opts, cb);
 Zopfli.compress(input, 'zlib', opts).then(then);
 Zopfli.compress(input, 'zlib').then(then);
 
-input = Zopfli.gzipSync();
-input = Zopfli.gzipSync(opts);
+let output: Buffer = Zopfli.gzipSync(input, {});
+output = Zopfli.gzipSync(input, opts);
 
-input = Zopfli.deflateSync();
-input = Zopfli.deflateSync(opts);
+output = Zopfli.deflateSync(input, {});
+output = Zopfli.deflateSync(input, opts);
 
-input = Zopfli.zlibSync();
-input = Zopfli.zlibSync(opts);
+output = Zopfli.zlibSync(input, {});
+output = Zopfli.zlibSync(input, opts);
 
 read.pipe(Zopfli.createGzip()).pipe(write);
 read.pipe(Zopfli.createGzip(opts)).pipe(write);

--- a/types/node-zopfli/tslint.json
+++ b/types/node-zopfli/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "no-outside-dependencies": false
+  }
+}

--- a/types/node-zopfli/tslint.json
+++ b/types/node-zopfli/tslint.json
@@ -1,6 +1,1 @@
-{
-  "extends": "dtslint/dt.json",
-  "rules": {
-    "no-outside-dependencies": false
-  }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- first argument is a `Buffer`
- options are not actually optional. `zopfli` throws an error if options are not at least an empty object

[reference code](https://github.com/pierreinglebert/node-zopfli/blob/master/lib/zopfli.js#L96)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
