### PR TITLE
feat(leaflet-freedraw): add types for the window.FreeDraw constructor

### DIFF
--- a/types/leaflet-freedraw/index.d.ts
+++ b/types/leaflet-freedraw/index.d.ts
@@ -8,7 +8,7 @@ import { FeatureGroup, LatLng, Polygon, LeafletEvent } from 'leaflet';
 export as namespace LeafletFreeDraw;
 
 /**
- * Deactivate Freedraw
+ * Deactivate FreeDraw
  */
 export const NONE: number;
 
@@ -43,29 +43,32 @@ export const EDIT_APPEND: number;
 export const ALL: number;
 
 /**
- * Initialize a new Freedraw instance
- * @param options Freedraw option for the new instance
+ * Initialize a new FreeDraw instance
+ * @param options FreeDraw option for the new instance
  */
 export function freeDraw(options?: FreeDrawOptions): FreeDraw;
 
 /**
- * Freedraw class
+ * FreeDraw class
  */
 declare class FreeDraw extends FeatureGroup {
     /**
-     * Instanciate a new FreeDraw instance, don't forget to add it to leaflet with addLayer
+     * Instantiate a new FreeDraw instance, don't forget to add it to leaflet with addLayer
      * @param options Instance options
      */
     constructor(options?: FreeDrawOptions);
 
     /**
      *
-     * @param latlngs Premade polygon to add to the map
+     * @param latlngs Pre-made polygon to add to the map
      * @param [options={concavePolgygons: false}] FreeDraw options, by default concavePolygons : false
      * @returns Polygon added to the FreeDraw instance
      */
     create(latlngs: ReadonlyArray<LatLng>, options?: FreeDrawOptions): Polygon;
 
+    /**
+     * Removes the layer from the map it is currently active on.
+     */
     remove(): this;
 
     /**
@@ -91,7 +94,7 @@ declare class FreeDraw extends FeatureGroup {
     cancel(): void;
 
     /**
-     * Returns the current ammount of polygons stored in FreeDraw
+     * Returns the current amount of polygons stored in FreeDraw
      */
     size(): number;
 
@@ -103,6 +106,9 @@ declare class FreeDraw extends FeatureGroup {
 
 export default FreeDraw;
 
+/**
+ * Option object accepted by the FreeDraw constructor
+ */
 export interface FreeDrawOptions {
     /**
      * Modifies the default mode.
@@ -165,6 +171,9 @@ export interface FreeDrawOptions {
     strokeWidth?: number;
 }
 
+/**
+ * Event payload sent by markers
+ */
 export interface MarkerEvent extends LeafletEvent {
     type: 'markers';
 
@@ -174,6 +183,9 @@ export interface MarkerEvent extends LeafletEvent {
     latLngs: LatLng[][];
 }
 
+/**
+ * Handler type for the "markers" event
+ */
 export type MarkerEventHandler = (event: MarkerEvent) => void;
 
 declare module "leaflet" {
@@ -192,17 +204,47 @@ type localNone = typeof NONE;
 type localAll = typeof ALL;
 
 declare namespace FreeDraw {
+    /**
+     * Create polygons
+     */
     const CREATE: localCreate;
+
+    /**
+     * Edit existing polygons
+     */
     const EDIT: localEdit;
+
+    /**
+     * Delete polygons
+     */
     const DELETE: localDelete;
+
+    /**
+     * Append points to an existing polygon
+     */
     const APPEND: localAppend;
+
+    /**
+     * Edit polygons and can append new points to an existing polygon
+     */
     const EDIT_APPEND: localEditAppend;
+
+    /**
+     * Deactivate FreeDraw
+     */
     const NONE: localNone;
+
+    /**
+     * Create edit delete and append polygons
+     */
     const ALL: localAll;
 }
 
 declare global {
     interface Window {
+        /**
+         * FreeDraw class
+         */
         FreeDraw: typeof FreeDraw;
     }
 }

--- a/types/leaflet-freedraw/index.d.ts
+++ b/types/leaflet-freedraw/index.d.ts
@@ -191,7 +191,7 @@ type localEditAppend = typeof EDIT_APPEND;
 type localNone = typeof NONE;
 type localAll = typeof ALL;
 
-declare namespace GlobalFreeDraw {
+declare namespace FreeDraw {
     const CREATE: localCreate;
     const EDIT: localEdit;
     const DELETE: localDelete;
@@ -203,6 +203,6 @@ declare namespace GlobalFreeDraw {
 
 declare global {
     interface Window {
-        FreeDraw: typeof FreeDraw & typeof GlobalFreeDraw;
+        FreeDraw: typeof FreeDraw;
     }
 }

--- a/types/leaflet-freedraw/index.d.ts
+++ b/types/leaflet-freedraw/index.d.ts
@@ -182,3 +182,27 @@ declare module "leaflet" {
         off(type: 'markers', fn?: MarkerEventHandler, context?: any): this;
     }
 }
+
+type localCreate = typeof CREATE;
+type localEdit = typeof EDIT;
+type localDelete = typeof DELETE;
+type localAppend = typeof APPEND;
+type localEditAppend = typeof EDIT_APPEND;
+type localNone = typeof NONE;
+type localAll = typeof ALL;
+
+declare namespace GlobalFreeDraw {
+    const CREATE: localCreate;
+    const EDIT: localEdit;
+    const DELETE: localDelete;
+    const APPEND: localAppend;
+    const EDIT_APPEND: localEditAppend;
+    const NONE: localNone;
+    const ALL: localAll;
+}
+
+declare global {
+    interface Window {
+        FreeDraw: typeof FreeDraw & typeof GlobalFreeDraw;
+    }
+}

--- a/types/leaflet-freedraw/leaflet-freedraw-tests.ts
+++ b/types/leaflet-freedraw/leaflet-freedraw-tests.ts
@@ -26,8 +26,3 @@ const freeDraw2 = new windowFreeDraw({
     mode: windowFreeDraw.CREATE | windowFreeDraw.DELETE
 });
 map.addLayer(freeDraw2);
-
-/* FreeDraw only augment itself with the constant if the window object exist,
- * so the constant are seggregated to the window.FreeDraw object */
-// $ExpectError
-const nonExistingNone = FreeDraw.NONE;

--- a/types/leaflet-freedraw/leaflet-freedraw-tests.ts
+++ b/types/leaflet-freedraw/leaflet-freedraw-tests.ts
@@ -1,5 +1,5 @@
 import { Map } from 'leaflet';
-import FreeDraw, { CREATE, EDIT } from 'leaflet-freedraw';
+import FreeDraw, { CREATE, DELETE, EDIT } from 'leaflet-freedraw';
 
 const mapNode = document.getElementById('foo')!;
 const map = new Map(mapNode);
@@ -20,3 +20,14 @@ document.addEventListener('keydown', event => {
 });
 
 freeDraw.off('markers');
+
+const windowFreeDraw = window.FreeDraw;
+const freeDraw2 = new windowFreeDraw({
+    mode: windowFreeDraw.CREATE | windowFreeDraw.DELETE
+});
+map.addLayer(freeDraw2);
+
+/* FreeDraw only augment itself with the constant if the window object exist,
+ * so the constant are seggregated to the window.FreeDraw object */
+// $ExpectError
+const nonExistingNone = FreeDraw.NONE;

--- a/types/leaflet-freedraw/leaflet-freedraw-tests.ts
+++ b/types/leaflet-freedraw/leaflet-freedraw-tests.ts
@@ -1,5 +1,5 @@
 import { Map } from 'leaflet';
-import FreeDraw, { CREATE, DELETE, EDIT } from 'leaflet-freedraw';
+import FreeDraw, { CREATE, EDIT } from 'leaflet-freedraw';
 
 const mapNode = document.getElementById('foo')!;
 const map = new Map(mapNode);


### PR DESCRIPTION
The window.FreeDraw object is only initialized when window isn't undefined. So I augmented the
global Window interface. Also since this is a conditional behaviour while the library does add the
mode constants to its constructor, I only added those constant when accessing FreeDraw from
window.FreeDraw.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Wildhoney/Leaflet.FreeDraw/blob/master/src/FreeDraw.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.