### PR TITLE
chore(concurrently): update promise callback types

### DIFF
--- a/types/concurrently/concurrently-tests.ts
+++ b/types/concurrently/concurrently-tests.ts
@@ -8,8 +8,8 @@ const _COMMAND_OBJ: CommandObj = {
 
 const _OPTIONS: Options = {};
 
-concurrently(['echo foo']); // $ExpectType Promise<null>
-// $ExpectType Promise<null>
+concurrently(['echo foo']); // $ExpectType Promise<ExitInfos[]>
+// $ExpectType Promise<ExitInfos[]>
 concurrently(
     [
         'echo foo',
@@ -31,6 +31,7 @@ concurrently(
     },
 );
 
+// $ExpectType Promise<void>
 concurrently(['npm:watch-*', { command: 'nodemon', name: 'server' }], {
     cwd: path.resolve(__dirname, 'scripts/watchers'),
     prefix: 'name',
@@ -38,6 +39,26 @@ concurrently(['npm:watch-*', { command: 'nodemon', name: 'server' }], {
     maxProcesses: 2,
     restartTries: 3,
 }).then(
+    // $ExpectType (results: ExitInfos[]) => void
     results => {},
+    // $ExpectType (reason: any) => void
+    reason => {},
+);
+
+/**
+ * @description
+ * example with returned exit information
+ */
+// $ExpectType Promise<void | ExitInfos[]>
+concurrently(['echo foo', 'npm:watch-*', { command: 'nodemon', name: 'server' }], {
+    cwd: path.resolve(__dirname, 'scripts/watchers'),
+    prefix: 'name',
+    killOthers: ['failure', 'success'],
+    maxProcesses: 2,
+    restartTries: 3,
+}).then(
+    // $ExpectType (results: ExitInfos[]) => ExitInfos[]
+    results => results,
+    // $ExpectType (reason: any) => void
     reason => {},
 );

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -9,7 +9,7 @@
 declare function concurrently(
     commands: Array<concurrently.CommandObj | string>,
     options?: concurrently.Options,
-): Promise<null>;
+): Promise<concurrently.ExitInfos[]>;
 
 declare namespace concurrently {
     interface CommandObj {
@@ -18,6 +18,13 @@ declare namespace concurrently {
         env?: NodeJS.ProcessEnv;
         name?: string;
         prefixColor?: string;
+    }
+    interface ExitInfos {
+        command: CommandObj;
+        /** process completion index */
+        index: number;
+        /** process exit code */
+        exitCode: number;
     }
     interface Options {
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kimmobrunfeldt/concurrently#programmatic-usage


***

### Background

The current types for `concurrently` specify that the `concurrently` default function will return `Promise<null>` .

However, the returned [fulfillment value](https://github.com/Microsoft/TypeScript/blob/master/src/lib/es2015.promise.d.ts#L13) is not `null`, but rather an array of some exit information about the finished processes.

This information is also documented in the `concurrently` README under [programmatic usage](https://github.com/kimmobrunfeldt/concurrently#programmatic-usage).

> Returns: a Promise that resolves if the run was successful (according to successCondition option), or rejects, containing an array of objects with information for each command that has been run, in the order that the commands terminated. The objects have the shape { command, index, exitCode }, where command is the object passed in the commands array and index its index there. Default values (empty strings or objects) are returned for the fields that were not specified.

### Source Code 

- The `concurrently` default function returns the result of `.listen` being called on a newly instantiated `CompletionListener` [source](https://github.com/kimmobrunfeldt/concurrently/blob/986bc3dea742f5c91fc916974bbb5e0a6f4ef3e0/src/concurrently.js#L63)

- `.listen` returns a promise (converted from an observable), which resolves or rejects with an array of exit information [source](https://github.com/kimmobrunfeldt/concurrently/blob/b62a2a1c92caa590b78f336cc8fcef745e5a7832/src/completion-listener.js#L25-L37)

### Updates

Changes return type in `concurrently` function:

- from `Promise<null>`

- to  `Promise<ExitInfos[]>`


The generic type for promises is the [fulfillment value](https://github.com/Microsoft/TypeScript/blob/master/src/lib/es2015.promise.d.ts#L13), which for `concurrently` always a consistent shape: `ExitInfos[]`.

The promise callback values are currently displaying type errors since typescript thinks they are `null`. PR fixes this and allows us to use these callback values.

### Demo

If you use `repl.it`, you can try this demo and run `npm run dev` inside the shell they provide (not the console):

https://repl.it/@dankreiger/concurrently-callbacks

You should see concurrently fire some processes, and log out the array of exit information as the fulfillment value when the processes complete.

***


### Note:

The naming for `ExitInfos[]` was adopted from its naming in the [source code](https://github.com/kimmobrunfeldt/concurrently/blob/b62a2a1c92caa590b78f336cc8fcef745e5a7832/src/completion-listener.js#L25-L37)


