### PR TITLE
Update bluebird tests for TS 4.3

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -798,7 +798,7 @@ fooProm = Bluebird.try(() => {
 // - - - - - - - - - - - - - - - - -
 
 fooProm = Bluebird.try(() => {
-    if (fooProm) {
+    if (!!fooProm) {
         return fooProm;
     }
     return foo;
@@ -819,7 +819,7 @@ fooProm = Bluebird.attempt(() => {
 // - - - - - - - - - - - - - - - - -
 
 fooProm = Bluebird.attempt(() => {
-    if (fooProm) {
+    if (!!fooProm) {
         return fooProm;
     }
     return foo;


### PR DESCRIPTION
TS 4.3 has uncalled-Promise checks, which conflict with the type of some code in bluebird tests. Make the check explicit rather than fixing the underlying type.