### PR TITLE
[serverless] Update type definitions

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -87,7 +87,7 @@ declare namespace Aws {
         managedPolicies?: string[];
         deploymentRole?: string;
     }
-    
+
     interface IamRoleStatements {
         statements?: IamRoleStatement[];
     }

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -81,11 +81,15 @@ declare namespace Aws {
     }
 
     interface IamSettings {
-        role?: string;
+        role?: string | IamRoleStatements;
         permissionBoundary?: string;
         statements?: IamRoleStatement[];
         managedPolicies?: string[];
         deploymentRole?: string;
+    }
+    
+    interface IamRoleStatements {
+        statements?: IamRoleStatement[];
     }
 
     interface Tags {
@@ -349,8 +353,8 @@ declare namespace Aws {
     }
 
     interface S3Rule {
-        prefix: string;
-        suffix: string;
+        prefix?: string;
+        suffix?: string;
     }
 
     interface S3 {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -258,6 +258,23 @@ const awsServerless: Aws.Serverless = {
                 NotResource: 'testNotResource'
             }
         ],
+        iam: {
+            role: {
+                statements: [
+                    {
+                        Effect: 'Allow',
+                        Sid: 'testSid',
+                        Condition: {
+                            testcondition: 'testconditionvalue'
+                        },
+                        Action: 'testAction',
+                        NotAction: 'testNotAction',
+                        Resource: 'testResource',
+                        NotResource: 'testNotResource'
+                    }
+                ]
+            }
+        },
         stackPolicy: [
             {
                 Effect: 'Allow',
@@ -459,6 +476,28 @@ const awsServerless: Aws.Serverless = {
                         rules: [
                             {
                                 prefix: 'testprefix',
+                                suffix: 'testsuffix',
+                            }
+                        ],
+                        existing: false
+                    }
+                }, {
+                    s3: {
+                        bucket: 'testbucket',
+                        event: 'testevent',
+                        rules: [
+                            {
+                                prefix: 'testprefix'
+                            }
+                        ],
+                        existing: false
+                    }
+                }, {
+                    s3: {
+                        bucket: 'testbucket',
+                        event: 'testevent',
+                        rules: [
+                            {
                                 suffix: 'testsuffix',
                             }
                         ],


### PR DESCRIPTION
Property `iam.role` can be a string or an object with the `statements` field being an array of `IamRoleStatement`.
S3 rule properties `prefix` and `suffix` should be optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.serverless.com/framework/docs/providers/aws/guide/iam/>>
