### PR TITLE
[ember-data] PromiseObject<T> does not behave the same as T

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -77,7 +77,7 @@ export namespace DS {
         async?: true;
     }
 
-    type AsyncBelongsTo<T extends Model> = T & PromiseObject<T>;
+    type AsyncBelongsTo<T extends Model> = PromiseObject<T>;
     /**
      * `DS.belongsTo` is used to define One-To-One and One-To-Many
      * relationships on a [DS.Model](/api/data/classes/DS.Model.html).
@@ -85,13 +85,16 @@ export namespace DS {
     function belongsTo<K extends keyof ModelRegistry>(
         modelName: K,
         options: RelationshipOptions<ModelRegistry[K]> & Sync
-    ): Ember.ComputedProperty<ModelRegistry[K]>;
+    ): Ember.ComputedProperty<
+        ModelRegistry[K],
+        ModelRegistry[K] | PromiseObject<ModelRegistry[K]>
+    >;
     function belongsTo<K extends keyof ModelRegistry>(
         modelName: K,
         options?: RelationshipOptions<ModelRegistry[K]> & Async
     ): Ember.ComputedProperty<
         AsyncBelongsTo<ModelRegistry[K]>,
-        ModelRegistry[K]
+        ModelRegistry[K] | PromiseObject<ModelRegistry[K]>
     >;
     type AsyncHasMany<T extends Model> = PromiseManyArray<T>;
     type SyncHasMany<T extends Model> = ManyArray<T>;
@@ -861,7 +864,7 @@ export namespace DS {
          * normalized hash of data and the object represented by the reference
          * will update.
          */
-        push(payload: RSVP.Promise<any> | {}): PromiseObject<T> & T;
+        push(payload: RSVP.Promise<any> | {}): PromiseObject<T>;
         /**
          * If the entity referred to by the reference is already loaded, it is
          * present as `reference.value`. Otherwise the value returned by this function
@@ -872,12 +875,12 @@ export namespace DS {
          * Triggers a fetch for the backing entity based on its `remoteType`
          * (see `remoteType` definitions per reference type).
          */
-        load(): PromiseObject<T> & T;
+        load(): PromiseObject<T>;
         /**
          * Reloads the record if it is already loaded. If the record is not
          * loaded it will load the record via `store.findRecord`
          */
-        reload(): PromiseObject<T> & T;
+        reload(): PromiseObject<T>;
     }
     /**
      * A `ManyArray` is a `MutableArray` that represents the contents of a has-many
@@ -1098,7 +1101,7 @@ export namespace DS {
             modelName: K,
             id: string | number,
             options?: {}
-        ): PromiseObject<ModelRegistry[K]> & ModelRegistry[K];
+        ): PromiseObject<ModelRegistry[K]>;
         /**
          * Get the reference for the specified record.
          */

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -16,8 +16,9 @@ declare module 'ember-data/types/registries/model' {
 }
 
 const folder = Folder.create();
-assertType<Folder>(folder.get('parent'));
-assertType<string>(folder.get('parent').get('name'));
+assertType<DS.AsyncBelongsTo<Folder>>(folder.get('parent'));
+assertType<string | undefined>(folder.get('parent').get('name'));
+folder.get('parent').set('name', 'New');
 folder.get('parent').then(parent => {
     assertType<Folder>(parent);
     assertType<string>(parent.get('name'));

--- a/types/ember-data/test/store.ts
+++ b/types/ember-data/test/store.ts
@@ -110,7 +110,7 @@ const SomeComponent = Ember.Object.extend({
     store: Ember.inject.service('store'),
 
     lookUpUsers() {
-        assertType<User>(this.get('store').findRecord('user', 123));
+        assertType<DS.PromiseObject<User>>(this.get('store').findRecord('user', 123));
         assertType<DS.PromiseArray<User>>(this.get('store').findAll('user'));
     },
 });


### PR DESCRIPTION
For example a PromiseObject requires the use of `get`. It also may
return undefined for a property when the underlying promise is not
yet resolved.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Unfortunately, it's difficult for me to find a solid documentation source for this behavior. However, I can seek to document it with some code examples if necessary.
