### PR TITLE
[fs-extra] Make compatible with @types/node@12.x

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -299,3 +299,9 @@ fs.realpath('src', (err, resolved) => {
 fs.realpath.native('src');
 // $ExpectType Promise<Buffer>
 fs.realpath.native('src', 'buffer');
+// $ExpectType Promise<string>
+fs.realpath.native('src', { encoding: 'utf-8' });
+// $ExpectType Promise<Buffer>
+fs.realpath.native('src', { encoding: 'buffer' });
+// $ExpectType Promise<string>
+fs.realpath.native('src', { encoding: null });

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -229,9 +229,9 @@ export function realpath(path: PathLike, cache?: { [path: string]: string }): Pr
 /* tslint:disable:unified-signatures */
 export namespace realpath {
     const native: {
-        (path: PathLike, options: fs.BaseEncodingOptions | BufferEncoding | undefined | null): Promise<string>;
-        (path: PathLike, options: fs.BufferEncodingOption): Promise<Buffer>;
-        (path: PathLike, options: fs.BaseEncodingOptions | string | undefined | null): Promise<string | Buffer>;
+        (path: PathLike, options: { encoding: BufferEncoding | null } | BufferEncoding | undefined | null): Promise<string>;
+        (path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
+        (path: PathLike, options: { encoding: BufferEncoding | null } | string | undefined | null): Promise<string | Buffer>;
         (path: PathLike): Promise<string>;
     } & typeof fs.realpath.native;
 }


### PR DESCRIPTION
Fixes #51521

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #51521
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A
