### PR TITLE
[react-virtualized] Remove unused imports

### DIFF
--- a/types/react-virtualized/dist/es/ArrowKeyStepper.d.ts
+++ b/types/react-virtualized/dist/es/ArrowKeyStepper.d.ts
@@ -1,5 +1,4 @@
-import { PureComponent, Validator, Requireable } from 'react';
-import * as PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { RenderedSection } from './Grid';
 
 export type OnSectionRenderedParams = RenderedSection;

--- a/types/react-virtualized/dist/es/AutoSizer.d.ts
+++ b/types/react-virtualized/dist/es/AutoSizer.d.ts
@@ -1,5 +1,4 @@
-import { PureComponent, Validator, Requireable } from 'react';
-import * as PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 
 export type Size = {
     height: number;

--- a/types/react-virtualized/dist/es/Collection.d.ts
+++ b/types/react-virtualized/dist/es/Collection.d.ts
@@ -6,7 +6,6 @@ import {
     ScrollPosition,
     SectionRenderedParams,
     SizeInfo,
-    SizeAndPositionInfo,
 } from '../../index';
 
 export type CollectionCellSizeAndPosition = {

--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -1,6 +1,4 @@
-import { Validator, Requireable, PureComponent, Component } from 'react';
-import { List } from './List';
-import { Table } from './Table';
+import { PureComponent } from 'react';
 import { CellMeasurerCache, MeasuredCellParent } from './CellMeasurer';
 import { Index, Map, Alignment, OverscanIndexRange } from '../../index';
 

--- a/types/react-virtualized/dist/es/InfiniteLoader.d.ts
+++ b/types/react-virtualized/dist/es/InfiniteLoader.d.ts
@@ -1,4 +1,4 @@
-import { PureComponent, Validator, Requireable } from 'react';
+import { PureComponent, Validator } from 'react';
 import { Index, IndexRange } from '../../index';
 
 export type InfiniteLoaderChildProps = {

--- a/types/react-virtualized/dist/es/List.d.ts
+++ b/types/react-virtualized/dist/es/List.d.ts
@@ -1,4 +1,4 @@
-import { PureComponent, Validator, Requireable } from 'react';
+import { PureComponent } from 'react';
 import { Grid, GridCoreProps, GridCellProps, OverscanIndicesGetter } from './Grid';
 import { Index, IndexRange, OverscanIndexRange, Alignment } from '../../index';
 import { CellMeasurerCache, CellPosition } from './CellMeasurer';

--- a/types/react-virtualized/dist/es/Masonry.d.ts
+++ b/types/react-virtualized/dist/es/Masonry.d.ts
@@ -1,6 +1,5 @@
-import { PureComponent, Validator, Requireable } from 'react';
+import { PureComponent } from 'react';
 import { CellMeasurerCacheInterface, KeyMapper, MeasuredCellParent } from './CellMeasurer';
-import { GridCellRenderer } from './Grid';
 import { IndexRange } from '../../index';
 /**
  * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.

--- a/types/react-virtualized/dist/es/MultiGrid.d.ts
+++ b/types/react-virtualized/dist/es/MultiGrid.d.ts
@@ -1,4 +1,4 @@
-import { PureComponent, Validator, Requireable } from 'react';
+import { PureComponent, Validator } from 'react';
 import { GridProps } from './Grid';
 import { CellPosition } from './CellMeasurer';
 

--- a/types/react-virtualized/dist/es/ScrollSync.d.ts
+++ b/types/react-virtualized/dist/es/ScrollSync.d.ts
@@ -1,4 +1,4 @@
-import { PureComponent, Validator, Requireable } from 'react';
+import { PureComponent, Validator } from 'react';
 
 export type OnScrollParams = {
     clientHeight: number;

--- a/types/react-virtualized/dist/es/WindowScroller.d.ts
+++ b/types/react-virtualized/dist/es/WindowScroller.d.ts
@@ -1,4 +1,4 @@
-import { Validator, Requireable, PureComponent } from 'react';
+import { PureComponent } from 'react';
 
 /**
  * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.


### PR DESCRIPTION
Removed unused imports for react-virtualized types. In some cases reduces overhead of using the types from other react-like libraries, e.g. preact.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
