### PR TITLE
Add react-big-calendar backgroundEvents

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-big-calendar 0.30
+// Type definitions for react-big-calendar 0.31
 // Project: https://github.com/jquense/react-big-calendar
 // Definitions by: Piotr Witek <https://github.com/piotrwitek>
 //                 Austin Turner <https://github.com/paustint>

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -293,6 +293,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     getNow?: () => Date;
     view?: View;
     events?: TEvent[];
+    backgroundEvents?: TEvent[];
     handleDragStart?: (event: TEvent) => void;
     onNavigate?: (newDate: Date, view: View, action: NavigateAction) => void;
     onView?: (view: View) => void;
@@ -399,6 +400,7 @@ export function move(View: ViewStatic | ViewKey, options: MoveOptions): Date;
 export interface TimeGridProps<TEvent extends object = Event, TResource extends object = object> {
     eventOffset: number;
     events?: TEvent[];
+    backgroundEvents?: TEvent[];
     resources?: TResource[];
     step?: number;
     timeslots?: number;

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -509,3 +509,8 @@ class MyDay extends Day {
         return date.toString();
     }
 }
+
+// Using backgroundEvents
+{
+    ReactDOM.render(<Calendar backgroundEvents={getEvents()} localizer={momentLocalizer(moment)} />, document.body);
+}


### PR DESCRIPTION
They're still missing in the official docs, but already annotated as prop type: https://github.com/jquense/react-big-calendar/blob/dbcc5785a0d2edd2c710706538389344dba737a8/src/Calendar.js#L136

See also https://github.com/jquense/react-big-calendar/pull/1851

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/react-big-calendar/pull/1851
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
