### PR TITLE
Added type definitions for image-decode

### DIFF
--- a/types/image-decode/image-decode-tests.ts
+++ b/types/image-decode/image-decode-tests.ts
@@ -1,0 +1,7 @@
+import decode = require("image-decode");
+
+// $ExpectType DecodedImage | null
+decode(new Uint8Array(), { type: "image/png" });
+
+// $ExpectType DecodedImage | null
+decode(new Uint8Array(), "image/png");

--- a/types/image-decode/image-decode-tests.ts
+++ b/types/image-decode/image-decode-tests.ts
@@ -5,3 +5,9 @@ decode(new Uint8Array(), { type: "image/png" });
 
 // $ExpectType DecodedImage | null
 decode(new Uint8Array(), "image/png");
+
+// $ExpectType DecodedImage | null
+decode("", "image/png");
+
+// $ExpectType DecodedImage | null
+decode("", { type: "image/png" });

--- a/types/image-decode/index.d.ts
+++ b/types/image-decode/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for image-decode 1.2
+// Project: https://github.com/dy/image-decode#readme
+// Definitions by: Priyanshu Rav <https://github.com/priyanshurav>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+interface Options {
+    /** The MIME type of the data */
+    type: string;
+}
+
+interface DecodedImage {
+    data: Uint8Array;
+    width: number;
+    height: number;
+}
+
+/**
+ * @param data The image buffer to decode
+ * @param options Options can be an object or it could be a string with the MIME type of the data
+ */
+declare function decode(
+    data: ArrayBuffer | Uint8Array | Buffer | string,
+    options?: Options | string,
+): DecodedImage | null;
+
+export = decode;

--- a/types/image-decode/tsconfig.json
+++ b/types/image-decode/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "image-decode-tests.ts"
+    ]
+}

--- a/types/image-decode/tslint.json
+++ b/types/image-decode/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds the type definitions for [image-decode](https://npmjs.org/package/image-decode/)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
