### PR TITLE
[react-native] Refine LayoutAnimation Types

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -628,29 +628,27 @@ export namespace AppRegistry {
     function getRunnable(appKey: string): Runnable | undefined;
 }
 
-export interface LayoutAnimationTypes {
-    spring: string;
-    linear: string;
-    easeInEaseOut: string;
-    easeIn: string;
-    easeOut: string;
-    keyboard: string;
-}
+export type LayoutAnimationType = 
+    | 'spring'
+    | 'linear'
+    | 'easeInEaseOut'
+    | 'easeIn'
+    | 'easeOut'
+    | 'keyboard';
 
-export interface LayoutAnimationProperties {
-    opacity: string;
-    scaleX: string;
-    scaleY: string;
-    scaleXY: string;
-}
+export type LayoutAnimationProperty =
+    | 'opacity'
+    | 'scaleX'
+    | 'scaleY'
+    | 'scaleXY';
 
 export interface LayoutAnimationAnim {
     duration?: number;
     delay?: number;
     springDamping?: number;
     initialVelocity?: number;
-    type?: string; //LayoutAnimationTypes
-    property?: string; //LayoutAnimationProperties
+    type?: LayoutAnimationType;
+    property?: LayoutAnimationProperty;
 }
 
 export interface LayoutAnimationConfig {
@@ -679,11 +677,11 @@ export interface LayoutAnimationStatic {
     /** Helper for creating a config for configureNext. */
     create: (
         duration: number,
-        type?: keyof LayoutAnimationTypes,
-        creationProp?: keyof LayoutAnimationProperties
+        type?: LayoutAnimationType,
+        creationProp?:LayoutAnimationProperty
     ) => LayoutAnimationConfig;
-    Types: LayoutAnimationTypes;
-    Properties: LayoutAnimationProperties;
+    Types: Record<LayoutAnimationType, LayoutAnimationType>;
+    Properties: Record<LayoutAnimationProperty, LayoutAnimationProperty>;
     configChecker: (shapeTypes: { [key: string]: any }) => any;
     Presets: {
         easeInEaseOut: LayoutAnimationConfig;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -636,11 +636,19 @@ export type LayoutAnimationType =
     | 'easeOut'
     | 'keyboard';
 
+export type LayoutAnimationTypes = {
+    [type in LayoutAnimationType]: type;
+}
+
 export type LayoutAnimationProperty =
     | 'opacity'
     | 'scaleX'
     | 'scaleY'
     | 'scaleXY';
+
+export type LayoutAnimationProperties = {
+    [prop in LayoutAnimationProperty]: prop;
+}
 
 export interface LayoutAnimationAnim {
     duration?: number;
@@ -680,8 +688,8 @@ export interface LayoutAnimationStatic {
         type?: LayoutAnimationType,
         creationProp?:LayoutAnimationProperty
     ) => LayoutAnimationConfig;
-    Types: Record<LayoutAnimationType, LayoutAnimationType>;
-    Properties: Record<LayoutAnimationProperty, LayoutAnimationProperty>;
+    Types: LayoutAnimationTypes;
+    Properties: LayoutAnimationProperties;
     configChecker: (shapeTypes: { [key: string]: any }) => any;
     Presets: {
         easeInEaseOut: LayoutAnimationConfig;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -628,7 +628,7 @@ export namespace AppRegistry {
     function getRunnable(appKey: string): Runnable | undefined;
 }
 
-export type LayoutAnimationType = 
+export type LayoutAnimationType =
     | 'spring'
     | 'linear'
     | 'easeInEaseOut'
@@ -686,7 +686,7 @@ export interface LayoutAnimationStatic {
     create: (
         duration: number,
         type?: LayoutAnimationType,
-        creationProp?:LayoutAnimationProperty
+        creationProp?: LayoutAnimationProperty
     ) => LayoutAnimationConfig;
     Types: LayoutAnimationTypes;
     Properties: LayoutAnimationProperties;

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1723,4 +1723,4 @@ LayoutAnimation.configureNext(LayoutAnimation.create(
     LayoutAnimation.Properties.opacity,
 ));
 
-LayoutAnimation.configureNext(LayoutAnimation.create(123, 'easeIn','opacity'));
+LayoutAnimation.configureNext(LayoutAnimation.create(123, 'easeIn', 'opacity'));

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -118,6 +118,7 @@ import {
     SectionListData,
     ToastAndroid,
     Touchable,
+    LayoutAnimation,
 } from 'react-native';
 
 declare module 'react-native' {
@@ -1714,3 +1715,12 @@ const I18nManagerTest = () => {
 
     console.log(isRTL, isRtlFlag, doLeftAndRightSwapInRTL, doLeftAndRightSwapInRtlFlag);
 };
+
+// LayoutAnimations
+LayoutAnimation.configureNext(LayoutAnimation.create(
+    123,
+    LayoutAnimation.Types.easeIn,
+    LayoutAnimation.Properties.opacity,
+));
+
+LayoutAnimation.configureNext(LayoutAnimation.create(123, 'easeIn','opacity'));


### PR DESCRIPTION
`LayoutAnimation` exposes some enum-style static objects. These are eachj a reflection of the key name. E.g.

https://github.com/facebook/react-native/blob/master/Libraries/LayoutAnimation/LayoutAnimation.js#L157
```js
  Types: Object.freeze({
    spring: 'spring',
    linear: 'linear',
    easeInEaseOut: 'easeInEaseOut',
    easeIn: 'easeIn',
    easeOut: 'easeOut',
    keyboard: 'keyboard',
  }),
```

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/dd4bf52c0b1d72af91229550cc5836b5d08240b1#commitcomment-48639431 my recent PR adding typings for 0.64 refined the type expected in LayoutAnimation functions to expect a type from a union of valid strings, instead of accepting any string. This matches internal flow typings. I missed updating these enums though, so only the string literals worked after the change.

Update the typings of the enum style objects as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/LayoutAnimation/LayoutAnimation.js#L157
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.