### PR TITLE
wavesurfer.js: fix incorrect type for a property

### DIFF
--- a/types/wavesurfer.js/index.d.ts
+++ b/types/wavesurfer.js/index.d.ts
@@ -52,7 +52,7 @@ declare class WaveSurfer extends Observer {
     init(): WaveSurfer;
     initPlugin(name: string): WaveSurfer;
     isPlaying(): boolean;
-    isReady(): boolean;
+    isReady: boolean;
     load(
         url: string | HTMLMediaElement,
         peaks?: ReadonlyArray<number> | ReadonlyArray<ReadonlyArray<number>>,

--- a/types/wavesurfer.js/wavesurfer.js-tests.ts
+++ b/types/wavesurfer.js/wavesurfer.js-tests.ts
@@ -13,6 +13,9 @@ wavesurfer.on("ready", () => {
 });
 // -- load an audio file
 wavesurfer.load("audio/sample.wav");
+if (wavesurfer.isReady) {
+    throw new Error('Should not be ready');
+}
 
 // - create an instance with "new"
 const wsNewed = new WaveSurfer({


### PR DESCRIPTION
`isReady` is a boolean value and not a function.

See: https://wavesurfer-js.org/api/class/src/wavesurfer.js~WaveSurfer.html#instance-member-isReady

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.