### PR TITLE
update(yargs): Types for arg in MiddlewareFunction

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -149,7 +149,7 @@ declare namespace yargs {
             description: string,
             builder?: BuilderCallback<T, U>,
             handler?: (args: Arguments<U>) => void,
-            middlewares?: MiddlewareFunction<U>[],
+            middlewares?: Array<MiddlewareFunction<U>>,
             deprecated?: boolean | string,
         ): Argv<U>;
         command<O extends { [key: string]: Options }>(
@@ -157,7 +157,7 @@ declare namespace yargs {
             description: string,
             builder?: O,
             handler?: (args: Arguments<InferredOptionTypes<O>>) => void,
-            middlewares?: MiddlewareFunction<InferredOptionTypes<O>>[],
+            middlewares?: Array<MiddlewareFunction<InferredOptionTypes<O>>>,
             deprecated?: boolean | string,
         ): Argv<T>;
         command<U>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<U>;
@@ -166,7 +166,7 @@ declare namespace yargs {
             showInHelp: false,
             builder?: BuilderCallback<T, U>,
             handler?: (args: Arguments<U>) => void,
-            middlewares?: MiddlewareFunction<U>[],
+            middlewares?: Array<MiddlewareFunction<U>>,
             deprecated?: boolean | string,
         ): Argv<T>;
         command<O extends { [key: string]: Options }>(

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -149,7 +149,7 @@ declare namespace yargs {
             description: string,
             builder?: BuilderCallback<T, U>,
             handler?: (args: Arguments<U>) => void,
-            middlewares?: MiddlewareFunction[],
+            middlewares?: MiddlewareFunction<U>[],
             deprecated?: boolean | string,
         ): Argv<U>;
         command<O extends { [key: string]: Options }>(
@@ -157,7 +157,7 @@ declare namespace yargs {
             description: string,
             builder?: O,
             handler?: (args: Arguments<InferredOptionTypes<O>>) => void,
-            middlewares?: MiddlewareFunction[],
+            middlewares?: MiddlewareFunction<InferredOptionTypes<O>>[],
             deprecated?: boolean | string,
         ): Argv<T>;
         command<U>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<U>;
@@ -166,7 +166,7 @@ declare namespace yargs {
             showInHelp: false,
             builder?: BuilderCallback<T, U>,
             handler?: (args: Arguments<U>) => void,
-            middlewares?: MiddlewareFunction[],
+            middlewares?: MiddlewareFunction<U>[],
             deprecated?: boolean | string,
         ): Argv<T>;
         command<O extends { [key: string]: Options }>(
@@ -835,7 +835,7 @@ declare namespace yargs {
     type SyncCompletionFunction = (current: string, argv: any) => string[];
     type AsyncCompletionFunction = (current: string, argv: any, done: (completion: ReadonlyArray<string>) => void) => void;
     type PromiseCompletionFunction = (current: string, argv: any) => Promise<string[]>;
-    type MiddlewareFunction<T = {}> = (args: Arguments<T>) => void;
+    type MiddlewareFunction<U> = (args: Arguments<U>) => void;
     type Choices = ReadonlyArray<string | number | true | undefined>;
     type PositionalOptionsType = "boolean" | "number" | "string";
 }


### PR DESCRIPTION
Middlewares in commands do not passed typed arguments. 
This will make sure that whatever types passed to `handler` also gets into `MiddlewareFunction`

Better types would have `handler` get a combination of types from returned values of `MiddlewareFunction` and `builder`
So a `middleware` can modify content of `args` before being passed to `handler`,  some other time I guess. 

The CI is failing with 
```
ERROR: 152:27  array-type  Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
92
ERROR: 160:27  array-type  Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
93
ERROR: 169:27  array-type  Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
94
```

But I haven't introduced `T[]` they were already there, is it ok if I change them to `Array<T>`?
I avoided changing existing conventions. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://yargs.js.org/docs/#api-reference-commandcmd-desc-module
