### PR TITLE
nodegit: Tag.listMatch() should receive 2 arguments

### DIFF
--- a/types/nodegit/index.d.ts
+++ b/types/nodegit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for nodegit 0.26
+// Type definitions for nodegit 0.27
 // Project: https://github.com/nodegit/nodegit, http://nodegit.org
 // Definitions by: Dolan Miu <https://github.com/dolanmiu>,
 //                 Tobias Nießen <https://github.com/tniessen>,

--- a/types/nodegit/tag.d.ts
+++ b/types/nodegit/tag.d.ts
@@ -10,7 +10,7 @@ export class Tag {
     static createLightweight(repo: Repository, tagName: string, target: Object, force: number): Promise<Oid>;
     static delete(repo: Repository, tagName: string): Promise<number>;
     static list(repo: Repository): Promise<any[]>;
-    static listMatch(tagNames: Strarray | string | string[], pattern: string, repo: Repository): number;
+    static listMatch(pattern: string, repo: Repository): Promise<any[]>;
     /**
      * Retrieves the tag pointed to by the oid
      *


### PR DESCRIPTION
Method signature: https://www.nodegit.org/api/tag/#listMatch

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.nodegit.org/api/tag/#listMatch>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
