### PR TITLE
Make properties of PerMessageOptions optional

### DIFF
--- a/types/sumo-logger/index.d.ts
+++ b/types/sumo-logger/index.d.ts
@@ -99,13 +99,13 @@ declare namespace SumoLogger {
          * Use this when the event being logged occurred
          * at a different time than when the log was sent.
          */
-        timestamp: Date;
+        timestamp?: Date;
 
         /** Override a session key set in the `config` call. */
-        sessionKey: string;
+        sessionKey?: string;
 
         /** Override client URL set in the config call. (Node version only) */
-        url: string;
+        url?: string;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
// I do not think this change requires any changes to the tests, but happy to make changes if someone has suggestions for what changes should be made.
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jbutz/js-logging-sdk#per-message-options

The docs for js-sumo-logger specify that PerMessageOptions can contain "any" of the fields, meaning that all of those fields should be optional, not required.
```
All variants of the log call take an optional object parameter, which can include any of the following fields:
```

Also, here is the example usage of PerMessageOptions:
```
sumoLogger.log('event message to log', {
      sessionKey: 'your session key value',
      url: 'https://youDomain.com/actual/page/served'
    });
```
Note that timestamp is omitted from the PerMessageOptions.