### PR TITLE
update: @types/rasha

### DIFF
--- a/types/rasha/index.d.ts
+++ b/types/rasha/index.d.ts
@@ -6,7 +6,7 @@
 export as namespace Rasha;
 
 export interface Jwk {
-    kty: string;
+    kty: "RSA";
     n: string;
     e: string;
     d: string;

--- a/types/rasha/rasha-tests.ts
+++ b/types/rasha/rasha-tests.ts
@@ -1,6 +1,6 @@
-import * as rasha from 'rasha';
+import * as rasha from "rasha";
 
-const gOptions: Rasha.GenerateOptions = { format: 'jwk' };
+const gOptions: Rasha.GenerateOptions = { format: "jwk" };
 
 rasha.generate(gOptions).then((keypair: Rasha.RsaKeys) => {
     console.log(keypair.private);


### PR DESCRIPTION
- [x] Test the change in your own code. (Compile and run.)
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Possible values for `kty` is `"RSA" | "EC" | "oct"` see [spec](https://tools.ietf.org/html/rfc7518#section-6.1). I looked at the source code for rasha and it only handles "RSA". I noticed the type error since we use the result from `rasha.import(...)` in '[jwk-to-pem](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jwk-to-pem/index.d.ts)' and get a type error (string !== "RSA").
