### PR TITLE
[materialize-css] Added a utility type allowing explicit passing of null to picker options that accept nullable properties

### DIFF
--- a/types/materialize-css/common.d.ts
+++ b/types/materialize-css/common.d.ts
@@ -30,6 +30,8 @@ declare namespace M {
         options: TOptions;
     }
 
+    type PartialWithNullable<T, K extends keyof T = never> = Partial<Omit<T, K>> & { [ P in K ] ?: T[P] | null };
+
     interface Openable {
         isOpen: boolean;
         open(): void;

--- a/types/materialize-css/common.d.ts
+++ b/types/materialize-css/common.d.ts
@@ -30,8 +30,6 @@ declare namespace M {
         options: TOptions;
     }
 
-    type PartialWithNullable<T, K extends keyof T = never> = Partial<Omit<T, K>> & { [ P in K ] ?: T[P] | null };
-
     interface Openable {
         isOpen: boolean;
         open(): void;

--- a/types/materialize-css/datepicker.d.ts
+++ b/types/materialize-css/datepicker.d.ts
@@ -88,6 +88,7 @@ declare namespace M {
 
         /**
          * The initial date to view when first opened.
+         * @default null
          */
         defaultDate: Date;
 

--- a/types/materialize-css/datepicker.d.ts
+++ b/types/materialize-css/datepicker.d.ts
@@ -10,12 +10,12 @@ declare namespace M {
         /**
          * Init Datepicker
          */
-        static init(els: Element, options?: Partial<DatepickerOptions>): Datepicker;
+        static init(els: Element, options?: PartialWithNullable<DatepickerOptions, "defaultDate">): Datepicker;
 
         /**
          * Init Datepickers
          */
-        static init(els: MElements, options?: Partial<DatepickerOptions>): Datepicker[];
+        static init(els: MElements, options?: PartialWithNullable<DatepickerOptions, "defaultDate">): Datepicker[];
 
         /**
          * If the picker is open.
@@ -197,5 +197,5 @@ interface JQuery {
     datepicker(method: keyof Pick<M.Datepicker, "open" | "close" | "destroy">): JQuery;
     datepicker(method: keyof Pick<M.Datepicker, "setDate">, date?: Date): JQuery;
     datepicker(method: keyof Pick<M.Datepicker, "gotoDate">, date: Date): JQuery;
-    datepicker(options?: Partial<M.DatepickerOptions>): JQuery;
+    datepicker(options?: M.PartialWithNullable<M.DatepickerOptions, "defaultDate">): JQuery;
 }

--- a/types/materialize-css/datepicker.d.ts
+++ b/types/materialize-css/datepicker.d.ts
@@ -83,6 +83,7 @@ declare namespace M {
 
         /**
          * Used to create date object from current input string.
+         * @default null
          */
         parse: (value: string, format: string) => Date;
 
@@ -106,6 +107,7 @@ declare namespace M {
 
         /**
          * Custom function to disable certain days.
+         * @default null
          */
         disableDayFn: (day: Date) => boolean;
 
@@ -117,11 +119,13 @@ declare namespace M {
 
         /**
          * The earliest date that can be selected.
+         * @default null
          */
         minDate: Date;
 
         /**
          * The latest date that can be selected.
+         * @default null
          */
         maxDate: Date;
 
@@ -174,21 +178,25 @@ declare namespace M {
 
         /**
          * Callback function when date is selected, first parameter is the newly selected date.
+         * @default null
          */
         onSelect: (this: Datepicker, selectedDate: Date) => void;
 
         /**
          * Callback function when Datepicker is opened
+         * @default null
          */
         onOpen: (this: Datepicker) => void;
 
         /**
          * Callback function when Datepicker is closed
+         * @default null
          */
         onClose: (this: Datepicker) => void;
 
         /**
          * Callback function when Datepicker HTML is refreshed
+         * @default null
          */
         onDraw: (this: Datepicker) => void;
     }

--- a/types/materialize-css/datepicker.d.ts
+++ b/types/materialize-css/datepicker.d.ts
@@ -10,12 +10,12 @@ declare namespace M {
         /**
          * Init Datepicker
          */
-        static init(els: Element, options?: PartialWithNullable<DatepickerOptions, "defaultDate">): Datepicker;
+        static init(els: Element, options?: Partial<DatepickerOptions>): Datepicker;
 
         /**
          * Init Datepickers
          */
-        static init(els: MElements, options?: PartialWithNullable<DatepickerOptions, "defaultDate">): Datepicker[];
+        static init(els: MElements, options?: Partial<DatepickerOptions>): Datepicker[];
 
         /**
          * If the picker is open.
@@ -85,13 +85,13 @@ declare namespace M {
          * Used to create date object from current input string.
          * @default null
          */
-        parse: (value: string, format: string) => Date;
+        parse: ((value: string, format: string) => Date) | null;
 
         /**
          * The initial date to view when first opened.
          * @default null
          */
-        defaultDate: Date;
+        defaultDate: Date | null;
 
         /**
          * Make the `defaultDate` the initial selected value
@@ -109,7 +109,7 @@ declare namespace M {
          * Custom function to disable certain days.
          * @default null
          */
-        disableDayFn: (day: Date) => boolean;
+        disableDayFn: ((day: Date) => boolean) | null;
 
         /**
          * First day of week (0: Sunday, 1: Monday etc).
@@ -121,13 +121,13 @@ declare namespace M {
          * The earliest date that can be selected.
          * @default null
          */
-        minDate: Date;
+        minDate: Date | null;
 
         /**
          * The latest date that can be selected.
          * @default null
          */
-        maxDate: Date;
+        maxDate: Date | null;
 
         /**
          * Number of years either side, or array of upper/lower range.
@@ -157,7 +157,7 @@ declare namespace M {
          * Specify a DOM element to render the calendar in, by default it will be placed before the input
          * @default null
          */
-        container: Element;
+        container: Element | null;
 
         /**
          * Show the clear button in the datepicker
@@ -180,25 +180,25 @@ declare namespace M {
          * Callback function when date is selected, first parameter is the newly selected date.
          * @default null
          */
-        onSelect: (this: Datepicker, selectedDate: Date) => void;
+        onSelect: ((this: Datepicker, selectedDate: Date) => void) | null;
 
         /**
          * Callback function when Datepicker is opened
          * @default null
          */
-        onOpen: (this: Datepicker) => void;
+        onOpen: ((this: Datepicker) => void) | null;
 
         /**
          * Callback function when Datepicker is closed
          * @default null
          */
-        onClose: (this: Datepicker) => void;
+        onClose: ((this: Datepicker) => void) | null;
 
         /**
          * Callback function when Datepicker HTML is refreshed
          * @default null
          */
-        onDraw: (this: Datepicker) => void;
+        onDraw: ((this: Datepicker) => void) | null;
     }
 }
 
@@ -206,5 +206,5 @@ interface JQuery {
     datepicker(method: keyof Pick<M.Datepicker, "open" | "close" | "destroy">): JQuery;
     datepicker(method: keyof Pick<M.Datepicker, "setDate">, date?: Date): JQuery;
     datepicker(method: keyof Pick<M.Datepicker, "gotoDate">, date: Date): JQuery;
-    datepicker(options?: M.PartialWithNullable<M.DatepickerOptions, "defaultDate">): JQuery;
+    datepicker(options?: Partial<M.DatepickerOptions>): JQuery;
 }

--- a/types/materialize-css/test/datepicker.test.ts
+++ b/types/materialize-css/test/datepicker.test.ts
@@ -36,6 +36,7 @@ datePicker.isOpen;
 
 $(".whatever").datepicker();
 $(".whatever").datepicker({ defaultDate: new Date() });
+$(".whatever").datepicker({ defaultDate: null });
 $(".whatever").datepicker("open");
 $(".whatever").datepicker("destroy");
 $(".whatever").datepicker("setDate", new Date());

--- a/types/materialize-css/test/datepicker.test.ts
+++ b/types/materialize-css/test/datepicker.test.ts
@@ -34,6 +34,20 @@ datePicker.el;
 // $ExpectType boolean
 datePicker.isOpen;
 
+// $ExpectType Datepicker
+const _datePickerWithNullableOptions = new materialize.Datepicker(elem, {
+    defaultDate: null,
+    minDate: null,
+    maxDate: null,
+    container: null,
+    parse: null,
+    disableDayFn: null,
+    onSelect : null,
+    onOpen : null,
+    onClose : null,
+    onDraw : null,
+});
+
 $(".whatever").datepicker();
 $(".whatever").datepicker({ defaultDate: new Date() });
 $(".whatever").datepicker({

--- a/types/materialize-css/test/datepicker.test.ts
+++ b/types/materialize-css/test/datepicker.test.ts
@@ -36,7 +36,18 @@ datePicker.isOpen;
 
 $(".whatever").datepicker();
 $(".whatever").datepicker({ defaultDate: new Date() });
-$(".whatever").datepicker({ defaultDate: null });
+$(".whatever").datepicker({
+    defaultDate: null,
+    minDate: null,
+    maxDate: null,
+    container: null,
+    parse: null,
+    disableDayFn: null,
+    onSelect : null,
+    onOpen : null,
+    onClose : null,
+    onDraw : null,
+});
 $(".whatever").datepicker("open");
 $(".whatever").datepicker("destroy");
 $(".whatever").datepicker("setDate", new Date());


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://materializecss.com/pickers.html>

The utility type is added to account for use cases where users of the library create wrappers relying on explicit defaulting of optional properties of the `M.DatepickerOptions` interface to `null` (for example when using the config object pattern). The following is the minimal example of what is not possible due to the second positional parameter to the `init` method being typed as `Partial<DatepickerOptions>`:

```typescript
type DateInputOptions = { id ?: string, name ?: string, initial ?: Date | null };

const makeDateInput = ({
  initial = null,
  id,
  name,
}: DateInputOptions) => {
  const wrap = document.createElement("div");
  wrap.classList.add("input-field");

  const maybeId = id || name;

  const input = makeTextInput(maybeId!, name); //defined elsewhere

  wrap.append(input);

  const inst = M.Datepicker.init(input, {
    defaultDate: initial //Type 'Date | null' is not assignable to type 'Date | undefined'.
  });

  const output: [
    inst: M.Datepicker,
    input: HTMLInputElement
  ] = [inst, input];

  return output;
};
```

Official docs say that the `defaultDate` (it is not the only one, but should the PR in any form be accepted, this can be extended to other options as well) option defaults to `null`, so it should be possible to pass through nullable option explicitly. Open to any suggestions on where would be the best place to define the utility, for now, opted for the `M` namespace in commons.

