### PR TITLE
[mongodb] fix typing of _id fields in arrays

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1877,8 +1877,8 @@ export type SetFields<TSchema> = ({
 
 export type PushOperator<TSchema> = ({
     readonly [key in KeysOfAType<TSchema, ReadonlyArray<any>>]?:
-        | UpdateOptionalId<Unpacked<TSchema[key]>>
-        | ArrayOperator<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
+        | Unpacked<TSchema[key]>
+        | ArrayOperator<Array<Unpacked<TSchema[key]>>>;
 } &
     NotAcceptedFields<TSchema, ReadonlyArray<any>>) & {
     readonly [key: string]: ArrayOperator<any> | any;

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -213,7 +213,7 @@ async function run() {
     buildUpdateQuery({ $push: { maybeFruitTags: 'apple' } });
     buildUpdateQuery({
         $push: {
-            subInterfaceArray: { field1: 'foo' },
+            subInterfaceArray: { _id: new ObjectId(), field1: 'foo' },
         },
     });
     buildUpdateQuery({
@@ -229,6 +229,7 @@ async function run() {
             subInterfaceArray: {
                 $each: [
                     {
+                        _id: new ObjectId(),
                         field1: 'foo',
                         field2: 'bar',
                     },
@@ -253,4 +254,27 @@ async function run() {
             },
         },
     );
+}
+
+async function testPushWithId () {
+    interface Model {
+        _id: ObjectId;
+        foo: Array<{ _id?: string, name: string }>;
+    }
+
+    const client = await connect(connectionString);
+    const db = client.db('test');
+    const collection = db.collection<Model>('test');
+
+    await collection.updateOne({}, {
+        $push: {
+            foo: { name: 'Foo' }
+        }
+    });
+
+    await collection.updateOne({}, {
+        $push: {
+            foo: { _id: 'foo', name: 'Foo' }
+        }
+    });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mongodb.com/manual/reference/operator/update/push/
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

The previous code would allow pushing objects without an `_id` field to arrays. This is not valid since `$push` does **not** add an `_id` property to the object that it adds to the array.

This could also be seen in the of the current test cases where `_id` was a required type on a sub-document, but it would _not actually be present in the database_ after the two operations.