### PR TITLE
Updating mui-datatables MUIDataTableProps interface to account for optional innerRef prop

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -855,6 +855,7 @@ export interface MUIDataTableProps {
     data: Array<object | number[] | string[]>;
     options?: MUIDataTableOptions;
     title: string | React.ReactNode;
+    innerRef?: React.RefObject<React.Component<MUIDataTableProps, MUIDataTableState> | null | undefined>;
 }
 
 export interface MUIDataTableExpandButton {

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,4 +1,4 @@
-import MUIDataTable, { ExpandButton, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps } from 'mui-datatables';
+import MUIDataTable, { ExpandButton, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState } from 'mui-datatables';
 import * as React from 'react';
 
 interface Props extends Omit<MUIDataTableProps, 'columns'> {
@@ -7,6 +7,7 @@ interface Props extends Omit<MUIDataTableProps, 'columns'> {
 
 const MuiCustomTable: React.FC<Props> = props => {
     const data: string[][] = props.data.map((asset: any) => Object.values(asset));
+    const tableRef = React.useRef<React.Component<MUIDataTableProps, MUIDataTableState> | null | undefined>();
     const columns: MUIDataTableColumn[] = [
         {
             name: 'id',
@@ -172,7 +173,7 @@ const MuiCustomTable: React.FC<Props> = props => {
         },
     };
 
-    return <MUIDataTable title={props.title} data={data} columns={columns} options={TableOptions} />;
+    return <MUIDataTable title={props.title} data={data} columns={columns} options={TableOptions} innerRef={tableRef} />;
 };
 
 const TableFruits = [


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/gregnb/mui-datatables/issues/756>>
- [x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As indicated in the issue linked above, this is to allow for the passing of an optional innerRef prop to the MUIDataTable component, commonly for the purpose of updating state related to pagination inside of the table.  The components unfortunately do not automatically respect page changes originating from outside of the table, and this can be cause to access the `changePage` method using a ref.  In particular [this](https://github.com/gregnb/mui-datatables/issues/756#issuecomment-510191071) comment provides an example of this.

Thanks for your time, have a great day.