### PR TITLE
Added type definitions for `discord-rich-presence`

### DIFF
--- a/types/discord-rich-presence/discord-rich-presence-tests.ts
+++ b/types/discord-rich-presence/discord-rich-presence-tests.ts
@@ -1,4 +1,4 @@
-import DiscordRPC from "discord-rich-presence";
+import * as DiscordRPC from "discord-rich-presence";
 
 const client = DiscordRPC("180984871685062656");
 

--- a/types/discord-rich-presence/discord-rich-presence-tests.ts
+++ b/types/discord-rich-presence/discord-rich-presence-tests.ts
@@ -1,0 +1,19 @@
+import DiscordRPC from "./";
+
+const client = DiscordRPC("180984871685062656");
+
+client.updatePresence({
+    state: "slithering",
+    details: "🐍",
+    startTimestamp: Date.now(),
+    endTimestamp: Date.now() + 1337,
+    largeImageKey: "snek_large",
+    smallImageKey: "snek_small",
+});
+
+client.on("error", err => console.log(`Error: ${err}`));
+
+client.on("connected", () => {
+    console.log("Connected.");
+    client.disconnect();
+});

--- a/types/discord-rich-presence/discord-rich-presence-tests.ts
+++ b/types/discord-rich-presence/discord-rich-presence-tests.ts
@@ -1,6 +1,6 @@
-import * as DiscordRPC from "discord-rich-presence";
+import * as createClient from "discord-rich-presence";
 
-const client = DiscordRPC("180984871685062656");
+const client = createClient("180984871685062656");
 
 client.updatePresence({
     state: "slithering",
@@ -11,7 +11,7 @@ client.updatePresence({
     smallImageKey: "snek_small",
 });
 
-client.on("error", err => console.log(`Error: ${err}`));
+client.on("error", (err: string) => console.log(`Error: ${err}`));
 
 client.on("connected", () => {
     console.log("Connected.");

--- a/types/discord-rich-presence/discord-rich-presence-tests.ts
+++ b/types/discord-rich-presence/discord-rich-presence-tests.ts
@@ -1,4 +1,4 @@
-import DiscordRPC from "./";
+import DiscordRPC from "discord-rich-presence";
 
 const client = DiscordRPC("180984871685062656");
 

--- a/types/discord-rich-presence/discord-rich-presence-tests.ts
+++ b/types/discord-rich-presence/discord-rich-presence-tests.ts
@@ -5,7 +5,7 @@ const client = createClient("180984871685062656");
 client.updatePresence({
     state: "slithering",
     details: "🐍",
-    startTimestamp: Date.now(),
+    startTimestamp: new Date(),
     endTimestamp: Date.now() + 1337,
     largeImageKey: "snek_large",
     smallImageKey: "snek_small",

--- a/types/discord-rich-presence/index.d.ts
+++ b/types/discord-rich-presence/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for discord-rich-presence 0.0
+// Project: https://github.com/devsnek/discord-rich-presence#readme
+// Definitions by: Sv443 <https://github.com/Sv443>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { EventEmitter } from "events";
+
+/**
+ * Go to the `Rich Presence > Visualizer` settings of your [Discord application](https://discord.com/developers/applications) to find out how this would be rendered.
+ */
+export interface PresenceInfo {
+    [key: string]: string | number | boolean;
+
+    /** The user's current party status */
+    state: string;
+    /** What the player is currently doing */
+    details: string;
+    /** Epoch seconds for game start - setting this will show the time as "elapsed" */
+    startTimestamp: number;
+    /** Epoch seconds until game's end - setting this will show the time as "remaining" */
+    endTimestamp: number;
+    /** Key of the uploaded image / asset for the large profile artwork */
+    largeImageKey: string;
+    /** Key of the uploaded image / asset for the small profile artwork */
+    smallImageKey: string;
+
+    instance: boolean;
+}
+
+export interface RP {
+    on(event: "error", listener: (err: string) => void): this;
+    on(event: "connected", listener: () => void): this;
+    on(event: "join" | "spectate", listener: (secret: string) => void): this;
+    on(event: "joinRequest", listener: (user: string) => void): this;
+}
+
+export class RP extends EventEmitter {
+    /**
+     * Updates the presence
+     * @param presence Presence settings object. All properties are optional.
+     */
+    updatePresence(presence: Partial<PresenceInfo>): void;
+
+    reply(user: string, response: "YES" | "NO" | "IGNORE"): void;
+    disconnect(): void;
+}
+
+/**
+ * Connects to your application
+ * @param clientID Get the client ID from the `General Information` page of your [Discord application](https://discord.com/developers/applications)
+ */
+export default function createClient(clientID: string): RP;

--- a/types/discord-rich-presence/index.d.ts
+++ b/types/discord-rich-presence/index.d.ts
@@ -7,7 +7,7 @@
 
 import { EventEmitter } from "events";
 
-declare namespace DiscordRPC {
+declare namespace createClient {
     /**
      * Go to the `Rich Presence > Visualizer` settings of your [Discord application](https://discord.com/developers/applications) to find out how this would be rendered.
      */
@@ -53,6 +53,6 @@ declare namespace DiscordRPC {
  * Connects to your application
  * @param clientID Get the client ID from the `General Information` page of your [Discord application](https://discord.com/developers/applications)
  */
-declare function DiscordRPC(clientID: string): DiscordRPC.RP;
+declare function createClient(clientID: string): createClient.RP;
 
-export = DiscordRPC;
+export = createClient;

--- a/types/discord-rich-presence/index.d.ts
+++ b/types/discord-rich-presence/index.d.ts
@@ -12,16 +12,16 @@ declare namespace createClient {
      * Go to the `Rich Presence > Visualizer` settings of your [Discord application](https://discord.com/developers/applications) to find out how this would be rendered.
      */
     interface PresenceInfo {
-        [key: string]: string | number | boolean;
+        [key: string]: string | number | Date | boolean;
 
         /** The user's current party status */
         state: string;
         /** What the player is currently doing */
         details: string;
         /** Epoch seconds for game start - setting this will show the time as "elapsed" */
-        startTimestamp: number;
+        startTimestamp: number | Date;
         /** Epoch seconds until game's end - setting this will show the time as "remaining" */
-        endTimestamp: number;
+        endTimestamp: number | Date;
         /** Key of the uploaded image / asset for the large profile artwork */
         largeImageKey: string;
         /** Key of the uploaded image / asset for the small profile artwork */

--- a/types/discord-rich-presence/index.d.ts
+++ b/types/discord-rich-presence/index.d.ts
@@ -7,48 +7,52 @@
 
 import { EventEmitter } from "events";
 
-/**
- * Go to the `Rich Presence > Visualizer` settings of your [Discord application](https://discord.com/developers/applications) to find out how this would be rendered.
- */
-export interface PresenceInfo {
-    [key: string]: string | number | boolean;
-
-    /** The user's current party status */
-    state: string;
-    /** What the player is currently doing */
-    details: string;
-    /** Epoch seconds for game start - setting this will show the time as "elapsed" */
-    startTimestamp: number;
-    /** Epoch seconds until game's end - setting this will show the time as "remaining" */
-    endTimestamp: number;
-    /** Key of the uploaded image / asset for the large profile artwork */
-    largeImageKey: string;
-    /** Key of the uploaded image / asset for the small profile artwork */
-    smallImageKey: string;
-
-    instance: boolean;
-}
-
-export interface RP {
-    on(event: "error", listener: (err: string) => void): this;
-    on(event: "connected", listener: () => void): this;
-    on(event: "join" | "spectate", listener: (secret: string) => void): this;
-    on(event: "joinRequest", listener: (user: string) => void): this;
-}
-
-export class RP extends EventEmitter {
+declare namespace DiscordRPC {
     /**
-     * Updates the presence
-     * @param presence Presence settings object. All properties are optional.
+     * Go to the `Rich Presence > Visualizer` settings of your [Discord application](https://discord.com/developers/applications) to find out how this would be rendered.
      */
-    updatePresence(presence: Partial<PresenceInfo>): void;
+    interface PresenceInfo {
+        [key: string]: string | number | boolean;
 
-    reply(user: string, response: "YES" | "NO" | "IGNORE"): void;
-    disconnect(): void;
+        /** The user's current party status */
+        state: string;
+        /** What the player is currently doing */
+        details: string;
+        /** Epoch seconds for game start - setting this will show the time as "elapsed" */
+        startTimestamp: number;
+        /** Epoch seconds until game's end - setting this will show the time as "remaining" */
+        endTimestamp: number;
+        /** Key of the uploaded image / asset for the large profile artwork */
+        largeImageKey: string;
+        /** Key of the uploaded image / asset for the small profile artwork */
+        smallImageKey: string;
+
+        instance: boolean;
+    }
+
+    interface RP {
+        on(event: "error", listener: (err: string) => void): this;
+        on(event: "connected", listener: () => void): this;
+        on(event: "join" | "spectate", listener: (secret: string) => void): this;
+        on(event: "joinRequest", listener: (user: string) => void): this;
+    }
+
+    class RP extends EventEmitter {
+        /**
+         * Updates the presence
+         * @param presence Presence settings object. All properties are optional.
+         */
+        updatePresence(presence: Partial<PresenceInfo>): void;
+
+        reply(user: string, response: "YES" | "NO" | "IGNORE"): void;
+        disconnect(): void;
+    }
 }
 
 /**
  * Connects to your application
  * @param clientID Get the client ID from the `General Information` page of your [Discord application](https://discord.com/developers/applications)
  */
-export default function createClient(clientID: string): RP;
+declare function DiscordRPC(clientID: string): DiscordRPC.RP;
+
+export = DiscordRPC;

--- a/types/discord-rich-presence/tsconfig.json
+++ b/types/discord-rich-presence/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/discord-rich-presence/tsconfig.json
+++ b/types/discord-rich-presence/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "discord-rich-presence-tests.ts"
     ]
 }

--- a/types/discord-rich-presence/tslint.json
+++ b/types/discord-rich-presence/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I'm not the package's maintainer. I've [submitted a PR](https://github.com/devsnek/discord-rich-presence/pull/32) to the repo, but the owner declined, so now I'm submitting it here instead.  
  
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.