### PR TITLE
fix ckeditor__ckeditor5-utils toarray

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -50,6 +50,7 @@ import priorities from "@ckeditor/ckeditor5-utils/src/priorities";
 import toMap from "@ckeditor/ckeditor5-utils/src/tomap";
 import { add } from "@ckeditor/ckeditor5-utils/src/translation-service";
 import uid from "@ckeditor/ckeditor5-utils/src/uid";
+import toArray from "@ckeditor/ckeditor5-utils/src/toarray";
 
 import {
     isCombiningMark,
@@ -653,14 +654,14 @@ bool = isInsideCombinedSymbol(str, 2);
 bool = isInsideSurrogatePair(str, 2);
 bool = isLowSurrogateHalf(String.fromCharCode(57166));
 
-// src/dom/position.d
+// src/dom/position ===========================================================
 
 let options: Options = {
     element: document.createElement("div"),
     target: () => document.createElement("div"),
     positions: [() => null, () => ({ top: 3, left: 3, name: "" })],
     limiter: () => document.createElement("div"),
-    fitInViewport: true
+    fitInViewport: true,
 };
 
 options = {
@@ -668,3 +669,8 @@ options = {
     target: document.createElement("div"),
     positions: [() => null, () => ({ top: 3, left: 3, name: "" })],
 };
+
+// utils/toArray ==============================================================
+let myArrayOfOneNumber: [number] = toArray(5);
+myArrayOfOneNumber = toArray([5]);
+const myArrayOfThreeNumbers: number[] = toArray([1, 2, 3]);

--- a/types/ckeditor__ckeditor5-utils/src/toarray.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/toarray.d.ts
@@ -2,5 +2,6 @@
  * Transforms any value to an array. If the provided value is already an array, it is returned unchanged.
  *
  */
-export default function toArray<T>(data: T): [T];
-export default function toArray<T>(data: T[]): T[];
+type Return<T> = T extends any[] ? T : [T];
+export default function toArray<T>(arg: T): Return<T>;
+export {};


### PR DESCRIPTION
Fix declaration of `toarray` function. Currently, if the argument is already an array, it wraps it in another array.

Implementation in source code, and expected types:

const foo: [number] = toarray(5);
const foo: [number] = toarray([5]);
const foo: number[] = toarray([1,2,3]);

Current types:
const foo: [number] = toarray(5);
const foo: [number][] = toarray([5]);
const foo: Array<number[]> = toarray([1,2,3]);

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/latest/api/module_utils_toarray.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
