### PR TITLE
Fix a parenthesis being unbalanced in the documentation for the totp-generator package

### DIFF
--- a/types/totp-generator/index.d.ts
+++ b/types/totp-generator/index.d.ts
@@ -7,7 +7,7 @@ interface TotpOptions {
     period?: number;
     /**
      * The desired SHA variant (SHA-1, SHA-224, SHA-256, SHA-384, SHA-512,
-     * SHA3-224, SHA3-256, SHA3-384, SHA3-512, SHAKE128, or SHAKE256.
+     * SHA3-224, SHA3-256, SHA3-384, SHA3-512, SHAKE128, or SHAKE256).
      */
     algorithm?: string;
     digits?: number;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.