### PR TITLE
fix asyncResource.emitDestroy() return type

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -151,7 +151,7 @@ declare module 'async_hooks' {
         /**
          * Call AsyncHooks destroy callbacks.
          */
-        emitDestroy(): void;
+        emitDestroy(): this;
 
         /**
          * @return the unique ID assigned to this AsyncResource instance.

--- a/types/node/test/async_hooks.ts
+++ b/types/node/test/async_hooks.ts
@@ -59,6 +59,8 @@ import {
     let res = AsyncResource.bind((x: number) => x)(42);
     const asyncResource = new AsyncResource('');
     res = asyncResource.bind((x: number) => x)(42);
+    // $ExpectType AsyncResource
+    asyncResource.emitDestroy();
 }
 
 {

--- a/types/node/v10/async_hooks.d.ts
+++ b/types/node/v10/async_hooks.d.ts
@@ -129,7 +129,7 @@ declare module "async_hooks" {
         /**
          * Call AsyncHooks destroy callbacks.
          */
-        emitDestroy(): void;
+        emitDestroy(): this;
 
         /**
          * @return the unique ID assigned to this AsyncResource instance.

--- a/types/node/v11/async_hooks.d.ts
+++ b/types/node/v11/async_hooks.d.ts
@@ -129,7 +129,7 @@ declare module "async_hooks" {
         /**
          * Call AsyncHooks destroy callbacks.
          */
-        emitDestroy(): void;
+        emitDestroy(): this;
 
         /**
          * @return the unique ID assigned to this AsyncResource instance.

--- a/types/node/v11/ts3.6/node-tests.ts
+++ b/types/node/v11/ts3.6/node-tests.ts
@@ -1131,6 +1131,10 @@ import * as constants from 'constants';
       triggerAsyncId: 0,
       requireManualDestroy: true
     });
+
+    const asyncResource = new async_hooks.AsyncResource('');
+    // $ExpectType AsyncResource
+    asyncResource.emitDestroy();
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/v12/async_hooks.d.ts
+++ b/types/node/v12/async_hooks.d.ts
@@ -151,7 +151,7 @@ declare module 'async_hooks' {
         /**
          * Call AsyncHooks destroy callbacks.
          */
-        emitDestroy(): void;
+        emitDestroy(): this;
 
         /**
          * @return the unique ID assigned to this AsyncResource instance.

--- a/types/node/v12/test/async_hooks.ts
+++ b/types/node/v12/test/async_hooks.ts
@@ -55,6 +55,10 @@ import {
       triggerAsyncId: 0,
       requireManualDestroy: true
     });
+
+    const asyncResource = new AsyncResource('');
+    // $ExpectType AsyncResource
+    asyncResource.emitDestroy();
 }
 
 {

--- a/types/node/v13/async_hooks.d.ts
+++ b/types/node/v13/async_hooks.d.ts
@@ -131,7 +131,7 @@ declare module "async_hooks" {
         /**
          * Call AsyncHooks destroy callbacks.
          */
-        emitDestroy(): void;
+        emitDestroy(): this;
 
         /**
          * @return the unique ID assigned to this AsyncResource instance.

--- a/types/node/v13/test/async_hooks.ts
+++ b/types/node/v13/test/async_hooks.ts
@@ -47,6 +47,10 @@ import { AsyncResource, createHook, triggerAsyncId, executionAsyncId, executionA
       triggerAsyncId: 0,
       requireManualDestroy: true
     });
+
+    const asyncResource = new AsyncResource('');
+    // $ExpectType AsyncResource
+    asyncResource.emitDestroy();
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes https://nodejs.org/docs/latest-v15.x/api/async_hooks.html#async_hooks_asyncresource_emitdestroy
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Based on documentation 
https://nodejs.org/docs/latest-v15.x/api/async_hooks.html#async_hooks_asyncresource_emitdestroy

and code snippet
```Javascript
emitDestroy() {
    if (this[destroyedSymbol] !== undefined) {
      this[destroyedSymbol].destroyed = true;
    }
    emitDestroy(this[async_id_symbol]);
    return this;
  }
```

The method `emitDestroy()` under class `AsyncResource` should return `this` rather than `void`