### PR TITLE
react-widgets: Improves DateTimePicker parse prop type

### DIFF
--- a/types/react-widgets/index.d.ts
+++ b/types/react-widgets/index.d.ts
@@ -14,10 +14,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export import Calendar = require('./lib/Calendar');
-export import Combobox = require('./lib/Combobox');
-export import DateTimePicker = require('./lib/DateTimePicker');
-export import DropdownList = require('./lib/DropdownList');
-export import Multiselect = require('./lib/Multiselect');
-export import NumberPicker = require('./lib/NumberPicker');
-export import SelectList = require('./lib/SelectList');
+export import Calendar = require("./lib/Calendar");
+export import Combobox = require("./lib/Combobox");
+export import DateTimePicker = require("./lib/DateTimePicker");
+export import DropdownList = require("./lib/DropdownList");
+export import Multiselect = require("./lib/Multiselect");
+export import NumberPicker = require("./lib/NumberPicker");
+export import SelectList = require("./lib/SelectList");

--- a/types/react-widgets/lib/Calendar.d.ts
+++ b/types/react-widgets/lib/Calendar.d.ts
@@ -1,8 +1,8 @@
-import { ComponentClass } from 'react';
-import { ReactWidgetsCommonProps, AutoFocus } from './CommonProps';
+import { ComponentClass } from "react";
+import { ReactWidgetsCommonProps, AutoFocus } from "./CommonProps";
 
 declare namespace Calendar {
-    type CalendarView = 'month' | 'year' | 'decade' | 'century';
+    type CalendarView = "month" | "year" | "decade" | "century";
 
     interface CalendarProps extends ReactWidgetsCommonProps, AutoFocus {
         /**

--- a/types/react-widgets/lib/Combobox.d.ts
+++ b/types/react-widgets/lib/Combobox.d.ts
@@ -1,5 +1,5 @@
-import { ComponentClass } from 'react';
-import { ReactWidgetsCommonDropdownProps, AutoFocus } from './CommonProps';
+import { ComponentClass } from "react";
+import { ReactWidgetsCommonDropdownProps, AutoFocus } from "./CommonProps";
 
 declare namespace Combobox {
     interface ComboboxMessages {

--- a/types/react-widgets/lib/DateTimePicker.d.ts
+++ b/types/react-widgets/lib/DateTimePicker.d.ts
@@ -88,7 +88,7 @@ declare namespace DateTimePicker {
          * parsing yourself. When parse is unspecified and the format prop is a String parse will
          * automatically use that format as its default
          */
-        parse?: ((str: string) => Date) | string[] | string;
+        parse?: ((str: string) => Date | undefined) | string[] | string;
         /**
          * The starting and lowest level view the calendar can navigate down to.
          */

--- a/types/react-widgets/lib/DateTimePicker.d.ts
+++ b/types/react-widgets/lib/DateTimePicker.d.ts
@@ -1,5 +1,5 @@
-import { ComponentClass, KeyboardEvent, ReactElement, ReactType } from 'react';
-import { ReactWidgetsCommonDropdownProps, AutoFocus } from './CommonProps';
+import { ComponentClass, KeyboardEvent, ReactElement, ReactType } from "react";
+import { ReactWidgetsCommonDropdownProps, AutoFocus } from "./CommonProps";
 
 declare namespace DateTimePicker {
     type Open = false | "date" | "time";

--- a/types/react-widgets/lib/DropdownList.d.ts
+++ b/types/react-widgets/lib/DropdownList.d.ts
@@ -1,12 +1,12 @@
-import { ComponentClass } from 'react';
-import { ReactWidgetsCommonDropdownProps, AutoFocus } from './CommonProps';
+import { ComponentClass } from "react";
+import { ReactWidgetsCommonDropdownProps, AutoFocus } from "./CommonProps";
 
 declare namespace DropdownList {
     interface DropdownListProps extends ReactWidgetsCommonDropdownProps, AutoFocus {
         /**
          * Allow to create a new option on the data list.
          */
-        allowCreate?: boolean | 'onFilter';
+        allowCreate?: boolean | "onFilter";
         /**
          * The current value of the DropdownList. This can be an object (such as a member of the
          * data array) or a primitive value, hinted to by the valueField. The widget value does not
@@ -207,6 +207,6 @@ declare namespace DropdownList {
     }
 }
 
-interface DropdownListClass extends ComponentClass<DropdownList.DropdownListProps> { }
+interface DropdownListClass extends ComponentClass<DropdownList.DropdownListProps> {}
 declare var DropdownList: DropdownListClass;
 export = DropdownList;

--- a/types/react-widgets/lib/Multiselect.d.ts
+++ b/types/react-widgets/lib/Multiselect.d.ts
@@ -1,10 +1,8 @@
-import { ComponentClass } from 'react';
+import { ComponentClass } from "react";
 import { ReactWidgetsCommonDropdownProps, AutoFocus } from "./CommonProps";
 
 declare namespace Multiselect {
-    interface MultiselectProps
-        extends ReactWidgetsCommonDropdownProps,
-            AutoFocus {
+    interface MultiselectProps extends ReactWidgetsCommonDropdownProps, AutoFocus {
         /**
          * Enables the list option creation UI. onFilter will only the UI when actively filtering for a list item.
          * @default 'onFilter'
@@ -31,7 +29,7 @@ declare namespace Multiselect {
                 originalEvent?: any;
                 lastValue?: any[];
                 searchTerm?: string;
-            }
+            },
         ) => void;
         /**
          * This handler fires when an item has been selected from the list. It fires before the
@@ -41,7 +39,7 @@ declare namespace Multiselect {
             value: any,
             metadata: {
                 originalEvent: any;
-            }
+            },
         ) => void;
         /**
          * This handler fires when the user chooses to create a new tag, not in the data list. It is
@@ -115,7 +113,7 @@ declare namespace Multiselect {
                 action: "clear" | "input";
                 lastSearchTerm?: string;
                 originalEvent?: any;
-            }
+            },
         ) => void;
         /**
          * Whether or not the Multiselect is open. When unset (undefined) the Multiselect will
@@ -136,12 +134,7 @@ declare namespace Multiselect {
          * item (analogous to the array.filter builtin)
          * @default startsWith
          */
-        filter?:
-            | false
-            | "startsWith"
-            | "endsWith"
-            | "contains"
-            | ((dataItem: any, searchTerm: string) => boolean);
+        filter?: false | "startsWith" | "endsWith" | "contains" | ((dataItem: any, searchTerm: string) => boolean);
         /**
          * Use in conjunction with the filter prop. Filter the list without regard for case. This
          * only applies to non function values for filter.

--- a/types/react-widgets/lib/NumberPicker.d.ts
+++ b/types/react-widgets/lib/NumberPicker.d.ts
@@ -1,5 +1,5 @@
-import { ComponentClass } from 'react';
-import { ReactWidgetsCommonProps, AutoFocus } from './CommonProps';
+import { ComponentClass } from "react";
+import { ReactWidgetsCommonProps, AutoFocus } from "./CommonProps";
 
 declare namespace NumberPicker {
     interface NumberPickerProps extends ReactWidgetsCommonProps, AutoFocus {

--- a/types/react-widgets/lib/SelectList.d.ts
+++ b/types/react-widgets/lib/SelectList.d.ts
@@ -1,5 +1,5 @@
-import { ComponentClass } from 'react';
-import { ReactWidgetsCommonProps, AutoFocus } from './CommonProps';
+import { ComponentClass } from "react";
+import { ReactWidgetsCommonProps, AutoFocus } from "./CommonProps";
 
 declare namespace SelectList {
     interface SelectListProps extends ReactWidgetsCommonProps, AutoFocus {

--- a/types/react-widgets/react-widgets-tests.tsx
+++ b/types/react-widgets/react-widgets-tests.tsx
@@ -1,15 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import {
-    Calendar,
-    Combobox,
-    DateTimePicker,
-    DropdownList,
-    Multiselect,
-    NumberPicker,
-    SelectList
-} from "react-widgets";
+import { Calendar, Combobox, DateTimePicker, DropdownList, Multiselect, NumberPicker, SelectList } from "react-widgets";
 import * as CalendarDefault from "react-widgets/lib/Calendar";
 import * as ComboboxDefault from "react-widgets/lib/Combobox";
 import * as DateTimePickerDefault from "react-widgets/lib/DateTimePicker";
@@ -71,29 +63,15 @@ class Test extends React.Component<React.Props<{}>> {
                     <SelectList defaultValue={"foo"} />
                 </div>
                 <div>
-                    <Multiselect
-                        tagComponent={tagComponent}
-                        itemComponent={itemComponent}
-                    />
-                    <Combobox
-                        itemComponent={itemComponent}
-                        listComponent={listComponent}
-                    />
-                    <DropdownList
-                        itemComponent={itemComponent}
-                        listComponent={listComponent}
-                    />
+                    <Multiselect tagComponent={tagComponent} itemComponent={itemComponent} />
+                    <Combobox itemComponent={itemComponent} listComponent={listComponent} />
+                    <DropdownList itemComponent={itemComponent} listComponent={listComponent} />
                     <Multiselect listComponent={listComponent} />
                     <SelectList listComponent={listComponent} />
                 </div>
                 <div>
                     <Calendar disabled readOnly />
-                    <Combobox
-                        disabled
-                        readOnly
-                        dropUp
-                        placeholder={"Some text"}
-                    />
+                    <Combobox disabled readOnly dropUp placeholder={"Some text"} />
                     <DateTimePicker disabled readOnly dropUp />
                     <DropdownList disabled readOnly dropUp />
                     <Multiselect disabled readOnly dropUp />
@@ -101,12 +79,7 @@ class Test extends React.Component<React.Props<{}>> {
                     <SelectList disabled readOnly />
                 </div>
                 <div>
-                    <Calendar
-                        autoFocus
-                        defaultValue={new Date()}
-                        defaultView="year"
-                        views={["year", "decade"]}
-                    />
+                    <Calendar autoFocus defaultValue={new Date()} defaultView="year" views={["year", "decade"]} />
                     <CalendarDefault
                         autoFocus
                         defaultValue={new Date()}
@@ -114,37 +87,30 @@ class Test extends React.Component<React.Props<{}>> {
                         views={["year", "decade"]}
                     />
                     <Combobox autoFocus delay={300} name="box" />
-                    <Combobox
-                        busy
-                        busySpinner={<span className="fas fa-sync fa-spin" />}
-                    />
+                    <Combobox busy busySpinner={<span className="fas fa-sync fa-spin" />} />
                     <DateTimePicker autoFocus open="date" />
-                    <DropdownList
-                        autoFocus
-                        delay={350}
-                        name="list"
-                        multiple={false}
-                    />
+                    <DropdownList autoFocus delay={350} name="list" multiple={false} />
                     <DropdownList containerClassName="list-items" />
                     <Multiselect autoFocus allowCreate />
                     <Multiselect containerClassName="multiselect-container" />
-                    <NumberPicker
-                        autoFocus
-                        name="numbers"
-                        placeholder="hello"
-                    />
-                    <SelectList
-                        autoFocus
-                        delay={400}
-                        tabIndex={-1}
-                        name="list"
-                    />
+                    <NumberPicker autoFocus name="numbers" placeholder="hello" />
+                    <SelectList autoFocus delay={400} tabIndex={-1} name="list" />
                 </div>
                 <div>
                     <DateTimePicker
                         dropUp={true}
                         containerClassName="d-flex"
                         timeIcon={<i className="fa fa-clock" />}
+                    />
+                </div>
+                <div>
+                    <DateTimePicker
+                        parse={(str: string): Date | undefined => {
+                            if (str) {
+                                return new Date(str);
+                            }
+                            return undefined;
+                        }}
                     />
                 </div>
             </div>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://github.com/jquense/react-widgets/blob/master/packages/react-widgets/src/DateTimePicker.js#L604)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Comments

It's valid for the `parse` prop on a react-widgets/DateTimePicker to return undefined (technically any falsy value) in order to disregard the text input value (i.e. parse failure). Like if someone just types "foo" into a DateTimePicker, then the input should be cleared upon blurring the field. But the existing DT types don't account for that return type.

I ran prettier as the documentation suggested, which updated most of the files within types/react-widgets. I assume this is OK, but let me know if there's an issue.

I have left comments on the two non-prettier changes I'm actually submitting.