### PR TITLE
[@types/meteor] Add modern-browsers package

### DIFF
--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -41,6 +41,7 @@
 /// <reference path="./globals/http.d.ts" />
 /// <reference path="./meteor.d.ts" />
 /// <reference path="./globals/meteor.d.ts" />
+/// <reference path="./modern-browsers.d.ts" />
 /// <reference path="./mongo.d.ts" />
 /// <reference path="./globals/mongo.d.ts" />
 /// <reference path="./promise.d.ts" />

--- a/types/meteor/modern-browsers.d.ts
+++ b/types/meteor/modern-browsers.d.ts
@@ -1,0 +1,6 @@
+declare module "meteor/modern-browsers" {
+    export function setMinimumBrowserVersions(
+        versions: Record<string, number | number[]>,
+        source: string
+    ): void;
+}

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -25,6 +25,7 @@ import { BrowserPolicy } from "meteor/browser-policy-common";
 import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
 import { Random } from "meteor/random"
 import { EJSON } from "meteor/ejson";
+import { setMinimumBrowserVersions } from "meteor/modern-browsers";
 
 declare module 'meteor/meteor' {
     namespace Meteor {
@@ -1054,3 +1055,6 @@ if (Meteor.isServer) {
 
     const hashedToken = Accounts._hashLoginToken(stampedToken.token); // $ExpectType string
 }
+
+// Covers modern-browsers
+setMinimumBrowserVersions({ samsungInternet: [6, 2] }, "custom-app");


### PR DESCRIPTION
[@types/meteor] Add modern-browsers package

Meteor has many packages. `modern-browsers` was not defined here.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/blob/37ff18354d29f676d1e43e352d550c012fbcb7cb/packages/modern-browsers/modern.js#L87
- Suggested here https://github.com/meteor/meteor/issues/11351#issuecomment-803578861