### PR TITLE
Fixed a typo in react-bootstrap-table2-filter comparator -> comparators

### DIFF
--- a/types/react-bootstrap-table2-filter/index.d.ts
+++ b/types/react-bootstrap-table2-filter/index.d.ts
@@ -121,7 +121,7 @@ export interface DateFilter<T extends object = any> extends TableColumnFilterPro
         date: Date;
         comparator: Comparator;
     };
-    comparator?: Comparator[];
+    comparators?: Comparator[];
     comparatorClassName?: string;
     dateClassName?: string;
     comparatorStyle?: CSSProperties;


### PR DESCRIPTION
Simple change to edit comparator -> comparators for the list of comparators provided in the filter. Matches the definition in the source package https://github.com/react-bootstrap-table/react-bootstrap-table2/blob/master/packages/react-bootstrap-table2-filter/src/components/date.js, and works

Please fill in this template.

- [yes] Use a meaningful title for the pull request. Include the name of the package modified.
- [yes] Test the change in your own code. (Compile and run.)
- [no] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- yes ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [yes] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [no] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [yes] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/react-bootstrap-table/react-bootstrap-table2/blob/master/packages/react-bootstrap-table2-filter/src/components/date.js](https://github.com/react-bootstrap-table/react-bootstrap-table2/blob/master/packages/react-bootstrap-table2-filter/src/components/date.js)
- [no] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - interface declaration was constant from the start