### PR TITLE
[leaflet.pattern] Update map interface and extend PathOptions interface

### DIFF
--- a/types/leaflet.pattern/index.d.ts
+++ b/types/leaflet.pattern/index.d.ts
@@ -8,11 +8,11 @@ import * as L from 'leaflet';
 
 declare module 'leaflet' {
     interface Map {
-        addPattern(pattern: Pattern | StripePattern | PatternShape | PatternCircle | PatternPath | PatternRect): Map;
+        addPattern(pattern: Pattern | StripePattern): Map;
 
-        removePattern(pattern: Pattern | StripePattern | PatternShape | PatternCircle | PatternPath | PatternRect): Map;
+        removePattern(pattern: Pattern | StripePattern): Map;
 
-        hasPattern(pattern: Pattern | StripePattern | PatternShape | PatternCircle | PatternPath | PatternRect): boolean;
+        hasPattern(pattern: Pattern | StripePattern): boolean;
     }
 
     interface PatternOptions {
@@ -105,7 +105,7 @@ declare module 'leaflet' {
 
         setStyle(style: PatternShapeOptions): this;
 
-        setShape(shape: this): void;
+        setShape(shape: PatternCircle | PatternPath | PatternRect): void;
     }
 
     class StripePattern extends Pattern {

--- a/types/leaflet.pattern/index.d.ts
+++ b/types/leaflet.pattern/index.d.ts
@@ -15,6 +15,10 @@ declare module 'leaflet' {
         hasPattern(pattern: Pattern | StripePattern): boolean;
     }
 
+    interface PathOptions {
+        fillPattern?: Pattern | StripePattern;
+    }
+
     interface PatternOptions {
         x?: number;
         y?: number;

--- a/types/leaflet.pattern/leaflet.pattern-tests.ts
+++ b/types/leaflet.pattern/leaflet.pattern-tests.ts
@@ -81,7 +81,9 @@ patternShape.addTo(new L.Pattern());
 patternShape.addTo(new L.StripePattern());
 patternShape.redraw();
 patternShape.setStyle(patternShapeOptions);
-patternShape.setShape(new L.PatternShape());
+patternShape.setShape(new L.PatternCircle());
+patternShape.setShape(new L.PatternPath());
+patternShape.setShape(new L.PatternRect());
 
 const stripePattern = new L.StripePattern(stripePatternOptions);
 stripePattern.initialize(stripePatternOptions);
@@ -106,6 +108,8 @@ patternCircle.addTo(new L.StripePattern());
 patternCircle.redraw();
 patternCircle.setStyle(patternCircleOptions);
 patternCircle.setShape(new L.PatternCircle());
+patternCircle.setShape(new L.PatternPath());
+patternCircle.setShape(new L.PatternRect());
 
 const patternPath = new L.PatternPath(patternPathOptions);
 patternPath.initialize(patternPathOptions);
@@ -115,7 +119,9 @@ patternPath.addTo(new L.Pattern());
 patternPath.addTo(new L.StripePattern());
 patternPath.redraw();
 patternPath.setStyle(patternPathOptions);
+patternPath.setShape(new L.PatternCircle());
 patternPath.setShape(new L.PatternPath());
+patternPath.setShape(new L.PatternRect());
 
 const patternRect = new L.PatternRect(patternRectOptions);
 patternRect.initialize(patternRectOptions);
@@ -125,25 +131,15 @@ patternRect.addTo(new L.Pattern());
 patternRect.addTo(new L.StripePattern());
 patternRect.redraw();
 patternRect.setStyle(patternRectOptions);
+patternRect.setShape(new L.PatternCircle());
+patternRect.setShape(new L.PatternPath());
 patternRect.setShape(new L.PatternRect());
 
 map.addPattern(pattern);
 map.addPattern(stripePattern);
-map.addPattern(patternShape);
-map.addPattern(patternCircle);
-map.addPattern(patternPath);
-map.addPattern(patternRect);
 
 map.removePattern(pattern);
 map.removePattern(stripePattern);
-map.removePattern(patternShape);
-map.removePattern(patternCircle);
-map.removePattern(patternPath);
-map.removePattern(patternRect);
 
 map.hasPattern(pattern);
 map.hasPattern(stripePattern);
-map.hasPattern(patternShape);
-map.hasPattern(patternCircle);
-map.hasPattern(patternPath);
-map.hasPattern(patternRect);

--- a/types/leaflet.pattern/leaflet.pattern-tests.ts
+++ b/types/leaflet.pattern/leaflet.pattern-tests.ts
@@ -143,3 +143,7 @@ map.removePattern(stripePattern);
 
 map.hasPattern(pattern);
 map.hasPattern(stripePattern);
+
+const pathOptions: L.PathOptions = {};
+pathOptions.fillPattern = pattern;
+pathOptions.fillPattern = stripePattern;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Yesterday I forgot to implement the usage part of the library. The whole idea of this leaflet plugin is you can add patterns to paths. This pull request will extend the PathOptions interface so it is possible to add a pattern to a path: https://github.com/pixelizedPeanut/Leaflet.pattern#usage

As well I added the wrong types to the map interface methods (`addPattern`, `removePattern` and `hasPattern`) as `setShape` method. This PR will fix it.

- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
