### PR TITLE
[@ember/object] Allow ObjectProxy to resolve to null

### DIFF
--- a/types/ember__object/proxy.d.ts
+++ b/types/ember__object/proxy.d.ts
@@ -9,14 +9,14 @@ import {
  * `Ember.ObjectProxy` forwards all properties not defined by the proxy itself
  * to a proxied `content` object.
  */
-export default class ObjectProxy<T extends object = object> extends EmberObject {
+export default class ObjectProxy<T extends object | null = object> extends EmberObject {
     /**
      * The object whose properties will be forwarded.
      */
     content: T | undefined;
 
     get<K extends keyof this>(key: K): UnwrapComputedPropertyGetter<this[K]>;
-    get<K extends keyof T>(key: K): UnwrapComputedPropertyGetter<T[K]> | undefined;
+    get<K extends keyof NonNullable<T>>(key: K): UnwrapComputedPropertyGetter<NonNullable<T>[K]> | undefined;
 
     getProperties<K extends keyof this>(
         list: K[]
@@ -24,17 +24,17 @@ export default class ObjectProxy<T extends object = object> extends EmberObject 
     getProperties<K extends keyof this>(
         ...list: K[]
     ): Pick<UnwrapComputedPropertyGetters<this>, K>;
-    getProperties<K extends keyof T>(
+    getProperties<K extends keyof NonNullable<T>>(
         list: K[]
-    ): Pick<Partial<UnwrapComputedPropertyGetters<T>>, K>;
-    getProperties<K extends keyof T>(
+    ): Pick<Partial<UnwrapComputedPropertyGetters<NonNullable<T>>>, K>;
+    getProperties<K extends keyof NonNullable<T>>(
         ...list: K[]
-    ): Pick<Partial<UnwrapComputedPropertyGetters<T>>, K>;
+    ): Pick<Partial<UnwrapComputedPropertyGetters<NonNullable<T>>>, K>;
 
     set<K extends keyof this>(key: K, value: UnwrapComputedPropertySetters<this>[K]): UnwrapComputedPropertySetters<this>[K];
-    set<K extends keyof T>(key: K, value: UnwrapComputedPropertySetters<T>[K]): UnwrapComputedPropertySetters<T>[K];
+    set<K extends keyof NonNullable<T>>(key: K, value: UnwrapComputedPropertySetters<NonNullable<T>>[K]): UnwrapComputedPropertySetters<NonNullable<T>>[K];
 
-    setProperties<K extends (keyof this | keyof T)>(
-        hash: Pick<UnwrapComputedPropertySetters<this & T>, K>
-    ): Pick<UnwrapComputedPropertySetters<this & T>, K>;
+    setProperties<K extends (keyof this | keyof NonNullable<T>)>(
+        hash: Pick<UnwrapComputedPropertySetters<this & NonNullable<T>>, K>
+    ): Pick<UnwrapComputedPropertySetters<this & NonNullable<T>>, K>;
 }

--- a/types/ember__object/test/proxy.ts
+++ b/types/ember__object/test/proxy.ts
@@ -10,7 +10,7 @@ interface Book {
 class DefaultProxy extends ObjectProxy {}
 DefaultProxy.create().content; // $ExpectType object | undefined
 
-class BookProxy extends ObjectProxy<Book> {
+class BookProxy extends ObjectProxy<Book | null> {
     private readonly baz = 'baz';
 
     altTitle = 'Alt';
@@ -25,7 +25,7 @@ class BookProxy extends ObjectProxy<Book> {
 }
 
 const book = BookProxy.create();
-book.content; // $ExpectType Book | undefined
+book.content; // $ExpectType Book | null | undefined
 
 book.get('unknownProperty'); // $ExpectError
 book.get('title'); // $ExpectType string | undefined


### PR DESCRIPTION
This behavior is at least possible for the return value of Ember
Data's belongsTo.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/emberjs/data/blob/2c57905b35a8239c637bef119a8d73bf1ed6e638/packages/store/addon/-private/system/model/internal-model.ts#L697