### PR TITLE
Add missing declarations for {rm, rmdir} in fs-extra

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -305,3 +305,18 @@ fs.realpath.native('src', { encoding: 'utf-8' });
 fs.realpath.native('src', { encoding: 'buffer' });
 // $ExpectType Promise<string>
 fs.realpath.native('src', { encoding: null });
+
+async function rmTest() {
+    await fs.rm('path');
+    await fs.rm('path', {
+        force: true,
+        maxRetries: 1,
+        recursive: true,
+        retryDelay: 200,
+    });
+}
+
+async function rmDirTest() {
+    await fs.rmdir('dir');
+    await fs.rmdir('dir', { maxRetries: 1, recursive: true, retryDelay: 200 });
+}

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -240,13 +240,15 @@ export namespace realpath {
 export function rename(oldPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 export function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
 
+export function rm(path: PathLike, options?: fs.RmOptions): Promise<void>;
+
 /**
  * Asynchronous rmdir - removes the directory specified in {path}
  *
  * @param callback No arguments other than a possible exception are given to the completion callback.
  */
 export function rmdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
-export function rmdir(path: PathLike): Promise<void>;
+export function rmdir(path: PathLike, options?: fs.RmDirOptions): Promise<void>;
 
 export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
 export function stat(path: PathLike): Promise<Stats>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/fs.d.ts#L874-L960
  - `fs-extra` exports promisified overloads of all [these functions](https://github.com/jprichardson/node-fs-extra/blob/master/lib/fs/index.js#L8-L41) in `fs`. For every overload in `fs` that takes a callback as a final parameter, `fs-extra` has an overload that omits that parameter and returns a promise.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
