### PR TITLE
prosemirror-state: narrow plugin state default from any to unknown

### DIFF
--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-state 1.2
+// Type definitions for prosemirror-state 1.3
 // Project: https://github.com/ProseMirror/prosemirror-state, https://github.com/prosemirror/prosemirror
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
@@ -16,7 +16,7 @@ import { EditorProps, EditorView } from 'prosemirror-view';
  * This is the type passed to the [`Plugin`](#state.Plugin)
  * constructor. It provides a definition for a plugin.
  */
-export interface PluginSpec<T = any, S extends Schema = any> {
+export interface PluginSpec<T = unknown, S extends Schema = any> {
     /**
      * The [view props](#view.EditorProps) added by this plugin. Props
      * that are functions will be bound to have the plugin instance as
@@ -76,7 +76,7 @@ export interface PluginSpec<T = any, S extends Schema = any> {
  * They are part of the [editor state](#state.EditorState) and
  * may influence that state and the view that contains it.
  */
-export class Plugin<T = any, S extends Schema = any> {
+export class Plugin<T = unknown, S extends Schema = any> {
     /**
      * Create a plugin.
      */
@@ -100,7 +100,7 @@ export class Plugin<T = any, S extends Schema = any> {
  * describes the state it wants to keep. Functions provided here are
  * always called with the plugin instance as their `this` binding.
  */
-export interface StateField<T = any, S extends Schema = Schema> {
+export interface StateField<T = unknown, S extends Schema = Schema> {
     /**
      * Initialize the value of the field. `config` will be the object
      * passed to [`EditorState.create`](#state.EditorState^create). Note
@@ -132,7 +132,7 @@ export interface StateField<T = any, S extends Schema = Schema> {
  * editor state. Assigning a key does mean only one plugin of that
  * type can be active in a state.
  */
-export class PluginKey<T = any, S extends Schema = any> {
+export class PluginKey<T = unknown, S extends Schema = any> {
     /**
      * Create a plugin key.
      */
@@ -141,11 +141,11 @@ export class PluginKey<T = any, S extends Schema = any> {
      * Get the active plugin with this key, if any, from an editor
      * state.
      */
-    get(state: EditorState<S>): Plugin<T, S> | null | undefined;
+    get(state: EditorState<S>): Plugin<T, S> | undefined;
     /**
      * Get the plugin's state from an editor state.
      */
-    getState(state: EditorState<S>): T | null | undefined;
+    getState(state: EditorState<S>): T | undefined;
 }
 /**
  * Superclass for editor selections. Every selection type should

--- a/types/prosemirror-state/prosemirror-state-tests.ts
+++ b/types/prosemirror-state/prosemirror-state-tests.ts
@@ -69,3 +69,7 @@ const res3_2: state.Selection = state.Selection.findFrom({} as model.ResolvedPos
 
 const res4_1 = new state.PluginKey<string>();
 const res4_2: string = res4_1.getState({} as state.EditorState)!;
+
+const res5_1 = new state.PluginKey();
+// // $ExpectType unknown
+res5_1.getState({} as state.EditorState);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
Cleans up the following [common mistake](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes) 
>  var foo: string | any: When any is used in a union type, the resulting type is still any [...]
