### PR TITLE
styled-components: Enable 'as' and 'forwardedAs' props to be linted

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -57,6 +57,18 @@ type Defaultize<P, D> = P extends any
 
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
+type MakeAttrsOptional<C extends string | React.ComponentType<any>, O extends object, A extends keyof any> = Omit<
+    ReactDefaultizedProps<
+        C,
+        React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never>
+    > &
+        O,
+    A
+> &
+    Partial<
+        Pick<React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never> & O, A>
+    >;
+
 export type StyledComponentProps<
     // The Component from whose props are derived
     C extends string | React.ComponentType<any>,
@@ -65,30 +77,16 @@ export type StyledComponentProps<
     // The other props added by the template
     O extends object,
     // The props that are made optional by .attrs
-    A extends keyof any
+    A extends keyof any,
+    // The Component passed with "as" prop
+    AsC extends string | React.ComponentType<any> = C,
+    // The Component passed with "forwardedAs" prop
+    FAsC extends string | React.ComponentType<any> = C
 > =
     // Distribute O if O is a union type
     O extends object
         ? WithOptionalTheme<
-              Omit<
-                  ReactDefaultizedProps<
-                      C,
-                      React.ComponentPropsWithRef<
-                          C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                      >
-                  > &
-                      O,
-                  A
-              > &
-                  Partial<
-                      Pick<
-                          React.ComponentPropsWithRef<
-                              C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
-                          > &
-                              O,
-                          A
-                      >
-                  >,
+              MakeAttrsOptional<C, O, A> & MakeAttrsOptional<AsC, O, A> & MakeAttrsOptional<FAsC, O, A>,
               T
           > &
               WithChildrenIfReactComponentClass<C>
@@ -109,8 +107,9 @@ type StyledComponentPropsWithAs<
     T extends object,
     O extends object,
     A extends keyof any,
-    F extends string | React.ComponentType<any> = C
-> = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
+    AsC extends string | React.ComponentType<any> = C,
+    FAsC extends string | React.ComponentType<any> = C
+> = StyledComponentProps<C, T, O, A, AsC, FAsC> & { as?: AsC; forwardedAs?: FAsC };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> = InterpolationValue | InterpolationFunction<P> | FlattenInterpolation<P>;
@@ -172,9 +171,9 @@ export interface StyledComponentBase<
     (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
         StyledComponentProps<C, T, O, A>
     >;
-    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
-        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
-    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = C>(
+        props: StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>,
+    ): React.ReactElement<StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC,

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -660,17 +660,17 @@ const ForwardedAsWithNestedAsExternalTest = (
     </>
 );
 
-interface OtherComponentProps {
+interface OtherExternalComponentProps {
     requiredProp: 'test';
 }
 
-const OtherComponent: React.FC<OtherComponentProps> = () => null;
-const HasAttributesOfAsComponent = (
+const OtherExternalComponent: React.FC<OtherExternalComponentProps> = () => null;
+const HasAttributesOfAsOrForwardedAsComponent = (
     <>
         <WrappedExternalAsComponent as="a" type="primitive" href="/" />
         <WrappedExternalAsComponent forwardedAs="a" type="complex" href="/" />
-        <WrappedExternalAsComponent as={OtherComponent} type="primitive" requiredProp="test" />
-        <WrappedExternalAsComponent forwardedAs={OtherComponent} type="complex" requiredProp="test" />
+        <WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" />
+        <WrappedExternalAsComponent forwardedAs={OtherExternalComponent} type="complex" requiredProp="test" />
     </>
 );
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -645,6 +645,8 @@ interface ExternalAsComponentProps {
 }
 const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
 const WrappedExternalAsComponent = styled(ExternalAsComponent)``;
+const testRequiredProp = <WrappedExternalAsComponent />; // $ExpectError
+const testRequiredPropWhenForwardedAs = <WrappedExternalAsComponent forwardedAs="h2" />; // $ExpectError
 const ForwardedAsWithWrappedExternalTest = (
     <>
         <WrappedExternalAsComponent forwardedAs="h2" type="primitive" />
@@ -655,6 +657,20 @@ const ForwardedAsWithNestedAsExternalTest = (
     <>
         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs="h2" type="primitive" />
         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs={WithComponentH2} type="complex" />
+    </>
+);
+
+interface OtherComponentProps {
+    requiredProp: 'test';
+}
+
+const OtherComponent: React.FC<OtherComponentProps> = () => null;
+const HasAttributesOfAsComponent = (
+    <>
+        <WrappedExternalAsComponent as="a" type="primitive" href="/" />
+        <WrappedExternalAsComponent forwardedAs="a" type="complex" href="/" />
+        <WrappedExternalAsComponent as={OtherComponent} type="primitive" requiredProp="test" />
+        <WrappedExternalAsComponent forwardedAs={OtherComponent} type="complex" requiredProp="test" />
     </>
 );
 
@@ -679,7 +695,8 @@ class Test2Container extends React.Component<Test2ContainerProps> {
     }
 }
 
-const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
+const containerTest = <StyledTestContainer as={Test2Container} type="foo" size="big"/>;
+const containerTestTwo = <StyledTestContainer forwardedAs={Test2Container} type="foo" size="big" />;
 
 // 4.0 refs
 


### PR DESCRIPTION
When passing a component or an html tag in `as` or `forwardedAs` the props of this component should appear and be allowed in the base component.

For example consider the following situation:
```
const Button = styled.button``;
const WrappedButton = styled(Button)``;

const HomeLink = () => <Button as="a" href="/home">Home</Button>;
const BlogLink = () => <WrappedButton forwardedAs="a" href="/blog">Blog</Button>;
```

Both situations should allow the prop `href` to be passed. 

This is related to https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50404
This enhances the behavior of PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49239, which was also the origin of the issue pointed above.

The inference of props is working for html tags and React.FC (or similar), I couldn't get the inference of required props of styled-components to work.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-components.com/docs/api#forwardedas-prop
