### PR TITLE
jsonwebtoken: Add complete flag to decode options

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -206,6 +206,5 @@ export function verify(
  * [options] - Options for decoding
  * returns - The decoded Token
  */
-
 export function decode(token: string, options: DecodeOptions & { json: true } | DecodeOptions & { complete: true }): null | { [key: string]: any };
 export function decode(token: string, options?: DecodeOptions): null | { [key: string]: any } | string;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -206,5 +206,6 @@ export function verify(
  * [options] - Options for decoding
  * returns - The decoded Token
  */
-export function decode(token: string, options: DecodeOptions & { json: true }): null | { [key: string]: any };
+
+export function decode(token: string, options: DecodeOptions & { json: true } | DecodeOptions & { complete: true }): null | { [key: string]: any };
 export function decode(token: string, options?: DecodeOptions): null | { [key: string]: any } | string;

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -163,3 +163,9 @@ if (decoded) {
     // $ExpectType { [key: string]: any; }
     decoded;
 }
+
+decoded = jwt.decode(token, { complete: true });
+if (decoded) {
+  // $ExpectType { [key: string]: any; }
+  decoded;
+}


### PR DESCRIPTION
The complete flag in the decode function jsonwebtoken modifies the response object, this change reflects that:

https://github.com/auth0/node-jsonwebtoken/blob/master/decode.js#L22

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
