### PR TITLE
[@types/node] Fix cipher/decipher output encoding

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -234,8 +234,8 @@ declare module 'crypto' {
         private constructor();
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Encoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: BinaryToTextEncoding): string;
-        update(data: string, input_encoding: Encoding | undefined, output_encoding: BinaryToTextEncoding): string;
+        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: Encoding): string;
+        update(data: string, input_encoding: Encoding | undefined, output_encoding: Encoding): string;
         final(): Buffer;
         final(output_encoding: BufferEncoding): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -279,9 +279,9 @@ declare module 'crypto' {
     class Decipher extends stream.Transform {
         private constructor();
         update(data: NodeJS.ArrayBufferView): Buffer;
-        update(data: string, input_encoding: BinaryToTextEncoding): Buffer;
+        update(data: string, input_encoding: Encoding): Buffer;
         update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: Encoding): string;
-        update(data: string, input_encoding: BinaryToTextEncoding | undefined, output_encoding: Encoding): string;
+        update(data: string, input_encoding: Encoding | undefined, output_encoding: Encoding): string;
         final(): Buffer;
         final(output_encoding: BufferEncoding): string;
         setAutoPadding(auto_padding?: boolean): this;

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -130,6 +130,7 @@ import { promisify } from 'node:util';
 }
 
 {
+    // crypto_cipheriv_decipheriv_aad_ccm_test
     const key: string | null = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);
     const aad = Buffer.from('0123456789', 'hex');
@@ -157,6 +158,7 @@ import { promisify } from 'node:util';
 }
 
 {
+    // crypto_cipheriv_decipheriv_aad_gcm_test
     const key = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);
     const aad = Buffer.from('0123456789', 'hex');
@@ -180,29 +182,53 @@ import { promisify } from 'node:util';
 }
 
 {
+    // crypto_cipheriv_decipheriv_cbc_string_encoding_test
     const key: string | null = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);
-    const aad = Buffer.from('0123456789', 'hex');
 
-    const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16,
-    });
+    const cipher = crypto.createCipheriv('aes-192-cbc', key, nonce);
     const plaintext = 'Hello world';
-    cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext),
-    });
-    const ciphertext = cipher.update(plaintext, 'utf8');
+     // $ExpectType string
+    const ciphertext = cipher.update(plaintext, 'utf8', 'binary');
     cipher.final();
-    const tag = cipher.getAuthTag();
 
-    const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16,
-    });
-    decipher.setAuthTag(tag);
-    decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length,
-    });
-    const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
+    const decipher = crypto.createDecipheriv('aes-192-cbc', key, nonce);
+     // $ExpectType string
+    const receivedPlaintext = decipher.update(ciphertext, 'binary', 'utf8');
+    decipher.final();
+}
+
+{
+    // crypto_cipheriv_decipheriv_cbc_buffer_encoding_test
+    const key: string | null = 'keykeykeykeykeykeykeykey';
+    const nonce = crypto.randomBytes(12);
+
+    const cipher = crypto.createCipheriv('aes-192-cbc', key, nonce);
+    const plaintext = 'Hello world';
+     // $ExpectType Buffer
+    const cipherBuf = cipher.update(plaintext, 'utf8');
+    cipher.final();
+
+    const decipher = crypto.createDecipheriv('aes-192-cbc', key, nonce);
+     // $ExpectType string
+    const receivedPlaintext = decipher.update(cipherBuf, undefined, 'utf8');
+    decipher.final();
+}
+
+{
+    // crypto_cipheriv_decipheriv_cbc_buffer_encoding_test
+    const key: string | null = 'keykeykeykeykeykeykeykey';
+    const nonce = crypto.randomBytes(12);
+
+    const cipher = crypto.createCipheriv('aes-192-cbc', key, nonce);
+    const plaintext = 'Hello world';
+     // $ExpectType Buffer
+    const cipherBuf = cipher.update(plaintext, 'utf8');
+    cipher.final();
+
+    const decipher = crypto.createDecipheriv('aes-192-cbc', key, nonce);
+     // $ExpectType Buffer
+    const receivedPlaintext = decipher.update(cipherBuf);
     decipher.final();
 }
 


### PR DESCRIPTION
Remove restriction on using `BinaryToTextEncoding` for cipher and decipher output encoding.  
The Node code base and documentation do not make this restriction.  

Node documentation:  
[cipher.update](https://nodejs.org/api/crypto.html#crypto_cipher_update_data_inputencoding_outputencoding)  
[decipher.update](https://nodejs.org/api/crypto.html#crypto_decipher_update_data_inputencoding_outputencoding)   
[encodings](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings)

- [x]  Use a meaningful title for the pull request. Include the name of the package modified.
- [x]  Test the change in your own code. (Compile and run.)
- [x]  Add or edit tests to reflect the change.
- [x]  Follow the advice from the readme.
- [x]  Avoid common mistakes.
- [x]  Run npm test <package to test>.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

