### PR TITLE
[@types/passport-spotify] fix verifyFunction arguments order, expires_in is not optional

### DIFF
--- a/types/passport-spotify/index.d.ts
+++ b/types/passport-spotify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for passport-spotify 1.1
+// Type definitions for passport-spotify 2.0
 // Project: https://github.com/jmperez/passport-spotify#readme
 // Definitions by: Rishi Kodali <https://github.com/rishikodali>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -46,18 +46,18 @@ export type VerifyCallback = (error?: Error | null, user?: object, info?: object
 export type VerifyFunction = (
     accessToken: string,
     refreshToken: string,
+    expires_in: number,
     profile: Profile,
-    done: VerifyCallback,
-    expires_in?: number,
+    done: VerifyCallback
 ) => void;
 
 export type VerifyFunctionWithRequest = (
     req: Request,
     accessToken: string,
     refreshToken: string,
+    expires_in: number,
     profile: Profile,
-    done: VerifyCallback,
-    expires_in?: number,
+    done: VerifyCallback
 ) => void;
 
 export class Strategy {

--- a/types/passport-spotify/passport-spotify-tests.ts
+++ b/types/passport-spotify/passport-spotify-tests.ts
@@ -18,6 +18,7 @@ const strategyOptions: StrategyOptions = {
 const verifyFunction: VerifyFunction = (
     accessToken: string,
     refreshToken: string,
+    expires_in: number,
     profile: Profile,
     done: VerifyCallback,
 ) => {
@@ -25,6 +26,7 @@ const verifyFunction: VerifyFunction = (
         profile,
         accessToken,
         refreshToken,
+        expires_in
     };
 
     done(null, user);
@@ -43,6 +45,7 @@ const verifyFunctionWithRequest: VerifyFunctionWithRequest = (
     req: Request,
     accessToken: string,
     refreshToken: string,
+    expires_in: number,
     profile: Profile,
     done: VerifyCallback,
 ) => {
@@ -50,6 +53,7 @@ const verifyFunctionWithRequest: VerifyFunctionWithRequest = (
         profile,
         accessToken,
         refreshToken,
+        expires_in
     };
 
     done(null, user);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JMPerez/passport-spotify/blob/98ca3f7c63af95cb031034da0f37a785dc85aeb2/lib/passport-spotify/strategy.js#L88
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

