### PR TITLE
[react-bootstrap-table-next] Fixed typing error in editor config options

### DIFF
--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -143,7 +143,7 @@ export interface ColumnDescription<T extends object = any, E = any> {
 
     tooltipDataField?: string;
     editable?: boolean | ((cell: any, row: T, rowIndex: number, colIndex: number) => boolean);
-    editor?: { type: string; options?: { value: string; label: string }[] };
+    editor?: { type: string; options?: Array<{ value: string; label: string }> };
     filter?: boolean | TableColumnFilterProps;
     filterValue?: (cell: T[keyof T], row: T) => string;
     headerAlign?: CellAlignment;

--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -143,7 +143,7 @@ export interface ColumnDescription<T extends object = any, E = any> {
 
     tooltipDataField?: string;
     editable?: boolean | ((cell: any, row: T, rowIndex: number, colIndex: number) => boolean);
-    editor?: { type: string; options?: [{ value: string; label: string }] };
+    editor?: { type: string; options?: { value: string; label: string }[] };
     filter?: boolean | TableColumnFilterProps;
     filterValue?: (cell: T[keyof T], row: T) => string;
     headerAlign?: CellAlignment;


### PR DESCRIPTION
The typing definition for the ColumnDescription. editor property had an error where it stated that a any array of size 1 contained `{ value: string; label: string }` rather than the correct array of `{ value: string; label: string }`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. --- N.B. no tests for this as it depends on a plugin that does not have typings yet
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [editor options](https://github.com/react-bootstrap-table/react-bootstrap-table2/blob/ef22dc47ebeb985b28980001f806eeb01a687973/packages/react-bootstrap-table2-editor/src/dropdown-editor.js#L72)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
