### PR TITLE
added types for camouflage-rewrite

### DIFF
--- a/types/camouflage-rewrite/camouflage-rewrite-tests.ts
+++ b/types/camouflage-rewrite/camouflage-rewrite-tests.ts
@@ -1,0 +1,20 @@
+import rewrite = require('camouflage-rewrite');
+import express = require('express');
+
+const app = express();
+
+// minimal options
+app.use(rewrite({
+    url: 'http://example.com/api'
+}));
+
+// full options
+app.use(rewrite({
+    rewriteContent: true,
+    rewriteHeaders: true,
+    mediaTypes: [
+        'text/turtle',
+        'application/ld+json'
+    ],
+    url: 'http://example.com/api'
+}));

--- a/types/camouflage-rewrite/index.d.ts
+++ b/types/camouflage-rewrite/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for camouflage-rewrite 1.2
+// Project: https://github.com/zazukoians/camouflage-rewrite
+// Definitions by: Tomasz Pluskiewicz <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { RequestHandler } from 'express';
+
+declare namespace CamouflageRewrite {
+    interface Options {
+        mediaTypes?: string[];
+        rewriteContent?: boolean;
+        rewriteHeaders?: boolean;
+        url: string;
+    }
+}
+
+declare function CamouflageRewrite(options: CamouflageRewrite.Options): RequestHandler;
+
+export = CamouflageRewrite;

--- a/types/camouflage-rewrite/tsconfig.json
+++ b/types/camouflage-rewrite/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "camouflage-rewrite-tests.ts"
+    ]
+}

--- a/types/camouflage-rewrite/tslint.json
+++ b/types/camouflage-rewrite/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
