### PR TITLE
[auth0-js] add implicit userMetadata property to signupAndLogin method

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -216,7 +216,7 @@ webAuth.popup.signupAndLogin({ email: "", password: "", connection: "" }, (err, 
     // do something with data
 });
 
-webAuth.redirect.signupAndLogin({ 
+webAuth.redirect.signupAndLogin({
     email: "",
     password: "",
     connection: "",

--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -211,7 +211,14 @@ webAuth.popup.passwordlessVerify({ type: "sms", phoneNumber: "", connection: "",
     if (err) /* handle error */ return;
     // do something with data
 });
-webAuth.popup.signupAndLogin({ email: "", password: "", connection: "" }, (err, data) => {
+webAuth.popup.signupAndLogin({ 
+    email: "",
+    password: "",
+    connection: "",
+    userMetadata: {
+        foo: 'bar'
+    }
+}, (err, data) => {
     if (err) /* handle error */ return;
     // do something with data
 });

--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -211,7 +211,12 @@ webAuth.popup.passwordlessVerify({ type: "sms", phoneNumber: "", connection: "",
     if (err) /* handle error */ return;
     // do something with data
 });
-webAuth.popup.signupAndLogin({ 
+webAuth.popup.signupAndLogin({ email: "", password: "", connection: "" }, (err, data) => {
+    if (err) /* handle error */ return;
+    // do something with data
+});
+
+webAuth.redirect.signupAndLogin({ 
     email: "",
     password: "",
     connection: "",

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -347,6 +347,8 @@ export class Redirect {
             password: string,
             /** name of the connection where the user will be created */
             connection: string,
+            /** allow user_metadata for signup */
+            userMetadata?: DbSignUpOptions
         },
         callback: Auth0Callback<any>,
     ): void;

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -347,7 +347,7 @@ export class Redirect {
             password: string,
             /** name of the connection where the user will be created */
             connection: string,
-            /** allow user_metadata for signup */
+            /** allow userMetadata to be passed to signUp */
             userMetadata?: DbSignUpOptions
         },
         callback: Auth0Callback<any>,

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -348,7 +348,7 @@ export class Redirect {
             /** name of the connection where the user will be created */
             connection: string,
             /** allow userMetadata to be passed to signUp */
-            userMetadata?: DbSignUpOptions
+            userMetadata?: unknown
         },
         callback: Auth0Callback<any>,
     ): void;
@@ -492,7 +492,7 @@ export class Popup {
             /** name of the connection where the user will be created */
             connection: string,
             /** allow userMetadata to be passed to signUp */
-            userMetadata?: DbSignUpOptions
+            userMetadata?: unknown
         },
         callback: Auth0Callback<any>,
     ): void;
@@ -913,7 +913,7 @@ export interface DbSignUpOptions {
     username?: string;
     scope?: string;
     /** additional signup attributes used for creating the user. Will be stored in `user_metadata` */
-    userMetadata?: any;
+    userMetadata?: unknown;
 }
 
 /** result of the signup request */

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -491,6 +491,8 @@ export class Popup {
             password: string,
             /** name of the connection where the user will be created */
             connection: string,
+            /** allow userMetadata to be passed to signUp */
+            userMetadata?: DbSignUpOptions
         },
         callback: Auth0Callback<any>,
     ): void;


### PR DESCRIPTION
Property `userMetadata: unknown` is missing from `signUpAndLogin` function on current type definitions. The userMetadata is an implicit additional option that auth0-js will sent for signup as in https://auth0.github.io/auth0.js/global.html#signup.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.github.io/auth0.js/global.html#signup

