### PR TITLE
[@types/rosie]: Allow `option`s of type `any` for dynamic attribute definitions in rosie factories

### DIFF
--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -100,6 +100,7 @@ declare namespace rosie {
     attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T>(name: K, dependencies: [D1, D2], generatorFunction: (value1: T[D1], value2: T[D2]) => T[K]): IFactory<T>;
     attr<K extends keyof T, D extends keyof T>(name: K, dependencies: D[], generatorFunction: (value: T[D]) => T[K]): IFactory<T>;
     attr<K extends keyof T, D extends keyof T>(name: K, dependencies: D[], generatorFunction: any): IFactory<T>;
+    attr<K extends keyof T>(name: K, dependencies: string[], generatorFunction: (...dependencies: any[]) => T[K]): IFactory<T>;
 
       /**
       * Convenience function for defining a set of attributes on this object as

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -78,6 +78,20 @@ const person = Factory.build<Person>('Person');
 let aString = '';
 aString = person.firstName;
 
+// It supports options not defined in the type definition
+const personWithNicknameFactory = new Factory<Person>()
+  .attr('firstName', 'Frances')
+  .attr('lastName', 'Parker')
+  .option('nickname', null)
+  .attr('fullName', ['firstName', 'lastName', 'nickname'], (firstName, lastName, nickname) => {
+    if (nickname) {
+      return `${firstName} "${nickname}" ${lastName}`;
+    }
+    return `${firstName} ${lastName}`;
+  });
+// $ExpectType Person
+const personWithNickname = personWithNicknameFactory.build({}, { nickname: 'Franny' });
+
 // Unregistered factories
 const unregisteredPersonFactory = new Factory<Person>();
 


### PR DESCRIPTION
This PR adds an alternate type for rosie's `attr` to allow `option` arguments that serve purely as a tool to dynamically generate other attributes on the factory, and are not part of the resultant object's attributes. See https://github.com/rosiejs/rosie#programmatic-generation-of-attributes as an example of this use case:
```
const moment = require('moment');

Factory.define('matches')
  .attr('seasonStart', '2016-01-01')
  .option('numMatches', 2)
  .attr('matches', ['numMatches', 'seasonStart'], (numMatches, seasonStart) => {
    const matches = [];
    for (const i = 1; i <= numMatches; i++) {
      matches.push({
        matchDate: moment(seasonStart).add(i, 'week').format('YYYY-MM-DD'),
        homeScore: Math.floor(Math.random() * 5),
        awayScore: Math.floor(Math.random() * 5),
      });
    }
    return matches;
  });

Factory.build('matches', { seasonStart: '2016-03-12' }, { numMatches: 3 });
// Built object (note scores are random):
//{
//  seasonStart: '2016-03-12',
//  matches: [
//    { matchDate: '2016-03-19', homeScore: 3, awayScore: 1 },
//    { matchDate: '2016-03-26', homeScore: 0, awayScore: 4 },
//    { matchDate: '2016-04-02', homeScore: 1, awayScore: 0 }
//  ]
//}
```
(option 'numMatches' is just a dependency for the 'matches' attribute)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [example of a factory whose `option` is not part of the returned object's type](https://github.com/rosiejs/rosie#programmatic-generation-of-attributes)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
> n/a

