### PR TITLE
[sanitize-html] fixed type of IDefaults.disallowedTagsMode

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -38,7 +38,7 @@ declare namespace sanitize {
     allowedSchemesAppliedToAttributes: string[];
     allowedTags: string[];
     allowProtocolRelative: boolean;
-    disallowedTagsMode: string;
+    disallowedTagsMode: DisallowedTagsModes;
     enforceHtmlBoundary: boolean;
     selfClosing: string[];
   }

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -48,7 +48,7 @@ sanitize.defaults.allowedSchemesAppliedToAttributes; // $ExpectType string[]
 sanitize.defaults.allowedSchemesByTag; // $ExpectType { [index: string]: string[]; }
 sanitize.defaults.allowedTags; // $ExpectType string[]
 sanitize.defaults.allowProtocolRelative; // $ExpectType boolean
-sanitize.defaults.disallowedTagsMode; // $ExpectType string
+sanitize.defaults.disallowedTagsMode; // $ExpectType DisallowedTagsModes
 sanitize.defaults.enforceHtmlBoundary; // $ExpectType boolean
 sanitize.defaults.selfClosing; // $ExpectType string[]
 
@@ -61,3 +61,5 @@ options.parser = {
 };
 
 safe = sanitize(unsafe, options);
+
+sanitize(unsafe, sanitize.defaults);


### PR DESCRIPTION
Fixed type of `IDefaults.disallowedTagsMode` as defined in `IOptions` so that i.e.
```js
sanitize(unsafe, sanitize.defaults);
```
won't fail any more.