### PR TITLE
@ember/routing Make Route generic accepting a Model type

### DIFF
--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -3,7 +3,7 @@ import ActionHandler from '@ember/object/-private/action-handler';
 import Transition from '@ember/routing/-private/transition';
 import Evented from '@ember/object/evented';
 import { RenderOptions, RouteQueryParam } from '@ember/routing/types';
-import Controller, { Registry as ControllerRegistry } from '@ember/controller';
+import Controller from '@ember/controller';
 
 // tslint:disable-next-line:strict-export-declare-modifiers
 type RouteModel = object | string | number;
@@ -12,7 +12,7 @@ type RouteModel = object | string | number;
  * The `Ember.Route` class is used to define individual routes. Refer to
  * the [routing guide](http://emberjs.com/guides/routing/) for documentation.
  */
-export default class Route extends EmberObject.extend(ActionHandler, Evented) {
+export default class Route<Model = any> extends EmberObject.extend(ActionHandler, Evented) {
     // methods
     /**
      * This hook is called after this route's model has resolved.
@@ -22,7 +22,7 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * logic that can only take place after the model has already
      * resolved.
      */
-    afterModel(resolvedModel: any, transition: Transition): any;
+    afterModel(resolvedModel: Model, transition: Transition): any;
 
     /**
      * This hook is the first of the route entry validation hooks
@@ -66,7 +66,7 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * A hook you can implement to convert the URL into the model for
      * this route.
      */
-    model(params: {}, transition: Transition): any;
+    model(params: {}, transition: Transition): Model | PromiseLike<Model>;
 
     /**
      * Returns the model of a parent (or any ancestor) route
@@ -77,7 +77,7 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * it can call `this.modelFor(theNameOfParentRoute)` to
      * retrieve it.
      */
-    modelFor(name: string): {};
+    modelFor(name: string): any;
 
     /**
      * Retrieves parameters, for current route using the state.params
@@ -105,7 +105,7 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * both the resolved model and attempted entry into this route
      * are considered to be fully validated.
      */
-    redirect(model: {}, transition: Transition): void;
+    redirect(model: Model, transition: Transition): void;
 
     /**
      * Refresh the model on this route and any child routes, firing the
@@ -175,7 +175,7 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * This method is called when `transitionTo` is called with a context
      * in order to populate the URL.
      */
-    serialize(model: {}, params: string[]): string | object;
+    serialize(model: Model, params: string[]): string | object;
 
     /**
      * A hook you can use to setup the controller for the current route.

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -142,7 +142,7 @@ export default class Route<Model = any> extends EmberObject.extend(ActionHandler
      * This method can be overridden to set up and render additional or
      * alternative templates.
      */
-    renderTemplate(controller: Controller, model: {}): void;
+    renderTemplate(controller: Controller, model: Model): void;
 
     /**
      * Transition into another route while replacing the current URL, if possible.
@@ -188,7 +188,7 @@ export default class Route<Model = any> extends EmberObject.extend(ActionHandler
      * when implementing your `setupController` function, make sure to call
      * `_super`
      */
-    setupController(controller: Controller, model: {}, transition: Transition): void;
+    setupController(controller: Controller, model: Model, transition: Transition): void;
 
     /**
      * Transition the application into another route. The route may

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -215,6 +215,14 @@ class TypedRoute extends Route<ExampleModel> {
             this.transitionTo('some.other.route');
         }
     }
+
+    setupController(controller: Controller, model: ExampleModel, transition: Transition) {
+        controller.set('model', model);
+    }
+
+    renderTemplate(controller: Controller, model: ExampleModel) {
+        this.render('template', { model: model });
+    }
 }
 
 interface InvalidModel { id: number; }
@@ -242,5 +250,15 @@ class InvalidTypedRoute extends Route<ExampleModel> {
         if (model.id === 0) {
             this.transitionTo('some.other.route');
         }
+    }
+
+    // $ExpectError
+    setupController(controller: Controller, model: InvalidModel, transition: Transition) {
+        controller.set('model', model);
+    }
+
+    // $ExpectError
+    renderTemplate(controller: Controller, model: InvalidModel) {
+        this.render('template', { model: model });
     }
 }

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -187,3 +187,60 @@ class RouteUsingClass extends Route.extend({
         this.intermediateTransitionTo('some.other.route', 1, 2, {});
     }
 }
+
+interface ExampleModel { id: string; }
+
+class TypedRoute extends Route<ExampleModel> {
+    model(params: any): ExampleModel | PromiseLike<ExampleModel> {
+        if (params.usePromise) {
+          return { id: '123' };
+        } else {
+          const promise: PromiseLike<ExampleModel> = new Promise((resolve) => resolve({ id: '123'}));
+          return promise;
+        }
+    }
+
+    serialize(model: ExampleModel): string {
+        return model.id;
+    }
+
+    afterModel(model: ExampleModel): void {
+        if (model.id === 'new') {
+            this.transitionTo('some.other.route');
+        }
+    }
+
+    redirect(model: ExampleModel): void {
+        if (model.id === 'new') {
+            this.transitionTo('some.other.route');
+        }
+    }
+}
+
+interface InvalidModel { id: number; }
+
+class InvalidTypedRoute extends Route<ExampleModel> {
+    // $ExpectError
+    model(params: any): InvalidModel {
+      return { id: 123 };
+    }
+
+    // $ExpectError
+    serialize(model: InvalidModel): number {
+        return model.id;
+    }
+
+    // $ExpectError
+    afterModel(model: InvalidModel): void {
+        if (model.id === 0) {
+            this.transitionTo('some.other.route');
+        }
+    }
+
+    // $ExpectError
+    redirect(model: InvalidModel): void {
+        if (model.id === 0) {
+            this.transitionTo('some.other.route');
+        }
+    }
+}

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -221,7 +221,7 @@ class TypedRoute extends Route<ExampleModel> {
     }
 
     renderTemplate(controller: Controller, model: ExampleModel) {
-        this.render('template', { model: model });
+        this.render('template', { model });
     }
 }
 
@@ -259,6 +259,6 @@ class InvalidTypedRoute extends Route<ExampleModel> {
 
     // $ExpectError
     renderTemplate(controller: Controller, model: InvalidModel) {
-        this.render('template', { model: model });
+        this.render('template', { model });
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember/3.25/classes/Route/methods/model?anchor=model
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header (it does not)

This is mostly an improvement to the existing types to allow for declaring the type for the model of the route. For backwards compatibility, I'm defaulting it to `any`. I also made a slight change in making `modelFor` return `any` instead of `{}`, since it can return `undefined` or `null` if either of those are returned by the `model` hook of the provided route, and it will return `undefined` if the route hasn't run (because it isn't a parent) or the route name was invalid.

Further progress could be made with this to make a registry of routes, such that `paramsFor` or `modelFor` could identify what types they're supposed to return based on what routes have been registered.