### PR TITLE
nodegit: Repository.discover returns Promise<string>, not Promise<buf>

### DIFF
--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -38,7 +38,7 @@ export class Repository {
     /**
      * Creates a branch with the passed in name pointing to the commit
      */
-    static discover(startPath: string, acrossFs: number, ceilingDirs: string): Promise<Buf>;
+    static discover(startPath: string, acrossFs: number, ceilingDirs: string): Promise<string>;
     static init(path: string, isBare: number): Promise<Repository>;
     static initExt(repoPath: string, options?: RepositoryInitOptions): Promise<Repository>;
     static open(path: string): Promise<Repository>;


### PR DESCRIPTION
See https://github.com/nodegit/nodegit/blob/7df154a5eb9e93ad933f0a9864f06e2395d32d21/test/tests/repository.js#L211-L218

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
