### PR TITLE
Add method override for moxios.stubRequest for Moxios v0.4.0

### DIFF
--- a/types/moxios/index.d.ts
+++ b/types/moxios/index.d.ts
@@ -144,6 +144,15 @@ declare let moxios: {
     stubRequest(urlOrRegExp: string | RegExp, response: Item): void;
 
     /**
+     * Stub a response to be used to respond to a request matching a URL or RegExp
+     *
+     * @param method An axios command
+     * @param urlOrRegExp A URL or RegExp to test against
+     * @param response The response to use when a match is made
+     */
+    stubRequest(method: string, urlOrRegExp: string | RegExp, response: Item): void;
+
+    /**
      * Stub a response to be used one or more times to respond to a request matching a
      * method and a URL or RegExp.
      *


### PR DESCRIPTION
Making a minor update to the stubRequest method in moxios to include a function definition that allows the use of HTTP method.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/axios/moxios/blob/master/index.js#L323-L338
