### PR TITLE
react-native-auth0 Added max_age to the AuthorizeParams interface

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -203,6 +203,7 @@ export interface AuthorizeParams {
     connection?: string;
     language?: string;
     prompt?: string;
+    max_age?: number;
 }
 
 export interface AuthorizeOptions {

--- a/types/react-native-auth0/react-native-auth0-tests.ts
+++ b/types/react-native-auth0/react-native-auth0-tests.ts
@@ -74,6 +74,13 @@ auth0.webAuth.authorize({
     prompt: 'login',
 });
 
+auth0.webAuth.authorize({
+    state: 'state',
+    nonce: 'nonce',
+    scope: 'openid',
+    max_age: 10,
+});
+
 // handle additional options object
 auth0.webAuth.authorize(
     {


### PR DESCRIPTION
@types/react-native-auth0 is missing a param for `auth0.webAuth.authorize()`

This param is called out in the docs here:
https://auth0.github.io/react-native-auth0/WebAuth.html#.authorize