### PR TITLE
fix(google-protobuf): Add static fromDate method.

### DIFF
--- a/types/google-protobuf/google-protobuf-tests.ts
+++ b/types/google-protobuf/google-protobuf-tests.ts
@@ -539,3 +539,5 @@ class MySimple extends jspb.Message {
 const myMessage: MySimple = new MySimple();
 const myClonedMessage: MySimple = myMessage.clone();
 const myClonedMessage2: MySimple = myMessage.cloneMessage()
+
+const myTimestamp = google_protobuf_timestamp_pb.Timestamp.fromDate(new Date());

--- a/types/google-protobuf/google/protobuf/timestamp_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/timestamp_pb.d.ts
@@ -21,6 +21,7 @@ export class Timestamp extends jspb.Message {
   static serializeBinaryToWriter(message: Timestamp, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Timestamp;
   static deserializeBinaryFromReader(message: Timestamp, reader: jspb.BinaryReader): Timestamp;
+  static fromDate(date: Date): Timestamp;
 }
 
 export namespace Timestamp {


### PR DESCRIPTION
Version 3.7.0 and later of google-protobuf have a static fromDate
method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/protocolbuffers/protobuf/blob/62c402ae37d86bf0d62ae8f6fbb1df31b6bd7e7e/src/google/protobuf/compiler/js/well_known_types_embed.cc#L117-L127
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.