### PR TITLE
update(halfred): v2 updates

### DIFF
--- a/types/halfred/halfred-tests.ts
+++ b/types/halfred/halfred-tests.ts
@@ -1,12 +1,10 @@
-
 // run test with: $ tsc --noImplicitAny --target es6 --module commonjs halfred-tests.ts
-import { parse } from 'halfred'; // require('halfred');
-let resource = parse({foo: "bar", "_links": { "self": { href: "fooo" }}});
-console.log(resource);
+import { parse } from "halfred";
+// $ExpectType Resource
+const resource = parse({ foo: "bar", _links: { self: { href: "fooo" } } });
 
-let allLinks = resource.allLinks();
-for (let key in allLinks) {
-  let link = allLinks[key];
-
-  console.log(link[0].href);
+const allLinks = resource.allLinks();
+for (const key in allLinks) {
+    // $ExpectType Link[]
+    const link = allLinks[key];
 }

--- a/types/halfred/index.d.ts
+++ b/types/halfred/index.d.ts
@@ -1,27 +1,25 @@
-// Type definitions for Halfred v1.0.0
+// Type definitions for Halfred 2.0
 // Project: https://github.com/basti1302/halfred
 // Definitions by: David Herges <https://github.com/dherges>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export as namespace halfred;
 
-declare module "halfred" {
+/**
+ * halfred.parse(object) returns a Resource object.
+ *
+ * @see https://github.com/basti1302/halfred#usage
+ */
+export function parse(object: any): Resource;
 
-  /**
-   * halfred.parse(object) returns a Resource object.
-   *
-   * @see https://github.com/basti1302/halfred#usage
-   */
-  export function parse(object: any): Resource;
+/** @see https://github.com/basti1302/halfred#enabledisable-validation */
+export function enableValidation(flag: boolean): void;
 
-  /** @see https://github.com/basti1302/halfred#enabledisable-validation */
-  export function enableValidation(flag: boolean): void;
+/** @see https://github.com/basti1302/halfred#enabledisable-validation */
+export function disableValidation(): void;
 
-  /** @see https://github.com/basti1302/halfred#enabledisable-validation */
-  export function disableValidation(): void;
-
-  /** @see https://github.com/basti1302/halfred#resource-api */
-  export interface Resource {
-
+/** @see https://github.com/basti1302/halfred#resource-api */
+export interface Resource {
     /**
      * Returns an object which has an array for each link that was present in the source object.
      * See below why each link is represented as an array.
@@ -72,7 +70,7 @@ declare module "halfred" {
     embeddedResource(key: string): Resource;
 
     /** Alias for embeddedResource(key) */
-    embedded(key: string): Resource;  
+    embedded(key: string): Resource;
 
     /**
      * Returns the unmodified, original object that was parsed to this resource. This is rather
@@ -131,25 +129,24 @@ declare module "halfred" {
     them). These are not intended to be accessed by clients directly, instead, use the provided
     methods to work with links and embedded resources.
     */
-  }
+}
 
-  /** @see https://github.com/basti1302/halfred#links-and-embedded-resources */
-  interface ResourceCollection {
+/** @see https://github.com/basti1302/halfred#links-and-embedded-resources */
+export interface ResourceCollection {
     [key: string]: Resource[];
-  }
+}
 
-  /** @see https://github.com/basti1302/halfred#links-and-embedded-resources */
-  interface LinkCollection {
-    [rel: string]: Link[]
-  }
+/** @see https://github.com/basti1302/halfred#links-and-embedded-resources */
+export interface LinkCollection {
+    [rel: string]: Link[];
+}
 
-  /**
-   * A Link Object represents a hyperlink from the containing resource to a URI.
-   *
-   * @see https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
-   */
-  interface Link {
-
+/**
+ * A Link Object represents a hyperlink from the containing resource to a URI.
+ *
+ * @see https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
+ */
+export interface Link {
     /**
      * The "href" property is REQUIRED.
      *
@@ -187,7 +184,7 @@ declare module "halfred" {
 
     /**
      * The "deprecation" property is OPTIONAL.
-     * 
+     *
      * Its presence indicates that the link is to be deprecated (i.e.
      * removed) at a future date.  Its value is a URL that SHOULD provide
      * further information about the deprecation.
@@ -241,7 +238,4 @@ declare module "halfred" {
      * @see https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5.8
      */
     hreflang?: string;
-
-  }
-
 }

--- a/types/halfred/tsconfig.json
+++ b/types/halfred/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/halfred/tslint.json
+++ b/types/halfred/tslint.json
@@ -1,16 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-declare-current-package": false,
-        "no-padding": false,
-        "no-single-declare-module": false,
-        "no-trailing-whitespace": false,
-        "object-literal-key-quotes": false,
-        "prefer-const": false,
-        "semicolon": false,
-        "strict-export-declare-modifiers": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- flatten module definition
- drop not required DOM dependency
- export missing types
- export for global consumption in browser
- amend tests
- default to DT default linting
- small formatting change using DT defaults
- bump version

The v2 is non breaking for API shape, but described as breaking on
release notes, this gives opportunity to correct module details:
https://github.com/traverson/halfred/compare/v1.1.1...v2.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.