### PR TITLE
Declare possible null attribute values to support strict null checking

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -2432,7 +2432,7 @@ declare namespace Xrm {
              * @returns The initial value.
              * @remarks Valid for OptionSet and boolean attribute types
              */
-            getInitialValue(): number | boolean;
+            getInitialValue(): T | null;
         }
 
         /**

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1825,7 +1825,7 @@ declare namespace Xrm {
          * @see {@link Attribute}
          * @deprecated Use {@link Xrm.Attributes.EnumAttribute} instead.
          */
-        interface EnumAttribute extends Attributes.EnumAttribute { }
+        interface EnumAttribute extends Attributes.EnumAttribute<number | boolean> { }
 
         /**
          * Interface for a Boolean attribute.
@@ -2223,7 +2223,7 @@ declare namespace Xrm {
         /**
          * Interface for an Entity attribute.
          */
-        interface Attribute {
+        interface Attribute<T = any> {
             /**
              * Adds a handler to be called when the attribute's value is changed.
              * @param handler The function reference.
@@ -2340,20 +2340,21 @@ declare namespace Xrm {
              * Gets the value.
              * @returns The value.
              */
-            getValue(): any;
+            getValue(): T | null;
 
             /**
              * Sets the value.
              * @param value The value.
+             * @remarks Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue(value: any): void;
+            setValue(value: T | null): void;
         }
 
         /**
          * Interface for a Number attribute.
          * @see {@link Attribute}
          */
-        interface NumberAttribute extends Attribute {
+        interface NumberAttribute extends Attribute<number> {
             /**
              * Gets the attribute format.
              * @returns The format of the attribute.
@@ -2380,19 +2381,6 @@ declare namespace Xrm {
             getPrecision(): number;
 
             /**
-             * Gets the value.
-             * @returns The value.
-             */
-            getValue(): number;
-
-            /**
-             * Sets the value.
-             * @param value The value.
-             * @remarks Attributes on Quick Create Forms will not save values set with this method.
-             */
-            setValue(value: number): void;
-
-            /**
              * A collection of all the controls on the form that interface with this attribute.
              * @see {@link https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/collections External Link: Collections (Client API reference)}
              */
@@ -2403,7 +2391,7 @@ declare namespace Xrm {
          * Interface for a String attribute.
          * @see {@link Attribute}
          */
-        interface StringAttribute extends Attribute {
+        interface StringAttribute extends Attribute<string> {
             /**
              * Gets the attribute format.
              * @returns The format of the attribute.
@@ -2419,20 +2407,13 @@ declare namespace Xrm {
             getMaxLength(): number;
 
             /**
-             * Gets the value.
-             *
-             * @returns The value.
-             */
-            getValue(): string;
-
-            /**
              * Sets the value.
              * @param value The value.
              * @remarks A String field with the {@link Attribute.getFormat|email} format enforces email
              *          address formatting. Attributes on Quick Create Forms will not save values set
              *          with this method.
              */
-            setValue(value: string): void;
+            setValue(value: string | null): void;
 
             /**
              * A collection of all the controls on the form that interface with this attribute.
@@ -2445,7 +2426,7 @@ declare namespace Xrm {
          * Common interface for enumeration attributes (OptionSet and Boolean).
          * @see {@link Attribute}
          */
-        interface EnumAttribute extends Attribute {
+        interface EnumAttribute<T extends number | boolean> extends Attribute<T> {
             /**
              * Gets the initial value of the attribute.
              * @returns The initial value.
@@ -2458,26 +2439,7 @@ declare namespace Xrm {
          * Interface for a Boolean attribute.
          * @see {@link EnumAttribute}
          */
-        interface BooleanAttribute extends EnumAttribute {
-            /**
-             * Gets the initial value of the attribute.
-             * @returns The initial value.
-             * @remarks Valid for OptionSet and boolean attribute types
-             */
-            getInitialValue(): boolean;
-
-            /**
-             * Gets the value.
-             * @returns true if it succeeds, false if it fails.
-             */
-            getValue(): boolean;
-
-            /**
-             * Sets the value.
-             * @param value The value.
-             * @remarks Attributes on Quick Create Forms will not save values set with this method.
-             */
-            setValue(value: boolean): void;
+        interface BooleanAttribute extends EnumAttribute<boolean> {
         }
 
         /**
@@ -2485,7 +2447,7 @@ declare namespace Xrm {
          *
          * @see {@link Attribute}
          */
-        interface DateAttribute extends Attribute {
+        interface DateAttribute extends Attribute<Date> {
             /**
              * Gets the attribute format.
              *
@@ -2493,19 +2455,6 @@ declare namespace Xrm {
              * Values returned are: date, datetime
              */
             getFormat(): DateAttributeFormat;
-
-            /**
-             * Gets the value.
-             * @returns The value.
-             */
-            getValue(): Date;
-
-            /**
-             * Sets the value.
-             * @param value The value.
-             * @remarks Attributes on Quick Create Forms will not save values set with this method.
-             */
-            setValue(value: Date): void;
 
             /**
              * A collection of all the controls on the form that interface with this attribute.
@@ -2518,20 +2467,13 @@ declare namespace Xrm {
          * Interface an OptionSet attribute.
          * @see {@link EnumAttribute}
          */
-        interface OptionSetAttribute extends EnumAttribute {
+        interface OptionSetAttribute extends EnumAttribute<number> {
             /**
              * Gets the attribute format.
              * @returns The format of the attribute.
              * Values returned are: language, timezone
              */
             getFormat(): OptionSetAttributeFormat;
-
-            /**
-             * Gets the initial value of the attribute.
-             * @returns The initial value.
-             * @remarks Valid for OptionSet and boolean attribute types
-             */
-            getInitialValue(): number;
 
             /**
              * Gets the option matching a value.
@@ -2566,12 +2508,6 @@ declare namespace Xrm {
             getText(): string;
 
             /**
-             * Gets the value.
-             * @returns The value.
-             */
-            getValue(): number;
-
-            /**
              * Sets the value.
              * @param value The value.
              * @remarks     The getOptions() method returns option values as strings. You must use parseInt
@@ -2579,7 +2515,7 @@ declare namespace Xrm {
              *              OptionSet attribute. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue(value: number): void;
+            setValue(value: number | null): void;
 
             /**
              * A collection of all the controls on the form that interface with this attribute.
@@ -2593,25 +2529,12 @@ declare namespace Xrm {
          *
          * @see {@link Attribute}
          */
-        interface LookupAttribute extends Attribute {
+        interface LookupAttribute extends Attribute<LookupValue[]> {
             /**
              * Gets a boolean value indicating whether the Lookup is a multi-value PartyList.
              * @returns true the attribute is a PartyList, otherwise false.
              */
             getIsPartyList(): boolean;
-
-            /**
-             * Gets the value.
-             * @returns An array of LookupValue.
-             */
-            getValue(): LookupValue[];
-
-            /**
-             * Sets the value.
-             * @param value The value.
-             * @remarks Attributes on Quick Create Forms will not save values set with this method.
-             */
-            setValue(value: LookupValue[]): void;
 
             /**
              * A collection of all the controls on the form that interface with this attribute.
@@ -4647,7 +4570,7 @@ declare namespace Xrm {
             /**
              * Type of view to load. Specify "savedquery" or "userquery".
              * */
-            viewType?: "savedquery" |"userquery";
+            viewType?: "savedquery" | "userquery";
         }
 
         interface PageInputHtmlWebResource {
@@ -5557,10 +5480,10 @@ declare namespace XrmEnum {
         Finished = "finished"
     }
 
-     /**
-      * Constant Enum: Command Bar Display options for Xrm.Url.FormOpenParameters.cmdbar, Xrm.Url.ViewOpenParameters.cmdbar, and Xrm.Utility.FormOpenParameters.cmdbar.
-      * @see {@link Xrm.Url.CmdBarDisplay}
-      */
+    /**
+     * Constant Enum: Command Bar Display options for Xrm.Url.FormOpenParameters.cmdbar, Xrm.Url.ViewOpenParameters.cmdbar, and Xrm.Utility.FormOpenParameters.cmdbar.
+     * @see {@link Xrm.Url.CmdBarDisplay}
+     */
     const enum CmdBarDisplay {
         True = "true",
         False = "false"

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -52,8 +52,14 @@ lookupAttribute.addPreSearch(() => { alert("A search was performed."); });
 const lookupValues = lookupAttribute.getAttribute().getValue();
 
 if (lookupValues !== null)
-    if (!lookupValues[0].id || !lookupValues[0].entityType)
+    if (lookupValues[0].id || lookupValues[0].entityType)
         throw new Error("Invalid value in Lookup control.");
+
+lookupAttribute.getAttribute().setValue(null);
+lookupAttribute.getAttribute().setValue([{
+    entityType: "contact",
+    id: "b9a1a53f-bc38-4e80-9fbb-fe51caa7df65"
+}]);
 
 /// Demonstrate v7.0 BPF API
 


### PR DESCRIPTION
All attributes types support null values. Make null-possibility detectable by TypeScript to support the strictNullChecks option, which will present an error if the developer's code does not have the necessary null checking in place.