### PR TITLE
[jsdom] fix: add abort to ResourceLoader#fetch return type

### DIFF
--- a/types/jsdom/base.d.ts
+++ b/types/jsdom/base.d.ts
@@ -12,6 +12,10 @@ declare module "jsdom" {
     const toughCookie: typeof tough;
     class CookieJar extends tough.CookieJar {}
 
+    interface AbortablePromise<T> extends Promise<T> {
+        abort(): void;
+    }
+
     class JSDOM {
         constructor(html?: string | Buffer | BinaryData, options?: ConstructorOptions);
 
@@ -54,7 +58,7 @@ declare module "jsdom" {
     }
 
     class ResourceLoader {
-        fetch(url: string, options: FetchOptions): Promise<Buffer> | null;
+        fetch(url: string, options: FetchOptions): AbortablePromise<Buffer> | null;
 
         constructor(obj?: ResourceLoaderConstructorOptions);
     }

--- a/types/jsdom/test/core.ts
+++ b/types/jsdom/test/core.ts
@@ -201,3 +201,7 @@ function test_custom_resource_loader() {
     }
     new JSDOM("", { resources: new CustomResourceLoader() });
 }
+
+function test_resource_loader_return_type(resourceLoader: ResourceLoader) {
+    resourceLoader.fetch("https://example.com", {}); // $ExpectType AbortablePromise<Buffer> | null
+}


### PR DESCRIPTION
When JSDOM's `ResourceLoader` returns a Promise, it has an additional `abort` method. So this PR adds it to the type definition.

Since JSDOM internally depends on the `abort` method, when you provide a custom `ResourceLoader` to JSDOM it must support that `abort` method, or there will be an error. The change in this PR would help developers notice this.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsdom/jsdom/blob/master/lib/jsdom/browser/resources/resource-loader.js#L60
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.