### PR TITLE
Add type declarations for `ultron`

### DIFF
--- a/types/ultron/index.d.ts
+++ b/types/ultron/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/unshiftio/ultron
 // Definitions by: Renée Kooi <https://github.com/goto-bus-stop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
 
 type Listener = (...args: any[]) => void;
 

--- a/types/ultron/index.d.ts
+++ b/types/ultron/index.d.ts
@@ -55,12 +55,12 @@ declare const Ultron: {
     /**
      * @param ee EventEmitter instance we need to wrap.
      */
-    (events: EventEmitter): Ultron;
+    (ee: EventEmitter): Ultron;
 
     /**
      * @param ee EventEmitter instance we need to wrap.
      */
-    new (events: EventEmitter): Ultron;
+    new (ee: EventEmitter): Ultron;
 };
 
 export = Ultron;

--- a/types/ultron/index.d.ts
+++ b/types/ultron/index.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for ultron 1.1
+// Project: https://github.com/unshiftio/ultron
+// Definitions by: Renée Kooi <https://github.com/goto-bus-stop>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type Listener = (...args: any[]) => void;
+
+/**
+ * A Node.js EventEmitter instance or an `eventemitter3` instance.
+ */
+interface EventEmitter {
+    on(event: string | symbol, fn: Listener): void;
+    once(event: string | symbol, fn: Listener): void;
+    removeListener(event: string | symbol, fn: Listener): void;
+    listeners(event: string | symbol): any[];
+    eventNames?(): Array<string | symbol>;
+}
+
+/**
+ * Ultron is high-intelligence robot. It gathers intelligence so it can start improving
+ * upon his rudimentary design. It will learn from your EventEmitting patterns
+ * and exterminate them.
+ */
+interface Ultron {
+    /**
+     * Register a new EventListener for the given event.
+     *
+     * @param event Name of the event.
+     * @param fn Callback function.
+     * @param context The context of the function.
+     */
+    on(event: string | symbol, fn: Listener, context?: any): this;
+
+    /**
+     * Add an EventListener that's only called once.
+     *
+     * @param event Name of the event.
+     * @param fn Callback function.
+     * @param context The context of the function.
+     */
+    once(event: string | symbol, fn: Listener, context?: any): this;
+
+    /**
+     * Remove the listeners we assigned for the given event(s).
+     */
+    remove(...names: Array<string | symbol>): this;
+
+    /**
+     * Destroy the Ultron instance, remove all listeners and release all references.
+     */
+    destroy(): boolean;
+}
+
+declare const Ultron: {
+    /**
+     * @param ee EventEmitter instance we need to wrap.
+     */
+    (events: EventEmitter): Ultron;
+
+    /**
+     * @param ee EventEmitter instance we need to wrap.
+     */
+    new (events: EventEmitter): Ultron;
+};
+
+export = Ultron;

--- a/types/ultron/index.d.ts
+++ b/types/ultron/index.d.ts
@@ -63,4 +63,8 @@ declare const Ultron: {
     new (ee: EventEmitter): Ultron;
 };
 
+declare namespace Ultron {
+    export { Listener, EventEmitter };
+}
+
 export = Ultron;

--- a/types/ultron/tsconfig.json
+++ b/types/ultron/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ultron-tests.ts"
+    ]
+}

--- a/types/ultron/tslint.json
+++ b/types/ultron/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/ultron/ultron-tests.ts
+++ b/types/ultron/ultron-tests.ts
@@ -4,6 +4,7 @@ import EventEmitter = require("events");
 import Ultron = require("ultron");
 
 const ee = new EventEmitter();
+const assignable: Ultron.EventEmitter = ee;
 
 {
     const constructed: Ultron = new Ultron(ee);
@@ -13,7 +14,7 @@ const ee = new EventEmitter();
 
 {
     const ultron = new Ultron(ee);
-    const handler = () => {};
+    const handler: Ultron.Listener = () => {};
     ultron.on("event-name", handler, { custom: "function context" });
     ultron.once("event-name", handler, { custom: "function context" });
     ultron.remove("event-name");

--- a/types/ultron/ultron-tests.ts
+++ b/types/ultron/ultron-tests.ts
@@ -1,0 +1,40 @@
+/// <reference types="node" />
+
+import EventEmitter = require("events");
+import Ultron = require("ultron");
+
+const ee = new EventEmitter();
+
+{
+    const constructed: Ultron = new Ultron(ee);
+    const called: Ultron = Ultron(ee);
+    const notAnEmitter = Ultron({}); // $ExpectError
+}
+
+{
+    const ultron = new Ultron(ee);
+    const handler = () => {};
+    ultron.on("event-name", handler, { custom: "function context" });
+    ultron.once("event-name", handler, { custom: "function context" });
+    ultron.remove("event-name");
+    ultron.remove("a", "b", "c");
+    ultron.remove();
+    ultron.destroy();
+}
+
+{
+    const ultron = new Ultron(ee);
+    const handler = () => {};
+
+    const chained: boolean = ultron.on("event-name", handler).once("event-name", handler).remove().destroy();
+}
+
+{
+    const ultron = new Ultron(ee);
+    const handler = () => {};
+    const sym = Symbol("test");
+
+    ultron.on(sym, handler);
+    ultron.once(sym, handler);
+    ultron.remove(sym);
+}


### PR DESCRIPTION
Adds a type declaration file for Ultron: https://github.com/primus/ultron

I declared a broad EventEmitter interface here since Ultron accepts different kinds of event emitters. In reality it's only tested to work with the Node.js builtin EventEmitter and the `eventemitter3` package, so perhaps a `NodeJS.EventEmitter | eventemitter3.EventEmitter` type would be ideal?

# Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

# Adding a new definition
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
