### PR TITLE
Adding missing types to Animejs

### DIFF
--- a/types/animejs/animejs-tests.ts
+++ b/types/animejs/animejs-tests.ts
@@ -1,4 +1,4 @@
-import anime from 'animejs';
+import anime, { AnimeInstance } from 'animejs';
 
 const test1 = anime({
     targets: 'div',
@@ -6,8 +6,10 @@ const test1 = anime({
     color: "#FFFFFF"
 });
 
-const callback = (anim: any) => {
+const callback = (anim: AnimeInstance) => {
     console.log(anim.completed);
+    console.log(anim.animatables[0].id);
+    console.log(anim.animations[0].duration);
 };
 
 const test2 = anime({

--- a/types/animejs/index.d.ts
+++ b/types/animejs/index.d.ts
@@ -83,6 +83,24 @@ declare namespace anime {
         // Just need this to merge both Params interfaces.
     }
 
+    interface Animatable {
+        id: number;
+        target: HTMLElement;
+        total: number;
+        transforms: object;
+    }
+
+    interface Animation {
+        animatable: Animatable;
+        currentValue: string;
+        delay: number;
+        duration: number;
+        endDelay: number;
+        property: string;
+        tweens: ReadonlyArray<object>;
+        type: string;
+    }
+
     interface AnimeInstance extends AnimeCallBack {
         play(): void;
         pause(): void;
@@ -107,8 +125,8 @@ declare namespace anime {
         remaining: number;
         reversed: boolean;
 
-        animatables: ReadonlyArray<object>;
-        animations: ReadonlyArray<object>;
+        animatables: ReadonlyArray<Animatable>;
+        animations: ReadonlyArray<Animation>;
     }
 
     interface AnimeTimelineAnimParams extends AnimeAnimParams {


### PR DESCRIPTION
Adding 2 missing types that are used in all callback functions of animejs: Animation and Animatable
Both are currently only typed as object

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://animejs.com/documentation/#update
