### PR TITLE
Restore highlightjs v9 types

### DIFF
--- a/types/highlightjs/index.d.ts
+++ b/types/highlightjs/index.d.ts
@@ -1,8 +1,5 @@
 // Type definitions for highlight.js 9.12
 // Project: https://github.com/isagalaev/highlight.js
-// Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
-//                 Jeremy Hull <https://github.com/sourrust>
-//                 Josh Goldberg <https://github.com/joshuakgoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/highlightjs/index.d.ts
+++ b/types/highlightjs/index.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for highlight.js 9.12
 // Project: https://github.com/isagalaev/highlight.js
+// Definitions by: Andrew Branch <https://github.com/andrewbranch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/highlightjs/index.d.ts
+++ b/types/highlightjs/index.d.ts
@@ -1,9 +1,155 @@
-// Type definitions for highlight.js 10.1
+// Type definitions for highlight.js 9.12
 // Project: https://github.com/isagalaev/highlight.js
-// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
+//                 Jeremy Hull <https://github.com/sourrust>
+//                 Josh Goldberg <https://github.com/joshuakgoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 2.2
 
-import highlightjs = require('highlight.js');
+declare namespace hljs {
+    // tslint:disable-next-line:no-empty-interface
+    interface Node { }
 
-export = highlightjs;
+    export function highlight(
+        name: string,
+        value: string,
+        ignore_illegals?: boolean,
+        continuation?: ICompiledMode): IHighlightResult;
+    export function highlightAuto(
+        value: string,
+        languageSubset?: string[]): IAutoHighlightResult;
+
+    export function fixMarkup(value: string): string;
+
+    export function highlightBlock(block: Node): void;
+
+    export function configure(options: IOptions): void;
+
+    export function initHighlighting(): void;
+    export function initHighlightingOnLoad(): void;
+
+    export function registerLanguage(
+        name: string,
+        language: (hljs?: HLJSStatic) => IModeBase): void;
+    export function listLanguages(): string[];
+    export function getLanguage(name: string): IMode;
+
+    export function inherit(parent: object, obj: object): object;
+
+    export function COMMENT(
+        begin: (string | RegExp),
+        end: (string | RegExp),
+        inherits: IModeBase): IMode;
+
+    // Common regexps
+    export const IDENT_RE: string;
+    export const UNDERSCORE_IDENT_RE: string;
+    export const NUMBER_RE: string;
+    export const C_NUMBER_RE: string;
+    export const BINARY_NUMBER_RE: string;
+    export const RE_STARTERS_RE: string;
+
+    // Common modes
+    export const BACKSLASH_ESCAPE: IMode;
+    export const APOS_STRING_MODE: IMode;
+    export const QUOTE_STRING_MODE: IMode;
+    export const PHRASAL_WORDS_MODE: IMode;
+    export const C_LINE_COMMENT_MODE: IMode;
+    export const C_BLOCK_COMMENT_MODE: IMode;
+    export const HASH_COMMENT_MODE: IMode;
+    export const NUMBER_MODE: IMode;
+    export const C_NUMBER_MODE: IMode;
+    export const BINARY_NUMBER_MODE: IMode;
+    export const CSS_NUMBER_MODE: IMode;
+    export const REGEX_MODE: IMode;
+    export const TITLE_MODE: IMode;
+    export const UNDERSCORE_TITLE_MODE: IMode;
+
+    export interface IHighlightResultBase {
+        relevance: number;
+        language: string;
+        value: string;
+    }
+
+    export interface IAutoHighlightResult extends IHighlightResultBase {
+        second_best?: IAutoHighlightResult;
+    }
+
+    export interface IHighlightResult extends IHighlightResultBase {
+        top: ICompiledMode;
+    }
+
+    export interface HLJSStatic {
+        inherit(parent: object, obj: object): object;
+
+        // Common regexps
+        IDENT_RE: string;
+        UNDERSCORE_IDENT_RE: string;
+        NUMBER_RE: string;
+        C_NUMBER_RE: string;
+        BINARY_NUMBER_RE: string;
+        RE_STARTERS_RE: string;
+
+        // Common modes
+        BACKSLASH_ESCAPE: IMode;
+        APOS_STRING_MODE: IMode;
+        QUOTE_STRING_MODE: IMode;
+        PHRASAL_WORDS_MODE: IMode;
+        C_LINE_COMMENT_MODE: IMode;
+        C_BLOCK_COMMENT_MODE: IMode;
+        HASH_COMMENT_MODE: IMode;
+        NUMBER_MODE: IMode;
+        C_NUMBER_MODE: IMode;
+        BINARY_NUMBER_MODE: IMode;
+        CSS_NUMBER_MODE: IMode;
+        REGEX_MODE: IMode;
+        TITLE_MODE: IMode;
+        UNDERSCORE_TITLE_MODE: IMode;
+    }
+
+    // Reference:
+    // https://github.com/isagalaev/highlight.js/blob/master/docs/reference.rst
+    export interface IModeBase {
+        className?: string;
+        aliases?: string[];
+        begin?: (string | RegExp);
+        end?: (string | RegExp);
+        case_insensitive?: boolean;
+        beginKeyword?: string;
+        endsWithParent?: boolean;
+        lexems?: string;
+        illegal?: string;
+        excludeBegin?: boolean;
+        excludeEnd?: boolean;
+        returnBegin?: boolean;
+        returnEnd?: boolean;
+        starts?: string;
+        subLanguage?: string;
+        subLanguageMode?: string;
+        relevance?: number;
+        variants?: IMode[];
+    }
+
+    export interface IMode extends IModeBase {
+        keywords?: any;
+        contains?: IMode[];
+    }
+
+    export interface ICompiledMode extends IModeBase {
+        compiled: boolean;
+        contains?: ICompiledMode[];
+        keywords?: object;
+        terminators: RegExp;
+        terminator_end?: string;
+    }
+
+    export interface IOptions {
+        classPrefix?: string;
+        tabReplace?: string;
+        useBR?: boolean;
+        languages?: string[];
+    }
+}
+
+export = hljs;
+export as namespace hljs;

--- a/types/highlightjs/package.json
+++ b/types/highlightjs/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "highlight.js": "^10.1.0"
-    }
-}

--- a/types/highlightjs/tslint.json
+++ b/types/highlightjs/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "npm-naming": false,
         "strict-export-declare-modifiers": false,
-        "interface-name": false
+        "interface-name": false,
+        "export-just-namespace": false
     }
 }

--- a/types/highlightjs/tslint.json
+++ b/types/highlightjs/tslint.json
@@ -1,6 +1,8 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "npm-naming": false
+        "npm-naming": false,
+        "strict-export-declare-modifiers": false,
+        "interface-name": false
     }
 }


### PR DESCRIPTION
This is to follow up on the discussion in #52120. The existing definitions for `@types/highlightjs` are incorrect because they’re a shim for `highlight.js` (note the `.`). (As it turns out, this was done by @ffflorian at my own suggestion in #37203... I clearly wasn’t thinking correctly about this at the time 😭.) `highlightjs` (no `.`) is no longer maintained and is deprecated at v9. Anyone still using that package should get these old types and not have a dependency on the its successor, `highlight.js`.

So, the plan is:

1. With this PR, break the incorrect dependency from `@types/highlightjs` -> `highlight.js`
2. After that’s been published, delete this directory from DT, since `highlightjs` itself is deprecated
3. Manually deprecate `@types/highlightjs@10.1.0` since it should never have existed
4. Move the `latest` dist-tag from `@types/highlightjs@10.1.0` if necessary, though I think that step (1) or (3) will do it automatically.

/cc @joshgoebel 

The contents of the typings are exactly copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cad55bca6d621f79176ae2799117e820dd54ff92/types/highlight.js/index.d.ts, with a couple lint fixes