### PR TITLE
update d3-chord tests for TS 4.3

### DIFF
--- a/types/d3-chord/d3-chord-tests.ts
+++ b/types/d3-chord/d3-chord-tests.ts
@@ -141,7 +141,7 @@ subgroupAccessor = svgRibbon.target();
 canvasRibbon = canvasRibbon.radius(30);
 
 svgRibbon = svgRibbon.radius(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     console.log('Subgroup startAngle', d.startAngle); // datum is of type Chord
     return 30;
 });
@@ -153,7 +153,7 @@ numAccessor = svgRibbon.radius();
 canvasRibbon = canvasRibbon.sourceRadius(30);
 
 svgRibbon = svgRibbon.sourceRadius(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     console.log('Subgroup startAngle', d.startAngle); // datum is of type Chord
     return 30;
 });
@@ -165,7 +165,7 @@ numAccessor = svgRibbon.sourceRadius();
 canvasRibbon = canvasRibbon.targetRadius(30);
 
 svgRibbon = svgRibbon.targetRadius(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     console.log('Subgroup startAngle', d.startAngle); // datum is of type Chord
     return 30;
 });
@@ -177,7 +177,7 @@ numAccessor = svgRibbon.targetRadius();
 canvasRibbon = canvasRibbon.startAngle(0);
 
 svgRibbon = svgRibbon.startAngle(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     return d.startAngle; // datum is of type ChordSubgroup
 });
 
@@ -188,7 +188,7 @@ numAccessor = svgRibbon.startAngle();
 canvasRibbon = canvasRibbon.endAngle(Math.PI);
 
 svgRibbon = svgRibbon.endAngle(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     return d.endAngle; // datum is of type ChordSubgroup
 });
 
@@ -199,7 +199,7 @@ numAccessor = svgRibbon.endAngle();
 canvasRibbon = canvasRibbon.padAngle(Math.PI);
 
 svgRibbon = svgRibbon.padAngle(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     return d.endAngle; // datum is of type ChordSubgroup
 });
 

--- a/types/d3-chord/v1/d3-chord-tests.ts
+++ b/types/d3-chord/v1/d3-chord-tests.ts
@@ -139,7 +139,7 @@ subgroupAccessor = svgRibbon.target();
 canvasRibbon = canvasRibbon.radius(30);
 
 svgRibbon = svgRibbon.radius(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     console.log('Subgroup startAngle', d.startAngle); // datum is of type Chord
     return 30;
 });
@@ -151,7 +151,7 @@ numAccessor = svgRibbon.radius();
 canvasRibbon = canvasRibbon.startAngle(0);
 
 svgRibbon = svgRibbon.startAngle(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     return d.startAngle; // datum is of type ChordSubgroup
 });
 
@@ -162,7 +162,7 @@ numAccessor = svgRibbon.startAngle();
 canvasRibbon = canvasRibbon.endAngle(Math.PI);
 
 svgRibbon = svgRibbon.endAngle(function(d) {
-    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.createSVGPathSegCurvetoCubicAbs); // this type SVGPathElement
+    console.log('SVGPathElement createSVGPathSegCurvetoCubicAbs method:', this.getTotalLength()); // this type SVGPathElement
     return d.endAngle; // datum is of type ChordSubgroup
 });
 


### PR DESCRIPTION
Switch to still-defined properties of SVGPathElement, since TS 4.3 removes some deprecated ones.