### PR TITLE
[pdfjs-dist] Add `workerPort` global option

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -14,6 +14,7 @@ declare const GlobalWorkerOptions: GlobalWorkerOptions;
 
 interface GlobalWorkerOptions {
     workerSrc: string;
+    workerPort: PDFWorker | null
 }
 
 interface PDFTreeNode {

--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -14,7 +14,7 @@ declare const GlobalWorkerOptions: GlobalWorkerOptions;
 
 interface GlobalWorkerOptions {
     workerSrc: string;
-    workerPort: PDFWorker | null
+    workerPort: PDFWorker | null;
 }
 
 interface PDFTreeNode {

--- a/types/pdfjs-dist/pdfjs-dist-tests.ts
+++ b/types/pdfjs-dist/pdfjs-dist-tests.ts
@@ -1,6 +1,6 @@
 import { getDocument, PDFDocumentProxy, Util, GlobalWorkerOptions, PDFWorker } from 'pdfjs-dist';
 
-GlobalWorkerOptions.workerPort = new PDFWorker()
+GlobalWorkerOptions.workerPort = new PDFWorker();
 
 //
 // Fetch the PDF document from the URL using promises

--- a/types/pdfjs-dist/pdfjs-dist-tests.ts
+++ b/types/pdfjs-dist/pdfjs-dist-tests.ts
@@ -1,4 +1,6 @@
-import { getDocument, PDFDocumentProxy, Util } from 'pdfjs-dist';
+import { getDocument, PDFDocumentProxy, Util, GlobalWorkerOptions, PDFWorker } from 'pdfjs-dist';
+
+GlobalWorkerOptions.workerPort = new PDFWorker()
 
 //
 // Fetch the PDF document from the URL using promises


### PR DESCRIPTION
This property is defined and documented below but was missing from the type definition: https://github.com/mozilla/pdf.js/blob/master/src/display/worker_options.js#L18-L19

Added a simple case that uses it in the test file

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla/pdf.js/blob/master/src/display/worker_options.js#L18-L19


