### PR TITLE
jest: add generic template-literals Each types

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -364,6 +364,11 @@ declare namespace jest {
             fn: (arg: any) => any,
             timeout?: number
         ) => void;
+        <T>(strings: TemplateStringsArray, ...placeholders: any[]): (
+            name: string,
+            fn: (arg: T) => any,
+            timeout?: number
+        ) => void;
     }
 
     /**

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1385,6 +1385,17 @@ describe.each`
     });
 });
 
+describe.each<Case>`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+`('$a + $b', ({ a, b, expected }) => {
+    test(`returns ${expected}`, () => {
+        expect(a + b).toBe(expected);
+    });
+});
+
 describe.only.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a, b, expected) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);


### PR DESCRIPTION
Adding a generic type to jest `test.each` with template literals.

ATM, to declare a type for the `test.each` parameters, you need to explicitly type them (as seen [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/jest-tests.ts#L1382)).
By introducing another type overload, we can pass a generic type to the `.each` method (as it is supported in the array case of `.each`, as can be seen [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts#L353))

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I've ran `npm test jest`, but it fails with:
```
ERROR: 369:23  no-unnecessary-generics  Type parameter T is used only once. See: https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md
```

I find the generic `.each<T>` more readable than the existing use case, but if you tend to disagree, please LMK and I'll close this PR.

if you do agree, please advice on how to make the tests pass (should I just disable lint for this line?)

Thanks.
