### PR TITLE
Unbreak Mithril on TS 4.3 and remove outdated 2.4 workaround

### DIFF
--- a/types/mithril-global/index.d.ts
+++ b/types/mithril-global/index.d.ts
@@ -12,7 +12,7 @@ import * as mithril from 'mithril';
 import * as stream from 'mithril/stream';
 
 declare namespace MithrilGlobal {
-    export type Lifecycle<A, S> = mithril.Lifecycle<A, S>;
+    export type CommonAttributes<A, S> = mithril.CommonAttributes<A, S>;
     export type Hyperscript = mithril.Hyperscript;
     export type RouteResolver<A = {}, S = {}> = mithril.RouteResolver<A, S>;
     export type RouteDefs = mithril.RouteDefs;
@@ -24,15 +24,15 @@ declare namespace MithrilGlobal {
     export type ChildArray = mithril.ChildArray;
     export type Children = mithril.Children;
     export type ChildArrayOrPrimitive = mithril.ChildArrayOrPrimitive;
-    export type Vnode<A = {}, S extends mithril.Lifecycle<A, S> = {}> = mithril.Vnode<A, S>;
-    export type VnodeDOM<A = {}, S extends mithril.Lifecycle<A, S> = {}> = mithril.VnodeDOM<A, S>;
+    export type Vnode<A = {}, S = {}> = mithril.Vnode<A, S>;
+    export type VnodeDOM<A = {}, S = {}> = mithril.VnodeDOM<A, S>;
     export type CVnode<A = {}> = mithril.CVnode<A>;
     export type CVnodeDOM<A = {}> = mithril.CVnodeDOM<A>;
     export type Component<A = {}, S = {}> = mithril.Component<A, S>;
-    export type Comp<A = {}, S extends mithril.Lifecycle<A, S> = {}> = mithril.Comp<A, S>;
+    export type Comp<A = {}, S extends Partial<mithril.Component<A, S>> = {}> = mithril.Comp<A, S>;
     export type ClassComponent<A = {}> = mithril.ClassComponent<A>;
     export type FactoryComponent<A = {}> = mithril.FactoryComponent<A>;
-    export type ComponentTypes<A = {}, S extends mithril.Lifecycle<A, S> = {}> = mithril.ComponentTypes<A, S>;
+    export type ComponentTypes<A = {}, S extends Partial<mithril.Component<A, S>> = {}> = mithril.ComponentTypes<A, S>;
     export type Attributes = mithril.Attributes;
     export type Static = mithril.Static & { stream: typeof stream };
     export type Stream<T> = stream<T>;

--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -23,7 +23,7 @@ declare function jsonp<T>(options: Mithril.JsonpOptions & { url: string }): Prom
 declare function jsonp<T>(url: string, options?: Mithril.JsonpOptions): Promise<T>; // tslint:disable-line:no-unnecessary-generics
 
 declare namespace Mithril {
-    interface Lifecycle<Attrs, State> {
+    interface CommonAttributes<Attrs, State> {
         /** The oninit hook is called before a vnode is touched by the virtual DOM engine. */
         oninit?(this: State, vnode: Vnode<Attrs, State>): any;
         /** The oncreate hook is called after a DOM element is created and attached to the document. */
@@ -36,8 +36,8 @@ declare namespace Mithril {
         onbeforeupdate?(this: State, vnode: Vnode<Attrs, State>, old: VnodeDOM<Attrs, State>): boolean | void;
         /** The onupdate hook is called after a DOM element is updated, while attached to the document. */
         onupdate?(this: State, vnode: VnodeDOM<Attrs, State>): any;
-        /** WORKAROUND: TypeScript 2.4 does not allow extending an interface with all-optional properties. */
-        [_: number]: any;
+        /** A key to optionally associate with this element. */
+        key?: string | number;
     }
 
     interface Hyperscript {
@@ -50,11 +50,11 @@ declare namespace Mithril {
         /** Creates a virtual element (Vnode). */
         <Attrs, State>(
             component: ComponentTypes<Attrs, State>,
-            attributes: Attrs & Lifecycle<Attrs, State> & { key?: string | number },
+            attributes: Attrs & CommonAttributes<Attrs, State>,
             ...args: Children[]
         ): Vnode<Attrs, State>;
         /** Creates a fragment virtual element (Vnode). */
-        fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: ChildArrayOrPrimitive): Vnode<any, any>;
+        fragment(attrs: CommonAttributes<any, any> & { [key: string]: any }, children: ChildArrayOrPrimitive): Vnode<any, any>;
         /** Turns an HTML string into a virtual element (Vnode). Do not use trust on unsanitized user input. */
         trust(html: string): Vnode<any, any>;
     }
@@ -204,7 +204,7 @@ declare namespace Mithril {
     type ChildArrayOrPrimitive = ChildArray | string | number | boolean;
 
     /** Virtual DOM nodes, or vnodes, are Javascript objects that represent an element (or parts of the DOM). */
-    interface Vnode<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> {
+    interface Vnode<Attrs = {}, State = {}> {
         /** The nodeName of a DOM element. It may also be the string [ if a vnode is a fragment, # if it's a text vnode, or < if it's a trusted HTML vnode. Additionally, it may be a component. */
         tag: string | ComponentTypes<Attrs, State>;
         /** A hashmap of DOM attributes, events, properties and lifecycle methods. */
@@ -225,12 +225,14 @@ declare namespace Mithril {
 
     // In some lifecycle methods, Vnode will have a dom property
     // and possibly a domSize property.
-    interface VnodeDOM<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> extends Vnode<Attrs, State> {
+    interface VnodeDOM<Attrs = {}, State = {}> extends Vnode<Attrs, State> {
         /** Points to the element that corresponds to the vnode. */
         dom: Element;
         /** This defines the number of DOM elements that the vnode represents (starting from the element referenced by the dom property). */
         domSize?: number;
     }
+
+    type _NoLifecycle<T> = Omit<T, keyof Component>;
 
     interface CVnode<A = {}> extends Vnode<A, ClassComponent<A>> {}
 
@@ -241,9 +243,21 @@ declare namespace Mithril {
      * Any Javascript object that has a view method can be used as a Mithril component.
      * Components can be consumed via the m() utility.
      */
-    interface Component<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> extends Lifecycle<Attrs, State> {
+    interface Component<Attrs = {}, State = {}> {
+        /** The oninit hook is called before a vnode is touched by the virtual DOM engine. */
+        oninit?(this: _NoLifecycle<this & State>, vnode: Vnode<Attrs, _NoLifecycle<this & State>>): any;
+        /** The oncreate hook is called after a DOM element is created and attached to the document. */
+        oncreate?(this: _NoLifecycle<this & State>, vnode: VnodeDOM<Attrs, _NoLifecycle<this & State>>): any;
+        /** The onbeforeremove hook is called before a DOM element is detached from the document. If a Promise is returned, Mithril only detaches the DOM element after the promise completes. */
+        onbeforeremove?(this: _NoLifecycle<this & State>, vnode: VnodeDOM<Attrs, _NoLifecycle<this & State>>): Promise<any> | void;
+        /** The onremove hook is called before a DOM element is removed from the document. */
+        onremove?(this: _NoLifecycle<this & State>, vnode: VnodeDOM<Attrs, _NoLifecycle<this & State>>): any;
+        /** The onbeforeupdate hook is called before a vnode is diffed in a update. */
+        onbeforeupdate?(this: _NoLifecycle<this & State>, vnode: Vnode<Attrs, _NoLifecycle<this & State>>, old: VnodeDOM<Attrs, _NoLifecycle<this & State>>): boolean | void;
+        /** The onupdate hook is called after a DOM element is updated, while attached to the document. */
+        onupdate?(this: _NoLifecycle<this & State>, vnode: VnodeDOM<Attrs, _NoLifecycle<this & State>>): any;
         /** Creates a view out of virtual elements. */
-        view(this: State, vnode: Vnode<Attrs, State>): Children | null | void;
+        view(this: _NoLifecycle<this & State>, vnode: Vnode<Attrs, _NoLifecycle<this & State>>): Children | null | void;
     }
 
     /**
@@ -251,7 +265,7 @@ declare namespace Mithril {
      * Any class that implements a view method can be used as a Mithril component.
      * Components can be consumed via the m() utility.
      */
-    interface ClassComponent<A = {}> extends Lifecycle<A, ClassComponent<A>> {
+    interface ClassComponent<A = {}> {
         /** The oninit hook is called before a vnode is touched by the virtual DOM engine. */
         oninit?(vnode: Vnode<A, this>): any;
         /** The oncreate hook is called after a DOM element is created and attached to the document. */
@@ -286,22 +300,20 @@ declare namespace Mithril {
      * Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse.
      * Any Javascript object that has a view method is a Mithril component. Components can be consumed via the m() utility.
      */
-    type Comp<Attrs = {}, State extends Lifecycle<Attrs, State> = {}> = Component<Attrs, State> & State;
+    type Comp<Attrs = {}, State = {}> = _NoLifecycle<State> & Component<Attrs, _NoLifecycle<State>>;
 
     /** Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse. Components can be consumed via the m() utility. */
-    type ComponentTypes<A = {}, S extends Lifecycle<A, S> = {}> =
+    type ComponentTypes<A = {}, S = {}> =
         | Component<A, S>
         | { new (vnode: CVnode<A>): ClassComponent<A> }
         | FactoryComponent<A>;
 
     /** This represents the attributes available for configuring virtual elements, beyond the applicable DOM attributes. */
-    interface Attributes extends Lifecycle<any, any> {
+    interface Attributes extends CommonAttributes<any, any> {
         /** The class name(s) for this virtual element, as a space-separated list. */
         className?: string;
         /** The class name(s) for this virtual element, as a space-separated list. */
         class?: string;
-        /** A key to optionally associate with this element. */
-        key?: string | number;
         /** Any other virtual element properties, including attributes and event handlers. */
         [property: string]: any;
     }

--- a/types/mithril/test/test-component.ts
+++ b/types/mithril/test/test-component.ts
@@ -192,3 +192,37 @@ const comp: Comp<Attrs, State> = {
     },
 };
 export default comp;
+
+///////////////////////////////////////////////////////////
+//
+// Bad hook parameter type
+//
+interface InvalidState1 {
+    oncreate(nope: string): string;
+}
+
+// Using the Comp type will apply the State intersection type for us.
+const invalidComp1: Comp<{}, InvalidState1> = {
+    // $ExpectError
+    oncreate(nope: string) { return nope; },
+    view() {
+        return 'test';
+    },
+};
+
+///////////////////////////////////////////////////////////
+//
+// Bad hook type
+//
+interface InvalidState2 {
+    oncreate: string;
+}
+
+// Using the Comp type will apply the State intersection type for us.
+const invalidComp2: Comp<{}, InvalidState2> = {
+    // $ExpectError
+    oncreate: 'nope',
+    view() {
+        return 'test';
+    },
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51842 + https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51765
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **Not needed**

/cc @sandersn The fix took some mild restructuring. I've verified this locally against the existing tests and it shouldn't break user code. This preserves the invariants that need asserted (and fixes a few of them to align with reality). I also added a couple new tests for the desired errors.