### PR TITLE
InputMask needs dom lib

### DIFF
--- a/types/inputmask/index.d.ts
+++ b/types/inputmask/index.d.ts
@@ -6,6 +6,8 @@
 
 // The documentation is mainly copied from the source repo README.
 
+/// <reference lib="dom" />
+
 declare namespace Inputmask {
     type Range = { start: string, end: string } | [string, string];
 


### PR DESCRIPTION
InputMask uses the KeyboardEvent DOM type on L153. This fixes a tsc compiler error TS2304: Cannot find name 'KeyboardEvent'.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: ~Line 153 in the current d.ts file.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. No library update