### PR TITLE
[three]: Fix for USDZExporter.d.ts parse return type

### DIFF
--- a/types/three/examples/jsm/exporters/USDZExporter.d.ts
+++ b/types/three/examples/jsm/exporters/USDZExporter.d.ts
@@ -3,5 +3,5 @@ import { Object3D } from '../../../src/Three';
 export class USDZExporter {
     constructor();
 
-    parse(scene: Object3D): Uint8Array;
+    parse(scene: Object3D): Promise<Uint8Array>;
 }


### PR DESCRIPTION
 the return type is a Promise<Uint8Array>, not an Uint8Array

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/dev/examples/jsm/exporters/USDZExporter.js
