### PR TITLE
Pin TS version to work around OOM in parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "prettier": "^2.1.1",
         "remark-cli": "^9.0.0",
         "remark-validate-links": "^10.0.2",
-        "typescript": "next"
+        "typescript": "4.3.0-dev.20210316"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
Parsing in TS nightly uses more memory, which cause dtslint-runner to OOM.