### PR TITLE
Eslint add comment return types to source code

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -56,7 +56,7 @@ sourceCode.getAllComments();
 sourceCode.getComments(AST).leading;
 sourceCode.getComments(AST).trailing;
 
-sourceCode.getJSDocComment(AST);
+sourceCode.getJSDocComment(AST); // $ExpectType Comment | null
 
 sourceCode.getNodeByRangeIndex(0);
 
@@ -70,7 +70,7 @@ loc.column; // $ExpectType number
 
 sourceCode.getIndexFromLoc({ line: 0, column: 0 });
 
-sourceCode.getTokenByRangeStart(0);
+sourceCode.getTokenByRangeStart(0); // $ExpectType Comment | Token | null
 sourceCode.getTokenByRangeStart(0, { includeComments: true });
 
 sourceCode.getFirstToken(AST);
@@ -214,6 +214,7 @@ sourceCode.getTokens(AST, { includeComments: true, filter: t => t.type === "Iden
 
 sourceCode.commentsExistBetween(AST, AST);
 sourceCode.commentsExistBetween(TOKEN, TOKEN);
+sourceCode.commentsExistBetween(COMMENT, COMMENT);
 
 sourceCode.getCommentsBefore(AST);
 sourceCode.getCommentsBefore(TOKEN);

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -154,7 +154,7 @@ export class SourceCode {
 
     getComments(node: ESTree.Node): { leading: ESTree.Comment[]; trailing: ESTree.Comment[] };
 
-    getJSDocComment(node: ESTree.Node): AST.Token | null;
+    getJSDocComment(node: ESTree.Node): ESTree.Comment | null;
 
     getNodeByRangeIndex(index: number): ESTree.Node | null;
 
@@ -167,70 +167,73 @@ export class SourceCode {
     // Inherited methods from TokenStore
     // ---------------------------------
 
-    getTokenByRangeStart(offset: number, options?: { includeComments?: boolean }): AST.Token | null;
+    getTokenByRangeStart(offset: number, options?: { includeComments?: boolean }): AST.Token | ESTree.Comment | null;
 
-    getFirstToken(node: ESTree.Node, options?: SourceCode.CursorWithSkipOptions): AST.Token | null;
+    getFirstToken(node: ESTree.Node, options?: SourceCode.CursorWithSkipOptions): AST.Token | ESTree.Comment | null;
 
-    getFirstTokens(node: ESTree.Node, options?: SourceCode.CursorWithCountOptions): AST.Token[];
+    getFirstTokens(node: ESTree.Node, options?: SourceCode.CursorWithCountOptions): Array<AST.Token | ESTree.Comment>;
 
-    getLastToken(node: ESTree.Node, options?: SourceCode.CursorWithSkipOptions): AST.Token | null;
+    getLastToken(node: ESTree.Node, options?: SourceCode.CursorWithSkipOptions): AST.Token | ESTree.Comment | null;
 
-    getLastTokens(node: ESTree.Node, options?: SourceCode.CursorWithCountOptions): AST.Token[];
+    getLastTokens(node: ESTree.Node, options?: SourceCode.CursorWithCountOptions): Array<AST.Token | ESTree.Comment>;
 
     getTokenBefore(
         node: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | null;
+    ): AST.Token | ESTree.Comment | null;
 
     getTokensBefore(
         node: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithCountOptions,
-    ): AST.Token[];
+    ): Array<AST.Token | ESTree.Comment>;
 
     getTokenAfter(
         node: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | null;
+    ): AST.Token | ESTree.Comment | null;
 
     getTokensAfter(
         node: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithCountOptions,
-    ): AST.Token[];
+    ): Array<AST.Token | ESTree.Comment>;
 
     getFirstTokenBetween(
         left: ESTree.Node | AST.Token | ESTree.Comment,
         right: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | null;
+    ): AST.Token | ESTree.Comment | null;
 
     getFirstTokensBetween(
         left: ESTree.Node | AST.Token | ESTree.Comment,
         right: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithCountOptions,
-    ): AST.Token[];
+    ): Array<AST.Token | ESTree.Comment>;
 
     getLastTokenBetween(
         left: ESTree.Node | AST.Token | ESTree.Comment,
         right: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | null;
+    ): AST.Token | ESTree.Comment | null;
 
     getLastTokensBetween(
         left: ESTree.Node | AST.Token | ESTree.Comment,
         right: ESTree.Node | AST.Token | ESTree.Comment,
         options?: SourceCode.CursorWithCountOptions,
-    ): AST.Token[];
+    ): Array<AST.Token | ESTree.Comment>;
 
     getTokensBetween(
         left: ESTree.Node | AST.Token | ESTree.Comment,
         right: ESTree.Node | AST.Token | ESTree.Comment,
-        padding?: number | SourceCode.FilterPredicate | SourceCode.CursorWithCountOptions,
-    ): AST.Token[];
+        padding?: SourceCode.CursorWithCountOptions,
+    ): Array<AST.Token | ESTree.Comment>;
 
     getTokens(node: ESTree.Node, beforeCount?: number, afterCount?: number): AST.Token[];
-    getTokens(node: ESTree.Node, options: SourceCode.FilterPredicate | SourceCode.CursorWithCountOptions): AST.Token[];
+    getTokens(node: ESTree.Node, options: SourceCode.CursorWithCountOptions): Array<AST.Token | ESTree.Comment>;
 
-    commentsExistBetween(left: ESTree.Node | AST.Token, right: ESTree.Node | AST.Token): boolean;
+    commentsExistBetween(
+        left: ESTree.Node | AST.Token | ESTree.Comment,
+        right: ESTree.Node | AST.Token | ESTree.Comment,
+    ): boolean;
 
     getCommentsBefore(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[];
 


### PR DESCRIPTION
Discussion for the change occurs in the issue #51921. This brings the types inline with what the code returns, even when it doesn't align with the jsdoc.

These types weren't formatted with prettier, so the first commit formats, and the second commit is the change in question.