### PR TITLE
Update definition owners for countryjs and add type declarations for country-emoji

### DIFF
--- a/types/country-emoji/country-emoji-tests.ts
+++ b/types/country-emoji/country-emoji-tests.ts
@@ -1,0 +1,15 @@
+import { flag, code, name, countries } from "country-emoji";
+
+flag("PT")!; // $ExpectType string
+flag("Portugal")!; // $ExpectType string
+flag("🇵🇹"); // $ExpectType string | undefined
+
+code("PT"); // $ExpectType string | undefined
+code("Portugal")!; // $ExpectType string
+code("🇵🇹")!; // $ExpectType string
+
+name("PT")!; // $ExpectType string
+name("Portugal"); // $ExpectType string | undefined
+name("🇵🇹")!; // $ExpectType string
+
+countries; // $ExpectType { [key: string]: [string, string]; }

--- a/types/country-emoji/index.d.ts
+++ b/types/country-emoji/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for country-emoji 1.5
+// Project: https://github.com/meeDamian/country-emoji#readme
+// Definitions by: ImRodry <https://github.com/ImRodry>
+//                 marzeq <https://github.com/marzeq>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Returns the flag emoji of a country.
+ *
+ * @param input - Country code or name.
+ * @returns The flag emoji of the country if the provided input is valid.
+ *
+ */
+export function flag(input: string): string | undefined;
+
+/**
+ * Returns the code of a country.
+ *
+ * @param input - Flag emoji or name.
+ * @returns The code of the country if the input is valid.
+ *
+ */
+export function code(input: string): string | undefined;
+
+/**
+ * Returns the name of a country.
+ *
+ * @param input - Flag emoji or county code.
+ * @returns The name of the country if the input is valid.
+ *
+ */
+export function name(input: string): string | undefined;
+
+/**
+ * Object that contains every single countries' name and language name.
+ *
+ * @example {"BG": ["Bulgaria", "Bulgarian"]}; countries["BG"] would be ["Bulgaria", "Bulgarian"]
+ *
+ */
+export const countries: {
+    [key: string]: [string, string];
+};

--- a/types/country-emoji/index.d.ts
+++ b/types/country-emoji/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for country-emoji 1.5
 // Project: https://github.com/meeDamian/country-emoji#readme
-// Definitions by: ImRodry <https://github.com/ImRodry>
+// Definitions by: Rodry <https://github.com/ImRodry>
 //                 marzeq <https://github.com/marzeq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/country-emoji/tsconfig.json
+++ b/types/country-emoji/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "country-emoji-tests.ts"
+    ]
+}

--- a/types/country-emoji/tslint.json
+++ b/types/country-emoji/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/countryjs/index.d.ts
+++ b/types/countryjs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for countryjs 1.8
 // Project: https://github.com/therebelrobot/countryjs
-// Definitions by: ImRodry <https://github.com/DefinitelyTyped>
+// Definitions by: ImRodry <https://github.com/ImRodry>
+//                 marzeq <https://github.com/marzeq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Country {

--- a/types/countryjs/index.d.ts
+++ b/types/countryjs/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for countryjs 1.8
 // Project: https://github.com/therebelrobot/countryjs
-// Definitions by: ImRodry <https://github.com/ImRodry>
+// Definitions by: Rodry <https://github.com/ImRodry>
 //                 marzeq <https://github.com/marzeq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

In this PR I added definition owners for my previous package countryjs and added type declarations for country-emoji.
country-emoji had its own type declarations added in v1.5.5, however, these were not uploaded to npm so I'm adding this to fix that and will remove it if the issue is ever fixed.