### PR TITLE
[karma-summary-reporter] Correct misspelled import 

### DIFF
--- a/types/karma-summary-reporter/index.d.ts
+++ b/types/karma-summary-reporter/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
-import 'karam';
+import 'karma';
 
 declare module 'karma' {
     interface ConfigOptions {


### PR DESCRIPTION
`karma-summary-reporter` depends on `karma`, not `karam`. That's just a typo, there is no `karam` or `@types/karam` package.

I'm not sure why the existing tests don't pick up the misspelled import.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).