### PR TITLE
fix(email-templates): remove direct 'dom' dependency

### DIFF
--- a/types/email-templates/email-templates-tests.ts
+++ b/types/email-templates/email-templates-tests.ts
@@ -1,10 +1,11 @@
+/// <reference lib="dom" />
 import Email = require('email-templates');
 import { createTransport } from 'nodemailer';
 import path = require('path');
 
 const locals = {
     locale: 'en',
-    name: 'Elon',
+    name: 'Edward',
 };
 
 let email = new Email();
@@ -34,9 +35,12 @@ email.render('mars/html.pug', locals);
 const sendPromise: Promise<any> = email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals});
 email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals})
 .then(res => {
-    console.log('res.originalMessage', res.originalMessage);
+    res; // $ExpectType any
 })
-.catch(console.error);
+.catch(err => {
+    err; // $ExpectType any
+});
+
 emailNoTransporter.render('mars/html.pug', locals);
 
 interface Locals {
@@ -52,10 +56,10 @@ const withTransportInstance = new Email<Locals>({
     })
 });
 
-withTransportInstance.render('tmpl', { firstName: 'TypeScript' });
+withTransportInstance.render('template', { firstName: 'TypeScript' });
 
 const emailOptions: Email.EmailOptions<Locals> = {
-    template: 'tmpl',
+    template: 'template',
     locals: {
         firstName: 'TypeScript'
     },
@@ -111,7 +115,7 @@ let emailNoMessage = new Email();
 emailNoMessage = new Email({});
 
 emailNoMessage.send({
-    template: 'sometemplate',
+    template: 'some-template',
     message: {
         from: 'definitelytyped@example.org',
         to: 'recipient@example.com',

--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -8,8 +8,6 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 ksewo <https://github.com/ksewo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.3
-
 /// <reference types="nodemailer"/>
 
 import { HtmlToTextOptions } from 'html-to-text';
@@ -67,7 +65,7 @@ declare namespace Email {
 
      interface ViewOptions {
         /**
-         *  View extansion. defaults to 'pug', and is the default file extension for templates
+         *  View extension. defaults to 'pug', and is the default file extension for templates
          */
         extension?: string;
 

--- a/types/email-templates/tsconfig.json
+++ b/types/email-templates/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
The 3rd party `juice` depends on `HTMLElement`, while it should probably
depends on `Element` types, provided by Cheerio. Due to this, in #49748
direct dependency to 'DOM' lib has been added. This proves to be
undesired for some scenarios, like backend only builds.
This change removes direct dependency on `dom` from DT configuration,
instead depending on this lib only during tests phase.

ref:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49748#discussion_r606746312

- rework `dom` dependency
- minor changes in tests
- be a literate citizen, when using string literals (to remve complaints from IDEs
  supporting spelling corrections, etc, in literals)

/cc @anantakrishna

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).