### PR TITLE
[Atom] Fix ConfigValues extensibility

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -400,6 +400,82 @@ function testConfig() {
     atom.config.transact(() => {});
 }
 
+declare function isNotAny<T>(x: T): T extends never ? null : true;
+declare function isTrue(x: true): void;
+// emulate some ambient declarations
+// NOTE: this is copy-pasted from autocomplete-plus/config.d.ts
+declare module 'atom' {
+    interface ConfigValues {
+        /**
+         *  Suggestions will show as you type if this preference is enabled. If it is
+         *  disabled, you can still see suggestions by using the keymapping for
+         *  'autocomplete-plus:activate' (shown below).
+         */
+        'autocomplete-plus.enableAutoActivation': boolean;
+    }
+}
+
+function testConfigValues() {
+    // test main ambient ConfigValues declarations
+    isTrue(isNotAny(atom.config.get('core.ignoredNames')));
+    isTrue(isNotAny(atom.config.get('core.ignoredNames')));
+    isTrue(isNotAny(atom.config.get('core.excludeVcsIgnoredPaths')));
+    isTrue(isNotAny(atom.config.get('core.followSymlinks')));
+    isTrue(isNotAny(atom.config.get('core.disabledPackages')));
+    isTrue(isNotAny(atom.config.get('core.versionPinnedPackages')));
+    isTrue(isNotAny(atom.config.get('core.customFileTypes')));
+    isTrue(isNotAny(atom.config.get('core.themes')));
+    isTrue(isNotAny(atom.config.get('core.audioBeep')));
+    isTrue(isNotAny(atom.config.get('core.closeDeletedFileTabs')));
+    isTrue(isNotAny(atom.config.get('core.destroyEmptyPanes')));
+    isTrue(isNotAny(atom.config.get('core.closeEmptyWindows')));
+    isTrue(isNotAny(atom.config.get('core.fileEncoding')));
+    isTrue(isNotAny(atom.config.get('core.openEmptyEditorOnStart')));
+    isTrue(isNotAny(atom.config.get('core.restorePreviousWindowsOnStart')));
+    isTrue(isNotAny(atom.config.get('core.reopenProjectMenuCount')));
+    isTrue(isNotAny(atom.config.get('core.automaticallyUpdate')));
+    isTrue(isNotAny(atom.config.get('core.useProxySettingsWhenCallingApm')));
+    isTrue(isNotAny(atom.config.get('core.allowPendingPaneItems')));
+    isTrue(isNotAny(atom.config.get('core.telemetryConsent')));
+    isTrue(isNotAny(atom.config.get('core.warnOnLargeFileLimit')));
+    isTrue(isNotAny(atom.config.get('core.fileSystemWatcher')));
+    isTrue(isNotAny(atom.config.get('core.useTreeSitterParsers')));
+    isTrue(isNotAny(atom.config.get('core.colorProfile')));
+    isTrue(isNotAny(atom.config.get('editor.commentStart')));
+    isTrue(isNotAny(atom.config.get('editor.commentEnd')));
+    isTrue(isNotAny(atom.config.get('editor.increaseIndentPattern')));
+    isTrue(isNotAny(atom.config.get('editor.decreaseIndentPattern')));
+    isTrue(isNotAny(atom.config.get('editor.foldEndPattern')));
+    isTrue(isNotAny(atom.config.get('editor.fontFamily')));
+    isTrue(isNotAny(atom.config.get('editor.fontSize')));
+    isTrue(isNotAny(atom.config.get('editor.lineHeight')));
+    isTrue(isNotAny(atom.config.get('editor.showCursorOnSelection')));
+    isTrue(isNotAny(atom.config.get('editor.showInvisibles')));
+    isTrue(isNotAny(atom.config.get('editor.showIndentGuide')));
+    isTrue(isNotAny(atom.config.get('editor.showLineNumbers')));
+    isTrue(isNotAny(atom.config.get('editor.atomicSoftTabs')));
+    isTrue(isNotAny(atom.config.get('editor.autoIndent')));
+    isTrue(isNotAny(atom.config.get('editor.autoIndentOnPaste')));
+    isTrue(isNotAny(atom.config.get('editor.nonWordCharacters')));
+    isTrue(isNotAny(atom.config.get('editor.preferredLineLength')));
+    isTrue(isNotAny(atom.config.get('editor.maxScreenLineLength')));
+    isTrue(isNotAny(atom.config.get('editor.tabLength')));
+    isTrue(isNotAny(atom.config.get('editor.softWrap')));
+    isTrue(isNotAny(atom.config.get('editor.softTabs')));
+    isTrue(isNotAny(atom.config.get('editor.tabType')));
+    isTrue(isNotAny(atom.config.get('editor.softWrapAtPreferredLineLength')));
+    isTrue(isNotAny(atom.config.get('editor.softWrapHangingIndent')));
+    isTrue(isNotAny(atom.config.get('editor.scrollSensitivity')));
+    isTrue(isNotAny(atom.config.get('editor.scrollPastEnd')));
+    isTrue(isNotAny(atom.config.get('editor.undoGroupingInterval')));
+    isTrue(isNotAny(atom.config.get('editor.confirmCheckoutHeadRevision')));
+    isTrue(isNotAny(atom.config.get('editor.invisibles')));
+    isTrue(isNotAny(atom.config.get('editor.zoomFontWhenCtrlScrolling')));
+
+    // test extended ambient ConfigValue declarations
+    isTrue(isNotAny(atom.config.get('autocomplete-plus.enableAutoActivation')));
+}
+
 // Cursor =====================================================================
 function testCursor() {
     // Event Subscription

--- a/types/atom/autocomplete-plus/config.d.ts
+++ b/types/atom/autocomplete-plus/config.d.ts
@@ -1,5 +1,7 @@
 import '../index';
 
+// NOTE: intentional; needed for config extensibility
+// tslint:disable-next-line:no-declare-current-package
 declare module 'atom' {
     interface ConfigValues {
         /**

--- a/types/atom/src/config-schema.d.ts
+++ b/types/atom/src/config-schema.d.ts
@@ -7,253 +7,262 @@ import { FileEncoding, Invisibles } from '../index';
  *  pairings merged into this interface will result in configuration values under
  *  the value of each key being templated by the type of the associated value.
  */
+// tslint:disable-next-line:no-empty-interface
 export interface ConfigValues {
-    /**
-     *  List of glob patterns. Files and directories matching these patterns will be
-     *  ignored by some packages, such as the fuzzy finder and tree view. Individual
-     *  packages might have additional config settings for ignoring names.
-     */
-    'core.ignoredNames': string[];
+    // NOTE: this is intentionally left empty, extended via ambient declarations
+}
 
-    /**
-     *  Files and directories ignored by the current project's VCS system will be ignored
-     *  by some packages, such as the fuzzy finder and find and replace. For example,
-     *  projects using Git have these paths defined in the .gitignore file. Individual
-     *  packages might have additional config settings for ignoring VCS ignored files and
-     *  folders.
-     */
-    'core.excludeVcsIgnoredPaths': boolean;
+// NOTE: A hack to make ConfigValues extensible
+// tslint:disable-next-line:no-declare-current-package
+declare module 'atom' {
+    interface ConfigValues {
+        /**
+         *  List of glob patterns. Files and directories matching these patterns will be
+         *  ignored by some packages, such as the fuzzy finder and tree view. Individual
+         *  packages might have additional config settings for ignoring names.
+         */
+        'core.ignoredNames': string[];
 
-    /**
-     *  Follow symbolic links when searching files and when opening files with the fuzzy
-     *  finder.
-     */
-    'core.followSymlinks': boolean;
+        /**
+         *  Files and directories ignored by the current project's VCS system will be ignored
+         *  by some packages, such as the fuzzy finder and find and replace. For example,
+         *  projects using Git have these paths defined in the .gitignore file. Individual
+         *  packages might have additional config settings for ignoring VCS ignored files and
+         *  folders.
+         */
+        'core.excludeVcsIgnoredPaths': boolean;
 
-    /** List of names of installed packages which are not loaded at startup. */
-    'core.disabledPackages': string[];
+        /**
+         *  Follow symbolic links when searching files and when opening files with the fuzzy
+         *  finder.
+         */
+        'core.followSymlinks': boolean;
 
-    /** List of names of installed packages which are not automatically updated. */
-    'core.versionPinnedPackages': string[];
+        /** List of names of installed packages which are not loaded at startup. */
+        'core.disabledPackages': string[];
 
-    /**
-     *  Associates scope names (e.g. "source.coffee") with arrays of file extensions
-     *  and file names (e.g. ["Cakefile", ".coffee2"]).
-     */
-    'core.customFileTypes': {
-        [key: string]: string[];
-    };
+        /** List of names of installed packages which are not automatically updated. */
+        'core.versionPinnedPackages': string[];
 
-    /** Names of UI and syntax themes which will be used when Atom starts. */
-    'core.themes': string[];
+        /**
+         *  Associates scope names (e.g. "source.coffee") with arrays of file extensions
+         *  and file names (e.g. ["Cakefile", ".coffee2"]).
+         */
+        'core.customFileTypes': {
+            [key: string]: string[];
+        };
 
-    /**
-     *  Trigger the system's beep sound when certain actions cannot be executed or
-     *  there are no results.
-     */
-    'core.audioBeep': boolean;
+        /** Names of UI and syntax themes which will be used when Atom starts. */
+        'core.themes': string[];
 
-    /** Close corresponding editors when a file is deleted outside Atom. */
-    'core.closeDeletedFileTabs': boolean;
+        /**
+         *  Trigger the system's beep sound when certain actions cannot be executed or
+         *  there are no results.
+         */
+        'core.audioBeep': boolean;
 
-    /** When the last tab of a pane is closed, remove that pane as well. */
-    'core.destroyEmptyPanes': boolean;
+        /** Close corresponding editors when a file is deleted outside Atom. */
+        'core.closeDeletedFileTabs': boolean;
 
-    /**
-     *  When a window with no open tabs or panes is given the 'Close Tab' command,
-     *  close that window.
-     */
-    'core.closeEmptyWindows': boolean;
+        /** When the last tab of a pane is closed, remove that pane as well. */
+        'core.destroyEmptyPanes': boolean;
 
-    /** Default character set encoding to use when reading and writing files. */
-    'core.fileEncoding': FileEncoding;
+        /**
+         *  When a window with no open tabs or panes is given the 'Close Tab' command,
+         *  close that window.
+         */
+        'core.closeEmptyWindows': boolean;
 
-    /**
-     *  When checked opens an untitled editor when loading a blank environment (such as
-     *  with 'File > New Window' or when "Restore Previous Windows On Start" is unchecked);
-     *  otherwise, no editor is opened when loading a blank environment.
-     *  This setting has no effect when restoring a previous state.
-     */
-    'core.openEmptyEditorOnStart': boolean;
+        /** Default character set encoding to use when reading and writing files. */
+        'core.fileEncoding': FileEncoding;
 
-    /**
-     *  When selected 'no', a blank environment is loaded. When selected 'yes' and Atom
-     *  is started from the icon or `atom` by itself from the command line, restores the
-     *  last state of all Atom windows; otherwise a blank environment is loaded. When
-     *  selected 'always', restores the last state of all Atom windows always, no matter
-     *  how Atom is started.
-     */
-    'core.restorePreviousWindowsOnStart': 'no' | 'yes' | 'always';
+        /**
+         *  When checked opens an untitled editor when loading a blank environment (such as
+         *  with 'File > New Window' or when "Restore Previous Windows On Start" is unchecked);
+         *  otherwise, no editor is opened when loading a blank environment.
+         *  This setting has no effect when restoring a previous state.
+         */
+        'core.openEmptyEditorOnStart': boolean;
 
-    /** How many recent projects to show in the Reopen Project menu. */
-    'core.reopenProjectMenuCount': number;
+        /**
+         *  When selected 'no', a blank environment is loaded. When selected 'yes' and Atom
+         *  is started from the icon or `atom` by itself from the command line, restores the
+         *  last state of all Atom windows; otherwise a blank environment is loaded. When
+         *  selected 'always', restores the last state of all Atom windows always, no matter
+         *  how Atom is started.
+         */
+        'core.restorePreviousWindowsOnStart': 'no' | 'yes' | 'always';
 
-    /** Automatically update Atom when a new release is available. */
-    'core.automaticallyUpdate': boolean;
+        /** How many recent projects to show in the Reopen Project menu. */
+        'core.reopenProjectMenuCount': number;
 
-    /** Use detected proxy settings when calling the `apm` command-line tool. */
-    'core.useProxySettingsWhenCallingApm': boolean;
+        /** Automatically update Atom when a new release is available. */
+        'core.automaticallyUpdate': boolean;
 
-    /**
-     *  Allow items to be previewed without adding them to a pane permanently, such as
-     *  when single clicking files in the tree view.
-     */
-    'core.allowPendingPaneItems': boolean;
+        /** Use detected proxy settings when calling the `apm` command-line tool. */
+        'core.useProxySettingsWhenCallingApm': boolean;
 
-    /**
-     *  Allow usage statistics and exception reports to be sent to the Atom team to help
-     *  improve the product.
-     */
-    'core.telemetryConsent': 'limited' | 'no' | 'undecided';
+        /**
+         *  Allow items to be previewed without adding them to a pane permanently, such as
+         *  when single clicking files in the tree view.
+         */
+        'core.allowPendingPaneItems': boolean;
 
-    /** Warn before opening files larger than this number of megabytes. */
-    'core.warnOnLargeFileLimit': number;
+        /**
+         *  Allow usage statistics and exception reports to be sent to the Atom team to help
+         *  improve the product.
+         */
+        'core.telemetryConsent': 'limited' | 'no' | 'undecided';
 
-    /**
-     *  Choose the underlying implementation used to watch for filesystem changes. Emulating
-     *  changes will miss any events caused by applications other than Atom, but may help
-     *  prevent crashes or freezes.
-     */
-    'core.fileSystemWatcher': 'native' | 'experimental' | 'poll' | 'atom';
+        /** Warn before opening files larger than this number of megabytes. */
+        'core.warnOnLargeFileLimit': number;
 
-    /** Use the new Tree-sitter parsing system for supported languages. */
-    'core.useTreeSitterParsers': boolean;
+        /**
+         *  Choose the underlying implementation used to watch for filesystem changes. Emulating
+         *  changes will miss any events caused by applications other than Atom, but may help
+         *  prevent crashes or freezes.
+         */
+        'core.fileSystemWatcher': 'native' | 'experimental' | 'poll' | 'atom';
 
-    /**
-     * Specify whether Atom should use the operating system's color profile (recommended)
-     * or an alternative color profile.
-     */
-    'core.colorProfile': 'default' | 'srgb';
+        /** Use the new Tree-sitter parsing system for supported languages. */
+        'core.useTreeSitterParsers': boolean;
 
-    'editor.commentStart': string | null;
+        /**
+         * Specify whether Atom should use the operating system's color profile (recommended)
+         * or an alternative color profile.
+         */
+        'core.colorProfile': 'default' | 'srgb';
 
-    'editor.commentEnd': string | null;
+        'editor.commentStart': string | null;
 
-    'editor.increaseIndentPattern': string | null;
+        'editor.commentEnd': string | null;
 
-    'editor.decreaseIndentPattern': string | null;
+        'editor.increaseIndentPattern': string | null;
 
-    'editor.foldEndPattern': string | null;
+        'editor.decreaseIndentPattern': string | null;
 
-    /** The name of the font family used for editor text. */
-    'editor.fontFamily': string;
+        'editor.foldEndPattern': string | null;
 
-    /** Height in pixels of editor text. */
-    'editor.fontSize': number;
+        /** The name of the font family used for editor text. */
+        'editor.fontFamily': string;
 
-    /** Height of editor lines, as a multiplier of font size. */
-    'editor.lineHeight': string | number;
+        /** Height in pixels of editor text. */
+        'editor.fontSize': number;
 
-    /** Show cursor while there is a selection. */
-    'editor.showCursorOnSelection': boolean;
+        /** Height of editor lines, as a multiplier of font size. */
+        'editor.lineHeight': string | number;
 
-    /** Render placeholders for invisible characters, such as tabs, spaces and newlines. */
-    'editor.showInvisibles': boolean;
+        /** Show cursor while there is a selection. */
+        'editor.showCursorOnSelection': boolean;
 
-    /** Show indentation indicators in the editor. */
-    'editor.showIndentGuide': boolean;
+        /** Render placeholders for invisible characters, such as tabs, spaces and newlines. */
+        'editor.showInvisibles': boolean;
 
-    /** Show line numbers in the editor's gutter. */
-    'editor.showLineNumbers': boolean;
+        /** Show indentation indicators in the editor. */
+        'editor.showIndentGuide': boolean;
 
-    /** Skip over tab-length runs of leading whitespace when moving the cursor. */
-    'editor.atomicSoftTabs': boolean;
+        /** Show line numbers in the editor's gutter. */
+        'editor.showLineNumbers': boolean;
 
-    /** Automatically indent the cursor when inserting a newline. */
-    'editor.autoIndent': boolean;
+        /** Skip over tab-length runs of leading whitespace when moving the cursor. */
+        'editor.atomicSoftTabs': boolean;
 
-    /** Automatically indent pasted text based on the indentation of the previous line. */
-    'editor.autoIndentOnPaste': boolean;
+        /** Automatically indent the cursor when inserting a newline. */
+        'editor.autoIndent': boolean;
 
-    /** A string of non-word characters to define word boundaries. */
-    'editor.nonWordCharacters': string;
+        /** Automatically indent pasted text based on the indentation of the previous line. */
+        'editor.autoIndentOnPaste': boolean;
 
-    /**
-     *  Identifies the length of a line which is used when wrapping text with the
-     *  `Soft Wrap At Preferred Line Length` setting enabled, in number of characters.
-     */
-    'editor.preferredLineLength': number;
+        /** A string of non-word characters to define word boundaries. */
+        'editor.nonWordCharacters': string;
 
-    /**
-     * Defines the maximum width of the editor window before soft wrapping is enforced,
-     * in number of characters.
-     */
-    'editor.maxScreenLineLength': number;
+        /**
+         *  Identifies the length of a line which is used when wrapping text with the
+         *  `Soft Wrap At Preferred Line Length` setting enabled, in number of characters.
+         */
+        'editor.preferredLineLength': number;
 
-    /** Number of spaces used to represent a tab. */
-    'editor.tabLength': number;
+        /**
+         * Defines the maximum width of the editor window before soft wrapping is enforced,
+         * in number of characters.
+         */
+        'editor.maxScreenLineLength': number;
 
-    /**
-     *  Wraps lines that exceed the width of the window. When `Soft Wrap At Preferred
-     *  Line Length` is set, it will wrap to the number of characters defined by the
-     *  `Preferred Line Length` setting.
-     */
-    'editor.softWrap': boolean;
+        /** Number of spaces used to represent a tab. */
+        'editor.tabLength': number;
 
-    /**
-     *  If the `Tab Type` config setting is set to "auto" and autodetection of tab type
-     *  from buffer content fails, then this config setting determines whether a soft tab
-     *  or a hard tab will be inserted when the Tab key is pressed.
-     */
-    'editor.softTabs': boolean;
+        /**
+         *  Wraps lines that exceed the width of the window. When `Soft Wrap At Preferred
+         *  Line Length` is set, it will wrap to the number of characters defined by the
+         *  `Preferred Line Length` setting.
+         */
+        'editor.softWrap': boolean;
 
-    /**
-     *  Determine character inserted when Tab key is pressed. Possible values: "auto",
-     *  "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs
-     *  (tab characters) are used. When set to "auto", the editor auto-detects the tab
-     *  type based on the contents of the buffer (it uses the first leading whitespace
-     *  on a non-comment line), or uses the value of the Soft Tabs config setting if
-     *  auto-detection fails.
-     */
-    'editor.tabType': 'auto' | 'soft' | 'hard';
+        /**
+         *  If the `Tab Type` config setting is set to "auto" and autodetection of tab type
+         *  from buffer content fails, then this config setting determines whether a soft tab
+         *  or a hard tab will be inserted when the Tab key is pressed.
+         */
+        'editor.softTabs': boolean;
 
-    /**
-     *  Instead of wrapping lines to the window's width, wrap lines to the number of
-     *  characters defined by the `Preferred Line Length` setting. This will only take
-     *  effect when the soft wrap config setting is enabled globally or for the current
-     *  language.
-     *  **Note:** If you want to hide the wrap guide (the vertical line) you can disable
-     *  the `wrap-guide` package.
-     */
-    'editor.softWrapAtPreferredLineLength': boolean;
+        /**
+         *  Determine character inserted when Tab key is pressed. Possible values: "auto",
+         *  "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs
+         *  (tab characters) are used. When set to "auto", the editor auto-detects the tab
+         *  type based on the contents of the buffer (it uses the first leading whitespace
+         *  on a non-comment line), or uses the value of the Soft Tabs config setting if
+         *  auto-detection fails.
+         */
+        'editor.tabType': 'auto' | 'soft' | 'hard';
 
-    /**
-     *  When soft wrap is enabled, defines length of additional indentation applied to
-     *  wrapped lines, in number of characters.
-     */
-    'editor.softWrapHangingIndent': number;
+        /**
+         *  Instead of wrapping lines to the window's width, wrap lines to the number of
+         *  characters defined by the `Preferred Line Length` setting. This will only take
+         *  effect when the soft wrap config setting is enabled globally or for the current
+         *  language.
+         *  **Note:** If you want to hide the wrap guide (the vertical line) you can disable
+         *  the `wrap-guide` package.
+         */
+        'editor.softWrapAtPreferredLineLength': boolean;
 
-    /** Determines how fast the editor scrolls when using a mouse or trackpad. */
-    'editor.scrollSensitivity': number;
+        /**
+         *  When soft wrap is enabled, defines length of additional indentation applied to
+         *  wrapped lines, in number of characters.
+         */
+        'editor.softWrapHangingIndent': number;
 
-    /** Allow the editor to be scrolled past the end of the last line. */
-    'editor.scrollPastEnd': boolean;
+        /** Determines how fast the editor scrolls when using a mouse or trackpad. */
+        'editor.scrollSensitivity': number;
 
-    /**
-     *  Time interval in milliseconds within which text editing operations will be
-     *  grouped together in the undo history.
-     */
-    'editor.undoGroupingInterval': number;
+        /** Allow the editor to be scrolled past the end of the last line. */
+        'editor.scrollPastEnd': boolean;
 
-    /**
-     *  Show confirmation dialog when checking out the HEAD revision and discarding
-     *  changes to current file since last commit.
-     */
-    'editor.confirmCheckoutHeadRevision': boolean;
+        /**
+         *  Time interval in milliseconds within which text editing operations will be
+         *  grouped together in the undo history.
+         */
+        'editor.undoGroupingInterval': number;
 
-    /**
-     *  A hash of characters Atom will use to render whitespace characters. Keys are
-     *  whitespace character types, values are rendered characters (use value false to
-     *  turn off individual whitespace character types).
-     */
-    'editor.invisibles': Invisibles;
+        /**
+         *  Show confirmation dialog when checking out the HEAD revision and discarding
+         *  changes to current file since last commit.
+         */
+        'editor.confirmCheckoutHeadRevision': boolean;
 
-    /**
-     *  Change the editor font size when pressing the Ctrl key and scrolling the mouse
-     *  up/down.
-     */
-    'editor.zoomFontWhenCtrlScrolling': boolean;
+        /**
+         *  A hash of characters Atom will use to render whitespace characters. Keys are
+         *  whitespace character types, values are rendered characters (use value false to
+         *  turn off individual whitespace character types).
+         */
+        'editor.invisibles': Invisibles;
 
-    // tslint:disable-next-line:no-any
-    [key: string]: any;
+        /**
+         *  Change the editor font size when pressing the Ctrl key and scrolling the mouse
+         *  up/down.
+         */
+        'editor.zoomFontWhenCtrlScrolling': boolean;
+
+        // tslint:disable-next-line:no-any
+        [key: string]: any;
+    }
 }

--- a/types/atom/src/config.d.ts
+++ b/types/atom/src/config.d.ts
@@ -1,5 +1,4 @@
-import { Disposable, ScopeDescriptor } from '../index';
-import { ConfigValues } from './config-schema';
+import { ConfigValues, Disposable, ScopeDescriptor } from '../index';
 
 /** Used to access all of Atom's configuration details. */
 export interface Config {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The last update broke `ConfigValues` extensibility which silently peppered the code with `any`. Apparently there are some peculiarities to how TypeScript resolves modules in type roots. This is a little hacky, but seems to work, which is arguably better than silently breaking.

This also adds some tests. Since there is no canonical way to assert a type is not `any` in TypeScript, I use a `T extends never` hack (which `any` does, but no concrete type should). This hack is known to not work reliably on some earlier (circa 2018) TypeScript versions (so something around pre-3.2). Perhaps we should bump the minimal version in the header. That said, the definitions _themselves_ "should" still work in older TS.