### PR TITLE
update(minizlib): minor changes

### DIFF
--- a/types/minizlib/index.d.ts
+++ b/types/minizlib/index.d.ts
@@ -2,95 +2,86 @@
 // Project: https://github.com/isaacs/minizlib
 // Definitions by: Sebastian Malton <https://github.com/nokel81>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.6
-
 /// <reference types="node" />
 
 // Import from dependencies
-import MiniPass = require('minipass');
-import zlib = require('zlib');
+import MiniPass = require("minipass");
+import zlib = require("zlib");
 
 // Exports only from typings
 export { constants } from "zlib";
 
 type BrotliMode = "BrotliCompress" | "BrotliDecompress";
-type ZlibMode = "Gzip"
-  | "Gunzip"
-  | "Deflate"
-  | "Inflate"
-  | "DeflateRaw"
-  | "InflateRaw"
-  | "Unzip";
+type ZlibMode = "Gzip" | "Gunzip" | "Deflate" | "Inflate" | "DeflateRaw" | "InflateRaw" | "Unzip";
 
 interface ZlibBaseOptions extends MiniPass.Options {
-  flush?: number;
-  finishFlush?: number;
+    flush?: number;
+    finishFlush?: number;
 }
 
 declare class ZlibBase extends MiniPass {
-  constructor(opts: ZlibBaseOptions & zlib.BrotliOptions, mode: BrotliMode);
-  constructor(opts: ZlibBaseOptions & zlib.ZlibOptions, mode: ZlibMode);
+    readonly ended: boolean;
+    constructor(opts: ZlibBaseOptions & zlib.BrotliOptions, mode: BrotliMode);
+    constructor(opts: ZlibBaseOptions & zlib.ZlibOptions, mode: ZlibMode);
 
-  close(): void;
-  reset(): void;
-  flush(flushFlag?: number): void;
+    close(): void;
+    reset(): void;
+    flush(flushFlag?: number): void;
 
-  end(chunk: any, cb?: () => void): void;
-  end(chunk?: any, encoding?: string | null, cb?: () => void): void;
+    end(chunk: any, cb?: () => void): void;
+    end(chunk?: any, encoding?: string | null, cb?: () => void): void;
 
-  get ended(): boolean;
-
-  write(chunk: any, cb?: () => void): boolean;
-  write(chunk?: any, encoding?: string | null, cb?: () => void): boolean;
+    write(chunk: any, cb?: () => void): boolean;
+    write(chunk?: any, encoding?: string | null, cb?: () => void): boolean;
 }
 
 interface ZlibOptions extends ZlibBaseOptions {
-  level?: number;
-  strategy?: number;
+    level?: number;
+    strategy?: number;
 }
 
 declare class Zlib extends ZlibBase {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions, mode: ZlibMode);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions, mode: ZlibMode);
 
-  params(level?: number, strategy?: number): void;
+    params(level?: number, strategy?: number): void;
 }
 
 export class Deflate extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 export class Inflate extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 export class Gzip extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 export class Gunzip extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 export class DeflateRaw extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 export class InflateRaw extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 export class Unzip extends Zlib {
-  constructor(opts: ZlibOptions & zlib.ZlibOptions);
+    constructor(opts: ZlibOptions & zlib.ZlibOptions);
 }
 
 declare class Brotli extends ZlibBase {
-  constructor(opts: ZlibOptions & zlib.BrotliOptions, mode: BrotliMode);
+    constructor(opts: ZlibOptions & zlib.BrotliOptions, mode: BrotliMode);
 }
 
 export class BrotliCompress extends Brotli {
-  constructor(opts: ZlibOptions & zlib.BrotliOptions);
+    constructor(opts: ZlibOptions & zlib.BrotliOptions);
 }
 
 export class BrotliDecompress extends Brotli {
-  constructor(opts: ZlibOptions & zlib.BrotliOptions);
+    constructor(opts: ZlibOptions & zlib.BrotliOptions);
 }

--- a/types/minizlib/minizlib-tests.ts
+++ b/types/minizlib/minizlib-tests.ts
@@ -1,28 +1,28 @@
-import minizlib = require("minizlib");
+import zlib = require("minizlib");
 
 // $ExpectType BrotliCompress
-new minizlib.BrotliCompress({});
+new zlib.BrotliCompress({});
 
 // $ExpectType BrotliDecompress
-new minizlib.BrotliDecompress({});
+new zlib.BrotliDecompress({});
 
 // $ExpectType Deflate
-new minizlib.Deflate({});
+new zlib.Deflate({});
 
 // $ExpectType Inflate
-new minizlib.Inflate({});
+new zlib.Inflate({});
 
 // $ExpectType Gzip
-new minizlib.Gzip({});
+new zlib.Gzip({});
 
 // $ExpectType Gunzip
-new minizlib.Gunzip({});
+new zlib.Gunzip({});
 
 // $ExpectType DeflateRaw
-new minizlib.DeflateRaw({});
+new zlib.DeflateRaw({});
 
 // $ExpectType InflateRaw
-new minizlib.InflateRaw({});
+new zlib.InflateRaw({});
 
 // $ExpectType Unzip
-new minizlib.Unzip({});
+new zlib.Unzip({});

--- a/types/minizlib/tsconfig.json
+++ b/types/minizlib/tsconfig.json
@@ -14,7 +14,6 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true,
         "strictFunctionTypes": true
     },
     "files": [


### PR DESCRIPTION
- drop minimum TS version requirement (using readony property as alias
  for getter method)
- drop `esModuleInterop` from configuration (this is pure CommonJS
  module)
- appy DT format and use naming from project README for tests

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).