### PR TITLE
[node] Http2ServerResponse should extends stream.Writable

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -652,7 +652,7 @@ declare module 'http2' {
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    export class Http2ServerResponse extends stream.Stream {
+    export class Http2ServerResponse extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
 
         readonly connection: net.Socket | tls.TLSSocket;

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -324,6 +324,7 @@ import { URL } from 'node:url';
         response.end('', 'utf8', () => {});
         response.end(Buffer.from([]));
         response.end(Buffer.from([]), () => {});
+        const writable: boolean = response.writable;
 
         request.on('aborted', (hadError: boolean, code: number) => {});
         request.on('close', () => {});

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { createGzip, constants } from 'node:zlib';
 import assert = require('node:assert');
+import { Http2ServerResponse } from 'node:http2';
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
@@ -171,6 +172,9 @@ function streamPipelineFinished() {
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
+
+    const http2ServerResponse: Http2ServerResponse = {} as any;
+    pipeline(process.stdin, http2ServerResponse, (err?: Error | null) => {});
 }
 
 async function asyncStreamPipelineFinished() {

--- a/types/node/v11/http2.d.ts
+++ b/types/node/v11/http2.d.ts
@@ -649,7 +649,7 @@ declare module "http2" {
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    export class Http2ServerResponse extends stream.Stream {
+    export class Http2ServerResponse extends stream.Writable {
         private constructor();
 
         addTrailers(trailers: OutgoingHttpHeaders): void;

--- a/types/node/v11/test/http2.ts
+++ b/types/node/v11/test/http2.ts
@@ -322,6 +322,7 @@ import { URL } from 'url';
         response.end('', 'utf8', () => {});
         response.end(Buffer.from([]));
         response.end(Buffer.from([]), () => {});
+        const writable: boolean = response.writable;
 
         request.on('aborted', (hadError: boolean, code: number) => {});
         request.on('close', () => {});

--- a/types/node/v11/test/stream.ts
+++ b/types/node/v11/test/stream.ts
@@ -3,6 +3,7 @@ import { promisify } from "util";
 import { createReadStream, createWriteStream } from "fs";
 import { createGzip, constants } from "zlib";
 import { ok as assert } from 'assert';
+import { Http2ServerResponse } from "http2";
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
@@ -166,6 +167,9 @@ function streamPipelineFinished() {
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
+
+    const http2ServerResponse: Http2ServerResponse = {} as any;
+    pipeline(process.stdin, http2ServerResponse, (err?: Error | null) => {});
 }
 
 async function asyncStreamPipelineFinished() {

--- a/types/node/v12/http2.d.ts
+++ b/types/node/v12/http2.d.ts
@@ -646,7 +646,7 @@ declare module 'http2' {
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    export class Http2ServerResponse extends stream.Stream {
+    export class Http2ServerResponse extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
 
         readonly connection: net.Socket | tls.TLSSocket;

--- a/types/node/v12/test/http2.ts
+++ b/types/node/v12/test/http2.ts
@@ -323,6 +323,7 @@ import { URL } from 'node:url';
         response.end('', 'utf8', () => {});
         response.end(Buffer.from([]));
         response.end(Buffer.from([]), () => {});
+        const writable: boolean = response.writable;
 
         request.on('aborted', (hadError: boolean, code: number) => {});
         request.on('close', () => {});

--- a/types/node/v12/test/stream.ts
+++ b/types/node/v12/test/stream.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { createGzip, constants } from 'node:zlib';
 import assert = require('node:assert');
+import { Http2ServerResponse } from 'node:http2';
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
@@ -170,6 +171,9 @@ function streamPipelineFinished() {
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
+
+    const http2ServerResponse: Http2ServerResponse = {} as any;
+    pipeline(process.stdin, http2ServerResponse, (err?: Error | null) => {});
 }
 
 async function asyncStreamPipelineFinished() {

--- a/types/node/v13/http2.d.ts
+++ b/types/node/v13/http2.d.ts
@@ -638,7 +638,7 @@ declare module "http2" {
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    export class Http2ServerResponse extends stream.Stream {
+    export class Http2ServerResponse extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
 
         readonly connection: net.Socket | tls.TLSSocket;

--- a/types/node/v13/test/http2.ts
+++ b/types/node/v13/test/http2.ts
@@ -323,6 +323,7 @@ import { URL } from 'url';
         response.end('', 'utf8', () => {});
         response.end(Buffer.from([]));
         response.end(Buffer.from([]), () => {});
+        const writable: boolean = response.writable;
 
         request.on('aborted', (hadError: boolean, code: number) => {});
         request.on('close', () => {});

--- a/types/node/v13/test/stream.ts
+++ b/types/node/v13/test/stream.ts
@@ -3,6 +3,7 @@ import { promisify } from "util";
 import { createReadStream, createWriteStream } from "fs";
 import { createGzip, constants } from "zlib";
 import { ok as assert } from 'assert';
+import { Http2ServerResponse } from "http2";
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
@@ -170,6 +171,9 @@ function streamPipelineFinished() {
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
+
+    const http2ServerResponse: Http2ServerResponse = {} as any;
+    pipeline(process.stdin, http2ServerResponse, (err?: Error | null) => {});
 }
 
 async function asyncStreamPipelineFinished() {


### PR DESCRIPTION
`http2.Http2ServerResponse` should be similar to `http.ServerResponse` and should extend `Writable` too.

It prevent to use it with `stream.pipeline` function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - <https://nodejs.org/api/http2.html#http2_class_http2_http2serverresponse>
  - <https://nodejs.org/api/http.html#http_class_http_serverresponse>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

