### PR TITLE
[bull-arena] Allow passing Redis instance directly

### DIFF
--- a/types/bull-arena/bull-arena-tests.ts
+++ b/types/bull-arena/bull-arena-tests.ts
@@ -1,7 +1,9 @@
 import Arena from 'bull-arena';
 import express from 'express';
 import Bull from 'bull';
+import Redis from 'ioredis';
 
+const connection = new Redis();
 const router = express.Router();
 
 const arena = Arena({
@@ -17,6 +19,10 @@ const arena = Arena({
         {
             name: 'QueueOptions-RedisClientConnectionOptions',
             redis: {},
+        },
+        {
+            name: 'QueueOptions-RedisClientConnectionOptions2',
+            redis: connection,
         },
     ],
     Bull,

--- a/types/bull-arena/index.d.ts
+++ b/types/bull-arena/index.d.ts
@@ -7,6 +7,7 @@
 
 import { RequestHandler } from "express";
 import { ClientOpts } from "redis";
+import { Redis } from "ioredis";
 
 declare function Arena(
     options: BullArena.MiddlewareOptions,
@@ -65,7 +66,7 @@ declare namespace BullArena {
     }
 
     interface RedisClientConnectionOptions {
-        redis: ClientOpts;
+        redis: ClientOpts | Redis;
     }
 }
 


### PR DESCRIPTION
BullMQ allows for passing a pre-made Redis object to it, allowing for more nuanced initialization of the connection. Bull-Arena also indirectly allows for this behavior by passing the connection to the `redis` parameter, so the typings should reflect that.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/bee-queue/arena/blob/52c9b8037618091fe6b6c99b2ffcb274c41772ee/index.js#L7
  - https://github.com/bee-queue/arena/blob/52c9b8037618091fe6b6c99b2ffcb274c41772ee/src/server/app.js#L21
  - https://github.com/bee-queue/arena/blob/52c9b8037618091fe6b6c99b2ffcb274c41772ee/src/server/queue/index.js#L4
  - https://github.com/bee-queue/arena/blob/52c9b8037618091fe6b6c99b2ffcb274c41772ee/src/server/queue/index.js#L103
  - https://docs.bullmq.io/guide/connections
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
