### PR TITLE
pixelmatch -- add Uint8ClampedArray as a type for the diff array

### DIFF
--- a/types/pixelmatch/index.d.ts
+++ b/types/pixelmatch/index.d.ts
@@ -13,7 +13,7 @@ declare function Pixelmatch(
     /** Image data of the second image to compare. Note: image dimensions must be equal. */
     img2: Buffer | Uint8Array | Uint8ClampedArray,
     /** Image data to write the diff to, or null if don't need a diff image. */
-    output: Buffer | Uint8Array | null,
+    output: Buffer | Uint8Array | Uint8ClampedArray | null,
     /** Width of the images. Note that all three images need to have the same dimensions. */
     width: number,
     /** Height of the images. Note that all three images need to have the same dimensions. */


### PR DESCRIPTION
this makes the code in the demo (https://observablehq.com/@mourner/pixelmatch-demo) actually work with typescript

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. -- not needed
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/pixelmatch (though frankly the [demo](https://observablehq.com/@mourner/pixelmatch-demo) is more instructive)

this works:
```
        const numDifferingPixels = pixelmatch(
          data1,
          data2,
          //@ts-ignore
          diff.data,
          width,
          height,
          options
        );
```

whereas you might think from the type definitions that you have to do this, which does not work:
```
        const numDifferingPixels = pixelmatch(
          data1,
          data2,
          Uint8Array.from(diff.data),
          width,
          height,
          options
        );
```
