### PR TITLE
Update webrtc for upcoming 4.3 DOM lib

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -94,7 +94,7 @@ interface RTCRtpEncodingParameters {
     //ssrc: number;
     //rtx: RTCRtpRtxParameters;
     //fec: RTCRtpFecParameters;
-    dtx?: RTCDtxStatus;
+    // dtx?: RTCDtxStatus;
     //active: boolean;
     //priority: RTCPriorityType;
     //maxBitrate: number;
@@ -131,7 +131,7 @@ interface RTCRtpParameters {
     //headerExtensions: RTCRtpHeaderExtensionParameters[];
     //rtcp: RTCRtcpParameters;
     //codecs: RTCRtpCodecParameters[];
-    degradationPreference?: RTCDegradationPreference; // default = 'balanced'
+    // degradationPreference?: RTCDegradationPreference; // default = 'balanced'
 }
 
 // https://www.w3.org/TR/webrtc/#dom-rtcrtpcontributingsource
@@ -235,7 +235,7 @@ interface RTCDataChannel extends EventTarget {
     readonly readyState: RTCDataChannelState;
     readonly bufferedAmount: number;
     bufferedAmountLowThreshold: number;
-    binaryType: string;
+    // binaryType: string;
 
     close(): void;
     send(data: string | Blob | ArrayBuffer | ArrayBufferView): void;

--- a/types/webrtc/test/RTCPeerConnection.ts
+++ b/types/webrtc/test/RTCPeerConnection.ts
@@ -20,7 +20,7 @@ window.RTCPeerConnection.generateCertificate("sha-256").then((cert: RTCCertifica
         iceServers: [ice1],
         iceTransportPolicy: 'relay',
         bundlePolicy: 'max-compat',
-        rtcpMuxPolicy: 'negotiate',
+        rtcpMuxPolicy: 'require',
         peerIdentity: 'dude',
         certificates: [cert],
         iceCandidatePoolSize: 5,


### PR DESCRIPTION
TS' nightly version of 4.3 recently changed some RTC types. I commented
out the ones that now conflict, as previous conflicts have done.

Also updates the tests for the new stricter types.