### PR TITLE
[jqueryui]: Fix return type of addClass (and similar methods) to match those of jquery.

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -1907,39 +1907,39 @@ interface JQuery {
     tooltip(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
 
-    addClass(classNames: string, speed?: number, callback?: Function): JQuery;
-    addClass(classNames: string, speed?: string, callback?: Function): JQuery;
-    addClass(classNames: string, speed?: number, easing?: string, callback?: Function): JQuery;
-    addClass(classNames: string, speed?: string, easing?: string, callback?: Function): JQuery;
+    addClass(classNames: string, speed?: number, callback?: Function): this;
+    addClass(classNames: string, speed?: string, callback?: Function): this;
+    addClass(classNames: string, speed?: number, easing?: string, callback?: Function): this;
+    addClass(classNames: string, speed?: string, easing?: string, callback?: Function): this;
 
-    removeClass(classNames: string, speed?: number, callback?: Function): JQuery;
-    removeClass(classNames: string, speed?: string, callback?: Function): JQuery;
-    removeClass(classNames: string, speed?: number, easing?: string, callback?: Function): JQuery;
-    removeClass(classNames: string, speed?: string, easing?: string, callback?: Function): JQuery;
+    removeClass(classNames: string, speed?: number, callback?: Function): this;
+    removeClass(classNames: string, speed?: string, callback?: Function): this;
+    removeClass(classNames: string, speed?: number, easing?: string, callback?: Function): this;
+    removeClass(classNames: string, speed?: string, easing?: string, callback?: Function): this;
 
-    switchClass(removeClassName: string, addClassName: string, duration?: number, easing?: string, complete?: Function): JQuery;
-    switchClass(removeClassName: string, addClassName: string, duration?: string, easing?: string, complete?: Function): JQuery;
+    switchClass(removeClassName: string, addClassName: string, duration?: number, easing?: string, complete?: Function): this;
+    switchClass(removeClassName: string, addClassName: string, duration?: string, easing?: string, complete?: Function): this;
 
-    toggleClass(className: string, duration?: number, easing?: string, complete?: Function): JQuery;
-    toggleClass(className: string, duration?: string, easing?: string, complete?: Function): JQuery;
-    toggleClass(className: string, aswitch?: boolean, duration?: number, easing?: string, complete?: Function): JQuery;
-    toggleClass(className: string, aswitch?: boolean, duration?: string, easing?: string, complete?: Function): JQuery;
+    toggleClass(className: string, duration?: number, easing?: string, complete?: Function): this;
+    toggleClass(className: string, duration?: string, easing?: string, complete?: Function): this;
+    toggleClass(className: string, aswitch?: boolean, duration?: number, easing?: string, complete?: Function): this;
+    toggleClass(className: string, aswitch?: boolean, duration?: string, easing?: string, complete?: Function): this;
 
-    effect(options: any): JQuery;
-    effect(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
-    effect(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
+    effect(options: any): this;
+    effect(effect: string, options?: any, duration?: number, complete?: Function): this;
+    effect(effect: string, options?: any, duration?: string, complete?: Function): this;
 
-    hide(options: any): JQuery;
-    hide(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
-    hide(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
+    hide(options: any): this;
+    hide(effect: string, options?: any, duration?: number, complete?: Function): this;
+    hide(effect: string, options?: any, duration?: string, complete?: Function): this;
 
-    show(options: any): JQuery;
-    show(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
-    show(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
+    show(options: any): this;
+    show(effect: string, options?: any, duration?: number, complete?: Function): this;
+    show(effect: string, options?: any, duration?: string, complete?: Function): this;
 
-    toggle(options: any): JQuery;
-    toggle(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
-    toggle(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
+    toggle(options: any): this;
+    toggle(effect: string, options?: any, duration?: number, complete?: Function): this;
+    toggle(effect: string, options?: any, duration?: string, complete?: Function): this;
 
     position(options: JQueryUI.JQueryPositionOptions): JQuery;
 

--- a/types/jqueryui/jqueryui-tests.ts
+++ b/types/jqueryui/jqueryui-tests.ts
@@ -1828,6 +1828,18 @@ function test_effects() {
     $("div").hide("drop", { direction: "down" }, "slow");
     $(this).switchClass("big", "blue", 1000, "easeInOutQuad");
     $(this).toggleClass("big-blue", 1000, "easeOutSine");
+
+    // test with non-HTMLElement
+    var $svg: JQuery<SVGElement> = <unknown>$('<svg>') as JQuery<SVGSVGElement>,
+        $ret: JQuery<SVGElement>;
+    $ret = $svg.addClass("newClass", 1000, callback);
+    $ret = $svg.removeClass("newClass", 1000, callback);
+    $ret = $svg.show(selectedEffect, options, 500, callback);
+    $ret = $svg.hide("drop", { direction: "down" }, "slow");
+    $ret = $svg.effect("transfer", { to: $("div").eq(5) }, 1000) ;
+    $ret = $svg.toggle(selectedEffect, options, 500);
+    $ret = $svg.toggleClass("newClass", 1000);
+    $ret = $svg.switchClass("big", "blue", 1000, "easeInOutQuad");
 }
 
 function test_methods() {


### PR DESCRIPTION
The methods `JQuery#addClass`, `JQuery#removeClass` are overloaded in `@types/jqueryui` along with a few similar methods, but the return value is declared as `JQuery` while it is, in fact, `this`.

In 99% of the cases this would not matter because `JQuery` defaults to `JQuery<HTMLElement>`, but if you're using e.g. `JQuery<SVGElement>` then you get reverted to `JQuery<HTMLElement>` after applying `addClass`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3a2b4f9ca044db6e53e205b4085ae9f2b1a2a79e/types/jquery/JQuery.d.ts#L421
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.