### PR TITLE
[root] fix incorrect gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ _infrastructure/tests/build
 *.iml
 
 *.js.map
-!*.js/
+!/*.js
 !scripts/new-package.js
 !scripts/not-needed.js
 !scripts/lint.js


### PR DESCRIPTION
### Description

This PR fixes the incorrect gitignore pattern in the root of the repository.

Based on the gitignore documentation

> If there is a separator at the end of the pattern then the pattern will only match directories, otherwise, the pattern can match both files and directories.

https://git-scm.com/docs/gitignore#_pattern_format

In this pattern, you used `*.js/` which means a directory called `*.js`. I don't think this is what you meant, and so I changed this to `/*.js` which means JavaScript files are allowed in the root of the repository.