### PR TITLE
Updated Big.js BigConstructor type definition

### DIFF
--- a/types/big.js/index.d.ts
+++ b/types/big.js/index.d.ts
@@ -97,6 +97,13 @@ export interface BigConstructor {
      * Default value: 21
      */
     PE: number;
+    /**
+     * The strict value determines if arguments and return values should be strictly string types.
+     * A number type as an argument will throw an error, and the toNumber method will return a string (effectively doesn't work) 
+     *
+     * Default value: false
+     */
+    strict: boolean;
 }
 
 export interface Big {


### PR DESCRIPTION
Currently, setting a Big.strict value throws a ts error.

https://mikemcl.github.io/big.js/