### PR TITLE
[office-js, office-js-preview] Remove type definitions for event handler functions for downstream ref docs

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -521,10 +521,6 @@ declare namespace Office {
         visibilityMode: Office.VisibilityMode;
     }
     /**
-     * Function type to turn off the event.
-     */
-    type RemoveEventListener = () => Promise<void>;
-    /**
      * Represents add-in level functionality for operating or configuring various aspects of the add-in.
      */
     interface Addin {
@@ -550,11 +546,11 @@ declare namespace Office {
         /**
          * Adds a listener for the `onVisibilityModeChanged` event.
          * @param listener - The listener function that is called when the event is emitted. This function takes in a message for the receiving component.
-         * @returns A promise that resolves to a function when the listener is added. The `RemoveEventListener` type is defined with `type RemoveEventListener = () => Promise<void>`. Calling it removes the listener.
+         * @returns A promise that resolves to a function when the listener is added. Calling it removes the listener.
          */
-        onVisibilityModeChanged(
+         onVisibilityModeChanged(
             listener: (message: VisibilityModeChangedMessage) => void,
-        ): Promise<RemoveEventListener>;
+        ): Promise<() => Promise<void>>;
     }
     /**
      * An interface that contains all the functionality provided to manage the state of the Office ribbon.
@@ -1498,18 +1494,14 @@ declare namespace Office {
          */
          column?: number
     }
-	/**
-	 * Used to strongly type the `handler` property of RemoveHandlerOptions.
-	 */
-	 type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any;
     /**
      * Provides options to determine which event handler or handlers are removed.
      */
     interface RemoveHandlerOptions {
         /**
-         * The handler to be removed. If a particular handler is not specified, then all handlers for the specified event type are removed. The `BindingEventHandler` type is defined with `type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any`.
+         * The handler to be removed. If a particular handler is not specified, then all handlers for the specified event type are removed.
          */
-        handler?: BindingEventHandler
+        handler?: (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any
         /**
          * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
          */


### PR DESCRIPTION
Before: https://docs.microsoft.com/en-us/javascript/api/office/office.addin?view=common-js
After: https://review.docs.microsoft.com/en-us/javascript/api/office/office.addin?view=common-js&branch=AlexJ-FixWarnings

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See above
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
