### PR TITLE
Add missing type definitions for @types/marked

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -323,6 +323,7 @@ declare namespace marked {
             type: 'blockquote';
             raw: string;
             text: string;
+            tokens?: Token;
         }
 
         interface BlockquoteStart {
@@ -358,6 +359,7 @@ declare namespace marked {
             raw: string;
             pre?: boolean;
             text: string;
+            tokens?: Token;
         }
 
         interface HTML {

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -180,7 +180,7 @@ declare namespace marked {
         heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6, raw: string, slugger: Slugger): string;
         hr(): string;
         list(body: string, ordered: boolean, start: number): string;
-        listitem(text: string): string;
+        listitem(text: string, task:boolean, checked: boolean): string;
         checkbox(checked: boolean): string;
         paragraph(text: string): string;
         table(header: string, body: string): string;


### PR DESCRIPTION
Tokens Attribute are missing on Paragraph and Blockquote. Can be seen here: https://marked.js.org/using_pro#lexer

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://marked.js.org/using_pro#lexer
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

