### PR TITLE
fix: (react) - allow reuse the raw function of a memo-ed function component wit…

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -26,6 +26,7 @@
 //                 JongChan Choi <https://github.com/disjukr>
 //                 Victor Magalhães <https://github.com/vhfmag>
 //                 Dale Tan <https://github.com/hellatan>
+//                 YinYa Han <https://github.com/TotooriaHyperion>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -842,6 +843,15 @@ declare namespace React {
         readonly type: T;
     };
 
+    // see https://github.com/facebook/react/blob/master/packages/react/src/ReactMemo.js
+    function memo<T extends SFC<any>>(
+        Component: T,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+    ): MemoExoticComponent<T>;
+    function memo<T extends FC<any>>(
+        Component: T,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+    ): MemoExoticComponent<T>;
     function memo<P extends object>(
         Component: SFC<P>,
         propsAreEqual?: (prevProps: Readonly<PropsWithChildren<P>>, nextProps: Readonly<PropsWithChildren<P>>) => boolean

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -267,6 +267,35 @@ const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 // $ExpectError
 <Memoized6 foo/>;
 
+const Memoized7 = React.memo<React.FC<{ test: boolean, onChange: () => void }>>(props => null);
+Memoized7.type({ test: false, onChange: () => {} });
+
+// this is prefered since it takes only one component tree level
+const Wrapped7 = React.memo<React.ComponentProps<typeof Memoized7>>(props => {
+    // const ctx = useContext(XXXContext);
+    return Memoized7.type({
+        ...props,
+        onChange: () => {
+            // do something with ctx
+            props.onChange();
+        },
+    });
+});
+// this takes 2 level of component tree
+const Wrapped7_2 = React.memo<React.ComponentProps<typeof Memoized7>>(props => {
+    // const ctx = useContext(XXXContext);
+    return <Memoized7
+        {...props}
+        onChange={() => {
+            // do something with ctx
+            props.onChange();
+        }}
+    />;
+});
+
+const Memoized8 = React.memo<React.SFC<{ test: boolean }>>(props => null);
+Memoized8.type({ test: false });
+
 // NOTE: this test _requires_ TypeScript 3.1
 // It is passing, for what it's worth.
 // const Memoized7 = React.memo((() => {

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -26,6 +26,7 @@
 //                 JongChan Choi <https://github.com/disjukr>
 //                 Victor Magalhães <https://github.com/vhfmag>
 //                 Dale Tan <https://github.com/hellatan>
+//                 YinYa Han <https://github.com/TotooriaHyperion>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -843,6 +844,15 @@ declare namespace React {
         readonly type: T;
     };
 
+    // see https://github.com/facebook/react/blob/master/packages/react/src/ReactMemo.js
+    function memo<T extends SFC<any>>(
+        Component: T,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+    ): MemoExoticComponent<T>;
+    function memo<T extends FC<any>>(
+        Component: T,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+    ): MemoExoticComponent<T>;
     function memo<P extends object>(
         Component: SFC<P>,
         propsAreEqual?: (prevProps: Readonly<PropsWithChildren<P>>, nextProps: Readonly<PropsWithChildren<P>>) => boolean


### PR DESCRIPTION
allow reuse the raw function of a memo-ed function component without adding extra component tree level

https://github.com/facebook/react/blob/master/packages/react/src/ReactMemo.js

use case:
```typescript
const Memoized7 = React.memo<React.FC<{ test: boolean, onChange?: () => void }>>(props => null);
Memoized7.type({ test: false });

// this is prefered since it takes only one component tree level
const Wrapped7 = React.memo<React.ComponentProps<typeof Memoized7>>(props => {
    // const ctx = useContext(XXXContext);
    return Memoized7.type({
        ...props,
        onChange: () => {
            // do something with ctx
            props.onChange?.();
        },
    })
});
// this takes 2 level of component tree
const Wrapped7_2 = React.memo<React.ComponentProps<typeof Memoized7>>(props => {
    // const ctx = useContext(XXXContext);
    return <Memoized7
        {...props}
        onChange={() => {
            // do something with ctx
            props.onChange?.();
        }} 
    />
});
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
