### PR TITLE
[@types/draft-js] Add missing 'preserveSelectionOnBlur' prop to 'DraftEditorProps'

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -192,6 +192,7 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
                         placeholder="Tell a story..."
                         ref="editor"
                         spellCheck={true}
+                        preserveSelectionOnBlur={false}
                     />
                 </div>
             </div>

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -13,7 +13,6 @@
 //                 Kevin Hawkinson <https://github.com/khawkinson>
 //                 Munif Tanjim <https://github.com/MunifTanjim>
 //                 Ben Salili-James <https://github.com/benhjames>
-//                 Peter Dekkers <https://github.com/PeterDekkers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Draft.js v0.10.5
+// Type definitions for Draft.js v0.11.1
 // Project: https://facebook.github.io/draft-js/
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
 //                 Eelco Lempsink <https://github.com/eelco>

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -13,6 +13,7 @@
 //                 Kevin Hawkinson <https://github.com/khawkinson>
 //                 Munif Tanjim <https://github.com/MunifTanjim>
 //                 Ben Salili-James <https://github.com/benhjames>
+//                 Peter Dekkers <https://github.com/PeterDekkers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -13,6 +13,7 @@
 //                 Kevin Hawkinson <https://github.com/khawkinson>
 //                 Munif Tanjim <https://github.com/MunifTanjim>
 //                 Ben Salili-James <https://github.com/benhjames>
+//                 Peter Dekkers <https://github.com/PeterDekkers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -135,6 +136,13 @@ declare namespace Draft {
                  * autocorrect is enabled as well.
                  */
                 spellCheck?: boolean;
+
+                /**
+                 * When the Editor loses focus (blurs) text selections are cleared
+                 * by default to mimic <textarea> behaviour, however in some situations
+                 * users may wish to preserve native behaviour.
+                 */
+                preserveSelectionOnBlur?: boolean;
 
                 /**
                  * Set whether to remove all style information from pasted content. If your


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/draft-js/commit/db792efd5121ceb312030c7b1d1a303bc8172ef4
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.