### PR TITLE
Add `architect/functions`.http.helpers object which was missing

### DIFF
--- a/types/architect__functions/http.d.ts
+++ b/types/architect__functions/http.d.ts
@@ -126,6 +126,17 @@ export interface HttpProxyOptions {
 
 export type HttpProxy = (options: HttpProxyOptions) => HttpHandler;
 
+export interface StaticOptions {
+    stagePath: string;
+}
+
+export interface Helpers {
+    bodyParser: (req: HttpRequest) => Record<string, any>;
+    interpolate: (req: HttpRequest) => HttpRequest;
+    static: (asset: string, options: StaticOptions) => string;
+    url: (url: string) => string;
+}
+
 export interface ArcHttp {
     /**
      * https://arc.codes/docs/en/reference/runtime/node#arc.http.async
@@ -135,6 +146,10 @@ export interface ArcHttp {
      * https://arc.codes/docs/en/reference/runtime/node#arc.http.express
      */
     express: HttpExpress;
+    /**
+     * https://github.com/architect/functions/blob/3f11406b651f2854371906ad5f9eb9c300433032/src/http/index.js#L21-L26
+     */
+    helpers: Helpers;
     /**
      * https://arc.codes/docs/en/reference/runtime/node#arc.http.proxy
      */

--- a/types/architect__functions/http.d.ts
+++ b/types/architect__functions/http.d.ts
@@ -133,7 +133,7 @@ export interface StaticOptions {
 export interface Helpers {
     bodyParser: (req: HttpRequest) => Record<string, any>;
     interpolate: (req: HttpRequest) => HttpRequest;
-    static: (asset: string, options: StaticOptions) => string;
+    static: (asset: string, options?: StaticOptions) => string;
     url: (url: string) => string;
 }
 

--- a/types/architect__functions/test/http-tests.ts
+++ b/types/architect__functions/test/http-tests.ts
@@ -38,7 +38,6 @@ async function handlerhelpers(req: arc.HttpRequest): Promise<arc.HttpResponse | 
     };
 }
 
-
 ////////////////////
 // tests for arc.http.session: https://arc.codes/docs/en/reference/runtime/node#arc.http.session
 async function handlersession(req: arc.HttpRequest): Promise<arc.HttpResponse | undefined> {

--- a/types/architect__functions/test/http-tests.ts
+++ b/types/architect__functions/test/http-tests.ts
@@ -27,14 +27,14 @@ app.get('/cool', (req, res) => res.send('very cool'));
 
 ////////////////////
 // tests for arc.http.helpers: https://github.com/architect/functions/blob/master/src/http/index.js#L21-L26
-async function handlersession(req: arc.HttpRequest): Promise<arc.HttpResponse | undefined> {
+async function handlerhelpers(req: arc.HttpRequest): Promise<arc.HttpResponse | undefined> {
     req = arc.http.helpers.interpolate(req);
     const data = arc.http.helpers.bodyParser(req);
     const image = arc.http.helpers.static('test.jpg');
     const description = arc.http.helpers.static('test.txt', {stagePath: '/staging'});
     return {
         statusCode: 307,
-        headers: { 'location': arc.http.helpers.url('test.txt') },
+        headers: { location: arc.http.helpers.url('test.txt') },
     };
 }
 

--- a/types/architect__functions/test/http-tests.ts
+++ b/types/architect__functions/test/http-tests.ts
@@ -26,6 +26,20 @@ app.get('/', (req, res) => res.send('Hello World!'));
 app.get('/cool', (req, res) => res.send('very cool'));
 
 ////////////////////
+// tests for arc.http.helpers: https://github.com/architect/functions/blob/master/src/http/index.js#L21-L26
+async function handlersession(req: arc.HttpRequest): Promise<arc.HttpResponse | undefined> {
+    req = arc.http.helpers.interpolate(req);
+    const data = arc.http.helpers.bodyParser(req);
+    const image = arc.http.helpers.static('test.jpg');
+    const description = arc.http.helpers.static('test.txt', {stagePath: '/staging'});
+    return {
+        statusCode: 307,
+        headers: { 'location': arc.http.helpers.url('test.txt') },
+    };
+}
+
+
+////////////////////
 // tests for arc.http.session: https://arc.codes/docs/en/reference/runtime/node#arc.http.session
 async function handlersession(req: arc.HttpRequest): Promise<arc.HttpResponse | undefined> {
     // read the session


### PR DESCRIPTION
The `architect/functions.http.helpers` object was missing from the type defintion. 

Looking at the source for the http module, we can see that it defines 4 properties, which I have added to the type defintions -- https://github.com/architect/functions/blob/master/src/http/index.js#L21-L26

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/architect/functions/blob/master/src/http/index.js#L21-L26)
~- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ 
