### PR TITLE
feat(prosemirror-model): update with feat from 1.12

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-model 1.11
+// Type definitions for prosemirror-model 1.12
 // Project: https://github.com/ProseMirror/prosemirror-model
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
@@ -6,6 +6,7 @@
 //                 Malte Blanken <https://github.com/neknalb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Anthony Weston <https://github.com/AnthonyWeston>
+//                 Martin Staffa <https://github.com/Narretz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -1381,7 +1382,7 @@ export interface DOMOutputSpecArray {
     8?: DOMOutputSpec | 0;
     9?: DOMOutputSpec | 0;
 }
-export type DOMOutputSpec = string | Node | DOMOutputSpecArray;
+export type DOMOutputSpec = string | Node | DOMOutputSpecArray | {dom: Node, contentDOM?: Node};
 /**
  * A DOM serializer knows how to convert ProseMirror nodes and
  * marks of various types to DOM nodes.

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -2,7 +2,14 @@ import * as model from 'prosemirror-model';
 
 const fragment = new model.Fragment();
 
+const divNode = document.createElement('div');
+const parentDivNode = document.createElement('div');
+
 let domOutputSpec: model.DOMOutputSpec;
+
+domOutputSpec = divNode;
+
+domOutputSpec = 'text';
 
 domOutputSpec = ['div'];
 domOutputSpec = ['div', { class: 'foo' }];
@@ -13,6 +20,9 @@ domOutputSpec = ['div', 0];
 domOutputSpec = ['div', ['div', 0]];
 domOutputSpec = ['div', ['div', { class: 'foo' }]];
 domOutputSpec = ['div', ['div', { class: 'foo' }, 0]];
+
+domOutputSpec = {dom: divNode};
+domOutputSpec = {dom: divNode, contentDOM: parentDivNode};
 
 export const nodeSpec: model.NodeSpec = {
     attrs: {


### PR DESCRIPTION
New type for DOMOutputSpec has been added in 1.12.0 (2020-10-11)

ParseRule.consuming has been added in 1.13.0 (2020-12-11)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. There are no rests for simple properties, so none have been added for 'consuming'. I've added the test for the new DOMOutputSpec type and added a few more tests for DOMOutputSpec itself.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [DOMOutputSpec](https://prosemirror.net/docs/ref/#model.DOMOutputSpec)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
