### PR TITLE
[@types/drawflow] getNodesFromName should return number array.

### DIFF
--- a/types/drawflow/index.d.ts
+++ b/types/drawflow/index.d.ts
@@ -139,7 +139,7 @@ export default class Drawflow {
    *  Return Array of nodes id. Ex: name: telegram
    *  @param name
    */
-  getNodesFromName(name: string): void;
+  getNodesFromName(name: string): number[];
 
   /**
    * Remove node. Ex id: node-x


### PR DESCRIPTION
From the origin drawflow repository \
https://github.com/jerosoler/Drawflow/blob/master/src/drawflow.js#L1314#L1325

this func should return number[]