### PR TITLE
[jslib-html5-camera-photo] Make mediaDevices property nullable

### DIFF
--- a/types/jslib-html5-camera-photo/index.d.ts
+++ b/types/jslib-html5-camera-photo/index.d.ts
@@ -59,7 +59,7 @@ export interface CaptureConfigOption {
 declare class CameraPhoto {
     videoElement: HTMLVideoElement;
     windowURL: URL;
-    mediaDevices: MediaDevices;
+    mediaDevices: MediaDevices | null;
     settings: MediaTrackSettings | null;
     numberOfMaxResolutionTry: number;
     stream: MediaStream | null;

--- a/types/jslib-html5-camera-photo/index.d.ts
+++ b/types/jslib-html5-camera-photo/index.d.ts
@@ -16,9 +16,9 @@ interface ImageTypes {
 type FacingMode = 'user' | 'environment';
 type ImageType = 'png' | 'jpg';
 
-interface Resolution {
-    height?: number;
-    width?: number;
+interface PartialMediaTrackConstraints {
+    height?: MediaTrackConstraints['height'];
+    width?: MediaTrackConstraints['width'];
 }
 
 export const FACING_MODES: FacingModes;
@@ -67,7 +67,7 @@ declare class CameraPhoto {
     constructor(videoElement: HTMLVideoElement);
     getCameraSettings(): MediaTrackSettings | null;
     getInputVideoDeviceInfos(): MediaDeviceInfo[];
-    startCamera(idealFacingMode?: FacingMode, idealResolution?: Resolution): Promise<MediaStream>;
+    startCamera(idealFacingMode?: FacingMode, idealResolution?: PartialMediaTrackConstraints): Promise<MediaStream>;
     startCameraMaxResolution(idealFacingMode?: FacingMode | {}): Promise<MediaStream>;
     getDataUri(userConfig: CaptureConfigOption): string;
     stopCamera(): Promise<void>;

--- a/types/jslib-html5-camera-photo/index.d.ts
+++ b/types/jslib-html5-camera-photo/index.d.ts
@@ -16,7 +16,7 @@ interface ImageTypes {
 type FacingMode = 'user' | 'environment';
 type ImageType = 'png' | 'jpg';
 
-interface PartialMediaTrackConstraints {
+interface Resolution {
     height?: MediaTrackConstraints['height'];
     width?: MediaTrackConstraints['width'];
 }
@@ -67,7 +67,7 @@ declare class CameraPhoto {
     constructor(videoElement: HTMLVideoElement);
     getCameraSettings(): MediaTrackSettings | null;
     getInputVideoDeviceInfos(): MediaDeviceInfo[];
-    startCamera(idealFacingMode?: FacingMode, idealResolution?: PartialMediaTrackConstraints): Promise<MediaStream>;
+    startCamera(idealFacingMode?: FacingMode, idealResolution?: Resolution): Promise<MediaStream>;
     startCameraMaxResolution(idealFacingMode?: FacingMode | {}): Promise<MediaStream>;
     getDataUri(userConfig: CaptureConfigOption): string;
     stopCamera(): Promise<void>;

--- a/types/jslib-html5-camera-photo/jslib-html5-camera-photo-tests.ts
+++ b/types/jslib-html5-camera-photo/jslib-html5-camera-photo-tests.ts
@@ -45,6 +45,16 @@ cameraPhoto
         /* ... */
     });
 
+// example of resultion with non-numeric width and height
+cameraPhoto
+    .startCamera(FACING_MODES.ENVIRONMENT, { width: { ideal: 3840 }, height: { ideal: 2160 } })
+    .then(stream => {
+        /* ... */
+    })
+    .catch(error => {
+        /* ... */
+    });
+
 // It will try the best to get the maximum resolution with the specified facingMode
 cameraPhoto
     .startCameraMaxResolution(FACING_MODES.ENVIRONMENT)

--- a/types/jslib-html5-camera-photo/jslib-html5-camera-photo-tests.ts
+++ b/types/jslib-html5-camera-photo/jslib-html5-camera-photo-tests.ts
@@ -98,3 +98,7 @@ cameraPhoto
     .catch(error => {
         /* ... */
     });
+
+if (cameraPhoto.mediaDevices) {
+    cameraPhoto.mediaDevices.getUserMedia();
+}


### PR DESCRIPTION
* `mediaDevices` is null when the browser doesn't support getUserMedia, or in non-secure contexts.
* Updated the `idealResolution` type. I realized that since the `width` and `height` are passed directly to `getUserMedia`, custom constraints can be used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/MABelanger/jslib-html5-camera-photo/blob/4a776199313e0a31bbbdcece3c49a96c979052e8/src/lib/MediaServices/index.js#L44>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
