### PR TITLE
Allow using `jpg` as a format in `sharp` package

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1145,6 +1145,7 @@ declare namespace sharp {
         heif: AvailableFormatInfo;
         input: AvailableFormatInfo;
         jpeg: AvailableFormatInfo;
+        jpg: AvailableFormatInfo;
         magick: AvailableFormatInfo;
         openslide: AvailableFormatInfo;
         pdf: AvailableFormatInfo;

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -199,6 +199,7 @@ sharp(input)
 
 sharp(input)
     .resize(100, 100)
+    .toFormat('jpg')
     .toBuffer({ resolveWithObject: false })
     .then((outputBuffer: Buffer) => {
         // Resolves with a Buffer object when resolveWithObject is false


### PR DESCRIPTION
Currently only `jpeg` is allowed

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See [https://sharp.pixelplumbing.com/api-output#toformat](https://sharp.pixelplumbing.com/api-output#toformat) and [https://sharp.pixelplumbing.com/api-output#examples-3](https://sharp.pixelplumbing.com/api-output#examples-3)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.