### PR TITLE
Revert "🤖 Merge PR #51252 fix(styled-components): limited use of 'Omi…

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -11,7 +11,6 @@
 //                 Yuki Ito <https://github.com/Lazyuki>
 //                 Maciej Goszczycki <https://github.com/mgoszcz2>
 //                 Danilo Fuchs <https://github.com/danilofuchs>
-//                 Junya Kani <https://github.com/ka2jun8>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // forward declarations
@@ -58,9 +57,6 @@ type Defaultize<P, D> = P extends any
 
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
-// return true if T is never
-type IsExtendsNever<T> = T extends never ? true : false;
-
 export type StyledComponentProps<
     // The Component from whose props are derived
     C extends string | React.ComponentType<any>,
@@ -74,33 +70,25 @@ export type StyledComponentProps<
     // Distribute O if O is a union type
     O extends object
         ? WithOptionalTheme<
-              false extends IsExtendsNever<A>
-                  ? Omit<
-                        ReactDefaultizedProps<
-                            C,
-                            React.ComponentPropsWithRef<
-                                C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                            >
-                        > &
-                            O,
-                        A
-                    >
-                  : ReactDefaultizedProps<
-                        C,
-                        React.ComponentPropsWithRef<
-                            C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                        >
-                    > &
-                        O &
-                        Partial<
-                            Pick<
-                                React.ComponentPropsWithRef<
-                                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                                > &
-                                    O,
-                                A
-                            >
-                        >,
+              Omit<
+                  ReactDefaultizedProps<
+                      C,
+                      React.ComponentPropsWithRef<
+                          C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                      >
+                  > &
+                      O,
+                  A
+              > &
+                  Partial<
+                      Pick<
+                          React.ComponentPropsWithRef<
+                              C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                          > &
+                              O,
+                          A
+                      >
+                  >,
               T
           > &
               WithChildrenIfReactComponentClass<C>
@@ -317,9 +305,9 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmp
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = (P extends { theme?: T }
-    ? Omit<P, 'theme'>
-    : { [K in keyof P]: P[K] }) & { theme?: T };
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+    theme?: T;
+};
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
 export interface ThemedStyledComponentsModule<T extends object, U extends object = T> {

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -331,6 +331,9 @@ const AttrsWithOnlyNewProps = styled.h2.attrs({ as: 'h1' })`
 const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: 'off' })``;
 <AttrsInputExtra />;
 
+const But = styled('button').attrs((a) => ({ type: a.type ?? 'button' }))``;
+const SomeBut: React.FC = () => <But type="submit">I am a button</But>;
+
 /**
  * withConfig
  */

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -16,8 +16,9 @@ import styled, {
     StyledComponent,
     ThemedStyledComponentsModule,
     FlattenSimpleInterpolation,
-    SimpleInterpolation,
     FlattenInterpolation,
+    GlobalStyleComponent,
+    DefaultTheme,
 } from 'styled-components';
 import {} from 'styled-components/cssprop';
 
@@ -1185,4 +1186,12 @@ function unionTest2() {
     <C bar="foobar" />;
     <C />; // $ExpectError
     <C foo={123} bar="foobar" />; // $ExpectError
+}
+
+function createCustomGlobalStyle(style: string): GlobalStyleComponent<null, DefaultTheme> {
+    return createGlobalStyle`
+        ${style}
+        * {
+        box-sizing: border-box;
+    }`;
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1190,11 +1190,3 @@ function unionTest2() {
     <C />; // $ExpectError
     <C foo={123} bar="foobar" />; // $ExpectError
 }
-
-function createCustomGlobalStyle(style: string): GlobalStyleComponent<null, DefaultTheme> {
-    return createGlobalStyle`
-        ${style}
-        * {
-        box-sizing: border-box;
-    }`;
-}

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1162,7 +1162,8 @@ function unionTest() {
         font-size: ${props => (props.kind === 'book' ? 16 : 14)};
     `;
 
-    <StyledReadable kind="book" author="Hejlsberg" />;
+    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
+    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -331,8 +331,8 @@ const AttrsWithOnlyNewProps = styled.h2.attrs({ as: 'h1' })`
 const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: 'off' })``;
 <AttrsInputExtra />;
 
-const But = styled('button').attrs((a) => ({ type: a.type ?? 'button' }))``;
-const SomeBut: React.FC = () => <But type="submit">I am a button</But>;
+const Button = styled('button').attrs((a) => ({ type: a.type ?? 'button' }))``;
+const SomeButton: React.FC = () => <Button type="submit">I am a button</Button>;
 
 /**
  * withConfig

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -17,8 +17,6 @@ import styled, {
     ThemedStyledComponentsModule,
     FlattenSimpleInterpolation,
     FlattenInterpolation,
-    GlobalStyleComponent,
-    DefaultTheme,
 } from 'styled-components';
 import {} from 'styled-components/cssprop';
 


### PR DESCRIPTION
I am sorry that this change (@types/styled-components@5.1.8) makes it broken.
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51252

It was reported the problem locally.
I added the test for reproduction of problem.
In addition, it might make some bugs of using "as" pattern.

I think I should revert the commit because I do not know how to fix it.

If you have any other idea, please tell me.
@henrikra @eps1lon @Daavidaviid

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

