### PR TITLE
update(css-minimizer-webpack-plugin): v1.3 and new options

### DIFF
--- a/types/css-minimizer-webpack-plugin/css-minimizer-webpack-plugin-tests.ts
+++ b/types/css-minimizer-webpack-plugin/css-minimizer-webpack-plugin-tests.ts
@@ -1,4 +1,4 @@
-import CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+import CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
 module.exports = {
     optimization: {
@@ -12,16 +12,21 @@ module.exports = {
                 exclude: /\/excludes/,
                 cache: true,
                 cacheKeys: (defaultCacheKeys, file) => {
-                    defaultCacheKeys.myCacheKey = 'myCacheKeyValue';
+                    defaultCacheKeys.myCacheKey = "myCacheKeyValue";
                     return defaultCacheKeys;
                 },
                 minimizerOptions: {
                     preset: [
-                        'default',
+                        "default",
                         {
                             discardComments: { removeAll: true },
                         },
                     ],
+                    processorOptions: {
+                        parser: "parser",
+                        stringifier: "parse",
+                        syntax: "syntax",
+                    },
                 },
                 parallel: true,
                 sourceMap: {

--- a/types/css-minimizer-webpack-plugin/index.d.ts
+++ b/types/css-minimizer-webpack-plugin/index.d.ts
@@ -1,13 +1,13 @@
-// Type definitions for css-minimizer-webpack-plugin 1.1
+// Type definitions for css-minimizer-webpack-plugin 1.3
 // Project: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
-import { Compiler, WebpackPluginInstance } from 'webpack';
-import { CssNanoOptions } from 'cssnano';
-import { SourceMapOptions } from 'postcss';
+import { Compiler } from "webpack";
+import { CssNanoOptions } from "cssnano";
+import { ProcessOptions, SourceMapOptions } from "postcss";
 
-declare class CssMinimizerPlugin implements WebpackPluginInstance {
+declare class CssMinimizerPlugin {
     constructor(options?: CssMinimizerPlugin.Options);
 
     /**
@@ -18,7 +18,16 @@ declare class CssMinimizerPlugin implements WebpackPluginInstance {
 
 declare namespace CssMinimizerPlugin {
     interface Options {
-        minimizerOptions?: CssNanoOptions;
+        minimizerOptions?: CssNanoOptions & {
+            processorOptions?: {
+                from?: ProcessOptions["from"];
+                map?: ProcessOptions["map"];
+                parser?: ProcessOptions["parser"] | string;
+                stringifier?: ProcessOptions["stringifier"] | string;
+                syntax?: ProcessOptions["syntax"] | string;
+                to?: ProcessOptions["to"];
+            };
+        };
         /**
          * Test to match files against.
          */
@@ -68,8 +77,8 @@ declare namespace CssMinimizerPlugin {
      */
     interface DefaultCacheKeys {
         cssMinimizer: string;
-        'css-minimizer-webpack-plugin': string;
-        'css-minimizer-webpack-plugin-options': string;
+        "css-minimizer-webpack-plugin": string;
+        "css-minimizer-webpack-plugin-options": string;
         path: string;
         hash: string;
     }

--- a/types/css-minimizer-webpack-plugin/package.json
+++ b/types/css-minimizer-webpack-plugin/package.json
@@ -1,6 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "^7.0.32"
+        "postcss": "^7.0.32",
+        "tapable": "^2.2.0",
+        "webpack": "^5.25.0"
     }
 }


### PR DESCRIPTION
- `processorOptions` for `cssnano`
- webpack 5 dependency (though it should probalby work with v4 of types)
- dependencies updated according to 1.3 version
- version bump
- tests amended

https://github.com/webpack-contrib/css-minimizer-webpack-plugin/commit/886542375dc37411e271d151b7060be574fc5898

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.