### PR TITLE
Update es-abstract tests for 4.3

### DIFF
--- a/types/es-abstract/test/es2015.test.ts
+++ b/types/es-abstract/test/es2015.test.ts
@@ -64,7 +64,7 @@ ES2015.Call(iterNext, generable());
 
 // $ExpectType IteratorResult<number, boolean>
 ES2015.Invoke(generable(), 'next', args as IArguments & [string]);
-ES2015.Invoke(generable(), Symbol.iterator, args);
+ES2015.Invoke(generable(), Symbol.iterator, args as IArguments & []);
 
 // $ExpectType boolean
 ES2015.Invoke(Reflect, 'has', args as IArguments & [object, PropertyKey]);


### PR DESCRIPTION
Typescript is better at handling symbols now, so the test needs to add a cast to the correct type, same as the string test on the line above.

