### PR TITLE
[ipv6addr] Add missing members to Addr, add alternative types to params

### DIFF
--- a/types/ip6addr/index.d.ts
+++ b/types/ip6addr/index.d.ts
@@ -4,36 +4,36 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ToStringOpts {
-    format?: 'auto' | 'v4' | 'v4-mapped' | 'v6';
-    zeroElide?: boolean;
-    zeroPad?: boolean;
+  format?: 'auto' | 'v4' | 'v4-mapped' | 'v6';
+  zeroElide?: boolean;
+  zeroPad?: boolean;
 }
 
 export interface Addr {
-    kind: () => 'ipv4' | 'ipv6';
-    toString: (opts?: ToStringOpts) => string;
-    toBuffer: (buff?: Uint8Array) => Uint8Array;
-    toLong: () => number;
-    offset: (num: number) => Addr | null;
-    compare: (other: string | Addr) => number;
-    clone: () => Addr;
-    and: (input: string | Addr) => Addr;
-    or: (input: string | Addr) => Addr;
-    not: () => Addr;
+  kind: () => 'ipv4' | 'ipv6';
+  toString: (opts?: ToStringOpts) => string;
+  toBuffer: (buff?: Uint8Array) => Uint8Array;
+  toLong: () => number;
+  offset: (num: number) => Addr | null;
+  compare: (other: string | Addr) => number;
+  clone: () => Addr;
+  and: (input: string | Addr) => Addr;
+  or: (input: string | Addr) => Addr;
+  not: () => Addr;
 }
 
 export interface AddrRange {
-    contains: (input: string | Addr) => boolean;
-    first: () => Addr;
-    last: () => Addr;
+  contains: (input: string | Addr) => boolean;
+  first: () => Addr;
+  last: () => Addr;
 }
 
 export interface CIDR extends AddrRange {
-    broadcast: () => Addr;
-    compare: (other: string | CIDR) => number;
-    prefixLength: (format?: 'auto' | 'v4' | 'v6') => number;
-    address: () => Addr;
-    toString: (opts?: ToStringOpts) => string;
+  broadcast: () => Addr;
+  compare: (other: string | CIDR) => number;
+  prefixLength: (format?: 'auto' | 'v4' | 'v6') => number;
+  address: () => Addr;
+  toString: (opts?: ToStringOpts) => string;
 }
 
 export function compare(addr1: string | Addr, addr2: string | Addr): number;

--- a/types/ip6addr/index.d.ts
+++ b/types/ip6addr/index.d.ts
@@ -4,13 +4,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ToStringOpts {
-    format?: "auto" | "v4" | "v4-mapped" | "v6";
+    format?: 'auto' | 'v4' | 'v4-mapped' | 'v6';
     zeroElide?: boolean;
     zeroPad?: boolean;
 }
 
 export interface Addr {
-    kind: () => "ipv4" | "ipv6";
+    kind: () => 'ipv4' | 'ipv6';
     toString: (opts?: ToStringOpts) => string;
     toBuffer: (buff?: Uint8Array) => Uint8Array;
     toLong: () => number;
@@ -31,7 +31,7 @@ export interface AddrRange {
 export interface CIDR extends AddrRange {
     broadcast: () => Addr;
     compare: (other: string | CIDR) => number;
-    prefixLength: (format?: "auto" | "v4" | "v6") => number;
+    prefixLength: (format?: 'auto' | 'v4' | 'v6') => number;
     address: () => Addr;
     toString: (opts?: ToStringOpts) => string;
 }

--- a/types/ip6addr/index.d.ts
+++ b/types/ip6addr/index.d.ts
@@ -4,43 +4,44 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ToStringOpts {
-  format?: 'auto' | 'v4' | 'v4-mapped' | 'v6';
-  zeroElide?: boolean;
-  zeroPad?: boolean;
+    format?: "auto" | "v4" | "v4-mapped" | "v6";
+    zeroElide?: boolean;
+    zeroPad?: boolean;
 }
 
 export interface Addr {
-  kind: () => 'ipv4' | 'ipv6';
-  toString: (opts?: ToStringOpts) => string;
-  toBuffer: (buff?: Uint8Array) => Uint8Array;
-  toLong: () => number;
-  offset: (num: number) => Addr | null;
-  compare: (other: Addr) => number;
+    kind: () => "ipv4" | "ipv6";
+    toString: (opts?: ToStringOpts) => string;
+    toBuffer: (buff?: Uint8Array) => Uint8Array;
+    toLong: () => number;
+    offset: (num: number) => Addr | null;
+    compare: (other: string | Addr) => number;
+    clone: () => Addr;
+    and: (input: string | Addr) => Addr;
+    or: (input: string | Addr) => Addr;
+    not: () => Addr;
 }
 
 export interface AddrRange {
-  contains: (input: string) => boolean;
-  first: () => Addr;
-  last: () => Addr;
+    contains: (input: string | Addr) => boolean;
+    first: () => Addr;
+    last: () => Addr;
 }
 
-export interface CIDR {
-  contains: (input: string) => boolean;
-  first: () => Addr;
-  last: () => Addr;
-  broadcast: () => Addr;
-  compare: (other: CIDR) => number;
-  prefixLength: () => number;
-  address: () => Addr;
-  toString: (opts?: ToStringOpts) => string;
+export interface CIDR extends AddrRange {
+    broadcast: () => Addr;
+    compare: (other: string | CIDR) => number;
+    prefixLength: (format?: "auto" | "v4" | "v6") => number;
+    address: () => Addr;
+    toString: (opts?: ToStringOpts) => string;
 }
 
-export function compare(addr1: string, addr2: string): number;
+export function compare(addr1: string | Addr, addr2: string | Addr): number;
 
-export function compareCIDR(cidr1: string, cidr2: string): number;
+export function compareCIDR(cidr1: string | CIDR, cidr2: string | CIDR): number;
 
-export function createAddrRange(begin: string, end: string): AddrRange;
+export function createAddrRange(begin: string | Addr, end: string | Addr): AddrRange;
 
-export function createCIDR(addr: string, len?: number): CIDR;
+export function createCIDR(addr: string | Addr, len?: number): CIDR;
 
-export function parse(input: string): Addr;
+export function parse(input: string | number | Addr): Addr;

--- a/types/ip6addr/ip6addr-tests.ts
+++ b/types/ip6addr/ip6addr-tests.ts
@@ -1,50 +1,50 @@
-import ip6addr = require("ip6addr");
+import ip6addr = require('ip6addr');
 
-const addr = ip6addr.parse("fd00::0123");
+const addr = ip6addr.parse('fd00::0123');
 addr.kind();
 addr.toString();
-addr.toString({ format: "v6" });
-addr.toString({ format: "v6", zeroElide: false, zeroPad: true });
+addr.toString({ format: 'v6' });
+addr.toString({ format: 'v6', zeroElide: false, zeroPad: true });
 addr.toBuffer();
 addr.toLong();
 addr.offset(1);
-const addr2 = ip6addr.parse("fd20::5");
+const addr2 = ip6addr.parse('fd20::5');
 addr.compare(addr2);
-addr.compare("fd20::5");
+addr.compare('fd20::5');
 const addr3: ip6addr.Addr = addr2.clone();
 const addr4: ip6addr.Addr = addr3.not();
-const addr5: ip6addr.Addr = addr4.and("127.0.0.1");
+const addr5: ip6addr.Addr = addr4.and('127.0.0.1');
 const addr6: ip6addr.Addr = addr4.and(addr);
-const addr7: ip6addr.Addr = addr4.or("127.0.0.1");
+const addr7: ip6addr.Addr = addr4.or('127.0.0.1');
 const addr8: ip6addr.Addr = addr4.or(addr);
 
-const cidr = ip6addr.createCIDR("fe80::/10");
-const cidr2 = ip6addr.createCIDR("10.0.0.0", 8);
+const cidr = ip6addr.createCIDR('fe80::/10');
+const cidr2 = ip6addr.createCIDR('10.0.0.0', 8);
 const cidr3 = ip6addr.createCIDR(addr, 16);
 cidr.toString();
-addr.toString({ format: "v6" });
-addr.toString({ format: "v6", zeroElide: false, zeroPad: true });
-cidr.contains("fe80::507f:baff:fe85:92eb");
+addr.toString({ format: 'v6' });
+addr.toString({ format: 'v6', zeroElide: false, zeroPad: true });
+cidr.contains('fe80::507f:baff:fe85:92eb');
 cidr.contains(addr2);
 cidr.first().toString();
 cidr.last().toString();
 cidr.broadcast().toString();
 cidr.compare(cidr2);
 cidr.prefixLength();
-cidr.prefixLength("auto");
+cidr.prefixLength('auto');
 cidr.address();
 
-const range = ip6addr.createAddrRange("fd00::123", "fd00::ea00");
+const range = ip6addr.createAddrRange('fd00::123', 'fd00::ea00');
 range.first().toString();
 range.last().toString();
 
-ip6addr.compare("10.0.1.76", "8.8.8.8");
-ip6addr.compareCIDR("192.168.0.0/24", "192.168.0.0/16");
+ip6addr.compare('10.0.1.76', '8.8.8.8');
+ip6addr.compareCIDR('192.168.0.0/24', '192.168.0.0/16');
 
 ip6addr.compare(addr, addr2);
 ip6addr.compareCIDR(cidr, cidr3);
 
-ip6addr.createAddrRange("8.8.8.8", "10.0.1.76");
+ip6addr.createAddrRange('8.8.8.8', '10.0.1.76');
 ip6addr.createAddrRange(addr, addr2);
 
 ip6addr.parse(3566161419);

--- a/types/ip6addr/ip6addr-tests.ts
+++ b/types/ip6addr/ip6addr-tests.ts
@@ -11,6 +11,7 @@ addr.offset(1);
 const addr2 = ip6addr.parse('fd20::5');
 addr.compare(addr2);
 addr.compare('fd20::5');
+
 const addr3: ip6addr.Addr = addr2.clone();
 const addr4: ip6addr.Addr = addr3.not();
 const addr5: ip6addr.Addr = addr4.and('127.0.0.1');

--- a/types/ip6addr/ip6addr-tests.ts
+++ b/types/ip6addr/ip6addr-tests.ts
@@ -1,32 +1,51 @@
-import ip6addr = require('ip6addr');
+import ip6addr = require("ip6addr");
 
-const addr = ip6addr.parse('fd00::0123');
+const addr = ip6addr.parse("fd00::0123");
 addr.kind();
 addr.toString();
-addr.toString({ format: 'v6' });
-addr.toString({ format: 'v6', zeroElide: false, zeroPad: true });
+addr.toString({ format: "v6" });
+addr.toString({ format: "v6", zeroElide: false, zeroPad: true });
 addr.toBuffer();
 addr.toLong();
 addr.offset(1);
-const addr2 = ip6addr.parse('fd20::5');
+const addr2 = ip6addr.parse("fd20::5");
 addr.compare(addr2);
+addr.compare("fd20::5");
+const addr3: ip6addr.Addr = addr2.clone();
+const addr4: ip6addr.Addr = addr3.not();
+const addr5: ip6addr.Addr = addr4.and("127.0.0.1");
+const addr6: ip6addr.Addr = addr4.and(addr);
+const addr7: ip6addr.Addr = addr4.or("127.0.0.1");
+const addr8: ip6addr.Addr = addr4.or(addr);
 
-const cidr = ip6addr.createCIDR('fe80::/10');
-const cidr2 = ip6addr.createCIDR('10.0.0.0', 8);
+const cidr = ip6addr.createCIDR("fe80::/10");
+const cidr2 = ip6addr.createCIDR("10.0.0.0", 8);
+const cidr3 = ip6addr.createCIDR(addr, 16);
 cidr.toString();
-addr.toString({ format: 'v6' });
-addr.toString({ format: 'v6', zeroElide: false, zeroPad: true });
-cidr.contains('fe80::507f:baff:fe85:92eb');
+addr.toString({ format: "v6" });
+addr.toString({ format: "v6", zeroElide: false, zeroPad: true });
+cidr.contains("fe80::507f:baff:fe85:92eb");
+cidr.contains(addr2);
 cidr.first().toString();
 cidr.last().toString();
 cidr.broadcast().toString();
 cidr.compare(cidr2);
 cidr.prefixLength();
+cidr.prefixLength("auto");
 cidr.address();
 
-const range = ip6addr.createAddrRange('fd00::123', 'fd00::ea00');
+const range = ip6addr.createAddrRange("fd00::123", "fd00::ea00");
 range.first().toString();
 range.last().toString();
 
-ip6addr.compare('10.0.1.76', '8.8.8.8');
-ip6addr.compareCIDR('192.168.0.0/24', '192.168.0.0/16');
+ip6addr.compare("10.0.1.76", "8.8.8.8");
+ip6addr.compareCIDR("192.168.0.0/24", "192.168.0.0/16");
+
+ip6addr.compare(addr, addr2);
+ip6addr.compareCIDR(cidr, cidr3);
+
+ip6addr.createAddrRange("8.8.8.8", "10.0.1.76");
+ip6addr.createAddrRange(addr, addr2);
+
+ip6addr.parse(3566161419);
+ip6addr.parse(addr8);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - Addr.and: https://github.com/joyent/node-ip6addr/blob/master/ip6addr.js#L304
    - Addr.or: https://github.com/joyent/node-ip6addr/blob/master/ip6addr.js#L314
    - Addr.not: https://github.com/joyent/node-ip6addr/blob/master/ip6addr.js#L324
    - Addr.clone: https://github.com/joyent/node-ip6addr/blob/master/ip6addr.js#L264
    - Alternative parameter types (string | Addr | CIDR | number) usually come from the [_toAddr()](https://github.com/joyent/node-ip6addr/blob/master/ip6addr.js#L51) calls
