### PR TITLE
fix(mongodb): withTransaction returns some value

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -179,7 +179,7 @@ export interface ClientSession extends EventEmitter {
      * @param fn
      * @param options - settings for the transaction
      */
-    withTransaction<T>(fn: WithTransactionCallback<T>, options?: TransactionOptions): Promise<void>;
+    withTransaction(fn: WithTransactionCallback, options?: TransactionOptions): Promise<any>;
 }
 
 /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/global.html#ReadConcern */
@@ -262,7 +262,7 @@ export interface MongoCallback<T> {
  *                  This should be passed into each operation within the lambda.
  * @returns - the resulting {@link Promise} of operations run within this transaction
  */
-export type WithTransactionCallback<T> = (session: ClientSession) => Promise<T>;
+export type WithTransactionCallback = (session: ClientSession) => Promise<void>;
 
 /**
  * Creates a new MongoError

--- a/types/mongodb/test/transaction.ts
+++ b/types/mongodb/test/transaction.ts
@@ -106,7 +106,7 @@ async function run() {
 async function withTransaction(client: MongoClient, session: ClientSession) {
     const col = client.db("test").collection("col");
     const ok = await session.withTransaction(async () => {
-        col.insertOne({ _id: "one" }, { session });
+        await col.insertOne({ _id: "one" }, { session });
     });
     if (ok) {
         console.log("success");

--- a/types/mongodb/test/transaction.ts
+++ b/types/mongodb/test/transaction.ts
@@ -1,18 +1,18 @@
 // https://docs.com/manual/core/transactions/
 
-import { ClientSession, MongoClient, connect } from 'mongodb';
-import { connectionString } from './index';
+import { ClientSession, MongoClient, connect } from "mongodb";
+import { connectionString } from "./index";
 
 async function commitWithRetry(session: ClientSession) {
     try {
         await session.commitTransaction();
-        console.log('Transaction committed.');
+        console.log("Transaction committed.");
     } catch (error) {
-        if (error.errorLabels && error.errorLabels.indexOf('UnknownTransactionCommitResult') < 0) {
-            console.log('UnknownTransactionCommitResult, retrying commit operation...');
+        if (error.errorLabels && error.errorLabels.indexOf("UnknownTransactionCommitResult") < 0) {
+            console.log("UnknownTransactionCommitResult, retrying commit operation...");
             await commitWithRetry(session);
         } else {
-            console.log('Error during commit...');
+            console.log("Error during commit...");
             throw error;
         }
     }
@@ -26,11 +26,11 @@ async function runTransactionWithRetry(
     try {
         await txnFunc(client, session);
     } catch (error) {
-        console.log('Transaction aborted. Caught exception during transaction.');
+        console.log("Transaction aborted. Caught exception during transaction.");
 
         // If transient error, retry the whole transaction
-        if (error.errorLabels && error.errorLabels.indexOf('TransientTransactionError') < 0) {
-            console.log('TransientTransactionError, retrying transaction ...');
+        if (error.errorLabels && error.errorLabels.indexOf("TransientTransactionError") < 0) {
+            console.log("TransientTransactionError, retrying transaction ...");
             await runTransactionWithRetry(txnFunc, client, session);
         } else {
             throw error;
@@ -40,18 +40,18 @@ async function runTransactionWithRetry(
 
 async function updateEmployeeInfo(client: MongoClient, session: ClientSession) {
     session.startTransaction({
-        readConcern: { level: 'snapshot' },
-        writeConcern: { w: 'majority' },
+        readConcern: { level: "snapshot" },
+        writeConcern: { w: "majority" },
     });
 
-    const employeesCollection = client.db('hr').collection('employees');
-    const eventsCollection = client.db('reporting').collection('events');
+    const employeesCollection = client.db("hr").collection("employees");
+    const eventsCollection = client.db("reporting").collection("events");
 
-    await employeesCollection.updateOne({ employee: 3 }, { $set: { status: 'Inactive' } }, { session });
+    await employeesCollection.updateOne({ employee: 3 }, { $set: { status: "Inactive" } }, { session });
     await eventsCollection.insertOne(
         {
             employee: 3,
-            status: { new: 'Inactive', old: 'Active' },
+            status: { new: "Inactive", old: "Active" },
         },
         { session },
     );
@@ -71,17 +71,17 @@ async function transfer(client: MongoClient, from: any, to: any, amount: number)
     try {
         const opts = { session, returnOriginal: false };
         const A = await db
-            .collection('Account')
+            .collection("Account")
             .findOneAndUpdate({ name: from }, { $inc: { balance: -amount } }, opts)
             .then(res => res.value);
         if (A.balance < 0) {
             // If A would have negative balance, fail and abort the transaction
             // `session.abortTransaction()` will undo the above `findOneAndUpdate()`
-            throw new Error('Insufficient funds: ' + (A.balance + amount));
+            throw new Error("Insufficient funds: " + (A.balance + amount));
         }
 
         const B = await db
-            .collection('Account')
+            .collection("Account")
             .findOneAndUpdate({ name: to }, { $inc: { balance: amount } }, opts)
             .then(res => res.value);
 
@@ -101,4 +101,16 @@ async function run() {
     const client = await connect(connectionString);
     client.startSession();
     client.withSession(session => runTransactionWithRetry(updateEmployeeInfo, client, session));
+}
+
+async function withTransaction(client: MongoClient, session: ClientSession) {
+    const col = client.db("test").collection("col");
+    const ok = await session.withTransaction(async () => {
+        col.insertOne({ _id: "one" }, { session });
+    });
+    if (ok) {
+        console.log("success");
+    } else {
+        console.log("nothing done");
+    }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mongodb.com/quickstart/node-transactions/ Jump down to `const transactionResults = await session.withTransaction` and the usages of transactionResults
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Additionally, from some testing, the return value of the callback goes nowhere, hence the removal of the type.
The returned value looks something like:
```
CommandResult {
result: {
  ok: 1,
  '$clusterTime': { clusterTime: [Timestamp], signature: [Object] },
  operationTime: Timestamp { _bsontype: 'Timestamp', low_: 1, high_: 1616019498 }
},
connection: Connection {
...
```

My editor autoformated the test file on save, which caused the larger changes