### PR TITLE
[aws-lambda] Added missing and edited fields in AppSyncResolverEvent

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -38,6 +38,7 @@
 //                 Ivan Martos <https://github.com/ivanmartos>
 //                 Zach Anthony <https://github.com/zach-anthony>
 //                 Peter Savnik <https://github.com/savnik>
+//                 Sven Milewski <https://github.com/svenmilewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -1,4 +1,7 @@
-import { AppSyncResolverHandler, AppSyncIdentityIAM, AppSyncIdentityCognito } from "aws-lambda";
+import { AppSyncIdentityCognito, AppSyncIdentityIAM, AppSyncResolverHandler } from 'aws-lambda';
+
+declare let objectOrNull: {} | null;
+declare let prevResultOrNull: { result: { [key: string]: any } } | null;
 
 interface TestArguments {
     id: string;
@@ -39,7 +42,10 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event,
     anyObj = event.info.variables;
     str = event.info.selectionSetList[0];
 
-    objectOrUndefined = event.source;
+    objectOrNull = event.source;
+    prevResultOrNull = event.prev;
+    anyObj = (event.prev as { result: { [key: string]: any } }).result;
+    anyObj = event.stash;
 
     return {
         id: '',

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -14,7 +14,7 @@ export interface AppSyncResolverEventHeaders {
 export interface AppSyncResolverEvent<T> {
     arguments: T;
     identity?: AppSyncIdentityIAM | AppSyncIdentityCognito;
-    source?: { [key: string]: any };
+    source: { [key: string]: any } | null;
     request: {
         headers: AppSyncResolverEventHeaders;
     };
@@ -25,6 +25,8 @@ export interface AppSyncResolverEvent<T> {
         fieldName: string;
         variables: { [key: string]: any };
     };
+    prev: { result: { [key: string]: any } } | null;
+    stash: { [key: string]: any };
 }
 
 export interface AppSyncIdentityIAM {
@@ -45,4 +47,5 @@ export interface AppSyncIdentityCognito {
     claims: any;
     sourceIp: string[];
     defaultAuthStrategy: string;
+    groups: string[] | null;
 }


### PR DESCRIPTION
Started using Pipeline Resolvers and missed the `prev.result` and `stash` fields in the event.

Also got `prev.result`, `stash` and `source` having `null` inside the event instead of being not defined.

Checked with Direct Lambda Resolver (without the VTL) and Request Mapping Templates backed Lambda calls.

As this is my first PR to DT - would love to hear your feedback! 😃 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  [AWS Docs](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html#aws-appsync-resolver-context-reference-info)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
