### PR TITLE
update(speed-measure-webpack-plugin): v1.5

### DIFF
--- a/types/speed-measure-webpack-plugin/index.d.ts
+++ b/types/speed-measure-webpack-plugin/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-import { Compiler, Configuration } from 'webpack';
+import { Compiler, Configuration } from "webpack";
 
 /**
  * See how fast (or not) your plugins and loaders are, so you can optimise your builds
@@ -19,11 +19,11 @@ declare class SpeedMeasurePlugin {
 declare namespace SpeedMeasurePlugin {
     type OutputFormat =
         /** produces a JSON blob */
-        | 'json'
+        | "json"
         /** produces a human readable output */
-        | 'human'
+        | "human"
         /** produces a more verbose version of the human readable output */
-        | 'humanVerbose'
+        | "humanVerbose"
         /** output the response */
         | ((json: any) => string);
 
@@ -32,6 +32,10 @@ declare namespace SpeedMeasurePlugin {
         | string
         /** calls the function with the output as the first parameter */
         | ((output: string, ...rest: any[]) => void);
+
+    type LoaderBuild = {
+        filePath: string;
+    } & Record<string, string>;
 
     /**
      * Pass these into the constructor, as an object:
@@ -53,9 +57,21 @@ declare namespace SpeedMeasurePlugin {
          * For some plugins this doesn't work (or you may want to override this default).
          * This option takes an object of pluginName: PluginConstructor
          */
-        pluginNames?: {
-            [key: string]: object;
-        };
+        pluginNames?: Record<string, object>;
+
+        /**
+         * You can configure SMP to include the files that take the most time per loader,
+         * when using outputFormat: 'humanVerbose'
+         * @default 0
+         */
+        loaderTopFiles?: number;
+
+        /**
+         * This option gives you a comparison over time of the module count and time spent, per loader.
+         * This option provides more data when outputFormat: "humanVerbose".
+         */
+        compareLoadersBuild?: LoaderBuild;
+
         /**
          * By default, SMP measures loaders in groups.
          * If truthy, this plugin will give per-loader timing information.

--- a/types/speed-measure-webpack-plugin/speed-measure-webpack-plugin-tests.ts
+++ b/types/speed-measure-webpack-plugin/speed-measure-webpack-plugin-tests.ts
@@ -1,25 +1,36 @@
-import SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
-import { Options } from 'speed-measure-webpack-plugin';
-import UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-import HtmlWebpackPlugin = require('html-webpack-plugin');
-import { Configuration } from 'webpack';
+import SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+import { LoaderBuild, Options } from "speed-measure-webpack-plugin";
+import UglifyJSPlugin = require("uglifyjs-webpack-plugin");
+import HtmlWebpackPlugin = require("html-webpack-plugin");
+import { Configuration } from "webpack";
 
 const uglify = new UglifyJSPlugin();
 
-const defualtOptions = new SpeedMeasurePlugin();
+new SpeedMeasurePlugin();
+
+const names: {
+    [name: string]: object;
+} = {
+    customUglifyName: uglify,
+};
+
+const loadersBuilds: LoaderBuild = {
+    filePath: "./buildInfo.json",
+};
 
 const options: Options = {
     disable: true,
     granularLoaderData: true,
-    pluginNames: {
-        customUglifyName: uglify,
-    },
-    outputFormat: 'human',
+    pluginNames: names,
+    loaderTopFiles: 10,
+    compareLoadersBuild: loadersBuilds,
+    outputFormat: "human",
     outputTarget: console.log,
 };
 
 const smp = new SpeedMeasurePlugin(options);
-const webpackConfig = smp.wrap({
+// $ExpectType Configuration
+smp.wrap({
     plugins: [new HtmlWebpackPlugin()],
 });
 
@@ -27,18 +38,19 @@ const webpackConfig = smp.wrap({
 
 const basic: Configuration = {
     entry: {
-        app: ['./app.js'],
+        app: ["./app.js"],
     },
     output: {
-        filename: 'someLibName.js',
+        filename: "someLibName.js",
     },
     module: {
         rules: [
             {
                 test: /\.js$/,
-                use: [{ loader: 'babel-loader' }],
+                use: [{ loader: "babel-loader" }],
             },
         ],
     },
 };
+// $ExpectType Configuration
 smp.wrap(basic);


### PR DESCRIPTION
- missing options `loaderTopFiles` and `compareLoadersBuild`
- tests amended
- minor reformat to DT defaults
- version bump

https://github.com/stephencookdev/speed-measure-webpack-plugin/releases/tag/v1.5.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
