### PR TITLE
js-yaml: Optional `construct` second argument for the tag type.

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -15,7 +15,7 @@ export class Type {
     constructor(tag: string, opts?: TypeConstructorOptions);
     kind: 'sequence' | 'scalar' | 'mapping' | null;
     resolve(data: any): boolean;
-    construct(data: any): any;
+    construct(data: any, type?: string): any;
     instanceOf: object | null;
     predicate: ((data: object) => boolean) | null;
     represent: ((data: object) => any) | { [x: string]: (data: object) => any } | null;
@@ -105,7 +105,7 @@ export interface DumpOptions {
 export interface TypeConstructorOptions {
     kind?: 'sequence' | 'scalar' | 'mapping';
     resolve?: (data: any) => boolean;
-    construct?: (data: any) => any;
+    construct?: (data: any, type?: string) => any;
     instanceOf?: object;
     predicate?: (data: object) => boolean;
     represent?: ((data: object) => any) | { [x: string]: (data: object) => any };

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -119,7 +119,7 @@ new yaml.Type(str, typeConstructorOptions);
 type.kind;
 // $ExpectType (data: any) => boolean
 type.resolve;
-// $ExpectType (data: any) => any
+// $ExpectType (data: any, type?: string | undefined) => any
 type.construct;
 // $ExpectType object | null
 type.instanceOf;


### PR DESCRIPTION
Used as a way to resolve unknown tags in js-yaml.

`construct()` can be [called with a second argument](https://github.com/nodeca/js-yaml/blob/ab31bba6b41f58390f431123ffec5031b986edf5/lib/loader.js#L1531).
Also shows up in the examples as a way to [handle unknown tags](https://github.com/nodeca/js-yaml/blob/master/examples/handle_unknown_types.js#L29).

- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
