### PR TITLE
Remove bogus type parameter from jsforce

### DIFF
--- a/types/jsforce/query.d.ts
+++ b/types/jsforce/query.d.ts
@@ -68,7 +68,7 @@ export class Query<T> extends Readable implements Promise<T> {
 
     where(conditions: Object | string): Query<T>;
 
-    finally<never>(): Promise<T>;
+    finally(): Promise<T>;
 
     [Symbol.toStringTag]: 'Promise';
 


### PR DESCRIPTION
As far as I can tell, there's no reason for it. If there is, it should be named `Unused` instead.

TS 4.3 doesn't allow the type parameter because it's named `never`, which is a reserved word. Previous versions of TS mistakenly allowed this.