### PR TITLE
[chrome] Add TabGroups API from Chrome 89 Manifest V3

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8445,6 +8445,142 @@ declare namespace chrome.tabs {
 }
 
 ////////////////////
+// Tab Groups
+////////////////////
+/**
+ * Use the chrome.tabGroups API to interact with the browser's tab grouping system. You can use this API to modify and rearrange tab groups in the browser. To group and ungroup tabs, or to query what tabs are in groups, use the chrome.tabs API.
+ * Permissions:  "tabGroups"
+ * @since Chrome 89. Manifest V3 and above.
+ */
+ declare namespace chrome.tabGroups {
+  export interface TabGroup {
+    /** Whether the group is collapsed. A collapsed group is one whose tabs are hidden. */
+    collapsed: boolean;
+    /**
+     * The group's color.
+     * One of: "grey", "blue", "red", "yellow", "green", "pink", "purple", or "cyan"
+     */
+    color: string;
+    /** The ID of the group. Group IDs are unique within a browser session. */
+    id: number;
+    /**
+     * Optional.
+     * The title of the group.
+     */
+    title?: string;
+    /** The ID of the window that contains the group. */
+    windowId: number;
+  }
+
+  export interface MoveProperties {
+    /**
+     * The position to move the group to. -1 will place the group at the end of the window.
+     */
+    index: number;
+    /**
+     * Optional.
+     * The window to move the group to.
+     * Defaults to the window the group is currently in. Note that groups can only be moved to and from windows with windows.WindowType type "normal".
+     */
+    windowId?: number;
+  }
+
+  export interface QueryInfo {
+    /**
+     * Optional.
+     * Whether the groups are collapsed.
+     */
+    collapsed?: boolean;
+    /**
+     * Optional. The group's color.
+     * One of: "grey", "blue", "red", "yellow", "green", "pink", "purple", or "cyan"
+     */
+    color?: 'grey'|'blue'|'red'|'yellow'|'green'|'pink'|'purple'|'cyan';
+    /**
+     * Optional.
+     * Match page titles against a pattern.
+     */
+    title?: string;
+    /**
+     * Optional.
+     * The ID of the parent window, or windows.WINDOW_ID_CURRENT for the current window.
+     */
+    windowId?: number;
+  }
+
+  export interface UpdateProperties {
+    /**
+     * Optional.
+     * Whether the group should be collapsed.
+     */
+    collapsed?: boolean;
+    /**
+     * Optional.
+     * The color of the group.
+     * One of: "grey", "blue", "red", "yellow", "green", "pink", "purple", or "cyan"
+     */
+    color?: 'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan';
+    /**
+     * Optional.
+     * The title of the group.
+     */
+    title?: string;
+  }
+
+  export interface GroupCreatedEvent extends chrome.events.Event<(group: TabGroup) => void> {}
+
+  export interface GroupMovedEvent extends chrome.events.Event<(group: TabGroup) => void> {}
+
+  export interface GroupRemovedEvent extends chrome.events.Event<(group: TabGroup) => void> {}
+
+  export interface GroupUpdatedEvent extends chrome.events.Event<(group: TabGroup) => void> {}
+
+  /** Retrieves details about the specified group. */
+  export function get(groupId: number, callback: (group: TabGroup) => void): void;
+  /**
+   * Moves the group and all its tabs within its window, or to a new window.
+   * @param groupId The ID of the group to move.
+   * @param callback Optional.
+   * Parameter group: Details about the moved group.
+   */
+  export function move(groupId: number, moveProperties: MoveProperties, callback?: (group: TabGroup) => void): void;
+  /**
+   * Gets all groups that have the specified properties, or all groups if no
+   * properties are specified.
+   */
+  export function query(queryInfo: QueryInfo, callback: (result: TabGroup[]) => void): void;
+  export function query(queryInfo: QueryInfo): Promise<TabGroup[]>;
+  /**
+   * Modifies the properties of a group. Properties that are not specified in
+   * updateProperties are not modified.
+   * @param groupId The ID of the group to modify.
+   * @param callback Optional.
+   * Optional parameter group: Details about the updated group.
+   */
+  export function update(groupId: number, updateProperties: UpdateProperties, callback?: (group?: TabGroup) => void): void;
+
+  /**
+   * An ID that represents the absence of a group.
+   */
+  export var TAB_GROUP_ID_NONE: -1;
+
+  /** Fired when a tab is created. */
+  export var onCreated: GroupCreatedEvent;
+  /**
+   * Fired when a group is moved within a window. Move events are still fired for the individual tabs within the group, as well as for the group itself. This event is not fired when a group is moved between windows; instead, it will be removed from one window and created in another.
+   */
+  export var onMoved: GroupMovedEvent;
+  /**
+   * Fired when a group is closed, either directly by the user or automatically because it contained zero tabs.
+   */
+  export var onRemoved: GroupRemovedEvent;
+  /**
+   * Fired when a group is updated.
+   */
+  export var onUpdated: GroupUpdatedEvent;
+ }
+
+////////////////////
 // Top Sites
 ////////////////////
 /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -389,6 +389,33 @@ async function testTabInterface() {
     tab.sessionId; // $ExpectType string | undefined
 }
 
+// tabGroups: https://developer.chrome.com/extensions/tabGroups#
+async function testTabGroupInterface() {
+  const options = { collapsed: false, title: 'Test' };
+
+  chrome.tabGroups.query(options, tabGroups => {
+      // $ExpectType TabGroup[]
+      tabGroups;
+
+      const [tabGroup] = tabGroups;
+      tabGroup.collapsed; // $ExpectType boolean
+      tabGroup.color; // $ExpectType string
+      tabGroup.id; // $ExpectType number
+      tabGroup.title; // $ExpectType string | undefined
+      tabGroup.windowId; // $ExpectType number
+  });
+
+  // $ExpectType TabGroup[]
+  const tabGroups = await chrome.tabGroups.query(options);
+
+  const [tabGroup] = tabGroups;
+  tabGroup.collapsed; // $ExpectType boolean
+  tabGroup.color; // $ExpectType string
+  tabGroup.id; // $ExpectType number
+  tabGroup.title; // $ExpectType string | undefined
+  tabGroup.windowId; // $ExpectType number
+}
+
 // https://developer.chrome.com/extensions/runtime#method-openOptionsPage
 function testOptionsPage() {
     chrome.runtime.openOptionsPage();

--- a/types/chrome/tslint.json
+++ b/types/chrome/tslint.json
@@ -10,6 +10,7 @@
         "no-empty-interface": false,
         "no-internal-module": false,
         "no-mergeable-namespace": false,
+        "no-outside-dependencies": false,
         "no-padding": false,
         "no-unnecessary-class": false,
         "no-unnecessary-generics": false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/tabGroups
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.