### PR TITLE
feat(jest): Add ./global-types as an alias to ./index

### DIFF
--- a/types/jest/OTHER_FILES.txt
+++ b/types/jest/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+global-types.d.ts

--- a/types/jest/OTHER_FILES.txt
+++ b/types/jest/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-global-types.d.ts

--- a/types/jest/global-types.d.ts
+++ b/types/jest/global-types.d.ts
@@ -1,0 +1,11 @@
+// Starting from jest v24.3.0, the jest package provides its own type definition.
+// @types/jest now serves a different purpose than that;
+// it declares global variables injeced by jest, rather than jest's own API.
+//
+// Unfortunately, that led to `types: ["jest"]` being resolved to the jest package,
+// causing problems when `typeRoots` is configured.
+//
+// This file enables users to specify `types: ["jest/global-types"]` in tsconfig.json
+// to clarify their intention.
+
+import "./index";

--- a/types/jest/global-types.d.ts
+++ b/types/jest/global-types.d.ts
@@ -8,4 +8,4 @@
 // This file enables users to specify `types: ["jest/global-types"]` in tsconfig.json
 // to clarify their intention.
 
-import "./index";
+/// <reference path="./index.d.ts" />

--- a/types/jest/test/global-types-tests.ts
+++ b/types/jest/test/global-types-tests.ts
@@ -1,4 +1,4 @@
-import "./global-types";
+/// <reference path="../global-types.d.ts" />
 
 describe("42", () => {
   expect(42).toBe(42);

--- a/types/jest/test/global-types-tests.ts
+++ b/types/jest/test/global-types-tests.ts
@@ -1,0 +1,5 @@
+import "./global-types";
+
+describe("42", () => {
+  expect(42).toBe(42);
+});

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -17,7 +17,6 @@
     },
     "files": [
         "index.d.ts",
-        "global-types.d.ts",
         "jest-tests.ts",
         "test/global-types-tests.ts"
     ]

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -17,6 +17,7 @@
     },
     "files": [
         "index.d.ts",
+        "global-types.d.ts",
         "jest-tests.ts"
     ]
 }

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -18,6 +18,7 @@
     "files": [
         "index.d.ts",
         "global-types.d.ts",
-        "jest-tests.ts"
+        "jest-tests.ts",
+        "test/global-types-tests.ts"
     ]
 }

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -17,6 +17,7 @@
     },
     "files": [
         "index.d.ts",
+        "global-types.d.ts",
         "jest-tests.ts",
         "test/global-types-tests.ts"
     ]

--- a/types/jest/tslint.json
+++ b/types/jest/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-bad-reference": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/pull/8024
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

----

Starting from jest v24.3.0, the jest package [provides its own type definition](https://github.com/facebook/jest/pull/8024).
`@types/jest` now serves a different purpose than that; it declares global variables injeced by jest, rather than jest's own API.

Unfortunately, that led to `types: ["jest"]` being resolved to the jest package, causing problems when `typeRoots` is configured. ([example repository](https://github.com/qnighy/jest-global-types-with-typeroots))

This file enables users to specify `types: ["jest/global-types"]` in tsconfig.json to clarify their intention.