### PR TITLE
Adding apiHost field type added in "datadog-metrics": "^0.9.2",

### DIFF
--- a/types/datadog-metrics/index.d.ts
+++ b/types/datadog-metrics/index.d.ts
@@ -33,9 +33,9 @@ export interface BufferedMetricsLoggerOptions {
      * Sets a default prefix for all metrics.
      */
     prefix?: string;
-    
-     /**
-     * Sets host address corresponding to your DD service region. 
+
+    /**
+     * Sets host address corresponding to your DD service region.
      */
     apiHost?: string;
 }

--- a/types/datadog-metrics/index.d.ts
+++ b/types/datadog-metrics/index.d.ts
@@ -33,6 +33,11 @@ export interface BufferedMetricsLoggerOptions {
      * Sets a default prefix for all metrics.
      */
     prefix?: string;
+    
+     /**
+     * Sets host address corresponding to your DD service region. 
+     */
+    apiHost?: string;
 }
 
 export class BufferedMetricsLogger {


### PR DESCRIPTION
I admit I gave up 10 minutes into the PR template readme. Delete PR please if non-compliant.



