### PR TITLE
n3 Parser type fix

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -134,6 +134,7 @@ export interface Token {
     type: string;
     value?: string;
     line: number;
+    prefix?: string;
 }
 export interface LexerOptions {
     lineMode?: boolean;

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -15,7 +15,7 @@ import * as RDF from "rdf-js";
 import { EventEmitter } from "events";
 
 export interface Prefixes<I = RDF.NamedNode> {
-  [key: string]: I;
+    [key: string]: I;
 }
 
 export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
@@ -42,7 +42,7 @@ export class BlankNode implements RDF.BlankNode {
     static subclass(type: any): void;
 }
 
-export class Variable  implements RDF.Variable {
+export class Variable implements RDF.Variable {
     readonly termType: "Variable";
     readonly value: string;
     constructor(name: string);
@@ -103,7 +103,7 @@ export class Quad extends BaseQuad implements RDF.Quad {
     toJSON(): string;
 }
 
-export class Triple extends Quad implements RDF.Quad {}
+export class Triple extends Quad implements RDF.Quad { }
 
 export namespace DataFactory {
     function namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
@@ -130,13 +130,11 @@ export interface BlankTriple<Q extends RDF.BaseQuad = RDF.Quad> {
     object: Q['object'];
 }
 
-
-export type Token = {
+export interface Token {
     type: string;
     value?: string;
     line: number;
 }
-
 export interface LexerOptions {
     lineMode?: boolean;
     n3?: boolean;
@@ -187,7 +185,7 @@ export class Writer<Q extends RDF.BaseQuad = RDF.Quad> {
     addQuad(subject: Q['subject'], predicate: Q['predicate'], object: Q['object'] | Array<Q['object']>, graph?: Q['graph'], done?: () => void): void;
     addQuad(quad: RDF.Quad): void;
     addQuads(quads: RDF.Quad[]): void;
-    addPrefix(prefix: string, iri: RDF.NamedNode | string , done?: () => void): void;
+    addPrefix(prefix: string, iri: RDF.NamedNode | string, done?: () => void): void;
     addPrefixes(prefixes: Prefixes<RDF.NamedNode | string>, done?: () => void): void;
     end(err?: ErrorCallback, result?: string): void;
     blank(predicate: Q['predicate'], object: Q['object']): BlankNode;
@@ -196,9 +194,9 @@ export class Writer<Q extends RDF.BaseQuad = RDF.Quad> {
 }
 
 export class StreamWriter<Q extends RDF.BaseQuad = RDF.Quad> extends stream.Transform implements RDF.Sink<RDF.Stream<Q>, EventEmitter> {
-  constructor(options?: WriterOptions);
-  constructor(fd: any, options?: WriterOptions);
-  import(stream: RDF.Stream<Q>): EventEmitter;
+    constructor(options?: WriterOptions);
+    constructor(fd: any, options?: WriterOptions);
+    import(stream: RDF.Stream<Q>): EventEmitter;
 }
 
 export class Store<Q_RDF extends RDF.BaseQuad = RDF.Quad, Q_N3 extends BaseQuad = Quad> implements RDF.Store<Q_RDF> {
@@ -242,12 +240,12 @@ export namespace Util {
     function isVariable(value: RDF.Term | null): boolean;
     function isDefaultGraph(value: RDF.Term | null): boolean;
     function inDefaultGraph(value: RDF.Quad): boolean;
-    function prefix(iri: RDF.NamedNode|string, factory?: RDF.DataFactory): PrefixedToIri;
+    function prefix(iri: RDF.NamedNode | string, factory?: RDF.DataFactory): PrefixedToIri;
     function prefixes(
-      defaultPrefixes: Prefixes<RDF.NamedNode|string>,
-      factory?: RDF.DataFactory
+        defaultPrefixes: Prefixes<RDF.NamedNode | string>,
+        factory?: RDF.DataFactory
     ): (prefix: string) => PrefixedToIri;
 }
 
-export function termToId(term: Term): string
-export function termFromId(id: string, factory: RDF.DataFactory): Term
+export function termToId(term: Term): string;
+export function termFromId(id: string, factory: RDF.DataFactory): Term;

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -228,3 +228,6 @@ export namespace Util {
       factory?: RDF.DataFactory
     ): (prefix: string) => PrefixedToIri;
 }
+
+export function termToId(term: Term): string
+export function termFromId(id: string, factory: RDF.DataFactory): Term

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for N3 1.8.1
+// Type definitions for N3 1.8
 // Project: https://github.com/rdfjs/n3.js
 // Definitions by: Fred Eisele <https://github.com/phreed>
 //                 Ruben Taelman <https://github.com/rubensworks>

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for N3 1.4
+// Type definitions for N3 1.8.1
 // Project: https://github.com/rdfjs/n3.js
 // Definitions by: Fred Eisele <https://github.com/phreed>
 //                 Ruben Taelman <https://github.com/rubensworks>
@@ -139,10 +139,13 @@ export interface ParserOptions {
 
 export type ParseCallback<Q extends BaseQuad = Quad> = (error: Error, quad: Q, prefixes: Prefixes) => void;
 
+export type PrefixCallback = (prefix: string, prefixNode: RDF.NamedNode) => void;
+
 export class Parser<Q extends BaseQuad = Quad> {
     constructor(options?: ParserOptions);
     parse(input: string): Q[];
-    parse(input: string, callback: ParseCallback<Q>): void;
+    parse(input: string, callback: null | undefined, prefixCallback: PrefixCallback): Q[];
+    parse(input: string, callback: ParseCallback<Q>, prefixCallback?: PrefixCallback): void;
 }
 
 export class StreamParser<Q extends BaseQuad = Quad> extends stream.Transform implements RDF.Stream<Q>, RDF.Sink<EventEmitter, RDF.Stream<Q>> {

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -146,7 +146,7 @@ export type TokenCallback = (error: Error, token: Token) => void;
 
 export class Lexer {
     constructor(options?: LexerOptions);
-    tokenize(input: string | EventEmitter): Token[];
+    tokenize(input: string): Token[];
     tokenize(input: string | EventEmitter, callback: TokenCallback): void;
 }
 export interface ParserOptions {

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -130,6 +130,26 @@ export interface BlankTriple<Q extends RDF.BaseQuad = RDF.Quad> {
     object: Q['object'];
 }
 
+
+export type Token = {
+    type: string;
+    value?: string;
+    line: number;
+}
+
+export interface LexerOptions {
+    lineMode?: boolean;
+    n3?: boolean;
+    comments?: boolean;
+}
+
+export type TokenCallback = (error: Error, token: Token) => void;
+
+export class Lexer {
+    constructor(options?: LexerOptions);
+    tokenize(input: string | EventEmitter): Token[];
+    tokenize(input: string | EventEmitter, callback: TokenCallback): void;
+}
 export interface ParserOptions {
     format?: string;
     factory?: RDF.DataFactory;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -66,6 +66,23 @@ function test_doc_rdf_to_triples_1() {
         });
 }
 
+function test_doc_rdf_to_triples_and_prefixes() {
+    const parser: N3.Parser = new N3.Parser();
+    parser.parse(`@prefix c: <http://example.org/cartoons#>.
+        c:Tom a c:Cat.
+        c:Jerry a c:Mouse;
+                c:smarterThan c:Tom.`,
+        (error: Error, quad: RDF.Quad) => {
+            if (quad)
+                console.log(quad.subject, quad.predicate, quad.object, quad.graph, '.');
+            else
+                console.log("# That's all, folks!");
+        },
+        (prefix: string, prefixNode: RDF.NamedNode) => {
+            console.log("@prefix#", prefix, prefixNode.value);
+        });
+}
+
 function test_doc_rdf_to_triples_2() {
     const parser1: N3.Parser = new N3.Parser({ format: 'N-Triples' });
     const parser2: N3.Parser = new N3.Parser({ format: 'application/trig' });
@@ -82,6 +99,17 @@ function test_doc_rdf_sync_to_triples_1() {
       c:Tom a c:Cat.
       c:Jerry a c:Mouse;
       c:smarterThan c:Tom.`);
+    result.forEach((s) => console.log(s));
+}
+
+function test_doc_rdf_sync_to_triples_and_prefixes() {
+    const parser: N3.Parser = new N3.Parser();
+    const result = parser.parse(`@prefix c: <http://example.org/cartoons#>.
+      c:Tom a c:Cat.
+      c:Jerry a c:Mouse;
+      c:smarterThan c:Tom.`, null, (prefix: string, prefixNode: RDF.NamedNode) => {
+        console.log("@prefix#", prefix, prefixNode.value);
+    });
     result.forEach((s) => console.log(s));
 }
 

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -300,3 +300,7 @@ function test_parser_options() {
         blankNodePrefix: '',
     });
 }
+
+function test_term_to_and_from_id() {
+    const label: string = N3.termToId(N3.termFromId('http://www.w3.org/2000/01/rdf-schema#label', N3.DataFactory));
+}

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -307,7 +307,7 @@ function test_term_to_and_from_id() {
 
 function test_lexer_sync() {
     const lexer: N3.Lexer = new N3.Lexer();
-    const result = lexer.tokenize(`@prefix c: <http://example.org/cartoons#>.
+    const result: N3.Token[] = lexer.tokenize(`@prefix c: <http://example.org/cartoons#>.
       c:Tom a c:Cat.
       c:Jerry a c:Mouse;
       c:smarterThan c:Tom.`);
@@ -316,7 +316,7 @@ function test_lexer_sync() {
 
 function test_lexer_async() {
     const lexer: N3.Lexer = new N3.Lexer();
-    const result = lexer.tokenize(`@prefix c: <http://example.org/cartoons#>.
+    lexer.tokenize(`@prefix c: <http://example.org/cartoons#>.
       c:Tom a c:Cat.
       c:Jerry a c:Mouse;
       c:smarterThan c:Tom.`, (error: Error, token: N3.Token) => {

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -37,9 +37,9 @@ function test_serialize() {
             }
         });
     writer.addQuad(N3.DataFactory.quad(
-      N3.DataFactory.namedNode("subject-name"),
-      N3.DataFactory.namedNode("predicate-name"),
-      N3.DataFactory.literal(12)
+        N3.DataFactory.namedNode("subject-name"),
+        N3.DataFactory.namedNode("predicate-name"),
+        N3.DataFactory.literal(12)
     ));
 
     writer.end((error, result) => {
@@ -115,12 +115,12 @@ function test_doc_rdf_sync_to_triples_and_prefixes() {
 
 function test_doc_rdf_stream_to_triples_1() {
     interface QuadBnode extends N3.BaseQuad {
-      subject: N3.BlankNode;
-      predicate: N3.BlankNode;
-      object: N3.BlankNode;
-      graph: N3.BlankNode;
+        subject: N3.BlankNode;
+        predicate: N3.BlankNode;
+        object: N3.BlankNode;
+        graph: N3.BlankNode;
     }
-    const parser: N3.Parser<QuadBnode> = new N3.Parser<QuadBnode>({factory: N3.DataFactory});
+    const parser: N3.Parser<QuadBnode> = new N3.Parser<QuadBnode>({ factory: N3.DataFactory });
     parser.parse('abc', console.log);
 
     const streamParser: N3.StreamParser = new N3.StreamParser();
@@ -146,9 +146,9 @@ function test_doc_from_triples_to_string() {
         N3.DataFactory.namedNode('http://example.org/cartoons#Cat')
     ));
     writer.addQuad(N3.DataFactory.quad(
-      N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
-      N3.DataFactory.namedNode('http://example.org/cartoons#name'),
-      N3.DataFactory.literal('Tom'),
+        N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
+        N3.DataFactory.namedNode('http://example.org/cartoons#name'),
+        N3.DataFactory.literal('Tom'),
     ));
     writer.end((error, result: string) => { console.log(result); });
 
@@ -159,14 +159,14 @@ function test_doc_from_triples_to_string() {
 function test_doc_from_triples_to_rdf_stream() {
     const writer: N3.Writer = new N3.Writer(process.stdout, { end: false, prefixes: { c: N3.DataFactory.namedNode('http://example.org/cartoons#') } });
     writer.addQuad(N3.DataFactory.quad(
-      N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
-      N3.DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
-      N3.DataFactory.namedNode('http://example.org/cartoons#Cat'),
+        N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
+        N3.DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        N3.DataFactory.namedNode('http://example.org/cartoons#Cat'),
     ));
     writer.addQuad(N3.DataFactory.quad(
-      N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
-      N3.DataFactory.namedNode('http://example.org/cartoons#name'),
-      N3.DataFactory.literal('Tom'),
+        N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
+        N3.DataFactory.namedNode('http://example.org/cartoons#name'),
+        N3.DataFactory.literal('Tom'),
     ));
     writer.end();
 }
@@ -228,23 +228,23 @@ function test_doc_storing() {
 
     const mickey: RDF.Quad = store.getQuads(N3.DataFactory.namedNode('http://ex.org/Mickey'), null, null, null)[0];
     if (mickey.object.termType === "Literal") {
-      console.log(mickey.object.datatype);
+        console.log(mickey.object.datatype);
     }
     console.log(mickey.subject, mickey.predicate, mickey.object, '.');
 
     const quadStream: RDF.Stream = store.match(N3.DataFactory.namedNode('http://ex.org/Mickey'));
 
     interface N3QuadGeneralized extends N3.BaseQuad {
-      subject: N3.Quad_Subject | N3.BlankNode | N3.Literal;
-      predicate: N3.Quad_Predicate | N3.BlankNode | N3.Literal;
-      object: N3.Quad_Object | N3.BlankNode | N3.Literal;
-      graph: N3.Quad_Graph | N3.BlankNode | N3.Literal;
+        subject: N3.Quad_Subject | N3.BlankNode | N3.Literal;
+        predicate: N3.Quad_Predicate | N3.BlankNode | N3.Literal;
+        object: N3.Quad_Object | N3.BlankNode | N3.Literal;
+        graph: N3.Quad_Graph | N3.BlankNode | N3.Literal;
     }
     interface RDFQuadGeneralized extends RDF.BaseQuad {
-      subject: RDF.Quad_Subject | RDF.BlankNode | RDF.Literal;
-      predicate: RDF.Quad_Predicate | RDF.BlankNode | RDF.Literal;
-      object: RDF.Quad_Object | RDF.BlankNode | RDF.Literal;
-      graph: RDF.Quad_Graph | RDF.BlankNode | RDF.Literal;
+        subject: RDF.Quad_Subject | RDF.BlankNode | RDF.Literal;
+        predicate: RDF.Quad_Predicate | RDF.BlankNode | RDF.Literal;
+        object: RDF.Quad_Object | RDF.BlankNode | RDF.Literal;
+        graph: RDF.Quad_Graph | RDF.BlankNode | RDF.Literal;
     }
     const storeGeneralized = new N3.Store<RDFQuadGeneralized, N3QuadGeneralized>();
     // storeGeneralized.
@@ -255,16 +255,16 @@ function test_store_queries() {
     const store: N3.Store = new N3.Store();
 
     const subjs: N3.Quad_Subject[] = store.getSubjects(null, null, null);
-    store.forSubjects((subj: N3.Quad_Subject) => {}, null, null, null);
+    store.forSubjects((subj: N3.Quad_Subject) => { }, null, null, null);
 
     const preds: N3.Quad_Predicate[] = store.getPredicates(null, null, null);
-    store.forPredicates((subj: N3.Quad_Predicate) => {}, null, null, null);
+    store.forPredicates((subj: N3.Quad_Predicate) => { }, null, null, null);
 
     const objs: N3.Quad_Object[] = store.getObjects(null, null, null);
-    store.forObjects((subj: N3.Quad_Object) => {}, null, null, null);
+    store.forObjects((subj: N3.Quad_Object) => { }, null, null, null);
 
     const graphs: N3.Quad_Graph[] = store.getGraphs(null, null, null);
-    store.forGraphs((subj: N3.Quad_Graph) => {}, null, null, null);
+    store.forGraphs((subj: N3.Quad_Graph) => { }, null, null, null);
 }
 
 function test_doc_utility() {

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -304,3 +304,36 @@ function test_parser_options() {
 function test_term_to_and_from_id() {
     const label: string = N3.termToId(N3.termFromId('http://www.w3.org/2000/01/rdf-schema#label', N3.DataFactory));
 }
+
+function test_lexer_sync() {
+    const lexer: N3.Lexer = new N3.Lexer();
+    const result = lexer.tokenize(`@prefix c: <http://example.org/cartoons#>.
+      c:Tom a c:Cat.
+      c:Jerry a c:Mouse;
+      c:smarterThan c:Tom.`);
+    result.forEach((s) => console.log(s));
+}
+
+function test_lexer_async() {
+    const lexer: N3.Lexer = new N3.Lexer();
+    const result = lexer.tokenize(`@prefix c: <http://example.org/cartoons#>.
+      c:Tom a c:Cat.
+      c:Jerry a c:Mouse;
+      c:smarterThan c:Tom.`, (error: Error, token: N3.Token) => {
+        if (error) {
+            console.log(error);
+        }
+        if (token)
+            console.log(token);
+        else
+            console.log("# That's all, folks!");
+    });
+}
+
+function test_lexer_options() {
+    const options: N3.LexerOptions = {
+        lineMode: true,
+        n3: true,
+        comments: true
+    };
+}


### PR DESCRIPTION
The [n3](https://github.com/rdfjs/N3.js) parser now accepts two callbacks, and a separate inline prefix callback.

https://github.com/rdfjs/N3.js/blob/42ab3a29e9ee82cf4d8fdf8994c1f7e74f9b1035/src/N3Parser.js#L982

My understanding is:
If giving a parse callback the function is async and the prefix callback is optional.

If the parse callback is not supplied or nullish, the parse is sync and returns the quads. 
Supplying null and a prefix callback also works synchronously and calls the prefix callback
while processing. (Not sure if this is intended, but it is useful).

I have updated the version as I assume this has changed at some point. I have not checked for other API changes.

Update: after being prompted, I have also added the other missing types. This maybe not be absolutely correct as I have not checked all the other existing types but is closer to the current version. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
