### PR TITLE
Define estree BigIntLiteral

### DIFF
--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -52,6 +52,7 @@ declare var identifier: ESTree.Identifier;
 declare var literal: ESTree.Literal;
 declare var simpleLiteral: ESTree.SimpleLiteral;
 declare var regExpLiteral: ESTree.RegExpLiteral;
+declare var bigIntLiteral: ESTree.BigIntLiteral;
 declare var unaryOperator: ESTree.UnaryOperator;
 declare var binaryOperator: ESTree.BinaryOperator;
 declare var logicalOperator: ESTree.LogicalOperator;

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -360,7 +360,7 @@ export interface Identifier extends BaseNode, BaseExpression, BasePattern {
   name: string;
 }
 
-export type Literal = SimpleLiteral | RegExpLiteral;
+export type Literal = SimpleLiteral | RegExpLiteral | BigIntLiteral;
 
 export interface SimpleLiteral extends BaseNode, BaseExpression {
   type: "Literal";
@@ -375,6 +375,13 @@ export interface RegExpLiteral extends BaseNode, BaseExpression {
     pattern: string;
     flags: string;
   };
+  raw?: string;
+}
+
+export interface BigIntLiteral extends BaseNode, BaseExpression {
+  type: "Literal";
+  value?: bigint | null;
+  bigint: string;
   raw?: string;
 }
 


### PR DESCRIPTION
I mimicked the type definition for `RegExpLiteral` as much as possible, because it’s the most similar node type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estree/estree/blob/master/es2020.md#bigintliteral 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.