### PR TITLE
fix(52056): re-introduce v4 for webpack-terser-plugin

### DIFF
--- a/types/terser-webpack-plugin/v4/index.d.ts
+++ b/types/terser-webpack-plugin/v4/index.d.ts
@@ -1,0 +1,114 @@
+// Type definitions for terser-webpack-plugin 4.2
+// Project: https://github.com/webpack-contrib/terser-webpack-plugin
+// Definitions by: Daniel Schopf <https://github.com/Danscho>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+import { Plugin } from 'webpack';
+import { MinifyOptions } from 'terser';
+
+/**
+ * This plugin uses terser to minify your JavaScript.
+ */
+declare namespace TerserPlugin {
+    interface MinifyResult {
+        map: any;
+        code: any;
+        extractedComments: any;
+    }
+
+    interface FileData {
+        readonly filename: string;
+        readonly basename: string;
+        readonly query: string;
+        readonly hash: string;
+    }
+
+    interface ExtractCommentOptions {
+        condition: string | RegExp | ExtractCommentFn;
+        filename?: string | FilenameFn;
+        banner?: boolean | string | FormatFn;
+    }
+
+    type ExtractCommentFn = (astNode: any, comment: any) => boolean | object;
+
+    type FormatFn = (input: string) => string;
+
+    type FilenameFn = (fileData: FileData) => string;
+
+    interface TerserPluginOptions {
+        /**
+         * Test to match files against.
+         * @default /\.m?js(\?.*)?$/i
+         */
+        test?: string | RegExp | Array<string | RegExp>;
+
+        /**
+         * Files to include.
+         * @default undefined
+         */
+        include?: string | RegExp | Array<string | RegExp>;
+
+        /**
+         * Files to exclude.
+         * @default undefined
+         */
+        exclude?: string | RegExp | Array<string | RegExp>;
+
+        /**
+         * ⚠ Ignored in webpack 5! Please use {@link webpack.js.org/configuration/other-options/#cache.}
+         * Enable/disable file caching.
+         * Default path to cache directory: `node_modules/.cache/terser-webpack-plugin`.
+         * @default true
+         */
+        cache?: boolean | string;
+
+        /**
+         * ⚠ Ignored in webpack 5! Please use {@link webpack.js.org/configuration/other-options/#cache}.
+         * Allows you to override default cache keys.
+         */
+        cacheKeys?: (defaultCacheKeys: any, file: any) => object;
+
+        /**
+         * Enable/disable multi-process parallel running.
+         * Use multi-process parallel running to improve the build speed. Default number of concurrent runs: os.cpus().length - 1.
+         * @default true
+         */
+        parallel?: boolean | number;
+
+        /**
+         * Use source maps to map error message locations to modules (this slows down the compilation).
+         * If you use your own minify function please read the minify section for handling source maps correctly.
+         * @default false
+         */
+        sourceMap?: boolean;
+
+        /**
+         * Allows you to override default minify function.
+         * By default plugin uses terser package. Useful for using and testing unpublished versions or forks
+         * @default undefined
+         */
+        minify?: (file: any, sourceMap: any, minimizerOptions?: MinifyOptions) => MinifyResult;
+
+        /**
+         * Terser minify {@link https://github.com/terser/terser#minify-options|options}.
+         */
+        terserOptions?: MinifyOptions;
+
+        /**
+         * Whether comments shall be extracted to a separate file, (see details).
+         * By default extract only comments using /^\**!|@preserve|@license|@cc_on/i regexp condition and remove remaining comments.
+         * If the original file is named foo.js, then the comments will be stored to foo.js.LICENSE.txt.
+         * The terserOptions.output.comments option specifies whether the comment will be preserved,
+         * i.e. it is possible to preserve some comments (e.g. annotations) while extracting others or even preserving comments that have been extracted
+         * @default true
+         */
+        extractComments?: boolean | string | RegExp | ExtractCommentFn | ExtractCommentOptions;
+    }
+}
+
+declare class TerserPlugin extends Plugin {
+    constructor(opts?: TerserPlugin.TerserPluginOptions);
+}
+
+export = TerserPlugin;

--- a/types/terser-webpack-plugin/v4/package.json
+++ b/types/terser-webpack-plugin/v4/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "terser": "^4.6.13"
+  }
+}

--- a/types/terser-webpack-plugin/v4/terser-webpack-plugin-tests.ts
+++ b/types/terser-webpack-plugin/v4/terser-webpack-plugin-tests.ts
@@ -1,0 +1,149 @@
+/// <reference types="node" />
+
+import webpack = require('webpack');
+import TerserPlugin = require('terser-webpack-plugin');
+
+const _ = webpack({
+    optimization: {
+        minimize: true,
+        minimizer: [
+            // test
+            new TerserPlugin({
+                test: /\.js(\?.*)?$/i,
+            }),
+            // include
+            new TerserPlugin({
+                include: /\/includes/,
+            }),
+            // exclude
+            new TerserPlugin({
+                exclude: /\/excludes/,
+            }),
+            // cache
+            new TerserPlugin({
+                cache: true,
+            }),
+            new TerserPlugin({
+                cache: 'path/to/cache',
+            }),
+            // cacheKeys
+            new TerserPlugin({
+                cache: true,
+                cacheKeys: (defaultCacheKeys, file) => {
+                    defaultCacheKeys.myCacheKey = 'myCacheKeyValue';
+                    return defaultCacheKeys;
+                },
+            }),
+            // parallel
+            new TerserPlugin({
+                parallel: true,
+            }),
+            new TerserPlugin({
+                parallel: 4,
+            }),
+            // sourceMap
+            new TerserPlugin({
+                sourceMap: true,
+            }),
+            // minify
+            new TerserPlugin({
+                minify: (file, sourceMap, minimizerOptions) => {
+                    minimizerOptions!; // $ExpectType MinifyOptions
+                    const results: TerserPlugin.MinifyResult = {
+                        code: '',
+                        extractedComments: [''],
+                        map: '',
+                    };
+                    return results;
+                },
+            }),
+            // terserOptions
+            new TerserPlugin({
+                terserOptions: {
+                    ecma: undefined,
+                    warnings: false,
+                    parse: {},
+                    compress: {},
+                    mangle: true, // Note `mangle.properties` is `false` by default.
+                    module: false,
+                    output: undefined,
+                    toplevel: false,
+                    nameCache: undefined,
+                    ie8: false,
+                    keep_classnames: undefined,
+                    keep_fnames: false,
+                    safari10: false,
+                },
+            }),
+            // extractComments
+            new TerserPlugin({
+                extractComments: true,
+            }),
+            new TerserPlugin({
+                extractComments: 'all',
+            }),
+            new TerserPlugin({
+                extractComments: /@extract/i,
+            }),
+            new TerserPlugin({
+                extractComments: (astNode, comment) => {
+                    if (/@extract/i.test(comment.value)) {
+                        return true;
+                    }
+                    return false;
+                },
+            }),
+            new TerserPlugin({
+                extractComments: {
+                    condition: /^\**!|@preserve|@license|@cc_on/i,
+                    filename: (fileData: TerserPlugin.FileData) => {
+                        // The "fileData" argument contains object with "filename", "basename", "query" and "hash"
+                        return `${fileData.filename}.LICENSE.txt${fileData.query}`;
+                    },
+                    banner: licenseFile => {
+                        return `License information can be found in ${licenseFile}`;
+                    },
+                },
+            }),
+            new TerserPlugin({
+                extractComments: {
+                    condition: /^\**!|@preserve|@license|@cc_on/i,
+                    banner: false,
+                },
+            }),
+            // varia
+            new TerserPlugin({
+                terserOptions: {
+                    output: {
+                        comments: /@license/i,
+                    },
+                },
+                extractComments: true,
+            }),
+            new TerserPlugin({
+                terserOptions: {
+                    output: {
+                        comments: false,
+                    },
+                },
+                extractComments: false,
+            }),
+            new TerserPlugin({
+                terserOptions: {
+                  ecma: undefined,
+                  parse: {},
+                  compress: {},
+                  mangle: true, // Note `mangle.properties` is `false` by default.
+                  module: false,
+                  output: undefined,
+                  toplevel: false,
+                  nameCache: undefined,
+                  ie8: false,
+                  keep_classnames: undefined,
+                  keep_fnames: false,
+                  safari10: false,
+                },
+              }),
+        ],
+    },
+});

--- a/types/terser-webpack-plugin/v4/tsconfig.json
+++ b/types/terser-webpack-plugin/v4/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "terser-webpack-plugin": [
+                "terser-webpack-plugin/v4"
+            ],
+            "webpack": [
+                "webpack/v4"
+            ],
+            "tapable": [
+                "tapable/v1"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "terser-webpack-plugin-tests.ts"]
+}

--- a/types/terser-webpack-plugin/v4/tslint.json
+++ b/types/terser-webpack-plugin/v4/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
To allow using v4 not passthrough version the proper tsconfig needs to
be in place and types be published with a change.

See #51712 for details.

Thanks!

/cc @rchl

Fixes: #52056

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

how-to:
- checkout detached branch  from latest 4.2 version commit
- move current into v4 and commit changes
- restore/rebase from current master and run tests