### PR TITLE
[ioredis] Added noDelay, stringNumbers, maxScriptsCachingTime to RedisOptions per ioredis documentation.

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1700,6 +1700,14 @@ declare namespace IORedis {
          * Whether to disable the Nagle's Algorithm.
          */
         noDelay?: boolean;
+        /**
+         * Force numbers to be always returned as JavaScript strings. This option is necessary when dealing with big numbers (exceed the [-2^53, +2^53] range).
+         */
+        stringNumbers?: boolean;
+        /**
+         * Default script definition caching time.
+         */
+        maxScriptsCachingTime?: number;
         connectionName?: string;
         /**
          * If set, client will send AUTH command with the value of this option as the first argument when connected. The `password` option must be set too. Username should only be set for Redis >=6.

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1696,6 +1696,10 @@ declare namespace IORedis {
          * TCP KeepAlive on the socket with a X ms delay before start. Set to a non-number value to disable keepAlive.
          */
         keepAlive?: number;
+        /**
+         * Whether to disable the Nagle's Algorithm.
+         */
+        noDelay?: boolean;
         connectionName?: string;
         /**
          * If set, client will send AUTH command with the value of this option as the first argument when connected. The `password` option must be set too. Username should only be set for Redis >=6.

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -322,6 +322,8 @@ new Redis({
     host: '127.0.0.1', // Redis host
     family: 4, // 4 (IPv4) or 6 (IPv6)
     noDelay: true,
+    stringNumbers: false,
+    maxScriptsCachingTime: 60000,
     username: 'user',
     password: 'auth',
     db: 0,

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -321,6 +321,7 @@ new Redis({
     port: 6379, // Redis port
     host: '127.0.0.1', // Redis host
     family: 4, // 4 (IPv4) or 6 (IPv6)
+    noDelay: true,
     username: 'user',
     password: 'auth',
     db: 0,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
