### PR TITLE
react-router: Make path prop for Route component readonly

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -91,7 +91,7 @@ export interface RouteProps<
     component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
     render?: (props: RouteComponentProps<Params>) => React.ReactNode;
     children?: ((props: RouteChildrenProps<Params>) => React.ReactNode) | React.ReactNode;
-    path?: Path | Path[];
+    path?: Path | readonly Path[];
     exact?: boolean;
     sensitive?: boolean;
     strict?: boolean;

--- a/types/react-router/test/Route.tsx
+++ b/types/react-router/test/Route.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
+const CONST_ROUTE_ARRAY = ['/const-route-1', '/const-route-2'] as const;
+
 const exhausted = (_: never): never => {
     throw new Error('unreachable');
 };
@@ -54,6 +56,11 @@ const RouteExample = () => (
                 return exhausted(params);
             }}
         />
+        <Route
+            path={CONST_ROUTE_ARRAY}
+        >
+            Matches const array
+        </Route>
         <Route
             path="/single/:id"
             children={route => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactrouter.com/web/api/Route/path-string-string

This change fixes a type error that results from passing a readonly array as the path prop to a Route component.

```
const ARRAY_OF_ROUTES = ['/route-1', '/route-2'] as const;

// ...in a <BrowserRouter> somewhere...
<Route
    path={ARRAY_OF_ROUTES}
//  ^^^^
//  The type 'readonly ["/route-1", "/route-2"]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
>
    ...
</Route>
```

You may want to be able to pass a readonly array though, as you might depend on having a type more specific than `string[]` somewhere else in your code. I'm currently working around this by doing...

```
    path={[...ARRAY_OF_ROUTES]}
```