### PR TITLE
[react-native] Fix docs for scrollEventThrottle

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6573,9 +6573,9 @@ export interface ScrollViewPropsIOS {
     pinchGestureEnabled?: boolean;
 
     /**
-     * This controls how often the scroll event will be fired while scrolling (in events per seconds).
-     * A higher number yields better accuracy for code that is tracking the scroll position,
-     * but can lead to scroll performance problems due to the volume of information being send over the bridge.
+     * This controls how often the scroll event will be fired while scrolling (as a time interval in ms).
+     * A lower number yields better accuracy for code that is tracking the scroll position,
+     * but can lead to scroll performance problems due to the volume of information being sent over the bridge.
      * The default value is zero, which means the scroll event will be sent only once each time the view is scrolled.
      */
     scrollEventThrottle?: number; // null


### PR DESCRIPTION
Documentation for `scrollEventThrottle` prop in `ScrollView` contains the same mistake that was present in React Native docs really long time ago (versions pre 0.23): the unit is ms, not events per second.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://reactnative.dev/docs/scrollview#scrolleventthrottle-ios
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.