### PR TITLE
[@types/serverless]: Provider.getServerlessDeploymentBucketName returns a Promise<string>

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -633,7 +633,7 @@ declare class Aws {
     naming: { [key: string]: () => string };
     getProviderName(): string;
     getRegion(): string;
-    getServerlessDeploymentBucketName(): string;
+    getServerlessDeploymentBucketName(): Promise<string>;
     getStage(): string;
     getAccountId(): Promise<string>;
     request(

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -91,6 +91,9 @@ provider.request(
     },
 );
 
+// Test provider's 'getServerlessDeploymentBucketName'
+provider.getServerlessDeploymentBucketName().then(bucketName => {});
+
 // Test ApiGateway validator
 getHttp(
     {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). (**NB: Prettier leads to a huge change, so I explicitly did not run that as part of this PR**)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/serverless/serverless/pull/8871, https://github.com/serverless/serverless/blob/5fb85d36c8ee965df691b8f2dfddeaab8315c77d/lib/plugins/aws/provider.js#L1454
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
