### PR TITLE
wojtekmaj/react-datetimerange-picker - Edit `value` and `onChange` typing according to library behavior

### DIFF
--- a/types/wojtekmaj__react-datetimerange-picker/index.d.ts
+++ b/types/wojtekmaj__react-datetimerange-picker/index.d.ts
@@ -7,9 +7,8 @@
 import { CalendarProps } from 'react-calendar';
 
 export default function DateTimeRangePicker(props: DateTimeRangePickerProps): JSX.Element;
-export type DateTimeRangePickerValue = string | Date | Date[];
 export type DateTimeRangePickerCalendarProps = Omit<CalendarProps, 'maxDetail' | 'onChange' | 'value'>;
-export interface DateTimeRangePickerProps<T = DateTimeRangePickerValue> extends DateTimeRangePickerCalendarProps {
+export interface DateTimeRangePickerProps extends DateTimeRangePickerCalendarProps {
     amPmAriaLabel?: string;
     autoFocus?: boolean;
     calendarAriaLabel?: string;
@@ -42,7 +41,7 @@ export interface DateTimeRangePickerProps<T = DateTimeRangePickerValue> extends 
     nativeInputAriaLabel?: string;
     onCalendarClose?: () => void;
     onCalendarOpen?: () => void;
-    onChange?: (val: T) => void;
+    onChange?: (val: [Date?, Date?] | null) => void;
     onFocus?: () => void;
     onClockClose?: () => void;
     onClockOpen?: () => void;
@@ -50,7 +49,7 @@ export interface DateTimeRangePickerProps<T = DateTimeRangePickerValue> extends 
     required?: boolean;
     secondAriaLabel?: string;
     secondPlaceholder?: string;
-    value: T;
+    value: Date | undefined | [Date?, Date?] | null;
     showLeadingZeros?: boolean;
     yearAriaLabel?: string;
     yearPlaceholder?: string;

--- a/types/wojtekmaj__react-datetimerange-picker/wojtekmaj__react-datetimerange-picker-tests.tsx
+++ b/types/wojtekmaj__react-datetimerange-picker/wojtekmaj__react-datetimerange-picker-tests.tsx
@@ -10,3 +10,40 @@ function MyApp() {
         </div>
     );
 }
+
+function IncorrectType() {
+    const [value, onChange] = React.useState([0, 0]);
+
+    return <DateTimeRangePicker onChange={onChange} value={value} />; // $ExpectError
+}
+
+function ChangeHandlerWrongType() {
+    const [value, _onChange] = React.useState<[Date?, Date?]>([new Date(), new Date()]);
+
+    const handleChange = React.useCallback((_: Date) => {}, []);
+
+    return (
+        <DateTimeRangePicker
+            onChange={handleChange} // $ExpectError
+            value={value}
+        />
+    );
+}
+
+function MayReturnNull() {
+    return (
+        <DateTimeRangePicker
+            onChange={React.useCallback((_: [Date?, Date?]) => {}, [])} // $ExpectError
+            value={[new Date(), new Date()]}
+        />
+    );
+}
+
+function MayReturnUndefined() {
+    return (
+        <DateTimeRangePicker
+            onChange={React.useCallback((_: [Date, Date?] | null) => {}, [])} // $ExpectError
+            value={[new Date(), new Date()]}
+        />
+    );
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/wojtekmaj/react-daterange-picker#props]()
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.


I've been playing with the library `value` and `onChange` props and from my observation:
 - it can handle `string` however it crashes if you try to edit the value
   - thus only `Date | undefined | null | [Date?, Date?]` is safe to use
 - it provides only typle `[Date?, Date?]` or `null` in `onChange` (even if `Date` is passed as value prop)
   - `null` when you click "X" to delete datetime
   - `undefined` instead of `Date` when you edit only one of the datetimes (range consists of startDate and endDatetime)

The mentioned documentation isn't much specific about data types though.

I would appreciate other opinions. Maybe I am missing something however I believe, that current state of typing isn't safe enough.