### PR TITLE
Fix type definitions left over from Jasmine 1.x

### DIFF
--- a/types/jasmine-node/index.d.ts
+++ b/types/jasmine-node/index.d.ts
@@ -4,40 +4,40 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-///<reference types="jasmine"/>
+import "jasmine";
 
-declare function it(expectation: string, assertion: (done: (err?: any) => void) => void, timeout?: number): void;
+declare global {
+    function it(expectation: string, assertion: (done: (err?: any) => void) => void, timeout?: number): void;
 
-declare namespace jasmine {
-    interface Env {
-        defaultTimeoutInterval: number;
-    }
+    namespace jasmine {
+        interface Env {
+            defaultTimeoutInterval: number;
+        }
 
-    interface ExecuteSpecsOptions {
-        specFolders: string[],
-        onComplete?: (runner: jasmine.Runner) => void,
-        isVerbose?: boolean,
-        showColors?: boolean,
-        teamcity?: string | boolean,
-        useRequireJs?: boolean,
-        regExpSpec: RegExp,
-        junitreport?: {
-            report: boolean,
-            savePath: string,
-            useDotNotation: boolean,
-            consolidate: boolean
-        },
-        includeStackTrace?: boolean,
-        growl?: boolean
-    }
+        interface ExecuteSpecsOptions {
+            specFolders: string[];
+            onComplete?: (runner: Runner) => void;
+            isVerbose?: boolean;
+            showColors?: boolean;
+            teamcity?: string | boolean;
+            useRequireJs?: boolean;
+            regExpSpec: RegExp;
+            junitreport?: {
+                report: boolean;
+                savePath: string;
+                useDotNotation: boolean;
+                consolidate: boolean;
+            };
+            includeStackTrace?: boolean;
+            growl?: boolean;
+        }
 
-    interface JasmineNode {
-        executeSpecsInFolder(options: ExecuteSpecsOptions): void;
-        loadHelpersInFolder(path: string, pattern: RegExp): void;
+        interface JasmineNode {
+            executeSpecsInFolder(options: ExecuteSpecsOptions): void;
+            loadHelpersInFolder(path: string, pattern: RegExp): void;
+        }
     }
 }
 
-declare module "jasmine-node" {
-    const jasmine: jasmine.JasmineNode;
-    export = jasmine;
-}
+declare const jasmine: jasmine.JasmineNode;
+export = jasmine;

--- a/types/jasmine-node/jasmine-node-tests.ts
+++ b/types/jasmine-node/jasmine-node-tests.ts
@@ -3,8 +3,8 @@
 // Definitions by: Sven Reglitzki <https://github.com/svi3c/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-it("should have a timeout parameter", () => { }, 1000);
-it("should have an optional timeout parameter", () => { });
+it("should have a timeout parameter", () => {}, 1000);
+it("should have an optional timeout parameter", () => {});
 
 import jasmine = require("jasmine-node");
 
@@ -12,7 +12,9 @@ jasmine.loadHelpersInFolder("root", /\.helper\.ts/);
 
 jasmine.executeSpecsInFolder({
     specFolders: [],
-    onComplete: (runner) => { console.log(runner.results().failedCount) },
+    onComplete: runner => {
+        console.log(runner.results().failedCount);
+    },
     isVerbose: true,
     showColors: true,
     teamcity: false,
@@ -22,8 +24,8 @@ jasmine.executeSpecsInFolder({
         report: false,
         savePath: "./reports/",
         useDotNotation: true,
-        consolidate: true
+        consolidate: true,
     },
     includeStackTrace: true,
-    growl: false
+    growl: false,
 });

--- a/types/jasmine-node/tsconfig.json
+++ b/types/jasmine-node/tsconfig.json
@@ -13,6 +13,9 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "jasmine": [ "jasmine/v1" ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -502,11 +502,16 @@ declare namespace jasmine {
 
     interface ExpectationResult extends Result {
         matcherName: string;
-        passed(): boolean;
+        passed: boolean;
         expected: any;
         actual: any;
         message: string;
-        trace: Trace;
+        stack: string;
+    }
+
+    interface DeprecationWarning extends Result {
+        message: string;
+        stack: string;
     }
 
     interface Order {
@@ -522,12 +527,6 @@ declare namespace jasmine {
 
             stack: any;
         }
-    }
-
-    interface Trace {
-        name: string;
-        message: string;
-        stack: any;
     }
 
     interface Matchers<T> {
@@ -982,8 +981,19 @@ declare namespace jasmine {
 
         new (): any;
 
-        suites(): Suite[];
+        suites(): {[id: string]: SuiteResult};
         results(): any;
+    }
+
+    interface SuiteResult {
+        id: number;
+        description: string;
+        fullName: string;
+        failedExpectations: ExpectationResult[];
+        deprecationWarnings: DeprecationWarning[];
+        status?: string;
+        duration?: number;
+        properties?: any;
     }
 
     interface Jasmine {

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -200,10 +200,6 @@ declare function spyOnProperty<T>(object: T, property: keyof T, accessType?: "ge
  */
 declare function spyOnAllFunctions<T>(object: T): jasmine.SpyObj<T>;
 
-declare function runs(asyncMethod: Function): void;
-declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;
-declare function waits(timeout?: number): void;
-
 declare namespace jasmine {
     type Func = (...args: any[]) => any;
 
@@ -324,6 +320,9 @@ declare namespace jasmine {
 
     function stringMatching(str: string | RegExp): AsymmetricMatcher<string>;
 
+    /**
+     * @deprecated Private method that may be changed or removed in the future
+     */
     function formatErrorMsg(domain: string, usage: string): (msg: string) => string;
 
     interface Any extends AsymmetricMatcher<any> {
@@ -354,20 +353,6 @@ declare namespace jasmine {
 
         jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
         jasmineToString?(): string;
-    }
-
-    interface Block {
-        new (env: Env, func: SpecFunction, spec: Spec): any;
-
-        execute(onComplete: () => void): void;
-    }
-
-    interface WaitsBlock extends Block {
-        new (env: Env, timeout: number, spec: Spec): any;
-    }
-
-    interface WaitsForBlock extends Block {
-        new (env: Env, timeout: number, latchFunction: SpecFunction, message: string, spec: Spec): any;
     }
 
     interface Clock {
@@ -448,30 +433,19 @@ declare namespace jasmine {
     }
 
     interface Env {
-        currentSpec: Spec;
+        addReporter(reporter: CustomReporter): void;
 
-        matchersClass: Matchers<any>;
-
-        version(): any;
-        versionString(): string;
-        nextSpecId(): number;
-        addReporter(reporter: Reporter | CustomReporter): void;
         execute(): void;
         describe(description: string, specDefinitions: () => void): Suite;
         // ddescribe(description: string, specDefinitions: () => void): Suite; Not a part of jasmine. Angular team adds these
         beforeEach(beforeEachFunction: ImplementationCallback, timeout?: number): void;
         beforeAll(beforeAllFunction: ImplementationCallback, timeout?: number): void;
-        currentRunner(): Runner;
         afterEach(afterEachFunction: ImplementationCallback, timeout?: number): void;
         afterAll(afterAllFunction: ImplementationCallback, timeout?: number): void;
         xdescribe(desc: string, specDefinitions: () => void): XSuite;
         it(description: string, func: () => void): Spec;
         // iit(description: string, func: () => void): Spec; Not a part of jasmine. Angular team adds these
         xit(desc: string, func: () => void): XSpec;
-        compareRegExps_(a: RegExp, b: RegExp, mismatchKeys: string[], mismatchValues: string[]): boolean;
-        compareObjects_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
-        equals_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
-        contains_(haystack: any, needle: any): boolean;
         addCustomEqualityTester(equalityTester: CustomEqualityTester): void;
         addMatchers(matchers: CustomMatcherFactories): void;
         specFilter(spec: Spec): boolean;
@@ -502,7 +476,7 @@ declare namespace jasmine {
          */
         setSuiteProperty(key: string, value: unknown): void;
 
-        provideFallbackReporter(reporter: Reporter): void;
+        provideFallbackReporter(reporter: CustomReporter): void;
         throwingExpectationFailures(): boolean;
         allowRespy(allow: boolean): void;
         randomTests(): boolean;
@@ -512,15 +486,6 @@ declare namespace jasmine {
         randomizeTests(b: boolean): void;
         clearReporters(): void;
         configure(configuration: EnvConfiguration): void;
-    }
-
-    interface FakeTimer {
-        new (): any;
-
-        reset(): void;
-        tick(millis: number): void;
-        runFunctionsWithinRange(oldMillis: number, nowMillis: number): void;
-        scheduleFunction(timeoutKey: any, funcToCall: () => void, millis: number, recurring: boolean): void;
     }
 
     interface HtmlReporter {
@@ -533,27 +498,6 @@ declare namespace jasmine {
 
     interface Result {
         type: string;
-    }
-
-    interface NestedResults extends Result {
-        description: string;
-
-        totalCount: number;
-        passedCount: number;
-        failedCount: number;
-
-        skipped: boolean;
-
-        rollupCounts(result: NestedResults): void;
-        log(values: any): void;
-        getItems(): Result[];
-        addResult(result: Result): void;
-        passed(): boolean;
-    }
-
-    interface MessageResult extends Result {
-        values: any;
-        trace: Trace;
     }
 
     interface ExpectationResult extends Result {
@@ -580,50 +524,10 @@ declare namespace jasmine {
         }
     }
 
-    interface TreeProcessor {
-        new (attrs: any): any;
-        execute: (done: Function) => void;
-        processTree(): any;
-    }
-
     interface Trace {
         name: string;
         message: string;
         stack: any;
-    }
-
-    interface PrettyPrinter {
-        new (): any;
-
-        format(value: any): void;
-        iterateObject(obj: any, fn: (property: string, isGetter: boolean) => void): void;
-        emitScalar(value: any): void;
-        emitString(value: string): void;
-        emitArray(array: any[]): void;
-        emitObject(obj: any): void;
-        append(value: any): void;
-    }
-
-    interface StringPrettyPrinter extends PrettyPrinter {}
-
-    interface Queue {
-        new (env: any): any;
-
-        env: Env;
-        ensured: boolean[];
-        blocks: Block[];
-        running: boolean;
-        index: number;
-        offset: number;
-        abort: boolean;
-
-        addBefore(block: Block, ensure?: boolean): void;
-        add(block: any, ensure?: boolean): void;
-        insertNext(block: any, ensure?: boolean): void;
-        start(onComplete?: () => void): void;
-        isRunning(): boolean;
-        next_(): void;
-        results(): NestedResults;
     }
 
     interface Matchers<T> {
@@ -847,19 +751,6 @@ declare namespace jasmine {
         not: AsyncMatchers<T, U>;
     }
 
-    interface Reporter {
-        reportRunnerStarting(runner: Runner): void;
-        reportRunnerResults(runner: Runner): void;
-        reportSuiteResults(suite: Suite): void;
-        reportSpecStarting(spec: Spec): void;
-        reportSpecResults(spec: Spec): void;
-        log(str: string): void;
-    }
-
-    interface MultiReporter extends Reporter {
-        addReporter(reporter: Reporter): void;
-    }
-
     interface SuiteInfo {
         totalSpecsDefined: number;
     }
@@ -948,73 +839,24 @@ declare namespace jasmine {
         jasmineDone?(runDetails: RunDetails): void;
     }
 
-    interface Runner {
-        new (env: Env): any;
-
-        execute(): void;
-        beforeEach(beforeEachFunction: SpecFunction): void;
-        afterEach(afterEachFunction: SpecFunction): void;
-        beforeAll(beforeAllFunction: SpecFunction): void;
-        afterAll(afterAllFunction: SpecFunction): void;
-        finishCallback(): void;
-        addSuite(suite: Suite): void;
-        add(block: Block): void;
-        specs(): Spec[];
-        suites(): Suite[];
-        topLevelSuites(): Suite[];
-        results(): NestedResults;
-    }
-
     type SpecFunction = (spec?: Spec) => void;
 
     interface SuiteOrSpec {
         id: number;
         env: Env;
         description: string;
-        queue: Queue;
     }
 
     interface Spec extends SuiteOrSpec {
-        new (env: Env, suite: Suite, description: string): any;
-
-        suite: Suite;
-
-        afterCallbacks: SpecFunction[];
-        spies_: Spy[];
-
-        results_: NestedResults;
-        matchersClass: Matchers<any>;
-
         getFullName(): string;
-        results(): NestedResults;
-        log(arguments: any): any;
-        runs(func: SpecFunction): Spec;
-        addToQueue(block: Block): void;
-        addMatcherResult(result: Result): void;
         getResult(): any;
         expect(actual: any): any;
-        waits(timeout: number): Spec;
-        waitsFor(latchFunction: SpecFunction, timeoutMessage?: string, timeout?: number): Spec;
-        fail(e?: any): void;
-        getMatchersClass_(): Matchers<any>;
-        addMatchers(matchersPrototype: CustomMatcherFactories): void;
-        finishCallback(): void;
-        finish(onComplete?: () => void): void;
-        after(doAfter: SpecFunction): void;
         execute(onComplete?: () => void, enabled?: boolean): any;
-        addBeforesAndAftersToQueue(): void;
-        explodes(): void;
-        spyOn(obj: any, methodName: string, ignoreMethodDoesntExist: boolean): Spy;
-        spyOnProperty(object: any, property: string, accessType?: "get" | "set"): Spy;
-        spyOnAllFunctions(object: any): Spy;
-
-        removeAllSpies(): void;
         throwOnExpectationFailure: boolean;
     }
 
     interface XSpec {
         id: number;
-        runs(): void;
     }
 
     interface Suite extends SuiteOrSpec {
@@ -1023,17 +865,12 @@ declare namespace jasmine {
         parentSuite: Suite;
 
         getFullName(): string;
-        finish(onComplete?: () => void): void;
         beforeEach(beforeEachFunction: SpecFunction): void;
         afterEach(afterEachFunction: SpecFunction): void;
         beforeAll(beforeAllFunction: SpecFunction): void;
         afterAll(afterAllFunction: SpecFunction): void;
-        results(): NestedResults;
-        add(suiteOrSpec: SuiteOrSpec): void;
         specs(): Spec[];
         suites(): Suite[];
-        children(): any[];
-        execute(onComplete?: () => void): void;
     }
 
     interface XSuite {
@@ -1138,22 +975,15 @@ declare namespace jasmine {
         extend(destination: any, source: any): any;
     }
 
-    interface JsApiReporter extends Reporter {
+    interface JsApiReporter extends CustomReporter {
         started: boolean;
         finished: boolean;
-        result: any;
-        messages: any;
         runDetails: RunDetails;
 
         new (): any;
 
         suites(): Suite[];
-        summarize_(suiteOrSpec: SuiteOrSpec): any;
         results(): any;
-        resultsForSpec(specId: any): any;
-        log(str: any): any;
-        resultsForSpecs(specIds: any): any;
-        summarizeResult_(result: any): any;
     }
 
     interface Jasmine {
@@ -1195,7 +1025,7 @@ declare module "jasmine" {
         constructor(options: any);
         jasmine: jasmine.Jasmine;
         addMatchers(matchers: jasmine.CustomMatcherFactories): void;
-        addReporter(reporter: jasmine.Reporter): void;
+        addReporter(reporter: jasmine.CustomReporter): void;
         addSpecFile(filePath: string): void;
         addSpecFiles(files: string[]): void;
         configureDefaultReporter(options: any, ...args: any[]): void;
@@ -1206,7 +1036,7 @@ declare module "jasmine" {
         loadHelpers(): void;
         loadSpecs(): void;
         onComplete(onCompleteCallback: (passed: boolean) => void): void;
-        provideFallbackReporter(reporter: jasmine.Reporter): void;
+        provideFallbackReporter(reporter: jasmine.CustomReporter): void;
         randomizeTests(value?: any): boolean;
         seed(value: any): void;
         showColors(value: any): void;

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -244,7 +244,7 @@ declare namespace jasmine {
         oneFailurePerSpec?: boolean;
         hideDisabled?: boolean;
         specFilter?: Function;
-        promise?: Function;
+        Promise?: Function;
     }
 
     function clock(): Clock;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -2015,6 +2015,40 @@ describe("setDefaultSpyStrategy", () => {
         htmlReporter.initialize();
         env.execute();
     };
+
+    afterAll(function() {
+        const jsApiReporter: jasmine.JsApiReporter = (window as any).jsApiReporter;
+        const suites = jsApiReporter.suites();
+
+        for (const k in suites) {
+            const suite: jasmine.SuiteResult = suites[k];
+            console.log(suite);
+            console.log("id", suite.id);
+            console.log("description", suite.description);
+            console.log("fullName", suite.fullName);
+            console.log("fe", suite.failedExpectations);
+
+            for (const fe of suite.failedExpectations) {
+                console.log(">> matcherName:", fe.matcherName);
+                console.log(">> passed:", fe.passed);
+                console.log(">> expected:", fe.expected);
+                console.log(">> actual:", fe.actual);
+                console.log(">> message:", fe.message);
+                console.log(">> stack:", fe.stack);
+            }
+
+            console.log("dw", suite.deprecationWarnings);
+
+            for (const fe of suite.deprecationWarnings) {
+                console.log(">> message:", fe.message);
+                console.log(">> stack:", fe.stack);
+            }
+
+            console.log("status", suite.status);
+            console.log("duraiton", suite.duration);
+            console.log("properties", suite.properties);
+        }
+    });
 })();
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;

--- a/types/jasminewd2/jasminewd2-tests.ts
+++ b/types/jasminewd2/jasminewd2-tests.ts
@@ -143,7 +143,6 @@ describe('jasminewd', () => {
       };
       jasmine.addMatchers(matchers);
       jasmine.getEnv().addMatchers(matchers);
-      jasmine.getEnv().currentSpec.addMatchers(matchers);
     });
   });
 });


### PR DESCRIPTION
This removes type definitions for things that were either removed or made unavailable in Jasmine 2.0, and fixes a couple of related mismatches between the type definitions and Jasmine itself. 

Jasmine 1.x didn't have a well-defined public API, and as a result much of the type definition file describes what are now private APIs. I've left those alone for now as long as (a) they're correct, and (b) it's plausible that a user could access them and do something useful with them. So e.g. I've left in the parts of Env that are now private but removed most of Spec (fails (a) and all of TreeBuilder (fails (b)).

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/3.7/global
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.