### PR TITLE
[chosen-js] adjust SelectedData, replace deprecated JQueryEventObject

### DIFF
--- a/types/chosen-js/chosen-js-tests.ts
+++ b/types/chosen-js/chosen-js-tests.ts
@@ -19,10 +19,19 @@ $(".my_select_box").chosen("destroy");
 
 // Triggered Events
 $(".my_select_box").on("change", (evt, params) => {
+    // $ExpectType TriggeredEvent<any, any, any, any>
+    evt;
     evt.preventDefault();
-    const s: string = params.selected;
-    const d: string = params.deselected;
-    console.log(s, d);
+    if ("selected" in params) {
+        const s: string = params.selected;
+    } else {
+        const d: string = params.deselected;
+    }
+    if ("deselected" in params) {
+        const s: string = params.deselected;
+    } else {
+        const d: string = params.selected;
+    }
 });
 
 $(".chosen-select").on("chosen:maxselected", () => {

--- a/types/chosen-js/index.d.ts
+++ b/types/chosen-js/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://harvesthq.github.io/chosen
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.4
 
-// Validated against Chosen version 1.8.5
+// Validated against Chosen version 1.8.7
 
 /// <reference types="jquery"/>
 
@@ -118,10 +118,17 @@ declare namespace Chosen {
         max_shown_results?: number;
     }
 
-    interface SelectedData {
+    /**
+     * Arguments passed to the event handler of the `change` event when an
+     * option was selected or deselected.
+     */
+    type SelectedData = {
+        /** When a new option was selected: the value of the newly selected option. */
         selected: string;
+    } | {
+        /** When a selection option was unselected: the value of the unselected option. */
         deselected: string;
-    }
+    };
 }
 
 interface JQuery {
@@ -130,7 +137,7 @@ interface JQuery {
     /**
      * Chosen triggers the standard DOM event whenever a selection is made (it also sends a selected or deselected parameter that tells you which option was changed).
      */
-    on(events: "change", handler: (eventObject: JQueryEventObject, args: Chosen.SelectedData) => any): JQuery;
+    on(events: "change", handler: (eventObject: JQuery.TriggeredEvent, args: Chosen.SelectedData) => any): JQuery;
 
     /**
      * * `chosen:ready` Triggered after Chosen has been fully instantiated.
@@ -139,11 +146,11 @@ interface JQuery {
      * * `chosen:hiding_dropdown` Triggered when Chosen’s dropdown is closed.
      * * `chosen:no_results` Triggered when a search returns no matching results.
      */
-    on(events: Chosen.OnEvent, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    on(events: Chosen.OnEvent, handler: (eventObject: JQuery.TriggeredEvent) => any): JQuery;
 
     /**
      * * `chosen:updated` This event should be triggered whenever Chosen’s underlying select element changes (such as a change in selected options).
-     * * `chosen:activate` This is the equivalant of focusing a standard HTML select field. When activated, Chosen will capure keypress events as if you had clicked the field directly.
+     * * `chosen:activate` This is the equivalent of focusing a standard HTML select field. When activated, Chosen will capture keypress events as if you had clicked the field directly.
      * * `chosen:open` This event activates Chosen and also displays the search results.
      * * `chosen:close` This event deactivates Chosen and hides the search results.
      */


### PR DESCRIPTION
* Replaced deprecated `JQueryEventObject` with `JQuery.TriggeredEvent`
* `SelectedData` can never be an object with `selected` and `deselected` properties, it is either an object with a `selected` property _or_ an object with a `deselected` property. This can be checked on the demo page https://harvesthq.github.io/chosen/ and seen in the code [here](https://github.com/harvesthq/chosen/blob/master/coffee/chosen.jquery.coffee#L385) and [here](https://github.com/harvesthq/chosen/blob/master/coffee/chosen.jquery.coffee#L413).
* Fixed 2 typos in the docs

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
