### PR TITLE
adding withCount to parse.

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -785,6 +785,7 @@ declare global {
             subscribe(): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
+            withCount(): this;
             withinGeoBox<K extends keyof T['attributes'] | keyof BaseAttributes>(
                 key: K,
                 southwest: GeoPoint,

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -785,7 +785,7 @@ declare global {
             subscribe(): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
-            withCount(): this;
+            withCount(includeCount?: boolean): this;
             withinGeoBox<K extends keyof T['attributes'] | keyof BaseAttributes>(
                 key: K,
                 southwest: GeoPoint,

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1793,7 +1793,7 @@ function testQuery() {
         query.startsWith('nonexistentProp', 'prefix string');
 
         // $ExpectType Query<MySubClass>
-        query.withCount();
+        query.withCount(true);
 
         // $ExpectType Query<MySubClass>
         query.withinGeoBox('attribute1', new Parse.GeoPoint(), new Parse.GeoPoint());

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1793,6 +1793,9 @@ function testQuery() {
         query.startsWith('nonexistentProp', 'prefix string');
 
         // $ExpectType Query<MySubClass>
+        query.withCount();
+
+        // $ExpectType Query<MySubClass>
         query.withinGeoBox('attribute1', new Parse.GeoPoint(), new Parse.GeoPoint());
         // $ExpectError
         query.withinGeoBox('nonexistentProp', new Parse.GeoPoint(), new Parse.GeoPoint());

--- a/types/parse/ts3.6/index.d.ts
+++ b/types/parse/ts3.6/index.d.ts
@@ -753,7 +753,7 @@ declare global {
             subscribe(): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
-            withCount(): this;
+            withCount(includeCount?: boolean): this;
             withinGeoBox<K extends keyof T['attributes'] | keyof BaseAttributes>(
                 key: K,
                 southwest: GeoPoint,

--- a/types/parse/ts3.6/index.d.ts
+++ b/types/parse/ts3.6/index.d.ts
@@ -753,6 +753,7 @@ declare global {
             subscribe(): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
+            withCount(): this;
             withinGeoBox<K extends keyof T['attributes'] | keyof BaseAttributes>(
                 key: K,
                 southwest: GeoPoint,

--- a/types/parse/ts3.6/parse-tests.ts
+++ b/types/parse/ts3.6/parse-tests.ts
@@ -1764,6 +1764,9 @@ function testQuery() {
         query.startsWith('nonexistentProp', 'prefix string');
 
         // $ExpectType Query<MySubClass>
+        query.withCount();
+
+        // $ExpectType Query<MySubClass>
         query.withinGeoBox('attribute1', new Parse.GeoPoint(), new Parse.GeoPoint());
         // $ExpectError
         query.withinGeoBox('nonexistentProp', new Parse.GeoPoint(), new Parse.GeoPoint());

--- a/types/parse/ts3.6/parse-tests.ts
+++ b/types/parse/ts3.6/parse-tests.ts
@@ -1764,7 +1764,7 @@ function testQuery() {
         query.startsWith('nonexistentProp', 'prefix string');
 
         // $ExpectType Query<MySubClass>
-        query.withCount();
+        query.withCount(true);
 
         // $ExpectType Query<MySubClass>
         query.withinGeoBox('attribute1', new Parse.GeoPoint(), new Parse.GeoPoint());

--- a/types/parse/ts4.0/index.d.ts
+++ b/types/parse/ts4.0/index.d.ts
@@ -757,6 +757,7 @@ declare global {
             subscribe(): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
+            withCount(): this;
             withinGeoBox<K extends keyof T['attributes'] | keyof BaseAttributes>(
                 key: K,
                 southwest: GeoPoint,

--- a/types/parse/ts4.0/index.d.ts
+++ b/types/parse/ts4.0/index.d.ts
@@ -757,7 +757,7 @@ declare global {
             subscribe(): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
-            withCount(): this;
+            withCount(includeCount?: boolean): this;
             withinGeoBox<K extends keyof T['attributes'] | keyof BaseAttributes>(
                 key: K,
                 southwest: GeoPoint,

--- a/types/parse/ts4.0/parse-tests.ts
+++ b/types/parse/ts4.0/parse-tests.ts
@@ -1784,6 +1784,9 @@ function testQuery() {
         query.startsWith('nonexistentProp', 'prefix string');
 
         // $ExpectType Query<MySubClass>
+        query.withCount();
+
+        // $ExpectType Query<MySubClass>
         query.withinGeoBox('attribute1', new Parse.GeoPoint(), new Parse.GeoPoint());
         // $ExpectError
         query.withinGeoBox('nonexistentProp', new Parse.GeoPoint(), new Parse.GeoPoint());

--- a/types/parse/ts4.0/parse-tests.ts
+++ b/types/parse/ts4.0/parse-tests.ts
@@ -1784,7 +1784,7 @@ function testQuery() {
         query.startsWith('nonexistentProp', 'prefix string');
 
         // $ExpectType Query<MySubClass>
-        query.withCount();
+        query.withCount(true);
 
         // $ExpectType Query<MySubClass>
         query.withinGeoBox('attribute1', new Parse.GeoPoint(), new Parse.GeoPoint());


### PR DESCRIPTION
[the `withCount` function](http://parseplatform.org/Parse-SDK-JS/api/3.1.0/Parse.Query.html#withCount) was missing on the Query object. This PR adds it and the corresponding tests.