### PR TITLE
fix(json-schema-faker): remove @deprecated JSDoc tag

### DIFF
--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -4,7 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 
-import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
+import { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
+
+export as namespace jsf;
+
+/**
+ * deprecated: calling JsonSchemaFaker() is deprecated, call either .generate() or .resolve()'
+ */
+declare function jsf(schema: jsf.Schema, refs?: string | jsf.Schema[]): any;
 
 declare namespace jsf {
     const version: string;
@@ -61,7 +68,4 @@ declare namespace jsf {
         | 'replaceEmptyByRandomValue';
 }
 
-/** @deprecated calling JsonSchemaFaker() is deprecated, call either .generate() or .resolve()' */
-declare function jsf(schema: jsf.Schema, refs?: string | jsf.Schema[]): any;
-export as namespace jsf;
 export = jsf;

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -1,7 +1,18 @@
 /// <reference types="node" />
-import jsf = require('json-schema-faker');
-import { Chance } from 'chance';
-import { Schema } from 'json-schema-faker';
+import jsf = require("json-schema-faker");
+import { Chance } from "chance";
+import { Schema } from "json-schema-faker";
+
+// $ExpectType any
+jsf({
+    type: "object",
+    properties: {
+        foo: { type: "string" },
+        bar: { type: "string" },
+    },
+    required: [],
+    additionalProperties: true,
+});
 
 // custom chance extension
 jsf.extend('chance', () => {


### PR DESCRIPTION
This worked against the expected results due to nature of DT CommonJS
method + namespace exporting. Resorted to be only remark in JSDoc
comment to prevent unwanted deprecation tagging in IDEs.

/cc @ITenthusiasm

Fixes #51734

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).