### PR TITLE
fix(rdf-loaders-registry): wrong return type

### DIFF
--- a/types/rdf-loaders-registry/index.d.ts
+++ b/types/rdf-loaders-registry/index.d.ts
@@ -25,7 +25,7 @@ declare namespace LoaderRegistry {
             TLoader extends Loader<T, TOptions> = Loader<T>,
             TOptions = TLoader extends Loader<T, infer U> ? U : {}>(
                 node: GraphPointer,
-                options?: TOptions): Promise<T | null>;
+                options?: TOptions): Promise<T> | T | null;
         loader(node: GraphPointer): Loader<any, any> | null;
     }
 }

--- a/types/rdf-loaders-registry/rdf-loaders-registry-tests.ts
+++ b/types/rdf-loaders-registry/rdf-loaders-registry-tests.ts
@@ -34,7 +34,11 @@ async function basicLoading() {
 }
 
 async function loadWithSpecificLoaderInferOptionType() {
-  const result: Nebula | null = await registry.load<Nebula, NebulaLoader>(node, { bar: 'baz'});
+  const result = registry.load<Nebula, NebulaLoader>(node, { bar: 'baz' });
+  if (result) {
+    const nebula: Nebula = await result;
+  }
+
   // $ExpectError
   await registry.load<Nebula, NebulaLoader>(node, {});
   // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/zazuko/rdf-loaders-registry/blob/v0.2.0/index.js#L32-L36>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
