### PR TITLE
Adds reference to extras.d.ts to index.d.ts for zen-observable

### DIFF
--- a/types/zen-observable/index.d.ts
+++ b/types/zen-observable/index.d.ts
@@ -6,6 +6,8 @@
 //                 BenoitZugmeyer <https://github.com/BenoitZugmeyer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+///<reference path="./extras.d.ts"/>
+
 declare global {
     interface SymbolConstructor {
         readonly observable: symbol;


### PR DESCRIPTION
The types for zen-observable to not reference extras.d.ts and so they are not included when the package is published to npm.

[Sandbox importing `combineLatest` using only JS](https://codesandbox.io/s/combinelatest-js-h9udh?file=/src/App.js)
[Sandbox importing `combineLatest` using TS](https://codesandbox.io/s/combinelatest-ts-br190?file=/src/index.ts) (Fails)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped#npm
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
