### PR TITLE
[rails__actioncable] Fix createConsumer return type

### DIFF
--- a/types/rails__actioncable/index.d.ts
+++ b/types/rails__actioncable/index.d.ts
@@ -201,5 +201,5 @@ export const logger: {
 /**
  * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/index.js
  */
-export function createConsumer(url?: string): typeof Consumer;
+export function createConsumer(url?: string): Consumer;
 export function getConfig(name: string): string | void;

--- a/types/rails__actioncable/rails__actioncable-tests.ts
+++ b/types/rails__actioncable/rails__actioncable-tests.ts
@@ -3,6 +3,7 @@ import {
     ConnectionMonitor,
     Consumer,
     createWebSocketURL,
+    createConsumer,
     INTERNAL,
     Subscription,
     Subscriptions,
@@ -26,6 +27,7 @@ createWebSocketURL('url'); // $ExpectType string
  * Consumer
  */
 const consumer = new Consumer('url'); // $ExpectType Consumer
+createConsumer('url'); // $ExpectType Consumer
 
 consumer.url; // $ExpectType string
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rails/rails/blob/291a3d2ef29a3842d1156ada7526f4ee60dd2b59/actioncable/app/javascript/action_cable/index.js#L22-L24
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
