### PR TITLE
Remove redundant @readonly tags

### DIFF
--- a/types/filesystem/index.d.ts
+++ b/types/filesystem/index.d.ts
@@ -73,13 +73,11 @@ interface LocalFileSystemSync {
 interface Metadata {
     /**
      * This is the time at which the file or directory was last modified.
-     * @readonly
      */
     modificationTime: Date;
 
     /**
      * The size of the file, in bytes. This must return 0 for directories.
-     * @readonly
      */
     size: number;
 }
@@ -102,13 +100,11 @@ interface Flags {
 interface FileSystem {
     /**
      * This is the name of the file system. The specifics of naming filesystems is unspecified, but a name must be unique across the list of exposed file systems.
-     * @readonly
      */
     name: string;
 
     /**
      * The root directory of the file system.
-     * @readonly
      */
     root: DirectoryEntry;
 }
@@ -391,13 +387,11 @@ interface FileSystemSync {
 interface EntrySync {
     /**
      * EntrySync is a file.
-     * @readonly
      */
     isFile: boolean;
 
     /**
      * EntrySync is a directory.
-     * @readonly
      */
     isDirectory: boolean;
 

--- a/types/filewriter/index.d.ts
+++ b/types/filewriter/index.d.ts
@@ -25,19 +25,16 @@ interface FileSaver extends EventTarget {
 
     /**
      * The blob is being written.
-     * @readonly
      */
     INIT: number;
 
     /**
      * The object has been constructed, but there is no pending write.
-     * @readonly
      */
     WRITING: number;
 
     /**
      * The entire Blob has been written to the file, an error occurred during the write, or the write was aborted using abort(). The FileSaver is no longer writing the blob.
-     * @readonly
      */
     DONE: number;
 
@@ -48,13 +45,11 @@ interface FileSaver extends EventTarget {
      * <li>WRITING</li>
      * <li>DONE</li>
      * <ul>
-     * @readonly
      */
     readyState: number;
 
     /**
      * The last error that occurred on the FileSaver.
-     * @readonly
      */
     error: Error;
 


### PR DESCRIPTION
These are caught now that the tslint rule doesn't crash anymore.