### PR TITLE
@ember routing fix typo of queryParam to queryParams

### DIFF
--- a/types/ember__routing/router-service.d.ts
+++ b/types/ember__routing/router-service.d.ts
@@ -200,7 +200,7 @@ export default class RouterService extends Service {
      */
     transitionTo(
         routeNameOrUrl: string,
-        options?: { queryParam: object }
+        options?: { queryParams: object }
     ): Transition;
     transitionTo(
         routeNameOrUrl: string,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember/3.25/classes/Route/methods/transitionTo?anchor=transitionTo
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (It does not)

This can't effectively be tested, because if you accidentally use ` { queryParam: ... }` instead then it will just assume that you're using the
```
transitionTo(
  routeNameOrUrl: string,
  models: RouteModel,
  options?: { queryParams: object }
): Transition;
```
definition instead, as that it would match `object` for being a `RouteModel`. It just helps with autocomplete, and may eventually be a necessary fix if a registry of `RouteModel`s is added.
