### PR TITLE
express-serve-static-core added an additional deferToNext for route in NextFunction

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -87,6 +87,11 @@ app.get('/nextrouter', (req, res, next) => {
     next('router'); // $ExpectType void
 });
 
+// Next can receive a 'route' parameter to fall back to next route
+app.get('/nextroute', (req, res, next) => {
+  next('route'); // $ExpectType void
+});
+
 // Default types
 app.post('/', (req, res) => {
     req.params[0]; // $ExpectType string

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -8,6 +8,7 @@
 //                 Jose Luis Leon <https://github.com/JoseLion>
 //                 David Stephens <https://github.com/dwrss>
 //                 Shin Ando <https://github.com/andoshin11>
+//                 Colin Richardson <https://github.com/WORMSS>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -38,6 +39,11 @@ export interface NextFunction {
      * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.router}
      */
     (deferToNext: 'router'): void;
+    /**
+     * "Break-out" of a route by calling {next('route')};
+     * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.application}
+     */
+    (deferToNext: 'route'): void;
 }
 
 export interface Dictionary<T> {

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -8,7 +8,6 @@
 //                 Jose Luis Leon <https://github.com/JoseLion>
 //                 David Stephens <https://github.com/dwrss>
 //                 Shin Ando <https://github.com/andoshin11>
-//                 Colin Richardson <https://github.com/WORMSS>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/guide/using-middleware.html#middleware.application

![image](https://user-images.githubusercontent.com/1384537/111165982-8d2ca000-8597-11eb-913a-a1617786c6f1.png)

- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
**api is older than the `(deferToNext: 'router') => void` that already exist in the definition**

