### PR TITLE
[micro] Change `object` to `{[s:string]: any}`

### DIFF
--- a/types/micro/index.d.ts
+++ b/types/micro/index.d.ts
@@ -25,4 +25,4 @@ export function buffer(req: IncomingMessage, info?: { limit?: string | number, e
 
 export function text(req: IncomingMessage, info?: { limit?: string | number, encoding?: string }): Promise<string>;
 
-export function json(req: IncomingMessage, info?: { limit?: string | number, encoding?: string }): Promise<object>;
+export function json(req: IncomingMessage, info?: { limit?: string | number, encoding?: string }): Promise<{[s:string]: any}>;

--- a/types/micro/index.d.ts
+++ b/types/micro/index.d.ts
@@ -17,12 +17,12 @@ export default serve;
 
 export function send(res: ServerResponse, code: number, data?: any): Promise<void>;
 
-export function sendError(req: IncomingMessage, res: ServerResponse, info: { statusCode?: number, status?: number, message?: string, stack?: string }): Promise<void>;
+export function sendError(req: IncomingMessage, res: ServerResponse, info: { statusCode?: number, status?: number, message?: string, stack?: string; }): Promise<void>;
 
-export function createError(code: number, msg: string, orig?: Error): Error & { statusCode: number, originalError?: Error };
+export function createError(code: number, msg: string, orig?: Error): Error & { statusCode: number, originalError?: Error; };
 
-export function buffer(req: IncomingMessage, info?: { limit?: string | number, encoding?: string }): Promise<Buffer | string>;
+export function buffer(req: IncomingMessage, info?: { limit?: string | number, encoding?: string; }): Promise<Buffer | string>;
 
-export function text(req: IncomingMessage, info?: { limit?: string | number, encoding?: string }): Promise<string>;
+export function text(req: IncomingMessage, info?: { limit?: string | number, encoding?: string; }): Promise<string>;
 
-export function json(req: IncomingMessage, info?: { limit?: string | number, encoding?: string }): Promise<{[s:string]: any}>;
+export function json(req: IncomingMessage, info?: { limit?: string | number, encoding?: string; }): Promise<{ [s: string]: any; }>;


### PR DESCRIPTION
`object` now means a literal empty object

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [index.js:128-134](https://github.com/vercel/micro/blob/master/packages/micro/lib/index.js#L128-L134)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.