### PR TITLE
Add type definitions for ember__destroyable

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -31,6 +31,7 @@
 /// <reference types="ember__test" />
 /// <reference types="ember__service" />
 /// <reference types="ember__template" />
+/// <reference types="ember__destroyable" />
 
 import {
     Objectify, Fix, UnwrapComputedPropertySetters,

--- a/types/ember__destroyable/index.d.ts
+++ b/types/ember__destroyable/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for non-npm package @ember/destroyable 3.22
+// Project: https://api.emberjs.com/ember/3.22/modules/@ember%2Fdestroyable
+// Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+
+export function associateDestroyableChild<T extends object>(parent: object, child: T): T;
+
+export function isDestroying(destroyable: object): boolean;
+
+export function isDestroyed(destroyable: object): boolean;
+
+export function destroy(destroyable: object): void;
+
+export function assertDestroyablesDestroyed(): void;
+
+export function enableDestroyableTracking(): void;
+
+export function registerDestructor<T extends object>(
+destroyable: T,
+destructor: (destroyable: T) => void
+): (destroyable: T) => void;
+
+export function unregisterDestructor<T extends object>(
+destroyable: T,
+destructor: (destroyable: T) => void
+): void;

--- a/types/ember__destroyable/test/lib/assert.ts
+++ b/types/ember__destroyable/test/lib/assert.ts
@@ -1,0 +1,2 @@
+/** Static assertion that `value` has type `T` */
+export declare function assertType<T>(value: T): T;

--- a/types/ember__destroyable/test/main.ts
+++ b/types/ember__destroyable/test/main.ts
@@ -9,12 +9,21 @@ import {
     unregisterDestructor
 } from '@ember/destroyable';
 
+import { assertType } from './lib/assert';
+
+enableDestroyableTracking(true); // $ExpectError
+enableDestroyableTracking({}); // $ExpectError
+enableDestroyableTracking('foo'); // $ExpectError
+enableDestroyableTracking(1); // $ExpectError
 enableDestroyableTracking();
 
 class Child {
     state: boolean;
     constructor() {
         this.state = true;
+        registerDestructor(); // $ExpectError
+        registerDestructor(this); // $ExpectError
+        registerDestructor(this.stateDestructor); // $ExpectError
         registerDestructor(this, this.stateDestructor);
     }
 
@@ -23,6 +32,9 @@ class Child {
     }
 
     keepForever() {
+        unregisterDestructor(); // $ExpectError
+        unregisterDestructor(this); // $ExpectError
+        unregisterDestructor(this.stateDestructor); // $ExpectError
         unregisterDestructor(this, this.stateDestructor);
     }
 }
@@ -31,6 +43,9 @@ class Parent {
     child: object;
 
     constructor(child: object) {
+        this.child = associateDestroyableChild(); // $ExpectError
+        this.child = associateDestroyableChild(this); // $ExpectError
+        this.child = associateDestroyableChild(child); // $ExpectError
         this.child = associateDestroyableChild(this, child);
     }
 }
@@ -38,15 +53,21 @@ class Parent {
 const c = new Child();
 const p = new Parent(c);
 
-isDestroyed(c);
-isDestroyed(p);
+destroy(); // $ExpectError
+
+assertType<boolean>(isDestroyed(c));
+assertType<boolean>(isDestroyed(p));
 
 destroy(p);
 
-isDestroying(c);
-isDestroying(p);
+assertType<boolean>(isDestroying(c));
+assertType<boolean>(isDestroying(p));
 
-isDestroyed(c);
-isDestroyed(p);
+assertType<boolean>(isDestroyed(c));
+assertType<boolean>(isDestroyed(p));
 
+assertDestroyablesDestroyed(true); // $ExpectError
+assertDestroyablesDestroyed({}); // $ExpectError
+assertDestroyablesDestroyed('foo'); // $ExpectError
+assertDestroyablesDestroyed(1); // $ExpectError
 assertDestroyablesDestroyed();

--- a/types/ember__destroyable/test/main.ts
+++ b/types/ember__destroyable/test/main.ts
@@ -1,0 +1,52 @@
+import {
+    assertDestroyablesDestroyed,
+    associateDestroyableChild,
+    destroy,
+    enableDestroyableTracking,
+    isDestroyed,
+    isDestroying,
+    registerDestructor,
+    unregisterDestructor
+} from '@ember/destroyable';
+
+enableDestroyableTracking();
+
+class Child {
+    state: boolean;
+    constructor() {
+        this.state = true;
+        registerDestructor(this, this.stateDestructor);
+    }
+
+    stateDestructor() {
+        this.state = !this.state;
+    }
+
+    keepForever() {
+        unregisterDestructor(this, this.stateDestructor);
+    }
+}
+
+class Parent {
+    child: object;
+
+    constructor(child: object) {
+        this.child = associateDestroyableChild(this, child);
+    }
+}
+
+const c = new Child();
+const p = new Parent(c);
+
+isDestroyed(c);
+isDestroyed(p);
+
+destroy(p);
+
+isDestroying(c);
+isDestroying(p);
+
+isDestroyed(c);
+isDestroyed(p);
+
+assertDestroyablesDestroyed();

--- a/types/ember__destroyable/tsconfig.json
+++ b/types/ember__destroyable/tsconfig.json
@@ -23,6 +23,7 @@
     },
     "files": [
         "index.d.ts",
+        "test/lib/assert.ts",
         "test/main.ts"
     ]
 }

--- a/types/ember__destroyable/tsconfig.json
+++ b/types/ember__destroyable/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/*": ["ember__*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/main.ts"
+    ]
+}

--- a/types/ember__destroyable/tslint.json
+++ b/types/ember__destroyable/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
ember 3.22 added a new Destroyable API. 

[Type definitions exist](https://github.com/ember-polyfills/ember-destroyable-polyfill/blob/master/index.d.ts) in [ember-destroyable-polyfill](https://github.com/ember-polyfills/ember-destroyable-polyfill). This ports those existing type definitions to DT.

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/1419


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
