### PR TITLE
Use commonjs import/export for tapable

### DIFF
--- a/types/tapable/index.d.ts
+++ b/types/tapable/index.d.ts
@@ -4,4 +4,5 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /* tslint:disable-next-line:no-self-import */
-export * from 'tapable';
+import tapable = require('tapable');
+export = tapable;


### PR DESCRIPTION
In enhanced-resolve, tapable's passthrough is used for tapable/v0, which uses a commonjs `export =`. The new import/export style works for all modules.