### PR TITLE
[@types/chrome] Define chrome.tabGroups API available in Chrome 89

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13,6 +13,7 @@
 //                 bdbai <https://github.com/bdbai>
 //                 pokutuna <https://github.com/pokutuna>
 //                 Jason Xian <https://github.com/JasonXian>
+//                 userTim <https://github.com/usertim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -3805,6 +3806,114 @@ declare namespace chrome.gcm {
     export var onMessagesDeleted: MessageDeletionEvent;
     /** Fired when it was not possible to send a message to the GCM server. */
     export var onSendError: GcmErrorEvent;
+}
+
+////////////////////
+// Tab Groups
+////////////////////
+/**
+ * Use the chrome.tabGroups API to interact with the browser's tab grouping system. You can use this API to modify and rearrange tab groups in the browser. To group and ungroup tabs, or to query what tabs are in groups, use the chrome.tabs API.
+ * Permissions:  "tabGroups"
+ * @since Chrome 89.
+ */
+ declare namespace chrome.tabGroups {
+
+    /** An ID that represents the absence of a group. */
+    export var TAB_GROUP_ID_NONE: number;
+
+	type ColorEnum = "grey" | "blue" | "red" | "yellow" | "green" | "pink" | "purple" | "cyan";
+
+	type TabGroup = {
+		/** Whether the group is collapsed. A collapsed group is one whose tabs are hidden. */
+		collapsed: boolean;
+		/** The group's color. */
+		color: ColorEnum;
+		/** The ID of the group. Group IDs are unique within a browser session. */
+		id: number;
+		/** The title of the group. */
+		title?: string;
+		/** The ID of the window that contains the group. */
+		windowId: number;
+	}
+
+    export interface UpdateProperties {
+        /** Whether the group should be collapsed. */
+        collapsed?: boolean;
+        /** The color of the group. */
+        color?: ColorEnum;
+        /** The title of the group. */
+        title?: string;
+    }
+
+    export interface MoveProperties {
+        /** The position to move the group to. Use -1 to place the group at the end of the window. */
+        index: number;
+        /** The window to move the group to. Defaults to the window the group is currently in. Note that groups can only be moved to and from windows with chrome.windows.WindowType type "normal". */
+        windowId?: number;
+    }
+
+    export interface QueryInfo {
+        /** Whether the groups are collapsed. */
+        collapsed?: boolean;
+        /** The color of the groups. */
+        color?: ColorEnum;
+        /** Match group titles against a pattern. */
+        title?: string;
+        /** The ID of the parent window, or chrome.windows.WINDOW_ID_CURRENT for the current window. */
+        windowId?: number;
+    }
+
+    /**
+     * Retrieves details about the specified group.
+     * @param groupId The ID of the tab group.
+     * @param callback Called with the retrieved tab group.
+     */
+    export function get(groupId: number, callback: (group: TabGroup) => void): void;
+
+    /**
+     * Moves the group and all its tabs within its window, or to a new window.
+     * @param groupId The ID of the group to move.
+     * @param moveProperties Move properties. Specify tab index, windowId
+     * @param callback Called with details about the moved group.
+    */
+    export function move(groupId: number, moveProperties: MoveProperties, callback: (group: TabGroup) => void): void;
+
+    /**
+     * Queries all groups that have the specified properties, or all groups if no properties are specified.
+     * @param queryInfo Object with search parameters.
+     * @param callback Called with retrieved tab groups
+     */
+     export function query(queryInfo: QueryInfo, callback: (result: TabGroup[]) => void): void;
+
+    /**
+     * Modifies the properties of a group. Properties that are not specified in updateProperties are not modified.
+     * @param groupId The ID of the group to modify.
+     * @param updateProperties The properties to update.
+     * @param callback Called with an updated tab group as parameter.
+     */
+    export function update(groupId: string, updateProperties: UpdateProperties, callback?: (group: TabGroup) => void): void;
+
+    export interface TabGroupCreatedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
+	export interface TabGroupMovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
+	export interface TabGroupRemovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
+	export interface TabGroupUpdated extends chrome.events.Event<(group: TabGroup) => void> { }
+
+    /**
+     * Fired when a group is created.
+     */
+    export var onCreated: TabGroupCreatedEvent;
+    /**
+     * Fired when a group is moved within a window. Move events are still fired for the individual tabs within the group, as well as for the group itself. This event is not fired when a group is moved between windows; instead, it will be removed from one window and created in another.
+     */
+    export var onMoved: TabGroupMovedEvent;
+     /**
+     * Fired when a group is closed, either directly by the user or automatically because it contained zero.
+     */
+    export var onRemoved: TabGroupRemovedEvent;
+    /**
+     * Fired when a group is updated.
+     */
+    export var onUpdated: TabGroupUpdated;
 }
 
 ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7830,6 +7830,11 @@ declare namespace chrome.tabs {
          * @since Chrome 31.
          */
         sessionId?: string;
+		/**
+		 * The ID of the group that the tab belongs to.
+		 * @since Chrome 88
+		 */
+		groupId: number;
     }
 
     /**
@@ -8013,6 +8018,18 @@ declare namespace chrome.tabs {
         frameId?: number;
     }
 
+	export interface GroupOptions {
+		/** Configurations for creating a group. Cannot be used if groupId is already specified. */
+		createProperties?: {
+			/** The window of the new group. Defaults to the current window. */
+			windowId?: number
+		},
+		/** The ID of the group to add the tabs to. If not specified, a new group will be created. */
+		groupId?: number;
+		/** The tab ID or list of tab IDs to add to the specified group. */
+		tabIds?: number | number[];
+	}
+
     export interface HighlightInfo {
         /** One or more tab indices to highlight. */
         tabs: number | number[];
@@ -8080,6 +8097,11 @@ declare namespace chrome.tabs {
          * @since Chrome 45.
          */
         muted?: boolean;
+		/**
+		 * The ID of the group that the tabs are in, or chrome.tabGroups.TAB_GROUP_ID_NONE for ungrouped tabs.
+		 * @since Chrome 88
+		 */
+		groupId?: number;
     }
 
     export interface TabHighlightInfo {
@@ -8495,7 +8517,13 @@ declare namespace chrome.tabs {
      * @param callback Optional. Called after the operation is completed.
      */
     export function goBack(tabId: number, callback?: () => void): void;
-
+	/**
+	 * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
+	 * @since Chrome 88
+	 * @param options Configurations object
+	 * @param callback Called with group ID as a parameter
+	 */
+	export function group(options: GroupOptions, callback: (groupId: number) => void): void
     /**
      * Fired when the highlighted or selected tabs in a window changes.
      * @since Chrome 18.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3809,114 +3809,6 @@ declare namespace chrome.gcm {
 }
 
 ////////////////////
-// Tab Groups
-////////////////////
-/**
- * Use the chrome.tabGroups API to interact with the browser's tab grouping system. You can use this API to modify and rearrange tab groups in the browser. To group and ungroup tabs, or to query what tabs are in groups, use the chrome.tabs API.
- * Permissions:  "tabGroups"
- * @since Chrome 89.
- */
- declare namespace chrome.tabGroups {
-
-    /** An ID that represents the absence of a group. */
-    export var TAB_GROUP_ID_NONE: number;
-
-	type ColorEnum = "grey" | "blue" | "red" | "yellow" | "green" | "pink" | "purple" | "cyan";
-
-	interface TabGroup {
-		/** Whether the group is collapsed. A collapsed group is one whose tabs are hidden. */
-		collapsed: boolean;
-		/** The group's color. */
-		color: ColorEnum;
-		/** The ID of the group. Group IDs are unique within a browser session. */
-		id: number;
-		/** The title of the group. */
-		title?: string;
-		/** The ID of the window that contains the group. */
-		windowId: number;
-	}
-
-    export interface UpdateProperties {
-        /** Whether the group should be collapsed. */
-        collapsed?: boolean;
-        /** The color of the group. */
-        color?: ColorEnum;
-        /** The title of the group. */
-        title?: string;
-    }
-
-    export interface MoveProperties {
-        /** The position to move the group to. Use -1 to place the group at the end of the window. */
-        index: number;
-        /** The window to move the group to. Defaults to the window the group is currently in. Note that groups can only be moved to and from windows with chrome.windows.WindowType type "normal". */
-        windowId?: number;
-    }
-
-    export interface QueryInfo {
-        /** Whether the groups are collapsed. */
-        collapsed?: boolean;
-        /** The color of the groups. */
-        color?: ColorEnum;
-        /** Match group titles against a pattern. */
-        title?: string;
-        /** The ID of the parent window, or chrome.windows.WINDOW_ID_CURRENT for the current window. */
-        windowId?: number;
-    }
-
-    /**
-     * Retrieves details about the specified group.
-     * @param groupId The ID of the tab group.
-     * @param callback Called with the retrieved tab group.
-     */
-    export function get(groupId: number, callback: (group: TabGroup) => void): void;
-
-    /**
-     * Moves the group and all its tabs within its window, or to a new window.
-     * @param groupId The ID of the group to move.
-     * @param moveProperties Move properties. Specify tab index, windowId
-     * @param callback Called with details about the moved group.
-    */
-    export function move(groupId: number, moveProperties: MoveProperties, callback: (group: TabGroup) => void): void;
-
-    /**
-     * Queries all groups that have the specified properties, or all groups if no properties are specified.
-     * @param queryInfo Object with search parameters.
-     * @param callback Called with retrieved tab groups
-     */
-     export function query(queryInfo: QueryInfo, callback: (result: TabGroup[]) => void): void;
-
-    /**
-     * Modifies the properties of a group. Properties that are not specified in updateProperties are not modified.
-     * @param groupId The ID of the group to modify.
-     * @param updateProperties The properties to update.
-     * @param callback Called with an updated tab group as parameter.
-     */
-    export function update(groupId: number, updateProperties: UpdateProperties, callback?: (group: TabGroup) => void): void;
-
-    export interface TabGroupCreatedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
-	export interface TabGroupMovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
-	export interface TabGroupRemovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
-	export interface TabGroupUpdated extends chrome.events.Event<(group: TabGroup) => void> { }
-
-    /**
-     * Fired when a group is created.
-     */
-    export var onCreated: TabGroupCreatedEvent;
-    /**
-     * Fired when a group is moved within a window. Move events are still fired for the individual tabs within the group, as well as for the group itself. This event is not fired when a group is moved between windows; instead, it will be removed from one window and created in another.
-     */
-    export var onMoved: TabGroupMovedEvent;
-     /**
-     * Fired when a group is closed, either directly by the user or automatically because it contained zero.
-     */
-    export var onRemoved: TabGroupRemovedEvent;
-    /**
-     * Fired when a group is updated.
-     */
-    export var onUpdated: TabGroupUpdated;
-}
-
-////////////////////
 // History
 ////////////////////
 /**
@@ -7830,11 +7722,11 @@ declare namespace chrome.tabs {
          * @since Chrome 31.
          */
         sessionId?: string;
-		/**
-		 * The ID of the group that the tab belongs to.
-		 * @since Chrome 88
-		 */
-		groupId: number;
+        /**
+         * The ID of the group that the tab belongs to.
+         * @since Chrome 88
+         */
+        groupId: number;
     }
 
     /**
@@ -8018,17 +7910,17 @@ declare namespace chrome.tabs {
         frameId?: number;
     }
 
-	export interface GroupOptions {
-		/** Configurations for creating a group. Cannot be used if groupId is already specified. */
-		createProperties?: {
-			/** The window of the new group. Defaults to the current window. */
-			windowId?: number
-		},
-		/** The ID of the group to add the tabs to. If not specified, a new group will be created. */
-		groupId?: number;
-		/** The tab ID or list of tab IDs to add to the specified group. */
-		tabIds?: number | number[];
-	}
+    export interface GroupOptions {
+        /** Optional. Configurations for creating a group. Cannot be used if groupId is already specified. */
+        createProperties?: {
+            /** Optional. The window of the new group. Defaults to the current window. */
+            windowId?: number
+        },
+        /** Optional. The ID of the group to add the tabs to. If not specified, a new group will be created. */
+        groupId?: number;
+        /** TOptional. he tab ID or list of tab IDs to add to the specified group. */
+        tabIds?: number | number[];
+    }
 
     export interface HighlightInfo {
         /** One or more tab indices to highlight. */
@@ -8097,11 +7989,11 @@ declare namespace chrome.tabs {
          * @since Chrome 45.
          */
         muted?: boolean;
-		/**
-		 * The ID of the group that the tabs are in, or chrome.tabGroups.TAB_GROUP_ID_NONE for ungrouped tabs.
-		 * @since Chrome 88
-		 */
-		groupId?: number;
+        /**
+         * Optional. The ID of the group that the tabs are in, or chrome.tabGroups.TAB_GROUP_ID_NONE for ungrouped tabs.
+         * @since Chrome 88
+         */
+        groupId?: number;
     }
 
     export interface TabHighlightInfo {
@@ -8517,13 +8409,13 @@ declare namespace chrome.tabs {
      * @param callback Optional. Called after the operation is completed.
      */
     export function goBack(tabId: number, callback?: () => void): void;
-	/**
-	 * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
-	 * @since Chrome 88
-	 * @param options Configurations object
-	 * @param callback Called with group ID as a parameter
-	 */
-	export function group(options: GroupOptions, callback: (groupId: number) => void): void
+    /**
+     * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
+     * @since Chrome 88
+     * @param options Configurations object
+     * @param callback Optional.
+     */
+    export function group(options: GroupOptions, callback?: (groupId: number) => void): void
     /**
      * Fired when the highlighted or selected tabs in a window changes.
      * @since Chrome 18.
@@ -8579,6 +8471,106 @@ declare namespace chrome.tabs {
      * @since Chrome 46.
      */
     export var TAB_ID_NONE: -1;
+}
+
+////////////////////
+// Tab Groups
+////////////////////
+/**
+ * Use the chrome.tabGroups API to interact with the browser's tab grouping system. You can use this API to modify and rearrange tab groups in the browser. To group and ungroup tabs, or to query what tabs are in groups, use the chrome.tabs API.
+ * Permissions:  "tabGroups"
+ * @since Chrome 89. Manifest V3 and above.
+ */
+ declare namespace chrome.tabGroups {
+
+    /** An ID that represents the absence of a group. */
+    export var TAB_GROUP_ID_NONE: -1;
+
+    export type ColorEnum = 'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan';
+
+    export interface TabGroup {
+        /** Whether the group is collapsed. A collapsed group is one whose tabs are hidden. */
+        collapsed: boolean;
+        /** The group's color. */
+        color: ColorEnum;
+        /** The ID of the group. Group IDs are unique within a browser session. */
+        id: number;
+        /** Optional. The title of the group. */
+        title?: string;
+        /** The ID of the window that contains the group. */
+        windowId: number;
+    }
+
+    export interface MoveProperties {
+        /** The position to move the group to. Use -1 to place the group at the end of the window. */
+        index: number;
+        /** Optional. The window to move the group to. Defaults to the window the group is currently in. Note that groups can only be moved to and from windows with chrome.windows.WindowType type "normal". */
+        windowId?: number;
+    }
+
+    export interface QueryInfo {
+        /** Optional. Whether the groups are collapsed. */
+        collapsed?: boolean;
+        /** Optional. The color of the groups. */
+        color?: ColorEnum;
+        /** Optional. Match group titles against a pattern. */
+        title?: string;
+        /** Optional. The ID of the window that contains the group. */
+        windowId?: number;
+    }
+
+    export interface UpdateProperties {
+        /** Optional. Whether the group should be collapsed. */
+        collapsed?: boolean;
+        /** Optional. The color of the group. */
+        color?: ColorEnum;
+        /** Optional. The title of the group. */
+        title?: string;
+    }
+
+    /**
+     * Retrieves details about the specified group.
+     * @param groupId The ID of the tab group.
+     * @param callback Called with the retrieved tab group.
+     */
+    export function get(groupId: number, callback: (group: TabGroup) => void): void;
+
+    /**
+     * Moves the group and all its tabs within its window, or to a new window.
+     * @param groupId The ID of the group to move.
+     * @param moveProperties Information on how to move the group.
+     * @param callback Optional.
+    */
+    export function move(groupId: number, moveProperties: MoveProperties, callback?: (group: TabGroup) => void): void;
+
+    /**
+     * Gets all groups that have the specified properties, or all groups if no properties are specified.
+     * @param queryInfo Object with search parameters.
+     * @param callback Called with retrieved tab groups.
+     */
+     export function query(queryInfo: QueryInfo, callback: (result: TabGroup[]) => void): void;
+
+    /**
+     * Modifies the properties of a group. Properties that are not specified in updateProperties are not modified.
+     * @param groupId The ID of the group to modify.
+     * @param updateProperties Information on how to update the group.
+     * @param callback Optional.
+     */
+    export function update(groupId: number, updateProperties: UpdateProperties, callback?: (group: TabGroup) => void): void;
+
+    export interface TabGroupCreatedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
+    export interface TabGroupMovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
+    export interface TabGroupRemovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
+    export interface TabGroupUpdated extends chrome.events.Event<(group: TabGroup) => void> { }
+
+    /** Fired when a group is created. */
+    export var onCreated: TabGroupCreatedEvent;
+    /** Fired when a group is moved within a window. Move events are still fired for the individual tabs within the group, as well as for the group itself. This event is not fired when a group is moved between windows; instead, it will be removed from one window and created in another. */
+    export var onMoved: TabGroupMovedEvent;
+    /** Fired when a group is closed, either directly by the user or automatically because it contained zero. */
+    export var onRemoved: TabGroupRemovedEvent;
+    /** Fired when a group is updated. */
+    export var onUpdated: TabGroupUpdated;
 }
 
 ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3891,7 +3891,7 @@ declare namespace chrome.gcm {
      * @param updateProperties The properties to update.
      * @param callback Called with an updated tab group as parameter.
      */
-    export function update(groupId: string, updateProperties: UpdateProperties, callback?: (group: TabGroup) => void): void;
+    export function update(groupId: number, updateProperties: UpdateProperties, callback?: (group: TabGroup) => void): void;
 
     export interface TabGroupCreatedEvent extends chrome.events.Event<(group: TabGroup) => void> { }
 	export interface TabGroupMovedEvent extends chrome.events.Event<(group: TabGroup) => void> { }

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3823,7 +3823,7 @@ declare namespace chrome.gcm {
 
 	type ColorEnum = "grey" | "blue" | "red" | "yellow" | "green" | "pink" | "purple" | "cyan";
 
-	type TabGroup = {
+	interface TabGroup {
 		/** Whether the group is collapsed. A collapsed group is one whose tabs are hidden. */
 		collapsed: boolean;
 		/** The group's color. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -389,6 +389,23 @@ async function testTabInterface() {
     tab.sessionId; // $ExpectType string | undefined
 }
 
+// tabGroups: https://developer.chrome.com/extensions/tabGroups#
+async function testTabGroupInterface() {
+    const options = { collapsed: false, title: 'Test' };
+
+    chrome.tabGroups.query(options, tabGroups => {
+        // $ExpectType TabGroup[]
+        tabGroups;
+
+        const [tabGroup] = tabGroups;
+        tabGroup.collapsed; // $ExpectType boolean
+        tabGroup.color; // $ExpectType string
+        tabGroup.id; // $ExpectType number
+        tabGroup.title; // $ExpectType string | undefined
+        tabGroup.windowId; // $ExpectType number
+    });
+  }
+
 // https://developer.chrome.com/extensions/runtime#method-openOptionsPage
 function testOptionsPage() {
     chrome.runtime.openOptionsPage();

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -399,7 +399,7 @@ async function testTabGroupInterface() {
 
         const [tabGroup] = tabGroups;
         tabGroup.collapsed; // $ExpectType boolean
-        tabGroup.color; // $ExpectType string
+        tabGroup.color; // $ExpectType ColorEnum
         tabGroup.id; // $ExpectType number
         tabGroup.title; // $ExpectType string | undefined
         tabGroup.windowId; // $ExpectType number

--- a/types/chrome/tslint.json
+++ b/types/chrome/tslint.json
@@ -10,6 +10,7 @@
         "no-empty-interface": false,
         "no-internal-module": false,
         "no-mergeable-namespace": false,
+        "no-outside-dependencies": false,
         "no-padding": false,
         "no-unnecessary-class": false,
         "no-unnecessary-generics": false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.chrome.com/docs/extensions/reference/tabGroups>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.