### PR TITLE
fix degit exports

### DIFF
--- a/types/degit/degit-tests.ts
+++ b/types/degit/degit-tests.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import degit from 'degit';
+import degit = require('degit');
 import { DegitError } from 'degit/utils';
 
 degit('user/repo');

--- a/types/degit/index.d.ts
+++ b/types/degit/index.d.ts
@@ -5,10 +5,8 @@
 
 import { EventEmitter } from 'events';
 
-export default function degit(src: string, opts?: Options): Degit;
-
-export class Degit extends EventEmitter {
-    constructor(src: string, opts?: Options);
+declare class Degit extends EventEmitter {
+    constructor(src: string, opts?: degit.Options);
 
     /**
      * @async
@@ -17,73 +15,78 @@ export class Degit extends EventEmitter {
     /**
      * @async
      */
-    remove(dir: string, dest: string, action: RemoveAction): Promise<void>;
-    on(event: 'info' | 'warn', callback: (info: Info) => void): this;
+    remove(dir: string, dest: string, action: degit.RemoveAction): Promise<void>;
+    on(event: 'info' | 'warn', callback: (info: degit.Info) => void): this;
 }
 
-export interface Options {
-    /**
-     * @default false
-     */
-    cache?: boolean;
-    /**
-     * @default false
-     */
-    force?: boolean;
-    /**
-     * @default undefined
-     */
-    mode?: ValidModes;
-    /**
-     * @default false
-     */
-    verbose?: boolean;
+declare function degit(src: string, opts?: degit.Options): Degit;
+declare namespace degit {
+    interface Options {
+        /**
+         * @default false
+         */
+        cache?: boolean;
+        /**
+         * @default false
+         */
+        force?: boolean;
+        /**
+         * @default undefined
+         */
+        mode?: ValidModes;
+        /**
+         * @default false
+         */
+        verbose?: boolean;
+    }
+
+    // varia
+    type ValidModes = 'tar' | 'git';
+
+    type InfoCode =
+        | 'SUCCESS'
+        | 'FILE_DOES_NOT_EXIST'
+        | 'REMOVED'
+        | 'DEST_NOT_EMPTY'
+        | 'DEST_IS_EMPTY'
+        | 'USING_CACHE'
+        | 'FOUND_MATCH'
+        | 'FILE_EXISTS'
+        | 'PROXY'
+        | 'DOWNLOADING'
+        | 'EXTRACTING';
+
+    type DegitErrorCode =
+        | 'DEST_NOT_EMPTY'
+        | 'MISSING_REF'
+        | 'COULD_NOT_DOWNLOAD'
+        | 'BAD_SRC'
+        | 'UNSUPPORTED_HOST'
+        | 'BAD_REF'
+        | 'COULD_NOT_FETCH';
+
+    interface Info {
+        readonly code: string;
+        readonly message: string;
+        readonly repo: Degit;
+        readonly dest: string;
+    }
+
+    interface Action {
+        action: string;
+        cache?: boolean;
+        verbose?: boolean;
+    }
+
+    interface DegitAction extends Action {
+        action: 'clone';
+        src: string;
+    }
+
+    interface RemoveAction extends Action {
+        action: 'remove';
+        files: string[];
+    }
 }
 
-// varia
-export type ValidModes = 'tar' | 'git';
-
-export type InfoCode =
-    | 'SUCCESS'
-    | 'FILE_DOES_NOT_EXIST'
-    | 'REMOVED'
-    | 'DEST_NOT_EMPTY'
-    | 'DEST_IS_EMPTY'
-    | 'USING_CACHE'
-    | 'FOUND_MATCH'
-    | 'FILE_EXISTS'
-    | 'PROXY'
-    | 'DOWNLOADING'
-    | 'EXTRACTING';
-
-export type DegitErrorCode =
-    | 'DEST_NOT_EMPTY'
-    | 'MISSING_REF'
-    | 'COULD_NOT_DOWNLOAD'
-    | 'BAD_SRC'
-    | 'UNSUPPORTED_HOST'
-    | 'BAD_REF'
-    | 'COULD_NOT_FETCH';
-
-export interface Info {
-    readonly code: string;
-    readonly message: string;
-    readonly repo: Degit;
-    readonly dest: string;
-}
-
-export interface Action {
-    action: string;
-    cache?: boolean;
-    verbose?: boolean;
-}
-
-export interface DegitAction extends Action {
-    action: 'clone';
-    src: string;
-}
-
-export interface RemoveAction extends Action {
-    action: 'remove';
-    files: string[];
-}
+export = degit;


### PR DESCRIPTION
degit actually has a single commonjs export, not an exported `default` property. Also, `class Degit` isn't exported: `new degit.Degit()` doesn't work. Previously it escaped this check; I'm not sure why.

Default import syntax will still be usable after this change, but it will require `esModuleInterop: true` in tsconfig.

Best reviewed ignoring whitespace.