### PR TITLE
[fnando__sparkline] Add support to datapoint type

### DIFF
--- a/types/fnando__sparkline/fnando__sparkline-tests.ts
+++ b/types/fnando__sparkline/fnando__sparkline-tests.ts
@@ -1,10 +1,10 @@
 // tslint:disable:no-duplicate-imports
 
-import { sparkline } from '@fnando/sparkline';
-import * as sparkline2 from '@fnando/sparkline';
-import sparkline3 from '@fnando/sparkline';
+import { sparkline } from "@fnando/sparkline";
+import * as sparkline2 from "@fnando/sparkline";
+import sparkline3 from "@fnando/sparkline";
 
-const svg = document.createElement('svg') as any as SVGSVGElement;
+const svg = (document.createElement("svg") as any) as SVGSVGElement;
 
 // number entries
 sparkline(svg, [1, 2, 3]);
@@ -14,17 +14,35 @@ sparkline(svg, [{ value: 1 }, { value: 2 }, { value: 3 }]);
 
 // all other entries (required fetch in options)
 sparkline(svg, [{ something: 1 }, { something: 2 }, { something: 3 }], {
-    fetch: (entry) => entry.something
+    fetch: entry => entry.something,
 });
 
 // all options
 sparkline(svg, [1, 2, 3], {
     cursorwidth: 5,
-    fetch: (entry) => entry,
+    fetch: entry => entry,
     interactive: true,
-    onmousemove: (event) => { console.log(event); },
-    onmouseout: (event) => { console.log(event); },
-    spotRadius: 5
+    onmousemove: (event, datapoint) => {
+        console.log(event, datapoint);
+    },
+    onmouseout: event => {
+        console.log(event);
+    },
+    spotRadius: 5,
+});
+
+// another all options call, but with a custom data point format
+sparkline(svg, [{ something: 1 }, { something: 2 }, { something: 3 }], {
+    cursorwidth: 5,
+    fetch: entry => entry.something,
+    interactive: true,
+    onmousemove: (event, datapoint) => {
+        console.log(event, datapoint);
+    },
+    onmouseout: event => {
+        console.log(event);
+    },
+    spotRadius: 5,
 });
 
 sparkline2.default(svg, [1, 2, 3]);

--- a/types/fnando__sparkline/index.d.ts
+++ b/types/fnando__sparkline/index.d.ts
@@ -2,9 +2,13 @@
 // Project: https://github.com/fnando/sparkline
 // Definitions by: Gábor Balogh <https://github.com/grabofus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 3.5
 
 type SparklineNativeEntry = number | { value: number };
+
+type SparklineDatapoint<TEntry> = TEntry extends number
+    ? { x: number; y: number; index: number; value: number }
+    : TEntry & { x: number; y: number; index: number };
 
 interface SparklineOptionsFetch<TEntry> {
     /**
@@ -13,11 +17,11 @@ interface SparklineOptionsFetch<TEntry> {
     fetch: (entry: TEntry) => number;
 }
 
-interface SparklineOptions {
+interface SparklineOptions<TEntry> {
     /**
      * By setting this callback function, you'll enable the interactive mode (unless you set options.interactive to false).
      */
-    onmousemove?: (event: MouseEvent) => void;
+    onmousemove?: (event: MouseEvent, datapoint: SparklineDatapoint<TEntry>) => void;
 
     /**
      * This callback function is called every time the mouse leaves the SVG area. You can use it to hide things like tooltips.
@@ -40,8 +44,8 @@ interface SparklineOptions {
     interactive?: boolean;
 }
 
-type SparklineNativeOptions<TEntry> = SparklineOptions | Partial<SparklineOptionsFetch<TEntry>>;
-type SparklineNonNativeOptions<TEntry> = SparklineOptions | SparklineOptionsFetch<TEntry>;
+type SparklineNativeOptions<TEntry> = SparklineOptions<TEntry> | Partial<SparklineOptionsFetch<TEntry>>;
+type SparklineNonNativeOptions<TEntry> = SparklineOptions<TEntry> | SparklineOptionsFetch<TEntry>;
 
 /**
  * Generate SVG sparklines with JavaScript without any external dependency.
@@ -49,7 +53,15 @@ type SparklineNonNativeOptions<TEntry> = SparklineOptions | SparklineOptionsFetc
  * @param entries You can either provide an array of numbers or an array of objects that respond to .value. If you have a different data structure, see options.fetch.
  * @param options This optional argument allows you to further customize the sparkline.
  */
-export function sparkline<TEntry extends SparklineNativeEntry>(svg: SVGSVGElement, entries: TEntry[], options?: SparklineNativeOptions<TEntry>): string;
-export function sparkline<TEntry>(svg: SVGSVGElement, entries: TEntry[], options: SparklineNonNativeOptions<TEntry>): string;
+export function sparkline<TEntry extends SparklineNativeEntry>(
+    svg: SVGSVGElement,
+    entries: TEntry[],
+    options?: SparklineNativeOptions<TEntry>,
+): string;
+export function sparkline<TEntry>(
+    svg: SVGSVGElement,
+    entries: TEntry[],
+    options: SparklineNonNativeOptions<TEntry>,
+): string;
 
 export default sparkline;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fnando/sparkline#sparklinesvg-values-options--

---

The reason for this edit is that the library has support for `onmousemove(event, datapoint)` from the docs. A `SparklineDatapoint` has been provided accordingly.

While the conditional types have been added to TypeScript since 2.8, I have bumped the header support version to 3.5 (from 2.1) instead, since the minimum version tested via `dtslint` is 3.5.

Please let me know if that looks OK to you. Thanks!