### PR TITLE
Update react audio player tests for 4.3

### DIFF
--- a/types/react-audio-player/react-audio-player-tests.tsx
+++ b/types/react-audio-player/react-audio-player-tests.tsx
@@ -8,7 +8,7 @@ render(<ReactAudioPlayer />, appContainer);
 
 render(<ReactAudioPlayer src="/files/George_Gershwin_playing_Rhapsody_in_Blue.ogg" controls />, appContainer);
 
-function test(rap: ReactAudioPlayer | null ) {
+function test(rap: ReactAudioPlayer | null) {
     render(
         <ReactAudioPlayer
         ref={r => {

--- a/types/react-audio-player/react-audio-player-tests.tsx
+++ b/types/react-audio-player/react-audio-player-tests.tsx
@@ -8,9 +8,9 @@ render(<ReactAudioPlayer />, appContainer);
 
 render(<ReactAudioPlayer src="/files/George_Gershwin_playing_Rhapsody_in_Blue.ogg" controls />, appContainer);
 
-let rap: ReactAudioPlayer | null = null;
-render(
-    <ReactAudioPlayer
+function test(rap: ReactAudioPlayer | null ) {
+    render(
+        <ReactAudioPlayer
         ref={r => {
             rap = r;
         }}
@@ -20,13 +20,14 @@ render(
         onError={() => {}}
         title="Fur Elise"
         volume={10}
-    />,
-    appContainer,
-);
+            />,
+        appContainer,
+    );
 
-if (rap !== null) {
-    rap!.clearListenTrack();
-    rap!.setListenTrack();
-    rap!.updateVolume(5);
-    rap!.audioEl.pause();
+    if (rap !== null) {
+        rap.clearListenTrack();
+        rap.setListenTrack();
+        rap.updateVolume(5);
+        rap.audioEl.pause();
+    }
 }


### PR DESCRIPTION
Smarter control flow meant the compiler caught some vacuous code in the tests. I made it work as originally intended.