### PR TITLE
Update linkify-it for 4.3

### DIFF
--- a/types/linkify-it/index.d.ts
+++ b/types/linkify-it/index.d.ts
@@ -48,7 +48,11 @@ declare namespace LinkifyIt {
     }
 
     interface LinkifyIt {
-        add(schema: string, rule: Rule | null): LinkifyIt;
+        // Use overloads to provide contextual typing to `FullRule.normalize`, which is ambiguous with string.normalize
+        // This appears unneeded to the unified-signatures lint rule.
+        add(schema: string, rule: string): LinkifyIt;
+        // tslint:disable-next-line: unified-signatures
+        add(schema: string, rule: FullRule | null): LinkifyIt;
         match(text: string): Match[] | null;
         normalize(raw: string): string;
         pretest(text: string): boolean;


### PR DESCRIPTION
`FullRule.normalize` is ambiguous with `string.normalize` in the second parameter of `LinkifyIt.add`. Previously, Typescript would still provide contextual typing for `normalize` in cases like:

```ts
linkifier.add("skype:", {
    validate: (text, pos, self) => {
        return 42;
    },
    normalize: match => {
        match.url = "forty-two";
    }
});
```

However, starting in 4.3, Typescript is stricter and considers both signatures from `string.normalize` and `FullRule.normalize`, which are too different to provide a single contextual type. This PR works around the change by splitting add into two overloads. The stricter one, for string, comes first.
