### PR TITLE
Update lodash test types for 4.3

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5270,7 +5270,7 @@ fp.now(); // $ExpectType number
 
     fp.get(Symbol.iterator, []); // $ExpectType any || () => IterableIterator<never>
     fp.get(Symbol.iterator)([]); // $ExpectType any || () => IterableIterator<never>
-    fp.get([Symbol.iterator], []); // $ExpectType any
+    fp.get([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never>
     fp.get(1)("abc"); // $ExpectType string
     fp.get("1")("abc"); // $ExpectType any
     fp.get("a", { a: { b: true } }); // $ExpectType { b: boolean; }


### PR DESCRIPTION
Inference from well-known symbols is better in TS 4.3, so update the tests to reflect that.