### PR TITLE
[dockerode] Add image build and push options

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -138,9 +138,9 @@ declare namespace Dockerode {
         get(callback: Callback<NodeJS.ReadableStream>): void;
         get(): Promise<NodeJS.ReadableStream>;
 
-        push(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+        push(options: ImagePushOptions, callback: Callback<NodeJS.ReadableStream>): void;
         push(callback: Callback<NodeJS.ReadableStream>): void;
-        push(options?: {}): Promise<NodeJS.ReadableStream>;
+        push(options?: ImagePushOptions): Promise<NodeJS.ReadableStream>;
 
         tag(options: {}, callback: Callback<any>): void;
         tag(callback: Callback<any>): void;
@@ -801,6 +801,38 @@ declare namespace Dockerode {
             Layers?: string[];
             BaseLayer?: string;
         };
+    }
+
+    interface ImageBuildOptions {
+        authconfig?: AuthConfig;
+        dockerfile?: string;
+        t?: string;
+        extrahosts?: string;
+        remote?: string;
+        q?: boolean;
+        cachefrom?: string;
+        pull?: string;
+        rm?: boolean;
+        forcerm?: boolean;
+        memory?: number;
+        memswap?: number;
+        cpushares?: number;
+        cpusetcpus?: number;
+        cpuperiod?: number;
+        cpuquota?: number;
+        buildargs?: {[key: string]: string};
+        shmsize?: number;
+        squash?: boolean;
+        labels?: {[key: string]: string};
+        networkmode?: string;
+        platform?: string;
+        target?: string;
+        outputs?: string;
+    }
+
+    interface ImagePushOptions {
+        tag?: string;
+        authconfig?: AuthConfig;
     }
 
     interface AuthConfig {
@@ -1627,7 +1659,7 @@ declare class Dockerode {
 
     buildImage(
         file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
-        options: {},
+        options: Dockerode.ImageBuildOptions,
         callback: Callback<NodeJS.ReadableStream>,
     ): void;
     buildImage(
@@ -1636,7 +1668,7 @@ declare class Dockerode {
     ): void;
     buildImage(
         file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
-        options?: {},
+        options?: Dockerode.ImageBuildOptions,
     ): Promise<NodeJS.ReadableStream>;
 
     getContainer(id: string): Dockerode.Container;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild
- https://github.com/apocas/dockerode/blob/master/lib/image.js#L171
- https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L161

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Note
Some of these changes might seem slightly strange, so I'll explain them.

### Authconfig
The `authconfig` property I've included is not part of the Docker API, but it _is_ part of the dockerode API. I've provided some links to the behaviour above.

### Labels
The Docker API linked above seems to suggest that 'labels' is a string but the description implies it is actually a string->string map. I've tested it as a string->string map and it seems correct to me.

### Buildargs
This is similar to labels, docker API docs list it as a string but describes it as a string->string map.