### PR TITLE
[express] replaced deprecated "var" with "let" in index.d.ts

### DIFF
--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -31,37 +31,37 @@ declare namespace e {
      * This is a built-in middleware function in Express. It parses incoming requests with JSON payloads and is based on body-parser.
      * @since 4.16.0
      */
-    var json: typeof bodyParser.json;
+    let json: typeof bodyParser.json;
 
     /**
      * This is a built-in middleware function in Express. It parses incoming requests with Buffer payloads and is based on body-parser.
      * @since 4.17.0
      */
-    var raw: typeof bodyParser.raw;
+    let raw: typeof bodyParser.raw;
 
     /**
      * This is a built-in middleware function in Express. It parses incoming requests with text payloads and is based on body-parser.
      * @since 4.17.0
      */
-    var text: typeof bodyParser.text;
+    let text: typeof bodyParser.text;
 
     /**
      * These are the exposed prototypes.
      */
-    var application: Application;
-    var request: Request;
-    var response: Response;
+    let application: Application;
+    let request: Request;
+    let response: Response;
 
     /**
      * This is a built-in middleware function in Express. It serves static files and is based on serve-static.
      */
-    var static: serveStatic.RequestHandlerConstructor<Response>;
+    let static: serveStatic.RequestHandlerConstructor<Response>;
 
     /**
      * This is a built-in middleware function in Express. It parses incoming requests with urlencoded payloads and is based on body-parser.
      * @since 4.16.0
      */
-    var urlencoded: typeof bodyParser.urlencoded;
+    let urlencoded: typeof bodyParser.urlencoded;
 
     /**
      * This is a built-in middleware function in Express. It parses incoming request query parameters.


### PR DESCRIPTION
replaced the use of keyword "var" with ES6 "let".
the package that was changed is index.d.ts within express

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
