### PR TITLE
react-instantsearch-core fix Insights API types

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -707,11 +707,23 @@ interface HighlightResultPrimitive {
   fullyHighlighted?: boolean;
 }
 
+type InsightsClient = (method: InsightsClientMethod, payload: InsightsClientPayload) => void;
+
+type InsightsClientMethod = 'clickedObjectIDsAfterSearch' | 'convertedObjectIDsAfterSearch';
+
+type InsightsClientPayload = {
+    index: string;
+    queryID: string;
+    eventName: string;
+    objectIDs: string[];
+    positions?: number[];
+};
+
 export function EXPERIMENTAL_connectConfigureRelatedItems(
   Composed: React.ComponentType<any>
 ): React.ComponentClass<any>;
 export function connectQueryRules(Composed: React.ComponentType<any>): React.ComponentClass<any>;
-export function connectHitInsights(Composed: React.ComponentType<any>): React.ComponentClass<any>;
+export function connectHitInsights(insightsClient: InsightsClient): React.FC<any>;
 export function connectVoiceSearch(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
 // Turn off automatic exports - so we don't export internal types like Omit<>

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -723,7 +723,9 @@ export function EXPERIMENTAL_connectConfigureRelatedItems(
   Composed: React.ComponentType<any>
 ): React.ComponentClass<any>;
 export function connectQueryRules(Composed: React.ComponentType<any>): React.ComponentClass<any>;
-export function connectHitInsights(insightsClient: InsightsClient): (props: Record<string, any>) => any;
+export function connectHitInsights(
+    insightsClient: InsightsClient,
+): (hitComponent: React.ComponentType<any>) => React.ComponentType<any>;
 export function connectVoiceSearch(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
 // Turn off automatic exports - so we don't export internal types like Omit<>

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -711,13 +711,13 @@ type InsightsClient = (method: InsightsClientMethod, payload: InsightsClientPayl
 
 type InsightsClientMethod = 'clickedObjectIDsAfterSearch' | 'convertedObjectIDsAfterSearch';
 
-type InsightsClientPayload = {
+export interface InsightsClientPayload {
     index: string;
     queryID: string;
     eventName: string;
     objectIDs: string[];
     positions?: number[];
-};
+}
 
 export function EXPERIMENTAL_connectConfigureRelatedItems(
   Composed: React.ComponentType<any>

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -719,13 +719,18 @@ export interface InsightsClientPayload {
     positions?: number[];
 }
 
+export interface ConnectHitInsightsProvided {
+    hit: Hit;
+    insights?: InsightsClient;
+}
+
 export function EXPERIMENTAL_connectConfigureRelatedItems(
   Composed: React.ComponentType<any>
 ): React.ComponentClass<any>;
 export function connectQueryRules(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 export function connectHitInsights(
     insightsClient: InsightsClient,
-): (hitComponent: React.ComponentType<any>) => React.ComponentType<any>;
+): (hitComponent: React.ComponentType<any>) => React.ComponentType<ConnectHitInsightsProvided>;
 export function connectVoiceSearch(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
 // Turn off automatic exports - so we don't export internal types like Omit<>

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -719,9 +719,10 @@ export interface InsightsClientPayload {
     positions?: number[];
 }
 
+export type WrappedInsightsClient = (method: InsightsClientMethod, payload: Partial<InsightsClientPayload>) => void;
 export interface ConnectHitInsightsProvided {
     hit: Hit;
-    insights?: InsightsClient;
+    insights: WrappedInsightsClient;
 }
 
 export function EXPERIMENTAL_connectConfigureRelatedItems(
@@ -730,7 +731,9 @@ export function EXPERIMENTAL_connectConfigureRelatedItems(
 export function connectQueryRules(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 export function connectHitInsights(
     insightsClient: InsightsClient,
-): (hitComponent: React.ComponentType<any>) => React.ComponentType<ConnectHitInsightsProvided>;
+): (
+    hitComponent: React.ComponentType<any>,
+) => React.ComponentType<Omit<ConnectHitInsightsProvided, { insights: WrappedInsightsClient }>>;
 export function connectVoiceSearch(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
 // Turn off automatic exports - so we don't export internal types like Omit<>

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -707,9 +707,9 @@ interface HighlightResultPrimitive {
   fullyHighlighted?: boolean;
 }
 
-type InsightsClient = (method: InsightsClientMethod, payload: InsightsClientPayload) => void;
+export type InsightsClient = (method: InsightsClientMethod, payload: InsightsClientPayload) => void;
 
-type InsightsClientMethod = 'clickedObjectIDsAfterSearch' | 'convertedObjectIDsAfterSearch';
+export type InsightsClientMethod = 'clickedObjectIDsAfterSearch' | 'convertedObjectIDsAfterSearch';
 
 export interface InsightsClientPayload {
     index: string;
@@ -723,7 +723,7 @@ export function EXPERIMENTAL_connectConfigureRelatedItems(
   Composed: React.ComponentType<any>
 ): React.ComponentClass<any>;
 export function connectQueryRules(Composed: React.ComponentType<any>): React.ComponentClass<any>;
-export function connectHitInsights(insightsClient: InsightsClient): React.FC<any>;
+export function connectHitInsights(insightsClient: InsightsClient): (props: Record<string, any>) => any;
 export function connectVoiceSearch(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
 // Turn off automatic exports - so we don't export internal types like Omit<>

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -644,10 +644,16 @@ import { Hits } from 'react-instantsearch-dom';
 };
 
 () => {
-    const HitComponent = ({ hit, insights }: { hit: Hit; insights: InsightsClient }) => (
-        <article>
-            <h1>{hit.name}</h1>
-        </article>
+    const HitComponent = ({ hit, insights }: ConnectHitInsightsProvided) => (
+        <button
+            onClick={() => {
+                insights('clickedObjectIDsAfterSearch', { eventName: 'hit clicked' });
+            }}
+        >
+            <article>
+                <h1>{hit.name}</h1>
+            </article>
+        </button>
     );
 
     const HitWithInsights = connectHitInsights(() => {})(HitComponent);

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -30,6 +30,7 @@ import {
     StatsProvided,
     connectHitInsights,
     InsightsClient,
+    ConnectHitInsightsProvided,
 } from 'react-instantsearch-core';
 
 import { Hits } from 'react-instantsearch-dom';

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -27,8 +27,12 @@ import {
   BasicDoc,
   AllSearchResults,
   connectStats,
-  StatsProvided
+    StatsProvided,
+    connectHitInsights,
+    InsightsClient,
 } from 'react-instantsearch-core';
+
+import { Hits } from 'react-instantsearch-dom';
 
 () => {
   <Index indexName={'test'} indexId="id">
@@ -637,4 +641,16 @@ import {
   const ConnectedTotalHits = connectStats(TotalHits);
 
   <ConnectedTotalHits />;
+};
+
+() => {
+    const HitComponent = ({ hit, insights }: { hit: Hit; insights: InsightsClient }) => (
+        <article>
+            <h1>{hit.name}</h1>
+        </article>
+    );
+
+    const HitWithInsights = connectHitInsights(() => {})(HitComponent);
+
+    <Hits hitComponent={HitWithInsights} />;
 };


### PR DESCRIPTION
`connectHitInsights`is currently declared as taking a React component and returning a React component. However, both the [implementation (line 73 - 86)](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts) and the [official Algolia docs (steps 1 and 2)](https://www.algolia.com/doc/api-reference/widgets/hits/react/#sending-click-and-conversion-events) actually takes the insights client and return a functional component that is callable (see line 10 of the screenshot below).

![image](https://user-images.githubusercontent.com/5275680/110260524-c34eaa80-8000-11eb-9265-b62522ea47be.png)

Add the following types taken from [`react-instantsearch-core`](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts)
- `InsightsClient`
- `InsightsClientMethod`
- `InsightsClientPayload`

Update type:
- `connectHitInsights` to reflect the implementation (takes arg `InsightsClient`, return a wrapped function)
