### PR TITLE
`react-autosuggest`: `InputProps`: strict function types

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -81,8 +81,8 @@ declare namespace Autosuggest {
 
     interface InputProps<TSuggestion>
         extends Omit<React.InputHTMLAttributes<HTMLElement>, 'onChange' | 'onBlur'> {
-        onChange(event: React.FormEvent<HTMLElement>, params: ChangeEvent): void;
-        onBlur?(event: React.FocusEvent<HTMLElement>, params?: BlurEvent<TSuggestion>): void;
+        onChange: (event: React.FormEvent<HTMLElement>, params: ChangeEvent) => void;
+        onBlur?: (event: React.FocusEvent<HTMLElement>, params?: BlurEvent<TSuggestion>) => void;
         value: string;
         ref?: React.Ref<HTMLInputElement>;
     }

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -614,3 +614,27 @@ const testInputOnChange: Autosuggest.InputProps<{ foo: string }>['onChange'] = e
     // https://stackblitz.com/edit/oliverjash-react-autosuggest-1lhfk3?file=index.tsx
     element.value; // $ExpectError
 };
+
+{
+    const CustomInput: React.FC<Pick<Autosuggest.InputProps<unknown>, "onChange">> = props => null;
+
+    const invalidOnChange = (event: React.FormEvent<HTMLDivElement>) => { };
+    const onChange = (event: React.FormEvent<HTMLElement>) => { };
+    <CustomInput
+        // $ExpectError
+        onChange={invalidOnChange}
+    />;
+    <CustomInput onChange={onChange} />;
+}
+
+{
+    const CustomInput: React.FC<Pick<Autosuggest.InputProps<unknown>, "onBlur">> = props => null;
+
+    const invalidOnBlur = (event: React.FocusEvent<HTMLDivElement>) => { };
+    const onBlur = (event: React.FocusEvent<HTMLElement>) => { };
+    <CustomInput
+        // $ExpectError
+        onBlur={invalidOnBlur}
+    />;
+    <CustomInput onBlur={onBlur} />;
+}


### PR DESCRIPTION
Depends on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51672

Previously these functions were declared as methods. Method-declared functions are bivariant in their parameters, which means it was possible to pass in the wrong function type. With this change, that is no longer possible. See the tests I added for an example.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
