### PR TITLE
fix: type error in styled-component

### DIFF
--- a/types/styled-system__should-forward-prop/index.d.ts
+++ b/types/styled-system__should-forward-prop/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tom Picton <https://github.com/tpict>, Jason Maurer <https://github.com/jsonmaur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type genericShouldForwardProp = (prop: string) => boolean;
+type genericShouldForwardProp = (prop: string | ReactText) => boolean;
 
 export const props: string[];
 export function createShouldForwardProp(props: string[]): genericShouldForwardProp;


### PR DESCRIPTION
on ``styled-component``  with ``withConfig`` function it  has a type error.  ``withConfig``'s ``shouldForwardProp`` property function  uses ``ReactText`` as a prop type.

I left ``string`` type because of ``emotion`` library uses that, so I just added  a new one.