### PR TITLE
Update mithril for 4.3

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -23,7 +23,7 @@ declare function jsonp<T>(options: Mithril.JsonpOptions & { url: string }): Prom
 declare function jsonp<T>(url: string, options?: Mithril.JsonpOptions): Promise<T>; // tslint:disable-line:no-unnecessary-generics
 
 declare namespace Mithril {
-    interface Lifecycle<Attrs, State> {
+    interface Lifecycle<Attrs, State extends Lifecycle<Attrs, State>> {
         /** The oninit hook is called before a vnode is touched by the virtual DOM engine. */
         oninit?(this: State, vnode: Vnode<Attrs, State>): any;
         /** The oncreate hook is called after a DOM element is created and attached to the document. */
@@ -46,9 +46,9 @@ declare namespace Mithril {
         /** Creates a virtual element (Vnode). */
         (selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
         /** Creates a virtual element (Vnode). */
-        <Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
+        <Attrs, State extends Lifecycle<Attrs, State>>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
         /** Creates a virtual element (Vnode). */
-        <Attrs, State>(
+        <Attrs, State extends Lifecycle<Attrs, State>>(
             component: ComponentTypes<Attrs, State>,
             attributes: Attrs & Lifecycle<Attrs, State> & { key?: string | number },
             ...args: Children[]
@@ -59,7 +59,7 @@ declare namespace Mithril {
         trust(html: string): Vnode<any, any>;
     }
 
-    interface RouteResolver<Attrs = {}, State = {}> {
+    interface RouteResolver<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> {
         /** The onmatch hook is called when the router needs to find a component to render. */
         onmatch?(
             this: this,

--- a/types/mithril/test/test-class-component.ts
+++ b/types/mithril/test/test-class-component.ts
@@ -5,6 +5,7 @@ import * as m from 'mithril';
 // Simplest component example - no attrs or state.
 //
 class Comp0 implements m.ClassComponent {
+    [_: number]: any;
     constructor(vnode: m.CVnode) {}
     view() {
         return m('span', 'Test');
@@ -22,6 +23,7 @@ m.mount(document.getElementById('comp0')!, null);
 // Simple example with lifecycle methods.
 //
 class Comp1 implements m.ClassComponent {
+    [_: number]: any;
     oninit(vnode: m.CVnode) {}
     oncreate({ dom }: m.CVnodeDOM) {}
     view(vnode: m.CVnode) {
@@ -39,6 +41,7 @@ interface Comp2Attrs {
 }
 
 class Comp2 implements m.ClassComponent<Comp2Attrs> {
+    [_: number]: any;
     view({ attrs: { title, description } }: m.CVnode<Comp2Attrs>) {
         return [m('h2', title), m('p', description)];
     }
@@ -51,6 +54,7 @@ class Comp2 implements m.ClassComponent<Comp2Attrs> {
 // lifecycle method.
 //
 class Comp3 implements m.ClassComponent<{ pageHead: string }> {
+    [_: number]: any;
     oncreate({ dom }: m.CVnodeDOM<{ pageHead: string }>) {
         // Can do stuff with dom
     }
@@ -83,6 +87,7 @@ interface Comp4Attrs {
 }
 
 class Comp4 implements m.ClassComponent<Comp4Attrs> {
+    [_: number]: any;
     count: number;
     constructor(vnode: m.CVnode<Comp4Attrs>) {
         this.count = 0;
@@ -126,6 +131,7 @@ export interface Attrs {
 }
 
 export default class MyComponent implements m.ClassComponent<Attrs> {
+    [_: number]: any;
     count = 0;
     view({ attrs }: m.CVnode<Attrs>) {
         return m('span', `name: ${attrs.name}, count: ${this.count}`);

--- a/types/mithril/test/test-component.ts
+++ b/types/mithril/test/test-component.ts
@@ -111,6 +111,7 @@ interface Comp4Attrs {
 }
 
 interface Comp4State {
+    [_: number]: any;
     count: number;
     add(this: Comp4State, num: number): void;
 }
@@ -181,6 +182,7 @@ interface Attrs {
 }
 
 interface State {
+    [_: number]: any;
     count: number;
 }
 

--- a/types/mithril/test/test-factory-component.ts
+++ b/types/mithril/test/test-factory-component.ts
@@ -155,6 +155,7 @@ function comp4(): Component<Comp4Attrs> {
 // Uses vnode.state instead of closure.
 //
 interface Comp5State {
+    [_: number]: any;
     count: number;
     add(num: number): void;
 }

--- a/types/mithril/test/test-route.ts
+++ b/types/mithril/test/test-route.ts
@@ -17,6 +17,7 @@ interface Attrs {
 }
 
 interface State {
+    [_: number]: any;
     text: string;
 }
 
@@ -32,6 +33,7 @@ const component3: m.Comp<Attrs, State> = {
 };
 
 class Component4 implements m.ClassComponent<Attrs> {
+    [_: number]: any;
     view({ attrs }: m.Vnode<Attrs>) {
         return m('p', 'id: ' + attrs.id);
     }
@@ -46,6 +48,7 @@ const component5: m.FactoryComponent<Attrs> = () => {
 };
 
 interface RRState {
+    [_: number]: any;
     message: string;
 }
 

--- a/types/mithril/test/test-tsx.tsx
+++ b/types/mithril/test/test-tsx.tsx
@@ -10,6 +10,7 @@ const PojoComp: m.Component<Attrs> = {
 };
 
 class ClassComp implements m.ClassComponent<Attrs> {
+    [_: number]: any;
     view({attrs}: m.Vnode<Attrs>) {
         return <p class="abc">{attrs.text}</p>;
     }


### PR DESCRIPTION
Assignability of index signatures is stricter in 4.3.

1. Add missing `Lifecycle` constraints where needed.
2. Add bogus numeric index signatures to tests where needed.

I suspect the Lifecycle constraint, as written, is representing something that Typescript isn't capable of analysing. For now I've silenced the errors rather than fix it, since I don't use mithril.

My previous attempt at #51765 simplified the types, but this erased too many Lifecycle constraints.