### PR TITLE
Update react-notifications-component with latest type changes up to v3.1

### DIFF
--- a/types/react-notifications-component/index.d.ts
+++ b/types/react-notifications-component/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-notifications-component 2.4
+// Type definitions for react-notifications-component 3.1
 // Project: https://github.com/teodosii/react-notifications-component
 // Definitions by: Sarhad Salam <https://github.com/SarhadSalam>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-notifications-component/index.d.ts
+++ b/types/react-notifications-component/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-notifications-component 3.1
 // Project: https://github.com/teodosii/react-notifications-component
 // Definitions by: Sarhad Salam <https://github.com/SarhadSalam>
+//                 Andrés Ignacio Torres <https://github.com/aitorres>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';

--- a/types/react-notifications-component/index.d.ts
+++ b/types/react-notifications-component/index.d.ts
@@ -27,7 +27,7 @@ export interface ReactNotificationOptions {
     message?: string | React.ReactNode | React.FunctionComponent;
     content?: React.ComponentClass | React.FunctionComponent | React.ReactNode;
     type?: 'success' | 'danger' | 'info' | 'default' | 'warning';
-    container: 'top-left' | 'top-right' | 'top-center' | 'center' | 'bottom-left' | 'bottom-right' | 'bottom-center';
+    container: 'top-full' | 'top-left' | 'top-right' | 'top-center' | 'center' | 'bottom-full' | 'bottom-left' | 'bottom-right' | 'bottom-center';
     insert?: 'top' | 'bottom';
     dismiss?: DismissOptions;
     animationIn?: string[];

--- a/types/react-notifications-component/index.d.ts
+++ b/types/react-notifications-component/index.d.ts
@@ -35,7 +35,10 @@ export interface ReactNotificationOptions {
     slidingEnter?: TransitionOptions;
     slidingExit?: TransitionOptions;
     touchRevert?: TransitionOptions;
-    touchSlidingExit?: TransitionOptions;
+    touchSlidingExit?: {
+        fade?: TransitionOptions;
+        swipe?: TransitionOptions;
+    };
     width?: number;
 }
 

--- a/types/react-notifications-component/react-notifications-component-tests.tsx
+++ b/types/react-notifications-component/react-notifications-component-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactNotification, { store } from 'react-notifications-component';
+import ReactNotification, { ReactNotificationOptions, store } from 'react-notifications-component';
 
 const SampleNotification = () => {
     store.addNotification({
@@ -32,4 +32,24 @@ const ComponentTest: React.SFC = () => {
 const WrongPropTest: React.SFC = () => {
     // $ExpectError
     return <ReactNotification randomProp={false} />;
+};
+
+const OptionsTest: ReactNotificationOptions = {
+    container: 'bottom-full',
+    touchSlidingExit: {
+        fade: {
+            duration: 3,
+            timingFunction: 'ease',
+            delay: 10
+        }
+    }
+};
+
+const WrongOptionsTest: ReactNotificationOptions = {
+    // $ExpectError
+    container: 'center-full',
+    touchSlidingExit: {
+        // $ExpectError
+        notValid: 1,
+    }
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - regarding touchSlidingExit:
    - README mentions the typing here: https://github.com/teodosii/react-notifications-component#change-transition
    - open issue about it here: https://github.com/teodosii/react-notifications-component/issues/92
  - regarding containers:
    - open issue about it here: https://github.com/teodosii/react-notifications-component/issues/93
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
