### PR TITLE
[Atom] Use standard tslint.json

### DIFF
--- a/types/atom/tslint.json
+++ b/types/atom/tslint.json
@@ -1,9 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "await-promise": [true, "CancellablePromise"],
-        "no-any": true,
-        "strict-export-declare-modifiers": false,
-        "invalid-void": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. N/A
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A

Explaination: DefinitelyTyped nowadays [recommends](https://github.com/DefinitelyTyped/DefinitelyTyped#linter-tslintjson) a very "bare bone" `tslint.json`. I did some tests. Apparently, our `tslint.json` is more or less entirely outdated, and definitions seemingly pass all tests with the current recommended tslint.json.

It's just one less thing for the typescript bot to complain about.