### PR TITLE
fix(49492): restore alphabetical sort of packages

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1265,10 +1265,6 @@
             "libraryName": "handsontable",
             "asOfVersion": "0.35.0"
         },
-        "hapi-auth-jwt2": {
-            "libraryName": "hapi-auth-jwt2",
-            "asOfVersion": "8.6.1"
-        },
         "hapi__accept": {
             "libraryName": "@hapi/accept",
             "asOfVersion": "5.0.0"
@@ -1304,6 +1300,10 @@
         "hapi__wreck": {
             "libraryName": "@hapi/wreck",
             "asOfVersion": "17.0.0"
+        },
+        "hapi-auth-jwt2": {
+            "libraryName": "hapi-auth-jwt2",
+            "asOfVersion": "8.6.1"
         },
         "hard-rejection": {
             "libraryName": "hard-rejection",
@@ -2017,10 +2017,6 @@
             "libraryName": "matcher",
             "asOfVersion": "2.0.0"
         },
-        "material-components-web": {
-            "libraryName": "material-components-web",
-            "asOfVersion": "1.0.0"
-        },
         "material__animation": {
             "libraryName": "@material/animation",
             "asOfVersion": "1.0.0"
@@ -2127,6 +2123,10 @@
         },
         "material__top-app-bar": {
             "libraryName": "@material/top-app-bar",
+            "asOfVersion": "1.0.0"
+        },
+        "material-components-web": {
+            "libraryName": "material-components-web",
             "asOfVersion": "1.0.0"
         },
         "matrix-appservice-bridge": {

--- a/scripts/not-needed.js
+++ b/scripts/not-needed.js
@@ -1,3 +1,4 @@
+/// <reference lib="esnext"/>
 // Script to remove a package from DefinitelyTyped and add it to notNeededPackages.json
 
 const fs = require("fs");
@@ -13,8 +14,14 @@ if (process.argv.length !== 4 && process.argv.length !== 5) {
 }
 
 rmdirRecursive(path.join("types", typingsPackageName));
+
+/**  @type  {{packages: Record<string, { libraryName: string; asOfVersion: string; }> }} */
 const notNeededPackages = JSON.parse(fs.readFileSync("notNeededPackages.json", "utf-8"));
 notNeededPackages.packages[typingsPackageName] = { libraryName, asOfVersion };
+const sortedPackages = Object.entries(notNeededPackages.packages).sort((packageA, packageB) =>
+    packageA[0].localeCompare(packageB[0]),
+);
+notNeededPackages.packages = Object.fromEntries(sortedPackages);
 fs.writeFileSync("notNeededPackages.json", JSON.stringify(notNeededPackages, undefined, 4) + "\n", "utf-8");
 
 function rmdirRecursive(dir) {


### PR DESCRIPTION
Unwated artefact of #49492 was a change in the order of no longer needed
pacakges from alphabetical sort to chronological (desc)

This commit restores the alphabetical sort.

Thanks!

/cc @jablko @andrewbranch

Tested in #52020