### PR TITLE
update type definitions for sharp 0.28.1

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharp 0.27
+// Type definitions for sharp 0.28
 // Project: https://github.com/lovell/sharp
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 Wooseop Kim <https://github.com/wooseopkim>
@@ -11,7 +11,7 @@
 
 /// <reference types="node" />
 
-import { Duplex } from 'stream';
+import { Duplex } from "stream";
 
 //#region Constructor functions
 
@@ -117,9 +117,10 @@ declare namespace sharp {
 
         /**
          * Ensure alpha channel, if missing. The added alpha channel will be fully opaque. This is a no-op if the image already has an alpha channel.
+         * @param alpha transparency level (0=fully-transparent, 1=fully-opaque) (optional, default 1).
          * @returns A sharp instance that can be used to chain operations
          */
-        ensureAlpha(): Sharp;
+        ensureAlpha(alpha?: number): Sharp;
 
         /**
          * Extract a single channel from a multi-channel image.
@@ -707,11 +708,17 @@ declare namespace sharp {
     }
 
     interface WriteableMetadata {
-        /** Number value of the EXIF Orientation header, if present */
+        /** Value between 1 and 8, used to update the EXIF Orientation tag. */
         orientation?: number;
+        /** Filesystem path to output ICC profile, defaults to sRGB. */
+        icc?: string;
+        /** Object keyed by IFD0, IFD1 etc. of key/value string pairs to write as EXIF data. (optional, default {}) */
+        exif?: Record<string, any>;
     }
 
-    interface Metadata extends WriteableMetadata {
+    interface Metadata {
+        /** Number value of the EXIF Orientation header, if present */
+        orientation?: number;
         /** Name of decoder used to decompress image data e.g. jpeg, png, webp, gif, svg */
         format?: keyof FormatEnum;
         /** Total size of image in bytes, for Stream and Buffer input only */
@@ -795,22 +802,22 @@ declare namespace sharp {
     }
 
     interface OutputOptions {
-        /** Quality, integer 1-100 (optional, default 80) */
-        quality?: number;
         /** Force format output, otherwise attempt to use input format (optional, default true) */
         force?: boolean;
     }
 
     interface JpegOptions extends OutputOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number;
         /** Use progressive (interlace) scan (optional, default false) */
         progressive?: boolean;
         /** Set to '4:4:4' to prevent chroma subsampling when quality <= 90 (optional, default '4:2:0') */
         chromaSubsampling?: string;
-        /** Apply trellis quantisation, requires mozjpeg (optional, default  false) */
+        /** Apply trellis quantisation (optional, default  false) */
         trellisQuantisation?: boolean;
-        /** Apply overshoot deringing, requires mozjpeg (optional, default  false) */
+        /** Apply overshoot deringing (optional, default  false) */
         overshootDeringing?: boolean;
-        /** Optimise progressive scans, forces progressive, requires mozjpeg (optional, default false) */
+        /** Optimise progressive scans, forces progressive (optional, default false) */
         optimiseScans?: boolean;
         /** Alternative spelling of optimiseScans (optional, default false) */
         optimizeScans?: boolean;
@@ -818,13 +825,17 @@ declare namespace sharp {
         optimiseCoding?: boolean;
         /** Alternative spelling of optimiseCoding (optional, default true) */
         optimizeCoding?: boolean;
-        /** Quantization table to use, integer 0-8, requires mozjpeg (optional, default 0) */
+        /** Quantization table to use, integer 0-8 (optional, default 0) */
         quantisationTable?: number;
         /** Alternative spelling of quantisationTable (optional, default 0) */
         quantizationTable?: number;
+        /** Use mozjpeg defaults (optional, default false) */
+        mozjpeg?: boolean;
     }
 
     interface WebpOptions extends OutputOptions, AnimationOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number;
         /** Quality of alpha layer, number from 0-100 (optional, default 100) */
         alphaQuality?: number;
         /** Use lossless compression mode (optional, default false) */
@@ -850,7 +861,7 @@ declare namespace sharp {
         /** quality, integer 1-100 (optional, default 50) */
         quality?: number;
         /** compression format: av1, hevc (optional, default 'av1') */
-        compression?: 'av1' | 'hevc';
+        compression?: "av1" | "hevc";
         /** use lossless compression (optional, default false) */
         lossless?: boolean;
         /** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default 5) */
@@ -865,6 +876,8 @@ declare namespace sharp {
     interface GifOptions extends OutputOptions, AnimationOptions {}
 
     interface TiffOptions extends OutputOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number;
         /** Compression options: lzw, deflate, jpeg, ccittfax4 (optional, default 'jpeg') */
         compression?: string;
         /** Compression predictor options: none, horizontal, float (optional, default 'horizontal') */
@@ -885,24 +898,22 @@ declare namespace sharp {
         bitdepth?: 1 | 2 | 4 | 8;
     }
 
-    interface PngOptions {
+    interface PngOptions extends OutputOptions {
         /** Use progressive (interlace) scan (optional, default false) */
         progressive?: boolean;
-        /** zlib compression level, 0-9 (optional, default 9) */
+        /** zlib compression level, 0-9 (optional, default 6) */
         compressionLevel?: number;
         /** use adaptive row filtering (optional, default false) */
         adaptiveFiltering?: boolean;
-        /** Force PNG output, otherwise attempt to use input format (optional, default  true) */
-        force?: boolean;
-        /** use the lowest number of colours needed to achieve given quality, requires libimagequant (optional, default `100`) */
+        /** use the lowest number of colours needed to achieve given quality (optional, default `100`) */
         quality?: number;
-        /** Quantise to a palette-based image with alpha transparency support, requires libimagequant (optional, default false) */
+        /** Quantise to a palette-based image with alpha transparency support (optional, default false) */
         palette?: boolean;
-        /** Maximum number of palette entries, requires libimagequant (optional, default 256) */
+        /** Maximum number of palette entries (optional, default 256) */
         colours?: number;
-        /** Alternative Spelling of "colours". Maximum number of palette entries, requires libimagequant (optional, default 256) */
+        /** Alternative Spelling of "colours". Maximum number of palette entries (optional, default 256) */
         colors?: number;
-        /**  Level of Floyd-Steinberg error diffusion, requires libimagequant (optional, default 1.0) */
+        /**  Level of Floyd-Steinberg error diffusion (optional, default 1.0) */
         dither?: number;
     }
 
@@ -947,11 +958,15 @@ declare namespace sharp {
     }
 
     interface ExtendOptions {
+        /** single pixel count to top edge (optional, default 0) */
         top?: number;
+        /** single pixel count to left edge (optional, default 0) */
         left?: number;
+        /** single pixel count to bottom edge (optional, default 0) */
         bottom?: number;
+        /** single pixel count to right edge (optional, default 0) */
         right?: number;
-        /** Background colour, parsed by the color module, defaults to black without transparency. (optional, default {r:0,g:0,b:0,alpha:1}) */
+        /** background colour, parsed by the color module, defaults to black without transparency. (optional, default {r:0,g:0,b:0,alpha:1}) */
         background?: Color;
     }
 
@@ -1061,65 +1076,65 @@ declare namespace sharp {
     }
 
     interface FitEnum {
-        contain: 'contain';
-        cover: 'cover';
-        fill: 'fill';
-        inside: 'inside';
-        outside: 'outside';
+        contain: "contain";
+        cover: "cover";
+        fill: "fill";
+        inside: "inside";
+        outside: "outside";
     }
 
     interface KernelEnum {
-        nearest: 'nearest';
-        cubic: 'cubic';
-        mitchell: 'mitchell';
-        lanczos2: 'lanczos2';
-        lanczos3: 'lanczos3';
+        nearest: "nearest";
+        cubic: "cubic";
+        mitchell: "mitchell";
+        lanczos2: "lanczos2";
+        lanczos3: "lanczos3";
     }
 
     interface BoolEnum {
-        and: 'and';
-        or: 'or';
-        eor: 'eor';
+        and: "and";
+        or: "or";
+        eor: "eor";
     }
 
     interface ColourspaceEnum {
         multiband: string;
-        'b-w': string;
+        "b-w": string;
         bw: string;
         cmyk: string;
         srgb: string;
     }
 
-    type TileLayout = 'dz' | 'iiif' | 'zoomify' | 'google';
+    type TileLayout = "dz" | "iiif" | "zoomify" | "google";
 
     type Blend =
-        | 'clear'
-        | 'source'
-        | 'over'
-        | 'in'
-        | 'out'
-        | 'atop'
-        | 'dest'
-        | 'dest-over'
-        | 'dest-in'
-        | 'dest-out'
-        | 'dest-atop'
-        | 'xor'
-        | 'add'
-        | 'saturate'
-        | 'multiply'
-        | 'screen'
-        | 'overlay'
-        | 'darken'
-        | 'lighten'
-        | 'colour-dodge'
-        | 'colour-dodge'
-        | 'colour-burn'
-        | 'colour-burn'
-        | 'hard-light'
-        | 'soft-light'
-        | 'difference'
-        | 'exclusion';
+        | "clear"
+        | "source"
+        | "over"
+        | "in"
+        | "out"
+        | "atop"
+        | "dest"
+        | "dest-over"
+        | "dest-in"
+        | "dest-out"
+        | "dest-atop"
+        | "xor"
+        | "add"
+        | "saturate"
+        | "multiply"
+        | "screen"
+        | "overlay"
+        | "darken"
+        | "lighten"
+        | "colour-dodge"
+        | "colour-dodge"
+        | "colour-burn"
+        | "colour-burn"
+        | "hard-light"
+        | "soft-light"
+        | "difference"
+        | "exclusion";
 
     type Gravity = number | string;
 

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -1,5 +1,6 @@
-import sharp = require('sharp');
-import { createReadStream, createWriteStream } from 'fs';
+import sharp = require("sharp");
+
+import { createReadStream, createWriteStream } from "fs";
 
 // Test samples taken from the official documentation
 
@@ -8,27 +9,32 @@ const readableStream: NodeJS.ReadableStream = createReadStream(input);
 const writableStream: NodeJS.WritableStream = createWriteStream(input);
 
 sharp(input)
-    .extractChannel('green')
-    .toFile('input_green.jpg', (err, info) => {
+    .extractChannel("green")
+    .toFile("input_green.jpg", (err, info) => {
         // info.channels === 1
         // input_green.jpg contains the green channel of the input image
     });
 
-sharp('3-channel-rgb-input.png')
+sharp("3-channel-rgb-input.png")
     .bandbool(sharp.bool.and)
-    .toFile('1-channel-output.png', (err, info) => {
+    .toFile("1-channel-output.png", (err, info) => {
         // The output will be a single channel image where each pixel `P = R & G & B`.
         // If `I(1,1) = [247, 170, 14] = [0b11110111, 0b10101010, 0b00001111]`
         // then `O(1,1) = 0b11110111 & 0b10101010 & 0b00001111 = 0b00000010 = 2`.
     });
 
-sharp('input.png')
+sharp("input.png")
     .rotate(180)
     .resize(300)
-    .flatten({ background: '#ff6600' })
-    .composite([{ input: 'overlay.png', gravity: sharp.gravity.southeast }])
+    .flatten({ background: "#ff6600" })
+    .composite([{ input: "overlay.png", gravity: sharp.gravity.southeast }])
     .sharpen()
     .withMetadata()
+    .withMetadata({
+        orientation: 8,
+        icc: "some/path",
+        exif: { IFD0: { Copyright: "Wernham Hogg" } },
+    })
     .webp({
         quality: 90,
     })
@@ -39,14 +45,14 @@ sharp('input.png')
         // sharpened, with metadata, 90% quality WebP image data. Phew!
     });
 
-sharp('input.jpg')
+sharp("input.jpg")
     .resize(300, 200)
-    .toFile('output.jpg', (err: Error) => {
+    .toFile("output.jpg", (err: Error) => {
         // output.jpg is a 300 pixels wide and 200 pixels high image
         // containing a scaled and cropped version of input.jpg
     });
 
-sharp('input.jpg').resize({ width: 300 }).blur(false).blur(true).toFile('output.jpg');
+sharp("input.jpg").resize({ width: 300 }).blur(false).blur(true).toFile("output.jpg");
 
 sharp({
     create: {
@@ -61,15 +67,15 @@ sharp({
 
 let transformer = sharp()
     .resize(300)
-    .on('info', (info: sharp.OutputInfo) => {
-        console.log('Image height is ' + info.height);
+    .on("info", (info: sharp.OutputInfo) => {
+        console.log("Image height is " + info.height);
     });
 readableStream.pipe(transformer).pipe(writableStream);
 
 console.log(sharp.format);
 console.log(sharp.versions);
 
-sharp.queue.on('change', (queueLength: number) => {
+sharp.queue.on("change", (queueLength: number) => {
     console.log(`Queue contains ${queueLength} task(s)`);
 });
 
@@ -107,7 +113,7 @@ readableStream.pipe(pipeline);
 
 sharp(input)
     .extract({ left: 0, top: 0, width: 100, height: 100 })
-    .toFile('output', (err: Error) => {
+    .toFile("output", (err: Error) => {
         // Extract a region of the input image, saving in the same format.
     });
 
@@ -115,7 +121,7 @@ sharp(input)
     .extract({ left: 0, top: 0, width: 100, height: 100 })
     .resize(200, 200)
     .extract({ left: 0, top: 0, width: 100, height: 100 })
-    .toFile('output', (err: Error) => {
+    .toFile("output", (err: Error) => {
         // Extract a region, resize, then extract from the resized image
     });
 
@@ -137,24 +143,24 @@ sharp(input)
         // of the input image with the horizontal Sobel operator
     });
 
-sharp('input.tiff')
+sharp("input.tiff")
     .png()
     .tile({
         size: 512,
     })
-    .toFile('output.dz', (err: Error, info: sharp.OutputInfo) => {
+    .toFile("output.dz", (err: Error, info: sharp.OutputInfo) => {
         // output.dzi is the Deep Zoom XML definition
         // output_files contains 512x512 tiles grouped by zoom level
     });
 
 sharp(input)
     .resize(200, 300, {
-        fit: 'contain',
-        position: 'north',
+        fit: "contain",
+        position: "north",
         kernel: sharp.kernel.lanczos2,
-        background: 'white',
+        background: "white",
     })
-    .toFile('output.tiff')
+    .toFile("output.tiff")
     .then(() => {
         // output.tiff is a 200 pixels wide and 300 pixels high image
         // containing a lanczos2/nohalo scaled version, embedded on a white canvas,
@@ -163,20 +169,20 @@ sharp(input)
 
 transformer = sharp()
     .resize(200, 200, {
-        fit: 'cover',
+        fit: "cover",
         position: sharp.strategy.entropy,
     })
-    .on('error', (err: Error) => {
+    .on("error", (err: Error) => {
         console.log(err);
     });
 // Read image data from readableStream
 // Write 200px square auto-cropped image data to writableStream
 readableStream.pipe(transformer).pipe(writableStream);
 
-sharp('input.gif')
+sharp("input.gif")
     .resize(200, 300, {
-        fit: 'contain',
-        position: 'north',
+        fit: "contain",
+        position: "north",
         background: { r: 0, g: 0, b: 0, alpha: 0 },
     })
     .toFormat(sharp.format.webp)
@@ -189,8 +195,8 @@ sharp('input.gif')
     });
 
 sharp(input)
-    .resize(200, 200, { fit: 'inside' })
-    .toFormat('jpeg')
+    .resize(200, 200, { fit: "inside" })
+    .toFormat("jpeg")
     .toBuffer()
     .then((outputBuffer: Buffer) => {
         // outputBuffer contains JPEG image data no wider than 200 pixels and no higher
@@ -199,7 +205,7 @@ sharp(input)
 
 sharp(input)
     .resize(100, 100)
-    .toFormat('jpg')
+    .toFormat("jpg")
     .toBuffer({ resolveWithObject: false })
     .then((outputBuffer: Buffer) => {
         // Resolves with a Buffer object when resolveWithObject is false
@@ -237,7 +243,7 @@ if (sharp.versions.cairo) {
     const cairoVersion: string = sharp.versions.cairo;
 }
 
-sharp('input.gif')
+sharp("input.gif")
     .linear(1)
     .linear(1, 0)
     .linear(null, 0)
@@ -254,7 +260,7 @@ sharp('input.gif')
 
 // From https://sharp.pixelplumbing.com/api-output#examples-9
 // Extract raw RGB pixel data from JPEG input
-sharp('input.jpg')
+sharp("input.jpg")
     .raw()
     .toBuffer({ resolveWithObject: true })
     .then(({ data, info }) => {
@@ -262,20 +268,48 @@ sharp('input.jpg')
         console.log(info);
     });
 
+sharp(input).jpeg().jpeg({}).jpeg({
+    progressive: false,
+    chromaSubsampling: "4:4:4",
+    trellisQuantisation: false,
+    overshootDeringing: false,
+    optimiseScans: false,
+    optimizeScans: false,
+    optimiseCoding: false,
+    optimizeCoding: false,
+    quantisationTable: 10,
+    quantizationTable: 10,
+    mozjpeg: false,
+    quality: 10,
+    force: false,
+});
+
+sharp(input).png().png({}).png({
+    progressive: false,
+    compressionLevel: 10,
+    adaptiveFiltering: false,
+    force: false,
+    quality: 10,
+    palette: false,
+    colours: 10,
+    colors: 10,
+    dither: 10,
+});
+
 sharp(input)
     .avif()
     .avif({})
     .avif({ quality: 50, lossless: false, speed: 5 })
     .heif()
     .heif({})
-    .heif({ quality: 50, compression: 'hevc', lossless: false, speed: 5 })
+    .heif({ quality: 50, compression: "hevc", lossless: false, speed: 5 })
     .toBuffer({ resolveWithObject: true })
     .then(({ data, info }) => {
         console.log(data);
         console.log(info);
     });
 
-sharp('input.jpg')
+sharp("input.jpg")
     .stats()
     .then(stats => {
         const {
@@ -288,8 +322,8 @@ sharp('input.jpg')
 
 // From https://sharp.pixelplumbing.com/api-output#examples-9
 // Extract alpha channel as raw pixel data from PNG input
-sharp('input.png').ensureAlpha().extractChannel(3).toColourspace('b-w').raw().toBuffer();
+sharp("input.png").ensureAlpha().ensureAlpha(0).extractChannel(3).toColourspace("b-w").raw().toBuffer();
 
 // From https://sharp.pixelplumbing.com/api-constructor#examples-4
 // Convert an animated GIF to an animated WebP
-sharp('in.gif', { animated: true }).toFile('out.webp');
+sharp("in.gif", { animated: true }).toFile("out.webp");


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test sharp`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://sharp.pixelplumbing.com/changelog#v028---bijou](https://sharp.pixelplumbing.com/changelog#v028---bijou)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Changelog

v0.28 - bijou
Requires libvips v8.10.6

v0.28.1 - 5th April 2021
- Ensure all installation errors are logged with a more obvious prefix.
- Allow withMetadata to set and update EXIF metadata.
- Add support for OME-TIFF Sub Image File Directories (subIFD).
- Allow ensureAlpha to set the alpha transparency level.

v0.28.0 - 29th March 2021
- Prebuilt binaries now include mozjpeg and libimagequant (BSD 2-Clause).
- Prebuilt binaries limit AVIF support to the most common 8-bit depth.
- Add mozjpeg option to jpeg method, sets mozjpeg defaults.
- Reduce the default PNG compressionLevel to the more commonly used 6.
- Reduce concurrency on glibc-based Linux when using the default memory allocator to help prevent fragmentation.
- Default missing edge properties of extend operation to zero.
- Ensure composite does not clip top and left offsets.
- Improve error handling of network failure at install time.
- Ensure @id attribute can be set for IIIF tile-based output.
- Ensure composite replicates the correct number of tiles for centred gravities.