### PR TITLE
Add text method to Blob in node-fetch

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -11,6 +11,7 @@
 //                 Alex Savin <https://github.com/alexandrusavin>
 //                 Alexis Tyler <https://github.com/OmgImAlexis>
 //                 Jakub Kisielewski <https://github.com/kbkk>
+//                 Tanet Trimas <https://github.com/tanettrimas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -135,6 +136,7 @@ export class Blob {
     readonly type: string;
     readonly size: number;
     slice(start?: number, end?: number): Blob;
+    text(): Promise<string>;
 }
 
 export class Body {

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -11,7 +11,6 @@
 //                 Alex Savin <https://github.com/alexandrusavin>
 //                 Alexis Tyler <https://github.com/OmgImAlexis>
 //                 Jakub Kisielewski <https://github.com/kbkk>
-//                 Tanet Trimas <https://github.com/tanettrimas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -209,6 +209,6 @@ function test_ResponseInit() {
     });
 }
 
-function test_BlobText() {
-    new Blob(["Hello world"]).text();
+async function test_BlobText() {
+    const someString = await new Blob(["Hello world"]).text(); // $ExpectType string
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -208,3 +208,7 @@ function test_ResponseInit() {
         });
     });
 }
+
+function test_BlobText() {
+    new Blob(["Hello world"]).text();
+}


### PR DESCRIPTION
The Blob class was missing the text() method which turns the blob arraybuffer into a string representation. This PR adds this.  

Implementation code: https://github.com/node-fetch/fetch-blob/blob/3b12a39ea222ff43637a488af560836088fa5753/index.js#L79

MDN reference: https://developer.mozilla.org/en-US/docs/Web/API/Blob/text

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
