### PR TITLE
`react-autosuggest`: `InputProps['onChange']`: restrict event type

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -80,9 +80,9 @@ declare namespace Autosuggest {
     }
 
     interface InputProps<TSuggestion>
-        extends Omit<React.InputHTMLAttributes<any>, 'onChange' | 'onBlur'> {
-        onChange(event: React.FormEvent<any>, params: ChangeEvent): void;
-        onBlur?(event: React.FocusEvent<any>, params?: BlurEvent<TSuggestion>): void;
+        extends Omit<React.InputHTMLAttributes<HTMLElement>, 'onChange' | 'onBlur'> {
+        onChange(event: React.FormEvent<HTMLElement>, params: ChangeEvent): void;
+        onBlur?(event: React.FocusEvent<HTMLElement>, params?: BlurEvent<TSuggestion>): void;
         value: string;
         ref?: React.Ref<HTMLInputElement>;
     }

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -605,3 +605,12 @@ function testMultiSections() {
         renderSuggestion={suggestion => suggestion}
     />;
 }
+
+const testInputOnChange: Autosuggest.InputProps<{ foo: string }>['onChange'] = event => {
+    const element = event.target;
+    // `value` only exists on the input element, but sometimes this function is
+    // called with a `target` pointing to a non-input element. For example, when
+    // the user clicks on a suggestion. Reduced test case:
+    // https://stackblitz.com/edit/oliverjash-react-autosuggest-1lhfk3?file=index.tsx
+    element.value; // $ExpectError
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: see comment in tests
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.