### PR TITLE
Simplify mithril types

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://mithril.js.org/, https://github.com/mithriljs/mithril.js
 // Definitions by: Mike Linkovich <https://github.com/spacejack>, Isiah Meadows <https://github.com/isiahmeadows>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
 
 /** Renders a vnode structure into a DOM element. */
 declare function render(el: Element, vnodes: Mithril.Children): void;
@@ -36,8 +35,6 @@ declare namespace Mithril {
         onbeforeupdate?(this: State, vnode: Vnode<Attrs, State>, old: VnodeDOM<Attrs, State>): boolean | void;
         /** The onupdate hook is called after a DOM element is updated, while attached to the document. */
         onupdate?(this: State, vnode: VnodeDOM<Attrs, State>): any;
-        /** WORKAROUND: TypeScript 2.4 does not allow extending an interface with all-optional properties. */
-        [_: number]: any;
     }
 
     interface Hyperscript {
@@ -204,7 +201,7 @@ declare namespace Mithril {
     type ChildArrayOrPrimitive = ChildArray | string | number | boolean;
 
     /** Virtual DOM nodes, or vnodes, are Javascript objects that represent an element (or parts of the DOM). */
-    interface Vnode<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> {
+    interface Vnode<Attrs = {}, State = {}> {
         /** The nodeName of a DOM element. It may also be the string [ if a vnode is a fragment, # if it's a text vnode, or < if it's a trusted HTML vnode. Additionally, it may be a component. */
         tag: string | ComponentTypes<Attrs, State>;
         /** A hashmap of DOM attributes, events, properties and lifecycle methods. */
@@ -241,7 +238,7 @@ declare namespace Mithril {
      * Any Javascript object that has a view method can be used as a Mithril component.
      * Components can be consumed via the m() utility.
      */
-    interface Component<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> extends Lifecycle<Attrs, State> {
+    interface Component<Attrs = {}, State = {}> extends Lifecycle<Attrs, State> {
         /** Creates a view out of virtual elements. */
         view(this: State, vnode: Vnode<Attrs, State>): Children | null | void;
     }
@@ -286,7 +283,7 @@ declare namespace Mithril {
      * Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse.
      * Any Javascript object that has a view method is a Mithril component. Components can be consumed via the m() utility.
      */
-    type Comp<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> = Component<Attrs, State> & State;
+    type Comp<Attrs = {}, State = {}> = Component<Attrs, State> & State;
 
     /** Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse. Components can be consumed via the m() utility. */
     type ComponentTypes<A = {}, S extends Lifecycle<A, S> = {}> =


### PR DESCRIPTION
A workaround in Lifecycle for Typescript 2.4 is no longer needed, which means that a lot of unneeded (and possibly incorrect) constraints on type parameters can be removed.

This makes mithril compile with Typescript 4.3, which now disallows the constraints on type parameters.
