### PR TITLE
fix(floreal): correct definition

### DIFF
--- a/types/floreal/date.d.ts
+++ b/types/floreal/date.d.ts
@@ -1,5 +1,5 @@
 declare class FlorealDate {
-    constructor(value?: number | string);
+    constructor(value?: number | string | Date);
 
     toFullDateString(): string;
     toShortDateString(): string;
@@ -25,6 +25,9 @@ declare class FlorealDate {
     decade(): number;
     dayName(): string;
     dayTitle(): string;
+
+    toDateString: FlorealDate["toShortDateString"];
+    toString: FlorealDate["toFullDateString"];
 
     static day_names: string[];
 

--- a/types/floreal/floreal-tests.ts
+++ b/types/floreal/floreal-tests.ts
@@ -1,10 +1,14 @@
-import { Date } from 'floreal';
+import { Date as Floreal } from "floreal";
 
-const fd1 = new Date();
-const fd2 = new Date('1799-11-09');
+const fd1 = new Floreal(); // $ExpectType FlorealDate
+const fd2 = new Floreal("1799-11-09"); // $ExpectType FlorealDate
+const fd3 = new Floreal(Date.now()); // $ExpectType FlorealDate
+const fd4 = new Floreal(new Date()); // $ExpectType FlorealDate
 
 fd1.dayName(); // $ExpectType: string
 fd2.firstDayOfYear(); // $ExpectType: Date
 fd1.foo(); // $ExpectError
-fd1.setYear('XII');
+fd1.setYear("XII");
 fd1.setYearDecimal(12);
+fd1.toDateString(); // $ExpectType string
+fd1.toString(); // $ExpectType string

--- a/types/floreal/index.d.ts
+++ b/types/floreal/index.d.ts
@@ -2,6 +2,5 @@
 // Project: https://github.com/seeschloss/floreal
 // Definitions by: mike castleman <https://github.com/mlc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-import FlorealDate = require('./date');
+import FlorealDate = require("./date");
 export { FlorealDate as Date };

--- a/types/floreal/tsconfig.json
+++ b/types/floreal/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
- missing Date as constructor option
- missing aliases: `toString` and `toDateString`
- amend tests

https://github.com/seeschloss/floreal/blob/master/date.js#L75-L273

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).