### PR TITLE
React-big-calendar: DnD - Changes allDay to isAllDay in drop/resize

### DIFF
--- a/types/react-big-calendar/lib/addons/dragAndDrop.d.ts
+++ b/types/react-big-calendar/lib/addons/dragAndDrop.d.ts
@@ -2,8 +2,8 @@ import { Calendar, CalendarProps, Components, Event, stringOrDate } from '../../
 import * as React from 'react';
 
 export interface withDragAndDropProps<TEvent extends object = Event, TResource extends object = object> {
-  onEventDrop?: (args: { event: TEvent, start: stringOrDate, end: stringOrDate, allDay: boolean }) => void;
-  onEventResize?: (args: { event: TEvent, start: stringOrDate, end: stringOrDate, allDay: boolean }) => void;
+  onEventDrop?: (args: { event: TEvent, start: stringOrDate, end: stringOrDate, isAllDay: boolean }) => void;
+  onEventResize?: (args: { event: TEvent, start: stringOrDate, end: stringOrDate, isAllDay: boolean }) => void;
   onDragStart?: (args: { event: TEvent, action: 'resize' | 'move', direction: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT' }) => void;
   onDragOver?: (event: React.DragEvent) => void;
   onDropFromOutside?: (args: { start: stringOrDate, end: stringOrDate, allDay: boolean}) => void;

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -136,7 +136,13 @@ class CalendarResource {
     interface Props {
         localizer: DateLocalizer;
     }
+    interface DragAndDropEvent {
+        isAllDay: boolean;
+    }
     const DragAndDropCalendar = withDragAndDrop<CalendarEvent, CalendarResource>(MyCalendar);
+    const handleEventMove = ({ isAllDay }: DragAndDropEvent) => {
+        console.log(isAllDay);
+    };
     const DnD = ({ localizer }: Props) => (
         <DragAndDropCalendar
             events={getEvents()}
@@ -147,8 +153,8 @@ class CalendarResource {
             localizer={localizer}
             selectable={true}
             resizable={true}
-            onEventDrop={console.log}
-            onEventResize={console.log}
+            onEventDrop={handleEventMove}
+            onEventResize={handleEventMove}
             onDragStart={console.log}
             onDropFromOutside={console.log}
             draggableAccessor={() => true}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (N/A)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Example illustrates the property name is `isAllDay` and not `allDay` for event drop handler: [here](https://github.com/jquense/react-big-calendar/blob/master/examples/demos/dnd.js#L45).  onEventDrop and onEventResize are called with the same argument as seen [here](https://github.com/jquense/react-big-calendar/blob/611a0ce7ceeae05b0537d698573b0a667fdd24d6/src/addons/dragAndDrop/withDragAndDrop.js#L97).  
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
