### PR TITLE
Update cross-domain-utils for 4.3

### DIFF
--- a/types/cross-domain-utils/types.d.ts
+++ b/types/cross-domain-utils/types.d.ts
@@ -4,24 +4,24 @@ export interface CrossDomainWindowType {
     location: string | {};
     self: CrossDomainWindowType;
     closed: boolean;
-    open: (url?: string, target?: string, features?: string) => CrossDomainWindowType | null;
-    close: () => void;
-    focus: () => void;
+    open(url?: string, target?: string, features?: string): CrossDomainWindowType | null;
+    close(): void;
+    focus(): void;
     top: CrossDomainWindowType;
-    frames: ReadonlyArray<CrossDomainWindowType> | CrossDomainWindowType;
+    frames: CrossDomainWindowType;
     opener?: CrossDomainWindowType;
     parent: CrossDomainWindowType;
     length: number;
-    postMessage: (a: string, b: string) => void;
+    postMessage(a: string, b: string): void;
 }
 
 export interface SameDomainWindowType {
     location: string | {};
     self: CrossDomainWindowType;
     closed: boolean;
-    open: (url?: string, target?: string, features?: string) => CrossDomainWindowType | null;
-    close: () => void;
-    focus: () => void;
+    open(url?: string, target?: string, features?: string): CrossDomainWindowType | null;
+    close(): void;
+    focus(): void;
     XMLHttpRequest?: typeof XMLHttpRequest;
     document: Document;
     navigator: {

--- a/types/cross-domain-utils/types.d.ts
+++ b/types/cross-domain-utils/types.d.ts
@@ -4,24 +4,24 @@ export interface CrossDomainWindowType {
     location: string | {};
     self: CrossDomainWindowType;
     closed: boolean;
-    open(url?: string, target?: string, features?: string): CrossDomainWindowType | null;
-    close(): void;
-    focus(): void;
+    open: (url?: string, target?: string, features?: string) => CrossDomainWindowType | null;
+    close: () => void;
+    focus: () => void;
     top: CrossDomainWindowType;
     frames: CrossDomainWindowType;
-    opener?: CrossDomainWindowType;
+    opener: CrossDomainWindowType | null;
     parent: CrossDomainWindowType;
     length: number;
-    postMessage(a: string, b: string): void;
+    postMessage: (a: string, b: string) => void;
 }
 
 export interface SameDomainWindowType {
     location: string | {};
     self: CrossDomainWindowType;
     closed: boolean;
-    open(url?: string, target?: string, features?: string): CrossDomainWindowType | null;
-    close(): void;
-    focus(): void;
+    open: (url?: string, target?: string, features?: string) => CrossDomainWindowType | null;
+    close: () => void;
+    focus: () => void;
     XMLHttpRequest?: typeof XMLHttpRequest;
     document: Document;
     navigator: {


### PR DESCRIPTION
The type of Window.frames is now stricter: just Window, not Window[].
Change CrossDomainWindowType.frames to match.
Edit: CrossDomainWindowType.opener also needs to use `null`, not `undefined`.