### PR TITLE
TailwindCSS: Add more color palettes to colors.js

### DIFF
--- a/types/tailwindcss/colors.d.ts
+++ b/types/tailwindcss/colors.d.ts
@@ -1,5 +1,22 @@
-import type { TailwindColorConfig } from './tailwind-config';
+import type { TailwindColorConfig, TailwindColorGroup } from './tailwind-config';
 
-declare const colors: TailwindColorConfig;
+interface TailwindColors extends TailwindColorConfig {
+    rose: TailwindColorGroup;
+    fuchsia: TailwindColorGroup;
+    violet: TailwindColorGroup;
+    lightBlue: TailwindColorGroup;
+    cyan: TailwindColorGroup;
+    teal: TailwindColorGroup;
+    emerald: TailwindColorGroup;
+    lime: TailwindColorGroup;
+    amber: TailwindColorGroup;
+    orange: TailwindColorGroup;
+    warmGray: TailwindColorGroup;
+    trueGray: TailwindColorGroup;
+    coolGray: TailwindColorGroup;
+    blueGray: TailwindColorGroup;
+}
+
+declare const colors: TailwindColors;
 
 export = colors;

--- a/types/tailwindcss/colors.d.ts
+++ b/types/tailwindcss/colors.d.ts
@@ -1,18 +1,28 @@
-import type { TailwindColorConfig, TailwindColorGroup } from './tailwind-config';
+import type { TailwindColorGroup } from './tailwind-config';
 
-interface TailwindColors extends TailwindColorConfig {
+interface TailwindColors {
+    black: string;
+    white: string;
     rose: TailwindColorGroup;
+    pink: TailwindColorGroup;
     fuchsia: TailwindColorGroup;
+    purple: TailwindColorGroup;
     violet: TailwindColorGroup;
+    indigo: TailwindColorGroup;
+    blue: TailwindColorGroup;
     lightBlue: TailwindColorGroup;
     cyan: TailwindColorGroup;
     teal: TailwindColorGroup;
     emerald: TailwindColorGroup;
+    green: TailwindColorGroup;
     lime: TailwindColorGroup;
+    yellow: TailwindColorGroup;
     amber: TailwindColorGroup;
     orange: TailwindColorGroup;
+    red: TailwindColorGroup;
     warmGray: TailwindColorGroup;
     trueGray: TailwindColorGroup;
+    gray: TailwindColorGroup;
     coolGray: TailwindColorGroup;
     blueGray: TailwindColorGroup;
 }

--- a/types/tailwindcss/tailwindcss-tests.ts
+++ b/types/tailwindcss/tailwindcss-tests.ts
@@ -2515,6 +2515,20 @@ tailwindConfig.theme.boxShadow['2xl'];
 // => '0 25px 50px -12px rgba(0, 0, 0, 0.25)'
 
 colors.red[500];
+colors.rose[500];
+colors.fuchsia[500];
+colors.violet[500];
+colors.lightBlue[500];
+colors.cyan[500];
+colors.teal[500];
+colors.emerald[500];
+colors.lime[500];
+colors.amber[500];
+colors.orange[500];
+colors.warmGray[500];
+colors.trueGray[500];
+colors.coolGray[500];
+colors.blueGray[500];
 
 defaultTheme.darkMode;
 defaultTheme.theme.colors.blue[800];


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tailwindcss.com/docs/customizing-colors#color-palette-reference
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Tailwind's color palette in colors.js actually has quite a few more than the actual build it generates, so I've added those in.
These are used in the v2 announcement: https://blog.tailwindcss.com/tailwindcss-v2#:~:text=require('tailwindcss/colors')
There's quite a bit of duplication in the color definitions in these types – might be something to look at – but for now I've just edited what is exported from colors.d.ts.