### PR TITLE
fix(mongoose): add missing Document and Subdocument .parent()

### DIFF
--- a/types/mongoose/README.md
+++ b/types/mongoose/README.md
@@ -1,18 +1,22 @@
 ## MongooseJS Typescript Docs
+
 Below are some examples of how to use these Definitions.<br>
 Scenarios where the Typescript code is identical to plain Javascript code are omitted.
 
 ### Table of Contents
-* [Mongoose Methods, Properties, Constructors](#mongoose-methods-properties-constructors)
-* [Creating and Saving Documents](#creating-and-saving-documents)
-* [Promises](#promises)
-* [Instance Methods, Virtual Properties](#instance-methods-and-virtual-properties)
-* [Static Methods](#static-methods)
-* [Plugins](#plugins)
-* [FAQ and Common Mistakes](#faq-and-common-mistakes)
+
+-   [Mongoose Methods, Properties, Constructors](#mongoose-methods-properties-constructors)
+-   [Creating and Saving Documents](#creating-and-saving-documents)
+-   [Promises](#promises)
+-   [Instance Methods, Virtual Properties](#instance-methods-and-virtual-properties)
+-   [Static Methods](#static-methods)
+-   [Plugins](#plugins)
+-   [FAQ and Common Mistakes](#faq-and-common-mistakes)
 
 #### Mongoose Methods, Properties, Constructors
+
 You can call methods from the mongoose instance using:
+
 ```typescript
 import * as mongoose from 'mongoose';
 var MyModel = mongoose.model(...);
@@ -20,53 +24,59 @@ var MySchema: mongoose.Schema = new mongoose.Schema(...);
 ```
 
 Alternatively, you can import individual names and call them:
+
 ```typescript
 import { model, Schema } from 'mongoose';
 var MyModel = model(...);
 var MySchema: Schema = new Schema(...):
 ```
+
 [top](#mongoosejs-typescript-docs)
 
 #### Creating and Saving Documents
+
 ```typescript
-import {Document, model, Model, Schema} from 'mongoose';
+import { Document, model, Model, Schema } from "mongoose";
 
 var UserSchema: Schema = new Schema({
-  username: {
-    type: String,
-    required: true,
-    unique: true
-  },
-  age: Number,
-  friends: [String],
-  data: [Schema.Types.Mixed]
+    username: {
+        type: String,
+        required: true,
+        unique: true,
+    },
+    age: Number,
+    friends: [String],
+    data: [Schema.Types.Mixed],
 });
 
 interface IUser extends Document {
-  username: string;
-  age: number;
-  friends: string[];
-  data: any[];
+    username: string;
+    age: number;
+    friends: string[];
+    data: any[];
 }
 
-var UserModel: Model<IUser> = model<IUser>('User', UserSchema);
+var UserModel: Model<IUser> = model<IUser>("User", UserSchema);
 
-var user = new UserModel({name: 'Jane'});
-user.username;     // IUser properties are available
-user.save();       // mongoose Document methods are available
+var user = new UserModel({ name: "Jane" });
+user.username; // IUser properties are available
+user.save(); // mongoose Document methods are available
 
 UserModel.findOne({}, (err: any, user: IUser) => {
-  user.username;   // IUser properties are available
-  user.save();     // mongoose Document methods are available
+    user.username; // IUser properties are available
+    user.save(); // mongoose Document methods are available
 });
 ```
+
 [top](#mongoosejs-typescript-docs)
 
 #### Promises
+
 These definitions use `global.Promise` by default. If you would like to use mongoose's own mpromise
 definition (which is deprecated), you can install definitions for [mongoose-promise](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/mongoose-promise).
 
 If you'd like to use something other than `global.Promise`, you'll need to create a simple `.d.ts` file:
+
 ```typescript
 // promise-bluebird.d.ts
 import * as Bluebird from 'bluebird';

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -48,7 +48,6 @@
 /// <reference types="mongodb" />
 /// <reference types="node" />
 
-
 /*
  * Guidelines for maintaining these definitions:
  * - If you spot an error here or there, please submit a PR.
@@ -77,608 +76,625 @@ To find a section, CTRL+F and type "section ___.js"
  */
 
 declare module "mongoose" {
-  import events = require('events');
-  import mongodb = require('mongodb');
-  import stream = require('stream');
-  import mongoose = require('mongoose');
+    import events = require("events");
+    import mongodb = require("mongodb");
+    import stream = require("stream");
+    import mongoose = require("mongoose");
 
-  // We can use TypeScript Omit once minimum required TypeScript Version is above 3.5
-  type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+    // We can use TypeScript Omit once minimum required TypeScript Version is above 3.5
+    type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-  type NonFunctionPropertyNames<T> = {
-    [K in keyof T]: T[K] extends Function ? never : K;
-  }[keyof T];
+    type NonFunctionPropertyNames<T> = {
+        [K in keyof T]: T[K] extends Function ? never : K;
+    }[keyof T];
 
-  type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
+    type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
 
-  type IfEquals<X, Y, A, B> =
-    (<T>() => T extends X ? 1 : 2) extends
-    (<T>() => T extends Y ? 1 : 2) ? A : B;
+    type IfEquals<X, Y, A, B> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B;
 
-  type ReadonlyKeysOf<T> = {
-    [P in keyof T]: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, never, P>
-  }[keyof T];
+    type ReadonlyKeysOf<T> = {
+        [P in keyof T]: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, never, P>;
+    }[keyof T];
 
-  type OmitReadonly<T> = Omit<T, ReadonlyKeysOf<T>>;
+    type OmitReadonly<T> = Omit<T, ReadonlyKeysOf<T>>;
 
-  type MongooseBuiltIns = mongodb.ObjectID | mongodb.Decimal128 | Date | number | boolean;
+    type MongooseBuiltIns = mongodb.ObjectID | mongodb.Decimal128 | Date | number | boolean;
 
-  type ImplicitMongooseConversions<T> =
-    T extends MongooseBuiltIns
-      ? T extends (boolean | mongodb.Decimal128 | Date) ? T | string | number // accept numbers for these
-      : T | string
-    : T;
+    type ImplicitMongooseConversions<T> = T extends MongooseBuiltIns
+        ? T extends boolean | mongodb.Decimal128 | Date
+            ? T | string | number // accept numbers for these
+            : T | string
+        : T;
 
-  type DeepCreateObjectTransformer<T> =
-    T extends MongooseBuiltIns
-      ? T
-      : T extends object
-        ? { [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
-          ? ImplicitMongooseConversions<DeepCreateTransformer<NonNullable<T[V]>>>
-          : ImplicitMongooseConversions<T[V]> }
-        :
-      T;
+    type DeepCreateObjectTransformer<T> = T extends MongooseBuiltIns
+        ? T
+        : T extends object
+        ? {
+              [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
+                  ? ImplicitMongooseConversions<DeepCreateTransformer<NonNullable<T[V]>>>
+                  : ImplicitMongooseConversions<T[V]>;
+          }
+        : T;
 
-  // removes functions from schema from all levels
-  type DeepCreateTransformer<T> =
-    T extends Map<infer KM, infer KV>
-      // handle map values
-      // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:
-      // ? Map<KM, DeepNonFunctionProperties<KV>>
-      ? { [key: string]: DeepCreateTransformer<KV> } | [KM, KV][] | Map<KM, KV>
-      :
-    T extends Array<infer U>
-      ? Array<DeepCreateObjectTransformer<U>>
-      :
-    DeepCreateObjectTransformer<T>;
+    // removes functions from schema from all levels
+    type DeepCreateTransformer<T> = T extends Map<infer KM, infer KV>
+        ? // handle map values
+          // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:
+          // ? Map<KM, DeepNonFunctionProperties<KV>>
+          { [key: string]: DeepCreateTransformer<KV> } | [KM, KV][] | Map<KM, KV>
+        : T extends Array<infer U>
+        ? Array<DeepCreateObjectTransformer<U>>
+        : DeepCreateObjectTransformer<T>;
 
-  // mongoose allows Map<K, V> to be specified either as a Map or a Record<K, V>
-  type DeepMapAsObject<T> = T extends object | undefined
-    ? {
-      [K in keyof T]: T[K] extends Map<infer KM, infer KV> | undefined
-        // if it's a map, transform it into Map | Record
-        // only string keys allowed
-        ? KM extends string ? Map<KM, DeepMapAsObject<KV>> | Record<KM, DeepMapAsObject<KV>> | [KM, DeepMapAsObject<KV>][] : never
-        // otherwise if it's an object or undefined (for optional props), recursively go again
-        : T[K] extends object | undefined
-          ? DeepMapAsObject<T[K]>
-          : T[K]
-      }
-    : T;
+    // mongoose allows Map<K, V> to be specified either as a Map or a Record<K, V>
+    type DeepMapAsObject<T> = T extends object | undefined
+        ? {
+              [K in keyof T]: T[K] extends Map<infer KM, infer KV> | undefined
+                  ? // if it's a map, transform it into Map | Record
+                    // only string keys allowed
+                    KM extends string
+                      ? Map<KM, DeepMapAsObject<KV>> | Record<KM, DeepMapAsObject<KV>> | [KM, DeepMapAsObject<KV>][]
+                      : never
+                  : // otherwise if it's an object or undefined (for optional props), recursively go again
+                  T[K] extends object | undefined
+                  ? DeepMapAsObject<T[K]>
+                  : T[K];
+          }
+        : T;
 
-  /* Helper type to extract a definition type from a Document type */
-  type DocumentDefinition<T> = Omit<T, Exclude<keyof Document, '_id'>>;
+    /* Helper type to extract a definition type from a Document type */
+    type DocumentDefinition<T> = Omit<T, Exclude<keyof Document, "_id">>;
 
-  type ScrubCreateDefinition<T> = DeepMapAsObject<DeepCreateTransformer<T>>
+    type ScrubCreateDefinition<T> = DeepMapAsObject<DeepCreateTransformer<T>>;
 
-  type CreateDocumentDefinition<T> = ScrubCreateDefinition<DocumentDefinition<T>>;
+    type CreateDocumentDefinition<T> = ScrubCreateDefinition<DocumentDefinition<T>>;
 
-  /**
-   * Patched version of FilterQuery to also allow:
-   * - documents, ObjectId and strings for `_id`
-   * - strings for properties defined as ObjectId
-   *
-   * Uses `[]` tuple syntax around the `Extract` to avoid distributing on unions.
-   * See: https://devblogs.microsoft.com/typescript/announcing-typescript-2-8-2/#conditional-types
-   *
-   * Negates the condition with `never`, because the following condition:
-   *   Extract<T[P], mongodb.ObjectId> extends mongodb.ObjectId
-   * Would result in `never extends mongodb.ObjectId` for non-ObjectId properties,
-   * which would result in a passing conditional, because `never` is included in all types.
-   */
-  export type MongooseFilterQuery<T> = {
-    [P in keyof T]?: P extends '_id'
-      ? [Extract<T[P], mongodb.ObjectId>] extends [never]
-        ? mongodb.Condition<T[P]>
-        : mongodb.Condition<T[P] | string | { _id: mongodb.ObjectId }>
-      : [Extract<T[P], mongodb.ObjectId>] extends [never]
-      ? mongodb.Condition<T[P]>
-      : mongodb.Condition<T[P] | string>;
-  } &
-    mongodb.RootQuerySelector<T>;
-
-  /* FilterQuery alias type for using as type for filter/conditions parameters */
-  export type FilterQuery<T> = MongooseFilterQuery<DocumentDefinition<T>>;
-
-  /**
-   * Patched version of UpdateQuery to also allow:
-   * - setting attributes directly in the root, without a `$set` wrapper
-   * - setting attributes via dot-notation
-   */
-  export type MongooseUpdateQuery<S> = mongodb.UpdateQuery<S> & mongodb.MatchKeysAndValues<S>;
-
-  export type UpdateQuery<D> = MongooseUpdateQuery<DocumentDefinition<D>>;
-
-  // check whether a type consists just of {_id: T} and no other properties
-  type HasJustId<T> = keyof Omit<T, "_id"> extends never ? true : false;
-
-  // ensure that if an empty document type is passed, we allow any properties
-  // for backwards compatibility
-  export type CreateQuery<D> = HasJustId<CreateDocumentDefinition<D>> extends true
-    ? { _id?: any } & Record<string, any>
-    : D extends { _id: infer TId }
-      ? mongodb.OptionalId<CreateDocumentDefinition<D> & { _id: TId }>
-      : CreateDocumentDefinition<D>
-
-  /**
-   * Gets and optionally overwrites the function used to pluralize collection names
-   * @param fn function to use for pluralization of collection names
-   * @returns the current function used to pluralize collection names (defaults to the `mongoose-legacy-pluralize` module's function)
-   */
-  export function pluralize(fn?: (str: string) => string): (str: string) => string;
-
-  /*
-   * Some mongoose classes have the same name as the native JS classes
-   * Keep references to native classes using a "Native" prefix
-   */
-  class NativeBuffer extends global.Buffer { }
-  class NativeDate extends global.Date { }
-  class NativeError extends global.Error { }
-
-  /*
-   * section index.js
-   * http://mongoosejs.com/docs/api.html#index-js
-   */
-  export var DocumentProvider: any;
-  // recursive constructor
-  export var Mongoose: new (...args: any[]) => typeof mongoose;
-  type Mongoose = typeof mongoose;
-  export var SchemaTypes: typeof Schema.Types;
-
-  /** Expose connection states for user-land */
-  export var STATES: typeof ConnectionStates;
-  /** The default connection of the mongoose module. */
-  export var connection: Connection;
-  /** An array containing all connections associated with this Mongoose instance. */
-  export var connections: Connection[];
-  /** Models registred on the default mongoose connection. */
-  export var models: { [index: string]: Model<any> };
-  /** The node-mongodb-native driver Mongoose uses. */
-  export var mongo: typeof mongodb;
-  /** The Mongoose version */
-  export var version: string;
-
-  /**
-   * Opens the default mongoose connection.
-   * Options passed take precedence over options included in connection strings.
-   * @returns pseudo-promise wrapper around this
-   */
-  export function connect(uris: string, options: ConnectionOptions, callback: (err: mongodb.MongoError) => void): Promise<Mongoose>;
-  export function connect(uris: string, callback: (err: mongodb.MongoError) => void): Promise<Mongoose>;
-  export function connect(uris: string, options?: ConnectionOptions): Promise<Mongoose>;
-
-  /**
-   * Creates a Connection instance.
-   * Each connection instance maps to a single database. This method is helpful
-   *   when mangaging multiple db connections.
-   * @param uri a mongodb:// URI
-   * @param options options to pass to the driver
-   * @returns the created Connection object
-   */
-  export function createConnection(): Connection;
-  export function createConnection(uri: string,
-    options?: ConnectionOptions
-  ): Connection & {
-    then: Promise<Connection>["then"];
-    catch: Promise<Connection>["catch"];
-  };
-
-  /**
-   * Disconnects all connections.
-   * @param fn called after all connection close.
-   */
-  export function disconnect(fn: (error?: any) => void): void;
-  /** Disconnects all connections. */
-  export function disconnect(): Promise<void>;
-
-  /** Gets mongoose options */
-  export function get(key: string): any;
-
-  /**
-   * Tests whether Mongoose can cast a value to an ObjectId
-   * @param value value to be tested if it can be cast to an ObjectId
-   */
-  export function isValidObjectId(value: any): boolean;
-
-  /**
-   * Defines a model or retrieves it.
-   * Models defined on the mongoose instance are available to all connection
-   *   created by the same mongoose instance.
-   * @param name model name
-   * @param collection (optional, induced from model name)
-   * @param skipInit whether to skip initialization (defaults to false)
-   */
-  export function model<T extends Document>(name: string, schema?: Schema, collection?: string,
-    skipInit?: boolean): Model<T>;
-  export function model<T extends Document, U extends Model<T>>(
-    name: string,
-    schema?: Schema,
-    collection?: string,
-    skipInit?: boolean
-  ): U;
-
-  /**
-   * Removes the model named `name` from the default connection on this instance
-   * of Mongoose. You can use this function to clean up any models you created
-   * in your tests to prevent OverwriteModelErrors.
-   */
-  export function deleteModel(name: string | RegExp): Connection;
-
-  /**
-   * Returns an array of model names created on the default connection for this
-   * instance of Mongoose. Does not include names of models created
-   * on additional connections that were created with `createConnection()`.
-   */
-  export function modelNames(): string[];
-
-  /**
-   * Declares a global plugin executed on all Schemas.
-   * Equivalent to calling .plugin(fn) on each Schema you create.
-   * @param fn plugin callback
-   * @param opts optional options
-   */
-  export function plugin(fn: Function): typeof mongoose;
-  export function plugin<T>(fn: Function, opts: T): typeof mongoose;
-
-  /** Sets mongoose options */
-  export function set(key: string, value: any): void;
-
-  export function startSession(options?: mongodb.SessionOptions, cb?: (err: any, session: mongodb.ClientSession) => void): Promise<mongodb.ClientSession>;
-
-  export type CastError = Error.CastError;
-
-  /*
-   * section connection.js
-   * http://mongoosejs.com/docs/api.html#connection-js
-   *
-   * The Connection class exposed by require('mongoose')
-   *   is actually the driver's NativeConnection class.
-   *   connection.js defines a base class that the native
-   *   versions extend. See:
-   *   http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
-   */
-  abstract class ConnectionBase extends events.EventEmitter {
     /**
-     * For practical reasons, a Connection equals a Db.
-     * @param base a mongoose instance
-     * @event connecting Emitted when connection.{open,openSet}() is executed on this connection.
-     * @event connected Emitted when this connection successfully connects to the db. May be emitted multiple times in reconnected scenarios.
-     * @event open Emitted after we connected and onOpen is executed on all of this connections models.
-     * @event disconnecting Emitted when connection.close() was executed.
-     * @event disconnected Emitted after getting disconnected from the db.
-     * @event close Emitted after we disconnected and onClose executed on all of this connections models.
-     * @event reconnected Emitted after we connected and subsequently disconnected, followed by successfully another successfull connection.
-     * @event error Emitted when an error occurs on this connection.
-     * @event fullsetup Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
-     * @event all Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
+     * Patched version of FilterQuery to also allow:
+     * - documents, ObjectId and strings for `_id`
+     * - strings for properties defined as ObjectId
+     *
+     * Uses `[]` tuple syntax around the `Extract` to avoid distributing on unions.
+     * See: https://devblogs.microsoft.com/typescript/announcing-typescript-2-8-2/#conditional-types
+     *
+     * Negates the condition with `never`, because the following condition:
+     *   Extract<T[P], mongodb.ObjectId> extends mongodb.ObjectId
+     * Would result in `never extends mongodb.ObjectId` for non-ObjectId properties,
+     * which would result in a passing conditional, because `never` is included in all types.
      */
-    constructor(base: typeof mongoose);
+    export type MongooseFilterQuery<T> = {
+        [P in keyof T]?: P extends "_id"
+            ? [Extract<T[P], mongodb.ObjectId>] extends [never]
+                ? mongodb.Condition<T[P]>
+                : mongodb.Condition<T[P] | string | { _id: mongodb.ObjectId }>
+            : [Extract<T[P], mongodb.ObjectId>] extends [never]
+            ? mongodb.Condition<T[P]>
+            : mongodb.Condition<T[P] | string>;
+    } &
+        mongodb.RootQuerySelector<T>;
+
+    /* FilterQuery alias type for using as type for filter/conditions parameters */
+    export type FilterQuery<T> = MongooseFilterQuery<DocumentDefinition<T>>;
 
     /**
-    * Opens the connection to MongoDB.
-    * @param uri mongodb connection string
-    * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
-    *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
-    *   See the node-mongodb-native driver instance for options that it understands.
-    *   Options passed take precedence over options included in connection strings.
-    */
-    openUri(uri: string, options?: ConnectionOptions): Promise<Connection>;
-    openUri(uri: string, callback: (err: any, conn?: Connection) => void): Connection;
-    openUri(
-        uri: string,
+     * Patched version of UpdateQuery to also allow:
+     * - setting attributes directly in the root, without a `$set` wrapper
+     * - setting attributes via dot-notation
+     */
+    export type MongooseUpdateQuery<S> = mongodb.UpdateQuery<S> & mongodb.MatchKeysAndValues<S>;
+
+    export type UpdateQuery<D> = MongooseUpdateQuery<DocumentDefinition<D>>;
+
+    // check whether a type consists just of {_id: T} and no other properties
+    type HasJustId<T> = keyof Omit<T, "_id"> extends never ? true : false;
+
+    // ensure that if an empty document type is passed, we allow any properties
+    // for backwards compatibility
+    export type CreateQuery<D> = HasJustId<CreateDocumentDefinition<D>> extends true
+        ? { _id?: any } & Record<string, any>
+        : D extends { _id: infer TId }
+        ? mongodb.OptionalId<CreateDocumentDefinition<D> & { _id: TId }>
+        : CreateDocumentDefinition<D>;
+
+    /**
+     * Gets and optionally overwrites the function used to pluralize collection names
+     * @param fn function to use for pluralization of collection names
+     * @returns the current function used to pluralize collection names (defaults to the `mongoose-legacy-pluralize` module's function)
+     */
+    export function pluralize(fn?: (str: string) => string): (str: string) => string;
+
+    /*
+     * Some mongoose classes have the same name as the native JS classes
+     * Keep references to native classes using a "Native" prefix
+     */
+    class NativeBuffer extends global.Buffer {}
+    class NativeDate extends global.Date {}
+    class NativeError extends global.Error {}
+
+    /*
+     * section index.js
+     * http://mongoosejs.com/docs/api.html#index-js
+     */
+    export var DocumentProvider: any;
+    // recursive constructor
+    export var Mongoose: new (...args: any[]) => typeof mongoose;
+    type Mongoose = typeof mongoose;
+    export var SchemaTypes: typeof Schema.Types;
+
+    /** Expose connection states for user-land */
+    export var STATES: typeof ConnectionStates;
+    /** The default connection of the mongoose module. */
+    export var connection: Connection;
+    /** An array containing all connections associated with this Mongoose instance. */
+    export var connections: Connection[];
+    /** Models registred on the default mongoose connection. */
+    export var models: { [index: string]: Model<any> };
+    /** The node-mongodb-native driver Mongoose uses. */
+    export var mongo: typeof mongodb;
+    /** The Mongoose version */
+    export var version: string;
+
+    /**
+     * Opens the default mongoose connection.
+     * Options passed take precedence over options included in connection strings.
+     * @returns pseudo-promise wrapper around this
+     */
+    export function connect(
+        uris: string,
         options: ConnectionOptions,
-        callback?: (err: any, conn?: Connection) => void
+        callback: (err: mongodb.MongoError) => void,
+    ): Promise<Mongoose>;
+    export function connect(uris: string, callback: (err: mongodb.MongoError) => void): Promise<Mongoose>;
+    export function connect(uris: string, options?: ConnectionOptions): Promise<Mongoose>;
+
+    /**
+     * Creates a Connection instance.
+     * Each connection instance maps to a single database. This method is helpful
+     *   when mangaging multiple db connections.
+     * @param uri a mongodb:// URI
+     * @param options options to pass to the driver
+     * @returns the created Connection object
+     */
+    export function createConnection(): Connection;
+    export function createConnection(
+        uri: string,
+        options?: ConnectionOptions,
     ): Connection & {
         then: Promise<Connection>["then"];
         catch: Promise<Connection>["catch"];
-      };
-
-    /** Helper for dropDatabase() */
-    dropDatabase(callback?: (err: any) => void): Promise<any>;
-
-    /** Helper for creating a collection */
-    createCollection<T = any>(name: string, options?: mongodb.CollectionCreateOptions): Promise<mongodb.Collection<T>>;
-    createCollection<T = any>(name: string, cb: (err: any, collection: mongodb.Collection<T>) => void): Promise<void>;
-    createCollection<T = any>(name: string, options: mongodb.CollectionCreateOptions, cb?: (err: any, collection: mongodb.Collection) => void): Promise<mongodb.Collection<T>>;
-
-    /** Helper for dropCollection() */
-    dropCollection(name: string, callback?: (err: any) => void): Promise<void>;
-
-    /** Closes the connection */
-    close(callback?: (err: any) => void): Promise<void>;
-
-    /** Closes the connection */
-    close(force?: boolean, callback?: (err: any) => void): Promise<void>;
+    };
 
     /**
-     * Retrieves a collection, creating it if not cached.
-     * Not typically needed by applications. Just talk to your collection through your model.
-     * @param name name of the collection
-     * @param options optional collection options
+     * Disconnects all connections.
+     * @param fn called after all connection close.
      */
-    collection(name: string, options?: any): Collection;
+    export function disconnect(fn: (error?: any) => void): void;
+    /** Disconnects all connections. */
+    export function disconnect(): Promise<void>;
+
+    /** Gets mongoose options */
+    export function get(key: string): any;
 
     /**
-     * Defines or retrieves a model.
-     * When no collection argument is passed, Mongoose produces a collection name by passing
-     * the model name to the utils.toCollectionName method. This method pluralizes the name.
-     * If you don't like this behavior, either pass a collection name or set your schemas
-     * collection name option.
-     * @param name the model name
-     * @param schema a schema. necessary when defining a model
-     * @param collection name of mongodb collection (optional) if not given it will be induced from model name
-     * @returns The compiled model
+     * Tests whether Mongoose can cast a value to an ObjectId
+     * @param value value to be tested if it can be cast to an ObjectId
      */
-    model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
-    model<T extends Document, U extends Model<T>>(
-      name: string,
-      schema?: Schema,
-      collection?: string
+    export function isValidObjectId(value: any): boolean;
+
+    /**
+     * Defines a model or retrieves it.
+     * Models defined on the mongoose instance are available to all connection
+     *   created by the same mongoose instance.
+     * @param name model name
+     * @param collection (optional, induced from model name)
+     * @param skipInit whether to skip initialization (defaults to false)
+     */
+    export function model<T extends Document>(
+        name: string,
+        schema?: Schema,
+        collection?: string,
+        skipInit?: boolean,
+    ): Model<T>;
+    export function model<T extends Document, U extends Model<T>>(
+        name: string,
+        schema?: Schema,
+        collection?: string,
+        skipInit?: boolean,
     ): U;
 
     /**
-     * Removes the model named `name` from this connection, if it exists. You can
-     * use this function to clean up any models you created in your tests to
-     * prevent OverwriteModelErrors.
+     * Removes the model named `name` from the default connection on this instance
+     * of Mongoose. You can use this function to clean up any models you created
+     * in your tests to prevent OverwriteModelErrors.
+     */
+    export function deleteModel(name: string | RegExp): Connection;
+
+    /**
+     * Returns an array of model names created on the default connection for this
+     * instance of Mongoose. Does not include names of models created
+     * on additional connections that were created with `createConnection()`.
+     */
+    export function modelNames(): string[];
+
+    /**
+     * Declares a global plugin executed on all Schemas.
+     * Equivalent to calling .plugin(fn) on each Schema you create.
+     * @param fn plugin callback
+     * @param opts optional options
+     */
+    export function plugin(fn: Function): typeof mongoose;
+    export function plugin<T>(fn: Function, opts: T): typeof mongoose;
+
+    /** Sets mongoose options */
+    export function set(key: string, value: any): void;
+
+    export function startSession(
+        options?: mongodb.SessionOptions,
+        cb?: (err: any, session: mongodb.ClientSession) => void,
+    ): Promise<mongodb.ClientSession>;
+
+    export type CastError = Error.CastError;
+
+    /*
+     * section connection.js
+     * http://mongoosejs.com/docs/api.html#connection-js
      *
-     * @param name if string, the name of the model to remove. If regexp, removes all models whose name matches the regexp.
-     * @returns this
+     * The Connection class exposed by require('mongoose')
+     *   is actually the driver's NativeConnection class.
+     *   connection.js defines a base class that the native
+     *   versions extend. See:
+     *   http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
      */
-    deleteModel(name: string | RegExp): Connection;
+    abstract class ConnectionBase extends events.EventEmitter {
+        /**
+         * For practical reasons, a Connection equals a Db.
+         * @param base a mongoose instance
+         * @event connecting Emitted when connection.{open,openSet}() is executed on this connection.
+         * @event connected Emitted when this connection successfully connects to the db. May be emitted multiple times in reconnected scenarios.
+         * @event open Emitted after we connected and onOpen is executed on all of this connections models.
+         * @event disconnecting Emitted when connection.close() was executed.
+         * @event disconnected Emitted after getting disconnected from the db.
+         * @event close Emitted after we disconnected and onClose executed on all of this connections models.
+         * @event reconnected Emitted after we connected and subsequently disconnected, followed by successfully another successfull connection.
+         * @event error Emitted when an error occurs on this connection.
+         * @event fullsetup Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
+         * @event all Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
+         */
+        constructor(base: typeof mongoose);
 
-    /** Returns an array of model names created on this connection. */
-    modelNames(): string[];
+        /**
+         * Opens the connection to MongoDB.
+         * @param uri mongodb connection string
+         * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
+         *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
+         *   See the node-mongodb-native driver instance for options that it understands.
+         *   Options passed take precedence over options included in connection strings.
+         */
+        openUri(uri: string, options?: ConnectionOptions): Promise<Connection>;
+        openUri(uri: string, callback: (err: any, conn?: Connection) => void): Connection;
+        openUri(
+            uri: string,
+            options: ConnectionOptions,
+            callback?: (err: any, conn?: Connection) => void,
+        ): Connection & {
+            then: Promise<Connection>["then"];
+            catch: Promise<Connection>["catch"];
+        };
 
-    /** A hash of the global options that are associated with this connection */
-      config: Pick<ConnectionOptions, 'autoIndex' | 'autoCreate' | 'useCreateIndex' | 'useFindAndModify' | 'bufferCommands'>;
+        /** Helper for dropDatabase() */
+        dropDatabase(callback?: (err: any) => void): Promise<any>;
 
-    /** The mongodb.Db instance, set when the connection is opened */
-    db: mongodb.Db;
+        /** Helper for creating a collection */
+        createCollection<T = any>(
+            name: string,
+            options?: mongodb.CollectionCreateOptions,
+        ): Promise<mongodb.Collection<T>>;
+        createCollection<T = any>(
+            name: string,
+            cb: (err: any, collection: mongodb.Collection<T>) => void,
+        ): Promise<void>;
+        createCollection<T = any>(
+            name: string,
+            options: mongodb.CollectionCreateOptions,
+            cb?: (err: any, collection: mongodb.Collection) => void,
+        ): Promise<mongodb.Collection<T>>;
 
-    /** A hash of the collections associated with this connection */
-    collections: { [index: string]: Collection };
+        /** Helper for dropCollection() */
+        dropCollection(name: string, callback?: (err: any) => void): Promise<void>;
 
-    /** A hash of models registered with this connection */
-    models: { [index: string]: Model<any> };
+        /** Closes the connection */
+        close(callback?: (err: any) => void): Promise<void>;
 
-    /**
-     * Connection ready state
-     * 0 = disconnected
-     * 1 = connected
-     * 2 = connecting
-     * 3 = disconnecting
-     * Each state change emits its associated event name.
-     */
-    readyState: number;
+        /** Closes the connection */
+        close(force?: boolean, callback?: (err: any) => void): Promise<void>;
 
-    /** Connected database name */
-    name: string
+        /**
+         * Retrieves a collection, creating it if not cached.
+         * Not typically needed by applications. Just talk to your collection through your model.
+         * @param name name of the collection
+         * @param options optional collection options
+         */
+        collection(name: string, options?: any): Collection;
 
-    /** Connected host */
-    host: string
+        /**
+         * Defines or retrieves a model.
+         * When no collection argument is passed, Mongoose produces a collection name by passing
+         * the model name to the utils.toCollectionName method. This method pluralizes the name.
+         * If you don't like this behavior, either pass a collection name or set your schemas
+         * collection name option.
+         * @param name the model name
+         * @param schema a schema. necessary when defining a model
+         * @param collection name of mongodb collection (optional) if not given it will be induced from model name
+         * @returns The compiled model
+         */
+        model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
+        model<T extends Document, U extends Model<T>>(name: string, schema?: Schema, collection?: string): U;
 
-    /** Connected port number */
-    port: number
+        /**
+         * Removes the model named `name` from this connection, if it exists. You can
+         * use this function to clean up any models you created in your tests to
+         * prevent OverwriteModelErrors.
+         *
+         * @param name if string, the name of the model to remove. If regexp, removes all models whose name matches the regexp.
+         * @returns this
+         */
+        deleteModel(name: string | RegExp): Connection;
 
-    /** mapping of ready states */
-    states: typeof ConnectionStates;
-  }
+        /** Returns an array of model names created on this connection. */
+        modelNames(): string[];
 
-  /**
-   * Connection optional settings.
-   *
-   * see
-   *   https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect
-   * and
-   *   http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html
-   * for all available options.
-   *
-   */
-  interface ConnectionOptions extends mongodb.MongoClientOptions {
-    /** mongoose-specific options */
-    /** See https://mongoosejs.com/docs/guide.html#bufferCommands */
-    bufferCommands?: boolean;
-    /** database Name for Mongodb Atlas Connection */
-    dbName?: string;
-    /** passed to the connection db instance */
-    db?: any;
-    config?: {
-      /**
-       * set to false to disable automatic index creation for all
-       * models associated with this connection.
-       */
-      autoIndex?: boolean;
-    };
-    autoIndex?: boolean;
+        /** A hash of the global options that are associated with this connection */
+        config: Pick<
+            ConnectionOptions,
+            "autoIndex" | "autoCreate" | "useCreateIndex" | "useFindAndModify" | "bufferCommands"
+        >;
 
-    /** Before Mongoose builds indexes, it calls Model.createCollection()
-     * to create the underlying collection in MongoDB if autoCreate
-     * is set to true.(default: false) */
-    autoCreate?: boolean;
+        /** The mongodb.Db instance, set when the connection is opened */
+        db: mongodb.Db;
 
+        /** A hash of the collections associated with this connection */
+        collections: { [index: string]: Collection };
 
-    /** Configure csfle as especified in MongoDB official guide */
-    autoEncryption?: {
-      keyVaultNamespace: string,
-      kmsProviders: any,
-      schemaMap: any,
-      extraOptions?: any
-    }
+        /** A hash of models registered with this connection */
+        models: { [index: string]: Model<any> };
 
-    /** Specify a journal write concern (default: false). */
-    journal?: boolean;
+        /**
+         * Connection ready state
+         * 0 = disconnected
+         * 1 = connected
+         * 2 = connecting
+         * 3 = disconnecting
+         * Each state change emits its associated event name.
+         */
+        readyState: number;
 
-    /** The current value of the parameter native_parser */
-    nativeParser?: boolean;
+        /** Connected database name */
+        name: string;
 
-    safe?: any;
-    slaveOk?: boolean;
+        /** Connected host */
+        host: string;
 
-    /** username for authentication */
-    user?: string;
-    /** password for authentication */
-    pass?: string;
+        /** Connected port number */
+        port: number;
 
-    /** If true, this connection will use createIndex() instead of ensureIndex() for automatic index builds via Model.init(). */
-    useCreateIndex?: boolean;
-    /** See https://mongoosejs.com/docs/connections.html#use-mongo-client **/
-    useMongoClient?: boolean;
-    /** Flag for using new URL string parser instead of current (deprecated) one */
-    useNewUrlParser?: boolean;
-    /** Set to false to make findOneAndUpdate() and findOneAndRemove() use native findOneAndUpdate() rather than findAndModify(). */
-    useFindAndModify?: boolean;
-    /** Flag for using new Server Discovery and Monitoring engine instead of current (deprecated) one */
-    useUnifiedTopology?: boolean;
-    /**
-     * With useUnifiedTopology, the MongoDB driver will try to find a server to send any given operation to,
-     * and keep retrying for serverSelectionTimeoutMS milliseconds.
-     * If not set, the MongoDB driver defaults to using 30000 (30 seconds).
-     */
-    serverSelectionTimeoutMS?: number;
-    /**
-     * With useUnifiedTopology, the MongoDB driver sends a heartbeat every heartbeatFrequencyMS to check on the status of the connection.
-     * A heartbeat is subject to serverSelectionTimeoutMS, so the MongoDB driver will retry failed heartbeats for up to 30 seconds by default.
-     * Mongoose only emits a 'disconnected' event after a heartbeat has failed,
-     * so you may want to decrease this setting to reduce the time between when your server goes down and when Mongoose emits 'disconnected'.
-     * We recommend you do not set this setting below 1000, too many heartbeats can lead to performance degradation.
-     */
-    heartbeatFrequencyMS?: number;
-
-    // Legacy properties - passed to the connection server instance(s)
-    mongos?: any;
-    server?: any;
-    replset?: any;
-  }
-
-  interface ClientSession extends mongodb.ClientSession { }
-
-  /*
-   * section drivers/node-mongodb-native/collection.js
-   * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
-   */
-  var Collection: Collection;
-  interface Collection extends CollectionBase {
-    /**
-     * Collection constructor
-     * @param name name of the collection
-     * @param conn A MongooseConnection instance
-     * @param opts optional collection options
-     */
-    new(name: string, conn: Connection, opts?: any): Collection;
-    /** Formatter for debug print args */
-    $format(arg: any): string;
-    /** Debug print helper */
-    $print(name: any, i: any, args: any[]): void;
-    /** Retrieves information about this collections indexes. */
-    getIndexes(): any;
-  }
-
-  interface ConnectionUseDbOptions {
-    /**
-     * If true, cache results so calling `useDb()` multiple times with the same name only creates 1 connection object.
-     */
-    useCache?: boolean;
-  }
-  /*
-   * section drivers/node-mongodb-native/connection.js
-   * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
-   */
-  class Connection extends ConnectionBase {
-    /**
-     * Switches to a different database using the same connection pool.
-     * @param name The database name
-     * @param options Additional options
-     * @returns New Connection Object
-     */
-    useDb(name: string, options?: ConnectionUseDbOptions): Connection;
-
-    startSession(options?: mongodb.SessionOptions, cb?: (err: any, session: mongodb.ClientSession) => void): Promise<mongodb.ClientSession>;
-
-    /** Expose the possible connection states. */
-    static STATES: typeof ConnectionStates;
-  }
-
-  export enum ConnectionStates {
-    disconnected = 0,
-    connected = 1,
-    connecting = 2,
-    disconnecting = 3,
-    uninitialized = 99,
-  }
-
-  /*
-   * section error.js
-   * http://mongoosejs.com/docs/api.html#error-js
-   */
-  class Error extends global.Error {
-
-    // "MongooseError" for instances of the current class,
-    // an other string for instances of derived classes.
-    name: "MongooseError" | string;
-
-    /**
-     * MongooseError constructor
-     * @param msg Error message
-     */
-    constructor(msg: string);
-
-    /**
-     * The default built-in validator error messages. These may be customized.
-     * As you might have noticed, error messages support basic templating
-     * {PATH} is replaced with the invalid document path
-     * {VALUE} is replaced with the invalid value
-     * {TYPE} is replaced with the validator type such as "regexp", "min", or "user defined"
-     * {MIN} is replaced with the declared min value for the Number.min validator
-     * {MAX} is replaced with the declared max value for the Number.max validator
-     */
-    static messages: any;
-
-    /** For backwards compatibility. Same as mongoose.Error.messages */
-    static Messages: any;
-
-  }
-
-  module Error {
-
-    /**
-     * section error/notFound.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.DocumentNotFoundError
-     *
-     * An instance of this error class will be returned when `save()` fails
-     * because the underlying
-     * document was not found. The constructor takes one parameter, the
-     * conditions that mongoose passed to `update()` when trying to update
-     * the document.
-     */
-    export class DocumentNotFoundError extends Error {
-      name: 'DocumentNotFoundError';
-      filter: any;
-      query: any;
-      constructor(filter: any);
+        /** mapping of ready states */
+        states: typeof ConnectionStates;
     }
 
     /**
-     * section error/cast.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.CastError
+     * Connection optional settings.
      *
-     * An instance of this error class will be returned when mongoose failed to
-     * cast a value.
+     * see
+     *   https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect
+     * and
+     *   http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html
+     * for all available options.
+     *
      */
-    export class CastError extends Error {
-      name: 'CastError';
-      stringValue: string;
-      kind: string;
-      value: any;
-      path: string;
-      reason?: any;
-      model?: any;
+    interface ConnectionOptions extends mongodb.MongoClientOptions {
+        /** mongoose-specific options */
+        /** See https://mongoosejs.com/docs/guide.html#bufferCommands */
+        bufferCommands?: boolean;
+        /** database Name for Mongodb Atlas Connection */
+        dbName?: string;
+        /** passed to the connection db instance */
+        db?: any;
+        config?: {
+            /**
+             * set to false to disable automatic index creation for all
+             * models associated with this connection.
+             */
+            autoIndex?: boolean;
+        };
+        autoIndex?: boolean;
 
-      constructor(type: string, value: any, path: string, reason?: NativeError);
+        /** Before Mongoose builds indexes, it calls Model.createCollection()
+         * to create the underlying collection in MongoDB if autoCreate
+         * is set to true.(default: false) */
+        autoCreate?: boolean;
 
-      setModel(model: any): void;
+        /** Configure csfle as especified in MongoDB official guide */
+        autoEncryption?: {
+            keyVaultNamespace: string;
+            kmsProviders: any;
+            schemaMap: any;
+            extraOptions?: any;
+        };
+
+        /** Specify a journal write concern (default: false). */
+        journal?: boolean;
+
+        /** The current value of the parameter native_parser */
+        nativeParser?: boolean;
+
+        safe?: any;
+        slaveOk?: boolean;
+
+        /** username for authentication */
+        user?: string;
+        /** password for authentication */
+        pass?: string;
+
+        /** If true, this connection will use createIndex() instead of ensureIndex() for automatic index builds via Model.init(). */
+        useCreateIndex?: boolean;
+        /** See https://mongoosejs.com/docs/connections.html#use-mongo-client **/
+        useMongoClient?: boolean;
+        /** Flag for using new URL string parser instead of current (deprecated) one */
+        useNewUrlParser?: boolean;
+        /** Set to false to make findOneAndUpdate() and findOneAndRemove() use native findOneAndUpdate() rather than findAndModify(). */
+        useFindAndModify?: boolean;
+        /** Flag for using new Server Discovery and Monitoring engine instead of current (deprecated) one */
+        useUnifiedTopology?: boolean;
+        /**
+         * With useUnifiedTopology, the MongoDB driver will try to find a server to send any given operation to,
+         * and keep retrying for serverSelectionTimeoutMS milliseconds.
+         * If not set, the MongoDB driver defaults to using 30000 (30 seconds).
+         */
+        serverSelectionTimeoutMS?: number;
+        /**
+         * With useUnifiedTopology, the MongoDB driver sends a heartbeat every heartbeatFrequencyMS to check on the status of the connection.
+         * A heartbeat is subject to serverSelectionTimeoutMS, so the MongoDB driver will retry failed heartbeats for up to 30 seconds by default.
+         * Mongoose only emits a 'disconnected' event after a heartbeat has failed,
+         * so you may want to decrease this setting to reduce the time between when your server goes down and when Mongoose emits 'disconnected'.
+         * We recommend you do not set this setting below 1000, too many heartbeats can lead to performance degradation.
+         */
+        heartbeatFrequencyMS?: number;
+
+        // Legacy properties - passed to the connection server instance(s)
+        mongos?: any;
+        server?: any;
+        replset?: any;
     }
 
-    /**
+    interface ClientSession extends mongodb.ClientSession {}
+
+    /*
+     * section drivers/node-mongodb-native/collection.js
+     * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
+     */
+    var Collection: Collection;
+    interface Collection extends CollectionBase {
+        /**
+         * Collection constructor
+         * @param name name of the collection
+         * @param conn A MongooseConnection instance
+         * @param opts optional collection options
+         */
+        new (name: string, conn: Connection, opts?: any): Collection;
+        /** Formatter for debug print args */
+        $format(arg: any): string;
+        /** Debug print helper */
+        $print(name: any, i: any, args: any[]): void;
+        /** Retrieves information about this collections indexes. */
+        getIndexes(): any;
+    }
+
+    interface ConnectionUseDbOptions {
+        /**
+         * If true, cache results so calling `useDb()` multiple times with the same name only creates 1 connection object.
+         */
+        useCache?: boolean;
+    }
+    /*
+     * section drivers/node-mongodb-native/connection.js
+     * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
+     */
+    class Connection extends ConnectionBase {
+        /**
+         * Switches to a different database using the same connection pool.
+         * @param name The database name
+         * @param options Additional options
+         * @returns New Connection Object
+         */
+        useDb(name: string, options?: ConnectionUseDbOptions): Connection;
+
+        startSession(
+            options?: mongodb.SessionOptions,
+            cb?: (err: any, session: mongodb.ClientSession) => void,
+        ): Promise<mongodb.ClientSession>;
+
+        /** Expose the possible connection states. */
+        static STATES: typeof ConnectionStates;
+    }
+
+    export enum ConnectionStates {
+        disconnected = 0,
+        connected = 1,
+        connecting = 2,
+        disconnecting = 3,
+        uninitialized = 99,
+    }
+
+    /*
+     * section error.js
+     * http://mongoosejs.com/docs/api.html#error-js
+     */
+    class Error extends global.Error {
+        // "MongooseError" for instances of the current class,
+        // an other string for instances of derived classes.
+        name: "MongooseError" | string;
+
+        /**
+         * MongooseError constructor
+         * @param msg Error message
+         */
+        constructor(msg: string);
+
+        /**
+         * The default built-in validator error messages. These may be customized.
+         * As you might have noticed, error messages support basic templating
+         * {PATH} is replaced with the invalid document path
+         * {VALUE} is replaced with the invalid value
+         * {TYPE} is replaced with the validator type such as "regexp", "min", or "user defined"
+         * {MIN} is replaced with the declared min value for the Number.min validator
+         * {MAX} is replaced with the declared max value for the Number.max validator
+         */
+        static messages: any;
+
+        /** For backwards compatibility. Same as mongoose.Error.messages */
+        static Messages: any;
+    }
+
+    module Error {
+        /**
+         * section error/notFound.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.DocumentNotFoundError
+         *
+         * An instance of this error class will be returned when `save()` fails
+         * because the underlying
+         * document was not found. The constructor takes one parameter, the
+         * conditions that mongoose passed to `update()` when trying to update
+         * the document.
+         */
+        export class DocumentNotFoundError extends Error {
+            name: "DocumentNotFoundError";
+            filter: any;
+            query: any;
+            constructor(filter: any);
+        }
+
+        /**
+         * section error/cast.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.CastError
+         *
+         * An instance of this error class will be returned when mongoose failed to
+         * cast a value.
+         */
+        export class CastError extends Error {
+            name: "CastError";
+            stringValue: string;
+            kind: string;
+            value: any;
+            path: string;
+            reason?: any;
+            model?: any;
+
+            constructor(type: string, value: any, path: string, reason?: NativeError);
+
+            setModel(model: any): void;
+        }
+
+        /**
      * section error/validation.js
      * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ValidationError
 
@@ -687,2047 +703,2768 @@ declare module "mongoose" {
      * instances of CastError or ValidationError.
      *
      */
-    export class ValidationError extends Error {
-      name: 'ValidationError';
+        export class ValidationError extends Error {
+            name: "ValidationError";
 
-      errors: {[path: string]: ValidatorError | CastError};
+            errors: { [path: string]: ValidatorError | CastError };
 
-      constructor(instance?: MongooseDocument);
+            constructor(instance?: MongooseDocument);
 
-      /** Console.log helper */
-      toString(): string;
+            /** Console.log helper */
+            toString(): string;
 
-      inspect(): object;
+            inspect(): object;
 
-      toJSON(): object;
+            toJSON(): object;
 
-      addError(path: string, error: any): void;
+            addError(path: string, error: any): void;
+        }
+
+        /**
+         * section error/validator.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ValidatorError
+         *
+         * A `ValidationError` has a hash of `errors` that contain individual `ValidatorError` instances
+         */
+        export class ValidatorError extends Error {
+            name: "ValidatorError";
+            properties: { message: string; type?: string; path?: string; value?: any; reason?: any };
+            kind: string;
+            path: string;
+            value: any;
+            reason: any;
+
+            constructor(properties: { message?: string; type?: string; path?: string; value?: any; reason?: any });
+
+            formatMessage(msg: string | Function, properties: any): string;
+
+            toString(): string;
+        }
+
+        /**
+         * section error/version.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.VersionError
+         *
+         * An instance of this error class will be returned when you call `save()` after
+         * the document in the database was changed in a potentially unsafe way. See
+         * the [`versionKey` option](http://mongoosejs.com/docs/guide.html#versionKey) for more information.
+         */
+        export class VersionError extends Error {
+            name: "VersionError";
+            version: any;
+            modifiedPaths: Array<any>;
+
+            constructor(doc: MongooseDocument, currentVersion: any, modifiedPaths: any);
+        }
+
+        /**
+         * section error/parallelSave.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ParallelSaveError
+         *
+         * An instance of this error class will be returned when you call `save()` multiple
+         * times on the same document in parallel. See the [FAQ](http://mongoosejs.com/docs/faq.html) for more
+         * information.
+         */
+        export class ParallelSaveError extends Error {
+            name: "ParallelSaveError";
+            constructor(doc: MongooseDocument);
+        }
+
+        /**
+         * section error/overwriteModel.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.OverwriteModelError
+         *
+         * Thrown when a model with the given name was already registered on the connection.
+         * See [the FAQ about `OverwriteModelError`](http://mongoosejs.com/docs/faq.html#overwrite-model-error).
+         */
+        export class OverwriteModelError extends Error {
+            name: "OverwriteModelError";
+            constructor(name: string);
+        }
+
+        /**
+         * section error/missingSchema.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.MissingSchemaError
+         *
+         * Thrown when you try to access a model that has not been registered yet
+         */
+        export class MissingSchemaError extends Error {
+            name: "MissingSchemaError";
+            constructor(name: string);
+        }
+
+        /**
+         * section error/divergentArray.js
+         * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.DivergentArrayError
+         *
+         * An instance of this error will be returned if you used an array projection
+         * and then modified the array in an unsafe way.
+         */
+        export class DivergentArrayError extends Error {
+            name: "DivergentArrayError";
+            constructor(paths: Array<any>);
+        }
     }
 
-    /**
-     * section error/validator.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ValidatorError
-     *
-     * A `ValidationError` has a hash of `errors` that contain individual `ValidatorError` instances
-     */
-    export class ValidatorError extends Error {
-      name: 'ValidatorError';
-      properties: {message: string, type?: string, path?: string, value?: any, reason?: any};
-      kind: string;
-      path: string;
-      value: any;
-      reason: any;
-
-      constructor(properties: {message?: string, type?: string, path?: string, value?: any, reason?: any});
-
-      formatMessage(msg: string | Function, properties: any): string;
-
-      toString(): string;
-    }
-
-    /**
-     * section error/version.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.VersionError
-     *
-     * An instance of this error class will be returned when you call `save()` after
-     * the document in the database was changed in a potentially unsafe way. See
-     * the [`versionKey` option](http://mongoosejs.com/docs/guide.html#versionKey) for more information.
-     */
-    export class VersionError extends Error {
-      name: 'VersionError';
-      version: any;
-      modifiedPaths: Array<any>;
-
-      constructor(doc: MongooseDocument, currentVersion: any, modifiedPaths: any);
-    }
-
-    /**
-     * section error/parallelSave.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ParallelSaveError
-     *
-     * An instance of this error class will be returned when you call `save()` multiple
-     * times on the same document in parallel. See the [FAQ](http://mongoosejs.com/docs/faq.html) for more
-     * information.
-     */
-    export class ParallelSaveError extends Error {
-      name: 'ParallelSaveError';
-      constructor(doc: MongooseDocument);
-    }
-
-    /**
-     * section error/overwriteModel.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.OverwriteModelError
-     *
-     * Thrown when a model with the given name was already registered on the connection.
-     * See [the FAQ about `OverwriteModelError`](http://mongoosejs.com/docs/faq.html#overwrite-model-error).
-     */
-    export class OverwriteModelError extends Error {
-      name: 'OverwriteModelError';
-      constructor(name: string);
-    }
-
-    /**
-     * section error/missingSchema.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.MissingSchemaError
-     *
-     * Thrown when you try to access a model that has not been registered yet
-     */
-    export class MissingSchemaError extends Error {
-      name: 'MissingSchemaError';
-      constructor(name: string);
-    }
-
-    /**
-     * section error/divergentArray.js
-     * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.DivergentArrayError
-     *
-     * An instance of this error will be returned if you used an array projection
-     * and then modified the array in an unsafe way.
-     */
-    export class DivergentArrayError extends Error {
-      name: 'DivergentArrayError';
-      constructor(paths: Array<any>);
-    }
-  }
-
-  interface EachAsyncOptions {
-    /** defaults to 1 */
-    parallel?: number;
-  }
-
-  /*
-   * section querycursor.js
-   * https://mongoosejs.com/docs/api.html#querycursor-js
-   *
-   * Callback signatures are from: https://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
-   * QueryCursor can only be accessed by query#cursor(), we only
-   *   expose its interface to enable type-checking.
-   */
-  class QueryCursor<T extends Document> extends stream.Readable {
-    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
-
-    /**
-     * A QueryCursor is a concurrency primitive for processing query results
-     * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
-     * in addition to several other mechanisms for loading documents from MongoDB
-     * one at a time.
-     * Unless you're an advanced user, do not instantiate this class directly.
-     * Use Query#cursor() instead.
-     * @param options query options passed to .find()
-     * @event cursor Emitted when the cursor is created
-     * @event error Emitted when an error occurred
-     * @event data Emitted when the stream is flowing and the next doc is ready
-     * @event end Emitted when the stream is exhausted
-     */
-    constructor(query: Query<T>, options: any);
-
-    /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
-    close(callback?: (error: any, result: any) => void): Promise<any>;
-
-    /**
-     * Execute fn for every document in the cursor. If fn returns a promise,
-     * will wait for the promise to resolve before iterating on to the next one.
-     * Returns a promise that resolves when done.
-     * @param fn Function to be executed for every document in the cursor
-     * @param callback Executed when all docs have been processed
-     */
-    eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): Promise<T>;
-
-    /**
-     * Execute fn for every document in the cursor. If fn returns a promise,
-     * will wait for the promise to resolve before iterating on to the next one.
-     * Returns a promise that resolves when done.
-     * @param fn Function to be executed for every document in the cursor
-     * @param options Async options (e. g. parallel function execution)
-     * @param callback Executed when all docs have been processed
-     */
-    eachAsync(fn: (doc: T) => any, options: EachAsyncOptions, callback?: (err: any) => void): Promise<T>;
-
-    /**
-     * Registers a transform function which subsequently maps documents retrieved
-     * via the streams interface or .next()
-     */
-    map(fn: (doc: T) => T): this;
-
-    /**
-     * Get the next document from this cursor. Will return null when there are
-     * no documents left.
-     */
-    next(callback?: (err: any, doc?: T) => void): Promise<any>;
-  }
-
-  /*
-   * section virtualtype.js
-   * http://mongoosejs.com/docs/api.html#virtualtype-js
-   */
-  class VirtualType {
-    /** This is what mongoose uses to define virtual attributes via Schema.prototype.virtual. */
-    constructor(options: any, name: string);
-    /** Applies getters to value using optional scope. */
-    applyGetters(value: any, scope: any): any;
-    /** Applies setters to value using optional scope. */
-    applySetters(value: any, scope: any): any;
-    /** Defines a getter. */
-    get(fn: Function): this;
-    /** Defines a setter. */
-    set(fn: Function): this;
-  }
-
-  interface HookOptions {
-    document?: boolean;
-    query?: boolean;
-  }
-
-  /*
-   * section schema.js
-   * http://mongoosejs.com/docs/api.html#schema-js
-   */
-  class Schema<T = any> extends events.EventEmitter {
-    /**
-     * Schema constructor.
-     * When nesting schemas, (children in the example above), always declare
-     * the child schema first before passing it into its parent.
-     * @event init Emitted after the schema is compiled into a Model.
-     */
-    constructor(definition?: SchemaDefinition, options?: SchemaOptions);
-
-    /** Adds key path / schema type pairs to this schema. */
-    add(obj: SchemaDefinition, prefix?: string): void;
-
-    /** Return a deep copy of this schema */
-    clone(): Schema;
-
-    /**
-     * Iterates the schemas paths similar to Array.forEach.
-     * @param fn callback function
-     * @returns this
-     */
-    eachPath(fn: (path: string, type: SchemaType) => void): this;
-
-    /**
-     * Gets a schema option.
-     * @param key option name
-     */
-    get(key: string): any;
-
-    /**
-     * Defines an index (most likely compound) for this schema.
-     * @param options Options to pass to MongoDB driver's createIndex() function
-     * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
-     *   expires option into seconds for the expireAfterSeconds in the above link.
-     */
-    index(fields: any, options?: {
-      expires?: string;
-      [other: string]: any;
-    }): this;
-
-    /** Compiles indexes from fields and schema-level indexes */
-    indexes(): any[];
-
-    /**
-     * Loads an ES6 class into a schema. Maps setters + getters, static methods, and
-     * instance methods to schema virtuals, statics, and methods.
-     */
-    loadClass(model: Function): this;
-
-    /**
-     * Adds an instance method to documents constructed from Models compiled from this schema.
-     * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
-     */
-    method<F extends keyof T>(method: F, fn: T[F]): this;
-    method(methodObj: {
-      [F in keyof T]: T[F]
-    }): this;
-
-    /**
-     * Gets/sets schema paths.
-     * Sets a path (if arity 2)
-     * Gets a path (if arity 1)
-     */
-    path(path: string): SchemaType;
-    path(path: string, constructor: any): this;
-
-    /**
-     * Returns the pathType of path for this schema.
-     * @returns whether it is a real, virtual, nested, or ad-hoc/undefined path.
-     */
-    pathType(path: string): string;
-
-    /**
-     * Registers a plugin for this schema.
-     * @param plugin callback
-     */
-    plugin(plugin: (schema: Schema) => void): this;
-    plugin<T>(plugin: (schema: Schema, options: T) => void, opts: T): this;
-
-    /**
-     * Defines a post hook for the document
-     * Post hooks fire on the event emitted from document instances of Models compiled
-     *   from this schema.
-     * @param method name of the method to hook
-     * @param fn callback
-     */
-    post<T extends Document>(method: 'insertMany', fn: (
-      this: Model<Document>,
-      error: mongodb.MongoError, docs: T[], next: (err?: NativeError) => void
-    ) => void): this;
-
-    post<T extends Document>(method: 'insertMany', fn: (
-      this: Model<Document>,
-      docs: T[], next: (err?: NativeError) => void
-    ) => void): this;
-
-    post<T extends Document>(method: 'insertMany', fn: (
-      this: Model<Document>,
-      docs: T[], next: (err?: NativeError) => Promise<any>
-    ) => void): this;
-
-    post<T extends Document>(method: 'remove' | 'deleteOne', { document, query }: HookOptions, fn: (
-      doc: T
-    ) => void): this;
-
-    post<T extends Document>(method: string | RegExp, fn: (
-      doc: T, next: (err?: NativeError) => void
-    ) => void): this;
-
-    post<T extends Document>(method: string | RegExp, fn: (
-      docs: T[], next: (err?: NativeError) => void
-    ) => void): this;
-
-    post<T extends Document>(method: string | RegExp, fn: (
-      docs: T[], next: (err?: NativeError) => void
-    ) => Promise<void>): this;
-
-    post<T extends Document>(method: string | RegExp, fn: (
-      error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void
-    ) => void): this;
-
-    /**
-     * Defines a pre hook for the document.
-     */
-    pre<T extends Document = Document>(
-      method: "init" | "validate" | "save" | "remove",
-      fn: HookSyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Query<any> = Query<any>>(
-      method:
-        | "count"
-        | "find"
-        | "findOne"
-        | "findOneAndRemove"
-        | "findOneAndUpdate"
-        | "update"
-        | "updateOne"
-        | "updateMany",
-      fn: HookSyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Aggregate<any> = Aggregate<any>>(
-      method: "aggregate",
-      fn: HookSyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Model<Document> = Model<Document>>(
-      method: "insertMany",
-      fn: HookSyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Document | Model<Document> | Query<any> | Aggregate<any>>(
-      method: string | RegExp,
-      fn: HookSyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-
-    pre<T extends Document = Document>(
-      method: "init" | "validate" | "save" | "remove",
-      parallel: boolean,
-      fn: HookAsyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Query<any> = Query<any>>(
-      method:
-        | "count"
-        | "find"
-        | "findOne"
-        | "findOneAndRemove"
-        | "findOneAndUpdate"
-        | "update"
-        | "updateOne"
-        | "updateMany",
-      parallel: boolean,
-      fn: HookAsyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Aggregate<any> = Aggregate<any>>(
-      method: "aggregate",
-      parallel: boolean,
-      fn: HookAsyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Model<Document> = Model<Document>>(
-      method: "insertMany",
-      parallel: boolean,
-      fn: HookAsyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-    pre<T extends Document | Model<Document> | Query<any> | Aggregate<any>>(
-      method: string | RegExp,
-      parallel: boolean,
-      fn: HookAsyncCallback<T>,
-      errorCb?: HookErrorCallback
-    ): this;
-
-    /**
-     * Adds a method call to the queue.
-     * @param name name of the document method to call later
-     * @param args arguments to pass to the method
-     */
-    queue(name: string, args: any[]): this;
-
-    /**
-     * Removes the given path (or [paths]).
-     */
-    remove(path: string | string[]): void;
-
-    /**
-     * @param invalidate refresh the cache
-     * @returns an Array of path strings that are required by this schema.
-     */
-    requiredPaths(invalidate?: boolean): string[];
-
-    /**
-     * Lists all paths and their type in the current schema.
-     */
-    paths: {
-      [key: string]: SchemaType;
-    }
-
-    /**
-     * Sets/gets a schema option.
-     * @param key option name
-     * @param value if not passed, the current option value is returned
-     */
-    set<T extends keyof SchemaOptions>(key: T): SchemaOptions[T];
-    set<T extends keyof SchemaOptions>(key: T, value: SchemaOptions[T]): this;
-
-    /**
-     * Adds static "class" methods to Models compiled from this schema.
-     */
-    static(name: string, fn: Function): this;
-    static(nameObj: { [name: string]: Function }): this;
-
-    /** Creates a virtual type with the given name. */
-    virtual(name: string, options?: any): VirtualType;
-
-    /** Returns the virtual type with the given name. */
-    virtualpath(name: string): VirtualType;
-
-    /** The allowed index types */
-    static indexTypes: string[];
-
-    /**
-     * Reserved document keys.
-     * Keys in this object are names that are rejected in schema declarations
-     * b/c they conflict with mongoose functionality. Using these key name
-     * will throw an error.
-     */
-    static reserved: any;
-
-    /** Object of currently defined methods on this schema. */
-    methods: {
-      [F in keyof T]: T[F]
-    };
-    /** Object of currently defined statics on this schema. */
-    statics: any;
-    /** Object of currently defined query helpers on this schema. */
-    query: any;
-    /** The original object passed to the schema constructor */
-    obj: any;
-  }
-
-  // Hook functions: https://github.com/vkarpov15/hooks-fixed
-  interface HookSyncCallback<T> {
-    (this: T, next: HookNextFunction, docs: any[]): Promise<any> | void;
-  }
-
-  interface HookAsyncCallback<T> {
-    (this: T, next: HookNextFunction, done: HookDoneFunction, docs: any[]): Promise<any> | void;
-  }
-
-  interface HookErrorCallback {
-    (error?: Error): any;
-  }
-
-  interface HookNextFunction {
-    (error?: Error): any;
-  }
-
-  interface HookDoneFunction {
-    (error?: Error): any;
-  }
-
-  interface SchemaOptions {
-    /** defaults to false (which means use the connection's autoIndex option) */
-    autoIndex?: boolean;
-    /**
-     * When false, use the connection's autoCreate option
-     * @default false
-     */
-    autoCreate?: boolean;
-    /** defaults to true */
-    bufferCommands?: boolean;
-    /** defaults to false */
-    capped?: boolean | number | { size?: number; max?: number; autoIndexId?: boolean; };
-    /** Sets a default collation for every query and aggregation. */
-    collation?: CollationOptions;
-    /** no default */
-    collection?: string;
-    /** defaults to "__t" */
-    discriminatorKey?: string;
-    /** defaults to false. */
-    emitIndexErrors?: boolean;
-    excludeIndexes?: any;
-    /** defaults to true */
-    id?: boolean;
-    /** defaults to true */
-    _id?: boolean;
-    /** controls document#toObject behavior when called manually - defaults to true */
-    minimize?: boolean;
-    /** When true, mongoose will throw a Version Error if a document has changed before saving - defaults to false */
-    optimisticConcurrency?: boolean;
-    read?: string;
-    writeConcern?: WriteConcern;
-    /** defaults to true. */
-    safe?: boolean | { w?: number | string; wtimeout?: number; j?: boolean };
-
-    /** defaults to null */
-    shardKey?: object;
-    /** no default */
-    strictQuery?: boolean;
-    /** defaults to true */
-    strict?: boolean | "throw";
-    /** no default */
-    toJSON?: DocumentToObjectOptions;
-    /** no default */
-    toObject?: DocumentToObjectOptions;
-    /** defaults to 'type' */
-    typeKey?: string;
-    /** defaults to false */
-    useNestedStrict?: boolean;
-    /** defaults to false */
-    usePushEach?: boolean;
-    /** defaults to true */
-    validateBeforeSave?: boolean;
-    /** defaults to "__v" */
-    versionKey?: string | boolean;
-    /**
-     * By default, Mongoose will automatically
-     * select() any populated paths.
-     * To opt out, set selectPopulatedPaths to false.
-     */
-    selectPopulatedPaths?: boolean;
-    /**
-     * skipVersioning allows excluding paths from
-     * versioning (the internal revision will not be
-     * incremented even if these paths are updated).
-     */
-    skipVersioning?: any;
-    /**
-     * Validation errors in a single nested schema are reported
-     * both on the child and on the parent schema.
-     * Set storeSubdocValidationError to false on the child schema
-     * to make Mongoose only report the parent error.
-     */
-    storeSubdocValidationError?: boolean;
-    /**
-     * If set timestamps, mongoose assigns createdAt
-     * and updatedAt fields to your schema, the type
-     * assigned is Date.
-     */
-    timestamps?: boolean | SchemaTimestampsConfig;
-    /**
-     * Determines whether a type set to a POJO becomes
-     * a Mixed path or a Subdocument (defaults to true).
-     */
-    typePojoToMixed?:boolean;
-  }
-
-  interface SchemaTimestampsConfig {
-    createdAt?: boolean | string;
-    updatedAt?: boolean | string;
-    currentTime?: () => (Date | number);
-  }
-
-  /*
-   * Intellisense for Schema definitions
-   */
-  interface SchemaDefinition {
-    [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
-  }
-
-  /*
-   * The standard options available when configuring a schema type:
-   * new Schema({
-   *   name: {
-   *     type: String,
-   *     required: true,
-   *     ...
-   *   }
-   * });
-   *
-   * Note: the properties have Object as a fallback type: | Object
-   *   because this interface does not apply to a schematype that
-   *   does not have a type property. Ex:
-   * new Schema({
-   *   name: {
-   *     first: String,    // since name does not have a "type" property
-   *     last: String      //   first and last can have any valid type
-   *     ...
-   *   }
-   * });
-   *
-   * References:
-   * - http://mongoosejs.com/docs/schematypes.html
-   * - http://mongoosejs.com/docs/api.html#schema_Schema.Types
-   */
-  interface SchemaTypeOpts<T> {
-    alias?: string;
-
-    /* Common Options for all schema types */
-    type?: T;
-
-    /** Sets a default value for this SchemaType. */
-    default?: SchemaTypeOpts.DefaultFn<T> | T;
-
-    /**
-     * Getters allow you to transform the representation of the data as it travels
-     * from the raw mongodb document to the value that you see.
-     */
-    get?: (value: T, schematype?: this) => T | any;
-
-    /** Declares the index options for this schematype. */
-    index?: SchemaTypeOpts.IndexOpts | boolean | string;
-
-    /**
-     * Adds a required validator to this SchemaType. The validator gets added
-     * to the front of this SchemaType's validators array using unshift().
-     */
-    required?: SchemaTypeOpts.RequiredFn<T> |
-    boolean | [boolean, string] |
-    string | [string, string] |
-    any;
-
-    /**
-     * Sets default select() behavior for this path.
-     * Set to true if this path should always be included in the results, false
-     * if it should be excluded by default. This setting can be overridden at
-     * the query level.
-     */
-    select?: boolean | any;
-
-    /**
-     * Setters allow you to transform the data before it gets to the raw mongodb
-     * document and is set as a value on an actual key.
-     */
-    set?: (value: T, schematype?: this) => T | any;
-
-    /** Declares a sparse index. */
-    sparse?: boolean | any;
-
-    /** Declares a full text index. */
-    text?: boolean | any;
-
-    /**
-     * Adds validator(s) for this document path.
-     * Validators always receive the value to validate as their first argument
-     * and must return Boolean. Returning false means validation failed.
-     */
-    validate?: RegExp | [RegExp, string] |
-    SchemaTypeOpts.ValidateFn<T> | [SchemaTypeOpts.ValidateFn<T>, string] |
-    SchemaTypeOpts.ValidateOpts | SchemaTypeOpts.AsyncValidateOpts |
-    SchemaTypeOpts.AsyncPromiseValidationFn<T> | [SchemaTypeOpts.AsyncPromiseValidationFn<T>, string] |
-    SchemaTypeOpts.AsyncPromiseValidationOpts |
-    (SchemaTypeOpts.ValidateOpts | SchemaTypeOpts.AsyncValidateOpts |
-      SchemaTypeOpts.AsyncPromiseValidationFn<T> | SchemaTypeOpts.AsyncPromiseValidationOpts)[];
-
-    /** Declares an unique index. */
-    unique?: boolean | any;
-
-
-    /* Options for specific schema types (String, Number, Date, etc.) */
-    /** String only - Adds an enum validator */
-    enum?: T[] | SchemaTypeOpts.EnumOpts<T> | any;
-    /** String only - Adds a lowercase setter. */
-    lowercase?: boolean | any;
-    /** String only - Sets a regexp validator. */
-    match?: RegExp | [RegExp, string] | any;
-    /** String only - Sets a maximum length validator. */
-    maxlength?: number | [number, string] | any;
-    /** String only - Sets a minimum length validator. */
-    minlength?: number | [number, string] | any;
-    /** String only - Adds a trim setter. */
-    trim?: boolean | any;
-    /** String only - Adds an uppercase setter. */
-    uppercase?: boolean | any;
-
-    /**
-     * Date, Number only - Sets a minimum number validator.
-     * Sets a minimum date validator.
-     */
-    min?: number | [number, string] |
-    Date | [Date, string] |
-    any;
-
-    /**
-     * Date, Number only - Sets a maximum number validator.
-     * Sets a maximum date validator.
-     */
-    max?: number | [number, string] |
-    Date | [Date, string] |
-    any;
-
-    /**
-     * Date only - Declares a TTL index (rounded to the nearest second)
-     * for Date types only.
-     */
-    expires?: number | string | any;
-
-    /** ObjectId only - Adds an auto-generated ObjectId default if turnOn is true. */
-    auto?: boolean | any;
-
-    /** Map only - Specifies the type of the map's attributes */
-    of?: any;
-
-    [other: string]: any;
-  }
-
-  // Interfaces specific to schema type options should be scoped in this namespace
-  namespace SchemaTypeOpts {
-    interface DefaultFn<T> {
-      (...args: any[]): T;
-    }
-
-    interface RequiredFn<T> {
-      (required: boolean, message?: string): T;
-    }
-
-    interface ValidateFn<T> {
-      (value: T): boolean;
-    }
-
-    interface AsyncValidateFn<T> {
-      (value: T, done: (result: boolean) => void): void;
-    }
-
-    interface ValidatorProps {
-      path: string;
-      value: any;
-    }
-
-    interface ValidatorMessageFn {
-      (props: ValidatorProps): string;
-    }
-
-    interface ValidateOptsBase {
-      msg?: string;
-      message?: string | ValidatorMessageFn;
-      type?: string;
-    }
-
-    interface ValidateOpts extends ValidateOptsBase {
-      /** deprecated */
-      isAsync?: false;
-      validator?: RegExp | ValidateFn<any>;
-    }
-
-    interface AsyncValidateOpts extends ValidateOptsBase {
-      /** deprecated */
-      isAsync: true;
-      validator: AsyncValidateFn<any>;
-    }
-
-    interface AsyncPromiseValidationFn<T> {
-      (value: T): Promise<boolean>;
-    }
-
-    interface AsyncPromiseValidationOpts extends ValidateOptsBase {
-      validator: AsyncPromiseValidationFn<any>;
-    }
-
-    interface EnumOpts<T> {
-      values?: T[];
-      message?: string;
-    }
-
-    interface IndexOpts {
-      background?: boolean,
-      expires?: number | string
-      sparse?: boolean,
-      type?: string,
-      unique?: boolean,
-    }
-  }
-
-  /*
-   * section document.js
-   * http://mongoosejs.com/docs/api.html#document-js
-   */
-  interface MongooseDocument extends MongooseDocumentOptionals { }
-  class MongooseDocument {
-    /** Checks if a path is set to its default. */
-    $isDefault(path?: string): boolean;
-
-    /** Getter/setter around the session associated with this document. */
-    $session(session?: ClientSession): ClientSession;
-
-    /**
-     * Takes a populated field and returns it to its unpopulated state.
-     * If the path was not populated, this is a no-op.
-     */
-    depopulate(path?: string): this;
-
-    /**
-     * Returns true if the Document stores the same data as doc.
-     * Documents are considered equal when they have matching _ids, unless neither document
-     * has an _id, in which case this function falls back to usin deepEqual().
-     * @param doc a document to compare
-     */
-    equals(doc: MongooseDocument): boolean;
-
-    /**
-     * Explicitly executes population and returns a promise.
-     * Useful for ES2015 integration.
-     * @returns promise that resolves to the document when population is done
-     */
-    execPopulate(): Promise<this>;
-
-    /** Checks if path was explicitly selected. If no projection, always returns true. */
-    isDirectSelected(path: string): boolean;
-
-    /**
-     * Returns the value of a path.
-     * @param type optionally specify a type for on-the-fly attributes
-     * @param options
-     * @param options.virtuals apply virtuals before getting this path
-     * @param options.getters if false, skip applying getters and just get the raw value
-     */
-    get(path: string, type?: any, options?: {
-      virtuals?: boolean;
-      getters?: boolean;
-    }): any;
-
-    /**
-     * Initializes the document without setters or marking anything modified.
-     * Called internally after a document is returned from mongodb.
-     * @param doc document returned by mongo
-     * @param opts Options
-     */
-    init(doc: MongooseDocument, opts?: any): this;
-
-    /** Helper for console.log */
-    inspect(options?: any): any;
-
-    /**
-     * Marks a path as invalid, causing validation to fail.
-     * The errorMsg argument will become the message of the ValidationError.
-     * The value argument (if passed) will be available through the ValidationError.value property.
-     * @param path the field to invalidate
-     * @param errorMsg the error which states the reason path was invalid
-     * @param value optional invalid value
-     * @param kind optional kind property for the error
-     * @returns the current ValidationError, with all currently invalidated paths
-     */
-    invalidate(path: string, errorMsg: string | NativeError, value?: any, kind?: string): Error.ValidationError | boolean;
-
-    /** Returns true if path was directly set and modified, else false. */
-    isDirectModified(path: string): boolean;
-
-    /** Checks if path was initialized */
-    isInit(path: string): boolean;
-
-    /**
-     * Returns true if this document was modified, else false.
-     * If path is given, checks if a path or any full path containing path as part of its path
-     * chain has been modified.
-     */
-    isModified(path?: string): boolean;
-
-    /** Checks if path was selected in the source query which initialized this document. */
-    isSelected(path: string): boolean;
-
-    /**
-     * Marks the path as having pending changes to write to the db.
-     * Very helpful when using Mixed types.
-     * @param path the path to mark modified
-     */
-    markModified(path: string): void;
-
-    /** Returns the list of paths that have been modified. */
-    modifiedPaths(): string[];
-
-    /**
-     * Populates document references, executing the callback when complete.
-     * If you want to use promises instead, use this function with
-     * execPopulate()
-     * Population does not occur unless a callback is passed or you explicitly
-     * call execPopulate(). Passing the same path a second time will overwrite
-     * the previous path options. See Model.populate() for explaination of options.
-     * @param path The path to populate or an options object
-     * @param names The properties to fetch from the populated document
-     * @param callback When passed, population is invoked
-     */
-    populate(callback: (err: any, res: this) => void): this;
-    populate(path: string, callback?: (err: any, res: this) => void): this;
-    populate(path: string, names: string, callback?: (err: any, res: this) => void): this;
-    populate(options: ModelPopulateOptions | ModelPopulateOptions[], callback?: (err: any, res: this) => void): this;
-
-    /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */
-    populated(path: string): any;
-
-    /**
-     * Sets the value of a path, or many paths.
-     * @param path path or object of key/vals to set
-     * @param val the value to set
-     * @param type optionally specify a type for "on-the-fly" attributes
-     * @param options optionally specify options that modify the behavior of the set
-     */
-    set(path: string, val: any, options?: any): this;
-    set(path: string, val: any, type: any, options?: any): this;
-    set(value: any): this;
-
-    /**
-     * Overwrite all values, except for immutable properties.
-     * @param obj the object to overwrite this document with
-     */
-    overwrite(obj: any): this;
-
-    /**
-     * The return value of this method is used in calls to JSON.stringify(doc).
-     * This method accepts the same options as Document#toObject. To apply the
-     * options to every document of your schema by default, set your schemas
-     * toJSON option to the same argument.
-     */
-    toJSON(options?: DocumentToObjectOptions): any;
-
-    /**
-     * Converts this document into a plain javascript object, ready for storage in MongoDB.
-     * Buffers are converted to instances of mongodb.Binary for proper storage.
-     */
-    toObject(options?: DocumentToObjectOptions): any;
-
-    /** Helper for console.log */
-    toString(): string;
-
-    /**
-     * Clears the modified state on the specified path.
-     * @param path the path to unmark modified
-     */
-    unmarkModified(path: string): void;
-
-    /** Sends an replaceOne command with this document _id as the query selector.  */
-    replaceOne(replacement: any, callback?: (err: any, raw: any) => void): Query<any>;
-
-    /** Sends an update command with this document _id as the query selector.  */
-    update(doc: any, callback?: (err: any, raw: any) => void): Query<any>;
-    update(doc: any, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any>;
-
-    /** Sends an updateOne command with this document _id as the query selector.  */
-    updateOne(doc: any, callback?: (err: any, raw: any) => void): Query<any>;
-    updateOne(doc: any, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any>;
-
-    /**
-     * Executes registered validation rules for this document.
-     * @param optional options internal options
-     * @param callback callback called after validation completes, passing an error if one occurred
-     */
-    validate(callback?: (err: any) => void): Promise<void>;
-    validate(optional: any, callback?: (err: any) => void): Promise<void>;
-
-    /**
-     * Executes registered validation rules (skipping asynchronous validators) for this document.
-     * This method is useful if you need synchronous validation.
-     * @param pathsToValidate only validate the given paths
-     * @returns ValidationError if there are errors during validation, or undefined if there is no error.
-     */
-    validateSync(pathsToValidate?: string | string[]): Error.ValidationError | undefined;
-
-    /** Hash containing current validation errors. */
-    errors: any;
-    /** This documents _id. */
-    _id: any;
-    /** Boolean flag specifying if the document is new. */
-    isNew: boolean;
-    /** The documents schema. */
-    schema: Schema;
-    /** Empty object that you can use for storing properties on the document */
-    $locals: { [k: string]: any };
-  }
-
-  interface MongooseDocumentOptionals {
-    /**
-     * Virtual getter that by default returns the document's _id field cast to a string,
-     * or in the case of ObjectIds, its hexString. This id getter may be disabled by
-     * passing the option { id: false } at schema construction time. If disabled, id
-     * behaves like any other field on a document and can be assigned any value.
-     */
-    id?: any;
-  }
-
-  interface DocumentToObjectOptions {
-    /** apply all getters (path and virtual getters) */
-    getters?: boolean;
-    /** apply virtual getters (can override getters option) */
-    virtuals?: boolean;
-    /** remove empty objects (defaults to true) */
-    minimize?: boolean;
-    /**
-     * A transform function to apply to the resulting document before returning
-     * @param doc The mongoose document which is being converted
-     * @param ret The plain object representation which has been converted
-     * @param options The options in use (either schema options or the options passed inline)
-     */
-    transform?: (doc: any, ret: any, options: any) => any;
-    /** depopulate any populated paths, replacing them with their original refs (defaults to false) */
-    depopulate?: boolean;
-    /** whether to include the version key (defaults to true) */
-    versionKey?: boolean;
-    /** whether to convert Maps to POJOs. (defaults to false) */
-    flattenMaps?: boolean;
-  }
-
-  namespace Types {
-    /*
-      * section types/subdocument.js
-      * http://mongoosejs.com/docs/api.html#types-subdocument-js
-      */
-    class Subdocument extends MongooseDocument {
-      /** Returns the top level document of this sub-document. */
-      ownerDocument(): MongooseDocument;
-
-      /**
-       * Null-out this subdoc
-       * @param callback optional callback for compatibility with Document.prototype.remove
-       */
-      remove(callback?: (err: any) => void): void;
-      remove(options: any, callback?: (err: any) => void): void;
+    interface EachAsyncOptions {
+        /** defaults to 1 */
+        parallel?: number;
     }
 
     /*
-     * section types/array.js
-     * http://mongoosejs.com/docs/api.html#types-array-js
+     * section querycursor.js
+     * https://mongoosejs.com/docs/api.html#querycursor-js
+     *
+     * Callback signatures are from: https://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
+     * QueryCursor can only be accessed by query#cursor(), we only
+     *   expose its interface to enable type-checking.
      */
-    class Array<T> extends global.Array<T> {
-      /**
-       * Atomically shifts the array at most one time per document save().
-       * Calling this mulitple times on an array before saving sends the same command as
-       * calling it once. This update is implemented using the MongoDB $pop method which
-       * enforces this restriction.
-       */
-      $shift(): T;
+    class QueryCursor<T extends Document> extends stream.Readable {
+        [Symbol.asyncIterator](): AsyncIterableIterator<T>;
 
-      /** Alias of pull */
-      remove(...args: any[]): this;
+        /**
+         * A QueryCursor is a concurrency primitive for processing query results
+         * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
+         * in addition to several other mechanisms for loading documents from MongoDB
+         * one at a time.
+         * Unless you're an advanced user, do not instantiate this class directly.
+         * Use Query#cursor() instead.
+         * @param options query options passed to .find()
+         * @event cursor Emitted when the cursor is created
+         * @event error Emitted when an error occurred
+         * @event data Emitted when the stream is flowing and the next doc is ready
+         * @event end Emitted when the stream is exhausted
+         */
+        constructor(query: Query<T>, options: any);
 
-      /**
-       * Pops the array atomically at most one time per document save().
-       * Calling this mulitple times on an array before saving sends the same command as
-       * calling it once. This update is implemented using the MongoDB $pop method which
-       * enforces this restriction.
-       */
-      $pop(): T;
+        /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
+        close(callback?: (error: any, result: any) => void): Promise<any>;
 
-      /**
-       * Adds values to the array if not already present.
-       * @returns the values that were added
-       */
-      addToSet(...args: any[]): T[];
+        /**
+         * Execute fn for every document in the cursor. If fn returns a promise,
+         * will wait for the promise to resolve before iterating on to the next one.
+         * Returns a promise that resolves when done.
+         * @param fn Function to be executed for every document in the cursor
+         * @param callback Executed when all docs have been processed
+         */
+        eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): Promise<T>;
 
-      /**
-       * Return the index of obj or -1 if not found.
-       * @param obj the item to look for
-       */
-      indexOf(obj: any): number;
+        /**
+         * Execute fn for every document in the cursor. If fn returns a promise,
+         * will wait for the promise to resolve before iterating on to the next one.
+         * Returns a promise that resolves when done.
+         * @param fn Function to be executed for every document in the cursor
+         * @param options Async options (e. g. parallel function execution)
+         * @param callback Executed when all docs have been processed
+         */
+        eachAsync(fn: (doc: T) => any, options: EachAsyncOptions, callback?: (err: any) => void): Promise<T>;
 
-      /** Helper for console.log */
-      inspect(): any;
+        /**
+         * Registers a transform function which subsequently maps documents retrieved
+         * via the streams interface or .next()
+         */
+        map(fn: (doc: T) => T): this;
 
-      /**
-       * Marks the entire array as modified, which if saved, will store it as a $set
-       * operation, potentially overwritting any changes that happen between when you
-       * retrieved the object and when you save it.
-       * @returns new length of the array
-       */
-      nonAtomicPush(...args: any[]): number;
-
-      /**
-       * Wraps Array#pop with proper change tracking.
-       * marks the entire array as modified which will pass the entire thing to $set
-       * potentially overwritting any changes that happen between when you retrieved
-       * the object and when you save it.
-       */
-      pop(): T;
-
-      /**
-       * Pulls items from the array atomically. Equality is determined by casting
-       * the provided value to an embedded document and comparing using
-       * the Document.equals() function.
-       */
-      pull(...args: any[]): this;
-
-      /**
-       * Wraps Array#push with proper change tracking.
-       * @returns new length of the array
-       */
-      push(...args: any[]): number;
-
-      /** Sets the casted val at index i and marks the array modified. */
-      set(i: number, val: any): this;
-
-      /**
-       * Wraps Array#shift with proper change tracking.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      shift(): T;
-
-      /**
-       * Wraps Array#sort with proper change tracking.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      // some lib.d.ts have return type "this" and others have return type "T[]"
-      // which causes errors. Let the inherited array provide the sort() method.
-      //sort(compareFn?: (a: T, b: T) => number): T[];
-
-      /**
-       * Wraps Array#splice with proper change tracking and casting.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      splice(...args: any[]): T[];
-
-      /** Returns a native js Array. */
-      toObject(options?: any): T[];
-
-      /**
-       * Wraps Array#unshift with proper change tracking.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      unshift(...args: any[]): number;
+        /**
+         * Get the next document from this cursor. Will return null when there are
+         * no documents left.
+         */
+        next(callback?: (err: any, doc?: T) => void): Promise<any>;
     }
 
     /*
-      * section types/documentarray.js
-      * http://mongoosejs.com/docs/api.html#types-documentarray-js
-      */
-    class DocumentArray<T extends MongooseDocument> extends Types.Array<T> {
-      /**
-       * Creates a subdocument casted to this schema.
-       * This is the same subdocument constructor used for casting.
-       * @param obj the value to cast to this arrays SubDocument schema
-       */
-      create(obj: any): T;
+     * section virtualtype.js
+     * http://mongoosejs.com/docs/api.html#virtualtype-js
+     */
+    class VirtualType {
+        /** This is what mongoose uses to define virtual attributes via Schema.prototype.virtual. */
+        constructor(options: any, name: string);
+        /** Applies getters to value using optional scope. */
+        applyGetters(value: any, scope: any): any;
+        /** Applies setters to value using optional scope. */
+        applySetters(value: any, scope: any): any;
+        /** Defines a getter. */
+        get(fn: Function): this;
+        /** Defines a setter. */
+        set(fn: Function): this;
+    }
 
-      /**
-       * Searches array items for the first document with a matching _id.
-       * @returns the subdocument or null if not found.
-       */
-      id(id: ObjectId | string | number | NativeBuffer): T;
-
-      /** Helper for console.log */
-      inspect(): T[];
-
-      /**
-       * Returns a native js Array of plain js objects
-       * @param options optional options to pass to each documents toObject
-       *   method call during conversion
-       */
-      toObject(options?: any): T[];
+    interface HookOptions {
+        document?: boolean;
+        query?: boolean;
     }
 
     /*
-     * section types/buffer.js
-     * http://mongoosejs.com/docs/api.html#types-buffer-js
+     * section schema.js
+     * http://mongoosejs.com/docs/api.html#schema-js
      */
-    class Buffer extends global.Buffer {
-      /**
-       * Copies the buffer.
-       * Buffer#copy does not mark target as modified so you must copy
-       * from a MongooseBuffer for it to work as expected. This is a
-       * work around since copy modifies the target, not this.
-       */
-      copy(target: NativeBuffer, ...nodeBufferArgs: any[]): number;
+    class Schema<T = any> extends events.EventEmitter {
+        /**
+         * Schema constructor.
+         * When nesting schemas, (children in the example above), always declare
+         * the child schema first before passing it into its parent.
+         * @event init Emitted after the schema is compiled into a Model.
+         */
+        constructor(definition?: SchemaDefinition, options?: SchemaOptions);
 
-      /** Determines if this buffer is equals to other buffer */
-      equals(other: NativeBuffer): boolean;
+        /** Adds key path / schema type pairs to this schema. */
+        add(obj: SchemaDefinition, prefix?: string): void;
 
-      /** Sets the subtype option and marks the buffer modified. */
-      subtype(subtype: number): void;
+        /** Return a deep copy of this schema */
+        clone(): Schema;
 
-      /** Converts this buffer to its Binary type representation. */
-      toObject(subtype?: number): mongodb.Binary;
+        /**
+         * Iterates the schemas paths similar to Array.forEach.
+         * @param fn callback function
+         * @returns this
+         */
+        eachPath(fn: (path: string, type: SchemaType) => void): this;
 
-      /** Writes the buffer. */
-      write(string: string, ...nodeBufferArgs: any[]): number;
+        /**
+         * Gets a schema option.
+         * @param key option name
+         */
+        get(key: string): any;
+
+        /**
+         * Defines an index (most likely compound) for this schema.
+         * @param options Options to pass to MongoDB driver's createIndex() function
+         * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
+         *   expires option into seconds for the expireAfterSeconds in the above link.
+         */
+        index(
+            fields: any,
+            options?: {
+                expires?: string;
+                [other: string]: any;
+            },
+        ): this;
+
+        /** Compiles indexes from fields and schema-level indexes */
+        indexes(): any[];
+
+        /**
+         * Loads an ES6 class into a schema. Maps setters + getters, static methods, and
+         * instance methods to schema virtuals, statics, and methods.
+         */
+        loadClass(model: Function): this;
+
+        /**
+         * Adds an instance method to documents constructed from Models compiled from this schema.
+         * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
+         */
+        method<F extends keyof T>(method: F, fn: T[F]): this;
+        method(
+            methodObj: {
+                [F in keyof T]: T[F];
+            },
+        ): this;
+
+        /**
+         * Gets/sets schema paths.
+         * Sets a path (if arity 2)
+         * Gets a path (if arity 1)
+         */
+        path(path: string): SchemaType;
+        path(path: string, constructor: any): this;
+
+        /**
+         * Returns the pathType of path for this schema.
+         * @returns whether it is a real, virtual, nested, or ad-hoc/undefined path.
+         */
+        pathType(path: string): string;
+
+        /**
+         * Registers a plugin for this schema.
+         * @param plugin callback
+         */
+        plugin(plugin: (schema: Schema) => void): this;
+        plugin<T>(plugin: (schema: Schema, options: T) => void, opts: T): this;
+
+        /**
+         * Defines a post hook for the document
+         * Post hooks fire on the event emitted from document instances of Models compiled
+         *   from this schema.
+         * @param method name of the method to hook
+         * @param fn callback
+         */
+        post<T extends Document>(
+            method: "insertMany",
+            fn: (
+                this: Model<Document>,
+                error: mongodb.MongoError,
+                docs: T[],
+                next: (err?: NativeError) => void,
+            ) => void,
+        ): this;
+
+        post<T extends Document>(
+            method: "insertMany",
+            fn: (this: Model<Document>, docs: T[], next: (err?: NativeError) => void) => void,
+        ): this;
+
+        post<T extends Document>(
+            method: "insertMany",
+            fn: (this: Model<Document>, docs: T[], next: (err?: NativeError) => Promise<any>) => void,
+        ): this;
+
+        post<T extends Document>(
+            method: "remove" | "deleteOne",
+            { document, query }: HookOptions,
+            fn: (doc: T) => void,
+        ): this;
+
+        post<T extends Document>(
+            method: string | RegExp,
+            fn: (doc: T, next: (err?: NativeError) => void) => void,
+        ): this;
+
+        post<T extends Document>(
+            method: string | RegExp,
+            fn: (docs: T[], next: (err?: NativeError) => void) => void,
+        ): this;
+
+        post<T extends Document>(
+            method: string | RegExp,
+            fn: (docs: T[], next: (err?: NativeError) => void) => Promise<void>,
+        ): this;
+
+        post<T extends Document>(
+            method: string | RegExp,
+            fn: (error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void) => void,
+        ): this;
+
+        /**
+         * Defines a pre hook for the document.
+         */
+        pre<T extends Document = Document>(
+            method: "init" | "validate" | "save" | "remove",
+            fn: HookSyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Query<any> = Query<any>>(
+            method:
+                | "count"
+                | "find"
+                | "findOne"
+                | "findOneAndRemove"
+                | "findOneAndUpdate"
+                | "update"
+                | "updateOne"
+                | "updateMany",
+            fn: HookSyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Aggregate<any> = Aggregate<any>>(
+            method: "aggregate",
+            fn: HookSyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Model<Document> = Model<Document>>(
+            method: "insertMany",
+            fn: HookSyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Document | Model<Document> | Query<any> | Aggregate<any>>(
+            method: string | RegExp,
+            fn: HookSyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+
+        pre<T extends Document = Document>(
+            method: "init" | "validate" | "save" | "remove",
+            parallel: boolean,
+            fn: HookAsyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Query<any> = Query<any>>(
+            method:
+                | "count"
+                | "find"
+                | "findOne"
+                | "findOneAndRemove"
+                | "findOneAndUpdate"
+                | "update"
+                | "updateOne"
+                | "updateMany",
+            parallel: boolean,
+            fn: HookAsyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Aggregate<any> = Aggregate<any>>(
+            method: "aggregate",
+            parallel: boolean,
+            fn: HookAsyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Model<Document> = Model<Document>>(
+            method: "insertMany",
+            parallel: boolean,
+            fn: HookAsyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+        pre<T extends Document | Model<Document> | Query<any> | Aggregate<any>>(
+            method: string | RegExp,
+            parallel: boolean,
+            fn: HookAsyncCallback<T>,
+            errorCb?: HookErrorCallback,
+        ): this;
+
+        /**
+         * Adds a method call to the queue.
+         * @param name name of the document method to call later
+         * @param args arguments to pass to the method
+         */
+        queue(name: string, args: any[]): this;
+
+        /**
+         * Removes the given path (or [paths]).
+         */
+        remove(path: string | string[]): void;
+
+        /**
+         * @param invalidate refresh the cache
+         * @returns an Array of path strings that are required by this schema.
+         */
+        requiredPaths(invalidate?: boolean): string[];
+
+        /**
+         * Lists all paths and their type in the current schema.
+         */
+        paths: {
+            [key: string]: SchemaType;
+        };
+
+        /**
+         * Sets/gets a schema option.
+         * @param key option name
+         * @param value if not passed, the current option value is returned
+         */
+        set<T extends keyof SchemaOptions>(key: T): SchemaOptions[T];
+        set<T extends keyof SchemaOptions>(key: T, value: SchemaOptions[T]): this;
+
+        /**
+         * Adds static "class" methods to Models compiled from this schema.
+         */
+        static(name: string, fn: Function): this;
+        static(nameObj: { [name: string]: Function }): this;
+
+        /** Creates a virtual type with the given name. */
+        virtual(name: string, options?: any): VirtualType;
+
+        /** Returns the virtual type with the given name. */
+        virtualpath(name: string): VirtualType;
+
+        /** The allowed index types */
+        static indexTypes: string[];
+
+        /**
+         * Reserved document keys.
+         * Keys in this object are names that are rejected in schema declarations
+         * b/c they conflict with mongoose functionality. Using these key name
+         * will throw an error.
+         */
+        static reserved: any;
+
+        /** Object of currently defined methods on this schema. */
+        methods: {
+            [F in keyof T]: T[F];
+        };
+        /** Object of currently defined statics on this schema. */
+        statics: any;
+        /** Object of currently defined query helpers on this schema. */
+        query: any;
+        /** The original object passed to the schema constructor */
+        obj: any;
+    }
+
+    // Hook functions: https://github.com/vkarpov15/hooks-fixed
+    interface HookSyncCallback<T> {
+        (this: T, next: HookNextFunction, docs: any[]): Promise<any> | void;
+    }
+
+    interface HookAsyncCallback<T> {
+        (this: T, next: HookNextFunction, done: HookDoneFunction, docs: any[]): Promise<any> | void;
+    }
+
+    interface HookErrorCallback {
+        (error?: Error): any;
+    }
+
+    interface HookNextFunction {
+        (error?: Error): any;
+    }
+
+    interface HookDoneFunction {
+        (error?: Error): any;
+    }
+
+    interface SchemaOptions {
+        /** defaults to false (which means use the connection's autoIndex option) */
+        autoIndex?: boolean;
+        /**
+         * When false, use the connection's autoCreate option
+         * @default false
+         */
+        autoCreate?: boolean;
+        /** defaults to true */
+        bufferCommands?: boolean;
+        /** defaults to false */
+        capped?: boolean | number | { size?: number; max?: number; autoIndexId?: boolean };
+        /** Sets a default collation for every query and aggregation. */
+        collation?: CollationOptions;
+        /** no default */
+        collection?: string;
+        /** defaults to "__t" */
+        discriminatorKey?: string;
+        /** defaults to false. */
+        emitIndexErrors?: boolean;
+        excludeIndexes?: any;
+        /** defaults to true */
+        id?: boolean;
+        /** defaults to true */
+        _id?: boolean;
+        /** controls document#toObject behavior when called manually - defaults to true */
+        minimize?: boolean;
+        /** When true, mongoose will throw a Version Error if a document has changed before saving - defaults to false */
+        optimisticConcurrency?: boolean;
+        read?: string;
+        writeConcern?: WriteConcern;
+        /** defaults to true. */
+        safe?: boolean | { w?: number | string; wtimeout?: number; j?: boolean };
+
+        /** defaults to null */
+        shardKey?: object;
+        /** no default */
+        strictQuery?: boolean;
+        /** defaults to true */
+        strict?: boolean | "throw";
+        /** no default */
+        toJSON?: DocumentToObjectOptions;
+        /** no default */
+        toObject?: DocumentToObjectOptions;
+        /** defaults to 'type' */
+        typeKey?: string;
+        /** defaults to false */
+        useNestedStrict?: boolean;
+        /** defaults to false */
+        usePushEach?: boolean;
+        /** defaults to true */
+        validateBeforeSave?: boolean;
+        /** defaults to "__v" */
+        versionKey?: string | boolean;
+        /**
+         * By default, Mongoose will automatically
+         * select() any populated paths.
+         * To opt out, set selectPopulatedPaths to false.
+         */
+        selectPopulatedPaths?: boolean;
+        /**
+         * skipVersioning allows excluding paths from
+         * versioning (the internal revision will not be
+         * incremented even if these paths are updated).
+         */
+        skipVersioning?: any;
+        /**
+         * Validation errors in a single nested schema are reported
+         * both on the child and on the parent schema.
+         * Set storeSubdocValidationError to false on the child schema
+         * to make Mongoose only report the parent error.
+         */
+        storeSubdocValidationError?: boolean;
+        /**
+         * If set timestamps, mongoose assigns createdAt
+         * and updatedAt fields to your schema, the type
+         * assigned is Date.
+         */
+        timestamps?: boolean | SchemaTimestampsConfig;
+        /**
+         * Determines whether a type set to a POJO becomes
+         * a Mixed path or a Subdocument (defaults to true).
+         */
+        typePojoToMixed?: boolean;
+    }
+
+    interface SchemaTimestampsConfig {
+        createdAt?: boolean | string;
+        updatedAt?: boolean | string;
+        currentTime?: () => Date | number;
     }
 
     /*
-      * section types/objectid.js
-      * http://mongoosejs.com/docs/api.html#types-objectid-js
-      */
-    var ObjectId: ObjectIdConstructor;
-
-    // mongodb.ObjectID does not allow mongoose.Types.ObjectId(id). This is
-    //   commonly used in mongoose and is found in an example in the docs:
-    //   http://mongoosejs.com/docs/api.html#aggregate_Aggregate
-    // constructor exposes static methods of mongodb.ObjectID and ObjectId(id)
-    type ObjectIdConstructor = typeof mongodb.ObjectID & {
-      (s?: string | number): mongodb.ObjectID;
-    };
-
-    // var objectId: mongoose.Types.ObjectId should reference mongodb.ObjectID not
-    //   the ObjectIdConstructor, so we add the interface below
-    interface ObjectId extends mongodb.ObjectID { }
-
-    class Decimal128 extends mongodb.Decimal128 { }
+     * Intellisense for Schema definitions
+     */
+    interface SchemaDefinition {
+        [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
+    }
 
     /*
-      * section types/embedded.js
-      * http://mongoosejs.com/docs/api.html#types-embedded-js
-      */
-    class Embedded extends MongooseDocument {
-      /** Helper for console.log */
-      inspect(): any;
+     * The standard options available when configuring a schema type:
+     * new Schema({
+     *   name: {
+     *     type: String,
+     *     required: true,
+     *     ...
+     *   }
+     * });
+     *
+     * Note: the properties have Object as a fallback type: | Object
+     *   because this interface does not apply to a schematype that
+     *   does not have a type property. Ex:
+     * new Schema({
+     *   name: {
+     *     first: String,    // since name does not have a "type" property
+     *     last: String      //   first and last can have any valid type
+     *     ...
+     *   }
+     * });
+     *
+     * References:
+     * - http://mongoosejs.com/docs/schematypes.html
+     * - http://mongoosejs.com/docs/api.html#schema_Schema.Types
+     */
+    interface SchemaTypeOpts<T> {
+        alias?: string;
 
-      /**
-       * Marks a path as invalid, causing validation to fail.
-       * @param path the field to invalidate
-       * @param err error which states the reason path was invalid
-       */
-      invalidate(path: string, err: string | NativeError): boolean;
+        /* Common Options for all schema types */
+        type?: T;
 
-      /** Returns the top level document of this sub-document. */
-      ownerDocument(): MongooseDocument;
-      /** Returns this sub-documents parent document. */
-      parent(): MongooseDocument;
-      /** Returns this sub-documents parent array. */
-      parentArray(): DocumentArray<MongooseDocument>;
+        /** Sets a default value for this SchemaType. */
+        default?: SchemaTypeOpts.DefaultFn<T> | T;
 
-      /** Removes the subdocument from its parent array. */
-      remove(options?: {
-        noop?: boolean;
-      }, fn?: (err: any) => void): this;
+        /**
+         * Getters allow you to transform the representation of the data as it travels
+         * from the raw mongodb document to the value that you see.
+         */
+        get?: (value: T, schematype?: this) => T | any;
 
-      /**
-       * Marks the embedded doc modified.
-       * @param path the path which changed
-       */
-      markModified(path: string): void;
+        /** Declares the index options for this schematype. */
+        index?: SchemaTypeOpts.IndexOpts | boolean | string;
+
+        /**
+         * Adds a required validator to this SchemaType. The validator gets added
+         * to the front of this SchemaType's validators array using unshift().
+         */
+        required?: SchemaTypeOpts.RequiredFn<T> | boolean | [boolean, string] | string | [string, string] | any;
+
+        /**
+         * Sets default select() behavior for this path.
+         * Set to true if this path should always be included in the results, false
+         * if it should be excluded by default. This setting can be overridden at
+         * the query level.
+         */
+        select?: boolean | any;
+
+        /**
+         * Setters allow you to transform the data before it gets to the raw mongodb
+         * document and is set as a value on an actual key.
+         */
+        set?: (value: T, schematype?: this) => T | any;
+
+        /** Declares a sparse index. */
+        sparse?: boolean | any;
+
+        /** Declares a full text index. */
+        text?: boolean | any;
+
+        /**
+         * Adds validator(s) for this document path.
+         * Validators always receive the value to validate as their first argument
+         * and must return Boolean. Returning false means validation failed.
+         */
+        validate?:
+            | RegExp
+            | [RegExp, string]
+            | SchemaTypeOpts.ValidateFn<T>
+            | [SchemaTypeOpts.ValidateFn<T>, string]
+            | SchemaTypeOpts.ValidateOpts
+            | SchemaTypeOpts.AsyncValidateOpts
+            | SchemaTypeOpts.AsyncPromiseValidationFn<T>
+            | [SchemaTypeOpts.AsyncPromiseValidationFn<T>, string]
+            | SchemaTypeOpts.AsyncPromiseValidationOpts
+            | (
+                  | SchemaTypeOpts.ValidateOpts
+                  | SchemaTypeOpts.AsyncValidateOpts
+                  | SchemaTypeOpts.AsyncPromiseValidationFn<T>
+                  | SchemaTypeOpts.AsyncPromiseValidationOpts
+              )[];
+
+        /** Declares an unique index. */
+        unique?: boolean | any;
+
+        /* Options for specific schema types (String, Number, Date, etc.) */
+        /** String only - Adds an enum validator */
+        enum?: T[] | SchemaTypeOpts.EnumOpts<T> | any;
+        /** String only - Adds a lowercase setter. */
+        lowercase?: boolean | any;
+        /** String only - Sets a regexp validator. */
+        match?: RegExp | [RegExp, string] | any;
+        /** String only - Sets a maximum length validator. */
+        maxlength?: number | [number, string] | any;
+        /** String only - Sets a minimum length validator. */
+        minlength?: number | [number, string] | any;
+        /** String only - Adds a trim setter. */
+        trim?: boolean | any;
+        /** String only - Adds an uppercase setter. */
+        uppercase?: boolean | any;
+
+        /**
+         * Date, Number only - Sets a minimum number validator.
+         * Sets a minimum date validator.
+         */
+        min?: number | [number, string] | Date | [Date, string] | any;
+
+        /**
+         * Date, Number only - Sets a maximum number validator.
+         * Sets a maximum date validator.
+         */
+        max?: number | [number, string] | Date | [Date, string] | any;
+
+        /**
+         * Date only - Declares a TTL index (rounded to the nearest second)
+         * for Date types only.
+         */
+        expires?: number | string | any;
+
+        /** ObjectId only - Adds an auto-generated ObjectId default if turnOn is true. */
+        auto?: boolean | any;
+
+        /** Map only - Specifies the type of the map's attributes */
+        of?: any;
+
+        [other: string]: any;
     }
 
-    /**
-     * section types/map.js
-     * https://mongoosejs.com/docs/schematypes.html#maps
-     */
-    class Map<V> extends global.Map<string, V> {
-      /** Returns this Map object as a POJO. */
-      toObject(options: { flattenMaps: true } & object): Record<string, V>;
-      /** Returns a native js Map. */
-      toObject(options?: any): GlobalMap<string, V>;
+    // Interfaces specific to schema type options should be scoped in this namespace
+    namespace SchemaTypeOpts {
+        interface DefaultFn<T> {
+            (...args: any[]): T;
+        }
+
+        interface RequiredFn<T> {
+            (required: boolean, message?: string): T;
+        }
+
+        interface ValidateFn<T> {
+            (value: T): boolean;
+        }
+
+        interface AsyncValidateFn<T> {
+            (value: T, done: (result: boolean) => void): void;
+        }
+
+        interface ValidatorProps {
+            path: string;
+            value: any;
+        }
+
+        interface ValidatorMessageFn {
+            (props: ValidatorProps): string;
+        }
+
+        interface ValidateOptsBase {
+            msg?: string;
+            message?: string | ValidatorMessageFn;
+            type?: string;
+        }
+
+        interface ValidateOpts extends ValidateOptsBase {
+            /** deprecated */
+            isAsync?: false;
+            validator?: RegExp | ValidateFn<any>;
+        }
+
+        interface AsyncValidateOpts extends ValidateOptsBase {
+            /** deprecated */
+            isAsync: true;
+            validator: AsyncValidateFn<any>;
+        }
+
+        interface AsyncPromiseValidationFn<T> {
+            (value: T): Promise<boolean>;
+        }
+
+        interface AsyncPromiseValidationOpts extends ValidateOptsBase {
+            validator: AsyncPromiseValidationFn<any>;
+        }
+
+        interface EnumOpts<T> {
+            values?: T[];
+            message?: string;
+        }
+
+        interface IndexOpts {
+            background?: boolean;
+            expires?: number | string;
+            sparse?: boolean;
+            type?: string;
+            unique?: boolean;
+        }
     }
-  }
 
-  // Because the mongoose Map type shares a name with the default global interface,
-  // this type alias has to exist outside of the namespace
-  interface GlobalMap<K, V> extends Map<K, V> {}
-
-  /*
-   * section query.js
-   * http://mongoosejs.com/docs/api.html#query-js
-   *
-   * Query<T> is for backwards compatibility. Example: Query<T>.find() returns Query<T[]>.
-   * If later in the query chain a method returns Query<T>, we will need to know type T.
-   * So we save this type as the second type parameter in DocumentQuery. Since people have
-   * been using Query<T>, we set it as an alias of DocumentQuery.
-   *
-   * Furthermore, Query<T> is used for function that has an option { rawResult: true }.
-   * for instance findOneAndUpdate.
-   */
-  class Query<T> extends DocumentQuery<T, any> { }
-  class DocumentQuery<T, DocType extends Document, QueryHelpers = {}> extends mquery {
-    [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
-
-    /**
-     * Specifies a javascript function or expression to pass to MongoDBs query system.
-     * Only use $where when you have a condition that cannot be met using other MongoDB
-     * operators like $lt. Be sure to read about all of its caveats before using.
-     * @param js javascript string or function
+    /*
+     * section document.js
+     * http://mongoosejs.com/docs/api.html#document-js
      */
-    $where(js: string | Function): this;
+    interface MongooseDocument extends MongooseDocumentOptionals {}
+    class MongooseDocument {
+        /** Checks if a path is set to its default. */
+        $isDefault(path?: string): boolean;
 
-    /**
-     * Specifies an $all query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    all(val: number): this;
-    all(path: string, val: number): this;
-    all(val: any[]): this;
-    all(path: string, val: any[]): this;
+        /** Getter/setter around the session associated with this document. */
+        $session(session?: ClientSession): ClientSession;
 
-    /**
-     * Specifies arguments for a $and condition.
-     * @param array array of conditions
-     */
-    and(array: any[]): this;
+        /**
+         * Takes a populated field and returns it to its unpopulated state.
+         * If the path was not populated, this is a no-op.
+         */
+        depopulate(path?: string): this;
 
-    /** Specifies the batchSize option. Cannot be used with distinct() */
-    batchSize(val: number): this;
+        /**
+         * Returns true if the Document stores the same data as doc.
+         * Documents are considered equal when they have matching _ids, unless neither document
+         * has an _id, in which case this function falls back to usin deepEqual().
+         * @param doc a document to compare
+         */
+        equals(doc: MongooseDocument): boolean;
 
-    /** Get the current error flag value */
-    error(): Error | null;
-    /** Unset the error flag set on this query */
-    error(unset: null): this;
-    /**
-     * Set the error flag on this query
-     * @param err The error flag
-     */
-    error(err: Error): this;
+        /**
+         * Explicitly executes population and returns a promise.
+         * Useful for ES2015 integration.
+         * @returns promise that resolves to the document when population is done
+         */
+        execPopulate(): Promise<this>;
 
-    /**
-     * Specifies a $box condition
-     * @param Upper Right Coords
-     */
-    box(val: any): this;
-    box(lower: number[], upper: number[]): this;
+        /** Checks if path was explicitly selected. If no projection, always returns true. */
+        isDirectSelected(path: string): boolean;
 
-    /** Casts this query to the schema of model, If obj is present, it is cast instead of this query.*/
-    cast(model: any, obj?: any): any;
+        /**
+         * Returns the value of a path.
+         * @param type optionally specify a type for on-the-fly attributes
+         * @param options
+         * @param options.virtuals apply virtuals before getting this path
+         * @param options.getters if false, skip applying getters and just get the raw value
+         */
+        get(
+            path: string,
+            type?: any,
+            options?: {
+                virtuals?: boolean;
+                getters?: boolean;
+            },
+        ): any;
 
-    /**
-     * Executes the query returning a Promise which will be
-     * resolved with either the doc(s) or rejected with the error.
-     * Like .then(), but only takes a rejection handler.
-     */
-    catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
+        /**
+         * Initializes the document without setters or marking anything modified.
+         * Called internally after a document is returned from mongodb.
+         * @param doc document returned by mongo
+         * @param opts Options
+         */
+        init(doc: MongooseDocument, opts?: any): this;
 
-    /**
-     * DEPRECATED Alias for circle
-     * Specifies a $center or $centerSphere condition.
-     * @deprecated Use circle instead.
-     */
-    center(area: any): this;
-    center(path: string, area: any): this;
-    /**
-     * DEPRECATED Specifies a $centerSphere condition
-     * @deprecated Use circle instead.
-     */
-    centerSphere(path: string, val: any): this;
-    centerSphere(val: any): this;
+        /** Helper for console.log */
+        inspect(options?: any): any;
 
-    /** Specifies a $center or $centerSphere condition. */
-    circle(area: any): this;
-    circle(path: string, area: any): this;
+        /**
+         * Marks a path as invalid, causing validation to fail.
+         * The errorMsg argument will become the message of the ValidationError.
+         * The value argument (if passed) will be available through the ValidationError.value property.
+         * @param path the field to invalidate
+         * @param errorMsg the error which states the reason path was invalid
+         * @param value optional invalid value
+         * @param kind optional kind property for the error
+         * @returns the current ValidationError, with all currently invalidated paths
+         */
+        invalidate(
+            path: string,
+            errorMsg: string | NativeError,
+            value?: any,
+            kind?: string,
+        ): Error.ValidationError | boolean;
 
-    /** Adds a collation to this op (MongoDB 3.4 and up) */
-    collation(value: CollationOptions): this;
+        /** Returns true if path was directly set and modified, else false. */
+        isDirectModified(path: string): boolean;
 
-    /** Specifies the comment option. Cannot be used with distinct() */
-    comment(val: string): this;
+        /** Checks if path was initialized */
+        isInit(path: string): boolean;
 
-    /**
-     * Specifying this query as a count query. Passing a callback executes the query.
-     * @param criteria mongodb selector
-     */
-    count(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-    count(criteria: FilterQuery<DocType>, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+        /**
+         * Returns true if this document was modified, else false.
+         * If path is given, checks if a path or any full path containing path as part of its path
+         * chain has been modified.
+         */
+        isModified(path?: string): boolean;
 
-    /**
-     * Specifies this query as a `countDocuments()` query. Behaves like `count()`,
-     * except it always does a full collection scan when passed an empty filter `{}`.
+        /** Checks if path was selected in the source query which initialized this document. */
+        isSelected(path: string): boolean;
+
+        /**
+         * Marks the path as having pending changes to write to the db.
+         * Very helpful when using Mixed types.
+         * @param path the path to mark modified
+         */
+        markModified(path: string): void;
+
+        /** Returns the list of paths that have been modified. */
+        modifiedPaths(): string[];
+
+        /**
+         * Populates document references, executing the callback when complete.
+         * If you want to use promises instead, use this function with
+         * execPopulate()
+         * Population does not occur unless a callback is passed or you explicitly
+         * call execPopulate(). Passing the same path a second time will overwrite
+         * the previous path options. See Model.populate() for explaination of options.
+         * @param path The path to populate or an options object
+         * @param names The properties to fetch from the populated document
+         * @param callback When passed, population is invoked
+         */
+        populate(callback: (err: any, res: this) => void): this;
+        populate(path: string, callback?: (err: any, res: this) => void): this;
+        populate(path: string, names: string, callback?: (err: any, res: this) => void): this;
+        populate(
+            options: ModelPopulateOptions | ModelPopulateOptions[],
+            callback?: (err: any, res: this) => void,
+        ): this;
+
+        /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */
+        populated(path: string): any;
+
+        /**
+         * Sets the value of a path, or many paths.
+         * @param path path or object of key/vals to set
+         * @param val the value to set
+         * @param type optionally specify a type for "on-the-fly" attributes
+         * @param options optionally specify options that modify the behavior of the set
+         */
+        set(path: string, val: any, options?: any): this;
+        set(path: string, val: any, type: any, options?: any): this;
+        set(value: any): this;
+
+        /**
+         * Overwrite all values, except for immutable properties.
+         * @param obj the object to overwrite this document with
+         */
+        overwrite(obj: any): this;
+
+        /**
+         * The return value of this method is used in calls to JSON.stringify(doc).
+         * This method accepts the same options as Document#toObject. To apply the
+         * options to every document of your schema by default, set your schemas
+         * toJSON option to the same argument.
+         */
+        toJSON(options?: DocumentToObjectOptions): any;
+
+        /**
+         * Converts this document into a plain javascript object, ready for storage in MongoDB.
+         * Buffers are converted to instances of mongodb.Binary for proper storage.
+         */
+        toObject(options?: DocumentToObjectOptions): any;
+
+        /** Helper for console.log */
+        toString(): string;
+
+        /**
+         * Clears the modified state on the specified path.
+         * @param path the path to unmark modified
+         */
+        unmarkModified(path: string): void;
+
+        /** Sends an replaceOne command with this document _id as the query selector.  */
+        replaceOne(replacement: any, callback?: (err: any, raw: any) => void): Query<any>;
+
+        /** Sends an update command with this document _id as the query selector.  */
+        update(doc: any, callback?: (err: any, raw: any) => void): Query<any>;
+        update(doc: any, options: ModelUpdateOptions, callback?: (err: any, raw: any) => void): Query<any>;
+
+        /** Sends an updateOne command with this document _id as the query selector.  */
+        updateOne(doc: any, callback?: (err: any, raw: any) => void): Query<any>;
+        updateOne(doc: any, options: ModelUpdateOptions, callback?: (err: any, raw: any) => void): Query<any>;
+
+        /**
+         * Executes registered validation rules for this document.
+         * @param optional options internal options
+         * @param callback callback called after validation completes, passing an error if one occurred
+         */
+        validate(callback?: (err: any) => void): Promise<void>;
+        validate(optional: any, callback?: (err: any) => void): Promise<void>;
+
+        /**
+         * Executes registered validation rules (skipping asynchronous validators) for this document.
+         * This method is useful if you need synchronous validation.
+         * @param pathsToValidate only validate the given paths
+         * @returns ValidationError if there are errors during validation, or undefined if there is no error.
+         */
+        validateSync(pathsToValidate?: string | string[]): Error.ValidationError | undefined;
+
+        /** Hash containing current validation errors. */
+        errors: any;
+        /** This documents _id. */
+        _id: any;
+        /** Boolean flag specifying if the document is new. */
+        isNew: boolean;
+        /** The documents schema. */
+        schema: Schema;
+        /** Empty object that you can use for storing properties on the document */
+        $locals: { [k: string]: any };
+    }
+
+    interface MongooseDocumentOptionals {
+        /**
+         * Virtual getter that by default returns the document's _id field cast to a string,
+         * or in the case of ObjectIds, its hexString. This id getter may be disabled by
+         * passing the option { id: false } at schema construction time. If disabled, id
+         * behaves like any other field on a document and can be assigned any value.
+         */
+        id?: any;
+    }
+
+    interface DocumentToObjectOptions {
+        /** apply all getters (path and virtual getters) */
+        getters?: boolean;
+        /** apply virtual getters (can override getters option) */
+        virtuals?: boolean;
+        /** remove empty objects (defaults to true) */
+        minimize?: boolean;
+        /**
+         * A transform function to apply to the resulting document before returning
+         * @param doc The mongoose document which is being converted
+         * @param ret The plain object representation which has been converted
+         * @param options The options in use (either schema options or the options passed inline)
+         */
+        transform?: (doc: any, ret: any, options: any) => any;
+        /** depopulate any populated paths, replacing them with their original refs (defaults to false) */
+        depopulate?: boolean;
+        /** whether to include the version key (defaults to true) */
+        versionKey?: boolean;
+        /** whether to convert Maps to POJOs. (defaults to false) */
+        flattenMaps?: boolean;
+    }
+
+    namespace Types {
+        /*
+         * section types/subdocument.js
+         * http://mongoosejs.com/docs/api.html#types-subdocument-js
+         */
+        class Subdocument extends MongooseDocument {
+            /** Returns the top level document of this sub-document. */
+            ownerDocument(): MongooseDocument;
+
+            /**
+             * Null-out this subdoc
+             * @param callback optional callback for compatibility with Document.prototype.remove
+             */
+            remove(callback?: (err: any) => void): void;
+            remove(options: any, callback?: (err: any) => void): void;
+        }
+
+        /*
+         * section types/array.js
+         * http://mongoosejs.com/docs/api.html#types-array-js
+         */
+        class Array<T> extends global.Array<T> {
+            /**
+             * Atomically shifts the array at most one time per document save().
+             * Calling this mulitple times on an array before saving sends the same command as
+             * calling it once. This update is implemented using the MongoDB $pop method which
+             * enforces this restriction.
+             */
+            $shift(): T;
+
+            /** Alias of pull */
+            remove(...args: any[]): this;
+
+            /**
+             * Pops the array atomically at most one time per document save().
+             * Calling this mulitple times on an array before saving sends the same command as
+             * calling it once. This update is implemented using the MongoDB $pop method which
+             * enforces this restriction.
+             */
+            $pop(): T;
+
+            /**
+             * Adds values to the array if not already present.
+             * @returns the values that were added
+             */
+            addToSet(...args: any[]): T[];
+
+            /**
+             * Return the index of obj or -1 if not found.
+             * @param obj the item to look for
+             */
+            indexOf(obj: any): number;
+
+            /** Helper for console.log */
+            inspect(): any;
+
+            /**
+             * Marks the entire array as modified, which if saved, will store it as a $set
+             * operation, potentially overwritting any changes that happen between when you
+             * retrieved the object and when you save it.
+             * @returns new length of the array
+             */
+            nonAtomicPush(...args: any[]): number;
+
+            /**
+             * Wraps Array#pop with proper change tracking.
+             * marks the entire array as modified which will pass the entire thing to $set
+             * potentially overwritting any changes that happen between when you retrieved
+             * the object and when you save it.
+             */
+            pop(): T;
+
+            /**
+             * Pulls items from the array atomically. Equality is determined by casting
+             * the provided value to an embedded document and comparing using
+             * the Document.equals() function.
+             */
+            pull(...args: any[]): this;
+
+            /**
+             * Wraps Array#push with proper change tracking.
+             * @returns new length of the array
+             */
+            push(...args: any[]): number;
+
+            /** Sets the casted val at index i and marks the array modified. */
+            set(i: number, val: any): this;
+
+            /**
+             * Wraps Array#shift with proper change tracking.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            shift(): T;
+
+            /**
+             * Wraps Array#sort with proper change tracking.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            // some lib.d.ts have return type "this" and others have return type "T[]"
+            // which causes errors. Let the inherited array provide the sort() method.
+            //sort(compareFn?: (a: T, b: T) => number): T[];
+
+            /**
+             * Wraps Array#splice with proper change tracking and casting.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            splice(...args: any[]): T[];
+
+            /** Returns a native js Array. */
+            toObject(options?: any): T[];
+
+            /**
+             * Wraps Array#unshift with proper change tracking.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            unshift(...args: any[]): number;
+        }
+
+        /*
+         * section types/documentarray.js
+         * http://mongoosejs.com/docs/api.html#types-documentarray-js
+         */
+        class DocumentArray<T extends MongooseDocument> extends Types.Array<T> {
+            /**
+             * Creates a subdocument casted to this schema.
+             * This is the same subdocument constructor used for casting.
+             * @param obj the value to cast to this arrays SubDocument schema
+             */
+            create(obj: any): T;
+
+            /**
+             * Searches array items for the first document with a matching _id.
+             * @returns the subdocument or null if not found.
+             */
+            id(id: ObjectId | string | number | NativeBuffer): T;
+
+            /** Helper for console.log */
+            inspect(): T[];
+
+            /**
+             * Returns a native js Array of plain js objects
+             * @param options optional options to pass to each documents toObject
+             *   method call during conversion
+             */
+            toObject(options?: any): T[];
+        }
+
+        /*
+         * section types/buffer.js
+         * http://mongoosejs.com/docs/api.html#types-buffer-js
+         */
+        class Buffer extends global.Buffer {
+            /**
+             * Copies the buffer.
+             * Buffer#copy does not mark target as modified so you must copy
+             * from a MongooseBuffer for it to work as expected. This is a
+             * work around since copy modifies the target, not this.
+             */
+            copy(target: NativeBuffer, ...nodeBufferArgs: any[]): number;
+
+            /** Determines if this buffer is equals to other buffer */
+            equals(other: NativeBuffer): boolean;
+
+            /** Sets the subtype option and marks the buffer modified. */
+            subtype(subtype: number): void;
+
+            /** Converts this buffer to its Binary type representation. */
+            toObject(subtype?: number): mongodb.Binary;
+
+            /** Writes the buffer. */
+            write(string: string, ...nodeBufferArgs: any[]): number;
+        }
+
+        /*
+         * section types/objectid.js
+         * http://mongoosejs.com/docs/api.html#types-objectid-js
+         */
+        var ObjectId: ObjectIdConstructor;
+
+        // mongodb.ObjectID does not allow mongoose.Types.ObjectId(id). This is
+        //   commonly used in mongoose and is found in an example in the docs:
+        //   http://mongoosejs.com/docs/api.html#aggregate_Aggregate
+        // constructor exposes static methods of mongodb.ObjectID and ObjectId(id)
+        type ObjectIdConstructor = typeof mongodb.ObjectID & {
+            (s?: string | number): mongodb.ObjectID;
+        };
+
+        // var objectId: mongoose.Types.ObjectId should reference mongodb.ObjectID not
+        //   the ObjectIdConstructor, so we add the interface below
+        interface ObjectId extends mongodb.ObjectID {}
+
+        class Decimal128 extends mongodb.Decimal128 {}
+
+        /*
+         * section types/embedded.js
+         * http://mongoosejs.com/docs/api.html#types-embedded-js
+         */
+        class Embedded extends MongooseDocument {
+            /** Helper for console.log */
+            inspect(): any;
+
+            /**
+             * Marks a path as invalid, causing validation to fail.
+             * @param path the field to invalidate
+             * @param err error which states the reason path was invalid
+             */
+            invalidate(path: string, err: string | NativeError): boolean;
+
+            /** Returns the top level document of this sub-document. */
+            ownerDocument(): MongooseDocument;
+            /** Returns this sub-documents parent document. */
+            parent(): MongooseDocument;
+            /** Returns this sub-documents parent array. */
+            parentArray(): DocumentArray<MongooseDocument>;
+
+            /** Removes the subdocument from its parent array. */
+            remove(
+                options?: {
+                    noop?: boolean;
+                },
+                fn?: (err: any) => void,
+            ): this;
+
+            /**
+             * Marks the embedded doc modified.
+             * @param path the path which changed
+             */
+            markModified(path: string): void;
+        }
+
+        /**
+         * section types/map.js
+         * https://mongoosejs.com/docs/schematypes.html#maps
+         */
+        class Map<V> extends global.Map<string, V> {
+            /** Returns this Map object as a POJO. */
+            toObject(options: { flattenMaps: true } & object): Record<string, V>;
+            /** Returns a native js Map. */
+            toObject(options?: any): GlobalMap<string, V>;
+        }
+    }
+
+    // Because the mongoose Map type shares a name with the default global interface,
+    // this type alias has to exist outside of the namespace
+    interface GlobalMap<K, V> extends Map<K, V> {}
+
+    /*
+     * section query.js
+     * http://mongoosejs.com/docs/api.html#query-js
      *
-     * There are also minor differences in how `countDocuments()` handles
-     * [`$where` and a couple geospatial operators](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
-     * versus `count()`.
+     * Query<T> is for backwards compatibility. Example: Query<T>.find() returns Query<T[]>.
+     * If later in the query chain a method returns Query<T>, we will need to know type T.
+     * So we save this type as the second type parameter in DocumentQuery. Since people have
+     * been using Query<T>, we set it as an alias of DocumentQuery.
      *
-     * Passing a `callback` executes the query.
-     *
-     * This function triggers the following middleware.
-     *
-     * - `countDocuments()`
-     *
-     *
-     * @param {Object} [criteria] mongodb selector
-     * @param {Function} [callback] optional params are (error, count)
-     * @return {Query} this
-    */
-    countDocuments(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-    countDocuments(criteria: FilterQuery<DocType>, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-
-    /**
-     * Estimates the number of documents in the MongoDB collection. Faster than
-     * using `countDocuments()` for large collections because
-     * `estimatedDocumentCount()` uses collection metadata rather than scanning
-     * the entire collection.
-     *
-     * @param {Object} [options] passed transparently to the [MongoDB driver](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount)
-     * @param {Function} [callback] optional params are (error, count)
-     * @return {Query} this
+     * Furthermore, Query<T> is used for function that has an option { rawResult: true }.
+     * for instance findOneAndUpdate.
      */
-    estimatedDocumentCount(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-    estimatedDocumentCount(options: any, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-
-    /**
-     * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
-     * Streams3-compatible interface, as well as a .next() function.
-     */
-    cursor(options?: any): QueryCursor<DocType>;
-
-    /** Declares or executes a distict() operation. Passing a callback executes the query. */
-    distinct(callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
-    distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
-    distinct(field: string, criteria: any | Query<any>,
-      callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
-
-    /** Specifies an $elemMatch condition */
-    elemMatch(criteria: (elem: Query<any>) => void): this;
-    elemMatch(criteria: any): this;
-    elemMatch(path: string | any | Function, criteria: (elem: Query<any>) => void): this;
-    elemMatch(path: string | any | Function, criteria: any): this;
-
-    /** Specifies the complementary comparison value for paths specified with where() */
-    equals<T>(val: T): this;
-
-    /** Executes the query */
-    exec(callback?: (err: NativeError, res: T) => void): Promise<T>;
-    exec(operation: string | Function, callback?: (err: any, res: T) => void): Promise<T>;
-
-    /** Specifies an $exists condition */
-    exists(val?: boolean): this;
-    exists(path: string, val?: boolean): this;
-
-    /**
-     * Finds documents. When no callback is passed, the query is not executed. When the
-     * query is executed, the result will be an array of documents.
-     * @param criteria mongodb selector
-     */
-    find(callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType, QueryHelpers> & QueryHelpers;
-    find(criteria: FilterQuery<DocType>,
-      callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Declares the query a findOne operation. When executed, the first found document is
-     * passed to the callback. Passing a callback executes the query. The result of the query
-     * is a single document.
-     * @param criteria mongodb selector
-     * @param projection optional fields to return
-     */
-    findOne(callback?: (err: any, res: DocType | null) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOne(criteria: FilterQuery<DocType>,
-      callback?: (err: any, res: DocType | null) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOne(criteria: FilterQuery<DocType>, projection: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOne(criteria: FilterQuery<DocType>, projection: any, options: { lean: true } & Omit<QueryFindBaseOptions, 'lean'>,
-      callback?: (err: any, res: T | null) => void): Query<DocumentDefinition<DocType>> & QueryHelpers;
-    findOne(criteria: FilterQuery<DocType>, projection: any, options: QueryFindBaseOptions,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issues a mongodb findAndModify remove command.
-     * Finds a matching document, removes it, passing the found document (if any) to the
-     * callback. Executes immediately if callback is passed.
-     *
-     * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
-     * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
-     */
-    findOneAndRemove(callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOneAndRemove(conditions: FilterQuery<DocType>,
-      callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOneAndRemove(conditions: FilterQuery<DocType>, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
-      callback?: (error: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, result: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
-    findOneAndRemove(conditions: FilterQuery<DocType>, options: QueryFindOneAndRemoveOptions,
-      callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issues a mongodb findAndModify update command.
-     * Finds a matching document, updates it according to the update arg, passing any options, and returns
-     * the found document (if any) to the callback. The query executes immediately if callback is passed.
-     *
-     * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
-     * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
-     */
-    findOneAndUpdate(callback?: (err: any, doc: DocType | null) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(update: UpdateQuery<DocType>,
-      callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(query: FilterQuery<DocType>, update: UpdateQuery<DocType>,
-      callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(query: FilterQuery<DocType>, update: UpdateQuery<DocType>,
-      options: { rawResult: true } & { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType>> & QueryHelpers;
-    findOneAndUpdate(query: FilterQuery<DocType>, update: UpdateQuery<DocType>,
-      options: { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: DocType, res: any) => void): DocumentQuery<DocType, DocType, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(query: FilterQuery<DocType>, update: UpdateQuery<DocType>, options: { rawResult: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
-    findOneAndUpdate(query: FilterQuery<DocType>, update: UpdateQuery<DocType>,
-      options: { lean: true } & Omit<QueryFindOneAndUpdateOptions, 'lean'>,
-      callback?: (err: any, doc: DocumentDefinition<DocType>, res: any) => void)
-        : Query<DocumentDefinition<DocType>> & QueryHelpers;
-    findOneAndUpdate(query: FilterQuery<DocType>, update: UpdateQuery<DocType>, options: QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Specifies a $geometry condition. geometry() must come after either intersects() or within().
-     * @param object Must contain a type property which is a String and a coordinates property which
-     *   is an Array. See the examples.
-     */
-    geometry(object: { type: string, coordinates: any[] }): this;
-
-    /**
-     * Returns the current query options as a JSON object.
-     * @returns current query options
-     */
-    getOptions(): any;
-
-    /**
-     * Returns the current query conditions as a JSON object.
-     * @returns current query conditions
-     * @deprecated You should use getFilter() instead of getQuery() where possible. getQuery() will likely be deprecated in a future release.
-     */
-    getQuery(): any;
-
-    /**
-     * Returns the current query filter (also known as conditions) as a POJO.
-     * @returns current query filter
-     */
-    getFilter(): any;
-
-    /**
-     * Returns the current update operations as a JSON object.
-     * @returns current update operations
-     */
-    getUpdate(): any;
-
-    /**
-     * Specifies a $gt query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    gt<T>(val: T): this;
-    gt<T>(path: string, val: T): this;
-
-    /**
-     * Specifies a $gte query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    gte<T>(val: T): this;
-    gte<T>(path: string, val: T): this;
-
-    /**
-     * Sets query hints.
-     * @param val a hint object
-     */
-    hint(val: any): this;
-
-    /**
-     * Specifies an $in query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    in(val: any[]): this;
-    in(path: string, val: any[]): this;
-
-    /** Declares an intersects query for geometry(). MUST be used after where(). */
-    intersects(arg?: any): this;
-
-    /**
-     * Sets the lean option.
-     * Documents returned from queries with the lean option enabled are plain
-     * javascript objects, not MongooseDocuments. They have no save method,
-     * getters/setters or other Mongoose magic applied.
-     * @param {Boolean|Object} bool defaults to true
-     */
-    lean<P = DocumentDefinition<DocType>>(bool?: boolean | object): Query<T extends Array<any> ? P[] : (P | null)> & QueryHelpers;
-
-    /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
-    limit(val: number): this;
-
-    /**
-     * Specifies a $lt query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    lt<T>(val: T): this;
-    lt<T>(path: string, val: T): this;
-
-    /**
-     * Specifies a $lte query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    lte<T>(val: T): this;
-    lte<T>(path: string, val: T): this;
-
-    /**
-     * Runs a function fn and treats the return value of fn as the new value for the query to resolve to.
-     * Any functions you pass to map() will run after any post hooks.
-     */
-    map<TRes>(fn: (res: T) => TRes): DocumentQuery<TRes, DocType, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Specifies a $maxDistance query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    maxDistance(val: number): this;
-    maxDistance(path: string, val: number): this;
-
-    /** @deprecated Alias of maxScan */
-    maxscan(val: number): this;
-    /** Specifies the maxScan option. Cannot be used with distinct() */
-    maxScan(val: number): this;
-
-    /** Specifies the maxTimeMS options. */
-    maxTimeMS(val: number): this;
-
-    /**
-     * Merges another Query or conditions object into this one.
-     * When a Query is passed, conditions, field selection and options are merged.
-     */
-    merge(source: any | Query<any>): this;
-
-    /** Specifies a $mod condition */
-    mod(val: number[]): this;
-    mod(path: string, val: number[]): this;
-
-    /**
-     * Specifies a $ne query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    ne(val: any): this;
-    ne(path: string, val: any): this;
-
-    /** Specifies a $near or $nearSphere condition. */
-    near(val: any): this;
-    near(path: string, val: any): this;
-
-    /**
-     * DEPRECATED Specifies a $nearSphere condition
-     * @deprecated Use query.near() instead with the spherical option set to true.
-     */
-    nearSphere(val: any): this;
-    nearSphere(path: string, val: any): this;
-
-    /**
-     * Specifies a $nin query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    nin(val: any[]): this;
-    nin(path: string, val: any[]): this;
-
-    /**
-     * Specifies arguments for a $nor condition.
-     * @param array array of conditions
-     */
-    nor(array: any[]): this;
-
-    /**
-     * Specifies arguments for an $or condition.
-     * @param array array of conditions
-     */
-    or(array: any[]): this;
-
-    /**
-     * Make this query throw an error if no documents match the given `filter`.
-     * This is handy for integrating with async/await, because `orFail()` saves you
-     * an extra `if` statement to check if no document was found.
-     *
-     * Example:
-     *
-     *     // Throws if no doc returned
-     *     await Model.findOne({ foo: 'bar' }).orFail();
-     *
-     *     // Throws if no document was updated
-     *     await Model.updateOne({ foo: 'bar' }, { name: 'test' }).orFail();
-     *
-     *     // Throws "No docs found!" error if no docs match `{ foo: 'bar' }`
-     *     await Model.find({ foo: 'bar' }).orFail(new Error('No docs found!'));
-     *
-     *     // Throws "Not found" error if no document was found
-     *     await Model.findOneAndUpdate({ foo: 'bar' }, { name: 'test' }).
-     *       orFail(() => Error('Not found'));
-     *
-     * @param err optional error to throw if no docs match `filter`
-     */
-    orFail(err?: Error | (() => Error)): DocumentQuery<NonNullable<T>, DocType, QueryHelpers>;
-
-    /** Specifies a $polygon condition */
-    polygon(...coordinatePairs: number[][]): this;
-    polygon(path: string, ...coordinatePairs: number[][]): this;
-
-    /**
-     * Specifies paths which should be populated with other documents.
-     * Paths are populated after the query executes and a response is received. A separate
-     * query is then executed for each path specified for population. After a response for
-     * each query has also been returned, the results are passed to the callback.
-     * @param path either the path to populate or an object specifying all parameters
-     * @param select Field selection for the population query
-     * @param model The model you wish to use for population. If not specified, populate
-     *   will look up the model by the name in the Schema's ref field.
-     * @param match Conditions for the population query
-     * @param options Options for the population query (sort, etc)
-     */
-    populate(path: string | any, select?: string | any, model?: any,
-      match?: any, options?: any): this;
-    populate(options: QueryPopulateOptions | QueryPopulateOptions[]): this;
-
-    /**
-     * Determines the MongoDB nodes from which to read.
-     * @param pref one of the listed preference options or aliases
-     * @param tags optional tags for this query
-     */
-    read(pref: string, tags?: any[]): this;
-
-    /**
-     * Sets the readConcern option for the query.
-     * @param level one of the listed read concern level or their aliases
-     */
-    readConcern(level: string): this;
-
-    /**
-     * Specifies a $regex query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    regex(val: RegExp): this;
-    regex(path: string, val: RegExp): this;
-
-    /**
-     * Declare and/or execute this query as a remove() operation.
-     * The operation is only executed when a callback is passed. To force execution without a callback,
-     * you must first call remove() and then execute it by using the exec() method.
-     * @param criteria mongodb selector
-     */
-    remove(callback?: (err: any) => void): Query<mongodb.WriteOpResult['result']> & QueryHelpers;
-    remove(criteria: FilterQuery<DocType> | Query<any>, callback?: (err: any) => void): Query<mongodb.WriteOpResult['result']> & QueryHelpers;
-
-    /** Specifies which document fields to include or exclude (also known as the query "projection") */
-    select(arg: string | any): this;
-    /** Determines if field selection has been made. */
-    selected(): boolean;
-    /** Determines if exclusive field selection has been made.*/
-    selectedExclusively(): boolean;
-    /** Determines if inclusive field selection has been made. */
-    selectedInclusively(): boolean;
-    /** Sets query options. */
-    setOptions(options: any): this;
-    /** Sets query conditions to the provided JSON object. */
-    setQuery(conditions: any): this;
-
-    /**
-     * Sets the [MongoDB session](https://docs.mongodb.com/manual/reference/server-sessions/)
-     * associated with this query. Sessions are how you mark a query as part of a
-     * [transaction](/docs/transactions.html).
-     */
-    session(session: mongodb.ClientSession | null): this;
-
-    /**
-     * Specifies a $size query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    size(val: number): this;
-    size(path: string, val: number): this;
-
-    /** Specifies the number of documents to skip. Cannot be used with distinct() */
-    skip(val: number): this;
-
-    /**
-     * DEPRECATED Sets the slaveOk option.
-     * @param v defaults to true
-     * @deprecated in MongoDB 2.2 in favor of read preferences.
-     */
-    slaveOk(v?: boolean): this;
-
-    /**
-     * Specifies a $slice projection for an array.
-     * @param val number/range of elements to slice
-     */
-    slice(val: number | number[]): this;
-    slice(path: string, val: number | number[]): this;
-
-    /** Specifies this query as a snapshot query. Cannot be used with distinct() */
-    snapshot(v?: boolean): this;
-
-    /**
-     * Sets the sort order
-     * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
-     * If a string is passed, it must be a space delimited list of path names. The
-     * sort order of each path is ascending unless the path name is prefixed with -
-     * which will be treated as descending.
-     */
-    sort(arg: string | any): this;
-
-    /**
-     * Sets the tailable option (for use with capped collections). Cannot be used with distinct()
-     * @param bool defaults to true
-     * @param opts options to set
-     * @param opts.numberOfRetries if cursor is exhausted, retry this many times before giving up
-     * @param opts.tailableRetryInterval if cursor is exhausted, wait this many milliseconds before retrying
-     */
-    tailable(bool?: boolean, opts?: {
-      numberOfRetries?: number;
-      tailableRetryInterval?: number;
-    }): this;
-
-    /** Executes this query and returns a promise */
-    then: Promise<T>["then"];
-
-    /**
-     * Converts this query to a customized, reusable query
-     * constructor with all arguments and options retained.
-     */
-    toConstructor<T>(): new (...args: any[]) => Query<T> & QueryHelpers;
-    toConstructor<T, Doc extends Document>(): new (...args: any[]) => DocumentQuery<T, Doc, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Declare and/or execute this query as an update() operation.
-     * All paths passed that are not $atomic operations will become $set ops.
-     * @param doc the update command
-     */
-    update(callback?: (err: any, affectedRows: number) => void): Query<number> & QueryHelpers;
-    update(doc: UpdateQuery<DocType>, callback?: (err: any, affectedRows: number) => void): Query<number> & QueryHelpers;
-    update(criteria: FilterQuery<DocType>, doc: UpdateQuery<DocType>,
-      callback?: (err: any, affectedRows: number) => void): Query<number> & QueryHelpers;
-    update(criteria: FilterQuery<DocType>, doc: UpdateQuery<DocType>, options: QueryUpdateOptions,
-      callback?: (err: any, affectedRows: number) => void): Query<number> & QueryHelpers;
-
-    /** Specifies a path for use with chaining. */
-    where(path?: string | any, val?: any): this;
-
-    /** Defines a $within or $geoWithin argument for geo-spatial queries. */
-    within(val?: any): this;
-    within(coordinate: number[], ...coordinatePairs: number[][]): this;
-
-    wtimeout(ms?: number): this;
-
-    /** Flag to opt out of using $geoWithin. */
-    static use$geoWithin: boolean;
-  }
-
-  // https://github.com/aheckmann/mquery
-  // mquery currently does not have a type definition please
-  //   replace it if one is ever created
-  class mquery { }
-
-  // https://mongoosejs.com/docs/api.html#query_Query-setOptions
-  interface QueryFindBaseOptions {
-    /** Sets a default collation for every query and aggregation. */
-    collation?: CollationOptions;
-    explain?: any;
-    lean?: boolean;
-    populate?: string | ModelPopulateOptions;
-    /** like select, it determines which fields to return */
-    projection?: any;
-    /** use client session for transaction */
-    session?: ClientSession;
-  }
-
-  interface QueryFindOptions extends QueryFindBaseOptions {
-    batchSize?: number;
-    comment?: any;
-    hint?: any;
-    limit?: number;
-    maxscan?: number;
-    readPreference?: mongodb.ReadPreferenceMode;
-    skip?: number;
-    snapshot?: any;
-    sort?: any;
-    tailable?: any;
-  }
-
-  interface QueryFindOneAndRemoveOptions {
-    /**
-      * if multiple docs are found by the conditions, sets the sort order to choose
-      * which doc to update
-      */
-    sort?: any;
-    /** puts a time limit on the query - requires mongodb >= 2.6.0 */
-    maxTimeMS?: number;
-    /** sets the document fields to return */
-    select?: any;
-    /** like select, it determines which fields to return */
-    projection?: any;
-    /** if true, returns the raw result from the MongoDB driver */
-    rawResult?: boolean;
-    /** overwrites the schema's strict mode option for this update */
-    strict?: boolean | "throw";
-    /** use client session for transaction */
-    session?: ClientSession;
-  }
-
-  interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
-    /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
-    new?: boolean;
-    /** creates the object if it doesn't exist. defaults to false. */
-    upsert?: boolean;
-    /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */
-    runValidators?: boolean;
-    /**
-     * if this and upsert are true, mongoose will apply the defaults specified in the model's schema if a new document
-     * is created. This option only works on MongoDB >= 2.4 because it relies on MongoDB's $setOnInsert operator.
-     */
-    setDefaultsOnInsert?: boolean;
-    /**
-     * if set to 'query' and runValidators is on, this will refer to the query in custom validator
-     * functions that update validation runs. Does nothing if runValidators is false.
-     */
-    context?: string;
-    /**
-     *  by default, mongoose only returns the first error that occurred in casting the query.
-     *  Turn on this option to aggregate all the cast errors.
-     */
-    multipleCastError?: boolean;
-    /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
-    fields?: any | string;
-    /**
-     * Only update elements that match the arrayFilters conditions in the document or documents that match the query conditions.
-    */
-    arrayFilters?: { [key: string]: any }[];
-    /**
-     * if truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document. See Query.lean() and the Mongoose lean tutorial.
-     */
-    lean?: any;
-    /** If true, delete any properties whose value is undefined when casting an update. In other words,
+    class Query<T> extends DocumentQuery<T, any> {}
+    class DocumentQuery<T, DocType extends Document, QueryHelpers = {}> extends mquery {
+        [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
+
+        /**
+         * Specifies a javascript function or expression to pass to MongoDBs query system.
+         * Only use $where when you have a condition that cannot be met using other MongoDB
+         * operators like $lt. Be sure to read about all of its caveats before using.
+         * @param js javascript string or function
+         */
+        $where(js: string | Function): this;
+
+        /**
+         * Specifies an $all query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        all(val: number): this;
+        all(path: string, val: number): this;
+        all(val: any[]): this;
+        all(path: string, val: any[]): this;
+
+        /**
+         * Specifies arguments for a $and condition.
+         * @param array array of conditions
+         */
+        and(array: any[]): this;
+
+        /** Specifies the batchSize option. Cannot be used with distinct() */
+        batchSize(val: number): this;
+
+        /** Get the current error flag value */
+        error(): Error | null;
+        /** Unset the error flag set on this query */
+        error(unset: null): this;
+        /**
+         * Set the error flag on this query
+         * @param err The error flag
+         */
+        error(err: Error): this;
+
+        /**
+         * Specifies a $box condition
+         * @param Upper Right Coords
+         */
+        box(val: any): this;
+        box(lower: number[], upper: number[]): this;
+
+        /** Casts this query to the schema of model, If obj is present, it is cast instead of this query.*/
+        cast(model: any, obj?: any): any;
+
+        /**
+         * Executes the query returning a Promise which will be
+         * resolved with either the doc(s) or rejected with the error.
+         * Like .then(), but only takes a rejection handler.
+         */
+        catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
+
+        /**
+         * DEPRECATED Alias for circle
+         * Specifies a $center or $centerSphere condition.
+         * @deprecated Use circle instead.
+         */
+        center(area: any): this;
+        center(path: string, area: any): this;
+        /**
+         * DEPRECATED Specifies a $centerSphere condition
+         * @deprecated Use circle instead.
+         */
+        centerSphere(path: string, val: any): this;
+        centerSphere(val: any): this;
+
+        /** Specifies a $center or $centerSphere condition. */
+        circle(area: any): this;
+        circle(path: string, area: any): this;
+
+        /** Adds a collation to this op (MongoDB 3.4 and up) */
+        collation(value: CollationOptions): this;
+
+        /** Specifies the comment option. Cannot be used with distinct() */
+        comment(val: string): this;
+
+        /**
+         * Specifying this query as a count query. Passing a callback executes the query.
+         * @param criteria mongodb selector
+         */
+        count(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+        count(
+            criteria: FilterQuery<DocType>,
+            callback?: (err: any, count: number) => void,
+        ): Query<number> & QueryHelpers;
+
+        /**
+         * Specifies this query as a `countDocuments()` query. Behaves like `count()`,
+         * except it always does a full collection scan when passed an empty filter `{}`.
+         *
+         * There are also minor differences in how `countDocuments()` handles
+         * [`$where` and a couple geospatial operators](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
+         * versus `count()`.
+         *
+         * Passing a `callback` executes the query.
+         *
+         * This function triggers the following middleware.
+         *
+         * - `countDocuments()`
+         *
+         *
+         * @param {Object} [criteria] mongodb selector
+         * @param {Function} [callback] optional params are (error, count)
+         * @return {Query} this
+         */
+        countDocuments(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+        countDocuments(
+            criteria: FilterQuery<DocType>,
+            callback?: (err: any, count: number) => void,
+        ): Query<number> & QueryHelpers;
+
+        /**
+         * Estimates the number of documents in the MongoDB collection. Faster than
+         * using `countDocuments()` for large collections because
+         * `estimatedDocumentCount()` uses collection metadata rather than scanning
+         * the entire collection.
+         *
+         * @param {Object} [options] passed transparently to the [MongoDB driver](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount)
+         * @param {Function} [callback] optional params are (error, count)
+         * @return {Query} this
+         */
+        estimatedDocumentCount(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+        estimatedDocumentCount(
+            options: any,
+            callback?: (err: any, count: number) => void,
+        ): Query<number> & QueryHelpers;
+
+        /**
+         * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
+         * Streams3-compatible interface, as well as a .next() function.
+         */
+        cursor(options?: any): QueryCursor<DocType>;
+
+        /** Declares or executes a distict() operation. Passing a callback executes the query. */
+        distinct(callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
+        distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
+        distinct(
+            field: string,
+            criteria: any | Query<any>,
+            callback?: (err: any, res: any[]) => void,
+        ): Query<any[]> & QueryHelpers;
+
+        /** Specifies an $elemMatch condition */
+        elemMatch(criteria: (elem: Query<any>) => void): this;
+        elemMatch(criteria: any): this;
+        elemMatch(path: string | any | Function, criteria: (elem: Query<any>) => void): this;
+        elemMatch(path: string | any | Function, criteria: any): this;
+
+        /** Specifies the complementary comparison value for paths specified with where() */
+        equals<T>(val: T): this;
+
+        /** Executes the query */
+        exec(callback?: (err: NativeError, res: T) => void): Promise<T>;
+        exec(operation: string | Function, callback?: (err: any, res: T) => void): Promise<T>;
+
+        /** Specifies an $exists condition */
+        exists(val?: boolean): this;
+        exists(path: string, val?: boolean): this;
+
+        /**
+         * Finds documents. When no callback is passed, the query is not executed. When the
+         * query is executed, the result will be an array of documents.
+         * @param criteria mongodb selector
+         */
+        find(
+            callback?: (err: any, res: DocType[]) => void,
+        ): DocumentQuery<DocType[], DocType, QueryHelpers> & QueryHelpers;
+        find(
+            criteria: FilterQuery<DocType>,
+            callback?: (err: any, res: DocType[]) => void,
+        ): DocumentQuery<DocType[], DocType, QueryHelpers> & QueryHelpers;
+
+        /**
+         * Declares the query a findOne operation. When executed, the first found document is
+         * passed to the callback. Passing a callback executes the query. The result of the query
+         * is a single document.
+         * @param criteria mongodb selector
+         * @param projection optional fields to return
+         */
+        findOne(
+            callback?: (err: any, res: DocType | null) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOne(
+            criteria: FilterQuery<DocType>,
+            callback?: (err: any, res: DocType | null) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOne(
+            criteria: FilterQuery<DocType>,
+            projection: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOne(
+            criteria: FilterQuery<DocType>,
+            projection: any,
+            options: { lean: true } & Omit<QueryFindBaseOptions, "lean">,
+            callback?: (err: any, res: T | null) => void,
+        ): Query<DocumentDefinition<DocType>> & QueryHelpers;
+        findOne(
+            criteria: FilterQuery<DocType>,
+            projection: any,
+            options: QueryFindBaseOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+
+        /**
+         * Issues a mongodb findAndModify remove command.
+         * Finds a matching document, removes it, passing the found document (if any) to the
+         * callback. Executes immediately if callback is passed.
+         *
+         * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
+         * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
+         */
+        findOneAndRemove(
+            callback?: (error: any, doc: DocType | null, result: any) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOneAndRemove(
+            conditions: FilterQuery<DocType>,
+            callback?: (error: any, doc: DocType | null, result: any) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOneAndRemove(
+            conditions: FilterQuery<DocType>,
+            options: { rawResult: true } & QueryFindOneAndRemoveOptions,
+            callback?: (error: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, result: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
+        findOneAndRemove(
+            conditions: FilterQuery<DocType>,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (error: any, doc: DocType | null, result: any) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+
+        /**
+         * Issues a mongodb findAndModify update command.
+         * Finds a matching document, updates it according to the update arg, passing any options, and returns
+         * the found document (if any) to the callback. The query executes immediately if callback is passed.
+         *
+         * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
+         * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
+         */
+        findOneAndUpdate(
+            callback?: (err: any, doc: DocType | null) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            update: UpdateQuery<DocType>,
+            callback?: (err: any, doc: DocType | null, res: any) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            query: FilterQuery<DocType>,
+            update: UpdateQuery<DocType>,
+            callback?: (err: any, doc: DocType | null, res: any) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            query: FilterQuery<DocType>,
+            update: UpdateQuery<DocType>,
+            options: { rawResult: true } & { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType>, res: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<DocType>> & QueryHelpers;
+        findOneAndUpdate(
+            query: FilterQuery<DocType>,
+            update: UpdateQuery<DocType>,
+            options: { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: DocType, res: any) => void,
+        ): DocumentQuery<DocType, DocType, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            query: FilterQuery<DocType>,
+            update: UpdateQuery<DocType>,
+            options: { rawResult: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, res: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
+        findOneAndUpdate(
+            query: FilterQuery<DocType>,
+            update: UpdateQuery<DocType>,
+            options: { lean: true } & Omit<QueryFindOneAndUpdateOptions, "lean">,
+            callback?: (err: any, doc: DocumentDefinition<DocType>, res: any) => void,
+        ): Query<DocumentDefinition<DocType>> & QueryHelpers;
+        findOneAndUpdate(
+            query: FilterQuery<DocType>,
+            update: UpdateQuery<DocType>,
+            options: QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: DocType | null, res: any) => void,
+        ): DocumentQuery<DocType | null, DocType, QueryHelpers> & QueryHelpers;
+
+        /**
+         * Specifies a $geometry condition. geometry() must come after either intersects() or within().
+         * @param object Must contain a type property which is a String and a coordinates property which
+         *   is an Array. See the examples.
+         */
+        geometry(object: { type: string; coordinates: any[] }): this;
+
+        /**
+         * Returns the current query options as a JSON object.
+         * @returns current query options
+         */
+        getOptions(): any;
+
+        /**
+         * Returns the current query conditions as a JSON object.
+         * @returns current query conditions
+         * @deprecated You should use getFilter() instead of getQuery() where possible. getQuery() will likely be deprecated in a future release.
+         */
+        getQuery(): any;
+
+        /**
+         * Returns the current query filter (also known as conditions) as a POJO.
+         * @returns current query filter
+         */
+        getFilter(): any;
+
+        /**
+         * Returns the current update operations as a JSON object.
+         * @returns current update operations
+         */
+        getUpdate(): any;
+
+        /**
+         * Specifies a $gt query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        gt<T>(val: T): this;
+        gt<T>(path: string, val: T): this;
+
+        /**
+         * Specifies a $gte query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        gte<T>(val: T): this;
+        gte<T>(path: string, val: T): this;
+
+        /**
+         * Sets query hints.
+         * @param val a hint object
+         */
+        hint(val: any): this;
+
+        /**
+         * Specifies an $in query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        in(val: any[]): this;
+        in(path: string, val: any[]): this;
+
+        /** Declares an intersects query for geometry(). MUST be used after where(). */
+        intersects(arg?: any): this;
+
+        /**
+         * Sets the lean option.
+         * Documents returned from queries with the lean option enabled are plain
+         * javascript objects, not MongooseDocuments. They have no save method,
+         * getters/setters or other Mongoose magic applied.
+         * @param {Boolean|Object} bool defaults to true
+         */
+        lean<P = DocumentDefinition<DocType>>(
+            bool?: boolean | object,
+        ): Query<T extends Array<any> ? P[] : P | null> & QueryHelpers;
+
+        /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
+        limit(val: number): this;
+
+        /**
+         * Specifies a $lt query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        lt<T>(val: T): this;
+        lt<T>(path: string, val: T): this;
+
+        /**
+         * Specifies a $lte query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        lte<T>(val: T): this;
+        lte<T>(path: string, val: T): this;
+
+        /**
+         * Runs a function fn and treats the return value of fn as the new value for the query to resolve to.
+         * Any functions you pass to map() will run after any post hooks.
+         */
+        map<TRes>(fn: (res: T) => TRes): DocumentQuery<TRes, DocType, QueryHelpers> & QueryHelpers;
+
+        /**
+         * Specifies a $maxDistance query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        maxDistance(val: number): this;
+        maxDistance(path: string, val: number): this;
+
+        /** @deprecated Alias of maxScan */
+        maxscan(val: number): this;
+        /** Specifies the maxScan option. Cannot be used with distinct() */
+        maxScan(val: number): this;
+
+        /** Specifies the maxTimeMS options. */
+        maxTimeMS(val: number): this;
+
+        /**
+         * Merges another Query or conditions object into this one.
+         * When a Query is passed, conditions, field selection and options are merged.
+         */
+        merge(source: any | Query<any>): this;
+
+        /** Specifies a $mod condition */
+        mod(val: number[]): this;
+        mod(path: string, val: number[]): this;
+
+        /**
+         * Specifies a $ne query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        ne(val: any): this;
+        ne(path: string, val: any): this;
+
+        /** Specifies a $near or $nearSphere condition. */
+        near(val: any): this;
+        near(path: string, val: any): this;
+
+        /**
+         * DEPRECATED Specifies a $nearSphere condition
+         * @deprecated Use query.near() instead with the spherical option set to true.
+         */
+        nearSphere(val: any): this;
+        nearSphere(path: string, val: any): this;
+
+        /**
+         * Specifies a $nin query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        nin(val: any[]): this;
+        nin(path: string, val: any[]): this;
+
+        /**
+         * Specifies arguments for a $nor condition.
+         * @param array array of conditions
+         */
+        nor(array: any[]): this;
+
+        /**
+         * Specifies arguments for an $or condition.
+         * @param array array of conditions
+         */
+        or(array: any[]): this;
+
+        /**
+         * Make this query throw an error if no documents match the given `filter`.
+         * This is handy for integrating with async/await, because `orFail()` saves you
+         * an extra `if` statement to check if no document was found.
+         *
+         * Example:
+         *
+         *     // Throws if no doc returned
+         *     await Model.findOne({ foo: 'bar' }).orFail();
+         *
+         *     // Throws if no document was updated
+         *     await Model.updateOne({ foo: 'bar' }, { name: 'test' }).orFail();
+         *
+         *     // Throws "No docs found!" error if no docs match `{ foo: 'bar' }`
+         *     await Model.find({ foo: 'bar' }).orFail(new Error('No docs found!'));
+         *
+         *     // Throws "Not found" error if no document was found
+         *     await Model.findOneAndUpdate({ foo: 'bar' }, { name: 'test' }).
+         *       orFail(() => Error('Not found'));
+         *
+         * @param err optional error to throw if no docs match `filter`
+         */
+        orFail(err?: Error | (() => Error)): DocumentQuery<NonNullable<T>, DocType, QueryHelpers>;
+
+        /** Specifies a $polygon condition */
+        polygon(...coordinatePairs: number[][]): this;
+        polygon(path: string, ...coordinatePairs: number[][]): this;
+
+        /**
+         * Specifies paths which should be populated with other documents.
+         * Paths are populated after the query executes and a response is received. A separate
+         * query is then executed for each path specified for population. After a response for
+         * each query has also been returned, the results are passed to the callback.
+         * @param path either the path to populate or an object specifying all parameters
+         * @param select Field selection for the population query
+         * @param model The model you wish to use for population. If not specified, populate
+         *   will look up the model by the name in the Schema's ref field.
+         * @param match Conditions for the population query
+         * @param options Options for the population query (sort, etc)
+         */
+        populate(path: string | any, select?: string | any, model?: any, match?: any, options?: any): this;
+        populate(options: QueryPopulateOptions | QueryPopulateOptions[]): this;
+
+        /**
+         * Determines the MongoDB nodes from which to read.
+         * @param pref one of the listed preference options or aliases
+         * @param tags optional tags for this query
+         */
+        read(pref: string, tags?: any[]): this;
+
+        /**
+         * Sets the readConcern option for the query.
+         * @param level one of the listed read concern level or their aliases
+         */
+        readConcern(level: string): this;
+
+        /**
+         * Specifies a $regex query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        regex(val: RegExp): this;
+        regex(path: string, val: RegExp): this;
+
+        /**
+         * Declare and/or execute this query as a remove() operation.
+         * The operation is only executed when a callback is passed. To force execution without a callback,
+         * you must first call remove() and then execute it by using the exec() method.
+         * @param criteria mongodb selector
+         */
+        remove(callback?: (err: any) => void): Query<mongodb.WriteOpResult["result"]> & QueryHelpers;
+        remove(
+            criteria: FilterQuery<DocType> | Query<any>,
+            callback?: (err: any) => void,
+        ): Query<mongodb.WriteOpResult["result"]> & QueryHelpers;
+
+        /** Specifies which document fields to include or exclude (also known as the query "projection") */
+        select(arg: string | any): this;
+        /** Determines if field selection has been made. */
+        selected(): boolean;
+        /** Determines if exclusive field selection has been made.*/
+        selectedExclusively(): boolean;
+        /** Determines if inclusive field selection has been made. */
+        selectedInclusively(): boolean;
+        /** Sets query options. */
+        setOptions(options: any): this;
+        /** Sets query conditions to the provided JSON object. */
+        setQuery(conditions: any): this;
+
+        /**
+         * Sets the [MongoDB session](https://docs.mongodb.com/manual/reference/server-sessions/)
+         * associated with this query. Sessions are how you mark a query as part of a
+         * [transaction](/docs/transactions.html).
+         */
+        session(session: mongodb.ClientSession | null): this;
+
+        /**
+         * Specifies a $size query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        size(val: number): this;
+        size(path: string, val: number): this;
+
+        /** Specifies the number of documents to skip. Cannot be used with distinct() */
+        skip(val: number): this;
+
+        /**
+         * DEPRECATED Sets the slaveOk option.
+         * @param v defaults to true
+         * @deprecated in MongoDB 2.2 in favor of read preferences.
+         */
+        slaveOk(v?: boolean): this;
+
+        /**
+         * Specifies a $slice projection for an array.
+         * @param val number/range of elements to slice
+         */
+        slice(val: number | number[]): this;
+        slice(path: string, val: number | number[]): this;
+
+        /** Specifies this query as a snapshot query. Cannot be used with distinct() */
+        snapshot(v?: boolean): this;
+
+        /**
+         * Sets the sort order
+         * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
+         * If a string is passed, it must be a space delimited list of path names. The
+         * sort order of each path is ascending unless the path name is prefixed with -
+         * which will be treated as descending.
+         */
+        sort(arg: string | any): this;
+
+        /**
+         * Sets the tailable option (for use with capped collections). Cannot be used with distinct()
+         * @param bool defaults to true
+         * @param opts options to set
+         * @param opts.numberOfRetries if cursor is exhausted, retry this many times before giving up
+         * @param opts.tailableRetryInterval if cursor is exhausted, wait this many milliseconds before retrying
+         */
+        tailable(
+            bool?: boolean,
+            opts?: {
+                numberOfRetries?: number;
+                tailableRetryInterval?: number;
+            },
+        ): this;
+
+        /** Executes this query and returns a promise */
+        then: Promise<T>["then"];
+
+        /**
+         * Converts this query to a customized, reusable query
+         * constructor with all arguments and options retained.
+         */
+        toConstructor<T>(): new (...args: any[]) => Query<T> & QueryHelpers;
+        toConstructor<T, Doc extends Document>(): new (...args: any[]) => DocumentQuery<T, Doc, QueryHelpers> &
+            QueryHelpers;
+
+        /**
+         * Declare and/or execute this query as an update() operation.
+         * All paths passed that are not $atomic operations will become $set ops.
+         * @param doc the update command
+         */
+        update(callback?: (err: any, affectedRows: number) => void): Query<number> & QueryHelpers;
+        update(
+            doc: UpdateQuery<DocType>,
+            callback?: (err: any, affectedRows: number) => void,
+        ): Query<number> & QueryHelpers;
+        update(
+            criteria: FilterQuery<DocType>,
+            doc: UpdateQuery<DocType>,
+            callback?: (err: any, affectedRows: number) => void,
+        ): Query<number> & QueryHelpers;
+        update(
+            criteria: FilterQuery<DocType>,
+            doc: UpdateQuery<DocType>,
+            options: QueryUpdateOptions,
+            callback?: (err: any, affectedRows: number) => void,
+        ): Query<number> & QueryHelpers;
+
+        /** Specifies a path for use with chaining. */
+        where(path?: string | any, val?: any): this;
+
+        /** Defines a $within or $geoWithin argument for geo-spatial queries. */
+        within(val?: any): this;
+        within(coordinate: number[], ...coordinatePairs: number[][]): this;
+
+        wtimeout(ms?: number): this;
+
+        /** Flag to opt out of using $geoWithin. */
+        static use$geoWithin: boolean;
+    }
+
+    // https://github.com/aheckmann/mquery
+    // mquery currently does not have a type definition please
+    //   replace it if one is ever created
+    class mquery {}
+
+    // https://mongoosejs.com/docs/api.html#query_Query-setOptions
+    interface QueryFindBaseOptions {
+        /** Sets a default collation for every query and aggregation. */
+        collation?: CollationOptions;
+        explain?: any;
+        lean?: boolean;
+        populate?: string | ModelPopulateOptions;
+        /** like select, it determines which fields to return */
+        projection?: any;
+        /** use client session for transaction */
+        session?: ClientSession;
+    }
+
+    interface QueryFindOptions extends QueryFindBaseOptions {
+        batchSize?: number;
+        comment?: any;
+        hint?: any;
+        limit?: number;
+        maxscan?: number;
+        readPreference?: mongodb.ReadPreferenceMode;
+        skip?: number;
+        snapshot?: any;
+        sort?: any;
+        tailable?: any;
+    }
+
+    interface QueryFindOneAndRemoveOptions {
+        /**
+         * if multiple docs are found by the conditions, sets the sort order to choose
+         * which doc to update
+         */
+        sort?: any;
+        /** puts a time limit on the query - requires mongodb >= 2.6.0 */
+        maxTimeMS?: number;
+        /** sets the document fields to return */
+        select?: any;
+        /** like select, it determines which fields to return */
+        projection?: any;
+        /** if true, returns the raw result from the MongoDB driver */
+        rawResult?: boolean;
+        /** overwrites the schema's strict mode option for this update */
+        strict?: boolean | "throw";
+        /** use client session for transaction */
+        session?: ClientSession;
+    }
+
+    interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
+        /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
+        new?: boolean;
+        /** creates the object if it doesn't exist. defaults to false. */
+        upsert?: boolean;
+        /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */
+        runValidators?: boolean;
+        /**
+         * if this and upsert are true, mongoose will apply the defaults specified in the model's schema if a new document
+         * is created. This option only works on MongoDB >= 2.4 because it relies on MongoDB's $setOnInsert operator.
+         */
+        setDefaultsOnInsert?: boolean;
+        /**
+         * if set to 'query' and runValidators is on, this will refer to the query in custom validator
+         * functions that update validation runs. Does nothing if runValidators is false.
+         */
+        context?: string;
+        /**
+         *  by default, mongoose only returns the first error that occurred in casting the query.
+         *  Turn on this option to aggregate all the cast errors.
+         */
+        multipleCastError?: boolean;
+        /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
+        fields?: any | string;
+        /**
+         * Only update elements that match the arrayFilters conditions in the document or documents that match the query conditions.
+         */
+        arrayFilters?: { [key: string]: any }[];
+        /**
+         * if truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document. See Query.lean() and the Mongoose lean tutorial.
+         */
+        lean?: any;
+        /** If true, delete any properties whose value is undefined when casting an update. In other words,
     if this is set, Mongoose will delete baz from the update in Model.updateOne({}, { foo: 'bar', baz: undefined })
     before sending the update to the server.**/
-    omitUndefined?: boolean;
-    /**
-     * If set to false and schema-level timestamps are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps.
-     * Does nothing if schema-level timestamps are not set.
-     */
-    timestamps?:boolean;
-    /**
-     * True by default. Set to false to make findOneAndUpdate() and findOneAndRemove() use native findOneAndUpdate() rather than findAndModify().
-     */
-    useFindAndModify?:boolean;
-    /**
-     * False by default. Setting this to true allows the update to overwrite the existing document if no update
-     * operators are included in the update. When set to false, mongoose will wrap the update in a $set.
-     */
-    overwrite?: boolean;
-
-    /**
-     * allow setting the discriminator key in the update.
-     * Will use the correct discriminator schema if the update changes the discriminator key.
-     */
-     overwriteDiscriminatorKey?: boolean;
-  }
-
-  interface QueryUpdateOptions extends ModelUpdateOptions {
-    /**
-     * if set to 'query' and runValidators is on, this will refer to the query
-     * in customvalidator functions that update validation runs. Does nothing
-     * if runValidators is false.
-     */
-    context?: string;
-  }
-
-  interface CollationOptions {
-    locale?: string;
-    caseLevel?: boolean;
-    caseFirst?: string;
-    strength?: number;
-    numericOrdering?: boolean;
-    alternate?: string;
-    maxVariable?: string;
-    backwards?: boolean;
-  }
-
-  namespace Schema {
-    namespace Types {
-      /*
-        * section schema/array.js
-        * http://mongoosejs.com/docs/api.html#schema-array-js
-        */
-      class Array extends SchemaType {
-        /** Array SchemaType constructor */
-        constructor(key: string, cast?: SchemaType, options?: any);
-
+        omitUndefined?: boolean;
         /**
-         * Check if the given value satisfies a required validator. The given value
-         * must be not null nor undefined, and have a non-zero length.
+         * If set to false and schema-level timestamps are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps.
+         * Does nothing if schema-level timestamps are not set.
          */
-        checkRequired<T extends { length: number }>(value: T): boolean;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/string.js
-        * http://mongoosejs.com/docs/api.html#schema-string-js
-        */
-      class String extends SchemaType {
-        /** String SchemaType constructor. */
-        constructor(key: string, options?: any);
-
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
+        timestamps?: boolean;
         /**
-         * Adds an enum validator
-         * @param args enumeration values
+         * True by default. Set to false to make findOneAndUpdate() and findOneAndRemove() use native findOneAndUpdate() rather than findAndModify().
          */
-        enum(args: string | string[] | any): this;
-
-        /** Adds a lowercase setter. */
-        lowercase(): this;
+        useFindAndModify?: boolean;
+        /**
+         * False by default. Setting this to true allows the update to overwrite the existing document if no update
+         * operators are included in the update. When set to false, mongoose will wrap the update in a $set.
+         */
+        overwrite?: boolean;
 
         /**
-         * Sets a regexp validator. Any value that does not pass regExp.test(val) will fail validation.
-         * @param regExp regular expression to test against
+         * allow setting the discriminator key in the update.
+         * Will use the correct discriminator schema if the update changes the discriminator key.
+         */
+        overwriteDiscriminatorKey?: boolean;
+    }
+
+    interface QueryUpdateOptions extends ModelUpdateOptions {
+        /**
+         * if set to 'query' and runValidators is on, this will refer to the query
+         * in customvalidator functions that update validation runs. Does nothing
+         * if runValidators is false.
+         */
+        context?: string;
+    }
+
+    interface CollationOptions {
+        locale?: string;
+        caseLevel?: boolean;
+        caseFirst?: string;
+        strength?: number;
+        numericOrdering?: boolean;
+        alternate?: string;
+        maxVariable?: string;
+        backwards?: boolean;
+    }
+
+    namespace Schema {
+        namespace Types {
+            /*
+             * section schema/array.js
+             * http://mongoosejs.com/docs/api.html#schema-array-js
+             */
+            class Array extends SchemaType {
+                /** Array SchemaType constructor */
+                constructor(key: string, cast?: SchemaType, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. The given value
+                 * must be not null nor undefined, and have a non-zero length.
+                 */
+                checkRequired<T extends { length: number }>(value: T): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/string.js
+             * http://mongoosejs.com/docs/api.html#schema-string-js
+             */
+            class String extends SchemaType {
+                /** String SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /**
+                 * Adds an enum validator
+                 * @param args enumeration values
+                 */
+                enum(args: string | string[] | any): this;
+
+                /** Adds a lowercase setter. */
+                lowercase(): this;
+
+                /**
+                 * Sets a regexp validator. Any value that does not pass regExp.test(val) will fail validation.
+                 * @param regExp regular expression to test against
+                 * @param message optional custom error message
+                 */
+                match(regExp: RegExp, message?: string): this;
+
+                /**
+                 * Sets a maximum length validator.
+                 * @param value maximum string length
+                 * @param message optional custom error message
+                 */
+                maxlength(value: number, message?: string): this;
+
+                /**
+                 * Sets a minimum length validator.
+                 * @param value minimum string length
+                 * @param message optional custom error message
+                 */
+                minlength(value: number, message?: string): this;
+
+                /** Adds a trim setter. The string value will be trimmed when set. */
+                trim(): this;
+                /** Adds an uppercase setter. */
+                uppercase(): this;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/documentarray.js
+             * http://mongoosejs.com/docs/api.html#schema-documentarray-js
+             */
+            class DocumentArray extends Array {
+                /** SubdocsArray SchemaType constructor */
+                constructor(key: string, schema: Schema, options?: any);
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+
+                /**
+                 * Adds a discriminator type.
+                 * @param name discriminator model name
+                 * @param schema discriminator model schema
+                 * @param value the string stored in the `discriminatorKey` property
+                 */
+                discriminator<U extends Document>(name: string, schema: Schema, value?: string): Model<U>;
+
+                /**
+                 * Adds a discriminator type.
+                 * @param name discriminator model name
+                 * @param schema discriminator model schema
+                 * @param value the string stored in the `discriminatorKey` property
+                 */
+                discriminator<U extends Document, M extends Model<U>>(name: string, schema: Schema, value?: string): M;
+            }
+
+            /*
+             * section schema/number.js
+             * http://mongoosejs.com/docs/api.html#schema-number-js
+             */
+            class Number extends SchemaType {
+                /** Number SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /**
+                 * Sets a maximum number validator.
+                 * @param maximum number
+                 * @param message optional custom error message
+                 */
+                max(maximum: number, message?: string): this;
+
+                /**
+                 * Sets a minimum number validator.
+                 * @param value minimum number
+                 * @param message optional custom error message
+                 */
+                min(value: number, message?: string): this;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/date.js
+             * http://mongoosejs.com/docs/api.html#schema-date-js
+             */
+            class Date extends SchemaType {
+                /** Date SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. To satisfy
+                 * a required validator, the given value must be an instance of Date.
+                 */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** Declares a TTL index (rounded to the nearest second) for Date types only. */
+                expires(when: number | string): this;
+
+                /**
+                 * Sets a maximum date validator.
+                 * @param maximum date
+                 * @param message optional custom error message
+                 */
+                max(maximum: NativeDate, message?: string): this;
+
+                /**
+                 * Sets a minimum date validator.
+                 * @param value minimum date
+                 * @param message optional custom error message
+                 */
+                min(value: NativeDate, message?: string): this;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/buffer.js
+             * http://mongoosejs.com/docs/api.html#schema-buffer-js
+             */
+            class Buffer extends SchemaType {
+                /** Buffer SchemaType constructor */
+                constructor(key: string, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. To satisfy a
+                 * required validator, a buffer must not be null or undefined and have
+                 * non-zero length.
+                 */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/boolean.js
+             * http://mongoosejs.com/docs/api.html#schema-boolean-js
+             */
+            class Boolean extends SchemaType {
+                /** Boolean SchemaType constructor. */
+                constructor(path: string, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. For a
+                 * boolean to satisfy a required validator, it must be strictly
+                 * equal to true or to false.
+                 */
+                checkRequired(value: any): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/objectid.js
+             * http://mongoosejs.com/docs/api.html#schema-objectid-js
+             */
+            class ObjectId extends SchemaType {
+                /** ObjectId SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /**
+                 * Adds an auto-generated ObjectId default if turnOn is true.
+                 * @param turnOn auto generated ObjectId defaults
+                 */
+                auto(turnOn: boolean): this;
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+            /*
+             * section schema/decimal128.js
+             * http://mongoosejs.com/docs/api.html#schema-decimal128-js
+             */
+            class Decimal128 extends SchemaType {
+                /** Decimal128 SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/mixed.js
+             * http://mongoosejs.com/docs/api.html#schema-mixed-js
+             */
+            class Mixed extends SchemaType {
+                /** Mixed SchemaType constructor. */
+                constructor(path: string, options?: any);
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/embedded.js
+             * http://mongoosejs.com/docs/api.html#schema-embedded-js
+             */
+            class Embedded extends SchemaType {
+                /** Sub-schema schematype constructor */
+                constructor(schema: Schema, key: string, options?: any);
+            }
+
+            /**
+             * section schema/map.js
+             * https://mongoosejs.com/docs/schematypes.html#maps
+             */
+            class Map extends SchemaType {
+                /** Sub-schema schematype constructor */
+                constructor(key: string, options?: any);
+            }
+        }
+    }
+
+    /*
+     * section aggregate.js
+     * http://mongoosejs.com/docs/api.html#aggregate-js
+     */
+    class Aggregate<T> {
+        /**
+         * Aggregate constructor used for building aggregation pipelines.
+         * Returned when calling Model.aggregate().
+         * @param ops aggregation operator(s) or operator array
+         */
+        constructor(ops?: any | any[], ...args: any[]);
+
+        /** Adds a cursor flag */
+        addCursorFlag(flag: string, value: boolean): this;
+
+        /**
+         * Appends a new $addFields operator to this aggregate pipeline. Requires MongoDB v3.4+ to work
+         * @param arg field specification
+         */
+        addFields(arg: any): this;
+
+        /**
+         * Sets the allowDiskUse option for the aggregation query (ignored for < 2.6.0)
+         * @param value Should tell server it can use hard drive to store data during aggregation.
+         * @param tags optional tags for this query
+         */
+        allowDiskUse(value: boolean, tags?: any[]): this;
+
+        /**
+         * Appends new operators to this aggregate pipeline
+         * @param ops operator(s) to append
+         */
+        append(...ops: any[]): this;
+
+        /** Adds a collation. */
+        collation(options: CollationOptions): this;
+
+        /**
+         * Appends a new $count operator to this aggregate pipeline.
+         * @param countName name of the count field
+         */
+        count(countName: string): this;
+
+        /**
+         * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
+         * Note the different syntax below: .exec() returns a cursor object, and no callback
+         * is necessary.
+         * @param options set the cursor batch size
+         */
+        cursor(options: any): this;
+
+        /**
+         * Appends a new $facet operator to this aggregate pipeline.
+         * @param arg $facet operator contents
+         */
+        facet(arg: { [outputField: string]: object[] }): this;
+
+        // If cursor option is on, could return an object
+        /** Executes the aggregate pipeline on the currently bound Model. */
+        exec(callback?: (err: any, result: T) => void): Promise<T> | any;
+
+        /** Execute the aggregation with explain */
+        explain(callback?: (err: any, result: T) => void): Promise<T>;
+
+        /**
+         * Appends a new custom $group operator to this aggregate pipeline.
+         * @param arg $group operator contents
+         */
+        group(arg: any): this;
+
+        /**
+         * Sets the hint option for the aggregation query (ignored for < 3.6.0)
+         * @param value a hint object or the index name
+         */
+        hint(value: object | string): this;
+
+        /**
+         * Appends a new $limit operator to this aggregate pipeline.
+         * @param num maximum number of records to pass to the next stage
+         */
+        limit(num: number): this;
+
+        /**
+         * Appends new custom $lookup operator(s) to this aggregate pipeline.
+         * @param options to $lookup as described in the above link
+         */
+        lookup(options: any): this;
+
+        /**
+         * Appends a new custom $match operator to this aggregate pipeline.
+         * @param arg $match operator contents
+         */
+        match(arg: any): this;
+
+        /**
+         * Binds this aggregate to a model.
+         * @param model the model to which the aggregate is to be bound
+         */
+        model(model: any): this;
+
+        /**
+         * Appends new custom $graphLookup operator(s) to this aggregate pipeline, performing a recursive search on a collection.
+         * Note that graphLookup can only consume at most 100MB of memory, and does not allow disk use even if { allowDiskUse: true } is specified.
+         * @param options options to $graphLookup
+         */
+        graphLookup(options: any): this;
+
+        /**
+         * Appends a new $geoNear operator to this aggregate pipeline.
+         * MUST be used as the first operator in the pipeline.
+         */
+        near(parameters: any): this;
+
+        /**
+         * Lets you set arbitrary options, for middleware or plugins.
+         * @param value  keys to merge into current options
+         */
+        option(value: any): this;
+
+        /** Returns the current pipeline */
+        pipeline(): any[];
+
+        /**
+         * Appends a new $project operator to this aggregate pipeline.
+         * Mongoose query selection syntax is also supported.
+         * @param arg field specification
+         */
+        project(arg: string | any): this;
+
+        /**
+         * Sets the readPreference option for the aggregation query.
+         * @param pref one of the listed preference options or their aliases
+         * @param tags optional tags for this query
+         */
+        read(pref: string, tags?: any[]): this;
+
+        /**
+         * Appends a new $replaceRoot operator to this aggregate pipeline.
+         * Note that the $replaceRoot operator requires field strings to start with '$'. If you are passing in a string Mongoose will prepend '$' if the specified field doesn't start '$'. If you are passing in an object the strings in your expression will not be altered.
+         * @param newRoot field or document which will become the new root document
+         */
+        replaceRoot(newRoot: string | object): this;
+
+        /**
+         * Appends new custom $sample operator(s) to this aggregate pipeline.
+         * @param size number of random documents to pick
+         */
+        sample(size: number): this;
+
+        session(session: mongodb.ClientSession | null): this;
+        /**
+         * Appends a new $skip operator to this aggregate pipeline.
+         * @param num number of records to skip before next stage
+         */
+        skip(num: number): this;
+
+        /**
+         * Appends a new $sort operator to this aggregate pipeline.
+         * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
+         * If a string is passed, it must be a space delimited list of path names. The sort order
+         * of each path is ascending unless the path name is prefixed with - which will be treated
+         * as descending.
+         */
+        sort(arg: string | any): this;
+
+        /** Provides promise for aggregate. */
+        then: Promise<T>["then"];
+
+        /**
+         * Appends new custom $unwind operator(s) to this aggregate pipeline.
+         * Note that the $unwind operator requires the path name to start with '$'.
+         * Mongoose will prepend '$' if the specified field doesn't start '$'.
+         * @param fields the field(s) to unwind
+         */
+        unwind(...fields: string[]): this;
+        /**
+         * Appends new custom $unwind operator(s) to this aggregate pipeline
+         * new in mongodb 3.2
+         */
+        unwind(...opts: { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean }[]): this;
+    }
+
+    /*
+     * section schematype.js
+     * http://mongoosejs.com/docs/api.html#schematype-js
+     */
+    class SchemaType {
+        /** SchemaType constructor */
+        constructor(path: string, options?: any, instance?: string);
+
+        /**
+         * Sets a default value for this SchemaType.
+         * Defaults can be either functions which return the value to use as the
+         * default or the literal value itself. Either way, the value will be cast
+         * based on its schema type before being set during document creation.
+         * @param val the default value
+         */
+        default(val: any): any;
+
+        /** Adds a getter to this schematype. */
+        get(fn: Function): this;
+
+        /**
+         * Declares the index options for this schematype.
+         * Indexes are created in the background by default. Specify background: false to override.
+         */
+        index(options: any | boolean | string): this;
+
+        /**
+         * Adds a required validator to this SchemaType. The validator gets added
+         * to the front of this SchemaType's validators array using unshift().
+         * @param required enable/disable the validator
          * @param message optional custom error message
          */
-        match(regExp: RegExp, message?: string): this;
+        required(required: boolean, message?: string): this;
+
+        /** Sets default select() behavior for this path. */
+        select(val: boolean): this;
+        /** Adds a setter to this schematype. */
+        set(fn: Function): this;
+        /** Declares a sparse index. */
+        sparse(bool: boolean): this;
+        /** Declares a full text index. */
+        text(bool: boolean): this;
+        /** Declares an unique index. */
+        unique(bool: boolean): this;
 
         /**
-         * Sets a maximum length validator.
-         * @param value maximum string length
-         * @param message optional custom error message
+         * Adds validator(s) for this document path.
+         * Validators always receive the value to validate as their first argument
+         * and must return Boolean. Returning false means validation failed.
+         * @param obj validator
+         * @param errorMsg optional error message
+         * @param type optional validator type
          */
-        maxlength(value: number, message?: string): this;
+        validate(obj: RegExp | Function | any, errorMsg?: string, type?: string): this;
+    }
+
+    /*
+     * section promise.js
+     * http://mongoosejs.com/docs/api.html#promise-js
+     */
+    /**
+     * To assign your own promise library:
+     *
+     * 1. Typescript does not allow assigning properties of imported modules.
+     *    To avoid compile errors use one of the options below in your code:
+     *
+     *    - (<any>mongoose).Promise = YOUR_PROMISE;
+     *    - require('mongoose').Promise = YOUR_PROMISE;
+     *    - import mongoose = require('mongoose');
+     *      mongoose.Promise = YOUR_PROMISE;
+     *
+     * 2. To assign type definitions for your promise library, you will need
+     *    to have a .d.ts file with the following code when you compile:
+     *
+     *    - import * as Q from 'q';
+     *      declare module 'mongoose' {
+     *        type Promise<T> = Q.promise<T>;
+     *      }
+     *
+     *    - import * as Bluebird from 'bluebird';
+     *      declare module 'mongoose' {
+     *        type Promise<T> = Bluebird<T>;
+     *      }
+     *
+     * Uses global.Promise by default. If you would like to use mongoose default
+     *   mpromise implementation (which is deprecated), you can omit step 1 and
+     *   run npm install @types/mongoose-promise
+     */
+    export var Promise: any;
+    export var PromiseProvider: any;
+
+    /*
+     * section model.js
+     * http://mongoosejs.com/docs/api.html#model-js
+     */
+    export var Model: Model<any>;
+    interface Model<T extends Document, QueryHelpers = {}> extends NodeJS.EventEmitter, ModelProperties {
+        /** Base Mongoose instance the model uses. */
+        base: typeof mongoose;
 
         /**
-         * Sets a minimum length validator.
-         * @param value minimum string length
-         * @param message optional custom error message
+         * If this is a discriminator model, baseModelName is the
+         * name of the base model.
          */
-        minlength(value: number, message?: string): this;
+        baseModelName: string | undefined;
 
-        /** Adds a trim setter. The string value will be trimmed when set. */
-        trim(): this;
-        /** Adds an uppercase setter. */
-        uppercase(): this;
+        /** Registered discriminators for this model. */
+        discriminators: { [name: string]: Model<any> } | undefined;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
+        /** The name of the model */
+        modelName: string;
 
-      }
+        /**
+         * Model constructor
+         * Provides the interface to MongoDB collections as well as creates document instances.
+         * @param doc values with which to create the document
+         * @event error If listening to this event, it is emitted when a document
+         *   was saved without passing a callback and an error occurred. If not
+         *   listening, the event bubbles to the connection used to create this Model.
+         * @event index Emitted after Model#ensureIndexes completes. If an error
+         *   occurred it is passed with the event.
+         * @event index-single-start Emitted when an individual index starts within
+         *   Model#ensureIndexes. The fields and options being used to build the index
+         *   are also passed with the event.
+         * @event index-single-done Emitted when an individual index finishes within
+         *   Model#ensureIndexes. If an error occurred it is passed with the event.
+         *   The fields, options, and index name are also passed.
+         */
+        new (doc?: any): T;
 
-      /*
-        * section schema/documentarray.js
-        * http://mongoosejs.com/docs/api.html#schema-documentarray-js
-        */
-      class DocumentArray extends Array {
-        /** SubdocsArray SchemaType constructor */
-        constructor(key: string, schema: Schema, options?: any);
+        /**
+         * Requires a replica set running MongoDB >= 3.6.0. Watches the underlying collection for changes using MongoDB change streams.
+         * This function does not trigger any middleware. In particular, it does not trigger aggregate middleware.
+         * @param pipeline See http://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch
+         * @param options See https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch
+         */
+        watch(
+            pipeline?: object[],
+            options?: mongodb.ChangeStreamOptions & { session?: ClientSession },
+        ): mongodb.ChangeStream;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
+        /**
+         * Translate any aliases fields/conditions so the final query or document object is pure
+         * @param raw fields/conditions that may contain aliased keys
+         * @return the translated 'pure' fields/conditions
+         */
+        translateAliases(raw: any): any;
+
+        /**
+         * Sends multiple insertOne, updateOne, updateMany, replaceOne, deleteOne, and/or deleteMany operations to the MongoDB server in one command. This is faster than sending multiple independent operations (like) if you use create()) because with bulkWrite() there is only one round trip to MongoDB.
+         * Mongoose will perform casting on all operations you provide.
+         * This function does not trigger any middleware, not save() nor update(). If you need to trigger save() middleware for every document use create() instead.
+         * @param writes Operations
+         * @param options Optional settings. See https://mongoosejs.com/docs/api/model.html#model_Model.bulkWrite
+         * @param cb callback
+         * @return `BulkWriteOpResult` if the operation succeeds
+         */
+        bulkWrite(
+            writes: any[],
+            cb?: (err: any, res: mongodb.BulkWriteOpResultObject) => void,
+        ): Promise<mongodb.BulkWriteOpResultObject>;
+        bulkWrite(
+            writes: any[],
+            options?: mongodb.CollectionBulkWriteOptions,
+        ): Promise<mongodb.BulkWriteOpResultObject>;
+        bulkWrite(
+            writes: any[],
+            options: mongodb.CollectionBulkWriteOptions,
+            cb: (err: any, res: mongodb.BulkWriteOpResultObject) => void,
+        ): void;
+
+        model<U extends Document>(name: string): Model<U>;
+
+        /**
+         * Creates a Query and specifies a $where condition.
+         * @param argument is a javascript string or anonymous function
+         */
+        $where(argument: string | Function): DocumentQuery<T, T, QueryHelpers> & QueryHelpers;
+
+        /**
+         * Performs aggregations on the models collection.
+         * If a callback is passed, the aggregate is executed and a Promise is returned.
+         * If a callback is not passed, the aggregate itself is returned.
+         * @param aggregations pipeline operator(s) or operator array
+         */
+        aggregate<U = any>(aggregations?: any[]): Aggregate<U[]>;
+        aggregate<U = any>(aggregations: any[], cb: Function): Promise<U[]>;
+
+        /** Counts number of matching documents in a database collection. */
+        count(conditions: FilterQuery<T>, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+
+        /**
+         * Counts number of documents matching `criteria` in a database collection.
+         *
+         * If you want to count all documents in a large collection,
+         * use the `estimatedDocumentCount()` instead.
+         * If you call `countDocuments({})`, MongoDB will always execute
+         * a full collection scan and **not** use any indexes.
+         *
+         * @param {Object} filter
+         * @param {Function} [callback]
+         * @return {Query}
+         */
+        countDocuments(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+        countDocuments(
+            criteria: FilterQuery<T>,
+            callback?: (err: any, count: number) => void,
+        ): Query<number> & QueryHelpers;
+
+        /**
+         * Estimates the number of documents in the MongoDB collection. Faster than
+         * using `countDocuments()` for large collections because
+         * `estimatedDocumentCount()` uses collection metadata rather than scanning
+         * the entire collection.
+         *
+         * @param {Object} [options]
+         * @param {Function} [callback]
+         * @return {Query}
+         */
+        estimatedDocumentCount(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
+        estimatedDocumentCount(
+            options: any,
+            callback?: (err: any, count: number) => void,
+        ): Query<number> & QueryHelpers;
+
+        /**
+         * Shortcut for saving one or more documents to the database. MyModel.create(docs)
+         * does new MyModel(doc).save() for every doc in docs.
+         * Triggers the save() hook.
+         */
+        create<TCreate = T>(doc: CreateQuery<TCreate>, options?: SaveOptions): Promise<T>;
+        create<TCreate = T>(doc: CreateQuery<TCreate>, callback?: (err: any, res: T[]) => void): Promise<T>;
+        create<TCreate = T>(docs: CreateQuery<TCreate>[], callback?: (err: any, res: T[]) => void): Promise<T[]>;
+        create<TCreate = T>(
+            docs: CreateQuery<TCreate>[],
+            options?: SaveOptions,
+            callback?: (err: any, res: T[]) => void,
+        ): Promise<T[]>;
+        create<TCreate = T>(...docs: CreateQuery<TCreate>[]): Promise<T>;
+        /**
+         * Create the collection for this model. By default, if no indexes are specified, mongoose will not create the
+         * collection for the model until any documents are created. Use this method to create the collection explicitly.
+         */
+        createCollection(options?: mongodb.CollectionCreateOptions, cb?: (err: any) => void): Promise<void>;
 
         /**
          * Adds a discriminator type.
@@ -2745,1151 +3482,720 @@ declare module "mongoose" {
          */
         discriminator<U extends Document, M extends Model<U>>(name: string, schema: Schema, value?: string): M;
 
-      }
-
-      /*
-        * section schema/number.js
-        * http://mongoosejs.com/docs/api.html#schema-number-js
-        */
-      class Number extends SchemaType {
-        /** Number SchemaType constructor. */
-        constructor(key: string, options?: any);
-
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
+        /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
+        distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
+        distinct(
+            field: string,
+            conditions: any,
+            callback?: (err: any, res: any[]) => void,
+        ): Query<any[]> & QueryHelpers;
 
         /**
-         * Sets a maximum number validator.
-         * @param maximum number
-         * @param message optional custom error message
+         * Makes the indexes in MongoDB match the indexes defined in this model's
+         * schema. This function will drop any indexes that are not defined in
+         * the model's schema except the `_id` index, and build any indexes that
+         * are in your schema but not in MongoDB.
+         * @param options options to pass to `ensureIndexes()`
+         * @param callback optional callback
+         * @return Returns `undefined` if callback is specified, returns a promise if no callback.
          */
-        max(maximum: number, message?: string): this;
+        syncIndexes(options: object | null | undefined, callback: (err: any) => void): void;
+        syncIndexes(options?: object | null): Promise<void>;
 
         /**
-         * Sets a minimum number validator.
-         * @param value minimum number
-         * @param message optional custom error message
+         * Lists the indexes currently defined in MongoDB. This may or may not be
+         * the same as the indexes defined in your schema depending on whether you
+         * use the [`autoIndex` option](/docs/guide.html#autoIndex) and if you
+         * build indexes manually.
+         * @param cb optional callback
+         * @return Returns `undefined` if callback is specified, returns a promise if no callback.
          */
-        min(value: number, message?: string): this;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/date.js
-        * http://mongoosejs.com/docs/api.html#schema-date-js
-        */
-      class Date extends SchemaType {
-        /** Date SchemaType constructor. */
-        constructor(key: string, options?: any);
+        listIndexes(callback: (err: any) => void): void;
+        listIndexes(): Promise<void>;
 
         /**
-         * Check if the given value satisfies a required validator. To satisfy
-         * a required validator, the given value must be an instance of Date.
+         * Sends ensureIndex commands to mongo for each index declared in the schema.
+         * @param options internal options
+         * @param cb optional callback
          */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
-        /** Declares a TTL index (rounded to the nearest second) for Date types only. */
-        expires(when: number | string): this;
+        ensureIndexes(callback?: (err: any) => void): Promise<void>;
+        ensureIndexes(options: any, callback?: (err: any) => void): Promise<void>;
 
         /**
-         * Sets a maximum date validator.
-         * @param maximum date
-         * @param message optional custom error message
+         * Similar to ensureIndexes(), except for it uses the createIndex function. The ensureIndex() function checks to see if an index with that name already exists, and, if not, does not attempt to create the index. createIndex() bypasses this check.
+         * @param cb Optional callback
          */
-        max(maximum: NativeDate, message?: string): this;
+        createIndexes(cb?: (err: any) => void): Promise<void>;
 
         /**
-         * Sets a minimum date validator.
-         * @param value minimum date
-         * @param message optional custom error message
+         * Returns true if at least one document exists in the database that matches
+         * the given `filter`, and false otherwise.
          */
-        min(value: NativeDate, message?: string): this;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/buffer.js
-        * http://mongoosejs.com/docs/api.html#schema-buffer-js
-        */
-      class Buffer extends SchemaType {
-        /** Buffer SchemaType constructor */
-        constructor(key: string, options?: any);
+        exists(filter: FilterQuery<T>, callback?: (err: any, res: boolean) => void): Promise<boolean>;
 
         /**
-         * Check if the given value satisfies a required validator. To satisfy a
-         * required validator, a buffer must not be null or undefined and have
-         * non-zero length.
+         * Finds documents.
+         * @param projection optional fields to return
          */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-
-      }
-
-      /*
-        * section schema/boolean.js
-        * http://mongoosejs.com/docs/api.html#schema-boolean-js
-        */
-      class Boolean extends SchemaType {
-        /** Boolean SchemaType constructor. */
-        constructor(path: string, options?: any);
+        find(callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
+        find(
+            conditions: FilterQuery<T>,
+            callback?: (err: any, res: T[]) => void,
+        ): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
+        find(
+            conditions: FilterQuery<T>,
+            projection?: any | null,
+            callback?: (err: any, res: T[]) => void,
+        ): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
+        find(
+            conditions: FilterQuery<T>,
+            projection?: any | null,
+            options?: { lean: true } & Omit<QueryFindOptions, "lean">,
+            callback?: (err: any, res: T[]) => void,
+        ): Query<DocumentDefinition<T>[]> & QueryHelpers;
+        find(
+            conditions: FilterQuery<T>,
+            projection?: any | null,
+            options?: QueryFindOptions,
+            callback?: (err: any, res: T[]) => void,
+        ): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
 
         /**
-         * Check if the given value satisfies a required validator. For a
-         * boolean to satisfy a required validator, it must be strictly
-         * equal to true or to false.
+         * Finds a single document by its _id field. findById(id) is almost*
+         * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.
+         * @param id value of _id to query by
+         * @param projection optional fields to return
          */
-        checkRequired(value: any): boolean;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/objectid.js
-        * http://mongoosejs.com/docs/api.html#schema-objectid-js
-        */
-      class ObjectId extends SchemaType {
-        /** ObjectId SchemaType constructor. */
-        constructor(key: string, options?: any);
+        findById(
+            id: any | string | number,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findById(
+            id: any | string | number,
+            projection: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findById(
+            id: any | string | number,
+            projection: any,
+            options: { lean: true } & Omit<QueryFindBaseOptions, "lean">,
+            callback?: (err: any, res: T | null) => void,
+        ): Query<DocumentDefinition<T>> & QueryHelpers;
+        findById(
+            id: any | string | number,
+            projection: any,
+            options: QueryFindBaseOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
         /**
-         * Adds an auto-generated ObjectId default if turnOn is true.
-         * @param turnOn auto generated ObjectId defaults
+         * Issue a mongodb findAndModify remove command by a document's _id field.
+         * findByIdAndRemove(id, ...) is equivalent to findOneAndRemove({ _id: id }, ...).
+         * Finds a matching document, removes it, passing the found document (if any) to the callback.
+         * Executes immediately if callback is passed, else a Query object is returned.
+         *
+         * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
+         * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
+         *
+         * Note: same signatures as findByIdAndDelete
+         *
+         * @param id value of _id to query by
          */
-        auto(turnOn: boolean): this;
+        findByIdAndRemove(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findByIdAndRemove(
+            id: any | number | string,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findByIdAndRemove(
+            id: any | number | string,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        findByIdAndRemove(
+            id: any | number | string,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
+        /**
+         * Issue a mongodb findOneAndDelete command by a document's _id field.
+         * findByIdAndDelete(id, ...) is equivalent to findOneAndDelete({ _id: id }, ...).
+         * Finds a matching document, removes it, passing the found document (if any) to the callback.
+         * Executes immediately if callback is passed, else a Query object is returned.
+         *
+         * Note: same signatures as findByIdAndRemove
+         *
+         * @param id value of _id to query by
+         */
+        findByIdAndDelete(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findByIdAndDelete(
+            id: any | number | string,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findByIdAndDelete(
+            id: any | number | string,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        findByIdAndDelete(
+            id: any | number | string,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-      /*
-        * section schema/decimal128.js
-        * http://mongoosejs.com/docs/api.html#schema-decimal128-js
-        */
-      class Decimal128 extends SchemaType {
-        /** Decimal128 SchemaType constructor. */
-        constructor(key: string, options?: any);
+        /**
+         * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
+         * is equivalent to findOneAndUpdate({ _id: id }, ...).
+         *
+         * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
+         * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
+         *
+         * @param id value of _id to query by
+         */
+        findByIdAndUpdate(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: UpdateQuery<T>,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: UpdateQuery<T>,
+            options: { rawResult: true } & { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, res: T) => void,
+        ): DocumentQuery<T, T, QueryHelpers> & QueryHelpers;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: UpdateQuery<T>,
+            options: { upsert: true; new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T>) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: UpdateQuery<T>,
+            options: { rawResult: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: UpdateQuery<T>,
+            options: { lean: true } & Omit<QueryFindOneAndUpdateOptions, "lean">,
+            callback?: (err: any, res: DocumentDefinition<T>) => void,
+        ): Query<DocumentDefinition<T>> & QueryHelpers;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: UpdateQuery<T>,
+            options: QueryFindOneAndUpdateOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
+        /**
+         * Finds one document.
+         * The conditions are cast to their respective SchemaTypes before the command is sent.
+         * @param projection optional fields to return
+         */
+        findOne(
+            conditions?: FilterQuery<T>,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOne(
+            conditions: FilterQuery<T>,
+            projection: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOne(
+            conditions: FilterQuery<T>,
+            projection: any,
+            options: { lean: true } & Omit<QueryFindBaseOptions, "lean">,
+            callback?: (err: any, res: T | null) => void,
+        ): Query<DocumentDefinition<T>> & QueryHelpers;
+        findOne(
+            conditions: FilterQuery<T>,
+            projection: any,
+            options: QueryFindBaseOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
+        /**
+         * Issue a mongodb findAndModify remove command.
+         * Finds a matching document, removes it, passing the found document (if any) to the callback.
+         * Executes immediately if callback is passed else a Query object is returned.
+         *
+         * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
+         * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
+         *
+         * Note: same signatures as findOneAndDelete
+         *
+         */
+        findOneAndRemove(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOneAndRemove(
+            conditions: FilterQuery<T>,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOneAndRemove(
+            conditions: FilterQuery<T>,
+            options: { rawResult: true } & QueryFindOneAndRemoveOptions,
+            callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        findOneAndRemove(
+            conditions: FilterQuery<T>,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-      /*
-        * section schema/mixed.js
-        * http://mongoosejs.com/docs/api.html#schema-mixed-js
-        */
-      class Mixed extends SchemaType {
-        /** Mixed SchemaType constructor. */
-        constructor(path: string, options?: any);
+        /**
+         * Issues a mongodb findOneAndDelete command.
+         * Finds a matching document, removes it, passing the found document (if any) to the
+         * callback. Executes immediately if callback is passed.
+         *
+         * Note: same signatures as findOneAndRemove
+         *
+         */
+        findOneAndDelete(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOneAndDelete(
+            conditions: FilterQuery<T>,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOneAndDelete(
+            conditions: FilterQuery<T>,
+            options: { rawResult: true } & QueryFindOneAndRemoveOptions,
+            callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        findOneAndDelete(
+            conditions: FilterQuery<T>,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
+        /**
+         * Issues a mongodb findAndModify update command.
+         * Finds a matching document, updates it according to the update arg, passing any options,
+         * and returns the found document (if any) to the callback. The query executes immediately
+         * if callback is passed else a Query object is returned.
+         *
+         * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than the deprecated findAndModify().
+         * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
+         */
+        findOneAndUpdate(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            conditions: FilterQuery<T>,
+            update: UpdateQuery<T>,
+            callback?: (err: any, doc: T | null, res: any) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            conditions: FilterQuery<T>,
+            update: UpdateQuery<T>,
+            options: { rawResult: true } & { upsert: true; new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T>, res: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
+        findOneAndUpdate(
+            conditions: FilterQuery<T>,
+            update: UpdateQuery<T>,
+            options: { upsert: true; new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: T, res: any) => void,
+        ): DocumentQuery<T, T, QueryHelpers> & QueryHelpers;
+        findOneAndUpdate(
+            conditions: FilterQuery<T>,
+            update: UpdateQuery<T>,
+            options: { rawResult: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void,
+        ): Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        findOneAndUpdate(
+            conditions: FilterQuery<T>,
+            update: UpdateQuery<T>,
+            options: { lean: true } & Omit<QueryFindOneAndUpdateOptions, "lean">,
+            callback?: (err: any, doc: DocumentDefinition<T>, res: any) => void,
+        ): Query<DocumentDefinition<T>> & QueryHelpers;
+        findOneAndUpdate(
+            conditions: FilterQuery<T>,
+            update: UpdateQuery<T>,
+            options: QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: T | null, res: any) => void,
+        ): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
 
-      /*
-        * section schema/embedded.js
-        * http://mongoosejs.com/docs/api.html#schema-embedded-js
-        */
-      class Embedded extends SchemaType {
-        /** Sub-schema schematype constructor */
-        constructor(schema: Schema, key: string, options?: any);
-      }
+        /**
+         * Implements $geoSearch functionality for Mongoose
+         * @param conditions an object that specifies the match condition (required)
+         * @param options for the geoSearch, some (near, maxDistance) are required
+         * @param callback optional callback
+         */
+        geoSearch(
+            conditions: any,
+            options: {
+                /** x,y point to search for */
+                near: number[];
+                /** the maximum distance from the point near that a result can be */
+                maxDistance: number;
+                /** The maximum number of results to return */
+                limit?: number;
+                /** return the raw object instead of the Mongoose Model */
+                lean?: boolean;
+            },
+            callback?: (err: any, res: T[]) => void,
+        ): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
 
-      /**
-       * section schema/map.js
-       * https://mongoosejs.com/docs/schematypes.html#maps
-       */
-      class Map extends SchemaType {
-        /** Sub-schema schematype constructor */
-        constructor(key: string, options?: any);
-      }
+        /**
+         * Shortcut for creating a new Document from existing raw data,
+         * pre-saved in the DB. The document returned has no paths marked
+         * as modified initially.
+         */
+        hydrate(obj: any): T;
+
+        /**
+         * Shortcut for validating an array of documents and inserting them into
+         * MongoDB if they're all valid. This function is faster than .create()
+         * because it only sends one operation to the server, rather than one for each
+         * document.
+         * This function does not trigger save middleware.
+         * @param docs Documents to insert.
+         * @param options Optional settings.
+         * @param options.ordered  if true, will fail fast on the first error encountered.
+         *        If false, will insert all the documents it can and report errors later.
+         * @param options.rawResult if false, the returned promise resolves to the documents that passed mongoose document validation.
+         *        If `true`, will return the [raw result from the MongoDB driver](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~insertWriteOpCallback)
+         *        with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
+         */
+        insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): Promise<T[]>;
+        insertMany(
+            docs: any[],
+            options?: { ordered?: boolean; rawResult?: boolean } & ModelOptions,
+            callback?: (error: any, docs: T[]) => void,
+        ): Promise<T[]>;
+        insertMany(doc: any, callback?: (error: any, doc: T) => void): Promise<T>;
+        insertMany(
+            doc: any,
+            options?: { ordered?: boolean; rawResult?: boolean } & ModelOptions,
+            callback?: (error: any, doc: T) => void,
+        ): Promise<T>;
+
+        /**
+         * Performs any async initialization of this model against MongoDB.
+         * This function is called automatically, so you don't need to call it.
+         * This function is also idempotent, so you may call it to get back a promise
+         * that will resolve when your indexes are finished building as an alternative
+         * to `MyModel.on('index')`
+         * @param callback optional
+         */
+        init(callback?: (err: any) => void): Promise<T>;
+
+        /**
+         * Executes a mapReduce command.
+         * @param o an object specifying map-reduce options
+         * @param callbackoptional callback
+         */
+        mapReduce<Key, Value>(
+            o: ModelMapReduceOption<T, Key, Value>,
+            callback?: (err: any, res: any) => void,
+        ): Promise<any>;
+
+        /**
+         * Populates document references.
+         * @param docs Either a single document or array of documents to populate.
+         * @param options A hash of key/val (path, options) used for population.
+         * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
+         */
+        populate(
+            docs: any[],
+            options: ModelPopulateOptions | ModelPopulateOptions[],
+            callback?: (err: any, res: T[]) => void,
+        ): Promise<T[]>;
+        populate<T>(
+            docs: any,
+            options: ModelPopulateOptions | ModelPopulateOptions[],
+            callback?: (err: any, res: T) => void,
+        ): Promise<T>;
+
+        /** Removes documents from the collection. */
+        remove(
+            conditions: FilterQuery<T>,
+            callback?: (err: any) => void,
+        ): Query<mongodb.DeleteWriteOpResultObject["result"] & { deletedCount?: number }> & QueryHelpers;
+        deleteOne(
+            conditions: FilterQuery<T>,
+            callback?: (err: any) => void,
+        ): Query<mongodb.DeleteWriteOpResultObject["result"] & { deletedCount?: number }> & QueryHelpers;
+        deleteOne(
+            conditions: FilterQuery<T>,
+            options: ModelOptions,
+            callback?: (err: any) => void,
+        ): Query<mongodb.DeleteWriteOpResultObject["result"] & { deletedCount?: number }> & QueryHelpers;
+        deleteMany(
+            conditions: FilterQuery<T>,
+            callback?: (err: any) => void,
+        ): Query<mongodb.DeleteWriteOpResultObject["result"] & { deletedCount?: number }> & QueryHelpers;
+        deleteMany(
+            conditions: FilterQuery<T>,
+            options: ModelOptions,
+            callback?: (err: any) => void,
+        ): Query<mongodb.DeleteWriteOpResultObject["result"] & { deletedCount?: number }> & QueryHelpers;
+
+        /**
+         * Same as update(), except MongoDB replace the existing document with the given document (no atomic operators like $set).
+         * This function triggers the following middleware: replaceOne
+         */
+        replaceOne(
+            conditions: FilterQuery<T>,
+            replacement: any,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+
+        /**
+         * Updates documents in the database without returning them.
+         * All update values are cast to their appropriate SchemaTypes before being sent.
+         */
+        update(
+            conditions: FilterQuery<T>,
+            doc: UpdateQuery<T>,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+        update(
+            conditions: FilterQuery<T>,
+            doc: UpdateQuery<T>,
+            options: ModelUpdateOptions,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+        updateOne(
+            conditions: FilterQuery<T>,
+            doc: UpdateQuery<T>,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+        updateOne(
+            conditions: FilterQuery<T>,
+            doc: UpdateQuery<T>,
+            options: ModelUpdateOptions,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+        updateMany(
+            conditions: FilterQuery<T>,
+            doc: UpdateQuery<T>,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+        updateMany(
+            conditions: FilterQuery<T>,
+            doc: UpdateQuery<T>,
+            options: ModelUpdateOptions,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any> & QueryHelpers;
+
+        /** Creates a Query, applies the passed conditions, and returns the Query. */
+        where(path: string, val?: any): Query<any> & QueryHelpers;
     }
-  }
 
-  /*
-   * section aggregate.js
-   * http://mongoosejs.com/docs/api.html#aggregate-js
-   */
-  class Aggregate<T> {
-    /**
-     * Aggregate constructor used for building aggregation pipelines.
-     * Returned when calling Model.aggregate().
-     * @param ops aggregation operator(s) or operator array
-     */
-    constructor(ops?: any | any[], ...args: any[]);
+    class Document {}
+    interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
+        /** Signal that we desire an increment of this documents version. */
+        increment(): this;
+
+        /**
+         * Returns another Model instance.
+         * @param name model name
+         */
+        model<T extends Document>(name: string): Model<T>;
+
+        /** Override whether mongoose thinks this doc is deleted or not */
+        $isDeleted(isDeleted: boolean): void;
+        /** whether mongoose thinks this doc is deleted. */
+        $isDeleted(): boolean;
+
+        /**
+         * Removes this document from the db.
+         * @param fn optional callback
+         */
+        remove(fn?: (err: any, product: this) => void): Promise<this>;
+
+        /**
+         * Deletes the document from the db.
+         * @param fn optional callback
+         */
+        deleteOne(fn?: (err: any, product: this) => void): Promise<this>;
+
+        /**
+         * Saves this document.
+         * @param options options optional options
+         * @param options.safe overrides schema's safe option
+         * @param options.validateBeforeSave set to false to save without validating.
+         * @param fn optional callback
+         */
+        save(options?: SaveOptions, fn?: (err: any, product: this) => void): Promise<this>;
+        save(fn?: (err: any, product: this) => void): Promise<this>;
+
+        /**
+         * Version using default version key. See http://mongoosejs.com/docs/guide.html#versionKey
+         * If you're using another key, you will have to access it using []: doc[_myVersionKey]
+         */
+        __v?: number;
+    }
+
+    interface SaveOptions {
+        checkKeys?: boolean;
+        safe?: boolean | WriteConcern;
+        validateBeforeSave?: boolean;
+        validateModifiedOnly?: boolean;
+        j?: boolean;
+        session?: ClientSession;
+        timestamps?: boolean;
+        w?: number | string;
+        wtimeout?: number;
+    }
+
+    interface WriteConcern {
+        j?: boolean;
+        w?: number | "majority" | TagSet;
+        wtimeout?: number;
+    }
+
+    interface TagSet {
+        [k: string]: string;
+    }
+
+    interface ModelProperties {
+        /** Collection the model uses. */
+        collection: Collection;
+
+        /** Connection the model uses. */
+        db: Connection;
+
+        /** Schema the model uses. */
+        schema: Schema;
+    }
+
+    /** https://mongoosejs.com/docs/api.html#query_Query-setOptions */
+    interface ModelOptions {
+        session?: ClientSession | null;
+    }
+
+    interface QueryPopulateOptions {
+        /** space delimited path(s) to populate */
+        path: string;
+        /** optional fields to select */
+        select?: any;
+        /** optional query conditions to match */
+        match?: any;
+        /** optional model to use for population */
+        model?: string | Model<any>;
+        /** optional query options like sort, limit, etc */
+        options?: any;
+        /** deep populate */
+        populate?: QueryPopulateOptions | QueryPopulateOptions[];
+    }
+
+    interface ModelPopulateOptions extends QueryPopulateOptions {
+        /** optional, if true Mongoose will always set path to an array. Inferred from schema by default */
+        justOne?: boolean;
+    }
+
+    interface ModelUpdateOptions extends ModelOptions {
+        /** safe mode (defaults to value set in schema (true)) */
+        safe?: boolean;
+        /** whether to create the doc if it doesn't match (false) */
+        upsert?: boolean;
+        /** whether multiple documents should be updated (false) */
+        multi?: boolean;
+        /**
+         * If true, runs update validators on this command. Update validators validate
+         * the update operation against the model's schema.
+         */
+        runValidators?: boolean;
+        /**
+         * If this and upsert are true, mongoose will apply the defaults specified in the
+         * model's schema if a new document is created. This option only works on MongoDB >= 2.4
+         * because it relies on MongoDB's $setOnInsert operator.
+         */
+        setDefaultsOnInsert?: boolean;
+        /** overrides the strict option for this update */
+        strict?: boolean | "throw";
+        /** disables update-only mode, allowing you to overwrite the doc (false) */
+        overwrite?: boolean;
+        /**
+         * Only update elements that match the arrayFilters conditions in the document or documents that match the query conditions.
+         */
+        arrayFilters?: { [key: string]: any }[];
+        /** other options */
+        [other: string]: any;
+        /**
+         *  by default, mongoose only returns the first error that occurred in casting the query.
+         *  Turn on this option to aggregate all the cast errors.
+         */
+        multipleCastError?: boolean;
+
+        /**
+         * allow setting the discriminator key in the update.
+         * Will use the correct discriminator schema if the update changes the discriminator key.
+         */
+        overwriteDiscriminatorKey?: boolean;
+    }
+
+    interface ModelMapReduceOption<T, Key, Val> {
+        map: Function | string;
+        reduce: (key: Key, vals: T[]) => Val;
+        /** query filter object. */
+        query?: any;
+        /** sort input objects using this key */
+        sort?: any;
+        /** max number of documents */
+        limit?: number;
+        /** keep temporary data default: false */
+        keeptemp?: boolean;
+        /** finalize function */
+        finalize?: (key: Key, val: Val) => Val;
+        /** scope variables exposed to map/reduce/finalize during execution */
+        scope?: any;
+        /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
+        jsMode?: boolean;
+        /** provide statistics on job execution time. default: false */
+        verbose?: boolean;
+        readPreference?: string;
+        /** sets the output target for the map reduce job. default: {inline: 1} */
+        out?: {
+            /** the results are returned in an array */
+            inline?: number;
+            /**
+             * {replace: 'collectionName'} add the results to collectionName: the
+             * results replace the collection
+             */
+            replace?: string;
+            /**
+             * {reduce: 'collectionName'} add the results to collectionName: if
+             * dups are detected, uses the reducer / finalize functions
+             */
+            reduce?: string;
+            /**
+             * {merge: 'collectionName'} add the results to collectionName: if
+             * dups exist the new docs overwrite the old
+             */
+            merge?: string;
+        };
+    }
+
+    interface MapReduceResult<Key, Val> {
+        _id: Key;
+        value: Val;
+    }
 
-    /** Adds a cursor flag */
-    addCursorFlag(flag: string, value: boolean): this;
-
-    /**
-     * Appends a new $addFields operator to this aggregate pipeline. Requires MongoDB v3.4+ to work
-     * @param arg field specification
-     */
-    addFields(arg: any): this;
-
-    /**
-     * Sets the allowDiskUse option for the aggregation query (ignored for < 2.6.0)
-     * @param value Should tell server it can use hard drive to store data during aggregation.
-     * @param tags optional tags for this query
-     */
-    allowDiskUse(value: boolean, tags?: any[]): this;
-
-    /**
-     * Appends new operators to this aggregate pipeline
-     * @param ops operator(s) to append
-     */
-    append(...ops: any[]): this;
-
-    /** Adds a collation. */
-    collation(options: CollationOptions): this;
-
-    /**
-     * Appends a new $count operator to this aggregate pipeline.
-     * @param countName name of the count field
-     */
-    count(countName: string): this;
-
-    /**
-     * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
-     * Note the different syntax below: .exec() returns a cursor object, and no callback
-     * is necessary.
-     * @param options set the cursor batch size
-     */
-    cursor(options: any): this;
-
-    /**
-     * Appends a new $facet operator to this aggregate pipeline.
-     * @param arg $facet operator contents
-     */
-    facet(arg: { [outputField: string]: object[] }): this;
-
-    // If cursor option is on, could return an object
-    /** Executes the aggregate pipeline on the currently bound Model. */
-    exec(callback?: (err: any, result: T) => void): Promise<T> | any;
-
-    /** Execute the aggregation with explain */
-    explain(callback?: (err: any, result: T) => void): Promise<T>;
-
-    /**
-     * Appends a new custom $group operator to this aggregate pipeline.
-     * @param arg $group operator contents
-     */
-    group(arg: any): this;
-
-    /**
-     * Sets the hint option for the aggregation query (ignored for < 3.6.0)
-     * @param value a hint object or the index name
-     */
-    hint(value: object | string): this;
-
-    /**
-     * Appends a new $limit operator to this aggregate pipeline.
-     * @param num maximum number of records to pass to the next stage
-     */
-    limit(num: number): this;
-
-    /**
-     * Appends new custom $lookup operator(s) to this aggregate pipeline.
-     * @param options to $lookup as described in the above link
-     */
-    lookup(options: any): this;
-
-    /**
-     * Appends a new custom $match operator to this aggregate pipeline.
-     * @param arg $match operator contents
-     */
-    match(arg: any): this;
-
-    /**
-     * Binds this aggregate to a model.
-     * @param model the model to which the aggregate is to be bound
-     */
-    model(model: any): this;
-
-    /**
-     * Appends new custom $graphLookup operator(s) to this aggregate pipeline, performing a recursive search on a collection.
-     * Note that graphLookup can only consume at most 100MB of memory, and does not allow disk use even if { allowDiskUse: true } is specified.
-     * @param options options to $graphLookup
-     */
-    graphLookup(options: any): this;
-
-    /**
-     * Appends a new $geoNear operator to this aggregate pipeline.
-     * MUST be used as the first operator in the pipeline.
-     */
-    near(parameters: any): this;
-
-    /**
-     * Lets you set arbitrary options, for middleware or plugins.
-     * @param value  keys to merge into current options
-     */
-    option(value: any): this;
-
-    /** Returns the current pipeline */
-    pipeline(): any[];
-
-    /**
-     * Appends a new $project operator to this aggregate pipeline.
-     * Mongoose query selection syntax is also supported.
-     * @param arg field specification
-     */
-    project(arg: string | any): this;
-
-    /**
-     * Sets the readPreference option for the aggregation query.
-     * @param pref one of the listed preference options or their aliases
-     * @param tags optional tags for this query
-     */
-    read(pref: string, tags?: any[]): this;
-
-    /**
-     * Appends a new $replaceRoot operator to this aggregate pipeline.
-     * Note that the $replaceRoot operator requires field strings to start with '$'. If you are passing in a string Mongoose will prepend '$' if the specified field doesn't start '$'. If you are passing in an object the strings in your expression will not be altered.
-     * @param newRoot field or document which will become the new root document
-     */
-    replaceRoot(newRoot: string | object): this;
-
-    /**
-     * Appends new custom $sample operator(s) to this aggregate pipeline.
-     * @param size number of random documents to pick
-     */
-    sample(size: number): this;
-
-    session(session: mongodb.ClientSession | null): this;
-    /**
-     * Appends a new $skip operator to this aggregate pipeline.
-     * @param num number of records to skip before next stage
-     */
-    skip(num: number): this;
-
-    /**
-     * Appends a new $sort operator to this aggregate pipeline.
-     * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
-     * If a string is passed, it must be a space delimited list of path names. The sort order
-     * of each path is ascending unless the path name is prefixed with - which will be treated
-     * as descending.
-     */
-    sort(arg: string | any): this;
-
-    /** Provides promise for aggregate. */
-    then: Promise<T>["then"];
-
-    /**
-     * Appends new custom $unwind operator(s) to this aggregate pipeline.
-     * Note that the $unwind operator requires the path name to start with '$'.
-     * Mongoose will prepend '$' if the specified field doesn't start '$'.
-     * @param fields the field(s) to unwind
-     */
-    unwind(...fields: string[]): this;
-    /**
-     * Appends new custom $unwind operator(s) to this aggregate pipeline
-     * new in mongodb 3.2
-     */
-    unwind(...opts: { path: string, includeArrayIndex?: string, preserveNullAndEmptyArrays?: boolean }[]): this;
-  }
-
-  /*
-   * section schematype.js
-   * http://mongoosejs.com/docs/api.html#schematype-js
-   */
-  class SchemaType {
-    /** SchemaType constructor */
-    constructor(path: string, options?: any, instance?: string);
-
-    /**
-     * Sets a default value for this SchemaType.
-     * Defaults can be either functions which return the value to use as the
-     * default or the literal value itself. Either way, the value will be cast
-     * based on its schema type before being set during document creation.
-     * @param val the default value
-     */
-    default(val: any): any;
-
-    /** Adds a getter to this schematype. */
-    get(fn: Function): this;
-
-    /**
-     * Declares the index options for this schematype.
-     * Indexes are created in the background by default. Specify background: false to override.
-     */
-    index(options: any | boolean | string): this;
-
-    /**
-     * Adds a required validator to this SchemaType. The validator gets added
-     * to the front of this SchemaType's validators array using unshift().
-     * @param required enable/disable the validator
-     * @param message optional custom error message
-     */
-    required(required: boolean, message?: string): this;
-
-    /** Sets default select() behavior for this path. */
-    select(val: boolean): this;
-    /** Adds a setter to this schematype. */
-    set(fn: Function): this;
-    /** Declares a sparse index. */
-    sparse(bool: boolean): this;
-    /** Declares a full text index. */
-    text(bool: boolean): this;
-    /** Declares an unique index. */
-    unique(bool: boolean): this;
-
-    /**
-     * Adds validator(s) for this document path.
-     * Validators always receive the value to validate as their first argument
-     * and must return Boolean. Returning false means validation failed.
-     * @param obj validator
-     * @param errorMsg optional error message
-     * @param type optional validator type
-     */
-    validate(obj: RegExp | Function | any, errorMsg?: string,
-      type?: string): this;
-  }
-
-  /*
-   * section promise.js
-   * http://mongoosejs.com/docs/api.html#promise-js
-   */
-  /**
-   * To assign your own promise library:
-   *
-   * 1. Typescript does not allow assigning properties of imported modules.
-   *    To avoid compile errors use one of the options below in your code:
-   *
-   *    - (<any>mongoose).Promise = YOUR_PROMISE;
-   *    - require('mongoose').Promise = YOUR_PROMISE;
-   *    - import mongoose = require('mongoose');
-   *      mongoose.Promise = YOUR_PROMISE;
-   *
-   * 2. To assign type definitions for your promise library, you will need
-   *    to have a .d.ts file with the following code when you compile:
-   *
-   *    - import * as Q from 'q';
-   *      declare module 'mongoose' {
-   *        type Promise<T> = Q.promise<T>;
-   *      }
-   *
-   *    - import * as Bluebird from 'bluebird';
-   *      declare module 'mongoose' {
-   *        type Promise<T> = Bluebird<T>;
-   *      }
-   *
-   * Uses global.Promise by default. If you would like to use mongoose default
-   *   mpromise implementation (which is deprecated), you can omit step 1 and
-   *   run npm install @types/mongoose-promise
-   */
-  export var Promise: any;
-  export var PromiseProvider: any;
-
-  /*
-   * section model.js
-   * http://mongoosejs.com/docs/api.html#model-js
-   */
-  export var Model: Model<any>;
-  interface Model<T extends Document, QueryHelpers = {}> extends NodeJS.EventEmitter, ModelProperties {
-    /** Base Mongoose instance the model uses. */
-    base: typeof mongoose;
-
-    /**
-     * If this is a discriminator model, baseModelName is the
-     * name of the base model.
-     */
-    baseModelName: string | undefined;
-
-    /** Registered discriminators for this model. */
-    discriminators: { [name: string]: Model<any> } | undefined;
-
-    /** The name of the model */
-    modelName: string;
-
-    /**
-     * Model constructor
-     * Provides the interface to MongoDB collections as well as creates document instances.
-     * @param doc values with which to create the document
-     * @event error If listening to this event, it is emitted when a document
-     *   was saved without passing a callback and an error occurred. If not
-     *   listening, the event bubbles to the connection used to create this Model.
-     * @event index Emitted after Model#ensureIndexes completes. If an error
-     *   occurred it is passed with the event.
-     * @event index-single-start Emitted when an individual index starts within
-     *   Model#ensureIndexes. The fields and options being used to build the index
-     *   are also passed with the event.
-     * @event index-single-done Emitted when an individual index finishes within
-     *   Model#ensureIndexes. If an error occurred it is passed with the event.
-     *   The fields, options, and index name are also passed.
-     */
-    new(doc?: any): T;
-
-    /**
-     * Requires a replica set running MongoDB >= 3.6.0. Watches the underlying collection for changes using MongoDB change streams.
-     * This function does not trigger any middleware. In particular, it does not trigger aggregate middleware.
-     * @param pipeline See http://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch
-     * @param options See https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch
-     */
-    watch(
-        pipeline?: object[],
-        options?: mongodb.ChangeStreamOptions & { session?: ClientSession },
-    ): mongodb.ChangeStream;
-
-    /**
-     * Translate any aliases fields/conditions so the final query or document object is pure
-     * @param raw fields/conditions that may contain aliased keys
-     * @return the translated 'pure' fields/conditions
-     */
-    translateAliases(raw: any): any;
-
-    /**
-     * Sends multiple insertOne, updateOne, updateMany, replaceOne, deleteOne, and/or deleteMany operations to the MongoDB server in one command. This is faster than sending multiple independent operations (like) if you use create()) because with bulkWrite() there is only one round trip to MongoDB.
-     * Mongoose will perform casting on all operations you provide.
-     * This function does not trigger any middleware, not save() nor update(). If you need to trigger save() middleware for every document use create() instead.
-     * @param writes Operations
-     * @param options Optional settings. See https://mongoosejs.com/docs/api/model.html#model_Model.bulkWrite
-     * @param cb callback
-     * @return `BulkWriteOpResult` if the operation succeeds
-     */
-    bulkWrite(writes: any[], cb?: (err: any, res: mongodb.BulkWriteOpResultObject) => void): Promise<mongodb.BulkWriteOpResultObject>;
-    bulkWrite(writes: any[], options?: mongodb.CollectionBulkWriteOptions): Promise<mongodb.BulkWriteOpResultObject>;
-    bulkWrite(writes: any[], options: mongodb.CollectionBulkWriteOptions, cb: (err: any, res: mongodb.BulkWriteOpResultObject) => void): void;
-
-    model<U extends Document>(name: string): Model<U>;
-
-    /**
-     * Creates a Query and specifies a $where condition.
-     * @param argument is a javascript string or anonymous function
-     */
-    $where(argument: string | Function): DocumentQuery<T, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Performs aggregations on the models collection.
-     * If a callback is passed, the aggregate is executed and a Promise is returned.
-     * If a callback is not passed, the aggregate itself is returned.
-     * @param aggregations pipeline operator(s) or operator array
-     */
-    aggregate<U = any>(aggregations?: any[]): Aggregate<U[]>;
-    aggregate<U = any>(aggregations: any[], cb: Function): Promise<U[]>;
-
-    /** Counts number of matching documents in a database collection. */
-    count(conditions: FilterQuery<T>, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-
-    /**
-     * Counts number of documents matching `criteria` in a database collection.
-     *
-     * If you want to count all documents in a large collection,
-     * use the `estimatedDocumentCount()` instead.
-     * If you call `countDocuments({})`, MongoDB will always execute
-     * a full collection scan and **not** use any indexes.
-     *
-     * @param {Object} filter
-     * @param {Function} [callback]
-     * @return {Query}
-     */
-    countDocuments(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-    countDocuments(criteria: FilterQuery<T>, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-
-    /**
-     * Estimates the number of documents in the MongoDB collection. Faster than
-     * using `countDocuments()` for large collections because
-     * `estimatedDocumentCount()` uses collection metadata rather than scanning
-     * the entire collection.
-     *
-     * @param {Object} [options]
-     * @param {Function} [callback]
-     * @return {Query}
-     */
-    estimatedDocumentCount(callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-    estimatedDocumentCount(options: any, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;
-
-    /**
-     * Shortcut for saving one or more documents to the database. MyModel.create(docs)
-     * does new MyModel(doc).save() for every doc in docs.
-     * Triggers the save() hook.
-     */
-    create<TCreate = T>(doc: CreateQuery<TCreate>, options?: SaveOptions): Promise<T>;
-    create<TCreate = T>(doc: CreateQuery<TCreate>, callback?: (err: any, res: T[]) => void): Promise<T>;
-    create<TCreate = T>(docs: CreateQuery<TCreate>[], callback?: (err: any, res: T[]) => void): Promise<T[]>;
-    create<TCreate = T>(docs: CreateQuery<TCreate>[], options?: SaveOptions, callback?: (err: any, res: T[]) => void): Promise<T[]>;
-    create<TCreate = T>(...docs: CreateQuery<TCreate>[]): Promise<T>;
-    /**
-     * Create the collection for this model. By default, if no indexes are specified, mongoose will not create the
-     * collection for the model until any documents are created. Use this method to create the collection explicitly.
-     */
-    createCollection(options?: mongodb.CollectionCreateOptions, cb?: (err: any) => void): Promise<void>;
-
-    /**
-     * Adds a discriminator type.
-     * @param name discriminator model name
-     * @param schema discriminator model schema
-     * @param value the string stored in the `discriminatorKey` property
-     */
-    discriminator<U extends Document>(name: string, schema: Schema, value?: string): Model<U>;
-
-    /**
-     * Adds a discriminator type.
-     * @param name discriminator model name
-     * @param schema discriminator model schema
-     * @param value the string stored in the `discriminatorKey` property
-     */
-    discriminator<U extends Document, M extends Model<U>>(name: string, schema: Schema, value?: string): M;
-
-    /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
-    distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
-    distinct(field: string, conditions: any,
-      callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
-
-    /**
-     * Makes the indexes in MongoDB match the indexes defined in this model's
-     * schema. This function will drop any indexes that are not defined in
-     * the model's schema except the `_id` index, and build any indexes that
-     * are in your schema but not in MongoDB.
-     * @param options options to pass to `ensureIndexes()`
-     * @param callback optional callback
-     * @return Returns `undefined` if callback is specified, returns a promise if no callback.
-     */
-    syncIndexes(options: object | null | undefined, callback: (err: any) => void): void;
-    syncIndexes(options?: object | null): Promise<void>;
-
-    /**
-     * Lists the indexes currently defined in MongoDB. This may or may not be
-     * the same as the indexes defined in your schema depending on whether you
-     * use the [`autoIndex` option](/docs/guide.html#autoIndex) and if you
-     * build indexes manually.
-     * @param cb optional callback
-     * @return Returns `undefined` if callback is specified, returns a promise if no callback.
-     */
-    listIndexes(callback: (err: any) => void): void;
-    listIndexes(): Promise<void>;
-
-    /**
-     * Sends ensureIndex commands to mongo for each index declared in the schema.
-     * @param options internal options
-     * @param cb optional callback
-     */
-    ensureIndexes(callback?: (err: any) => void): Promise<void>;
-    ensureIndexes(options: any, callback?: (err: any) => void): Promise<void>;
-
-    /**
-     * Similar to ensureIndexes(), except for it uses the createIndex function. The ensureIndex() function checks to see if an index with that name already exists, and, if not, does not attempt to create the index. createIndex() bypasses this check.
-     * @param cb Optional callback
-     */
-    createIndexes(cb?: (err: any) => void): Promise<void>;
-
-    /**
-     * Returns true if at least one document exists in the database that matches
-     * the given `filter`, and false otherwise.
-     */
-    exists(filter: FilterQuery<T>, callback?: (err: any, res: boolean) => void): Promise<boolean>;
-
-    /**
-     * Finds documents.
-     * @param projection optional fields to return
-     */
-    find(callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
-    find(conditions: FilterQuery<T>, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
-    find(conditions: FilterQuery<T>, projection?: any | null,
-      callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
-    find(conditions: FilterQuery<T>, projection?: any | null, options?: { lean: true } & Omit<QueryFindOptions, 'lean'>,
-      callback?: (err: any, res: T[]) => void): Query<DocumentDefinition<T>[]> & QueryHelpers;
-    find(conditions: FilterQuery<T>, projection?: any | null, options?: QueryFindOptions,
-      callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Finds a single document by its _id field. findById(id) is almost*
-     * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.
-     * @param id value of _id to query by
-     * @param projection optional fields to return
-     */
-    findById(id: any | string | number,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findById(id: any | string | number, projection: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findById(id: any | string | number, projection: any, options: { lean: true } & Omit<QueryFindBaseOptions, 'lean'>,
-      callback?: (err: any, res: T | null) => void): Query<DocumentDefinition<T>> & QueryHelpers;
-    findById(id: any | string | number, projection: any, options: QueryFindBaseOptions,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issue a mongodb findAndModify remove command by a document's _id field.
-     * findByIdAndRemove(id, ...) is equivalent to findOneAndRemove({ _id: id }, ...).
-     * Finds a matching document, removes it, passing the found document (if any) to the callback.
-     * Executes immediately if callback is passed, else a Query object is returned.
-     *
-     * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
-     * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
-     *
-     * Note: same signatures as findByIdAndDelete
-     *
-     * @param id value of _id to query by
-     */
-    findByIdAndRemove(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findByIdAndRemove(id: any | number | string,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findByIdAndRemove(id: any | number | string, options: QueryFindOneAndRemoveOptions,
-      callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
-    findByIdAndRemove(id: any | number | string, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-
-     /**
-     * Issue a mongodb findOneAndDelete command by a document's _id field.
-     * findByIdAndDelete(id, ...) is equivalent to findOneAndDelete({ _id: id }, ...).
-     * Finds a matching document, removes it, passing the found document (if any) to the callback.
-     * Executes immediately if callback is passed, else a Query object is returned.
-     *
-     * Note: same signatures as findByIdAndRemove
-     *
-     * @param id value of _id to query by
-     */
-    findByIdAndDelete(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findByIdAndDelete(id: any | number | string,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findByIdAndDelete(id: any | number | string, options: QueryFindOneAndRemoveOptions,
-      callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
-    findByIdAndDelete(id: any | number | string, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
-     * is equivalent to findOneAndUpdate({ _id: id }, ...).
-     *
-     * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
-     * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
-     *
-     * @param id value of _id to query by
-     */
-    findByIdAndUpdate(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findByIdAndUpdate(id: any | number | string, update: UpdateQuery<T>,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findByIdAndUpdate(id: any | number | string, update: UpdateQuery<T>,
-      options: { rawResult: true } & { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, res: T) => void): DocumentQuery<T, T, QueryHelpers> & QueryHelpers;
-    findByIdAndUpdate(id: any | number | string, update: UpdateQuery<T>,
-      options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
-    findByIdAndUpdate(id: any | number | string, update: UpdateQuery<T>,
-      options: { rawResult : true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
-    findByIdAndUpdate(id: any | number | string, update: UpdateQuery<T>,
-      options: { lean: true } & Omit<QueryFindOneAndUpdateOptions, 'lean'>,
-      callback?: (err: any, res: DocumentDefinition<T>) => void)
-        : Query<DocumentDefinition<T>> & QueryHelpers;
-    findByIdAndUpdate(id: any | number | string, update: UpdateQuery<T>,
-      options: QueryFindOneAndUpdateOptions,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Finds one document.
-     * The conditions are cast to their respective SchemaTypes before the command is sent.
-     * @param projection optional fields to return
-     */
-    findOne(conditions?: FilterQuery<T>,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOne(conditions: FilterQuery<T>, projection: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOne(conditions: FilterQuery<T>, projection: any, options: { lean: true } & Omit<QueryFindBaseOptions, 'lean'>,
-      callback?: (err: any, res: T | null) => void): Query<DocumentDefinition<T>> & QueryHelpers;
-    findOne(conditions: FilterQuery<T>, projection: any, options: QueryFindBaseOptions,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issue a mongodb findAndModify remove command.
-     * Finds a matching document, removes it, passing the found document (if any) to the callback.
-     * Executes immediately if callback is passed else a Query object is returned.
-     *
-     * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than deprecated findAndModify().
-     * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
-     *
-     * Note: same signatures as findOneAndDelete
-     *
-     */
-    findOneAndRemove(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOneAndRemove(conditions: FilterQuery<T>,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOneAndRemove(conditions: FilterQuery<T>, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
-      callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
-    findOneAndRemove(conditions: FilterQuery<T>, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issues a mongodb findOneAndDelete command.
-     * Finds a matching document, removes it, passing the found document (if any) to the
-     * callback. Executes immediately if callback is passed.
-     *
-     * Note: same signatures as findOneAndRemove
-     *
-     */
-    findOneAndDelete(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOneAndDelete(conditions: FilterQuery<T>,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOneAndDelete(conditions: FilterQuery<T>, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
-      callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
-    findOneAndDelete(conditions: FilterQuery<T>, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Issues a mongodb findAndModify update command.
-     * Finds a matching document, updates it according to the update arg, passing any options,
-     * and returns the found document (if any) to the callback. The query executes immediately
-     * if callback is passed else a Query object is returned.
-     *
-     * If mongoose option 'useFindAndModify': set to false it uses native findOneAndUpdate() rather than the deprecated findAndModify().
-     * https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
-     */
-    findOneAndUpdate(): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(conditions: FilterQuery<T>, update: UpdateQuery<T>,
-      callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(conditions: FilterQuery<T>, update: UpdateQuery<T>,
-      options: { rawResult : true } & { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
-    findOneAndUpdate(conditions: FilterQuery<T>, update: UpdateQuery<T>,
-      options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: T, res: any) => void): DocumentQuery<T, T, QueryHelpers> & QueryHelpers;
-    findOneAndUpdate(conditions: FilterQuery<T>, update: UpdateQuery<T>,
-      options: { rawResult: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
-    findOneAndUpdate(conditions: FilterQuery<T>, update: UpdateQuery<T>,
-      options: { lean: true } & Omit<QueryFindOneAndUpdateOptions, 'lean'>,
-      callback?: (err: any, doc: DocumentDefinition<T>, res: any) => void): Query<DocumentDefinition<T>> & QueryHelpers;
-    findOneAndUpdate(conditions: FilterQuery<T>, update: UpdateQuery<T>,
-      options: QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Implements $geoSearch functionality for Mongoose
-     * @param conditions an object that specifies the match condition (required)
-     * @param options for the geoSearch, some (near, maxDistance) are required
-     * @param callback optional callback
-     */
-    geoSearch(conditions: any, options: {
-      /** x,y point to search for */
-      near: number[];
-      /** the maximum distance from the point near that a result can be */
-      maxDistance: number;
-      /** The maximum number of results to return */
-      limit?: number;
-      /** return the raw object instead of the Mongoose Model */
-      lean?: boolean;
-    }, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T, QueryHelpers> & QueryHelpers;
-
-    /**
-     * Shortcut for creating a new Document from existing raw data,
-     * pre-saved in the DB. The document returned has no paths marked
-     * as modified initially.
-     */
-    hydrate(obj: any): T;
-
-    /**
-     * Shortcut for validating an array of documents and inserting them into
-     * MongoDB if they're all valid. This function is faster than .create()
-     * because it only sends one operation to the server, rather than one for each
-     * document.
-     * This function does not trigger save middleware.
-     * @param docs Documents to insert.
-     * @param options Optional settings.
-     * @param options.ordered  if true, will fail fast on the first error encountered.
-     *        If false, will insert all the documents it can and report errors later.
-     * @param options.rawResult if false, the returned promise resolves to the documents that passed mongoose document validation.
-     *        If `true`, will return the [raw result from the MongoDB driver](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~insertWriteOpCallback)
-     *        with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
-     */
-    insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): Promise<T[]>;
-    insertMany(docs: any[], options?: { ordered?: boolean, rawResult?: boolean } & ModelOptions, callback?: (error: any, docs: T[]) => void): Promise<T[]>;
-    insertMany(doc: any, callback?: (error: any, doc: T) => void): Promise<T>;
-    insertMany(doc: any, options?: { ordered?: boolean, rawResult?: boolean } & ModelOptions, callback?: (error: any, doc: T) => void): Promise<T>;
-
-    /**
-     * Performs any async initialization of this model against MongoDB.
-     * This function is called automatically, so you don't need to call it.
-     * This function is also idempotent, so you may call it to get back a promise
-     * that will resolve when your indexes are finished building as an alternative
-     * to `MyModel.on('index')`
-     * @param callback optional
-     */
-    init(callback?: (err: any) => void): Promise<T>;
-
-    /**
-     * Executes a mapReduce command.
-     * @param o an object specifying map-reduce options
-     * @param callbackoptional callback
-     */
-    mapReduce<Key, Value>(
-      o: ModelMapReduceOption<T, Key, Value>,
-      callback?: (err: any, res: any) => void
-    ): Promise<any>;
-
-    /**
-     * Populates document references.
-     * @param docs Either a single document or array of documents to populate.
-     * @param options A hash of key/val (path, options) used for population.
-     * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
-     */
-    populate(docs: any[], options: ModelPopulateOptions | ModelPopulateOptions[],
-      callback?: (err: any, res: T[]) => void): Promise<T[]>;
-    populate<T>(docs: any, options: ModelPopulateOptions | ModelPopulateOptions[],
-      callback?: (err: any, res: T) => void): Promise<T>;
-
-    /** Removes documents from the collection. */
-    remove(conditions: FilterQuery<T>, callback?: (err: any) => void): Query<mongodb.DeleteWriteOpResultObject['result'] & { deletedCount?: number }> & QueryHelpers;
-    deleteOne(conditions: FilterQuery<T>, callback?: (err: any) => void): Query<mongodb.DeleteWriteOpResultObject['result'] & { deletedCount?: number }> & QueryHelpers;
-    deleteOne(conditions: FilterQuery<T>, options: ModelOptions, callback?: (err: any) => void): Query<mongodb.DeleteWriteOpResultObject['result'] & { deletedCount?: number }> & QueryHelpers;
-    deleteMany(conditions: FilterQuery<T>, callback?: (err: any) => void): Query<mongodb.DeleteWriteOpResultObject['result'] & { deletedCount?: number }> & QueryHelpers;
-    deleteMany(conditions: FilterQuery<T>, options: ModelOptions, callback?: (err: any) => void): Query<mongodb.DeleteWriteOpResultObject['result'] & { deletedCount?: number }> & QueryHelpers;
-
-    /**
-     * Same as update(), except MongoDB replace the existing document with the given document (no atomic operators like $set).
-     * This function triggers the following middleware: replaceOne
-     */
-    replaceOne(conditions: FilterQuery<T>, replacement: any, callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-
-    /**
-     * Updates documents in the database without returning them.
-     * All update values are cast to their appropriate SchemaTypes before being sent.
-     */
-    update(conditions: FilterQuery<T>, doc: UpdateQuery<T>,
-      callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-    update(conditions: FilterQuery<T>, doc: UpdateQuery<T>, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-    updateOne(conditions: FilterQuery<T>, doc: UpdateQuery<T>,
-      callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-    updateOne(conditions: FilterQuery<T>, doc: UpdateQuery<T>, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-    updateMany(conditions: FilterQuery<T>, doc: UpdateQuery<T>,
-      callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-    updateMany(conditions: FilterQuery<T>, doc: UpdateQuery<T>, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any> & QueryHelpers;
-
-    /** Creates a Query, applies the passed conditions, and returns the Query. */
-    where(path: string, val?: any): Query<any> & QueryHelpers;
-  }
-
-  class Document {}
-  interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
-    /** Signal that we desire an increment of this documents version. */
-    increment(): this;
-
-    /**
-     * Returns another Model instance.
-     * @param name model name
-     */
-    model<T extends Document>(name: string): Model<T>;
-
-    /** Override whether mongoose thinks this doc is deleted or not */
-    $isDeleted(isDeleted: boolean): void;
-    /** whether mongoose thinks this doc is deleted. */
-    $isDeleted(): boolean;
-
-    /**
-     * Removes this document from the db.
-     * @param fn optional callback
-     */
-    remove(fn?: (err: any, product: this) => void): Promise<this>;
-
-    /**
-     * Deletes the document from the db.
-     * @param fn optional callback
-     */
-    deleteOne(fn?: (err: any, product: this) => void): Promise<this>;
-
-    /**
-     * Saves this document.
-     * @param options options optional options
-     * @param options.safe overrides schema's safe option
-     * @param options.validateBeforeSave set to false to save without validating.
-     * @param fn optional callback
-     */
-    save(options?: SaveOptions, fn?: (err: any, product: this) => void): Promise<this>;
-    save(fn?: (err: any, product: this) => void): Promise<this>;
-
-    /**
-     * Version using default version key. See http://mongoosejs.com/docs/guide.html#versionKey
-     * If you're using another key, you will have to access it using []: doc[_myVersionKey]
-     */
-    __v?: number;
-  }
-
-  interface SaveOptions {
-    checkKeys?: boolean;
-    safe?: boolean | WriteConcern;
-    validateBeforeSave?: boolean;
-    validateModifiedOnly?: boolean;
-    j?: boolean;
-    session?: ClientSession;
-    timestamps?: boolean;
-    w?: number | string;
-    wtimeout?: number;
-  }
-
-  interface WriteConcern {
-    j?: boolean;
-    w?: number | 'majority' | TagSet;
-    wtimeout?: number;
-  }
-
-  interface TagSet {
-    [k: string]: string;
-  }
-
-  interface ModelProperties {
-    /** Collection the model uses. */
-    collection: Collection;
-
-    /** Connection the model uses. */
-    db: Connection;
-
-    /** Schema the model uses. */
-    schema: Schema;
-  }
-
-  /** https://mongoosejs.com/docs/api.html#query_Query-setOptions */
-  interface ModelOptions {
-    session?: ClientSession | null;
-  }
-
-  interface QueryPopulateOptions {
-    /** space delimited path(s) to populate */
-    path: string;
-    /** optional fields to select */
-    select?: any;
-    /** optional query conditions to match */
-    match?: any;
-    /** optional model to use for population */
-    model?: string | Model<any>;
-    /** optional query options like sort, limit, etc */
-    options?: any;
-    /** deep populate */
-    populate?: QueryPopulateOptions | QueryPopulateOptions[];
-  }
-
-  interface ModelPopulateOptions extends QueryPopulateOptions {
-    /** optional, if true Mongoose will always set path to an array. Inferred from schema by default */
-    justOne?: boolean;
-  }
-
-  interface ModelUpdateOptions extends ModelOptions {
-    /** safe mode (defaults to value set in schema (true)) */
-    safe?: boolean;
-    /** whether to create the doc if it doesn't match (false) */
-    upsert?: boolean;
-    /** whether multiple documents should be updated (false) */
-    multi?: boolean;
-    /**
-     * If true, runs update validators on this command. Update validators validate
-     * the update operation against the model's schema.
-     */
-    runValidators?: boolean;
-    /**
-     * If this and upsert are true, mongoose will apply the defaults specified in the
-     * model's schema if a new document is created. This option only works on MongoDB >= 2.4
-     * because it relies on MongoDB's $setOnInsert operator.
-     */
-    setDefaultsOnInsert?: boolean;
-    /** overrides the strict option for this update */
-    strict?: boolean | "throw";
-    /** disables update-only mode, allowing you to overwrite the doc (false) */
-    overwrite?: boolean;
-    /**
-     * Only update elements that match the arrayFilters conditions in the document or documents that match the query conditions.
-     */
-    arrayFilters?: { [key: string]: any }[];
-    /** other options */
-    [other: string]: any;
-    /**
-     *  by default, mongoose only returns the first error that occurred in casting the query.
-     *  Turn on this option to aggregate all the cast errors.
-     */
-    multipleCastError?: boolean;
-
-    /**
-     * allow setting the discriminator key in the update.
-     * Will use the correct discriminator schema if the update changes the discriminator key.
-     */
-    overwriteDiscriminatorKey?: boolean;
-  }
-
-  interface ModelMapReduceOption<T, Key, Val> {
-    map: Function | string;
-    reduce: (key: Key, vals: T[]) => Val;
-    /** query filter object. */
-    query?: any;
-    /** sort input objects using this key */
-    sort?: any;
-    /** max number of documents */
-    limit?: number;
-    /** keep temporary data default: false */
-    keeptemp?: boolean;
-    /** finalize function */
-    finalize?: (key: Key, val: Val) => Val;
-    /** scope variables exposed to map/reduce/finalize during execution */
-    scope?: any;
-    /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
-    jsMode?: boolean;
-    /** provide statistics on job execution time. default: false */
-    verbose?: boolean;
-    readPreference?: string;
-    /** sets the output target for the map reduce job. default: {inline: 1} */
-    out?: {
-      /** the results are returned in an array */
-      inline?: number;
-      /**
-       * {replace: 'collectionName'} add the results to collectionName: the
-       * results replace the collection
-       */
-      replace?: string;
-      /**
-       * {reduce: 'collectionName'} add the results to collectionName: if
-       * dups are detected, uses the reducer / finalize functions
-       */
-      reduce?: string;
-      /**
-       * {merge: 'collectionName'} add the results to collectionName: if
-       * dups exist the new docs overwrite the old
-       */
-      merge?: string;
-    };
-  }
-
-  interface MapReduceResult<Key, Val> {
-    _id: Key;
-    value: Val;
-  }
-
-  /*
-   * section collection.js
-   * http://mongoosejs.com/docs/api.html#collection-js
-   */
-  interface CollectionBase extends mongodb.Collection {
     /*
-      * Abstract methods. Some of these are already defined on the
-      * mongodb.Collection interface so they've been commented out.
-      */
-    ensureIndex(...args: any[]): any;
-    //find(...args: any[]): any;
-    findAndModify(...args: any[]): any;
-    //findOne(...args: any[]): any;
-    getIndexes(...args: any[]): any;
-    //insert(...args: any[]): any;
-    //mapReduce(...args: any[]): any;
-    //save(...args: any[]): any;
-    //update(...args: any[]): any;
+     * section collection.js
+     * http://mongoosejs.com/docs/api.html#collection-js
+     */
+    interface CollectionBase extends mongodb.Collection {
+        /*
+         * Abstract methods. Some of these are already defined on the
+         * mongodb.Collection interface so they've been commented out.
+         */
+        ensureIndex(...args: any[]): any;
+        //find(...args: any[]): any;
+        findAndModify(...args: any[]): any;
+        //findOne(...args: any[]): any;
+        getIndexes(...args: any[]): any;
+        //insert(...args: any[]): any;
+        //mapReduce(...args: any[]): any;
+        //save(...args: any[]): any;
+        //update(...args: any[]): any;
 
-    /** The collection name */
-    collectionName: string;
-    /** The Connection instance */
-    conn: Connection;
-    /** The collection name */
-    name: string;
-  }
+        /** The collection name */
+        collectionName: string;
+        /** The Connection instance */
+        conn: Connection;
+        /** The collection name */
+        name: string;
+    }
 }

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1609,6 +1609,12 @@ declare module "mongoose" {
         modifiedPaths(): string[];
 
         /**
+         * If this document is a subdocument or populated document, returns the document's parent.
+         * Returns undefined otherwise.
+         */
+        parent(): undefined | MongooseDocument;
+
+        /**
          * Populates document references, executing the callback when complete.
          * If you want to use promises instead, use this function with
          * execPopulate()
@@ -1749,6 +1755,8 @@ declare module "mongoose" {
         class Subdocument extends MongooseDocument {
             /** Returns the top level document of this sub-document. */
             ownerDocument(): MongooseDocument;
+            /** Returns this sub-document's parent document. */
+            parent(): MongooseDocument;
 
             /**
              * Null-out this subdoc
@@ -1959,9 +1967,9 @@ declare module "mongoose" {
 
             /** Returns the top level document of this sub-document. */
             ownerDocument(): MongooseDocument;
-            /** Returns this sub-documents parent document. */
+            /** Returns this sub-document's parent document. */
             parent(): MongooseDocument;
-            /** Returns this sub-documents parent array. */
+            /** Returns this sub-document's parent array. */
             parentArray(): DocumentArray<MongooseDocument>;
 
             /** Removes the subdocument from its parent array. */

--- a/types/mongoose/test/definitions.ts
+++ b/types/mongoose/test/definitions.ts
@@ -1,14 +1,17 @@
-import * as mongodb from 'mongodb';
-import * as mongoose from 'mongoose';
+import * as mongodb from "mongodb";
+import * as mongoose from "mongoose";
 
-export const MyModel = mongoose.model('test', new mongoose.Schema({
-    name: {
-        type: String,
-        alias: 'foo',
-        default: 'Val '
-    },
-    wheels: Number
-}));
+export const MyModel = mongoose.model(
+    "test",
+    new mongoose.Schema({
+        name: {
+            type: String,
+            alias: "foo",
+            default: "Val ",
+        },
+        wheels: Number,
+    }),
+);
 
 export interface OtherLocation extends mongoose.Document {
     type: string;
@@ -23,4 +26,4 @@ export interface Location extends mongoose.Document {
     ref1: mongodb.ObjectId;
     // This type is useful for using with `populate()`
     ref2: mongodb.ObjectId | OtherLocation;
-};
+}

--- a/types/mongoose/test/document.ts
+++ b/types/mongoose/test/document.ts
@@ -1,6 +1,6 @@
-import * as mongoose from 'mongoose';
+import * as mongoose from "mongoose";
 
-import { MyModel } from './definitions';
+import { MyModel } from "./definitions";
 
 // dummy variables
 var cb = function () {};
@@ -10,186 +10,204 @@ var cb = function () {};
  * https://mongoosejs.com/docs/api/document.html
  */
 var doc = new mongoose.Document();
-doc.$isDefault('path').valueOf();
-doc.$locals.field = 'value';
-const docDotDepopulate: mongoose.Document = doc.depopulate('path');
+doc.$isDefault("path").valueOf();
+doc.$locals.field = "value";
+const docDotDepopulate: mongoose.Document = doc.depopulate("path");
 doc.equals(doc).valueOf();
-doc.execPopulate().then(function (arg) {
-  arg.execPopulate();
-}).catch(function (err) {});
-doc.get('path', Number);
-doc.get('path', Number, { virtuals: true, getters: false });
+doc.execPopulate()
+    .then(function (arg) {
+        arg.execPopulate();
+    })
+    .catch(function (err) {});
+doc.get("path", Number);
+doc.get("path", Number, { virtuals: true, getters: false });
 doc.init(doc).init(doc, {});
 doc.inspect();
-doc.invalidate('path', new Error('hi')).toString();
-doc.invalidate('path', new Error('hi'), 999).toString();
-doc.isDirectModified('path').valueOf();
-doc.isInit('path').valueOf();
-doc.isModified('path').valueOf();
-doc.isSelected('path').valueOf();
-doc.markModified('path');
+doc.invalidate("path", new Error("hi")).toString();
+doc.invalidate("path", new Error("hi"), 999).toString();
+doc.isDirectModified("path").valueOf();
+doc.isInit("path").valueOf();
+doc.isModified("path").valueOf();
+doc.isSelected("path").valueOf();
+doc.markModified("path");
 doc.modifiedPaths()[0].toLowerCase();
 doc.populate(function (err, doc) {
-  doc.populate('path', function (err, doc) {
-    doc.populate({
-      path: 'path',
-      select: 'path',
-      match: {}
+    doc.populate("path", function (err, doc) {
+        doc.populate({
+            path: "path",
+            select: "path",
+            match: {},
+        });
     });
-  });
 });
-doc.populated('path');
-doc.set('path', 999, {}).set({ path: 999 });
-doc.overwrite({path: 999});
+doc.populated("path");
+doc.set("path", 999, {}).set({ path: 999 });
+doc.overwrite({ path: 999 });
 doc.toJSON({
-  getters: true,
-  virtuals: false
+    getters: true,
+    virtuals: false,
 });
 doc.toObject({
-  transform: function (doc, ret, options) {
-    doc.toObject();
-  }
+    transform: function (doc, ret, options) {
+        doc.toObject();
+    },
 });
 doc.toString().toLowerCase();
-doc.unmarkModified('path');
+doc.unmarkModified("path");
 doc.update(doc, cb).cursor();
-doc.update(doc, {
-  safe: true,
-  upsert: true,
-  strict: "throw"
-}, cb).cursor();
+doc.update(
+    doc,
+    {
+        safe: true,
+        upsert: true,
+        strict: "throw",
+    },
+    cb,
+).cursor();
 doc.validate({}, function (err) {});
 doc.validate().then(null).catch(null);
 (() => {
-  // Scope to avoid type mixing
-  var validationError = doc.validateSync(['path1', 'path2']);
-  if (validationError) {
-      validationError.stack
-  }
+    // Scope to avoid type mixing
+    var validationError = doc.validateSync(["path1", "path2"]);
+    if (validationError) {
+        validationError.stack;
+    }
 })();
 
 /* practical examples */
 
 doc = new MyModel();
-doc.$isDefault('name');
-MyModel.findOne().populate('author').exec(function (err, doc) {
-  if (doc) {
-    doc.depopulate('author');
-  }
-});
-MyModel.replaceOne({foo: 'bar'}, {qux: 'baz'}).where();
-MyModel.replaceOne({foo: 'bar'}, {qux: 'baz'}, (err, raw) => {})
-MyModel.bulkWrite([{foo:'bar'}]).then(r => {
-  console.log(r.deletedCount);
+doc.$isDefault("name");
+MyModel.findOne()
+    .populate("author")
+    .exec(function (err, doc) {
+        if (doc) {
+            doc.depopulate("author");
+        }
+    });
+MyModel.replaceOne({ foo: "bar" }, { qux: "baz" }).where();
+MyModel.replaceOne({ foo: "bar" }, { qux: "baz" }, (err, raw) => {});
+MyModel.bulkWrite([{ foo: "bar" }]).then(r => {
+    console.log(r.deletedCount);
 });
 MyModel.bulkWrite([], (err, res) => {
-  console.log(res.modifiedCount);
+    console.log(res.modifiedCount);
 });
 MyModel.bulkWrite([], { ordered: false }, (err, res) => {
-  console.log(res.modifiedCount);
+    console.log(res.modifiedCount);
 });
-doc.populate('path');
-doc.populate({path: 'hello'});
-doc.populate('path', cb)
-doc.populate({path: 'hello'}, cb);
+doc.populate("path");
+doc.populate({ path: "hello" });
+doc.populate("path", cb);
+doc.populate({ path: "hello" }, cb);
 doc.populate(cb);
-doc.populate({path: 'hello'}).execPopulate().catch(cb);
-doc.update({
-  $inc: { wheels: 1 }
-}, { w: 1 }, cb);
+doc.populate({ path: "hello" }).execPopulate().catch(cb);
+doc.update(
+    {
+        $inc: { wheels: 1 },
+    },
+    { w: 1 },
+    cb,
+);
 
-const ImageSchema = new mongoose.Schema({
-  name: {type: String, required: true},
-  id: {type: Number, unique: true, required: true, index: true},
-}, { id: false });
+const ImageSchema = new mongoose.Schema(
+    {
+        name: { type: String, required: true },
+        id: { type: Number, unique: true, required: true, index: true },
+    },
+    { id: false },
+);
 
 const clonedSchema: mongoose.Schema = new mongoose.Schema().clone();
 
 interface ImageDoc extends mongoose.Document {
-  name: string,
-  id: number
+    name: string;
+    id: number;
 }
 
-const ImageModel = mongoose.model<ImageDoc>('image', ImageSchema);
+const ImageModel = mongoose.model<ImageDoc>("image", ImageSchema);
 
-ImageModel.findOne({}, function(err, doc) {
-  if (doc) {
-    doc.name;
-    doc.id;
-  }
+ImageModel.findOne({}, function (err, doc) {
+    if (doc) {
+        doc.name;
+        doc.id;
+    }
 });
 
 /* Using flatten maps example */
 interface Submission extends mongoose.Document {
-  name: string;
-  fields: Record<string,string>;
+    name: string;
+    fields: Record<string, string>;
 }
 var SubmissionSchema = new mongoose.Schema({
-  name: String,
-  fields: {
-    type: Map,
-    of: String
-  }
+    name: String,
+    fields: {
+        type: Map,
+        of: String,
+    },
 });
-const SubmissionModel = mongoose.model<Submission>('Submission', SubmissionSchema);
+const SubmissionModel = mongoose.model<Submission>("Submission", SubmissionSchema);
 const submission = new SubmissionModel({
-  name: "Submission Name",
-  fields: {
-    extra: "Value",
-    other: "Thing"
-  }
+    name: "Submission Name",
+    fields: {
+        extra: "Value",
+        other: "Thing",
+    },
 });
-submission.save()
-.then(result => {
-  console.log(result.toObject({
-    flattenMaps: true
-  }));
-})
-.catch(() => {
-  console.log("Flatten maps error");
-});
+submission
+    .save()
+    .then(result => {
+        console.log(
+            result.toObject({
+                flattenMaps: true,
+            }),
+        );
+    })
+    .catch(() => {
+        console.log("Flatten maps error");
+    });
 
 /** Delete one with post hook example. */
 interface User extends mongoose.Document {
-  username: string;
+    username: string;
 }
 
 const UserSchema = new mongoose.Schema({
-  username: String
+    username: String,
 });
 
-const UserModel = mongoose.model<User>('User', UserSchema);
+const UserModel = mongoose.model<User>("User", UserSchema);
 
-UserSchema.post<User>('deleteOne', {document: true, query: false}, function cleanup(doc) {
-  // Perform cleanup action here.
-  // This can be used to cascade your db and remove any references to the given user.
-  console.log('User deleteOne hook called for:', doc._id);
+UserSchema.post<User>("deleteOne", { document: true, query: false }, function cleanup(doc) {
+    // Perform cleanup action here.
+    // This can be used to cascade your db and remove any references to the given user.
+    console.log("User deleteOne hook called for:", doc._id);
 });
 
-UserSchema.post<User>('remove', {document: true, query: false}, function cleanup(doc) {
-  // Perform cleanup action here.
-  // This can be used to cascade your db and remove any references to the given user.
-  console.log('User remove hook called for:', doc._id);
+UserSchema.post<User>("remove", { document: true, query: false }, function cleanup(doc) {
+    // Perform cleanup action here.
+    // This can be used to cascade your db and remove any references to the given user.
+    console.log("User remove hook called for:", doc._id);
 });
 
 async function createAndDeleteUser(): Promise<void> {
-  try {
-    const doc = await UserModel.create({ username: 'Test' });
-    await doc.deleteOne();
-    console.log('Deleted user document!');
-  } catch (e) {
-    console.log('Error creating or deleting user:', e.message);
-  }
+    try {
+        const doc = await UserModel.create({ username: "Test" });
+        await doc.deleteOne();
+        console.log("Deleted user document!");
+    } catch (e) {
+        console.log("Error creating or deleting user:", e.message);
+    }
 }
 
 async function createAndRemoveUser(): Promise<void> {
-  try {
-    const doc = await UserModel.create({ username: 'Test' });
-    await doc.remove();
-    console.log('Removed user document!');
-  } catch (e) {
-    console.log('Error creating or removing user:', e.message);
-  }
+    try {
+        const doc = await UserModel.create({ username: "Test" });
+        await doc.remove();
+        console.log("Removed user document!");
+    } catch (e) {
+        console.log("Error creating or removing user:", e.message);
+    }
 }
 
 createAndDeleteUser();

--- a/types/mongoose/test/document.ts
+++ b/types/mongoose/test/document.ts
@@ -31,6 +31,7 @@ doc.isModified("path").valueOf();
 doc.isSelected("path").valueOf();
 doc.markModified("path");
 doc.modifiedPaths()[0].toLowerCase();
+doc.parent();
 doc.populate(function (err, doc) {
     doc.populate("path", function (err, doc) {
         doc.populate({

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -724,7 +724,7 @@ interface ModelWithFunction extends mongoose.Document {
 
     selfRefArray2?: ModelWithFunction[] | mongodb.ObjectID[];
 
-    parent?: {
+    myParent?: {
         ref:
             | {
                   _id: mongodb.ObjectId;

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -1,5 +1,5 @@
-import * as mongodb from 'mongodb';
-import * as mongoose from 'mongoose';
+import * as mongodb from "mongodb";
+import * as mongoose from "mongoose";
 
 // dummy variables
 var cb = function () {};
@@ -8,21 +8,28 @@ var cb = function () {};
  * section model.js
  * http://mongoosejs.com/docs/api.html#model-js
  */
-var MongoModel = mongoose.model('MongoModel', new mongoose.Schema({
-    name: String,
-    type: {
-      type: mongoose.Schema.Types.Mixed,
-      required: true
-    }
-}), 'myCollection', true);
+var MongoModel = mongoose.model(
+    "MongoModel",
+    new mongoose.Schema({
+        name: String,
+        type: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+        },
+    }),
+    "myCollection",
+    true,
+);
 
 MongoModel.init().then(cb);
-MongoModel.find({}).$where('indexOf("val") !== -1').exec(function (err, docs) {
-    docs[0].save();
-    docs[0].__v;
-});
+MongoModel.find({})
+    .$where('indexOf("val") !== -1')
+    .exec(function (err, docs) {
+        docs[0].save();
+        docs[0].__v;
+    });
 MongoModel.findById(999, function (err, doc) {
-    var handleSave = function(err: Error, product: mongoose.Document) {};
+    var handleSave = function (err: Error, product: mongoose.Document) {};
     if (!doc) {
         return;
     }
@@ -30,20 +37,33 @@ MongoModel.findById(999, function (err, doc) {
     doc.save(handleSave).then(cb).catch(cb);
     doc.save({ validateBeforeSave: false }, handleSave).then(cb).catch(cb);
     doc.save({ safe: true }, handleSave).then(cb).catch(cb);
-    doc.save({ safe: { w: 2, j: true } }, handleSave).then(cb).catch(cb);
-    doc.save({ safe: { w: 'majority', wtimeout: 10000 } }, handleSave).then(cb).catch(cb);
+    doc.save({ safe: { w: 2, j: true } }, handleSave)
+        .then(cb)
+        .catch(cb);
+    doc.save({ safe: { w: "majority", wtimeout: 10000 } }, handleSave)
+        .then(cb)
+        .catch(cb);
 
     // test if Typescript can infer the types of (err, product, numAffected)
-    doc.save(function(err, product) { product.save(); })
-        .then(function(p) { p.save() }).catch(cb);
-    doc.save({ validateBeforeSave: false }, function(err, product) {
+    doc.save(function (err, product) {
         product.save();
-    }).then(function(p) { p.save() }).catch(cb);
+    })
+        .then(function (p) {
+            p.save();
+        })
+        .catch(cb);
+    doc.save({ validateBeforeSave: false }, function (err, product) {
+        product.save();
+    })
+        .then(function (p) {
+            p.save();
+        })
+        .catch(cb);
 });
-MongoModel = (new MongoModel()).model('MongoModel');
+MongoModel = new MongoModel().model("MongoModel");
 var mongoModel = new MongoModel();
 mongoModel.remove(function (err, product) {
-    if (err) throw(err);
+    if (err) throw err;
     MongoModel.findById(product._id, function (err, product) {
         if (product) {
             product.id.toLowerCase();
@@ -55,40 +75,47 @@ mongoModel.save().then(function (product) {
     product.save().then(cb).catch(cb);
 });
 MongoModel.aggregate(
-    [
-        { $group: { _id: null, maxBalance: { $max: '$balance' }}},
-        { $project: { _id: 0, maxBalance: 1 }}
-    ],
-    cb
+    [{ $group: { _id: null, maxBalance: { $max: "$balance" } } }, { $project: { _id: 0, maxBalance: 1 } }],
+    cb,
 );
 MongoModel.aggregate([])
-    .group({ _id: null, maxBalance: { $max: '$balance' } })
+    .group({ _id: null, maxBalance: { $max: "$balance" } })
     .hint({ _id: 1, maxBalance: 1 })
     .exec(cb);
-MongoModel.count({ type: 'jungle' }, function (err, count) {
+MongoModel.count({ type: "jungle" }, function (err, count) {
     count.toFixed();
 });
-MongoModel.create({
-    type: 'jelly bean'
-}, {
-    type: 'snickers'
-}, cb).then(function (a) {
+MongoModel.create(
+    {
+        type: "jelly bean",
+    },
+    {
+        type: "snickers",
+    },
+    cb,
+).then(function (a) {
     a.save();
-})
-MongoModel.create([{ type: 'jelly bean' }, {
-    type: 'snickers'
-}], function (err, candies) {
-    var jellybean = candies[0];
-    var snickers = candies[1];
-}).then(function (arg) {
+});
+MongoModel.create(
+    [
+        { type: "jelly bean" },
+        {
+            type: "snickers",
+        },
+    ],
+    function (err, candies) {
+        var jellybean = candies[0];
+        var snickers = candies[1];
+    },
+).then(function (arg) {
     arg[0].save();
     arg[1].save();
 });
 MongoModel.createCollection().then(() => {});
 MongoModel.createCollection({ capped: true, max: 42 }).then(() => {});
 MongoModel.createCollection({ capped: true, max: 42 }, err => {});
-MongoModel.distinct('url', { clicks: {$gt: 100}}, function (err, result) {});
-MongoModel.distinct('url').exec(cb);
+MongoModel.distinct("url", { clicks: { $gt: 100 } }, function (err, result) {});
+MongoModel.distinct("url").exec(cb);
 MongoModel.syncIndexes().then(() => {});
 MongoModel.syncIndexes({}).then(() => {});
 MongoModel.syncIndexes(null).then(() => {});
@@ -99,8 +126,8 @@ MongoModel.syncIndexes(undefined, err => {});
 MongoModel.listIndexes();
 MongoModel.listIndexes(cb);
 MongoModel.ensureIndexes({}, cb);
-MongoModel.find({ name: 'john', age: { $gte: 18 }});
-MongoModel.find({ name: 'john', age: { $gte: 18 }}, function (err, docs) {
+MongoModel.find({ name: "john", age: { $gte: 18 } });
+MongoModel.find({ name: "john", age: { $gte: 18 } }, function (err, docs) {
     docs[0].remove();
     docs[1].execPopulate();
 });
@@ -109,25 +136,27 @@ async () => {
         item.model;
     }
 };
-MongoModel.find({ name: /john/i }, 'name friends', function (err, docs) { })
-MongoModel.find({ name: /john/i }, null, { skip: 10 })
+MongoModel.find({ name: /john/i }, "name friends", function (err, docs) {});
+MongoModel.find({ name: /john/i }, null, { skip: 10 });
 MongoModel.find({ name: /john/i }, null, { skip: 10 }, function (err, docs) {});
 MongoModel.find({ name: /john/i }, null, { skip: 10 }).exec(function (err, docs) {});
 MongoModel.findById(999, function (err, adventure) {});
 MongoModel.findById(999).exec(cb);
-MongoModel.findById(999, 'name length', function (err, adventure) {
+MongoModel.findById(999, "name length", function (err, adventure) {
     if (adventure) {
         adventure.save();
     }
 });
-MongoModel.findById(999, 'name length').exec(cb);
-MongoModel.findById(999, '-length').exec(function (err, adventure) {
+MongoModel.findById(999, "name length").exec(cb);
+MongoModel.findById(999, "-length").exec(function (err, adventure) {
     if (adventure) {
-        adventure.addListener('click', cb);
+        adventure.addListener("click", cb);
     }
 });
-MongoModel.findById(999, 'name', { lean: true }, function (err, doc) {});
-MongoModel.findById(999, 'name').lean().exec(function (err, doc) {});
+MongoModel.findById(999, "name", { lean: true }, function (err, doc) {});
+MongoModel.findById(999, "name")
+    .lean()
+    .exec(function (err, doc) {});
 MongoModel.findByIdAndRemove(999, {}, cb);
 MongoModel.findByIdAndRemove(999, {});
 MongoModel.findByIdAndRemove(999, cb);
@@ -139,13 +168,13 @@ MongoModel.findByIdAndUpdate(999, {}, { upsert: true, new: true });
 MongoModel.findByIdAndUpdate(999, {}, cb);
 MongoModel.findByIdAndUpdate(999, {});
 MongoModel.findByIdAndUpdate();
-MongoModel.findOne({ type: 'iphone' }, function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }).exec(function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }, 'name', function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }, 'name').exec(function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }, 'name', { lean: true }, cb);
-MongoModel.findOne({ type: 'iphone' }, 'name', { lean: true }).exec(cb);
-MongoModel.findOne({ type: 'iphone' }).select('name').lean().exec(cb);
+MongoModel.findOne({ type: "iphone" }, function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }).exec(function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }, "name", function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }, "name").exec(function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }, "name", { lean: true }, cb);
+MongoModel.findOne({ type: "iphone" }, "name", { lean: true }).exec(cb);
+MongoModel.findOne({ type: "iphone" }).select("name").lean().exec(cb);
 
 interface ModelUser {
     _id: any;
@@ -161,45 +190,53 @@ MongoModel.findOneAndRemove();
 MongoModel.findOneAndUpdate({}, {}, {}, cb);
 MongoModel.findOneAndUpdate({}, {}, {});
 MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true });
-MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true, arrayFilters: [{ 'elem._id': 123 }] });
+MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true, arrayFilters: [{ "elem._id": 123 }] });
 MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true, timestamps: true });
 MongoModel.findOneAndUpdate({}, {}, { overwrite: true });
 MongoModel.findOneAndUpdate({}, {}, { overwriteDiscriminatorKey: true });
 MongoModel.findOneAndUpdate({}, {}, cb);
 MongoModel.findOneAndUpdate({}, {});
 MongoModel.findOneAndUpdate();
-MongoModel.geoSearch({ type : "house" }, {
-    near: [10, 10], maxDistance: 5
-}, function(err, res) {
-    res[0].remove();
-});
+MongoModel.geoSearch(
+    { type: "house" },
+    {
+        near: [10, 10],
+        maxDistance: 5,
+    },
+    function (err, res) {
+        res[0].remove();
+    },
+);
 MongoModel.hydrate({
-    _id: '54108337212ffb6d459f854c',
-    type: 'jelly bean'
+    _id: "54108337212ffb6d459f854c",
+    type: "jelly bean",
 }).execPopulate();
-MongoModel.insertMany([
-    { name: 'Star Wars' },
-    { name: 'The Empire Strikes Back' }
-], function(error, docs) {});
-MongoModel.insertMany({name: 'Star Wars'}, function(error, doc) {});
-MongoModel.mapReduce({
-    map: cb,
-    reduce: cb
-}, function (err, results) {
-    console.log(results)
-}).then(function (model) {
-    return model.find().where('value').gt(10).exec();
-}).then(function (docs) {
-    console.log(docs);
-}).then(null, cb);
+MongoModel.insertMany([{ name: "Star Wars" }, { name: "The Empire Strikes Back" }], function (error, docs) {});
+MongoModel.insertMany({ name: "Star Wars" }, function (error, doc) {});
+MongoModel.mapReduce(
+    {
+        map: cb,
+        reduce: cb,
+    },
+    function (err, results) {
+        console.log(results);
+    },
+)
+    .then(function (model) {
+        return model.find().where("value").gt(10).exec();
+    })
+    .then(function (docs) {
+        console.log(docs);
+    })
+    .then(null, cb);
 MongoModel.findById(999, function (err, user) {
     if (!user) {
         return;
     }
     var opts = [
-        { path: 'company', match: { x: 1 }, select: 'name' },
-        { path: 'notes', options: { limit: 10 }, model: 'override' }
-    ]
+        { path: "company", match: { x: 1 }, select: "name" },
+        { path: "notes", options: { limit: 10 }, model: "override" },
+    ];
     MongoModel.populate(user, opts, cb);
     MongoModel.populate(user, opts, function (err, user) {
         console.log(user);
@@ -207,42 +244,57 @@ MongoModel.findById(999, function (err, user) {
 });
 // $ExpectError
 MongoModel.find(999, function (err, users) {
-    var opts = [{ path: 'company', match: { x: 1 }, select: 'name' }]
+    var opts = [{ path: "company", match: { x: 1 }, select: "name" }];
     var promise = MongoModel.populate(users, opts);
     promise.then(console.log);
 });
-MongoModel.populate({
-    name: 'Indiana Jones',
-    weapon: 389
-}, {
-    path: 'weapon',
-    model: 'Weapon'
-}, cb);
-var users = [{ name: 'Indiana Jones', weapon: 389 }]
-users.push({ name: 'Batman', weapon: 8921 })
-MongoModel.populate(users, { path: 'weapon' }, function (err, users) {
+MongoModel.populate(
+    {
+        name: "Indiana Jones",
+        weapon: 389,
+    },
+    {
+        path: "weapon",
+        model: "Weapon",
+    },
+    cb,
+);
+var users = [{ name: "Indiana Jones", weapon: 389 }];
+users.push({ name: "Batman", weapon: 8921 });
+MongoModel.populate(users, { path: "weapon" }, function (err, users) {
     users.forEach(cb);
 });
-MongoModel.remove({ title: 'baby born from alien father' }, cb);
-MongoModel.remove({_id: '999'}).exec().then(cb).catch(cb);
-MongoModel.remove({_id: '999'}).exec().then(res=>console.log(res.ok));
-MongoModel.deleteOne({_id: '999'}).then(res=>console.log(res.ok));
-MongoModel.deleteOne({_id: '999'}).exec().then(res=>console.log(res.ok));
-MongoModel.deleteMany({_id: '999'}).then(res=>console.log('Success?',!!res.ok, 'deleted count', res.n));
-MongoModel.deleteMany({_id: '999'}).exec().then(res=>console.log(res.ok));
+MongoModel.remove({ title: "baby born from alien father" }, cb);
+MongoModel.remove({ _id: "999" }).exec().then(cb).catch(cb);
+MongoModel.remove({ _id: "999" })
+    .exec()
+    .then(res => console.log(res.ok));
+MongoModel.deleteOne({ _id: "999" }).then(res => console.log(res.ok));
+MongoModel.deleteOne({ _id: "999" })
+    .exec()
+    .then(res => console.log(res.ok));
+MongoModel.deleteMany({ _id: "999" }).then(res => console.log("Success?", !!res.ok, "deleted count", res.n));
+MongoModel.deleteMany({ _id: "999" })
+    .exec()
+    .then(res => console.log(res.ok));
 MongoModel.update({ age: { $gt: 18 } }, { oldEnough: true }, cb);
-MongoModel.update({ name: 'Tobi' }, { ferret: true }, { multi: true,  arrayFilters: [{ element: { $gte: 100 } }] }, cb);
-MongoModel.update({ name: 'Tobi' }, { ferret: true }, { multi: true,  arrayFilters: [{ element: { $gte: 100 } }], overwriteDiscriminatorKey: true }, cb);
-MongoModel.where('age').gte(21).lte(65).exec(cb);
-MongoModel.where('age').gte(21).lte(65).where('name', /^b/i);
-new (MongoModel.base.model(''))();
+MongoModel.update({ name: "Tobi" }, { ferret: true }, { multi: true, arrayFilters: [{ element: { $gte: 100 } }] }, cb);
+MongoModel.update(
+    { name: "Tobi" },
+    { ferret: true },
+    { multi: true, arrayFilters: [{ element: { $gte: 100 } }], overwriteDiscriminatorKey: true },
+    cb,
+);
+MongoModel.where("age").gte(21).lte(65).exec(cb);
+MongoModel.where("age").gte(21).lte(65).where("name", /^b/i);
+new (MongoModel.base.model(""))();
 // $ExpectError
 mongoModel.baseModelName;
 MongoModel.baseModelName && MongoModel.baseModelName.toLowerCase();
 mongoModel.collection.$format(99);
 mongoModel.collection.initializeOrderedBulkOp;
 mongoModel.collection.findOne;
-mongoModel.db.openUri('');
+mongoModel.db.openUri("");
 // $ExpectError
 mongoModel.discriminators;
 MongoModel.discriminators;
@@ -250,59 +302,59 @@ MongoModel.discriminators;
 mongoModel.modelName;
 MongoModel.modelName;
 MongoModel.modelName.toLowerCase();
-MongoModel = MongoModel.base.model('new', mongoModel.schema);
+MongoModel = MongoModel.base.model("new", mongoModel.schema);
 
 /* model inherited properties */
 MongoModel.collection;
 mongoModel.collection;
 mongoModel._id;
 mongoModel.execPopulate();
-mongoModel.on('data', cb);
-mongoModel.addListener('event', cb);
+mongoModel.on("data", cb);
+mongoModel.addListener("event", cb);
 MongoModel.findOne({ title: /timex/i })
-    .populate('_creator', 'name')
+    .populate("_creator", "name")
     .exec(function (err, story) {
         if (story) {
             story.execPopulate();
         }
     });
 MongoModel.find({
-    id: 999
+    id: 999,
 })
-.populate({
-    path: 'fans',
-    match: { age: { $gte: 21 }},
-    select: 'name -_id',
-    options: { limit: 5 }
-})
-.exec();
+    .populate({
+        path: "fans",
+        match: { age: { $gte: 21 } },
+        select: "name -_id",
+        options: { limit: 5 },
+    })
+    .exec();
 
 /* practical example */
 interface Note extends mongoose.Document {
-    text: string
+    text: string;
 }
-const noteSchema = new mongoose.Schema({ text: String })
+const noteSchema = new mongoose.Schema({ text: String });
 
 interface Location extends mongoose.Document {
-  _id: mongodb.ObjectId;
-  name: string;
-  address: string;
-  rating: number;
-  facilities: string[];
-  coords: number[];
-  openingTimes: any[];
-  reviews: any[];
-  notes: Note[]
-};
+    _id: mongodb.ObjectId;
+    name: string;
+    address: string;
+    rating: number;
+    facilities: string[];
+    coords: number[];
+    openingTimes: any[];
+    reviews: any[];
+    notes: Note[];
+}
 const locationSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  address: String,
-  rating: { type: Number, "default": 0, min: 0, max: 5 },
-  facilities: [String],
-  coords: { type: [Number], index: "2dsphere" },
-  openingTimes: [mongoose.Schema.Types.Mixed],
-  reviews: [mongoose.SchemaTypes.Mixed],
-  notes: [noteSchema]
+    name: { type: String, required: true },
+    address: String,
+    rating: { type: Number, default: 0, min: 0, max: 5 },
+    facilities: [String],
+    coords: { type: [Number], index: "2dsphere" },
+    openingTimes: [mongoose.Schema.Types.Mixed],
+    reviews: [mongoose.SchemaTypes.Mixed],
+    notes: [noteSchema],
 });
 
 var locDocument = <Location>{};
@@ -313,8 +365,8 @@ LocModel.findById(999)
         if (!location) {
             return;
         }
-        location.name = 'blah';
-        location.address = 'blah';
+        location.name = "blah";
+        location.address = "blah";
         location.reviews.forEach(review => {});
         location.facilities.forEach(facility => {
             facility.toLowerCase();
@@ -322,41 +374,42 @@ LocModel.findById(999)
     });
 
 LocModel.find()
-    .select('-reviews -rating')
+    .select("-reviews -rating")
     .exec(function (err, locations) {
         locations.forEach(location => {
-            location.name = 'blah';
-            location.address = 'blah';
+            location.name = "blah";
+            location.address = "blah";
             location.reviews.forEach(review => {});
             location.facilities.forEach(facility => {
                 facility.toLowerCase();
             });
         });
     });
-LocModel.find({}).$where('')
+LocModel.find({})
+    .$where("")
     .exec(function (err, locations) {
         locations[0].name;
         locations[1].openingTimes;
     });
 LocModel.find({
-    name: 'foo',
+    name: "foo",
     address: /bar/, // strings are allowed as RegExp
     rating: 10,
     facilities: { $exists: true },
-    'reviews.0': { $exists: true } // additional queries are allowed
+    "reviews.0": { $exists: true }, // additional queries are allowed
 });
 LocModel.find({ _id: new mongodb.ObjectId() });
-LocModel.find({ _id: 'string-allowed' });
+LocModel.find({ _id: "string-allowed" });
 LocModel.find({ _id: locDocument });
 // $ExpectError
 LocModel.find({ _id: 123 });
 // $ExpectError
-LocModel.find({ _id: { foo: 'bar' } });
+LocModel.find({ _id: { foo: "bar" } });
 // $ExpectError
 LocModel.find({ name: 123 });
 // $ExpectError
-LocModel.find({ rating: 'foo' });
-LocModel.find({ name: 'foo' }).then(function(doc) {
+LocModel.find({ rating: "foo" });
+LocModel.find({ name: "foo" }).then(function (doc) {
     if (doc && doc.length > 0) {
         // $ExpectType ObjectId
         doc[0]._id;
@@ -367,7 +420,7 @@ LocModel.find({ name: 'foo' }).then(function(doc) {
         doc[0].save();
     }
 });
-LocModel.find({ name: 'foo' }, null, { lean: true }).then(function(doc) {
+LocModel.find({ name: "foo" }, null, { lean: true }).then(function (doc) {
     if (doc && doc.length > 0) {
         // $ExpectType string
         doc[0].name;
@@ -378,7 +431,7 @@ LocModel.find({ name: 'foo' }, null, { lean: true }).then(function(doc) {
     }
 });
 
-LocModel.findById('test-id').then(function(doc) {
+LocModel.findById("test-id").then(function (doc) {
     if (doc) {
         // $ExpectType string
         doc.name;
@@ -387,27 +440,7 @@ LocModel.findById('test-id').then(function(doc) {
         doc.save();
     }
 });
-LocModel.findById('test-id', null, { lean: true }).then(function(doc) {
-    if (doc) {
-        // $ExpectType string
-        doc.name;
-        // $ExpectError
-        doc.unknown;
-        // $ExpectError
-        doc.save();
-    }
-});
-
-LocModel.findByIdAndUpdate('test-id', { $set: { name: "bb" } }).then((doc) => {
-    if (doc) {
-        // $ExpectType string
-        doc.name;
-        // $ExpectError
-        doc.unknown;
-        doc.save();
-    }
-});
-LocModel.findByIdAndUpdate('test-id', { $set: { name: "bb" } }, { lean: true }).then((doc) => {
+LocModel.findById("test-id", null, { lean: true }).then(function (doc) {
     if (doc) {
         // $ExpectType string
         doc.name;
@@ -418,32 +451,51 @@ LocModel.findByIdAndUpdate('test-id', { $set: { name: "bb" } }, { lean: true }).
     }
 });
 
-LocModel.count({ name: 'foo'})
-    .exec(function (err, count) {
-        count.toFixed();
-    });
+LocModel.findByIdAndUpdate("test-id", { $set: { name: "bb" } }).then(doc => {
+    if (doc) {
+        // $ExpectType string
+        doc.name;
+        // $ExpectError
+        doc.unknown;
+        doc.save();
+    }
+});
+LocModel.findByIdAndUpdate("test-id", { $set: { name: "bb" } }, { lean: true }).then(doc => {
+    if (doc) {
+        // $ExpectType string
+        doc.name;
+        // $ExpectError
+        doc.unknown;
+        // $ExpectError
+        doc.save();
+    }
+});
+
+LocModel.count({ name: "foo" }).exec(function (err, count) {
+    count.toFixed();
+});
 // $ExpectError
 LocModel.count({ name: 123 });
-LocModel.countDocuments({ name: 'foo' });
+LocModel.countDocuments({ name: "foo" });
 // $ExpectError
 LocModel.countDocuments({ name: 123 });
-LocModel.distinct('')
-    .select('-review')
+LocModel.distinct("")
+    .select("-review")
     .exec(function (err, distinct) {
         distinct.concat;
     })
-    .then(cb).catch(cb);
-LocModel.exists({ name: 'foo' });
+    .then(cb)
+    .catch(cb);
+LocModel.exists({ name: "foo" });
 // $ExpectError
 LocModel.exists({ name: 123 });
-LocModel.findByIdAndRemove()
-    .exec(function (err, doc) {
-        if (!doc) {
-            return;
-        }
-        doc.addListener;
-        doc.openingTimes;
-    });
+LocModel.findByIdAndRemove().exec(function (err, doc) {
+    if (!doc) {
+        return;
+    }
+    doc.addListener;
+    doc.openingTimes;
+});
 LocModel.findByIdAndUpdate()
     .select({})
     .exec(function (err, location) {
@@ -463,7 +515,7 @@ LocModel.findOne({}, function (err, doc) {
         doc.openingTimes;
     }
 });
-LocModel.findOne({ name: 'foo', rating: 10 }, 'name', { lean: true }).then(function(doc) {
+LocModel.findOne({ name: "foo", rating: 10 }, "name", { lean: true }).then(function (doc) {
     if (doc) {
         // $ExpectType ObjectId
         doc._id;
@@ -475,11 +527,10 @@ LocModel.findOne({ name: 'foo', rating: 10 }, 'name', { lean: true }).then(funct
         doc.save();
     }
 });
-LocModel
-    .findOne({ name: 'foo', rating: 10 })
+LocModel.findOne({ name: "foo", rating: 10 })
     .lean()
     .exec()
-    .then(function(doc) {
+    .then(function (doc) {
         if (doc) {
             // $ExpectType ObjectId
             doc._id;
@@ -491,24 +542,25 @@ LocModel
             doc.save();
         }
     });
-LocModel.findOneAndRemove()
-    .exec(function (err, location) {
-        if (location) {
-            location.name;
-        }
-    });
-LocModel.findOneAndRemove({ name: 'foo', rating: 10 });
-LocModel.findOneAndDelete({ name: 'foo', rating: 10 });
-LocModel.findOneAndUpdate({ name: 'foo' }, { rating: 20 }).exec().then(function (doc) {
-    if (doc) {
-        // $ExpectType string
-        doc.name;
-        // $ExpectError
-        doc.unknown;
-        doc.save();
-        doc.openingTimes;
+LocModel.findOneAndRemove().exec(function (err, location) {
+    if (location) {
+        location.name;
     }
 });
+LocModel.findOneAndRemove({ name: "foo", rating: 10 });
+LocModel.findOneAndDelete({ name: "foo", rating: 10 });
+LocModel.findOneAndUpdate({ name: "foo" }, { rating: 20 })
+    .exec()
+    .then(function (doc) {
+        if (doc) {
+            // $ExpectType string
+            doc.name;
+            // $ExpectError
+            doc.unknown;
+            doc.save();
+            doc.openingTimes;
+        }
+    });
 LocModel.findOneAndUpdate(
     // find a document with that filter
     { name: "aa" },
@@ -520,10 +572,10 @@ LocModel.findOneAndUpdate(
         new: true,
         runValidators: true,
         rawResult: true,
-        multipleCastError: true
-    }
+        multipleCastError: true,
+    },
 );
-LocModel.findOneAndUpdate({ name: "aa" }, { $set: { name: "bb" } }, { lean: true }).then((doc) => {
+LocModel.findOneAndUpdate({ name: "aa" }, { $set: { name: "bb" } }, { lean: true }).then(doc => {
     if (doc) {
         // $ExpectType string
         doc.name;
@@ -533,96 +585,116 @@ LocModel.findOneAndUpdate({ name: "aa" }, { $set: { name: "bb" } }, { lean: true
         doc.save();
     }
 });
-LocModel.geoSearch({}, {
-    near: [1, 2],
-    maxDistance: 22
-}, function (err, res) { res[0].openingTimes; });
-LocModel.remove({ name: 'foo' });
-LocModel.deleteOne({ name: 'foo' });
-LocModel.deleteMany({ name: 'foo' });
-LocModel.replaceOne({ name: 'foo' }, { name: 'bar' });
-
-LocModel.update({ name: 'foo' }, {
-    name: 'bar',
-    'reviews.0': 'test',
-    $unset: {
-        rating: ''
+LocModel.geoSearch(
+    {},
+    {
+        near: [1, 2],
+        maxDistance: 22,
     },
-    $pull: {
-        facilities: 'foo'
+    function (err, res) {
+        res[0].openingTimes;
     },
-    $push: {
-        coords: 100
-    }
-});
-// $ExpectError
-LocModel.update({ name: 'foo' }, { name: 123 });
-// $ExpectError
-LocModel.update({ name: 'foo' }, { $pull: { facilities: 123 } });
-// $ExpectError
-LocModel.update({ name: 'foo' }, { $push: { coords: 'bar' } });
-
-LocModel.updateOne({ name: 'foo' }, {
-    name: 'bar',
-    'reviews.0': 'test',
-    $unset: {
-        rating: ''
-    },
-    $pull: {
-        facilities: 'foo'
-    },
-    $push: {
-        coords: 100
-    }
-});
-// $ExpectError
-LocModel.updateOne({ name: 'foo' }, { name: 123 });
-// $ExpectError
-LocModel.updateOne({ name: 'foo' }, { $pull: { facilities: 123 } });
-// $ExpectError
-LocModel.updateOne({ name: 'foo' }, { $push: { coords: 'bar' } });
-
-LocModel.updateMany({ name: 'foo' }, {
-    name: 'bar',
-    'reviews.0': 'test',
-    $unset: {
-        rating: ''
-    },
-    $pull: {
-        facilities: 'foo'
-    },
-    $push: {
-        coords: 100
-    }
-});
-// $ExpectError
-LocModel.updateMany({ name: 'foo' }, { name: 123 });
-// $ExpectError
-LocModel.updateMany({ name: 'foo' }, { $pull: { facilities: 123 } });
-// $ExpectError
-LocModel.updateMany({ name: 'foo' }, { $push: { coords: 'bar' } });
-
-LocModel.findByIdAndUpdate('someId',
-  { $pull: { notes: { _id: ['someId'] } } }
 );
-LocModel.findByIdAndUpdate('someId',
-  { $pull: { notes: { _id: { $in: ['someId', 'someId'] } } } }
-)
+LocModel.remove({ name: "foo" });
+LocModel.deleteOne({ name: "foo" });
+LocModel.deleteMany({ name: "foo" });
+LocModel.replaceOne({ name: "foo" }, { name: "bar" });
+
+LocModel.update(
+    { name: "foo" },
+    {
+        name: "bar",
+        "reviews.0": "test",
+        $unset: {
+            rating: "",
+        },
+        $pull: {
+            facilities: "foo",
+        },
+        $push: {
+            coords: 100,
+        },
+    },
+);
+// $ExpectError
+LocModel.update({ name: "foo" }, { name: 123 });
+// $ExpectError
+LocModel.update({ name: "foo" }, { $pull: { facilities: 123 } });
+// $ExpectError
+LocModel.update({ name: "foo" }, { $push: { coords: "bar" } });
+
+LocModel.updateOne(
+    { name: "foo" },
+    {
+        name: "bar",
+        "reviews.0": "test",
+        $unset: {
+            rating: "",
+        },
+        $pull: {
+            facilities: "foo",
+        },
+        $push: {
+            coords: 100,
+        },
+    },
+);
+// $ExpectError
+LocModel.updateOne({ name: "foo" }, { name: 123 });
+// $ExpectError
+LocModel.updateOne({ name: "foo" }, { $pull: { facilities: 123 } });
+// $ExpectError
+LocModel.updateOne({ name: "foo" }, { $push: { coords: "bar" } });
+
+LocModel.updateMany(
+    { name: "foo" },
+    {
+        name: "bar",
+        "reviews.0": "test",
+        $unset: {
+            rating: "",
+        },
+        $pull: {
+            facilities: "foo",
+        },
+        $push: {
+            coords: 100,
+        },
+    },
+);
+// $ExpectError
+LocModel.updateMany({ name: "foo" }, { name: 123 });
+// $ExpectError
+LocModel.updateMany({ name: "foo" }, { $pull: { facilities: 123 } });
+// $ExpectError
+LocModel.updateMany({ name: "foo" }, { $push: { coords: "bar" } });
+
+LocModel.findByIdAndUpdate("someId", { $pull: { notes: { _id: ["someId"] } } });
+LocModel.findByIdAndUpdate("someId", { $pull: { notes: { _id: { $in: ["someId", "someId"] } } } });
 
 // $ExpectError
 LocModel.create({ address: "foo", coords: [1, 2], facilities: ["foo", "bar"] });
 
-LocModel.create({ address: "foo", coords: [1, 2], facilities: ["foo", "bar"], name: "bar", openingTimes: ["foo"], rating: 10, reviews: ["foo"], notes: [] });
-LocModel.create<{address: string}>({ address: "foo" });
+LocModel.create({
+    address: "foo",
+    coords: [1, 2],
+    facilities: ["foo", "bar"],
+    name: "bar",
+    openingTimes: ["foo"],
+    rating: 10,
+    reviews: ["foo"],
+    notes: [],
+});
+LocModel.create<{ address: string }>({ address: "foo" });
 
 enum SchemaEnum {
     Foo,
-    Bar
+    Bar,
 }
 
 enum StringSchemaEnum {
     Foo = "foo",
-    Bar = "bar"
+    Bar = "bar",
 }
 
 interface ModelWithFunction extends mongoose.Document {
@@ -644,7 +716,6 @@ interface ModelWithFunction extends mongoose.Document {
 
     enum2?: StringSchemaEnum;
 
-
     selfRef?: ModelWithFunction | mongodb.ObjectID;
 
     selfRef2?: ModelWithFunction | mongodb.ObjectID;
@@ -654,11 +725,13 @@ interface ModelWithFunction extends mongoose.Document {
     selfRefArray2?: ModelWithFunction[] | mongodb.ObjectID[];
 
     parent?: {
-        ref: {
-            _id: mongodb.ObjectId;
-            child: ModelWithFunction
-        } | mongodb.ObjectID;
-    }
+        ref:
+            | {
+                  _id: mongodb.ObjectId;
+                  child: ModelWithFunction;
+              }
+            | mongodb.ObjectID;
+    };
 
     enumArray?: SchemaEnum[];
 
@@ -673,40 +746,51 @@ interface ModelWithFunction extends mongoose.Document {
         array?: number[];
 
         deepArray?: Array<{
-            title: string,
-            func: () => {}, // should be excluded in CreateQuery<T>
-            tuple?: [number, number]
+            title: string;
+            func: () => {}; // should be excluded in CreateQuery<T>
+            tuple?: [number, number];
             objectId?: mongoose.Types.ObjectId;
 
-            mapWithFuncs?: Map<string, {
-                title: string,
-                func: () => {}, // should be excluded in CreateQuery<T>
-                innerMap: Map<string, {
-                    title: string,
-                    func: () => {} // should be excluded in CreateQuery<T>
+            mapWithFuncs?: Map<
+                string,
+                {
+                    title: string;
+                    func: () => {}; // should be excluded in CreateQuery<T>
+                    innerMap: Map<
+                        string,
+                        {
+                            title: string;
+                            func: () => {}; // should be excluded in CreateQuery<T>
+                            readonly readonly: unknown; // should be excluded in CreateQuery<T>
+                            objectId?: mongoose.Types.ObjectId;
+                        }
+                    >;
+                }
+            >;
+        }>;
+    };
+
+    map?: Map<string, boolean>;
+
+    mapWithFuncs?: Map<
+        string,
+        {
+            title: string;
+            func: () => {}; // should be excluded in CreateQuery<T>
+            innerMap: Map<
+                string,
+                {
+                    title: string;
+                    func: () => {}; // should be excluded in CreateQuery<T>
                     readonly readonly: unknown; // should be excluded in CreateQuery<T>
-                    objectId?: mongoose.Types.ObjectId;
-                }>
-            }>;
-        }>
-    }
-
-    map?: Map<string, boolean>
-
-    mapWithFuncs?: Map<string, {
-        title: string,
-        func: () => {}, // should be excluded in CreateQuery<T>
-        innerMap: Map<string, {
-            title: string,
-            func: () => {} // should be excluded in CreateQuery<T>
-            readonly readonly: unknown; // should be excluded in CreateQuery<T>
-        }>
-    }>;
-
+                }
+            >;
+        }
+    >;
 
     jobs: Array<{
-        title: string,
-        readonly readonly: unknown // should be excluded in CreateQuery<T>
+        title: string;
+        readonly readonly: unknown; // should be excluded in CreateQuery<T>
     }>;
 
     titles?: Array<{ title: string }>;
@@ -717,32 +801,37 @@ interface ModelWithFunction extends mongoose.Document {
 // we are only testing the types, not the functionality, so no mongoose.Schema needed
 var ModelWithFunctionInSchema = mongoose.model<ModelWithFunction>("ModelWithFunction", {} as any);
 
-ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { test: "test", array: [1, 2, 3], tuple: [1, 2] } });
+ModelWithFunctionInSchema.create({
+    name: "test",
+    jobs: [],
+    deeperFuncTest: { test: "test", array: [1, 2, 3], tuple: [1, 2] },
+});
 
 ModelWithFunctionInSchema.create({
     name: "test",
     jobs: [],
     deeperFuncTest: {
         test: "hello",
-        deepArray: [{
-            title: "test",
-            tuple: [1, 2],
-            objectId: "valid-object-id-source",
-            mapWithFuncs: {
-                test: {
-                    title: "test",
-                    innerMap: {
-                        test: {
-                            title: "hello",
-                            objectId: "valid-object-id-source"
+        deepArray: [
+            {
+                title: "test",
+                tuple: [1, 2],
+                objectId: "valid-object-id-source",
+                mapWithFuncs: {
+                    test: {
+                        title: "test",
+                        innerMap: {
+                            test: {
+                                title: "hello",
+                                objectId: "valid-object-id-source",
+                            },
                         },
-                    }
-                }
-            }
-        }]
-    }
+                    },
+                },
+            },
+        ],
+    },
 });
-
 
 // ------------------------------------------------------------------------------------
 // TESTS DISABLED: note that these tests does not properly pass $ExpectError on TS 3.3
@@ -764,7 +853,6 @@ ModelWithFunctionInSchema.create({ foo: "bar" });
 // $ExpectError
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], foo: "bar" });
 
-
 // $ExpectError
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], someFunc: {} as any });
 
@@ -780,7 +868,11 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], map: [["test", true]]
 ModelWithFunctionInSchema.create({ name: "test", jobs: [{ title: "hello" }] });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [{ title: "hello" }], titles: [{ title: "test" }] });
 
-ModelWithFunctionInSchema.create({ name: "test", jobs: [], mapWithFuncs: { test: { title: "hello", innerMap: { test: { title: "hello" } } }} });
+ModelWithFunctionInSchema.create({
+    name: "test",
+    jobs: [],
+    mapWithFuncs: { test: { title: "hello", innerMap: { test: { title: "hello" } } } },
+});
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], enum: SchemaEnum.Bar });
 
@@ -788,7 +880,13 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], enumArray: [SchemaEnu
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [] }).then(ref => {
     const id: mongodb.ObjectID = ref._id;
-    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRef: ref, selfRef2: ref._id, selfRefArray: [ref, id] });
+    ModelWithFunctionInSchema.create({
+        name: "test",
+        jobs: [],
+        selfRef: ref,
+        selfRef2: ref._id,
+        selfRefArray: [ref, id],
+    });
     ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRefArray2: [id, id] });
     ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRefArray2: [ref, ref] });
 });
@@ -797,13 +895,13 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], objectId: "valid-obje
 ModelWithFunctionInSchema.create({
     name: "test",
     jobs: [],
-    objectId: new mongodb.ObjectID("valid-object-id-source")
+    objectId: new mongodb.ObjectID("valid-object-id-source"),
 });
 
 ModelWithFunctionInSchema.create({
     name: "test",
     jobs: [],
-    date: new Date()
+    date: new Date(),
 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: "2020-01-01" });
 

--- a/types/mongoose/test/mongoose.ts
+++ b/types/mongoose/test/mongoose.ts
@@ -1,7 +1,7 @@
-import * as mongodb from 'mongodb';
-import * as mongoose from 'mongoose';
+import * as mongodb from "mongodb";
+import * as mongoose from "mongoose";
 
-import { MyModel } from './definitions';
+import { MyModel } from "./definitions";
 
 // dummy variables
 var cb = function () {};
@@ -18,27 +18,27 @@ var cb = function () {};
  * section index.js
  * http://mongoosejs.com/docs/api.html#index-js
  */
-var connectUri = 'mongodb://user:pass@localhost:port/database';
+var connectUri = "mongodb://user:pass@localhost:port/database";
 const connection1: Promise<mongoose.Mongoose> = mongoose.connect(connectUri);
 const connection2: Promise<mongoose.Mongoose> = mongoose.connect(connectUri, {
-  user: 'larry',
-  pass: 'housan',
-  config: {
+    user: "larry",
+    pass: "housan",
+    config: {
+        autoIndex: true,
+    },
+    mongos: true,
+    bufferCommands: false,
+    useNewUrlParser: true,
+    useFindAndModify: true,
+    useUnifiedTopology: true,
+    serverSelectionTimeoutMS: 30000,
+    heartbeatFrequencyMS: 2000,
+    useCreateIndex: true,
     autoIndex: true,
-  },
-  mongos: true,
-  bufferCommands: false,
-  useNewUrlParser: true,
-  useFindAndModify: true,
-  useUnifiedTopology: true,
-  serverSelectionTimeoutMS: 30000,
-  heartbeatFrequencyMS: 2000,
-  useCreateIndex: true,
-  autoIndex: true,
-  autoCreate: true,
+    autoCreate: true,
 });
 const connection3 = mongoose.connect(connectUri, function (error) {
-  error.stack;
+    error.stack;
 });
 
 /**
@@ -46,56 +46,69 @@ const connection3 = mongoose.connect(connectUri, function (error) {
  * https://docs.mongodb.com/drivers/use-cases/client-side-field-level-encryption-guide
  */
 
-const connection4:Promise<mongoose.Mongoose> = mongoose.connect(connectUri,{
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-  autoEncryption: {
-    keyVaultNamespace: 'encryption.__keyVault',
-    kmsProviders: {},
-    schemaMap: {},
-    extraOptions: {}
-  }
-})
+const connection4: Promise<mongoose.Mongoose> = mongoose.connect(connectUri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    autoEncryption: {
+        keyVaultNamespace: "encryption.__keyVault",
+        kmsProviders: {},
+        schemaMap: {},
+        extraOptions: {},
+    },
+});
 
 var mongooseConnection: mongoose.Connection = mongoose.createConnection();
-mongooseConnection.dropDatabase().then(()=>{});
-mongooseConnection.dropCollection('foo').then(()=>{});
-mongoose.createConnection(connectUri).then((conn)=> {
-  return conn.collections;
-}, () => {
-
-var connections: mongoose.Connection[] = mongoose.connections;
-
-});
-mongoose.createConnection(connectUri).openUri('');
-mongoose.createConnection(connectUri, {
-  db: {
-    native_parser: true
-  }
-}).openUri('');
+mongooseConnection.dropDatabase().then(() => {});
+mongooseConnection.dropCollection("foo").then(() => {});
+mongoose.createConnection(connectUri).then(
+    conn => {
+        return conn.collections;
+    },
+    () => {
+        var connections: mongoose.Connection[] = mongoose.connections;
+    },
+);
+mongoose.createConnection(connectUri).openUri("");
+mongoose
+    .createConnection(connectUri, {
+        db: {
+            native_parser: true,
+        },
+    })
+    .openUri("");
 const dcWithCallback: void = mongoose.disconnect(cb);
 const dcPromise: Promise<void> = mongoose.disconnect();
-mongoose.get('test');
-mongoose.model('Actor', new mongoose.Schema({
-  name: String
-}, {
-    autoCreate: true,
-    autoIndex: true,
-}), 'collectionName', true).find({});
-mongoose.model('Actor').find({});
+mongoose.get("test");
+mongoose
+    .model(
+        "Actor",
+        new mongoose.Schema(
+            {
+                name: String,
+            },
+            {
+                autoCreate: true,
+                autoIndex: true,
+            },
+        ),
+        "collectionName",
+        true,
+    )
+    .find({});
+mongoose.model("Actor").find({});
 mongoose.modelNames()[0].toLowerCase();
-mongoose.deleteModel('Actor');
+mongoose.deleteModel("Actor");
 mongoose.models.Actor.findOne({}).exec();
-new (new mongoose.Mongoose(9, 8, 7)).Mongoose(1, 2, 3).connect('');
-mongoose.plugin(cb, {}).connect('');
-mongoose.set('test', 'value');
-mongoose.set('debug', function(collectionName: any, methodName: any, arg1: any, arg2: any) {});
-mongoose.STATES.hasOwnProperty('');
+new new mongoose.Mongoose(9, 8, 7).Mongoose(1, 2, 3).connect("");
+mongoose.plugin(cb, {}).connect("");
+mongoose.set("test", "value");
+mongoose.set("debug", function (collectionName: any, methodName: any, arg1: any, arg2: any) {});
+mongoose.STATES.hasOwnProperty("");
 mongoose.STATES.disconnected === 0;
 mongoose.STATES.connected === 1;
 
-mongoose.connection.on('error', cb);
-new mongoose.mongo.MongoError('error').stack;
+mongoose.connection.on("error", cb);
+new mongoose.mongo.MongoError("error").stack;
 mongoose.SchemaTypes.String;
 mongoose.SchemaTypes.ObjectId;
 mongoose.SchemaTypes.Decimal128;
@@ -104,23 +117,20 @@ mongoose.Types.ObjectId;
 mongoose.Types.Decimal128;
 mongoose.version.toLowerCase();
 
-const sslConnections: {[key: string]: mongoose.Connection} = {
-  basic: mongoose.createConnection(connectUri, {ssl: true}),
-  customCA: mongoose.createConnection(
-    connectUri,
-    {
-      ssl: true,
-      sslCA: [new Buffer('ca string')],
-      sslCRL: [new Buffer('crl buffer')],
-      sslCert: 'ssl cert',
-      sslKey: new Buffer('ssl private key'),
-      sslPass: 'ssl password',
-      servername: 'localhost',
-      checkServerIdentity: true,
-      ciphers: 'ciphers',
-      ecdhCurve: 'ecdhCurve',
-    }
-  ),
+const sslConnections: { [key: string]: mongoose.Connection } = {
+    basic: mongoose.createConnection(connectUri, { ssl: true }),
+    customCA: mongoose.createConnection(connectUri, {
+        ssl: true,
+        sslCA: [new Buffer("ca string")],
+        sslCRL: [new Buffer("crl buffer")],
+        sslCert: "ssl cert",
+        sslKey: new Buffer("ssl private key"),
+        sslPass: "ssl password",
+        servername: "localhost",
+        checkServerIdentity: true,
+        ciphers: "ciphers",
+        ecdhCurve: "ecdhCurve",
+    }),
 };
 
 /*
@@ -130,9 +140,9 @@ const sslConnections: {[key: string]: mongoose.Connection} = {
  * section drivers/node-mongodb-native/collection.js
  * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
  */
-var coll1 = <mongoose.Collection> {};
+var coll1 = <mongoose.Collection>{};
 coll1.$format(999).toLowerCase();
-coll1.$print('name', 'i', [1, 2, 3]);
+coll1.$print("name", "i", [1, 2, 3]);
 coll1.getIndexes();
 /* inherited properties */
 coll1.collectionName;
@@ -142,7 +152,7 @@ coll1.ensureIndex();
 coll1.find({});
 coll1.insert({}, {});
 
-var coll2 = new mongoose.Collection('', new mongoose.Connection(mongoose));
+var coll2 = new mongoose.Collection("", new mongoose.Connection(mongoose));
 coll2.$format(999).toLowerCase();
 /* inherited properties */
 coll2.initializeOrderedBulkOp;
@@ -155,69 +165,75 @@ coll2.indexExists;
  * section section drivers/node-mongodb-native/connection.js
  * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
  */
-var conn1: mongoose.Connection = mongoose.createConnection('mongodb://user:pass@localhost:port/database');
+var conn1: mongoose.Connection = mongoose.createConnection("mongodb://user:pass@localhost:port/database");
 conn1 = new mongoose.Connection(mongoose);
-conn1.close().then(function () {}).catch(function (err) {});
-conn1.close(true).then(function () {}).catch(function (err) {});
+conn1
+    .close()
+    .then(function () {})
+    .catch(function (err) {});
+conn1
+    .close(true)
+    .then(function () {})
+    .catch(function (err) {});
 conn1.close(function (err) {});
 conn1.close(true, function (err) {});
-conn1.collection('name').$format(999);
-conn1.model('myModel', new mongoose.Schema({}), 'myCol').find();
-conn1.deleteModel('myModel');
+conn1.collection("name").$format(999);
+conn1.model("myModel", new mongoose.Schema({}), "myCol").find();
+conn1.deleteModel("myModel");
 conn1.models.myModel.findOne().exec();
 interface IStatics {
-  staticMethod1: (a: number) => string;
+    staticMethod1: (a: number) => string;
 }
 conn1.modelNames()[0].toLowerCase();
-conn1.config.hasOwnProperty('');
+conn1.config.hasOwnProperty("");
 conn1.db.bufferMaxEntries;
-conn1.collections['coll'].$format(999);
+conn1.collections["coll"].$format(999);
 conn1.readyState.toFixed();
-conn1.name.toLowerCase()
-conn1.host.toLowerCase()
-conn1.port.toFixed()
-conn1.useDb('myDb').useDb('');
-conn1.useDb('myDb').useDb('', {});
-conn1.useDb('myDb').useDb('', {useCache: false});
-conn1.useDb('myDb').useDb('', {useCache: true});
-mongoose.Connection.STATES.hasOwnProperty('');
+conn1.name.toLowerCase();
+conn1.host.toLowerCase();
+conn1.port.toFixed();
+conn1.useDb("myDb").useDb("");
+conn1.useDb("myDb").useDb("", {});
+conn1.useDb("myDb").useDb("", { useCache: false });
+conn1.useDb("myDb").useDb("", { useCache: true });
+mongoose.Connection.STATES.hasOwnProperty("");
 mongoose.Connection.STATES.disconnected === 0;
 mongoose.Connection.STATES.connected === 1;
 
 /* inherited properties */
-conn1.on('data', cb);
-conn1.addListener('close', cb);
+conn1.on("data", cb);
+conn1.addListener("close", cb);
 
 // The connection returned by useDb is *not* thenable.
 // From https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26057#issuecomment-396150819
-const getDB = async (tenant: string)=> {
-  return conn1.useDb(tenant);
+const getDB = async (tenant: string) => {
+    return conn1.useDb(tenant);
 };
 
 /*
  * section error.js
  * http://mongoosejs.com/docs/api.html#error-js
  */
-var mongooseError: mongoose.Error = new mongoose.Error('error');
+var mongooseError: mongoose.Error = new mongoose.Error("error");
 mongooseError.name;
 /* inherited properties */
 mongooseError.message;
 mongooseError.stack;
 /* static properties */
-mongoose.Error.messages.hasOwnProperty('');
-mongoose.Error.Messages.hasOwnProperty('');
+mongoose.Error.messages.hasOwnProperty("");
+mongoose.Error.Messages.hasOwnProperty("");
 
 /*
  * section error/cast.js
  * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.CastError
  */
-var castError: mongoose.Error.CastError = new mongoose.Error.CastError('', '', '');
+var castError: mongoose.Error.CastError = new mongoose.Error.CastError("", "", "");
 castError.name;
 castError.stringValue;
 castError.kind;
 castError.path;
 castError.value;
-castError.setModel('foo');
+castError.setModel("foo");
 /* inherited properties */
 castError.message;
 castError.stack;
@@ -226,15 +242,17 @@ castError.stack;
  * section error/validator.js
  * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ValidatorError
  */
-var validatorError: mongoose.Error.ValidatorError = new mongoose.Error.ValidatorError({ message: 'bar' })
+var validatorError: mongoose.Error.ValidatorError = new mongoose.Error.ValidatorError({ message: "bar" });
 validatorError.name;
 validatorError.properties;
 validatorError.kind;
 validatorError.path;
 validatorError.value;
 validatorError.toString().toLowerCase();
-validatorError.formatMessage('foo', {});
-validatorError.formatMessage('foo', (bar: any)=>{ return bar; });
+validatorError.formatMessage("foo", {});
+validatorError.formatMessage("foo", (bar: any) => {
+    return bar;
+});
 /* inherited properties */
 validatorError.message;
 validatorError.stack;
@@ -245,17 +263,17 @@ validatorError.stack;
  */
 var doc = <mongoose.Document>{};
 (() => {
-  // Scope to avoid type mixing
-  var validationError: mongoose.Error.ValidationError | undefined = new mongoose.Error.ValidationError(doc);
-  validationError.name;
-  validationError.toString().toLowerCase();
-  validationError.inspect();
-  validationError.toJSON().hasOwnProperty('');
-  validationError.addError('foo', validatorError)
-  /* inherited properties */
-  validationError.message;
-  validationError.stack;
-})()
+    // Scope to avoid type mixing
+    var validationError: mongoose.Error.ValidationError | undefined = new mongoose.Error.ValidationError(doc);
+    validationError.name;
+    validationError.toString().toLowerCase();
+    validationError.inspect();
+    validationError.toJSON().hasOwnProperty("");
+    validationError.addError("foo", validatorError);
+    /* inherited properties */
+    validationError.message;
+    validationError.stack;
+})();
 
 /*
  * section error/parallelSave.js
@@ -271,7 +289,7 @@ parallelSaveError.stack;
  * section error/overwriteModel.js
  * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.OverwriteModelError
  */
-var overwriteModelError: mongoose.Error.OverwriteModelError = new mongoose.Error.OverwriteModelError('foo');
+var overwriteModelError: mongoose.Error.OverwriteModelError = new mongoose.Error.OverwriteModelError("foo");
 overwriteModelError.name;
 /* inherited properties */
 overwriteModelError.message;
@@ -281,7 +299,7 @@ overwriteModelError.stack;
  * section error/missingSchema.js
  * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.MissingSchemaError
  */
-var missingSchemaError: mongoose.Error.MissingSchemaError = new mongoose.Error.MissingSchemaError('foo');
+var missingSchemaError: mongoose.Error.MissingSchemaError = new mongoose.Error.MissingSchemaError("foo");
 missingSchemaError.name;
 /* inherited properties */
 missingSchemaError.message;
@@ -291,57 +309,74 @@ missingSchemaError.stack;
  * section error/divergentArray.js
  * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.MissingSchemaError
  */
-var divergentArrayError: mongoose.Error.DivergentArrayError = new mongoose.Error.DivergentArrayError(['foo','bar']);
+var divergentArrayError: mongoose.Error.DivergentArrayError = new mongoose.Error.DivergentArrayError(["foo", "bar"]);
 missingSchemaError.name;
 /* inherited properties */
 missingSchemaError.message;
 missingSchemaError.stack;
 
 const pluralize = mongoose.pluralize();
-const plural: string = pluralize('foo');
+const plural: string = pluralize("foo");
 
 /*
  * section querycursor.js
  * http://mongoosejs.com/docs/api.html#querycursor-js
  */
-var querycursor = <mongoose.QueryCursor<any>> {};
-querycursor.close(function (error, result) {
-  result.execPopulate();
-}).catch(cb);
-querycursor.eachAsync(function (doc) {
-  doc.execPopulate();
-}, function (err) {}).catch(cb);
+var querycursor = <mongoose.QueryCursor<any>>{};
+querycursor
+    .close(function (error, result) {
+        result.execPopulate();
+    })
+    .catch(cb);
+querycursor
+    .eachAsync(
+        function (doc) {
+            doc.execPopulate();
+        },
+        function (err) {},
+    )
+    .catch(cb);
 querycursor.next(cb).catch(cb);
 /* inherited properties */
 querycursor.pause();
 querycursor.pipe(process.stdout);
 /* practical example */
-var QCModel = mongoose.model('QC', new mongoose.Schema({name: String}));
-QCModel.find({}).cursor({}).on('data', function (doc: any) {
-  doc.depopulate('name');
-}).on('error', function (error: any) {
-  throw error;
-}).close().then(cb).catch(cb);
-querycursor.map(function (doc) {
-  doc.foo = "bar";
-  return doc;
-}).on('data', function (doc: any) {
-  console.log(doc.foo);
-});
-querycursor.map(function (doc) {
-  doc.foo = "bar";
-  return doc;
-}).next(function (error, doc) {
-  console.log(doc.foo);
+var QCModel = mongoose.model("QC", new mongoose.Schema({ name: String }));
+QCModel.find({})
+    .cursor({})
+    .on("data", function (doc: any) {
+        doc.depopulate("name");
+    })
+    .on("error", function (error: any) {
+        throw error;
+    })
+    .close()
+    .then(cb)
+    .catch(cb);
+querycursor
+    .map(function (doc) {
+        doc.foo = "bar";
+        return doc;
+    })
+    .on("data", function (doc: any) {
+        console.log(doc.foo);
+    });
+querycursor
+    .map(function (doc) {
+        doc.foo = "bar";
+        return doc;
+    })
+    .next(function (error, doc) {
+        console.log(doc.foo);
+    });
+
+QCModel.watch().once("change", (change: any) => {
+    console.log(change);
 });
 
-QCModel.watch().once('change', (change: any) => {
-  console.log(change);
-});
-
-QCModel.watch([{ $match: { author: 'dave' } }], {
+QCModel.watch([{ $match: { author: "dave" } }], {
     maxAwaitTimeMS: 10,
-}).once('change', (change: any) => {
+}).once("change", (change: any) => {
     console.log(change);
 });
 
@@ -349,7 +384,7 @@ QCModel.watch([{ $match: { author: 'dave' } }], {
  * section virtualtype.js
  * http://mongoosejs.com/docs/api.html#virtualtype-js
  */
-var virtualtype: mongoose.VirtualType = new mongoose.VirtualType({}, 'hello');
+var virtualtype: mongoose.VirtualType = new mongoose.VirtualType({}, "hello");
 virtualtype.applyGetters({}, {});
 virtualtype.applySetters({}, {});
 virtualtype.get(cb).get(cb);
@@ -360,58 +395,67 @@ virtualtype.set(cb).set(cb);
  * http://mongoosejs.com/docs/api.html#schema-js
  */
 var schema: mongoose.Schema = new mongoose.Schema({
-  name: String,
-  binary: Buffer,
-  living: Boolean,
-  updated: { type: Date, default: Date.now },
-  age: { type: Number, min: 18, max: 65 },
-  mixed: mongoose.Schema.Types.Mixed,
-  _someId: mongoose.Schema.Types.ObjectId,
-  someDecimal: mongoose.Schema.Types.Decimal128,
-  array: [],
-  ofString: [String],
-  ofNumber: [Number],
-  ofDates: [Date],
-  ofBuffer: [Buffer],
-  ofBoolean: [Boolean],
-  ofMixed: [mongoose.Schema.Types.Mixed],
-  ofObjectId: [mongoose.Schema.Types.ObjectId],
-  map: {
-    type: Map,
-    of: String,
-  },
-  nested: {
-    stuff: { type: String, lowercase: true, trim: true },
-  },
+    name: String,
+    binary: Buffer,
+    living: Boolean,
+    updated: { type: Date, default: Date.now },
+    age: { type: Number, min: 18, max: 65 },
+    mixed: mongoose.Schema.Types.Mixed,
+    _someId: mongoose.Schema.Types.ObjectId,
+    someDecimal: mongoose.Schema.Types.Decimal128,
+    array: [],
+    ofString: [String],
+    ofNumber: [Number],
+    ofDates: [Date],
+    ofBuffer: [Buffer],
+    ofBoolean: [Boolean],
+    ofMixed: [mongoose.Schema.Types.Mixed],
+    ofObjectId: [mongoose.Schema.Types.ObjectId],
+    map: {
+        type: Map,
+        of: String,
+    },
+    nested: {
+        stuff: { type: String, lowercase: true, trim: true },
+    },
 });
-schema.add({
-  mixedArray: {
-    type: [mongoose.Schema.Types.Mixed],
-    required: true
-  }
-}, 'prefix');
-schema.eachPath(function (path, type) {
-  path.toLowerCase();
-  type.sparse(true);
-}).eachPath(cb);
-schema.get('path');
-schema.index({
-  name: 1,
-  binary: -1
-}).index({}, {});
+schema.add(
+    {
+        mixedArray: {
+            type: [mongoose.Schema.Types.Mixed],
+            required: true,
+        },
+    },
+    "prefix",
+);
+schema
+    .eachPath(function (path, type) {
+        path.toLowerCase();
+        type.sparse(true);
+    })
+    .eachPath(cb);
+schema.get("path");
+schema
+    .index({
+        name: 1,
+        binary: -1,
+    })
+    .index({}, {});
 schema.indexes().slice();
-schema.method('name', cb).method({
-  m1: cb,
-  m2: cb
+schema.method("name", cb).method({
+    m1: cb,
+    m2: cb,
 });
-schema.path('a', mongoose.Schema.Types.Buffer).path('a');
-schema.pathType('m1').toLowerCase();
-schema.plugin(function (schema: mongoose.Schema, opts?: any) {
-  schema.get('path');
-  if (opts) {
-    opts.hasOwnProperty('');
-  }
-}).plugin(cb, {opts: true});
+schema.path("a", mongoose.Schema.Types.Buffer).path("a");
+schema.pathType("m1").toLowerCase();
+schema
+    .plugin(function (schema: mongoose.Schema, opts?: any) {
+        schema.get("path");
+        if (opts) {
+            opts.hasOwnProperty("");
+        }
+    })
+    .plugin(cb, { opts: true });
 
 /* `.pre` hook tests */
 
@@ -431,332 +475,437 @@ const preHookTestSchemaArr: mongoose.Schema[] = [];
 
 // Document
 preHookTestSchemaArr.push(
-  schema.pre("init", function (next) {
-    const isDefaultType: mongoose.Document = this;
-  }, err => {})
+    schema.pre(
+        "init",
+        function (next) {
+            const isDefaultType: mongoose.Document = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestDocumentInterface>("init", function (next) {
-    const isSpecificType: PreHookTestDocumentInterface = this;
-    return Promise.resolve("");
-  }, err => {})
+    schema.pre<PreHookTestDocumentInterface>(
+        "init",
+        function (next) {
+            const isSpecificType: PreHookTestDocumentInterface = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre("init", true, function (next, done) {
-    const isDefaultType: mongoose.Document = this;
-  }, err => {})
+    schema.pre(
+        "init",
+        true,
+        function (next, done) {
+            const isDefaultType: mongoose.Document = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestDocumentInterface>("init", true, function (next, done) {
-    const isSpecificType: PreHookTestDocumentInterface = this;
-    return Promise.resolve("");
-  }, err => {})
+    schema.pre<PreHookTestDocumentInterface>(
+        "init",
+        true,
+        function (next, done) {
+            const isSpecificType: PreHookTestDocumentInterface = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 
 // Query
 preHookTestSchemaArr.push(
-  schema.pre("count", function (next) {
-    const isDefaultType: mongoose.Query<any> = this;
-  }, err => {})
+    schema.pre(
+        "count",
+        function (next) {
+            const isDefaultType: mongoose.Query<any> = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestQueryInterface<number>>("count", function (next) {
-    const isSpecificType: PreHookTestQueryInterface<number> = this;
-    return Promise.resolve("");
-  }, err => {})
+    schema.pre<PreHookTestQueryInterface<number>>(
+        "count",
+        function (next) {
+            const isSpecificType: PreHookTestQueryInterface<number> = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre("count", true, function (next, done) {
-    const isDefaultType: mongoose.Query<any> = this;
-  }, err => {})
+    schema.pre(
+        "count",
+        true,
+        function (next, done) {
+            const isDefaultType: mongoose.Query<any> = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestQueryInterface<number>>("count", true, function (next, done) {
-    const isSpecificType: PreHookTestQueryInterface<number> = this;
-    return Promise.resolve("");
-  }, err => {})
+    schema.pre<PreHookTestQueryInterface<number>>(
+        "count",
+        true,
+        function (next, done) {
+            const isSpecificType: PreHookTestQueryInterface<number> = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 
 // Aggregate
 preHookTestSchemaArr.push(
-  schema.pre("aggregate", function(next) {
-    const isDefaultType: mongoose.Aggregate<any> = this;
-  }, err => {})
+    schema.pre(
+        "aggregate",
+        function (next) {
+            const isDefaultType: mongoose.Aggregate<any> = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestAggregateInterface<number>>("aggregate", function(next) {
-    const isSpecificType: PreHookTestAggregateInterface<number> = this;
-    return Promise.resolve("")
-  }, err => {})
+    schema.pre<PreHookTestAggregateInterface<number>>(
+        "aggregate",
+        function (next) {
+            const isSpecificType: PreHookTestAggregateInterface<number> = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre("aggregate", true, function(next, done) {
-    const isDefaultType: mongoose.Aggregate<any> = this;
-  }, err => {})
+    schema.pre(
+        "aggregate",
+        true,
+        function (next, done) {
+            const isDefaultType: mongoose.Aggregate<any> = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestAggregateInterface<number>>("aggregate", true, function(next, done) {
-    const isSpecificType: PreHookTestAggregateInterface<number> = this;
-    return Promise.resolve("")
-  }, err => {})
+    schema.pre<PreHookTestAggregateInterface<number>>(
+        "aggregate",
+        true,
+        function (next, done) {
+            const isSpecificType: PreHookTestAggregateInterface<number> = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 
 // Model<Document>
 preHookTestSchemaArr.push(
-  schema.pre("insertMany", function(next, docs) {
-    const isDefaultType: mongoose.Model<mongoose.Document> = this;
-  }, err => {})
+    schema.pre(
+        "insertMany",
+        function (next, docs) {
+            const isDefaultType: mongoose.Model<mongoose.Document> = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestModelInterface<PreHookTestDocumentInterface>>("insertMany", function(next, docs) {
-    const isSpecificType: PreHookTestModelInterface<PreHookTestDocumentInterface> = this;
-    return Promise.resolve("")
-  }, err => {})
+    schema.pre<PreHookTestModelInterface<PreHookTestDocumentInterface>>(
+        "insertMany",
+        function (next, docs) {
+            const isSpecificType: PreHookTestModelInterface<PreHookTestDocumentInterface> = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre("insertMany", true, function(next, done, docs) {
-    const isDefaultType: mongoose.Model<mongoose.Document> = this;
-  }, err => {})
+    schema.pre(
+        "insertMany",
+        true,
+        function (next, done, docs) {
+            const isDefaultType: mongoose.Model<mongoose.Document> = this;
+        },
+        err => {},
+    ),
 );
 preHookTestSchemaArr.push(
-  schema.pre<PreHookTestModelInterface<PreHookTestDocumentInterface>>("insertMany", true, function(next, done, docs) {
-    const isSpecificType: PreHookTestModelInterface<PreHookTestDocumentInterface> = this;
-    return Promise.resolve("")
-  }, err => {})
+    schema.pre<PreHookTestModelInterface<PreHookTestDocumentInterface>>(
+        "insertMany",
+        true,
+        function (next, done, docs) {
+            const isSpecificType: PreHookTestModelInterface<PreHookTestDocumentInterface> = this;
+            return Promise.resolve("");
+        },
+        err => {},
+    ),
 );
 
 schema
-.post('save', function (error: mongoose.Error, doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
-  error.stack;
-  doc.model;
-  next.apply;
-})
-.post('save', function (doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
-  doc.model;
-  next(new Error());
-})
-.post('save', function (doc: mongoose.Document) {
-  doc.model;
-});
+    .post("save", function (error: mongoose.Error, doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
+        error.stack;
+        doc.model;
+        next.apply;
+    })
+    .post("save", function (doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
+        doc.model;
+        next(new Error());
+    })
+    .post("save", function (doc: mongoose.Document) {
+        doc.model;
+    });
 
-schema.post('insertMany', function(docs: mongoose.Document[], next: () => void) {
+schema.post("insertMany", function (docs: mongoose.Document[], next: () => void) {
     const isDefaultType: mongoose.Model<mongoose.Document> = this;
     next();
 });
 
-schema.post('insertMany', function(error, docs: mongoose.Document[], next) {
+schema.post("insertMany", function (error, docs: mongoose.Document[], next) {
     const isDefaultType: mongoose.Model<mongoose.Document> = this;
     next();
 });
 
-schema.post('insertMany', async function(docs: mongoose.Document[]): Promise<void> {
+schema.post("insertMany", async function (docs: mongoose.Document[]): Promise<void> {
     const isDefaultType: mongoose.Model<mongoose.Document> = this;
     return;
 });
 
-schema.post('find', function(docs: mongoose.Document[], next: (err?: mongoose.NativeError) => void): void {
-  const isDefaultType: mongoose.Query<mongoose.Document> = this;
-  return;
+schema.post("find", function (docs: mongoose.Document[], next: (err?: mongoose.NativeError) => void): void {
+    const isDefaultType: mongoose.Query<mongoose.Document> = this;
+    return;
 });
 
-schema.post('find', async function(docs: mongoose.Document[], next: (err?: mongoose.NativeError) => void): Promise<void> {
-  const isDefaultType: mongoose.Query<mongoose.Document> = this;
-  return;
-});
+schema.post(
+    "find",
+    async function (docs: mongoose.Document[], next: (err?: mongoose.NativeError) => void): Promise<void> {
+        const isDefaultType: mongoose.Query<mongoose.Document> = this;
+        return;
+    },
+);
 
-schema.queue('m1', [1, 2, 3]).queue('m2', [[]]);
-schema.remove('path');
-schema.remove(['path1', 'path2', 'path3']);
+schema.queue("m1", [1, 2, 3]).queue("m2", [[]]);
+schema.remove("path");
+schema.remove(["path1", "path2", "path3"]);
 schema.requiredPaths(true)[0].toLowerCase();
-schema.set('id', true).set('id');
-schema.static('static', cb).static({
-  s1: cb,
-  s2: cb
+schema.set("id", true).set("id");
+schema.static("static", cb).static({
+    s1: cb,
+    s2: cb,
 });
-schema.virtual('virt', {}).applyGetters({}, {});
-schema.virtualpath('path').applyGetters({}, {});
+schema.virtual("virt", {}).applyGetters({}, {});
+schema.virtualpath("path").applyGetters({}, {});
 /* static properties */
 mongoose.Schema.indexTypes[0].toLowerCase();
-mongoose.Schema.reserved.hasOwnProperty('');
+mongoose.Schema.reserved.hasOwnProperty("");
 /* inherited properties */
-schema.addListener('e', cb);
+schema.addListener("e", cb);
 /* practical examples */
 interface Animal {
-  findSimilarTypes(cb: any): Promise<Animal>
+    findSimilarTypes(cb: any): Promise<Animal>;
 }
 var animalSchema = new mongoose.Schema<Animal>({
-  name: String,
-  type: String
+    name: String,
+    type: String,
 });
 animalSchema.methods.findSimilarTypes = function (cb) {
-  return this.model('Animal').find({ type: this.type }, cb);
+    return this.model("Animal").find({ type: this.type }, cb);
 };
-var Animal: any = mongoose.model('Animal', animalSchema);
-var dog: any = new Animal({type: 'dog'});
-dog['findSimilarTypes'](function (err: any, dogs: any) {
-  console.log(dogs);
+var Animal: any = mongoose.model("Animal", animalSchema);
+var dog: any = new Animal({ type: "dog" });
+dog["findSimilarTypes"](function (err: any, dogs: any) {
+    console.log(dogs);
 });
 new mongoose.Schema({
-  title:  String,
-  author: String,
-  body:   String,
-  comments: [{ body: String, date: Date }],
-  date: { type: Date, default: Date.now },
-  hidden: Boolean,
-  meta: {
-    votes: Number,
-    favs:  Number,
-    text: String
-  },
-  meta2: {
-    text: mongoose.Schema.Types.Number,
-    select: {
-      type: String
-    }
-  }
+    title: String,
+    author: String,
+    body: String,
+    comments: [{ body: String, date: Date }],
+    date: { type: Date, default: Date.now },
+    hidden: Boolean,
+    meta: {
+        votes: Number,
+        favs: Number,
+        text: String,
+    },
+    meta2: {
+        text: mongoose.Schema.Types.Number,
+        select: {
+            type: String,
+        },
+    },
 });
-new mongoose.Schema({ name: { type: String, index: true }});
-new mongoose.Schema({ loc: { type: [Number], index: 'hashed' }});
-new mongoose.Schema({ loc: { type: [Number], index: '2d', sparse: true }});
-new mongoose.Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }}});
-new mongoose.Schema({ date: { type: Date, index: { unique: true, expires: '1d' }}});
-new mongoose.Schema({ born: { type: Date, required: '{PATH} is required!' }});
-new mongoose.Schema({ born: { type: Date, required: function() {
-  return this.age >= 18;
-}}});
-new mongoose.Schema({ state: { type: String, enum: ['opening', 'open', 'closing', 'closed'] }});
-new mongoose.Schema({ state: { type: String, enum: {
-  values: ['opening', 'open', 'closing', 'closed'],
-  message: 'enum validator failed for path `{PATH}` with value `{VALUE}`'
-}}});
-new mongoose.Schema({ name: { type: String, match: /^a/ }});
-new mongoose.Schema({ name: { type: String, match: [
-  /\.html$/, "That file doesn't end in .html ({VALUE})"
-]}});
+new mongoose.Schema({ name: { type: String, index: true } });
+new mongoose.Schema({ loc: { type: [Number], index: "hashed" } });
+new mongoose.Schema({ loc: { type: [Number], index: "2d", sparse: true } });
+new mongoose.Schema({ loc: { type: [Number], index: { type: "2dsphere", sparse: true } } });
+new mongoose.Schema({ date: { type: Date, index: { unique: true, expires: "1d" } } });
+new mongoose.Schema({ born: { type: Date, required: "{PATH} is required!" } });
 new mongoose.Schema({
-  createdAt: {type: Date, expires: 60 * 60 * 24}
+    born: {
+        type: Date,
+        required: function () {
+            return this.age >= 18;
+        },
+    },
 });
-new mongoose.Schema({ createdAt: { type: Date, expires: '1.5h' }});
-new mongoose.Schema({ d: { type: Date, max: new Date('2014-01-01') }});
-new mongoose.Schema({ d: { type: Date, max: [
-  new Date('2014-01-01'),
-  'The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX}).'
-]}});
-new mongoose.Schema({d: {type: Date, min: [
-  new Date('1970-01-01'),
-  'The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN}).'
-]}});
+new mongoose.Schema({ state: { type: String, enum: ["opening", "open", "closing", "closed"] } });
 new mongoose.Schema({
-  integerOnly: {
-    type: Number,
-    get: (v: number) => Math.round(v),
-    set: (v: number) => Math.round(v),
-    validate: {
-      isAsync: false,
-      validator: (val: number): boolean => {
-        return false;
-      }
-    }
-  },
-  asyncValidated: {
-    type: Number,
-    validate: {
-      isAsync: true,
-      validator: (val: number, done): void => {
-        setImmediate(done, true);
-      },
-      message: (props) => `${props.value} is invalid`
-    }
-  },
-  promiseValidated: {
-    type: Number,
-    validate: {
-      validator: async (val: number) => {
-        return val === 2;
-      },
-      message: 'Number is invalid'
-    }
-  },
+    state: {
+        type: String,
+        enum: {
+            values: ["opening", "open", "closing", "closed"],
+            message: "enum validator failed for path `{PATH}` with value `{VALUE}`",
+        },
+    },
+});
+new mongoose.Schema({ name: { type: String, match: /^a/ } });
+new mongoose.Schema({ name: { type: String, match: [/\.html$/, "That file doesn't end in .html ({VALUE})"] } });
+new mongoose.Schema({
+    createdAt: { type: Date, expires: 60 * 60 * 24 },
+});
+new mongoose.Schema({ createdAt: { type: Date, expires: "1.5h" } });
+new mongoose.Schema({ d: { type: Date, max: new Date("2014-01-01") } });
+new mongoose.Schema({
+    d: { type: Date, max: [new Date("2014-01-01"), "The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX})."] },
 });
 new mongoose.Schema({
-  fnOnly: { type: String, validate: () => true },
-  fnStringArray: { type: String, validate: [() => true, 'failed'] },
-  fnStringObject: { type: String, validate: { validator: () => true, message: 'failed' } },
-  promiseFnOnly: { type: String, validate: () => Promise.reject(new Error('oops')) },
-  promiseFnStringArray: { type: String, validate: [() => Promise.reject(), 'oops'] },
-  promiseFnStringObject: { type: String, validate: { validator: () => Promise.reject(), message: 'oops' } },
+    d: {
+        type: Date,
+        min: [new Date("1970-01-01"), "The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN})."],
+    },
 });
-new mongoose.Schema({ name: { type: String, validate: [
-  { validator: () => {return true}, msg: 'uh oh' },
-  { validator: () => {return true}, msg: 'failed' }
-]}});
-animalSchema.statics.findByName = function(name: any, cb: any) {
-  return this.find({ name: new RegExp(name, 'i') }, cb);
+new mongoose.Schema({
+    integerOnly: {
+        type: Number,
+        get: (v: number) => Math.round(v),
+        set: (v: number) => Math.round(v),
+        validate: {
+            isAsync: false,
+            validator: (val: number): boolean => {
+                return false;
+            },
+        },
+    },
+    asyncValidated: {
+        type: Number,
+        validate: {
+            isAsync: true,
+            validator: (val: number, done): void => {
+                setImmediate(done, true);
+            },
+            message: props => `${props.value} is invalid`,
+        },
+    },
+    promiseValidated: {
+        type: Number,
+        validate: {
+            validator: async (val: number) => {
+                return val === 2;
+            },
+            message: "Number is invalid",
+        },
+    },
+});
+new mongoose.Schema({
+    fnOnly: { type: String, validate: () => true },
+    fnStringArray: { type: String, validate: [() => true, "failed"] },
+    fnStringObject: { type: String, validate: { validator: () => true, message: "failed" } },
+    promiseFnOnly: { type: String, validate: () => Promise.reject(new Error("oops")) },
+    promiseFnStringArray: { type: String, validate: [() => Promise.reject(), "oops"] },
+    promiseFnStringObject: { type: String, validate: { validator: () => Promise.reject(), message: "oops" } },
+});
+new mongoose.Schema({
+    name: {
+        type: String,
+        validate: [
+            {
+                validator: () => {
+                    return true;
+                },
+                msg: "uh oh",
+            },
+            {
+                validator: () => {
+                    return true;
+                },
+                msg: "failed",
+            },
+        ],
+    },
+});
+animalSchema.statics.findByName = function (name: any, cb: any) {
+    return this.find({ name: new RegExp(name, "i") }, cb);
 };
-Animal['findByName']('fido', function(err: any, animals: any) {
-  console.log(animals);
+Animal["findByName"]("fido", function (err: any, animals: any) {
+    console.log(animals);
 });
-animalSchema.virtual('name.full').get(function () {
-  return this.name.first + ' ' + this.name.last;
+animalSchema.virtual("name.full").get(function () {
+    return this.name.first + " " + this.name.last;
 });
 var childSchema = new mongoose.Schema({ name: String });
 var parentSchema = new mongoose.Schema({
-  children: [childSchema],
-  child: childSchema,
-  name: {
-    index: true,
-    required: true
-  }
+    children: [childSchema],
+    child: childSchema,
+    name: {
+        index: true,
+        required: true,
+    },
 });
 new mongoose.Schema({
-  eggs: {
-    type: Number,
-    min: [6, 'Too few eggs'],
-    max: 12
-  },
-  bacon: {
-    type: Number,
-    required: [true, 'Why no bacon?']
-  },
-  drink: {
-    type: String,
-    enum: ['Coffee', 'Tea']
-  }
+    eggs: {
+        type: Number,
+        min: [6, "Too few eggs"],
+        max: 12,
+    },
+    bacon: {
+        type: Number,
+        required: [true, "Why no bacon?"],
+    },
+    drink: {
+        type: String,
+        enum: ["Coffee", "Tea"],
+    },
 });
 
-(new mongoose.Schema({})).plugin<any>(function (schema: mongoose.Schema, options: any) {
-  schema.add({ lastMod: Date })
-  schema.pre('save', function (next: Function) {
-    (this as any).lastMod = new Date
-    next()
-  })
-  if (options && options['index']) {
-    schema.path('lastMod').index(options['index'])
-  }
-}, { index: true }).plugin<any>(function (schema: mongoose.Schema, options: any) {
-  schema.add({ lastMod: Date })
-  schema.pre('save', function (next: Function) {
-    (this as any).lastMod = new Date
-    next()
-  })
-  if (options && options['index']) {
-    schema.path('lastMod').index(options['index'])
-  }
-}, {index: true});
+new mongoose.Schema({})
+    .plugin<any>(
+        function (schema: mongoose.Schema, options: any) {
+            schema.add({ lastMod: Date });
+            schema.pre("save", function (next: Function) {
+                (this as any).lastMod = new Date();
+                next();
+            });
+            if (options && options["index"]) {
+                schema.path("lastMod").index(options["index"]);
+            }
+        },
+        { index: true },
+    )
+    .plugin<any>(
+        function (schema: mongoose.Schema, options: any) {
+            schema.add({ lastMod: Date });
+            schema.pre("save", function (next: Function) {
+                (this as any).lastMod = new Date();
+                next();
+            });
+            if (options && options["index"]) {
+                schema.path("lastMod").index(options["index"]);
+            }
+        },
+        { index: true },
+    );
 
-new mongoose.Schema({foo: String}, {strict: 'throw', strictQuery: true});
+new mongoose.Schema({ foo: String }, { strict: "throw", strictQuery: true });
 
-export default function(schema: mongoose.Schema) {
-  schema.pre('init', function(this: mongoose.Document, next: (err?: Error) => void): void {
-     console.log('success!');
-  });
+export default function (schema: mongoose.Schema) {
+    schema.pre("init", function (this: mongoose.Document, next: (err?: Error) => void): void {
+        console.log("success!");
+    });
 }
 
 // plugins
-function MyPlugin(schema: mongoose.Schema, opts?: string) {
-}
-new mongoose.Schema({})
-    .plugin(MyPlugin)
+function MyPlugin(schema: mongoose.Schema, opts?: string) {}
+new mongoose.Schema({}).plugin(MyPlugin);
 
 interface PluginOption {
     modelName: string;
@@ -769,16 +918,15 @@ function logger(modelName: string, timestamp: string) {
 
 function AwesomeLoggerPlugin(schema: mongoose.Schema, options: PluginOption) {
     if (options) {
-        schema.pre('save', function (next: Function) {
-            logger(options.modelName, options.timestamp)
-        })
+        schema.pre("save", function (next: Function) {
+            logger(options.modelName, options.timestamp);
+        });
     }
 }
 
-new mongoose.Schema({})
-    .plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', timestamp: 'yyyy/MM/dd'})
+new mongoose.Schema({}).plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", timestamp: "yyyy/MM/dd" });
 
-mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', timestamp: 'yyyy/MM/dd'})
+mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", timestamp: "yyyy/MM/dd" });
 
 /*
  * section types/subdocument.js
@@ -788,7 +936,7 @@ mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', time
 var subdocument: mongoose.Types.Subdocument = new mongoose.Types.Subdocument();
 subdocument.ownerDocument().errors;
 subdocument.remove({}, function (err) {
-  return 6;
+    return 6;
 });
 /* inherited properties */
 subdocument.execPopulate();
@@ -801,49 +949,49 @@ var mongooseArray: mongoose.Types.Array<string> = new mongoose.Types.Array<strin
 mongooseArray.$shift().toLowerCase();
 mongooseArray.remove().$shift();
 mongooseArray.$pop().toLowerCase();
-mongooseArray.addToSet('hi', 9, 9, '4')[0].toLowerCase();
-mongooseArray.indexOf({name: 'obj'}).toFixed();
+mongooseArray.addToSet("hi", 9, 9, "4")[0].toLowerCase();
+mongooseArray.indexOf({ name: "obj" }).toFixed();
 mongooseArray.inspect();
-mongooseArray.nonAtomicPush(9, 8, 'hi').toFixed();
+mongooseArray.nonAtomicPush(9, 8, "hi").toFixed();
 mongooseArray.pop().toLowerCase();
-mongooseArray.pull(5, 4, 'hi').$shift();
+mongooseArray.pull(5, 4, "hi").$shift();
 mongooseArray.push([]).toFixed();
-mongooseArray.set(1, 'hi').$shift();
+mongooseArray.set(1, "hi").$shift();
 mongooseArray.shift().toLowerCase();
-mongooseArray.sort(function (a, b) {
-  return a.length - b.length;
-}).unshift();
+mongooseArray
+    .sort(function (a, b) {
+        return a.length - b.length;
+    })
+    .unshift();
 mongooseArray.splice(4, 1).unshift();
-mongooseArray.toObject({depopulate: true}).unshift();
-mongooseArray.unshift(2, 4, 'hi').toFixed();
+mongooseArray.toObject({ depopulate: true }).unshift();
+mongooseArray.unshift(2, 4, "hi").toFixed();
 /* inherited properties */
 mongooseArray.concat();
 mongooseArray.length;
 /* practical examples */
 interface MySubEntity extends mongoose.Types.Subdocument {
-  property1: string;
-  property2: string;
+    property1: string;
+    property2: string;
 }
 interface MyEntity extends mongoose.Document {
-  sub: mongoose.Types.Array<MySubEntity>
+    sub: mongoose.Types.Array<MySubEntity>;
 }
-var myEntity = <MyEntity> {};
+var myEntity = <MyEntity>{};
 var subDocArray = myEntity.sub.filter(sd => {
-  sd.property1;
-  sd.property2.toLowerCase();
-  return true;
+    sd.property1;
+    sd.property2.toLowerCase();
+    return true;
 });
-
 
 /*
  * section types/documentarray.js
  * http://mongoosejs.com/docs/api.html#types-documentarray-js
  */
 // The constructor is private api, but we'll use it to test
-var documentArray: mongoose.Types.DocumentArray<mongoose.Document> =
-  new mongoose.Types.DocumentArray();
+var documentArray: mongoose.Types.DocumentArray<mongoose.Document> = new mongoose.Types.DocumentArray();
 documentArray.create({}).errors;
-documentArray.id(new Buffer('hi'));
+documentArray.id(new Buffer("hi"));
 documentArray.inspect();
 documentArray.toObject({}).length;
 /* inherited from mongoose.Types.Array */
@@ -852,26 +1000,26 @@ documentArray.$shift();
 documentArray.concat();
 /* practical example */
 interface MySubEntity1 extends mongoose.Types.Subdocument {
-  property1: string;
-  property2: string;
+    property1: string;
+    property2: string;
 }
 interface MyEntity1 extends mongoose.Document {
-  sub: mongoose.Types.DocumentArray<MySubEntity>
+    sub: mongoose.Types.DocumentArray<MySubEntity>;
 }
-var newEnt = <MyEntity1> {};
+var newEnt = <MyEntity1>{};
 var newSub: MySubEntity1 = newEnt.sub.create({ property1: "example", property2: "example" });
 
 /*
  * section types/buffer.js
  * http://mongoosejs.com/docs/api.html#types-buffer-js
  */
-var mongooseBuffer: mongoose.Types.Buffer = new mongoose.Types.Buffer('hello');
+var mongooseBuffer: mongoose.Types.Buffer = new mongoose.Types.Buffer("hello");
 mongooseBuffer.copy(mongooseBuffer, 1, 2, 3).toFixed();
-mongooseBuffer.copy(new Buffer('hi')).toFixed();
-mongooseBuffer.equals(new Buffer('hi')).valueOf();
+mongooseBuffer.copy(new Buffer("hi")).toFixed();
+mongooseBuffer.equals(new Buffer("hi")).valueOf();
 mongooseBuffer.subtype(123);
 mongooseBuffer.toObject().value();
-mongooseBuffer.write('world', 3, 2, 1).toFixed();
+mongooseBuffer.write("world", 3, 2, 1).toFixed();
 /* inherited properties */
 mongooseBuffer.compare(mongooseBuffer);
 /* inherited static properties */
@@ -881,37 +1029,37 @@ mongoose.Types.Buffer.from([1, 2, 3]);
  * section types/decimal128.js
  * http://mongoosejs.com/docs/api.html#types-decimal128-js
  */
-var decimal128: mongoose.Types.Decimal128 = mongoose.Types.Decimal128.fromString('123.45678901234567');
-decimal128 = new mongoose.Types.Decimal128(new Buffer('12345'));
+var decimal128: mongoose.Types.Decimal128 = mongoose.Types.Decimal128.fromString("123.45678901234567");
+decimal128 = new mongoose.Types.Decimal128(new Buffer("12345"));
 /* practical examples */
 export interface ILargeValuesSchema extends mongoose.Document {
-  sum: mongoose.Schema.Types.Decimal128;
+    sum: mongoose.Schema.Types.Decimal128;
 }
 export var LargeValuesSchema = new mongoose.Schema({
-  sum: {
-    type: mongoose.Schema.Types.Decimal128,
-    required: true
-  }
+    sum: {
+        type: mongoose.Schema.Types.Decimal128,
+        required: true,
+    },
 });
 
 /*
  * section types/objectid.js
  * http://mongoosejs.com/docs/api.html#types-objectid-js
  */
-var objectId: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString('0x1234');
+var objectId: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString("0x1234");
 objectId = new mongoose.Types.ObjectId(12345);
 objectId = mongoose.Types.ObjectId(12345);
 objectId.getTimestamp();
 /* practical examples */
 export interface IManagerSchema extends mongoose.Document {
-  user: mongoose.Schema.Types.ObjectId;
+    user: mongoose.Schema.Types.ObjectId;
 }
 export var ManagerSchema = new mongoose.Schema({
-  user: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
-    required: true
-  }
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+        required: true,
+    },
 });
 
 /*
@@ -919,13 +1067,13 @@ export var ManagerSchema = new mongoose.Schema({
  * http://mongoosejs.com/docs/api.html#types-embedded-js
  */
 var embeddedDocument: mongoose.Types.Embedded = new mongoose.Types.Embedded();
-embeddedDocument.inspect().hasOwnProperty('');
-embeddedDocument.invalidate('hi', new Error('bleh')).valueOf();
+embeddedDocument.inspect().hasOwnProperty("");
+embeddedDocument.invalidate("hi", new Error("bleh")).valueOf();
 embeddedDocument.ownerDocument().execPopulate();
 embeddedDocument.parent().execPopulate();
 embeddedDocument.parentArray().$shift();
-embeddedDocument.remove().invalidate('hi', new Error('hi'));
-embeddedDocument.markModified('path');
+embeddedDocument.remove().invalidate("hi", new Error("hi"));
+embeddedDocument.markModified("path");
 /* inherited properties */
 embeddedDocument.execPopulate();
 
@@ -934,19 +1082,22 @@ embeddedDocument.execPopulate();
  * https://mongoosejs.com/docs/schematypes.html#maps
  */
 var map: mongoose.Types.Map<string> = new mongoose.Types.Map<string>();
-map.get('key');
-map.set('key', 'value');
-map.delete('key');
+map.get("key");
+map.set("key", "value");
+map.delete("key");
 map.toObject().delete;
 map.toObject({ flattenMaps: true }).key;
-
 
 /*
  * section schema/array.js
  * http://mongoosejs.com/docs/api.html#schema-array-js
  */
-var schemaArray: mongoose.Schema.Types.Array = new mongoose.Schema.Types.Array('key', new mongoose.SchemaType('hi'), {});
-schemaArray.checkRequired('hello').valueOf();
+var schemaArray: mongoose.Schema.Types.Array = new mongoose.Schema.Types.Array(
+    "key",
+    new mongoose.SchemaType("hi"),
+    {},
+);
+schemaArray.checkRequired("hello").valueOf();
 /** static properties */
 mongoose.Schema.Types.Array.schemaName.toLowerCase();
 /** inherited properties */
@@ -956,14 +1107,14 @@ schemaArray.sparse(true);
  * section schema/string.js
  * http://mongoosejs.com/docs/api.html#schema-string-js
  */
-var MongoDocument = <mongoose.Document> {};
-var schemastring: mongoose.Schema.Types.String = new mongoose.Schema.Types.String('hello');
+var MongoDocument = <mongoose.Document>{};
+var schemastring: mongoose.Schema.Types.String = new mongoose.Schema.Types.String("hello");
 schemastring.checkRequired(234, MongoDocument).valueOf();
-schemastring.enum(['hi', 'a', 'b']).enum('hi').enum({});
+schemastring.enum(["hi", "a", "b"]).enum("hi").enum({});
 schemastring.lowercase().lowercase();
-schemastring.match(/re/, 'error').match(/re/);
-schemastring.maxlength(999, 'error').maxlength(999);
-schemastring.minlength(999, 'error').minlength(999);
+schemastring.match(/re/, "error").match(/re/);
+schemastring.maxlength(999, "error").maxlength(999);
+schemastring.minlength(999, "error").minlength(999);
 schemastring.trim().trim();
 schemastring.uppercase().uppercase();
 /* static properties */
@@ -975,24 +1126,27 @@ schemastring.sparse(true);
  * section schema/documentarray.js
  * http://mongoosejs.com/docs/api.html#schema-documentarray-js
  */
-var documentarray: mongoose.Schema.Types.DocumentArray = new mongoose.Schema.Types.DocumentArray('key', new mongoose.Schema());
+var documentarray: mongoose.Schema.Types.DocumentArray = new mongoose.Schema.Types.DocumentArray(
+    "key",
+    new mongoose.Schema(),
+);
 /* static properties */
 mongoose.Schema.Types.DocumentArray.schemaName.toLowerCase();
 /* inherited properties */
 documentarray.sparse(true);
 /* http://thecodebarbarian.com/mongoose-4.8-embedded-discriminators */
-documentarray.discriminator('name', new mongoose.Schema({ foo: String }));
+documentarray.discriminator("name", new mongoose.Schema({ foo: String }));
 /* https://mongoosejs.com/docs/api.html#documentarraypath_DocumentArrayPath-discriminator */
-documentarray.discriminator('name2', new mongoose.Schema({ bar: String }), "circle");
+documentarray.discriminator("name2", new mongoose.Schema({ bar: String }), "circle");
 
 /*
  * section schema/number.js
  * http://mongoosejs.com/docs/api.html#schema-number-js
  */
-var schemanumber: mongoose.Schema.Types.Number = new mongoose.Schema.Types.Number('num', {});
+var schemanumber: mongoose.Schema.Types.Number = new mongoose.Schema.Types.Number("num", {});
 schemanumber.checkRequired(999, MongoDocument).valueOf();
-schemanumber.max(999, 'error').max(999);
-schemanumber.min(999, 'error').min(999);
+schemanumber.max(999, "error").max(999);
+schemanumber.min(999, "error").min(999);
 /* static properties */
 mongoose.Schema.Types.Number.schemaName.toLowerCase();
 /* inherited properties */
@@ -1002,11 +1156,11 @@ schemanumber.sparse(true);
  * section schema/date.js
  * http://mongoosejs.com/docs/api.html#schema-date-js
  */
-var schemadate: mongoose.Schema.Types.Date = new mongoose.Schema.Types.Date('99');
+var schemadate: mongoose.Schema.Types.Date = new mongoose.Schema.Types.Date("99");
 schemadate.checkRequired([], MongoDocument).valueOf();
-schemadate.expires(99).expires('now');
-schemadate.max(new Date(), 'error').max(new Date(''));
-schemadate.min(new Date(), 'error').min(new Date(''));
+schemadate.expires(99).expires("now");
+schemadate.max(new Date(), "error").max(new Date(""));
+schemadate.min(new Date(), "error").min(new Date(""));
 /* static properties */
 mongoose.Schema.Types.Date.schemaName.toLowerCase();
 /* inherited properties */
@@ -1016,7 +1170,7 @@ schemadate.sparse(true);
  * section schema/buffer.js
  * http://mongoosejs.com/docs/api.html#schema-buffer-js
  */
-var schemabuffer: mongoose.Schema.Types.Buffer = new mongoose.Schema.Types.Buffer('99');
+var schemabuffer: mongoose.Schema.Types.Buffer = new mongoose.Schema.Types.Buffer("99");
 schemabuffer.checkRequired(999, MongoDocument).valueOf();
 /* static properties */
 mongoose.Schema.Types.Buffer.schemaName.toLowerCase();
@@ -1027,7 +1181,7 @@ schemabuffer.sparse(true);
  * section schema/boolean.js
  * http://mongoosejs.com/docs/api.html#schema-boolean-js
  */
-var schemaboolean: mongoose.Schema.Types.Boolean = new mongoose.Schema.Types.Boolean('99');
+var schemaboolean: mongoose.Schema.Types.Boolean = new mongoose.Schema.Types.Boolean("99");
 schemaboolean.checkRequired(99).valueOf();
 /* static properties */
 mongoose.Schema.Types.Boolean.schemaName.toLowerCase();
@@ -1038,7 +1192,7 @@ schemaboolean.sparse(true);
  * section schema/objectid.js
  * http://mongoosejs.com/docs/api.html#schema-objectid-js
  */
-var schemaobjectid: mongoose.Schema.Types.ObjectId = new mongoose.Schema.Types.ObjectId('99');
+var schemaobjectid: mongoose.Schema.Types.ObjectId = new mongoose.Schema.Types.ObjectId("99");
 schemaobjectid.auto(true).auto(false);
 schemaobjectid.checkRequired(99, MongoDocument).valueOf();
 /* static properties */
@@ -1050,7 +1204,7 @@ schemaobjectid.sparse(true);
  * section schema/mixed.js
  * http://mongoosejs.com/docs/api.html#schema-mixed-js
  */
-var schemamixed: mongoose.Schema.Types.Mixed = new mongoose.Schema.Types.Mixed('99');
+var schemamixed: mongoose.Schema.Types.Mixed = new mongoose.Schema.Types.Mixed("99");
 /* static properties */
 mongoose.Schema.Types.Mixed.schemaName.toLowerCase();
 /* inherited properties */
@@ -1060,8 +1214,7 @@ schemamixed.sparse(true);
  * section schema/embedded.js
  * http://mongoosejs.com/docs/api.html#schema-embedded-js
  */
-var schemaembedded: mongoose.Schema.Types.Embedded =
-  new mongoose.Schema.Types.Embedded(new mongoose.Schema(), '99');
+var schemaembedded: mongoose.Schema.Types.Embedded = new mongoose.Schema.Types.Embedded(new mongoose.Schema(), "99");
 /* inherited properties */
 schemaembedded.sparse(true);
 
@@ -1070,121 +1223,127 @@ schemaembedded.sparse(true);
  * http://mongoosejs.com/docs/api.html#aggregate-js
  */
 var aggregate: mongoose.Aggregate<Object[]>;
-aggregate = mongoose.model('ex').aggregate([{ $match: { age: { $gte: 21 }}}]);
+aggregate = mongoose.model("ex").aggregate([{ $match: { age: { $gte: 21 } } }]);
 aggregate = new mongoose.Aggregate<Object[]>();
 aggregate = new mongoose.Aggregate<Object[]>({ $project: { a: 1, b: 1 } });
 aggregate = new mongoose.Aggregate<Object[]>({ $project: { a: 1, b: 1 } }, { $skip: 5 });
 aggregate = new mongoose.Aggregate<Object[]>([{ $project: { a: 1, b: 1 } }, { $skip: 5 }]);
-aggregate.addCursorFlag('flag', true).addCursorFlag('', false);
+aggregate.addCursorFlag("flag", true).addCursorFlag("", false);
 aggregate.allowDiskUse(true).allowDiskUse(false, []);
-aggregate.append({ $project: { field: 1 }}, { $limit: 2 });
-aggregate.append([{ $match: { daw: 'Logic Audio X' }} ]);
-aggregate.collation({ locale: 'en_US', strength: 1 });
-aggregate.count('countName');
+aggregate.append({ $project: { field: 1 } }, { $limit: 2 });
+aggregate.append([{ $match: { daw: "Logic Audio X" } }]);
+aggregate.collation({ locale: "en_US", strength: 1 });
+aggregate.count("countName");
 aggregate.facet({ fieldA: [{ a: 1 }], fieldB: [{ b: 1 }] });
 aggregate.cursor({ batchSize: 1000 }).exec().each(cb);
 aggregate.exec().then(cb).catch(cb);
-aggregate.option({foo: 'bar'}).exec();
+aggregate.option({ foo: "bar" }).exec();
 const aggregateDotPipeline: any[] = aggregate.pipeline();
 aggregate.explain(cb).then(cb).catch(cb);
 aggregate.group({ _id: "$department" }).group({ _id: "$department" });
-aggregate.hint({ _id: 1 })
+aggregate.hint({ _id: 1 });
 aggregate.limit(10).limit(10);
 var lookupOpt = {
-  from: 'users', localField:
-  'userId', foreignField: '_id',
-  as: 'users'
+    from: "users",
+    localField: "userId",
+    foreignField: "_id",
+    as: "users",
 };
 aggregate.lookup(lookupOpt).lookup(lookupOpt);
 aggregate.match({
-  department: {$in: [ "sales", "engineering"]}
+    department: { $in: ["sales", "engineering"] },
 });
-aggregate.model(new (mongoose.model('xx'))()).model(null);
+aggregate.model(new (mongoose.model("xx"))()).model(null);
 aggregate.near({
-  near: [40.724, -73.997],
-  distanceField: "dist.calculated",
-  maxDistance: 0.008,
-  query: { type: "public" },
-  includeLocs: "dist.location",
-  uniqueDocs: true,
-  num: 5
+    near: [40.724, -73.997],
+    distanceField: "dist.calculated",
+    maxDistance: 0.008,
+    query: { type: "public" },
+    includeLocs: "dist.location",
+    uniqueDocs: true,
+    num: 5,
 });
 aggregate.project("a b -_id");
-aggregate.project({a: 1, b: 1, _id: 0});
+aggregate.project({ a: 1, b: 1, _id: 0 });
 aggregate.project({
-    newField: '$b.nested'
-  , plusTen: { $add: ['$val', 10]}
-  , sub: {
-    name: '$a'
-  }
-})
-aggregate.project({ salary_k: { $divide: [ "$salary", 1000 ]}});
-aggregate.read('primaryPreferred').read('pp');
+    newField: "$b.nested",
+    plusTen: { $add: ["$val", 10] },
+    sub: {
+        name: "$a",
+    },
+});
+aggregate.project({ salary_k: { $divide: ["$salary", 1000] } });
+aggregate.read("primaryPreferred").read("pp");
 aggregate.replaceRoot("user");
-aggregate.replaceRoot({x: {$concat: ['$this', '$that']}});
+aggregate.replaceRoot({ x: { $concat: ["$this", "$that"] } });
 aggregate.sample(3).sample(3);
 aggregate.skip(10).skip(10);
-aggregate.sort({ field: 'asc', test: -1 });
-aggregate.sort('field -test');
+aggregate.sort({ field: "asc", test: -1 });
+aggregate.sort("field -test");
 aggregate.then(cb).catch(cb);
-aggregate.unwind("tags").unwind('tags');
-aggregate.unwind("a", "b", "c").unwind('tag1', 'tag2');
-aggregate.unwind(
-  {
-    path: "tags",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  })
-  .unwind({
-    path: "tags",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  });
-aggregate.unwind(
-  {
-    path: "a",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  }, {
-    path: "b",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  }, {
-    path: "c",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  })
-  .unwind({
-    path: "tag1",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  }, {
-    path: "tag2",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  });
+aggregate.unwind("tags").unwind("tags");
+aggregate.unwind("a", "b", "c").unwind("tag1", "tag2");
+aggregate
+    .unwind({
+        path: "tags",
+        includeArrayIndex: "idx",
+        preserveNullAndEmptyArrays: true,
+    })
+    .unwind({
+        path: "tags",
+        includeArrayIndex: "idx",
+        preserveNullAndEmptyArrays: true,
+    });
+aggregate
+    .unwind(
+        {
+            path: "a",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+        {
+            path: "b",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+        {
+            path: "c",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+    )
+    .unwind(
+        {
+            path: "tag1",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+        {
+            path: "tag2",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+    );
 
 /*
  * section schematype.js
  * http://mongoosejs.com/docs/api.html#schematype-js
  */
-new mongoose.SchemaType('hello', 9, 'hello' );
+new mongoose.SchemaType("hello", 9, "hello");
 var STSchema = new mongoose.Schema({
-  mixed: mongoose.Schema.Types.Mixed
+    mixed: mongoose.Schema.Types.Mixed,
 });
-var schematype = schema.path('mixed');
-schematype.default('default');
-STSchema.path('born').get(cb).get(cb);
-STSchema.path('name').index(true).index({ unique: true, sparse: true });
-schematype.required(true, 'mess').required(true);
+var schematype = schema.path("mixed");
+schematype.default("default");
+STSchema.path("born").get(cb).get(cb);
+STSchema.path("name").index(true).index({ unique: true, sparse: true });
+schematype.required(true, "mess").required(true);
 schematype.select(true).select(false);
-STSchema.path('name').set(cb).set(cb);
+STSchema.path("name").set(cb).set(cb);
 schematype.sparse(true).sparse(true);
 schematype.text(true).text(true);
 schematype.unique(true).unique(true);
-schematype.validate(/re/)
-  .validate({}, 'error')
-  .validate(cb, 'try', 'tri');
+schematype.validate(/re/).validate({}, "error").validate(cb, "try", "tri");
 
 /*
  * section promise.js
@@ -1192,410 +1351,480 @@ schematype.validate(/re/)
  */
 var mongopromise = new mongoose.Promise();
 mongopromise = new mongoose.Promise(function (err: any, arg: any) {
-  arg.sparse(true);
-  err.stack;
+    arg.sparse(true);
+    err.stack;
 });
 mongopromise = new mongoose.Promise(function (err: any, arg1: any, arg2: any) {
-  arg1.sparse(true);
-  arg2.sparse(true);
-  err.stack;
+    arg1.sparse(true);
+    arg2.sparse(true);
+    err.stack;
 });
-mongopromise.addBack(function (err: any, arg: any) {
-  err.stack;
-  arg.sparse(true);
-}).addBack(function (err: any, arg1: any, arg2: any) {
-  err.stack;
-  arg1.sparse(true);
-  arg2.sparse(true);
-});
-mongopromise.addCallback(function (arg: any) {
-  arg.sparse(true);
-}).addCallback(function (arg1: any, arg2: any) {
-  arg1.sparse(true);
-  arg2.sparse(true);
-});
-mongopromise.addErrback(function (err: any) {
-  err.stack;
-}).addErrback(function () {});
-mongopromise.catch(function (err: any) {
-  err.stack;
-}).catch(function () {});
+mongopromise
+    .addBack(function (err: any, arg: any) {
+        err.stack;
+        arg.sparse(true);
+    })
+    .addBack(function (err: any, arg1: any, arg2: any) {
+        err.stack;
+        arg1.sparse(true);
+        arg2.sparse(true);
+    });
+mongopromise
+    .addCallback(function (arg: any) {
+        arg.sparse(true);
+    })
+    .addCallback(function (arg1: any, arg2: any) {
+        arg1.sparse(true);
+        arg2.sparse(true);
+    });
+mongopromise
+    .addErrback(function (err: any) {
+        err.stack;
+    })
+    .addErrback(function () {});
+mongopromise
+    .catch(function (err: any) {
+        err.stack;
+    })
+    .catch(function () {});
 mongopromise.end();
 mongopromise.error(999).error([]);
-mongopromise.on('init', function () {}).on('init', function () {});
-mongopromise.reject({}).reject('').reject(new Error('hi'));
-mongopromise.resolve(new Error('hi'), {}).resolve();
-mongopromise.then(function (arg: any) {
-  arg.sparse(true);
-}, function (err: any) {
-  err.stack;
-}).then(function (arg1: any, arg2: any) {
-  arg1.sparse(true);
-  arg2.sparse(true);
-});
-mongopromise.complete(new mongoose.SchemaType('')).complete(
-  new mongoose.SchemaType(''),
-  new mongoose.SchemaType('')
-);
+mongopromise.on("init", function () {}).on("init", function () {});
+mongopromise.reject({}).reject("").reject(new Error("hi"));
+mongopromise.resolve(new Error("hi"), {}).resolve();
+mongopromise
+    .then(
+        function (arg: any) {
+            arg.sparse(true);
+        },
+        function (err: any) {
+            err.stack;
+        },
+    )
+    .then(function (arg1: any, arg2: any) {
+        arg1.sparse(true);
+        arg2.sparse(true);
+    });
+mongopromise.complete(new mongoose.SchemaType("")).complete(new mongoose.SchemaType(""), new mongoose.SchemaType(""));
 /* static properties */
 mongoose.Promise.ES6(function (complete: Function, error: Function) {
-  complete.apply(this);
-  error.apply(this);
+    complete.apply(this);
+    error.apply(this);
 });
 
 /* inherited properties */
 mongopromise.chain(mongopromise);
 mongoose.Promise.FAILURE;
 /* practical example */
-mongoose.model('')
-  .findOne({})
-  .exec()
-  .then(function (arg) {
-    if (arg) {
-      arg.save;
-    }
-    return 1;
-  }).then(function (num) {
-    num.toFixed;
-    return new Promise<string>((resolve, reject) => {
-      resolve('string');
+mongoose
+    .model("")
+    .findOne({})
+    .exec()
+    .then(function (arg) {
+        if (arg) {
+            arg.save;
+        }
+        return 1;
+    })
+    .then(function (num) {
+        num.toFixed;
+        return new Promise<string>((resolve, reject) => {
+            resolve("string");
+        });
+    })
+    .then(function (str) {
+        str.toLowerCase;
+        return mongoose.model("").findOne({}).exec();
+    })
+    .then(function (arg) {
+        if (arg) {
+            arg.save;
+        }
+        return 1;
+    })
+    .catch(function (err) {
+        return 1;
+    })
+    .then(function (arg) {
+        arg.toFixed;
+        return new Promise<{ a: string; b: number }>((resolve, reject) => {
+            resolve({ a: "hi", b: 29 });
+        });
+    })
+    .then(function (arg) {
+        arg.a.toLowerCase;
+        arg.b.toFixed;
     });
-  }).then(function (str) {
-    str.toLowerCase
-    return (mongoose.model('')).findOne({}).exec();
-  }).then(function (arg) {
-    if (arg) {
-      arg.save;
-    }
-    return 1;
-  }).catch(function (err) {
-    return 1;
-  }).then(function (arg) {
-    arg.toFixed;
-    return new Promise<{a: string, b: number}>((resolve, reject) => {
-      resolve({a: 'hi', b: 29});
-    });
-  }).then(function (arg) {
-    arg.a.toLowerCase;
-    arg.b.toFixed;
-  });
 
-mongoose.model('').findOne({})
-  .then(function (arg) {
-    if (arg) {
-      arg.save;
-    }
-    return 2;
-  }).then(function (num) {
-    num.toFixed;
-    return new Promise<string>((resolve, reject) => {
-      resolve('str');
+mongoose
+    .model("")
+    .findOne({})
+    .then(function (arg) {
+        if (arg) {
+            arg.save;
+        }
+        return 2;
+    })
+    .then(function (num) {
+        num.toFixed;
+        return new Promise<string>((resolve, reject) => {
+            resolve("str");
+        });
+    })
+    .then(function (str) {
+        str.toLowerCase;
     });
-  }).then(function (str) {
-    str.toLowerCase;
-  });
 
-mongoose.model('').aggregate([])
-  .then(function (arg) {
-    return 2;
-  }).then(function (num) {
-    num.toFixed;
-    return new Promise<string>((resolve, reject) => {
-      resolve('str');
+mongoose
+    .model("")
+    .aggregate([])
+    .then(function (arg) {
+        return 2;
+    })
+    .then(function (num) {
+        num.toFixed;
+        return new Promise<string>((resolve, reject) => {
+            resolve("str");
+        });
+    })
+    .then(function (str) {
+        str.toLowerCase;
     });
-  }).then(function (str) {
-    str.toLowerCase;
-  });
 
 /* pluggable promise */
 (<any>mongoose).Promise = Promise;
-require('mongoose').Promise = Promise;
+require("mongoose").Promise = Promise;
 mongoose.Promise.race;
 mongoose.Promise.all;
 
-mongoose.model('').findOne()
-  .exec().then(cb);
+mongoose.model("").findOne().exec().then(cb);
 
 function testPromise_all() {
-  interface IUser extends mongoose.Document {
-    name: string;
-  }
+    interface IUser extends mongoose.Document {
+        name: string;
+    }
 
-  const User = mongoose.model<IUser>('User', new mongoose.Schema({name: String}))
+    const User = mongoose.model<IUser>("User", new mongoose.Schema({ name: String }));
 
-  const dc: mongoose.DocumentQuery<IUser|null, IUser> = User.findOne({});
-  const dc2: PromiseLike<IUser|null> = dc;
-  Promise.all([dc])
+    const dc: mongoose.DocumentQuery<IUser | null, IUser> = User.findOne({});
+    const dc2: PromiseLike<IUser | null> = dc;
+    Promise.all([dc]);
 }
 
 interface IStatics {
-  staticMethod2: (a: number) => string;
+    staticMethod2: (a: number) => string;
 }
 interface MyDocument extends mongoose.Document {
-  prop: string;
-  method: () => void;
+    prop: string;
+    method: () => void;
 }
 interface MyModel extends mongoose.Model<MyDocument> {
-  staticProp: string;
-  staticMethod: () => void;
+    staticProp: string;
+    staticMethod: () => void;
 }
 interface ModelStruct {
-  doc: MyDocument;
-  model: MyModel;
-  method1: (callback: (model: MyModel, doc: MyDocument) => void) => MyModel;
+    doc: MyDocument;
+    model: MyModel;
+    method1: (callback: (model: MyModel, doc: MyDocument) => void) => MyModel;
 }
-var modelStruct1 = <ModelStruct> {};
+var modelStruct1 = <ModelStruct>{};
 var myModel1: MyModel;
 var myDocument1: MyDocument;
-modelStruct1.method1(function (myModel1, myDocument1) {
-  myModel1.staticProp;
-  myModel1.staticMethod();
-  myDocument1.prop;
-  myDocument1.method();
-}).staticProp.toLowerCase();
+modelStruct1
+    .method1(function (myModel1, myDocument1) {
+        myModel1.staticProp;
+        myModel1.staticMethod();
+        myDocument1.prop;
+        myDocument1.method();
+    })
+    .staticProp.toLowerCase();
 var mySchema = new mongoose.Schema({});
-export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>('Final', mySchema);
+export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>("Final", mySchema);
 Final.findOne(function (err: any, doc: MyDocument) {
-  doc.save();
-  doc.remove();
-  doc.model('');
+    doc.save();
+    doc.remove();
+    doc.model("");
 });
-export var Final2: MyModel = mongoose.model<MyDocument, MyModel>('Final2', mySchema);
+export var Final2: MyModel = mongoose.model<MyDocument, MyModel>("Final2", mySchema);
 Final2.staticMethod();
 Final2.staticProp;
 var final2 = new Final2();
 final2.prop;
-final2.method;interface ibase extends mongoose.Document {
-  username: string;
+final2.method;
+interface ibase extends mongoose.Document {
+    username: string;
 }
 interface extended extends ibase {
-  email: string;
+    email: string;
 }
-const base: mongoose.Model<ibase> = mongoose.model<ibase>('testfour')
-const extended: mongoose.Model<extended> = base.discriminator<extended>('extendedS', schema);
+const base: mongoose.Model<ibase> = mongoose.model<ibase>("testfour");
+const extended: mongoose.Model<extended> = base.discriminator<extended>("extendedS", schema);
 const x = new extended({
-  username: 'hi',     // required in baseSchema
-  email: 'beddiw',    // required in extededSchema
+    username: "hi", // required in baseSchema
+    email: "beddiw", // required in extededSchema
 });
 // Setting a different value for `discriminatorKey`
-const extended2: mongoose.Model<extended> = base.discriminator<extended>('extendedS', schema, 'extended');
+const extended2: mongoose.Model<extended> = base.discriminator<extended>("extendedS", schema, "extended");
 
-new mongoose.Schema({}, {
-  timestamps: {
-    createdAt: 'foo',
-    updatedAt: 'bar'
-  }
-});
+new mongoose.Schema(
+    {},
+    {
+        timestamps: {
+            createdAt: "foo",
+            updatedAt: "bar",
+        },
+    },
+);
 
-new mongoose.Schema({}, {
-  collation: {
-    strength: 1,
-    locale: 'en_US'
-  }
-});
+new mongoose.Schema(
+    {},
+    {
+        collation: {
+            strength: 1,
+            locale: "en_US",
+        },
+    },
+);
 
-new mongoose.Schema({}, {
-  toObject: {
-    versionKey: false
-  },
-  toJSON: {
-    depopulate: true
-  }
-})
+new mongoose.Schema(
+    {},
+    {
+        toObject: {
+            versionKey: false,
+        },
+        toJSON: {
+            depopulate: true,
+        },
+    },
+);
 
 const aggregatePrototypeGraphLookup: mongoose.Aggregate<any> = MyModel.aggregate([]).graphLookup({});
-const addFieldsAgg: mongoose.Aggregate<any> = aggregatePrototypeGraphLookup.addFields({})
+const addFieldsAgg: mongoose.Aggregate<any> = aggregatePrototypeGraphLookup.addFields({});
 
-MyModel.findById('foo').then((doc: mongoose.Document) => {
-  const a: boolean = doc.isDirectSelected('bar');
-  const b: boolean = doc.$isDeleted();
-  doc.$isDeleted(true);
+MyModel.findById("foo").then((doc: mongoose.Document) => {
+    const a: boolean = doc.isDirectSelected("bar");
+    const b: boolean = doc.$isDeleted();
+    doc.$isDeleted(true);
 });
 
 MyModel.translateAliases({});
 
 const queryPrototypeError: Error | null = MyModel.findById({}).error();
-const queryProrotypeErrorSetUnset: mongoose.Query<any> = MyModel.findById({}).error(null).error(new Error('foo'));
+const queryProrotypeErrorSetUnset: mongoose.Query<any> = MyModel.findById({}).error(null).error(new Error("foo"));
 
 MyModel.createIndexes().then(() => {});
 MyModel.createIndexes((err: any): void => {}).then(() => {});
 
-mongoose.connection.createCollection('foo').then(() => {});
-mongoose.connection.createCollection('foo', {wtimeout: 5}).then(() => {});
-mongoose.connection.createCollection('foo', {wtimeout: 5}, (err: Error, coll): void => {coll.collectionName}).then(() => {});
+mongoose.connection.createCollection("foo").then(() => {});
+mongoose.connection.createCollection("foo", { wtimeout: 5 }).then(() => {});
+mongoose.connection
+    .createCollection("foo", { wtimeout: 5 }, (err: Error, coll): void => {
+        coll.collectionName;
+    })
+    .then(() => {});
 
 const db = mongoose.connection;
-const User = mongoose.model('User', new mongoose.Schema({ name: String }));
+const User = mongoose.model("User", new mongoose.Schema({ name: String }));
 
 db.states.disconnected === 0;
 db.states.connected === 1;
 
 let session: mongoose.ClientSession;
-mongoose.connection.createCollection('users').
-  then(() => db.startSession()).
-  then(_session => {
-    session = _session;
-    session.startTransaction();
-    User.findOne({ name: 'foo' }).session(session);
-    session.commitTransaction();
-    return User.create({ name: 'foo' });
-  });
+mongoose.connection
+    .createCollection("users")
+    .then(() => db.startSession())
+    .then(_session => {
+        session = _session;
+        session.startTransaction();
+        User.findOne({ name: "foo" }).session(session);
+        session.commitTransaction();
+        return User.create({ name: "foo" });
+    });
 
-const Event = db.model('Event', new mongoose.Schema({ createdAt: Date }), 'Event');
+const Event = db.model("Event", new mongoose.Schema({ createdAt: Date }), "Event");
 
-db.createCollection('users').
-  then(() => db.startSession()).
-  then(_session => {
-    session = _session;
-    return User.create({ name: 'foo' });
-  }).
-  then(() => {
-    session.startTransaction();
-    return User.findOne({ name: 'foo' }).session(session).exec();
-  }).
-  then(() => {
-    session.commitTransaction();
-    return User.findOne({ name: 'bar' }).exec();
-  }).
-  catch(() => {
-    session.abortTransaction();
-  });
-  db.createCollection('Event').
-  then(() => db.startSession()).
-  then(_session => {
-    session = _session;
-    session.startTransaction();
-    return Event.insertMany([
-      { createdAt: new Date('2018-06-01') },
-      { createdAt: new Date('2018-06-02') },
-      { createdAt: new Date('2017-06-01') },
-      { createdAt: new Date('2017-05-31') }
-    ], { session: session });
-  }).
-  then(() => Event.aggregate([
-    {
-      $group: {
-        _id: {
-          month: { $month: '$createdAt' },
-          year: { $year: '$createdAt' }
-        },
-        count: { $sum: 1 }
-      }
-    },
-    { $sort: { count: -1, '_id.year': -1, '_id.month': -1 } }
-  ]).session(session).exec()).
-  then((res: any) => {
-    session.commitTransaction();
-  });
+db.createCollection("users")
+    .then(() => db.startSession())
+    .then(_session => {
+        session = _session;
+        return User.create({ name: "foo" });
+    })
+    .then(() => {
+        session.startTransaction();
+        return User.findOne({ name: "foo" }).session(session).exec();
+    })
+    .then(() => {
+        session.commitTransaction();
+        return User.findOne({ name: "bar" }).exec();
+    })
+    .catch(() => {
+        session.abortTransaction();
+    });
+db.createCollection("Event")
+    .then(() => db.startSession())
+    .then(_session => {
+        session = _session;
+        session.startTransaction();
+        return Event.insertMany(
+            [
+                { createdAt: new Date("2018-06-01") },
+                { createdAt: new Date("2018-06-02") },
+                { createdAt: new Date("2017-06-01") },
+                { createdAt: new Date("2017-05-31") },
+            ],
+            { session: session },
+        );
+    })
+    .then(() =>
+        Event.aggregate([
+            {
+                $group: {
+                    _id: {
+                        month: { $month: "$createdAt" },
+                        year: { $year: "$createdAt" },
+                    },
+                    count: { $sum: 1 },
+                },
+            },
+            { $sort: { count: -1, "_id.year": -1, "_id.month": -1 } },
+        ])
+            .session(session)
+            .exec(),
+    )
+    .then((res: any) => {
+        session.commitTransaction();
+    });
 
 /** https://mongoosejs.com/docs/transactions.html */
 
-const Customer = db.model('Customer', new mongoose.Schema({ name: String }));
+const Customer = db.model("Customer", new mongoose.Schema({ name: String }));
 
-db.createCollection('customers').
-  then(() => db.startSession()).
-  then(_session => {
-    session = _session;
-    // Start a transaction
-    session.startTransaction();
-    // This `create()` is part of the transaction because of the `session`
-    // option.
-    return Customer.create([{ name: 'Test' }], { session: session });
-  }).
-  // Transactions execute in isolation, so unless you pass a `session`
-  // to `findOne()` you won't see the document until the transaction
-  // is committed.
-  then((customer: mongoose.Document[]) => Customer.findOne({ name: 'Test' }).exec()).
-  // This `findOne()` will return the doc, because passing the `session`
-  // means this `findOne()` will run as part of the transaction.
-  then(() => Customer.findOne({ name: 'Test' }).session(session).exec()).
-  // Once the transaction is committed, the write operation becomes
-  // visible outside of the transaction.
-  then(() => session.commitTransaction()).
-  then(() => Customer.findOne({ name: 'Test' }).exec())
+db.createCollection("customers")
+    .then(() => db.startSession())
+    .then(_session => {
+        session = _session;
+        // Start a transaction
+        session.startTransaction();
+        // This `create()` is part of the transaction because of the `session`
+        // option.
+        return Customer.create([{ name: "Test" }], { session: session });
+    })
+    // Transactions execute in isolation, so unless you pass a `session`
+    // to `findOne()` you won't see the document until the transaction
+    // is committed.
+    .then((customer: mongoose.Document[]) => Customer.findOne({ name: "Test" }).exec())
+    // This `findOne()` will return the doc, because passing the `session`
+    // means this `findOne()` will run as part of the transaction.
+    .then(() => Customer.findOne({ name: "Test" }).session(session).exec())
+    // Once the transaction is committed, the write operation becomes
+    // visible outside of the transaction.
+    .then(() => session.commitTransaction())
+    .then(() => Customer.findOne({ name: "Test" }).exec());
 
 /**
  * https://mongoosejs.com/docs/guide.html#writeConcern
  */
-new mongoose.Schema({ name: String }, {
-  writeConcern: {
-    w: 'majority',
-    j: true,
-    wtimeout: 1000
-  }
-});
+new mongoose.Schema(
+    { name: String },
+    {
+        writeConcern: {
+            w: "majority",
+            j: true,
+            wtimeout: 1000,
+        },
+    },
+);
 
 /**
  * https://mongoosejs.com/docs/guide.html#shardKey
  */
-new mongoose.Schema({name: String}, {
-  shardKey: {
-    tag: 1, name: 1
-  }
-})
+new mongoose.Schema(
+    { name: String },
+    {
+        shardKey: {
+            tag: 1,
+            name: 1,
+        },
+    },
+);
 
 /* Query helpers: https://mongoosejs.com/docs/guide.html#query-helpers */
 
 interface Animal2 extends mongoose.Document {
-  name: string;
-  type: string;
-  tags: string[];
+    name: string;
+    type: string;
+    tags: string[];
 }
 var animal2Schema = new mongoose.Schema({
-  name: String,
-  type: String,
-  tags: { type: [String], index: true } // field level
+    name: String,
+    type: String,
+    tags: { type: [String], index: true }, // field level
 });
 let animal2QueryHelpers = {
-  byName<Q extends mongoose.DocumentQuery<any, Animal2>>(this: Q, name: string) {
-    return this.where({ name: new RegExp(name, 'i') });
-  }
+    byName<Q extends mongoose.DocumentQuery<any, Animal2>>(this: Q, name: string) {
+        return this.where({ name: new RegExp(name, "i") });
+    },
 };
 animal2Schema.query = animal2QueryHelpers;
-var Animal2 = mongoose.model<Animal2, mongoose.Model<Animal2, typeof animal2QueryHelpers>>('Animal', animal2Schema);
-Animal2.find().byName('fido').exec(function(err, animals) {
-  console.log(animals);
-});
-Animal2.findOne().byName('fido').exec(function(err, animal) {
-  console.log(animal);
-});
-Animal2.find().distinct('_id').byName('fido').exec(function(err, animal) {
-  console.log(animal);
-});
-Animal2.findOne().where({ type: 'dog' }).byName('fido').exec(function(err, animal) {
-  console.log(animal);
-});
-
+var Animal2 = mongoose.model<Animal2, mongoose.Model<Animal2, typeof animal2QueryHelpers>>("Animal", animal2Schema);
+Animal2.find()
+    .byName("fido")
+    .exec(function (err, animals) {
+        console.log(animals);
+    });
+Animal2.findOne()
+    .byName("fido")
+    .exec(function (err, animal) {
+        console.log(animal);
+    });
+Animal2.find()
+    .distinct("_id")
+    .byName("fido")
+    .exec(function (err, animal) {
+        console.log(animal);
+    });
+Animal2.findOne()
+    .where({ type: "dog" })
+    .byName("fido")
+    .exec(function (err, animal) {
+        console.log(animal);
+    });
 
 /* Filter query */
 
 interface Foobar extends mongoose.Document {
-  _id: number;
-  name: string;
-  type: string;
-  tags: string[];
+    _id: number;
+    name: string;
+    type: string;
+    tags: string[];
 }
 var foobarSchema = new mongoose.Schema({
-  _id: Number,
-  name: String,
-  type: String,
-  tags: { type: [String], index: true } // field level
+    _id: Number,
+    name: String,
+    type: String,
+    tags: { type: [String], index: true }, // field level
 });
-var Foobar = mongoose.model<Foobar, mongoose.Model<Foobar>>('AnimFoobarl', foobarSchema);
+var Foobar = mongoose.model<Foobar, mongoose.Model<Foobar>>("AnimFoobarl", foobarSchema);
 Foobar.find({ _id: 123 });
-                                                     
-new mongoose.Schema({
-  createdAt: Number,
-  updatedAt: Number,
-  name: String
-}, {
-  timestamps: { currentTime: () => Math.floor(Date.now() / 1000) }
-});
 
-new mongoose.Schema({
-  createdAt: Number,
-  updatedAt: Number,
-  name: String
-}, {
-  timestamps: { currentTime: () => new Date() }
-});
+new mongoose.Schema(
+    {
+        createdAt: Number,
+        updatedAt: Number,
+        name: String,
+    },
+    {
+        timestamps: { currentTime: () => Math.floor(Date.now() / 1000) },
+    },
+);
+
+new mongoose.Schema(
+    {
+        createdAt: Number,
+        updatedAt: Number,
+        name: String,
+    },
+    {
+        timestamps: { currentTime: () => new Date() },
+    },
+);

--- a/types/mongoose/test/mongoose.ts
+++ b/types/mongoose/test/mongoose.ts
@@ -935,6 +935,7 @@ mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", tim
 // The constructor is private api, but we'll use it to test
 var subdocument: mongoose.Types.Subdocument = new mongoose.Types.Subdocument();
 subdocument.ownerDocument().errors;
+subdocument.parent().parent();
 subdocument.remove({}, function (err) {
     return 6;
 });

--- a/types/mongoose/test/query.ts
+++ b/types/mongoose/test/query.ts
@@ -1,7 +1,7 @@
-import * as mongodb from 'mongodb';
-import * as mongoose from 'mongoose';
+import * as mongodb from "mongodb";
+import * as mongoose from "mongoose";
 
-import { Location } from './definitions';
+import { Location } from "./definitions";
 
 // dummy variables
 var cb = function () {};
@@ -12,110 +12,157 @@ var cb = function () {};
  */
 var doc = <mongoose.Document>{};
 var query = <mongoose.Query<mongoose.Document[]>>{};
-query.$where('').$where(cb);
-query.all(99).all('path', 99);
-query.find().where('path').all(['val1', 'val2', 'val3']);
-query.find().all('path', ['val1', 'val2', 'val3']);
-query.and([{ color: 'green' }, { status: 'ok' }]).and([]);
+query.$where("").$where(cb);
+query.all(99).all("path", 99);
+query.find().where("path").all(["val1", "val2", "val3"]);
+query.find().all("path", ["val1", "val2", "val3"]);
+query.and([{ color: "green" }, { status: "ok" }]).and([]);
 query.batchSize(100).batchSize(100);
-var lowerLeft = [40.73083, -73.99756]
-var upperRight = [40.741404,  -73.988135]
-query.where('loc').within().box(lowerLeft, upperRight)
-query.where('loc').wtimeout()
-query.where('loc').wtimeout(10)
-query.box({ ll : lowerLeft, ur : upperRight }).box({});
-var queryModel = mongoose.model('QModel')
-query.cast(new queryModel(), {}).hasOwnProperty('');
+var lowerLeft = [40.73083, -73.99756];
+var upperRight = [40.741404, -73.988135];
+query.where("loc").within().box(lowerLeft, upperRight);
+query.where("loc").wtimeout();
+query.where("loc").wtimeout(10);
+query.box({ ll: lowerLeft, ur: upperRight }).box({});
+var queryModel = mongoose.model("QModel");
+query.cast(new queryModel(), {}).hasOwnProperty("");
 query.catch(cb).catch(cb);
 query.center({}).center({});
-query.centerSphere({ center: [50, 50], radius: 10 }).centerSphere('path', {});
-query.circle({ center: [50, 50], radius: 10 }).circle('path');
-query.collation({ locale: 'en_US', strength: 1 });
-query.comment('comment').comment('comment');
-query.where({color: 'black'}).count(function (err, count) {
-  count.toFixed();
-}).then(function (res) {
-  res.toFixed();
-}).catch(function (err) {});
+query.centerSphere({ center: [50, 50], radius: 10 }).centerSphere("path", {});
+query.circle({ center: [50, 50], radius: 10 }).circle("path");
+query.collation({ locale: "en_US", strength: 1 });
+query.comment("comment").comment("comment");
+query
+    .where({ color: "black" })
+    .count(function (err, count) {
+        count.toFixed();
+    })
+    .then(function (res) {
+        res.toFixed();
+    })
+    .catch(function (err) {});
 query.cursor().close();
-query.distinct('field', {}, cb);
-query.distinct('field', {});
-query.distinct('field', cb);
-query.distinct('field');
+query.distinct("field", {}, cb);
+query.distinct("field", {});
+query.distinct("field", cb);
+query.distinct("field");
 query.distinct(cb);
 query.distinct();
-query.elemMatch('comment', {
-  author: 'autobot',
-  votes: {$gte: 5}
-}).elemMatch('comment', function (elem) {
-  elem.where('author').equals('autobot');
-  elem.where('votes').gte(5);
-});
-query.where('age').equals(49);
-query.exec('find', function (err, res) {
-  res[0].execPopulate();
-}).then(function (arg) {
-  arg[0].execPopulate();
-}).catch(cb);
-query.where('name').exists().exists('age', false);
-query.find({name: 'aa'}, function (err, res) {
-  res[0].execPopulate();
-}).find();
-query.findOne(function (err, res) {
-  res.execPopulate();
-}).findOne();
-query.findOneAndRemove({name: 'aa'}, {
-  rawResult: true
-}, function (err, doc) {
-    doc.lastErrorObject
-}).findOneAndRemove();
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, {
-
-});
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, {
-  rawResult: true
-}, cb);
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, cb);
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'});
+query
+    .elemMatch("comment", {
+        author: "autobot",
+        votes: { $gte: 5 },
+    })
+    .elemMatch("comment", function (elem) {
+        elem.where("author").equals("autobot");
+        elem.where("votes").gte(5);
+    });
+query.where("age").equals(49);
+query
+    .exec("find", function (err, res) {
+        res[0].execPopulate();
+    })
+    .then(function (arg) {
+        arg[0].execPopulate();
+    })
+    .catch(cb);
+query.where("name").exists().exists("age", false);
+query
+    .find({ name: "aa" }, function (err, res) {
+        res[0].execPopulate();
+    })
+    .find();
+query
+    .findOne(function (err, res) {
+        res.execPopulate();
+    })
+    .findOne();
+query
+    .findOneAndRemove(
+        { name: "aa" },
+        {
+            rawResult: true,
+        },
+        function (err, doc) {
+            doc.lastErrorObject;
+        },
+    )
+    .findOneAndRemove();
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" }, {});
+query.findOneAndUpdate(
+    { name: "aa" },
+    { name: "bb" },
+    {
+        rawResult: true,
+    },
+    cb,
+);
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" }, cb);
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" });
 query.findOneAndUpdate({}, {}, { upsert: true, new: true });
-query.findOneAndUpdate({name: 'bb'}, cb);
-query.findOneAndUpdate({name: 'bb'});
+query.findOneAndUpdate({ name: "bb" }, cb);
+query.findOneAndUpdate({ name: "bb" });
 query.findOneAndUpdate(cb);
-query.findOneAndUpdate().then(function (doc) {
-  doc.execPopulate();
-}).catch(cb);
-var polyA = [[[ 10, 20 ], [ 10, 40 ], [ 30, 40 ], [ 30, 20 ]]]
-query.where('loc').within().geometry({ type: 'Polygon', coordinates: polyA })
-var polyB = [[ 0, 0 ], [ 1, 1 ]]
-query.where('loc').within().geometry({ type: 'LineString', coordinates: polyB })
-var polyC = [ 0, 0 ]
-query.where('loc').within().geometry({ type: 'Point', coordinates: polyC })
-query.where('loc').intersects().geometry({ type: 'Point', coordinates: polyC })
+query
+    .findOneAndUpdate()
+    .then(function (doc) {
+        doc.execPopulate();
+    })
+    .catch(cb);
+var polyA = [
+    [
+        [10, 20],
+        [10, 40],
+        [30, 40],
+        [30, 20],
+    ],
+];
+query.where("loc").within().geometry({ type: "Polygon", coordinates: polyA });
+var polyB = [
+    [0, 0],
+    [1, 1],
+];
+query.where("loc").within().geometry({ type: "LineString", coordinates: polyB });
+var polyC = [0, 0];
+query.where("loc").within().geometry({ type: "Point", coordinates: polyC });
+query.where("loc").intersects().geometry({ type: "Point", coordinates: polyC });
 query.getQuery();
 query.getFilter();
 query.getUpdate();
-query.find().where('age').gt(21);
-query.find().gt('age', 21);
-query.find().where('age').gte(21);
-query.find().gte('age', 21);
-query.hint({ indexA: 1, indexB: -1}).hint({});
-query.in([1, 2, 3]).in('num', [1, 2, 3]);
-query.where('path').intersects().geometry({
-    type: 'LineString'
-  , coordinates: [[180.0, 11.0], [180, 9.0]]
+query.find().where("age").gt(21);
+query.find().gt("age", 21);
+query.find().where("age").gte(21);
+query.find().gte("age", 21);
+query.hint({ indexA: 1, indexB: -1 }).hint({});
+query.in([1, 2, 3]).in("num", [1, 2, 3]);
+query
+    .where("path")
+    .intersects()
+    .geometry({
+        type: "LineString",
+        coordinates: [
+            [180.0, 11.0],
+            [180, 9.0],
+        ],
+    });
+query.where("path").intersects({
+    type: "LineString",
+    coordinates: [
+        [180.0, 11.0],
+        [180, 9.0],
+    ],
 });
-query.where('path').intersects({
-    type: 'LineString'
-  , coordinates: [[180.0, 11.0], [180, 9.0]]
-});
-query.find().lean().exec(function (err: any, docs: any) {
-  docs[0];
-});
+query
+    .find()
+    .lean()
+    .exec(function (err: any, docs: any) {
+        docs[0];
+    });
 query.limit(20).limit(20);
-query.find().where('age').lt(21);
-query.find().lt('age', 21);
-query.find().where('age').lte(21);
-query.find().lte('age', 21);
+query.find().where("age").lt(21);
+query.find().lt("age", 21);
+query.find().where("age").lte(21);
+query.find().lte("age", 21);
 query
     .find()
     .map(res => {
@@ -128,7 +175,7 @@ query
         return { c: true };
     })
     .then(res => {
-        typeof res.c === 'boolean';
+        typeof res.c === "boolean";
     });
 query
     .findOne()
@@ -139,81 +186,86 @@ query
     .then(res => {
         res._id;
     });
-query.maxDistance('path', 21).maxDistance(21);
+query.maxDistance("path", 21).maxDistance(21);
 query.maxTimeMS(1000);
 query.maxscan(100).maxScan(100);
 query.maxScan(100).maxScan(100);
 query.merge(query).merge({});
 query.mod([1, 2]).mod([5, 6]);
-query.find().where('age').ne(21);
-query.find().ne('age', 21);
-query.where('loc').near({ center: [10, 10] });
-query.where('loc').near({ center: [10, 10], maxDistance: 5 });
-query.where('loc').near({ center: [10, 10], maxDistance: 5, spherical: true });
-query.near('loc', { center: [10, 10], maxDistance: 5 });
-query.where('loc').nearSphere({ center: [10, 10], maxDistance: 5 });
-query.find().where('age').in([20, 21]);
-query.find().in('age', [20, 21]);
-query.nor([{ color: 'green' }, { status: 'ok' }]).nor([]);
-query.or([{ color: 'red' }, { status: 'emergency' }]).or([]);
-query.find({ color: 'blue' }).orFail();
-query.where('loc').within().polygon([10,20], [13, 25], [7,15]);
-query.polygon('loc', [10,20], [13, 25], [7,15]);
-query.findOne().populate('owner').exec(function (err, kitten) {
-  kitten.execPopulate();
-});
-query.find().populate({
-    path: 'owner'
-  , select: 'name'
-  , match: { color: 'black' }
-  , options: { sort: { name: -1 }}
-}).exec(function (err, kittens) {
-  kittens[0].execPopulate();
-});
-query.find().populate('owner', 'name', null, {sort: { name: -1 }}).exec(function (err, kittens) {
-  kittens[0].execPopulate();
-});
-query.read('primary', []).read('primary');
-query.readConcern('majority').readConcern('m');
-query.regex(/re/).regex('path', /re/);
+query.find().where("age").ne(21);
+query.find().ne("age", 21);
+query.where("loc").near({ center: [10, 10] });
+query.where("loc").near({ center: [10, 10], maxDistance: 5 });
+query.where("loc").near({ center: [10, 10], maxDistance: 5, spherical: true });
+query.near("loc", { center: [10, 10], maxDistance: 5 });
+query.where("loc").nearSphere({ center: [10, 10], maxDistance: 5 });
+query.find().where("age").in([20, 21]);
+query.find().in("age", [20, 21]);
+query.nor([{ color: "green" }, { status: "ok" }]).nor([]);
+query.or([{ color: "red" }, { status: "emergency" }]).or([]);
+query.find({ color: "blue" }).orFail();
+query.where("loc").within().polygon([10, 20], [13, 25], [7, 15]);
+query.polygon("loc", [10, 20], [13, 25], [7, 15]);
+query
+    .findOne()
+    .populate("owner")
+    .exec(function (err, kitten) {
+        kitten.execPopulate();
+    });
+query
+    .find()
+    .populate({
+        path: "owner",
+        select: "name",
+        match: { color: "black" },
+        options: { sort: { name: -1 } },
+    })
+    .exec(function (err, kittens) {
+        kittens[0].execPopulate();
+    });
+query
+    .find()
+    .populate("owner", "name", null, { sort: { name: -1 } })
+    .exec(function (err, kittens) {
+        kittens[0].execPopulate();
+    });
+query.read("primary", []).read("primary");
+query.readConcern("majority").readConcern("m");
+query.regex(/re/).regex("path", /re/);
 query.remove({}, cb);
 query.remove({});
 query.remove(cb);
 query.remove();
-query.select('a b');
-query.select('-c -d');
+query.select("a b");
+query.select("-c -d");
 query.select({ a: 1, b: 1 });
 query.select({ c: 0, d: 0 });
-query.select('+path');
+query.select("+path");
 query.selected();
 query.selectedExclusively();
 query.selectedInclusively();
 query.setOptions({
-  tailable: true,
-  batchSize: true,
-  lean: false
+    tailable: true,
+    batchSize: true,
+    lean: false,
 });
 query.setQuery({ age: 5 });
-query.size(0).size('age', 0);
+query.size(0).size("age", 0);
 query.skip(100).skip(100);
 query.slaveOk().slaveOk(false);
-query.slice('comments', 5);
-query.slice('comments', -5);
-query.slice('comments', [10, 5]);
-query.where('comments').slice(5);
-query.where('comments').slice([-10, 5]);
+query.slice("comments", 5);
+query.slice("comments", -5);
+query.slice("comments", [10, 5]);
+query.where("comments").slice(5);
+query.where("comments").slice([-10, 5]);
 query.snapshot().snapshot(true);
-query.sort({ field: 'asc', test: -1 });
-query.sort('field -test');
+query.sort({ field: "asc", test: -1 });
+query.sort("field -test");
 query.tailable().tailable(false);
 query.then(cb).catch(cb);
-(new (query.toConstructor())(1, 2, 3)).toConstructor();
-query.update({}, doc, {
-
-}, cb);
-query.update({}, doc, {
-
-});
+new (query.toConstructor())(1, 2, 3).toConstructor();
+query.update({}, doc, {}, cb);
+query.update({}, doc, {});
 query.update({}, doc, cb);
 query.update({}, doc);
 query.update(doc, cb);
@@ -222,82 +274,98 @@ query.update(cb);
 // $ExpectError
 query.update(true);
 query.update();
-query.where('age').gte(21).lte(65)
-  .where('name', /^vonderful/i)
-  .where('friends').slice(10)
-  .exec(cb);
-query.where('path').within().box({})
-query.where('path').within().circle({})
-query.where('path').within().geometry({type: 'c', coordinates: []});
-query.where('loc').within({ center: [50,50], radius: 10, unique: true, spherical: true });
-query.where('loc').within({ box: [[40.73, -73.9], [40.7, -73.988]] });
-query.where('loc').within({ polygon: [[],[],[],[]] });
-query.where('loc').within([], [], []);
-query.where('loc').within([], []);
-query.where('loc').within({ type: 'LineString', coordinates: [] });
+query
+    .where("age")
+    .gte(21)
+    .lte(65)
+    .where("name", /^vonderful/i)
+    .where("friends")
+    .slice(10)
+    .exec(cb);
+query.where("path").within().box({});
+query.where("path").within().circle({});
+query.where("path").within().geometry({ type: "c", coordinates: [] });
+query.where("loc").within({ center: [50, 50], radius: 10, unique: true, spherical: true });
+query.where("loc").within({
+    box: [
+        [40.73, -73.9],
+        [40.7, -73.988],
+    ],
+});
+query.where("loc").within({ polygon: [[], [], [], []] });
+query.where("loc").within([], [], []);
+query.where("loc").within([], []);
+query.where("loc").within({ type: "LineString", coordinates: [] });
 mongoose.Query.use$geoWithin = false;
 /* practical example */
-query.
-  find({
-    occupation: /host/,
-    'name.last': 'Ghost',
-    age: { $gt: 17, $lt: 66 },
-    likes: { $in: ['vaporizing', 'talking'] }
-  }).
-  limit(10).
-  sort({ occupation: -1 }).
-  select({ name: 1, occupation: 1 }).
-  exec(cb).then(cb).catch(cb);
-query.
-  find({ occupation: /host/ }).
-  where('name.last').equals('Ghost').
-  where('age').gt(17).lt(66).
-  where('likes').in(['vaporizing', 'talking']).
-  limit(10).
-  sort('-occupation').
-  select('name occupation').
-  exec(cb).then(cb).catch(cb);
+query
+    .find({
+        occupation: /host/,
+        "name.last": "Ghost",
+        age: { $gt: 17, $lt: 66 },
+        likes: { $in: ["vaporizing", "talking"] },
+    })
+    .limit(10)
+    .sort({ occupation: -1 })
+    .select({ name: 1, occupation: 1 })
+    .exec(cb)
+    .then(cb)
+    .catch(cb);
+query
+    .find({ occupation: /host/ })
+    .where("name.last")
+    .equals("Ghost")
+    .where("age")
+    .gt(17)
+    .lt(66)
+    .where("likes")
+    .in(["vaporizing", "talking"])
+    .limit(10)
+    .sort("-occupation")
+    .select("name occupation")
+    .exec(cb)
+    .then(cb)
+    .catch(cb);
 /**
  * https://mongoosejs.com/docs/api.html#query_Query-lean
  */
-query.lean() // true
-query.lean(false)
-query.lean({})
-
+query.lean(); // true
+query.lean(false);
+query.lean({});
 
 var locDocument = <Location>{};
 var locationQuery = <mongoose.DocumentQuery<Location, Location>>{};
-locationQuery.count({ name: 'foo' });
+locationQuery.count({ name: "foo" });
 // $ExpectError
 locationQuery.count({ name: 123 });
-locationQuery.countDocuments({ name: 'foo' });
+locationQuery.countDocuments({ name: "foo" });
 locationQuery.find({ _id: new mongodb.ObjectId() });
-locationQuery.find({ _id: 'string-allowed' });
+locationQuery.find({ _id: "string-allowed" });
 locationQuery.find({ _id: locDocument });
 // $ExpectError
 locationQuery.find({ _id: 123 });
 // $ExpectError
-locationQuery.find({ _id: { foo: 'bar' } });
+locationQuery.find({ _id: { foo: "bar" } });
 locationQuery.find({ ref1: new mongodb.ObjectId() });
-locationQuery.find({ ref1: 'string-allowed' });
+locationQuery.find({ ref1: "string-allowed" });
 // $ExpectError
 locationQuery.find({ ref1: 123 });
 locationQuery.find({ ref2: new mongodb.ObjectId() });
-locationQuery.find({ ref2: 'string-allowed' });
+locationQuery.find({ ref2: "string-allowed" });
 // $ExpectError
 locationQuery.find({ ref2: 123 });
 locationQuery.find({
-    name: 'foo',
+    name: "foo",
     address: /bar/, // strings are allowed as RegExp
     rating: 10,
     facilities: { $exists: true },
-    'reviews.0': { $exists: true } // additional queries are allowed
+    "reviews.0": { $exists: true }, // additional queries are allowed
 });
 // $ExpectError
 locationQuery.find({ name: 123 });
 // $ExpectError
-locationQuery.find({ rating: 'foo' });
-locationQuery.findOne({ name: 'foo', rating: 10 }).then(location => {
+locationQuery.find({ rating: "foo" });
+locationQuery.findOne({ name: "foo", rating: 10 }).then(location => {
     if (location) {
         // $ExpectType ObjectId
         location._id;
@@ -308,7 +376,7 @@ locationQuery.findOne({ name: 'foo', rating: 10 }).then(location => {
         location.save();
     }
 });
-locationQuery.findOne({ name: 'foo' }, 'name', { lean: true }).then(location => {
+locationQuery.findOne({ name: "foo" }, "name", { lean: true }).then(location => {
     if (location) {
         // $ExpectType ObjectId
         location._id;
@@ -321,24 +389,11 @@ locationQuery.findOne({ name: 'foo' }, 'name', { lean: true }).then(location => 
     }
 });
 // $ExpectError
-locationQuery.findOne({ rating: 'foo' });
-locationQuery.findOneAndRemove({ name: 'foo', rating: 10 });
+locationQuery.findOne({ rating: "foo" });
+locationQuery.findOneAndRemove({ name: "foo", rating: 10 });
 // $ExpectError
-locationQuery.findOneAndRemove({ rating: 'foo' });
-locationQuery.findOneAndUpdate({ name: 'foo' }, { rating: 20 }).then(location => {
-    if (location) {
-        // $ExpectType ObjectId
-        location._id;
-        // $ExpectType string
-        location.name;
-        // $ExpectType number
-        location.rating;
-        // $ExpectError
-        location.unknown;
-        location.save();
-    }
-});
-locationQuery.findOneAndUpdate({ name: 'foo' }, { rating: 20 }, { lean: true }).then(location => {
+locationQuery.findOneAndRemove({ rating: "foo" });
+locationQuery.findOneAndUpdate({ name: "foo" }, { rating: 20 }).then(location => {
     if (location) {
         // $ExpectType ObjectId
         location._id;
@@ -348,44 +403,60 @@ locationQuery.findOneAndUpdate({ name: 'foo' }, { rating: 20 }, { lean: true }).
         location.rating;
         // $ExpectError
         location.unknown;
+        location.save();
+    }
+});
+locationQuery.findOneAndUpdate({ name: "foo" }, { rating: 20 }, { lean: true }).then(location => {
+    if (location) {
+        // $ExpectType ObjectId
+        location._id;
+        // $ExpectType string
+        location.name;
+        // $ExpectType number
+        location.rating;
+        // $ExpectError
+        location.unknown;
         // $ExpectError
         location.save();
     }
 });
 // $ExpectError
-locationQuery.findOneAndUpdate({ rating: 'foo' }, { rating: 20 });
-locationQuery.remove({ name: 'foo', rating: 10 });
+locationQuery.findOneAndUpdate({ rating: "foo" }, { rating: 20 });
+locationQuery.remove({ name: "foo", rating: 10 });
 // $ExpectError
-locationQuery.remove({ rating: 'foo' });
+locationQuery.remove({ rating: "foo" });
 
-locationQuery.update({ name: 'foo', rating: 10 }, { rating: 20 });
+locationQuery.update({ name: "foo", rating: 10 }, { rating: 20 });
 // $ExpectError
-locationQuery.update({ rating: 'foo' }, {rating: 20 });
-locationQuery.update({ name: 'foo' }, {
-    rating: 20,
-    'untyped.field': 'test',
-    $set: {
-      name: 'bar',
-      'untyped.field': 'foo'
+locationQuery.update({ rating: "foo" }, { rating: 20 });
+locationQuery.update(
+    { name: "foo" },
+    {
+        rating: 20,
+        "untyped.field": "test",
+        $set: {
+            name: "bar",
+            "untyped.field": "foo",
+        },
+        $unset: {
+            address: "",
+        },
+        $pull: {
+            reviews: "foo",
+            "untyped.field": "foo",
+        },
+        $push: {
+            reviews: "bar",
+            "untyped.field": "bar",
+        },
     },
-    $unset: {
-        address: ''
-    },
-    $pull: {
-        reviews: 'foo',
-        'untyped.field': 'foo'
-    },
-    $push: {
-        reviews: 'bar',
-        'untyped.field': 'bar'
-    }
-});
+);
 // $ExpectError
-locationQuery.update({ name: 'foo' }, { name: 123 });
+locationQuery.update({ name: "foo" }, { name: 123 });
 // $ExpectError
-locationQuery.update({ name: 'foo' }, { $pull: { reviews: 123 } });
+locationQuery.update({ name: "foo" }, { $pull: { reviews: 123 } });
 // $ExpectError
-locationQuery.update({ name: 'foo' }, { $push: { reviews: 123 } });
+locationQuery.update({ name: "foo" }, { $push: { reviews: 123 } });
 
 locationQuery.lean().then(location => {
     if (location) {
@@ -406,7 +477,7 @@ interface LocationWithStringID extends mongoose.Document {
     _id: string;
     name: string;
     rating: number;
-};
+}
 var locWithStringIDQuery = <mongoose.DocumentQuery<LocationWithStringID, LocationWithStringID>>{};
 locWithStringIDQuery.lean().then(location => {
     if (location) {
@@ -426,6 +497,6 @@ locWithStringIDQuery.lean().then(location => {
 async function testOrFail() {
     var lq = <mongoose.DocumentQuery<Location, Location>>{};
 
-    var x = await lq.findOne({ color: 'blue' }).orFail().exec(); 
+    var x = await lq.findOne({ color: "blue" }).orFail().exec();
     x.toJSON();
 }

--- a/types/mongoose/v3/index.d.ts
+++ b/types/mongoose/v3/index.d.ts
@@ -5,661 +5,732 @@
 
 ///<reference types="node" />
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from "events";
 
 declare module "mongoose" {
-  function connect(uri: string, options?: ConnectionOptions , callback?: (err: any) => void): Mongoose;
-  function createConnection(): Connection;
-  function createConnection(uri: string, options?: ConnectionOptions): Connection;
-  function createConnection(host: string, database_name: string, port?: number, options?: ConnectionOptions): Connection;
-  function disconnect(callback?: (err?: any) => void): Mongoose;
+    function connect(uri: string, options?: ConnectionOptions, callback?: (err: any) => void): Mongoose;
+    function createConnection(): Connection;
+    function createConnection(uri: string, options?: ConnectionOptions): Connection;
+    function createConnection(
+        host: string,
+        database_name: string,
+        port?: number,
+        options?: ConnectionOptions,
+    ): Connection;
+    function disconnect(callback?: (err?: any) => void): Mongoose;
 
-  function model<T extends Document>(name: string, schema?: Schema, collection?: string, skipInit?: boolean): Model<T>;
-  function modelNames(): string[];
-  function plugin(plugin: (schema: Schema) => void): Mongoose;
-  function plugin<T>(plugin: (schema: Schema, options: T) => void, options: T): Mongoose;
+    function model<T extends Document>(
+        name: string,
+        schema?: Schema,
+        collection?: string,
+        skipInit?: boolean,
+    ): Model<T>;
+    function modelNames(): string[];
+    function plugin(plugin: (schema: Schema) => void): Mongoose;
+    function plugin<T>(plugin: (schema: Schema, options: T) => void, options: T): Mongoose;
 
-  function get(key: string): any;
-  function set(key: string, value: any): void;
+    function get(key: string): any;
+    function set(key: string, value: any): void;
 
-  var mongo: any;
-  var mquery: any;
-  var version: string;
-  var connection: Connection;
+    var mongo: any;
+    var mquery: any;
+    var version: string;
+    var connection: Connection;
 
-  export class Mongoose {
-    connect(uri: string, options?: ConnectOpenOptionsBase, callback?: (err: any) => void): Mongoose;
-    createConnection(): Connection;
-    createConnection(uri: string, options?: Object): Connection;
-    createConnection(host: string, database_name: string, port?: number, options?: ConnectOpenOptionsBase): Connection;
-    disconnect(callback?: (err?: any) => void): Mongoose;
-    get(key: string): any;
-    model<T extends Document>(name: string, schema?: Schema, collection?: string, skipInit?: boolean): Model<T>;
-    modelNames(): string[];
-    plugin(plugin: (schema: Schema) => void): Mongoose;
-    plugin<T>(plugin: (schema: Schema, options: T) => void, options: T): Mongoose;
-    set(key: string, value: any): void;
+    export class Mongoose {
+        connect(uri: string, options?: ConnectOpenOptionsBase, callback?: (err: any) => void): Mongoose;
+        createConnection(): Connection;
+        createConnection(uri: string, options?: Object): Connection;
+        createConnection(
+            host: string,
+            database_name: string,
+            port?: number,
+            options?: ConnectOpenOptionsBase,
+        ): Connection;
+        disconnect(callback?: (err?: any) => void): Mongoose;
+        get(key: string): any;
+        model<T extends Document>(name: string, schema?: Schema, collection?: string, skipInit?: boolean): Model<T>;
+        modelNames(): string[];
+        plugin(plugin: (schema: Schema) => void): Mongoose;
+        plugin<T>(plugin: (schema: Schema, options: T) => void, options: T): Mongoose;
+        set(key: string, value: any): void;
 
-    mongo: any;
-    mquery: any;
-    version: string;
-    connection: Connection;
-    Promise: any;
-  }
-
-  export class Connection extends EventEmitter {
-    constructor(base: Mongoose);
-
-    close(callback?: (err: any) => void): Connection;
-    collection(name: string, options?: Object): Collection;
-    model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
-    modelNames(): string[];
-    open(host: string, database?: string, port?: number, options?: OpenSetConnectionOptions, callback?: (err: any) => void): Connection;
-    openSet(uris: string, database?: string, options?: OpenSetConnectionOptions, callback?: (err: any) => void): Connection;
-
-    db: any;
-    collections: {[index: string]: Collection};
-    readyState: number;
-  }
-
-  export interface ConnectOpenOptionsBase {
-    db?: any;
-    server?: any;
-    replset?: any;
-    /** Username for authentication if not supplied in the URI. */
-    user?: string;
-    /** Password for authentication if not supplied in the URI. */
-    pass?: string;
-    /** Options for authentication */
-    auth?: any;
-    useMongoClient?: boolean;
-  }
-
-  export interface ConnectionOptions extends ConnectOpenOptionsBase {
-    /** Passed to the underlying driver's Mongos instance. */
-    mongos?: MongosOptions | boolean;
-  }
-
-  interface OpenSetConnectionOptions extends ConnectOpenOptionsBase {
-      /** If true, enables High Availability support for mongos */
-      mongos?: boolean;
-  }
-
-  interface MongosOptions {
-      /** Turn on high availability monitoring. (default: true) */
-      ha?: boolean;
-      /** Time between each replicaset status check. (default: 5000) */
-      haInterval?: number;
-      /**
-       * Number of connections in the connection pool for each
-       * server instance. (default: 5 (for legacy reasons)) */
-      poolSize?: number;
-      /**
-       * Use ssl connection (needs to have a mongod server with
-       * ssl support). (default: false).
-       */
-      ssl?: boolean;
-      /**
-       * Validate mongod server certificate against ca
-       * (needs to have a mongod server with ssl support, 2.4 or higher)
-       * (default: true)
-       */
-      sslValidate?: boolean;
-      /** Turn on high availability monitoring. */
-      sslCA?: (Buffer|string)[];
-      sslKey?: Buffer|string;
-      sslPass?: Buffer|string;
-      socketOptions?: {
-          noDelay?: boolean;
-          keepAlive?: number;
-          connectionTimeoutMS?: number;
-          socketTimeoutMS?: number;
-      };
-  }
-
-  export interface Collection {
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#initializeOrderedBulkOp
-    initializeOrderedBulkOp(options?: CollectionOptions): OrderedBulkOperation;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#initializeUnorderedBulkOp
-    initializeUnorderedBulkOp(options?: CollectionOptions): UnorderedBulkOperation;
-  }
-
-  export interface CollectionOptions {
-    //The write concern.
-    w?: number | string;
-    //The write concern timeout.
-    wtimeout?: number;
-    //Specify a journal write concern.
-    j?: boolean;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html
-  export interface OrderedBulkOperation {
-    length: number;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html#execute
-    execute(callback: MongoCallback<BulkWriteResult>): void;
-    execute(options?: FSyncOptions): Promise<BulkWriteResult>;
-    execute(options: FSyncOptions, callback: MongoCallback<BulkWriteResult>): void;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html#find
-    find(selector: Object): FindOperatorsOrdered;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html#insert
-    insert(doc: Object): OrderedBulkOperation;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html
-  export interface UnorderedBulkOperation {
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html#execute
-    execute(callback: MongoCallback<BulkWriteResult>): void;
-    execute(options?: FSyncOptions): Promise<BulkWriteResult>;
-    execute(options: FSyncOptions, callback: MongoCallback<BulkWriteResult>): void;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html#find
-    find(selector: Object): FindOperatorsUnordered;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html#insert
-    insert(doc: Object): UnorderedBulkOperation;
-  }
-
-  export interface MongoCallback<T> {
-    (error: MongoError, result: T): void;
-  }
-
-  // http://mongodb.github.io/node-mongodb-native/2.1/api/MongoError.html
-  export class MongoError extends Error {
-    constructor(message: string);
-    static create(options: Object): MongoError;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/BulkWriteResult.html
-  export interface BulkWriteResult {
-    ok: number;
-    nInserted: number;
-    nUpdated: number;
-    nUpserted: number;
-    nModified: number;
-    nRemoved: number;
-
-    getInsertedIds(): Array<Object>;
-    getLastOp(): Object;
-    getRawResponse(): Object;
-    getUpsertedIdAt(index: number): Object;
-    getUpsertedIds(): Array<Object>;
-    getWriteConcernError(): WriteConcernError;
-    getWriteErrorAt(index: number): WriteError;
-    getWriteErrorCount(): number;
-    getWriteErrors(): Array<Object>;
-    hasWriteErrors(): boolean;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/WriteError.html
-  export interface WriteError {
-    //Write concern error code.
-    code: number;
-    //Write concern error original bulk operation index.
-    index: number;
-    //Write concern error message.
-    errmsg: string;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/WriteConcernError.html
-  export interface WriteConcernError {
-    //Write concern error code.
-    code: number;
-    //Write concern error message.
-    errmsg: string;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/Admin.html#removeUser
-  export interface FSyncOptions {
-    w?: number | string;
-    wtimeout?: number;
-    j?: boolean;
-    fsync?: boolean
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/FindOperatorsOrdered.html
-  export interface FindOperatorsOrdered {
-    delete(): OrderedBulkOperation;
-    deleteOne(): OrderedBulkOperation;
-    replaceOne(doc: Object): OrderedBulkOperation;
-    update(doc: Object): OrderedBulkOperation;
-    updateOne(doc: Object): OrderedBulkOperation;
-    upsert(): FindOperatorsOrdered;
-  }
-
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/FindOperatorsUnordered.html
-  export interface FindOperatorsUnordered {
-    length: number;
-    remove(): UnorderedBulkOperation;
-    removeOne(): UnorderedBulkOperation;
-    replaceOne(doc: Object): UnorderedBulkOperation;
-    update(doc: Object): UnorderedBulkOperation;
-    updateOne(doc: Object): UnorderedBulkOperation;
-    upsert(): FindOperatorsUnordered;
-  }
-
-  export class SchemaType { }
-  export class VirtualType {
-    get(fn: Function): VirtualType;
-    set(fn: Function): VirtualType;
-  }
-  export module Types {
-    export class ObjectId {
-      constructor(id?: string|number);
-      toHexString(): string;
-      equals(other: ObjectId): boolean;
-      getTimestamp(): Date;
-      isValid(): boolean;
-      static createFromTime(time: number): ObjectId;
-      static createFromHexString(hexString: string): ObjectId;
-      static isValid(id?: string|number):boolean;
+        mongo: any;
+        mquery: any;
+        version: string;
+        connection: Connection;
+        Promise: any;
     }
-  }
 
-  export class Schema {
-    static Types: {
-      String: String;
-      ObjectId: Types.ObjectId;
-      OId: Types.ObjectId;
-      Mixed: any;
-    };
+    export class Connection extends EventEmitter {
+        constructor(base: Mongoose);
 
-    methods: any;
-    statics: any;
+        close(callback?: (err: any) => void): Connection;
+        collection(name: string, options?: Object): Collection;
+        model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
+        modelNames(): string[];
+        open(
+            host: string,
+            database?: string,
+            port?: number,
+            options?: OpenSetConnectionOptions,
+            callback?: (err: any) => void,
+        ): Connection;
+        openSet(
+            uris: string,
+            database?: string,
+            options?: OpenSetConnectionOptions,
+            callback?: (err: any) => void,
+        ): Connection;
 
-    constructor(schema?: Object, options?: Object);
+        db: any;
+        collections: { [index: string]: Collection };
+        readyState: number;
+    }
 
-    add(obj: Object, prefix?: string): void;
-    eachPath(fn: (path: string, type: any) => void): Schema;
-    get(key: string): any;
-    index(fields: Object, options?: Object): Schema;
-    indexes(): void;
-    method(name: string, fn: Function): Schema;
-    method(method: Object): Schema;
-    path(path: string): any;
-    path(path: string, constructor: any): Schema;
-    pathType(path: string): string;
-    plugin(plugin: (schema: Schema) => void): Schema;
-    plugin<T>(plugin: (schema: Schema, options: T) => void, options: T): Schema;
+    export interface ConnectOpenOptionsBase {
+        db?: any;
+        server?: any;
+        replset?: any;
+        /** Username for authentication if not supplied in the URI. */
+        user?: string;
+        /** Password for authentication if not supplied in the URI. */
+        pass?: string;
+        /** Options for authentication */
+        auth?: any;
+        useMongoClient?: boolean;
+    }
 
-    pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): Schema;
-    pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): Schema;
-    post(method: string, fn: (doc: Document, next?: HookNextFunction) => any ): Schema;
+    export interface ConnectionOptions extends ConnectOpenOptionsBase {
+        /** Passed to the underlying driver's Mongos instance. */
+        mongos?: MongosOptions | boolean;
+    }
 
-    requiredPaths(): string[];
-    set(key: string, value: any): void;
-    static(name: string, fn: Function): Schema;
-    virtual(name: string, options?: Object): VirtualType;
-    virtualpath(name: string): VirtualType;
+    interface OpenSetConnectionOptions extends ConnectOpenOptionsBase {
+        /** If true, enables High Availability support for mongos */
+        mongos?: boolean;
+    }
 
-  }
+    interface MongosOptions {
+        /** Turn on high availability monitoring. (default: true) */
+        ha?: boolean;
+        /** Time between each replicaset status check. (default: 5000) */
+        haInterval?: number;
+        /**
+         * Number of connections in the connection pool for each
+         * server instance. (default: 5 (for legacy reasons)) */
+        poolSize?: number;
+        /**
+         * Use ssl connection (needs to have a mongod server with
+         * ssl support). (default: false).
+         */
+        ssl?: boolean;
+        /**
+         * Validate mongod server certificate against ca
+         * (needs to have a mongod server with ssl support, 2.4 or higher)
+         * (default: true)
+         */
+        sslValidate?: boolean;
+        /** Turn on high availability monitoring. */
+        sslCA?: (Buffer | string)[];
+        sslKey?: Buffer | string;
+        sslPass?: Buffer | string;
+        socketOptions?: {
+            noDelay?: boolean;
+            keepAlive?: number;
+            connectionTimeoutMS?: number;
+            socketTimeoutMS?: number;
+        };
+    }
 
-  // hook functions: https://github.com/vkarpov15/hooks-fixed
-  export interface HookSyncCallback {
-    (next: HookNextFunction, ...hookArgs:any[]): any;
-  }
+    export interface Collection {
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#initializeOrderedBulkOp
+        initializeOrderedBulkOp(options?: CollectionOptions): OrderedBulkOperation;
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#initializeUnorderedBulkOp
+        initializeUnorderedBulkOp(options?: CollectionOptions): UnorderedBulkOperation;
+    }
 
-  export interface HookAsyncCallback {
-    (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
-  }
+    export interface CollectionOptions {
+        //The write concern.
+        w?: number | string;
+        //The write concern timeout.
+        wtimeout?: number;
+        //Specify a journal write concern.
+        j?: boolean;
+    }
 
-  export interface HookErrorCallback {
-    (error: Error): any;
-  }
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html
+    export interface OrderedBulkOperation {
+        length: number;
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html#execute
+        execute(callback: MongoCallback<BulkWriteResult>): void;
+        execute(options?: FSyncOptions): Promise<BulkWriteResult>;
+        execute(options: FSyncOptions, callback: MongoCallback<BulkWriteResult>): void;
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html#find
+        find(selector: Object): FindOperatorsOrdered;
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html#insert
+        insert(doc: Object): OrderedBulkOperation;
+    }
 
-  export interface HookNextFunction {
-    (error: Error): any;
-    (...hookArgs:any[]): any;
-  }
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html
+    export interface UnorderedBulkOperation {
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html#execute
+        execute(callback: MongoCallback<BulkWriteResult>): void;
+        execute(options?: FSyncOptions): Promise<BulkWriteResult>;
+        execute(options: FSyncOptions, callback: MongoCallback<BulkWriteResult>): void;
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html#find
+        find(selector: Object): FindOperatorsUnordered;
+        //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html#insert
+        insert(doc: Object): UnorderedBulkOperation;
+    }
 
-  export interface HookDoneFunction {
-    (error: Error): any;
-    (...hookArgs:any[]): any;
-  }
+    export interface MongoCallback<T> {
+        (error: MongoError, result: T): void;
+    }
 
-  interface CappedOptions {
-    size: number;
-    max?: number;
-    autoIndexId?: boolean;
-  }
+    // http://mongodb.github.io/node-mongodb-native/2.1/api/MongoError.html
+    export class MongoError extends Error {
+        constructor(message: string);
+        static create(options: Object): MongoError;
+    }
 
-  export interface SchemaOption {
-    autoIndex?: boolean;
-    bufferCommands?: boolean;
-    capped?: boolean | number | CappedOptions;
-    collection?: string;
-    id?: boolean;
-    _id?: boolean;
-    minimize?: boolean;
-    read?: string;
-    safe?: boolean;
-    shardKey?: boolean;
-    strict?: boolean;
-    toJSON?: Object;
-    toObject?: Object;
-    versionKey?: boolean;
-  }
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/BulkWriteResult.html
+    export interface BulkWriteResult {
+        ok: number;
+        nInserted: number;
+        nUpdated: number;
+        nUpserted: number;
+        nModified: number;
+        nRemoved: number;
 
-  export interface Model<T extends Document> extends NodeJS.EventEmitter {
-    new(doc?: Object, fields?: Object, skipInit?: boolean): T;
+        getInsertedIds(): Array<Object>;
+        getLastOp(): Object;
+        getRawResponse(): Object;
+        getUpsertedIdAt(index: number): Object;
+        getUpsertedIds(): Array<Object>;
+        getWriteConcernError(): WriteConcernError;
+        getWriteErrorAt(index: number): WriteError;
+        getWriteErrorCount(): number;
+        getWriteErrors(): Array<Object>;
+        hasWriteErrors(): boolean;
+    }
 
-    aggregate(...aggregations: Object[]): Aggregate<T[]>;
-    aggregate(aggregation: Object, callback: (err: any, res: T[]) => void): Promise<T[]>;
-    aggregate(aggregation1: Object, aggregation2: Object, callback: (err: any, res: T[]) => void): Promise<T[]>;
-    aggregate(aggregation1: Object, aggregation2: Object, aggregation3: Object, callback: (err: any, res: T[]) => void): Promise<T[]>;
-    count(conditions: Object, callback?: (err: any, count: number) => void): Query<number>;
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/WriteError.html
+    export interface WriteError {
+        //Write concern error code.
+        code: number;
+        //Write concern error original bulk operation index.
+        index: number;
+        //Write concern error message.
+        errmsg: string;
+    }
 
-    create(doc: Object, fn?: (err: any, res: T) => void): Promise<T>;
-    create(doc1: Object, doc2: Object, fn?: (err: any, res1: T, res2: T) => void): Promise<T[]>;
-    create(doc1: Object, doc2: Object, doc3: Object, fn?: (err: any, res1: T, res2: T, res3: T) => void): Promise<T[]>;
-    discriminator<U extends Document>(name: string, schema: Schema): Model<U>;
-    distinct(field: string, callback?: (err: any, res: T[]) => void): Query<T[]>;
-    distinct(field: string, conditions: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
-    ensureIndexes(callback: (err: any) => void): Promise<T>;
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/WriteConcernError.html
+    export interface WriteConcernError {
+        //Write concern error code.
+        code: number;
+        //Write concern error message.
+        errmsg: string;
+    }
 
-    find(): Query<T[]>;
-    find(cond: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
-    find(cond: Object, fields: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
-    find(cond: Object, fields: Object, options: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
-    findById(id: string, callback?: (err: any, res: T) => void): Query<T>;
-    findById(id: string, fields: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findById(id: string, fields: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findByIdAndRemove(id: string, callback?: (err: any, res: T) => void): Query<T>;
-    findByIdAndRemove(id: string, options: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findByIdAndUpdate(id: string, update: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findByIdAndUpdate(id: string, update: Object, options: FindAndUpdateOption, callback?: (err: any, res: T) => void): Query<T>;
-    findOne(cond?: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOne(cond: Object, fields: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOne(cond: Object, fields: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndRemove(cond: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndRemove(cond: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndUpdate(cond: Object, update: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndUpdate(cond: Object, update: Object, options: FindAndUpdateOption, callback?: (err: any, res: T) => void): Query<T>;
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/Admin.html#removeUser
+    export interface FSyncOptions {
+        w?: number | string;
+        wtimeout?: number;
+        j?: boolean;
+        fsync?: boolean;
+    }
 
-    geoNear(point: { type: string; coordinates: number[] }, options: Object, callback?: (err: any, res: T[], stats: any) => void): Query<T[]>;
-    geoNear(point: number[], options: Object, callback?: (err: any, res: T[], stats: any) => void): Query<T[]>;
-    geoSearch(cond: Object, options: GeoSearchOption, callback?: (err: any, res: T[]) => void): Query<T[]>;
-    increment(): T;
-    mapReduce<K, V>(options: MapReduceOption<T, K, V>, callback?: (err: any, res: MapReduceResult<K, V>[]) => void): Promise<MapReduceResult<K, V>[]>;
-    mapReduce<K, V>(options: MapReduceOption2<T, K, V>, callback?: (err: any, res: MapReduceResult<K, V>[]) => void): Promise<MapReduceResult<K, V>[]>;
-    model<U extends Document>(name: string): Model<U>;
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/FindOperatorsOrdered.html
+    export interface FindOperatorsOrdered {
+        delete(): OrderedBulkOperation;
+        deleteOne(): OrderedBulkOperation;
+        replaceOne(doc: Object): OrderedBulkOperation;
+        update(doc: Object): OrderedBulkOperation;
+        updateOne(doc: Object): OrderedBulkOperation;
+        upsert(): FindOperatorsOrdered;
+    }
 
-    populate<U>(doc: U[], options: Object, callback?: (err: any, res: U[]) => void): Promise<U[]>;
-    populate<U>(doc: U, options: Object, callback?: (err: any, res: U) => void): Promise<U>;
-    update(cond: Object, update: Object, callback?: (err: any, affectedRows: number, raw: any) => void): Query<T>;
-    update(cond: Object, update: Object, options: Object, callback?: (err: any, affectedRows: number, raw: any) => void): Query<T>;
-    remove(cond: Object, callback?: (err: any) => void): Query<{}>;
-    save(callback?: (err: any, result: T, numberAffected: number) => void): Query<T>;
-    where(path: string, val?: Object): Query<T[]>;
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/FindOperatorsUnordered.html
+    export interface FindOperatorsUnordered {
+        length: number;
+        remove(): UnorderedBulkOperation;
+        removeOne(): UnorderedBulkOperation;
+        replaceOne(doc: Object): UnorderedBulkOperation;
+        update(doc: Object): UnorderedBulkOperation;
+        updateOne(doc: Object): UnorderedBulkOperation;
+        upsert(): FindOperatorsUnordered;
+    }
 
-    $where(argument: string): Query<T>;
-    $where(argument: Function): Query<T>;
+    export class SchemaType {}
+    export class VirtualType {
+        get(fn: Function): VirtualType;
+        set(fn: Function): VirtualType;
+    }
+    export module Types {
+        export class ObjectId {
+            constructor(id?: string | number);
+            toHexString(): string;
+            equals(other: ObjectId): boolean;
+            getTimestamp(): Date;
+            isValid(): boolean;
+            static createFromTime(time: number): ObjectId;
+            static createFromHexString(hexString: string): ObjectId;
+            static isValid(id?: string | number): boolean;
+        }
+    }
 
-    base: Mongoose;
-    collection: Collection;
-    db: any;
-    discriminators: any;
-    modelName: string;
-    schema: Schema;
-  }
-  export interface FindAndUpdateOption {
-    new?: boolean;
-    upsert?: boolean;
-    sort?: Object;
-    select?: Object;
-  }
-  export interface GeoSearchOption {
-    near: number[];
-    maxDistance: number;
-    limit?: number;
-    lean?: boolean;
-  }
-  export interface MapReduceOption<T extends Document, Key, Val> {
-    map: () => void;
-    reduce: (key: Key, vals: T[]) => Val;
-    query?: Object;
-    limit?: number;
-    keeptemp?: boolean;
-    finalize?: (key: Key, val: Val) => Val;
-    scope?: Object;
-    jsMode?: boolean;
-    verbose?: boolean;
-    out?: {
-      inline?: number;
-      replace?: string;
-      reduce?: string;
-      merge?: string;
-    };
-  }
-  export interface MapReduceOption2<T extends Document, Key, Val> {
-    map: string;
-    reduce: (key: Key, vals: T[]) => Val;
-    query?: Object;
-    limit?: number;
-    keeptemp?: boolean;
-    finalize?: (key: Key, val: Val) => Val;
-    scope?: Object;
-    jsMode?: boolean;
-    verbose?: boolean;
-    out?: {
-      inline?: number;
-      replace?: string;
-      reduce?: string;
-      merge?: string;
-    };
-  }
-  export interface MapReduceResult<Key, Val> {
-    _id: Key;
-    value: Val;
-  }
+    export class Schema {
+        static Types: {
+            String: String;
+            ObjectId: Types.ObjectId;
+            OId: Types.ObjectId;
+            Mixed: any;
+        };
 
-  export class Query<T> {
-    exec(callback?: (err: any, res: T) => void): Promise<T>;
-    exec(operation: string, callback?: (err: any, res: T) => void): Promise<T>;
-    exec(operation: Function, callback?: (err: any, res: T) => void): Promise<T>;
+        methods: any;
+        statics: any;
 
-    all(val: number): Query<T>;
-    all(path: string, val: number): Query<T>;
-    and(array: Object[]): Query<T>;
-    box(val: Object): Query<T>;
-    box(a: number[], b: number[]): Query<T>;
-    batchSize(val: number): Query<T>;
-    cast<U extends Document>(model: Model<U>, obj: Object): U;
-    //center(): Query<T>;
-    //centerSphere(path: string, val: Object): Query<T>;
-    circle(area: Object): Query<T>;
-    circle(path: string, area: Object): Query<T>;
-    comment(val: any): Query<T>;
-    count(callback?: (err: any, count: number) => void): Query<number>;
-    count(criteria: Object, callback?: (err: any, count: number) => void): Query<number>;
-    distinct(callback?: (err: any, res: T) => void): Query<T>;
-    distinct(field: string, callback?: (err: any, res: T) => void): Query<T>;
-    distinct(criteria: Object, field: string, callback?: (err: any, res: T) => void): Query<T>;
-    distinct(criteria: Query<T>, field: string, callback?: (err: any, res: T) => void): Query<T>;
-    elemMatch(criteria: Object): Query<T>;
-    elemMatch(criteria: (elem: Query<T>) => void): Query<T>;
-    elemMatch(path: string, criteria: Object): Query<T>;
-    elemMatch(path: string, criteria: (elem: Query<T>) => void): Query<T>;
-    equals(val: Object): Query<T>;
-    exists(val?: boolean): Query<T>;
-    exists(path: string, val?: boolean): Query<T>;
-    find(callback?: (err: any, res: T) => void): Query<T>;
-    find(criteria: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOne(callback?: (err: any, res: T) => void): Query<T>;
-    findOne(criteria: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndRemove(callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndRemove(cond: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndRemove(cond: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndUpdate(callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndUpdate(update: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndUpdate(cond: Object, update: Object, callback?: (err: any, res: T) => void): Query<T>;
-    findOneAndUpdate(cond: Object, update: Object, options: FindAndUpdateOption, callback?: (err: any, res: T) => void): Query<T>;
-    geometry(object: Object): Query<T>;
-    gt(val: number): Query<T>;
-    gt(path: string, val: number): Query<T>;
-    gte(val: number): Query<T>;
-    gte(path: string, val: number): Query<T>;
-    hint(val: Object): Query<T>;
-    in(val: any[]): Query<T>;
-    in(path: string, val: any[]): Query<T>;
-    intersects(arg?: Object): Query<T>;
-    lean(bool?: boolean): Query<T>;
-    limit(val: number): Query<T>;
-    lt(val: number): Query<T>;
-    lt(path: string, val: number): Query<T>;
-    lte(val: number): Query<T>;
-    lte(path: string, val: number): Query<T>;
-    maxDistance(val: number): Query<T>;
-    maxDistance(path: string, val: number): Query<T>;
-    maxScan(val: number): Query<T>;
-    merge(source: Query<T>): Query<T>;
-    merge(source: Object): Query<T>;
-    mod(val: number[]): Query<T>;
-    mod(path: string, val: number[]): Query<T>;
-    ne(val: any): Query<T>;
-    ne(path: string, val: any): Query<T>;
-    near(val: Object): Query<T>;
-    near(path: string, val: Object): Query<T>;
-    nearSphere(val: Object): Query<T>;
-    nearSphere(path: string, val: Object): Query<T>;
-    nin(val: any[]): Query<T>;
-    nin(path: string, val: any[]): Query<T>;
-    nor(array: Object[]): Query<T>;
-    or(array: Object[]): Query<T>;
-    polygon(...coordinatePairs: number[][]): Query<T>;
-    polygon(path: string, ...coordinatePairs: number[][]): Query<T>;
-    populate(path: string, select?: string, match?: Object, options?: Object): Query<T>;
-    populate(path: string, select: string, model: string, match?: Object, options?: Object): Query<T>;
-    populate(opt: PopulateOption): Query<T>;
-    read(pref: string, tags?: Object[]): Query<T>;
-    regex(val: RegExp): Query<T>;
-    regex(path: string, val: RegExp): Query<T>;
-    remove(callback?: (err: any, res: T) => void): Query<T>;
-    remove(criteria: Object, callback?: (err: any, res: T) => void): Query<T>;
-    select(arg: string): Query<T>;
-    select(arg: Object): Query<T>;
-    setOptions(options: Object): Query<T>;
-    size(val: number): Query<T>;
-    size(path: string, val: number): Query<T>;
-    skip(val: number): Query<T>;
-    slaveOk(v?: boolean): Query<T>;
-    slice(val: number): Query<T>;
-    slice(val: number[]): Query<T>;
-    slice(path: string, val: number): Query<T>;
-    slice(path: string, val: number[]): Query<T>;
-    snapshot(v?: boolean): Query<T>;
-    sort(arg: Object): Query<T>;
-    sort(arg: string): Query<T>;
-    stream(options?: { transform?: Function; }): QueryStream;
-    tailable(v?: boolean): Query<T>;
-    toConstructor(): Query<T>;
-    update(callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
-    update(doc: Object, callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
-    update(criteria: Object, doc: Object, callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
-    update(criteria: Object, doc: Object, options: Object, callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
-    where(path?: string, val?: any): Query<T>;
-    where(path?: Object, val?: any): Query<T>;
-    within(val?: Object): Query<T>;
-    within(coordinate: number[], ...coordinatePairs: number[][]): Query<T>;
+        constructor(schema?: Object, options?: Object);
 
-    $where(argument: string): Query<T>;
-    $where(argument: Function): Query<T>;
+        add(obj: Object, prefix?: string): void;
+        eachPath(fn: (path: string, type: any) => void): Schema;
+        get(key: string): any;
+        index(fields: Object, options?: Object): Schema;
+        indexes(): void;
+        method(name: string, fn: Function): Schema;
+        method(method: Object): Schema;
+        path(path: string): any;
+        path(path: string, constructor: any): Schema;
+        pathType(path: string): string;
+        plugin(plugin: (schema: Schema) => void): Schema;
+        plugin<T>(plugin: (schema: Schema, options: T) => void, options: T): Schema;
 
-    static use$geoWithin: boolean;
-  }
+        pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): Schema;
+        pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): Schema;
+        post(method: string, fn: (doc: Document, next?: HookNextFunction) => any): Schema;
 
-  export interface PopulateOption {
-    path: string;
-    select?: string;
-    model?: string;
-    match?: Object;
-    options?: Object;
-  }
+        requiredPaths(): string[];
+        set(key: string, value: any): void;
+        static(name: string, fn: Function): Schema;
+        virtual(name: string, options?: Object): VirtualType;
+        virtualpath(name: string): VirtualType;
+    }
 
-  export interface QueryStream extends NodeJS.EventEmitter {
-    destory(err?: any): void;
-    pause(): void;
-    resume(): void;
-    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
-    paused: number;
-    readable: boolean;
-  }
+    // hook functions: https://github.com/vkarpov15/hooks-fixed
+    export interface HookSyncCallback {
+        (next: HookNextFunction, ...hookArgs: any[]): any;
+    }
 
-  export interface Document {
-    id?: string;
-    _id: any;
+    export interface HookAsyncCallback {
+        (next: HookNextFunction, done: HookDoneFunction, ...hookArgs: any[]): any;
+    }
 
-    equals(doc: Document): boolean;
-    get(path: string, type?: new(...args: any[]) => any): any;
-    inspect(options?: Object): string;
-    invalidate(path: string, errorMsg: string, value: any): void;
-    invalidate(path: string, error: Error, value: any): void;
-    isDirectModified(path: string): boolean;
-    isInit(path: string): boolean;
-    isModified(path?: string): boolean;
-    isSelected(path: string): boolean;
-    markModified(path: string): void;
-    modifiedPaths(): string[];
-    populate<T>(callback?: (err: any, res: T) => void): Document;
-    populate<T>(path?: string, callback?: (err: any, res: T) => void): Document;
-    populate<T>(opt: PopulateOption, callback?: (err: any, res: T) => void): Document;
-    populated(path: string): any;
-    remove<T>(callback?: (err: any) => void): Query<T>;
-    save<T>(callback?: (err: any, res: T) => void): void;
-    set(path: string, val: any, type?: new(...args: any[]) => any, options?: Object): void;
-    set(path: string, val: any, options?: Object): void;
-    set(value: Object): void;
-    toJSON(options?: Object): Object;
-    toObject(options?: Object): Object;
-    toString(): string;
-    update<T>(doc: Object, options: Object, callback: (err: any, affectedRows: number, raw: any) => void): Query<T>;
-    validate(cb: (err: any) => void): void;
+    export interface HookErrorCallback {
+        (error: Error): any;
+    }
 
-    isNew: boolean;
-    errors: Object;
-    schema: Object;
-  }
+    export interface HookNextFunction {
+        (error: Error): any;
+        (...hookArgs: any[]): any;
+    }
 
+    export interface HookDoneFunction {
+        (error: Error): any;
+        (...hookArgs: any[]): any;
+    }
 
-  export class Aggregate<T> {
-    constructor(...options: Object[]);
+    interface CappedOptions {
+        size: number;
+        max?: number;
+        autoIndexId?: boolean;
+    }
 
-    append(...options: Object[]): Aggregate<T>;
-    group(arg: Object): Aggregate<T>;
-    limit(num: number): Aggregate<T>;
-    match(arg: Object): Aggregate<T>;
-    near(parameters: Object): Aggregate<T>;
-    project(arg: string): Aggregate<T>;
-    project(arg: Object): Aggregate<T>;
-    select(filter: string): Aggregate<T>;
-    skip(num: number): Aggregate<T>;
-    sort(arg: string): Aggregate<T>;
-    sort(arg: Object): Aggregate<T>;
-    unwind(fiels: string, ...rest: string[]): Aggregate<T>;
+    export interface SchemaOption {
+        autoIndex?: boolean;
+        bufferCommands?: boolean;
+        capped?: boolean | number | CappedOptions;
+        collection?: string;
+        id?: boolean;
+        _id?: boolean;
+        minimize?: boolean;
+        read?: string;
+        safe?: boolean;
+        shardKey?: boolean;
+        strict?: boolean;
+        toJSON?: Object;
+        toObject?: Object;
+        versionKey?: boolean;
+    }
 
-    exec(callback?: (err: any, result: T) => void): Promise<T>;
-    read(pref: string, ...tags: Object[]): Aggregate<T>;
-  }
+    export interface Model<T extends Document> extends NodeJS.EventEmitter {
+        new (doc?: Object, fields?: Object, skipInit?: boolean): T;
 
-  export class Promise<T> {
-    constructor(fn?: (err: any, result: T) => void);
+        aggregate(...aggregations: Object[]): Aggregate<T[]>;
+        aggregate(aggregation: Object, callback: (err: any, res: T[]) => void): Promise<T[]>;
+        aggregate(aggregation1: Object, aggregation2: Object, callback: (err: any, res: T[]) => void): Promise<T[]>;
+        aggregate(
+            aggregation1: Object,
+            aggregation2: Object,
+            aggregation3: Object,
+            callback: (err: any, res: T[]) => void,
+        ): Promise<T[]>;
+        count(conditions: Object, callback?: (err: any, count: number) => void): Query<number>;
 
-    then<U>(onFulFill: (result: T) => void | U | Promise<U>, onReject?: (err: any) => void | U | Promise<U>): Promise<U>;
-    end(): void;
+        create(doc: Object, fn?: (err: any, res: T) => void): Promise<T>;
+        create(doc1: Object, doc2: Object, fn?: (err: any, res1: T, res2: T) => void): Promise<T[]>;
+        create(
+            doc1: Object,
+            doc2: Object,
+            doc3: Object,
+            fn?: (err: any, res1: T, res2: T, res3: T) => void,
+        ): Promise<T[]>;
+        discriminator<U extends Document>(name: string, schema: Schema): Model<U>;
+        distinct(field: string, callback?: (err: any, res: T[]) => void): Query<T[]>;
+        distinct(field: string, conditions: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
+        ensureIndexes(callback: (err: any) => void): Promise<T>;
 
-    fulfill(result: T): Promise<T>;
-    reject(err: any): Promise<T>;
-    resolve(err: any, result: T): Promise<T>;
+        find(): Query<T[]>;
+        find(cond: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
+        find(cond: Object, fields: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
+        find(cond: Object, fields: Object, options: Object, callback?: (err: any, res: T[]) => void): Query<T[]>;
+        findById(id: string, callback?: (err: any, res: T) => void): Query<T>;
+        findById(id: string, fields: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findById(id: string, fields: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findByIdAndRemove(id: string, callback?: (err: any, res: T) => void): Query<T>;
+        findByIdAndRemove(id: string, options: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findByIdAndUpdate(id: string, update: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findByIdAndUpdate(
+            id: string,
+            update: Object,
+            options: FindAndUpdateOption,
+            callback?: (err: any, res: T) => void,
+        ): Query<T>;
+        findOne(cond?: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOne(cond: Object, fields: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOne(cond: Object, fields: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndRemove(cond: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndRemove(cond: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndUpdate(cond: Object, update: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndUpdate(
+            cond: Object,
+            update: Object,
+            options: FindAndUpdateOption,
+            callback?: (err: any, res: T) => void,
+        ): Query<T>;
 
-    onFulfill(listener: (result: T) => void): Promise<T>;
-    onReject(listener: (err: any) => void): Promise<T>;
-    onResolve(listener: (err: any, result: T) => void): Promise<T>;
-    on(event: string, listener: Function): Promise<T>;
+        geoNear(
+            point: { type: string; coordinates: number[] },
+            options: Object,
+            callback?: (err: any, res: T[], stats: any) => void,
+        ): Query<T[]>;
+        geoNear(point: number[], options: Object, callback?: (err: any, res: T[], stats: any) => void): Query<T[]>;
+        geoSearch(cond: Object, options: GeoSearchOption, callback?: (err: any, res: T[]) => void): Query<T[]>;
+        increment(): T;
+        mapReduce<K, V>(
+            options: MapReduceOption<T, K, V>,
+            callback?: (err: any, res: MapReduceResult<K, V>[]) => void,
+        ): Promise<MapReduceResult<K, V>[]>;
+        mapReduce<K, V>(
+            options: MapReduceOption2<T, K, V>,
+            callback?: (err: any, res: MapReduceResult<K, V>[]) => void,
+        ): Promise<MapReduceResult<K, V>[]>;
+        model<U extends Document>(name: string): Model<U>;
 
-    // Deprecated methods.
-    addBack(listener: (err: any, result: T) => void): Promise<T>;
-    addCallback(listener: (result: T) => void): Promise<T>;
-    addErrback(listener: (err: any) => void): Promise<T>;
-    complete(result: T): Promise<T>;
-    error(err: any): Promise<T>;
-  }
+        populate<U>(doc: U[], options: Object, callback?: (err: any, res: U[]) => void): Promise<U[]>;
+        populate<U>(doc: U, options: Object, callback?: (err: any, res: U) => void): Promise<U>;
+        update(cond: Object, update: Object, callback?: (err: any, affectedRows: number, raw: any) => void): Query<T>;
+        update(
+            cond: Object,
+            update: Object,
+            options: Object,
+            callback?: (err: any, affectedRows: number, raw: any) => void,
+        ): Query<T>;
+        remove(cond: Object, callback?: (err: any) => void): Query<{}>;
+        save(callback?: (err: any, result: T, numberAffected: number) => void): Query<T>;
+        where(path: string, val?: Object): Query<T[]>;
 
+        $where(argument: string): Query<T>;
+        $where(argument: Function): Query<T>;
+
+        base: Mongoose;
+        collection: Collection;
+        db: any;
+        discriminators: any;
+        modelName: string;
+        schema: Schema;
+    }
+    export interface FindAndUpdateOption {
+        new?: boolean;
+        upsert?: boolean;
+        sort?: Object;
+        select?: Object;
+    }
+    export interface GeoSearchOption {
+        near: number[];
+        maxDistance: number;
+        limit?: number;
+        lean?: boolean;
+    }
+    export interface MapReduceOption<T extends Document, Key, Val> {
+        map: () => void;
+        reduce: (key: Key, vals: T[]) => Val;
+        query?: Object;
+        limit?: number;
+        keeptemp?: boolean;
+        finalize?: (key: Key, val: Val) => Val;
+        scope?: Object;
+        jsMode?: boolean;
+        verbose?: boolean;
+        out?: {
+            inline?: number;
+            replace?: string;
+            reduce?: string;
+            merge?: string;
+        };
+    }
+    export interface MapReduceOption2<T extends Document, Key, Val> {
+        map: string;
+        reduce: (key: Key, vals: T[]) => Val;
+        query?: Object;
+        limit?: number;
+        keeptemp?: boolean;
+        finalize?: (key: Key, val: Val) => Val;
+        scope?: Object;
+        jsMode?: boolean;
+        verbose?: boolean;
+        out?: {
+            inline?: number;
+            replace?: string;
+            reduce?: string;
+            merge?: string;
+        };
+    }
+    export interface MapReduceResult<Key, Val> {
+        _id: Key;
+        value: Val;
+    }
+
+    export class Query<T> {
+        exec(callback?: (err: any, res: T) => void): Promise<T>;
+        exec(operation: string, callback?: (err: any, res: T) => void): Promise<T>;
+        exec(operation: Function, callback?: (err: any, res: T) => void): Promise<T>;
+
+        all(val: number): Query<T>;
+        all(path: string, val: number): Query<T>;
+        and(array: Object[]): Query<T>;
+        box(val: Object): Query<T>;
+        box(a: number[], b: number[]): Query<T>;
+        batchSize(val: number): Query<T>;
+        cast<U extends Document>(model: Model<U>, obj: Object): U;
+        //center(): Query<T>;
+        //centerSphere(path: string, val: Object): Query<T>;
+        circle(area: Object): Query<T>;
+        circle(path: string, area: Object): Query<T>;
+        comment(val: any): Query<T>;
+        count(callback?: (err: any, count: number) => void): Query<number>;
+        count(criteria: Object, callback?: (err: any, count: number) => void): Query<number>;
+        distinct(callback?: (err: any, res: T) => void): Query<T>;
+        distinct(field: string, callback?: (err: any, res: T) => void): Query<T>;
+        distinct(criteria: Object, field: string, callback?: (err: any, res: T) => void): Query<T>;
+        distinct(criteria: Query<T>, field: string, callback?: (err: any, res: T) => void): Query<T>;
+        elemMatch(criteria: Object): Query<T>;
+        elemMatch(criteria: (elem: Query<T>) => void): Query<T>;
+        elemMatch(path: string, criteria: Object): Query<T>;
+        elemMatch(path: string, criteria: (elem: Query<T>) => void): Query<T>;
+        equals(val: Object): Query<T>;
+        exists(val?: boolean): Query<T>;
+        exists(path: string, val?: boolean): Query<T>;
+        find(callback?: (err: any, res: T) => void): Query<T>;
+        find(criteria: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOne(callback?: (err: any, res: T) => void): Query<T>;
+        findOne(criteria: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndRemove(callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndRemove(cond: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndRemove(cond: Object, options: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndUpdate(callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndUpdate(update: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndUpdate(cond: Object, update: Object, callback?: (err: any, res: T) => void): Query<T>;
+        findOneAndUpdate(
+            cond: Object,
+            update: Object,
+            options: FindAndUpdateOption,
+            callback?: (err: any, res: T) => void,
+        ): Query<T>;
+        geometry(object: Object): Query<T>;
+        gt(val: number): Query<T>;
+        gt(path: string, val: number): Query<T>;
+        gte(val: number): Query<T>;
+        gte(path: string, val: number): Query<T>;
+        hint(val: Object): Query<T>;
+        in(val: any[]): Query<T>;
+        in(path: string, val: any[]): Query<T>;
+        intersects(arg?: Object): Query<T>;
+        lean(bool?: boolean): Query<T>;
+        limit(val: number): Query<T>;
+        lt(val: number): Query<T>;
+        lt(path: string, val: number): Query<T>;
+        lte(val: number): Query<T>;
+        lte(path: string, val: number): Query<T>;
+        maxDistance(val: number): Query<T>;
+        maxDistance(path: string, val: number): Query<T>;
+        maxScan(val: number): Query<T>;
+        merge(source: Query<T>): Query<T>;
+        merge(source: Object): Query<T>;
+        mod(val: number[]): Query<T>;
+        mod(path: string, val: number[]): Query<T>;
+        ne(val: any): Query<T>;
+        ne(path: string, val: any): Query<T>;
+        near(val: Object): Query<T>;
+        near(path: string, val: Object): Query<T>;
+        nearSphere(val: Object): Query<T>;
+        nearSphere(path: string, val: Object): Query<T>;
+        nin(val: any[]): Query<T>;
+        nin(path: string, val: any[]): Query<T>;
+        nor(array: Object[]): Query<T>;
+        or(array: Object[]): Query<T>;
+        polygon(...coordinatePairs: number[][]): Query<T>;
+        polygon(path: string, ...coordinatePairs: number[][]): Query<T>;
+        populate(path: string, select?: string, match?: Object, options?: Object): Query<T>;
+        populate(path: string, select: string, model: string, match?: Object, options?: Object): Query<T>;
+        populate(opt: PopulateOption): Query<T>;
+        read(pref: string, tags?: Object[]): Query<T>;
+        regex(val: RegExp): Query<T>;
+        regex(path: string, val: RegExp): Query<T>;
+        remove(callback?: (err: any, res: T) => void): Query<T>;
+        remove(criteria: Object, callback?: (err: any, res: T) => void): Query<T>;
+        select(arg: string): Query<T>;
+        select(arg: Object): Query<T>;
+        setOptions(options: Object): Query<T>;
+        size(val: number): Query<T>;
+        size(path: string, val: number): Query<T>;
+        skip(val: number): Query<T>;
+        slaveOk(v?: boolean): Query<T>;
+        slice(val: number): Query<T>;
+        slice(val: number[]): Query<T>;
+        slice(path: string, val: number): Query<T>;
+        slice(path: string, val: number[]): Query<T>;
+        snapshot(v?: boolean): Query<T>;
+        sort(arg: Object): Query<T>;
+        sort(arg: string): Query<T>;
+        stream(options?: { transform?: Function }): QueryStream;
+        tailable(v?: boolean): Query<T>;
+        toConstructor(): Query<T>;
+        update(callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
+        update(doc: Object, callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
+        update(criteria: Object, doc: Object, callback?: (err: any, affectedRows: number, doc: T) => void): Query<T>;
+        update(
+            criteria: Object,
+            doc: Object,
+            options: Object,
+            callback?: (err: any, affectedRows: number, doc: T) => void,
+        ): Query<T>;
+        where(path?: string, val?: any): Query<T>;
+        where(path?: Object, val?: any): Query<T>;
+        within(val?: Object): Query<T>;
+        within(coordinate: number[], ...coordinatePairs: number[][]): Query<T>;
+
+        $where(argument: string): Query<T>;
+        $where(argument: Function): Query<T>;
+
+        static use$geoWithin: boolean;
+    }
+
+    export interface PopulateOption {
+        path: string;
+        select?: string;
+        model?: string;
+        match?: Object;
+        options?: Object;
+    }
+
+    export interface QueryStream extends NodeJS.EventEmitter {
+        destory(err?: any): void;
+        pause(): void;
+        resume(): void;
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean }): T;
+        paused: number;
+        readable: boolean;
+    }
+
+    export interface Document {
+        id?: string;
+        _id: any;
+
+        equals(doc: Document): boolean;
+        get(path: string, type?: new (...args: any[]) => any): any;
+        inspect(options?: Object): string;
+        invalidate(path: string, errorMsg: string, value: any): void;
+        invalidate(path: string, error: Error, value: any): void;
+        isDirectModified(path: string): boolean;
+        isInit(path: string): boolean;
+        isModified(path?: string): boolean;
+        isSelected(path: string): boolean;
+        markModified(path: string): void;
+        modifiedPaths(): string[];
+        populate<T>(callback?: (err: any, res: T) => void): Document;
+        populate<T>(path?: string, callback?: (err: any, res: T) => void): Document;
+        populate<T>(opt: PopulateOption, callback?: (err: any, res: T) => void): Document;
+        populated(path: string): any;
+        remove<T>(callback?: (err: any) => void): Query<T>;
+        save<T>(callback?: (err: any, res: T) => void): void;
+        set(path: string, val: any, type?: new (...args: any[]) => any, options?: Object): void;
+        set(path: string, val: any, options?: Object): void;
+        set(value: Object): void;
+        toJSON(options?: Object): Object;
+        toObject(options?: Object): Object;
+        toString(): string;
+        update<T>(doc: Object, options: Object, callback: (err: any, affectedRows: number, raw: any) => void): Query<T>;
+        validate(cb: (err: any) => void): void;
+
+        isNew: boolean;
+        errors: Object;
+        schema: Object;
+    }
+
+    export class Aggregate<T> {
+        constructor(...options: Object[]);
+
+        append(...options: Object[]): Aggregate<T>;
+        group(arg: Object): Aggregate<T>;
+        limit(num: number): Aggregate<T>;
+        match(arg: Object): Aggregate<T>;
+        near(parameters: Object): Aggregate<T>;
+        project(arg: string): Aggregate<T>;
+        project(arg: Object): Aggregate<T>;
+        select(filter: string): Aggregate<T>;
+        skip(num: number): Aggregate<T>;
+        sort(arg: string): Aggregate<T>;
+        sort(arg: Object): Aggregate<T>;
+        unwind(fiels: string, ...rest: string[]): Aggregate<T>;
+
+        exec(callback?: (err: any, result: T) => void): Promise<T>;
+        read(pref: string, ...tags: Object[]): Aggregate<T>;
+    }
+
+    export class Promise<T> {
+        constructor(fn?: (err: any, result: T) => void);
+
+        then<U>(
+            onFulFill: (result: T) => void | U | Promise<U>,
+            onReject?: (err: any) => void | U | Promise<U>,
+        ): Promise<U>;
+        end(): void;
+
+        fulfill(result: T): Promise<T>;
+        reject(err: any): Promise<T>;
+        resolve(err: any, result: T): Promise<T>;
+
+        onFulfill(listener: (result: T) => void): Promise<T>;
+        onReject(listener: (err: any) => void): Promise<T>;
+        onResolve(listener: (err: any, result: T) => void): Promise<T>;
+        on(event: string, listener: Function): Promise<T>;
+
+        // Deprecated methods.
+        addBack(listener: (err: any, result: T) => void): Promise<T>;
+        addCallback(listener: (result: T) => void): Promise<T>;
+        addErrback(listener: (err: any) => void): Promise<T>;
+        complete(result: T): Promise<T>;
+        error(err: any): Promise<T>;
+    }
 }

--- a/types/mongoose/v3/mongoose-tests.ts
+++ b/types/mongoose/v3/mongoose-tests.ts
@@ -1,43 +1,50 @@
-var fs = require('fs');
-import mongoose = require('mongoose');
+var fs = require("fs");
+import mongoose = require("mongoose");
 
 var createInstance = new mongoose.Mongoose();
 
 var Schema = mongoose.Schema;
 var CreateSchema = new Schema({});
 
-mongoose.connect('mongodb://user:pass@localhost:port/database');
-mongoose.connect('mongodb://hostA:27501,hostB:27501', { mongos: true });
+mongoose.connect("mongodb://user:pass@localhost:port/database");
+mongoose.connect("mongodb://hostA:27501,hostB:27501", { mongos: true });
 
-var conn: mongoose.Connection = mongoose.createConnection('mongodb://user:pass@localhost:port/database');
-conn = mongoose.createConnection('mongodb://user:pass@localhost:port/database,mongodb://anotherhost:port,mongodb://yetanother:port', { replset: { strategy: 'ping', rs_name: 'testSet' }});
-conn = mongoose.createConnection('localhost', 'database', 27014);
-conn = mongoose.createConnection('localhost', 'database', 27014, { server: { auto_reconnect: false }, user: 'username', pass: 'mypassword' });
+var conn: mongoose.Connection = mongoose.createConnection("mongodb://user:pass@localhost:port/database");
+conn = mongoose.createConnection(
+    "mongodb://user:pass@localhost:port/database,mongodb://anotherhost:port,mongodb://yetanother:port",
+    { replset: { strategy: "ping", rs_name: "testSet" } },
+);
+conn = mongoose.createConnection("localhost", "database", 27014);
+conn = mongoose.createConnection("localhost", "database", 27014, {
+    server: { auto_reconnect: false },
+    user: "username",
+    pass: "mypassword",
+});
 conn = mongoose.createConnection();
-conn.open('localhost', 'database', 27014, {});
+conn.open("localhost", "database", 27014, {});
 
 var db = mongoose.createConnection();
 db.openSet("mongodb://user:pwd@localhost:27020/testing,mongodb://example.com:27020,mongodb://localhost:27019");
-db.openSet('mongodb://mongosA:27501,mongosB:27501', 'db', { mongos: true }, (err: any) => {});
+db.openSet("mongodb://mongosA:27501,mongosB:27501", "db", { mongos: true }, (err: any) => {});
 db.close();
 
-var collection = db.collection('collection1');
+var collection = db.collection("collection1");
 
-mongoose.connection.on('error', (err: any) => {});
+mongoose.connection.on("error", (err: any) => {});
 mongoose.disconnect();
 
-mongoose.set('test', 1234567890);
-var value = mongoose.get('test');
-mongoose.set('debug', true);
+mongoose.set("test", 1234567890);
+var value = mongoose.get("test");
+mongoose.set("debug", true);
 
 interface IActor extends mongoose.Document {
-  name: string;
+    name: string;
 }
-mongoose.model<IActor>('Actor', new Schema({ name: String }));
-db.model<IActor>('Actor', new Schema({ name: String }));
-var schema: mongoose.Schema = new Schema({ name: String }, { collection: 'actor' });
-schema.set('collection', 'actor');
-var Model = mongoose.model<IActor>('Actor', schema, 'actor');
+mongoose.model<IActor>("Actor", new Schema({ name: String }));
+db.model<IActor>("Actor", new Schema({ name: String }));
+var schema: mongoose.Schema = new Schema({ name: String }, { collection: "actor" });
+schema.set("collection", "actor");
+var Model = mongoose.model<IActor>("Actor", schema, "actor");
 
 interface IZip extends mongoose.Document {
     _id: string;
@@ -51,128 +58,132 @@ interface IThing extends mongoose.Document {
 
 var names: string[] = mongoose.modelNames();
 var names: string[] = db.modelNames();
-mongoose.plugin((schema: mongoose.Schema) => {
-}, { index: true });
-
+mongoose.plugin((schema: mongoose.Schema) => {}, { index: true });
 
 var aggregate = new mongoose.Aggregate();
 var aggregate = new mongoose.Aggregate({ $project: { a: 1, b: 1 } });
 var aggregate = new mongoose.Aggregate({ $project: { a: 1, b: 1 } }, { $skip: 5 });
 var aggregate = new mongoose.Aggregate([{ $project: { a: 1, b: 1 } }, { $skip: 5 }]);
-aggregate.append({ $project: { field: 1 }}, { $limit: 2 });
-aggregate.append([{ $match: { daw: 'Logic Audio X' }} ]);
+aggregate.append({ $project: { field: 1 } }, { $limit: 2 });
+aggregate.append([{ $match: { daw: "Logic Audio X" } }]);
 aggregate.group({ _id: "$department" });
 aggregate.skip(10);
 aggregate.limit(10);
-aggregate.match({ department: { $in: [ "sales", "engineering" ] } });
+aggregate.match({ department: { $in: ["sales", "engineering"] } });
 aggregate.near({
-  near: [40.724, -73.997],
-  distanceField: "dist.calculated", // required
-  maxDistance: 0.008,
-  query: { type: "public" },
-  includeLocs: "dist.location",
-  uniqueDocs: true,
-  num: 5
+    near: [40.724, -73.997],
+    distanceField: "dist.calculated", // required
+    maxDistance: 0.008,
+    query: { type: "public" },
+    includeLocs: "dist.location",
+    uniqueDocs: true,
+    num: 5,
 });
 aggregate.project("a b -_id");
-aggregate.project({a: 1, b: 1, _id: 0});
+aggregate.project({ a: 1, b: 1, _id: 0 });
 aggregate.project({
-  newField: '$b.nested',
-  plusTen: { $add: ['$val', 10]},
-  sub: {
-    name: '$a'
-  }
+    newField: "$b.nested",
+    plusTen: { $add: ["$val", 10] },
+    sub: {
+        name: "$a",
+    },
 });
-aggregate.project({ salary_k: { $divide: [ "$salary", 1000 ] } });
-aggregate.sort({ field: 'asc', test: -1 });
-aggregate.sort('field -test');
+aggregate.project({ salary_k: { $divide: ["$salary", 1000] } });
+aggregate.sort({ field: "asc", test: -1 });
+aggregate.sort("field -test");
 aggregate.unwind("tags");
 aggregate.unwind("a", "b", "c");
 var p = aggregate.exec();
-aggregate.read('primaryPreferred').exec((err: any, result: {}) => {});
+aggregate.read("primaryPreferred").exec((err: any, result: {}) => {});
 
-
-var p = new mongoose.Promise;
-var p2 = p.then(function() { throw new Error('shucks') }).end();
-setTimeout(function() {
-  p.fulfill({});
+var p = new mongoose.Promise();
+var p2 = p
+    .then(function () {
+        throw new Error("shucks");
+    })
+    .end();
+setTimeout(function () {
+    p.fulfill({});
 }, 10);
 var promise = new mongoose.Promise<number>();
-promise.then(function (meetups: number) {
-  return new mongoose.Promise<string[]>();
-}).then(function (people: string[]) {
-  if (people.length < 10000) {
-    throw new Error('Too few people!!!');
-  } else {
-    throw new Error('Still need more people!!!');
-  }
-}).then(null, function (err: Error) {
-}).end();
+promise
+    .then(function (meetups: number) {
+        return new mongoose.Promise<string[]>();
+    })
+    .then(function (people: string[]) {
+        if (people.length < 10000) {
+            throw new Error("Too few people!!!");
+        } else {
+            throw new Error("Still need more people!!!");
+        }
+    })
+    .then(null, function (err: Error) {})
+    .end();
 
+Model.findOne({ name: "john" }, (err: any, doc: mongoose.Document) => {
+    doc.invalidate("size", "must be less than 20", 14);
+    doc.validate((err: any) => {});
 
-Model.findOne({ name: 'john' }, (err: any, doc: mongoose.Document) => {
-  doc.invalidate('size', 'must be less than 20', 14);
-  doc.validate((err: any) => { });
+    doc.set("documents.0.title", "changed");
+    doc.get("documents.0");
+    doc.set({
+        path: 1,
+        path2: {
+            path: 2,
+        },
+    });
+    doc.set("path", "value", { strict: false });
+    doc.set("path3", "1", Number);
+    doc.get("path3", Number);
+    doc.id;
+    doc._id;
 
-  doc.set('documents.0.title', 'changed');
-  doc.get('documents.0');
-  doc.set({
-    'path' : 1,
-    'path2' : {
-      'path' : 2
-    }
-  });
-  doc.set('path', 'value', { strict: false });
-  doc.set('path3', '1', Number);
-  doc.get('path3', Number);
-  doc.id;
-  doc._id;
+    doc.isModified();
+    doc.isModified("documents");
+    doc.isModified("documents.0.title");
+    doc.isDirectModified("documents.0.title");
+    doc.isDirectModified("documents");
+    doc.isSelected("name");
 
-  doc.isModified();
-  doc.isModified('documents');
-  doc.isModified('documents.0.title');
-  doc.isDirectModified('documents.0.title');
-  doc.isDirectModified('documents');
-  doc.isSelected('name');
+    doc.markModified("mixed.type");
+    doc.populate("user");
+    doc.populate("other", (err: any, doc: mongoose.Document) => {});
+    doc.populated("author");
+    doc.save();
 
-  doc.markModified('mixed.type');
-  doc.populate('user');
-  doc.populate('other', (err: any, doc: mongoose.Document) => {});
-  doc.populated('author');
-  doc.save();
-
-  doc.toJSON({ getters: true, virtuals: false });
-  var data: any = doc.toObject();
-  delete data['age']; // tslint:disable-line no-dynamic-delete
-  delete data['weight']; // tslint:disable-line no-dynamic-delete
-  data['isAwesome'] = true;
+    doc.toJSON({ getters: true, virtuals: false });
+    var data: any = doc.toObject();
+    delete data["age"]; // tslint:disable-line no-dynamic-delete
+    delete data["weight"]; // tslint:disable-line no-dynamic-delete
+    data["isAwesome"] = true;
 });
 
-Model.model('User').findById('id', (err: any, res: IActor) => {});
-Model.count({ type: 'jungle' }, (err: any, count: number) => {});
+Model.model("User").findById("id", (err: any, res: IActor) => {});
+Model.count({ type: "jungle" }, (err: any, count: number) => {});
 Model.remove((err: any, res: IActor[]) => {});
 Model.save((err: any, res: IActor, numberAffected: number) => {});
-Model.create({ type: 'jelly bean' }, { type: 'snickers' }, (err: any, res1: IActor, res2: IActor) => {});
-Model.create({ type: 'jawbreaker' });
-Model.create({ type: 'muffin' }).then(function (res) {
+Model.create({ type: "jelly bean" }, { type: "snickers" }, (err: any, res1: IActor, res2: IActor) => {});
+Model.create({ type: "jawbreaker" });
+Model.create({ type: "muffin" }).then(function (res) {
     res.name;
 });
-Model.distinct('url', { clicks: {$gt: 100}}, (err: any, result: IActor[]) => {});
-Model.distinct('url');
+Model.distinct("url", { clicks: { $gt: 100 } }, (err: any, result: IActor[]) => {});
+Model.distinct("url");
 
 Model.aggregate(
-  { $group: { _id: null, maxBalance: { $max: '$balance' }}},
-  { $project: { _id: 0, maxBalance: 1 }},
-  (err: any, res: IActor[]) => {});
+    { $group: { _id: null, maxBalance: { $max: "$balance" } } },
+    { $project: { _id: 0, maxBalance: 1 } },
+    (err: any, res: IActor[]) => {},
+);
 Model.aggregate()
-  .group({ _id: null, maxBalance: { $max: '$balance' } })
-  .select('-id maxBalance')
-  .exec((err: any, res: IActor[]) => {});
-Model.ensureIndexes((err) => {});
+    .group({ _id: null, maxBalance: { $max: "$balance" } })
+    .select("-id maxBalance")
+    .exec((err: any, res: IActor[]) => {});
+Model.ensureIndexes(err => {});
 
-Model.find({ name: 'john', age: { $gte: 18 }});
-Model.find({ name: 'john', age: { $gte: 18 }}, (err: any, docs: IActor[]) => {});
-Model.find({ name: /john/i }, 'name friends', (err: any, docs: IActor[]) => {});
+Model.find({ name: "john", age: { $gte: 18 } });
+Model.find({ name: "john", age: { $gte: 18 } }, (err: any, docs: IActor[]) => {});
+Model.find({ name: /john/i }, "name friends", (err: any, docs: IActor[]) => {});
 Model.find({ name: /john/i }, null, { skip: 10 });
 Model.find({ name: /john/i }, null, { skip: 10 }, (err: any, docs: IActor[]) => {});
 Model.find({ name: /john/i }, null, { skip: 10 }).exec((err: any, docs: IActor[]) => {});
@@ -180,207 +191,279 @@ var query = Model.find({ name: /john/i }, null, { skip: 10 });
 var promise1 = query.exec();
 promise1.addBack((err: any, docs: IActor[]) => {});
 
-Model.findById('id', (err: any, res: IActor) => {});
-Model.findById('id').exec((err: any, res: IActor) => {});
-Model.findById('id', 'name length', (err: any, res: IActor) => {});
-Model.findById('id', '-length').exec((err: any, res: IActor) => {});
-Model.findById('id', 'name', { lean: true }, (err: any, res: IActor) => {});
-Model.findById('id', 'name').lean().exec((err: any, res: IActor) => {});
-Model.findByIdAndRemove('id1', { select: 'name' }, (err: any, res: IActor) => {});
-Model.findByIdAndRemove('id1', { select: 'name' }).exec((err: any, res: IActor) => {});
-Model.findByIdAndRemove('id1', (err: any, res: IActor) => {});
-Model.findByIdAndRemove('id1').exec((err: any, res: IActor) => {});
-Model.findByIdAndUpdate('id2', { $set: { name: 'jason borne' }}, { upsert: true }, (err: any, res: IActor) => {});
+Model.findById("id", (err: any, res: IActor) => {});
+Model.findById("id").exec((err: any, res: IActor) => {});
+Model.findById("id", "name length", (err: any, res: IActor) => {});
+Model.findById("id", "-length").exec((err: any, res: IActor) => {});
+Model.findById("id", "name", { lean: true }, (err: any, res: IActor) => {});
+Model.findById("id", "name")
+    .lean()
+    .exec((err: any, res: IActor) => {});
+Model.findByIdAndRemove("id1", { select: "name" }, (err: any, res: IActor) => {});
+Model.findByIdAndRemove("id1", { select: "name" }).exec((err: any, res: IActor) => {});
+Model.findByIdAndRemove("id1", (err: any, res: IActor) => {});
+Model.findByIdAndRemove("id1").exec((err: any, res: IActor) => {});
+Model.findByIdAndUpdate("id2", { $set: { name: "jason borne" } }, { upsert: true }, (err: any, res: IActor) => {});
 
-Model.findOne({ type: 'iphone' }, (err: any, res: IActor) => {});
-Model.findOne({ type: 'iphone' }).exec((err: any, res: IActor) => {});
-Model.findOne({ type: 'iphone' }, 'name', (err: any, res: IActor) => {});
-Model.findOne({ type: 'iphone' }, 'name').exec((err: any, res: IActor) => {});
-Model.findOne({ type: 'iphone' }, 'name', { lean: true }, (err: any, res: IActor) => {});
-Model.findOne({ type: 'iphone' }, 'name', { lean: true }).exec((err: any, res: IActor) => {});
-Model.findOne({ type: 'iphone' }).select('name').lean().exec((err: any, res: IActor) => {});
-Model.findOneAndRemove({ type: 'iphone' }, { select: 'name' }, (err: any, res: IActor) => {});
-Model.findOneAndRemove({ type: 'iphone' }, { select: 'name' }).exec((err: any, res: IActor) => {});
-Model.findOneAndUpdate({ type: 'iphone' }, { $set: { name: 'jason borne' }}, { upsert: true }, (err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" }, (err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" }).exec((err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" }, "name", (err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" }, "name").exec((err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" }, "name", { lean: true }, (err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" }, "name", { lean: true }).exec((err: any, res: IActor) => {});
+Model.findOne({ type: "iphone" })
+    .select("name")
+    .lean()
+    .exec((err: any, res: IActor) => {});
+Model.findOneAndRemove({ type: "iphone" }, { select: "name" }, (err: any, res: IActor) => {});
+Model.findOneAndRemove({ type: "iphone" }, { select: "name" }).exec((err: any, res: IActor) => {});
+Model.findOneAndUpdate(
+    { type: "iphone" },
+    { $set: { name: "jason borne" } },
+    { upsert: true },
+    (err: any, res: IActor) => {},
+);
 
-Model.geoNear([1, 3], { maxDistance : 5, spherical : true }, (err: any, res: IActor[], stats: any) => {});
-Model.geoNear({ type : "Point", coordinates : [9,9] }, { maxDistance : 5, spherical : true }, (err: any, res: IActor[], stats: any) => {});
-Model.geoSearch({ type : "house" }, { near: [10, 10], maxDistance: 5 }, (err: any, res: IActor[]) => {});
+Model.geoNear([1, 3], { maxDistance: 5, spherical: true }, (err: any, res: IActor[], stats: any) => {});
+Model.geoNear(
+    { type: "Point", coordinates: [9, 9] },
+    { maxDistance: 5, spherical: true },
+    (err: any, res: IActor[], stats: any) => {},
+);
+Model.geoSearch({ type: "house" }, { near: [10, 10], maxDistance: 5 }, (err: any, res: IActor[]) => {});
 
 var o = {
-  map: function () { this.emit(this.name, 1) },
-  reduce: function (k: string, vals: IActor[]) { return vals.length },
+    map: function () {
+        this.emit(this.name, 1);
+    },
+    reduce: function (k: string, vals: IActor[]) {
+        return vals.length;
+    },
 };
 Model.mapReduce(o, (err: any, res: any[]) => {});
 
-Model.findById('id', (err: any, res: IActor) => {
-  var opts = [
-    { path: 'company', match: { x: 1 }, select: 'name' },
-    { path: 'notes', options: { limit: 10 }, model: 'override' }
-  ];
-  Model.populate(res, opts, (err: any, res: IActor) => {});
+Model.findById("id", (err: any, res: IActor) => {
+    var opts = [
+        { path: "company", match: { x: 1 }, select: "name" },
+        { path: "notes", options: { limit: 10 }, model: "override" },
+    ];
+    Model.populate(res, opts, (err: any, res: IActor) => {});
 });
-Model.find({ type: 'iphone' }, (err: any, res: IActor[]) => {
-  var opts = [{ path: 'company', match: { x: 1 }, select: 'name' }];
-  var promise = Model.populate(res, opts);
-  promise.then(console.log).end();
+Model.find({ type: "iphone" }, (err: any, res: IActor[]) => {
+    var opts = [{ path: "company", match: { x: 1 }, select: "name" }];
+    var promise = Model.populate(res, opts);
+    promise.then(console.log).end();
 });
-Model.populate({ name: 'Test A' }, { path: 'weapon', model: 'Weapon' }, (err: any, user: { name: string }) => {});
-Model.populate([
-  { name: 'User hoge' },
-  { name: 'User fuga' },
-], { path: 'weapon' }, (err: any, users: { name: string }[]) => {});
+Model.populate({ name: "Test A" }, { path: "weapon", model: "Weapon" }, (err: any, user: { name: string }) => {});
+Model.populate(
+    [{ name: "User hoge" }, { name: "User fuga" }],
+    { path: "weapon" },
+    (err: any, users: { name: string }[]) => {},
+);
 
-Model.remove({ title: 'baby born from alien father' }, (err: any) => {});
-var query2 = Model.remove({ _id: 'id' });
+Model.remove({ title: "baby born from alien father" }, (err: any) => {});
+var query2 = Model.remove({ _id: "id" });
 query2.exec();
 Model.update({ age: { $gt: 18 } }, { oldEnough: true }, (err: any, numberAffected: number, raw: any) => {});
-Model.update({ name: 'Tobi' }, { ferret: true }, { multi: true }, (err: any, numberAffected: number, raw: any) => {});
-Model.update({ _id: 'id' }, { $set: { text: 'changed' }}).exec();
+Model.update({ name: "Tobi" }, { ferret: true }, { multi: true }, (err: any, numberAffected: number, raw: any) => {});
+Model.update({ _id: "id" }, { $set: { text: "changed" } }).exec();
 
-Model.where('age').gte(21).lte(65).exec((err: any, res: IActor[]) => {});
-var query3 =Model
-  .where('age').gt(21).lt(65)
-  .where('name', /^b/i).all('type', 1);
+Model.where("age")
+    .gte(21)
+    .lte(65)
+    .exec((err: any, res: IActor[]) => {});
+var query3 = Model.where("age").gt(21).lt(65).where("name", /^b/i).all("type", 1);
 query3.all(25);
-query3.and([{ color: 'green' }, { status: 'ok' }]);
+query3.and([{ color: "green" }, { status: "ok" }]);
 query3.batchSize(100);
-query3.where('loc').within().box([40.73083, -73.99756], [40.741404,  -73.988135]);
-query3.where('loc').within().circle({ center: [50, 50], radius: 10, unique: true });
-query3.circle('loc', { center: [50, 50], radius: 10, unique: true });
-query3.comment('login query');
-query3.where({ 'color': 'black' }).count();
-query3.count({ color: 'black' }).count((err: any, count: number) => {});
-query3.count({ color: 'black' }, (err: any, count: number) => {});
-query3.where({ color: 'black' }).count((err: any, count: number) => {});
-query3.elemMatch('comment', { author: 'autobot', votes: {$gte: 5}});
-query3.where('comment').elemMatch({ author: 'autobot', votes: {$gte: 5}});
-query.elemMatch('comment', (elem: mongoose.Query<IActor>) => {
-  elem.where('author').equals('autobot');
-  elem.where('votes').gte(5);
+query3.where("loc").within().box([40.73083, -73.99756], [40.741404, -73.988135]);
+query3
+    .where("loc")
+    .within()
+    .circle({ center: [50, 50], radius: 10, unique: true });
+query3.circle("loc", { center: [50, 50], radius: 10, unique: true });
+query3.comment("login query");
+query3.where({ color: "black" }).count();
+query3.count({ color: "black" }).count((err: any, count: number) => {});
+query3.count({ color: "black" }, (err: any, count: number) => {});
+query3.where({ color: "black" }).count((err: any, count: number) => {});
+query3.elemMatch("comment", { author: "autobot", votes: { $gte: 5 } });
+query3.where("comment").elemMatch({ author: "autobot", votes: { $gte: 5 } });
+query.elemMatch("comment", (elem: mongoose.Query<IActor>) => {
+    elem.where("author").equals("autobot");
+    elem.where("votes").gte(5);
 });
-query3.where('age').equals(49);
-query3.where('age', 49);
+query3.where("age").equals(49);
+query3.where("age", 49);
 query3.exec();
-query3.exec('update');
-query3.where('name').exists();
-query3.where('name').exists(true);
-query3.find().exists('name');
-query3.where('name').exists(false);
-query3.find().exists('name', false);
-query3.find({ name: 'Los Pollos Hermanos' }).find((err: any, res: IActor[]) => {});
-query3.where('loc').within().geometry({ type: 'Polygon', coordinates: [[[ 10, 20 ], [ 10, 40 ], [ 30, 40 ], [ 30, 20 ]]] });
-query3.find().where('age').gt(21);
-query3.find().gt('age', 21);
-query3.hint({ indexA: 1, indexB: -1});
-query3.where('path').intersects().geometry({ type: 'LineString', coordinates: [[180.0, 11.0], [180, 9.0]] });
-query3.where('path').intersects({ type: 'LineString', coordinates: [[180.0, 11.0], [180, 9.0]] });
+query3.exec("update");
+query3.where("name").exists();
+query3.where("name").exists(true);
+query3.find().exists("name");
+query3.where("name").exists(false);
+query3.find().exists("name", false);
+query3.find({ name: "Los Pollos Hermanos" }).find((err: any, res: IActor[]) => {});
+query3
+    .where("loc")
+    .within()
+    .geometry({
+        type: "Polygon",
+        coordinates: [
+            [
+                [10, 20],
+                [10, 40],
+                [30, 40],
+                [30, 20],
+            ],
+        ],
+    });
+query3.find().where("age").gt(21);
+query3.find().gt("age", 21);
+query3.hint({ indexA: 1, indexB: -1 });
+query3
+    .where("path")
+    .intersects()
+    .geometry({
+        type: "LineString",
+        coordinates: [
+            [180.0, 11.0],
+            [180, 9.0],
+        ],
+    });
+query3.where("path").intersects({
+    type: "LineString",
+    coordinates: [
+        [180.0, 11.0],
+        [180, 9.0],
+    ],
+});
 query3.maxScan(100);
-query3.where('loc').near({ center: [10, 10] });
-query3.where('loc').near({ center: [10, 10], maxDistance: 5 });
-query3.where('loc').near({ center: [10, 10], maxDistance: 5, spherical: true });
-query3.near('loc', { center: [10, 10], maxDistance: 5 });
-query3.where('loc').nearSphere({ center: [10, 10], maxDistance: 5 });
-query3.nor([{ color: 'green' }, { status: 'ok' }]);
-query3.or([{ color: 'red' }, { status: 'emergency' }]);
-query3.where('loc').within().polygon([10,20], [13, 25], [7,15]);
-query3.polygon('loc', [10,20], [13, 25], [7,15]);
+query3.where("loc").near({ center: [10, 10] });
+query3.where("loc").near({ center: [10, 10], maxDistance: 5 });
+query3.where("loc").near({ center: [10, 10], maxDistance: 5, spherical: true });
+query3.near("loc", { center: [10, 10], maxDistance: 5 });
+query3.where("loc").nearSphere({ center: [10, 10], maxDistance: 5 });
+query3.nor([{ color: "green" }, { status: "ok" }]);
+query3.or([{ color: "red" }, { status: "emergency" }]);
+query3.where("loc").within().polygon([10, 20], [13, 25], [7, 15]);
+query3.polygon("loc", [10, 20], [13, 25], [7, 15]);
 
-query3.findOne().populate('owner').exec((err: any, res: IActor[]) => {});
-query3.find().populate({
-  path: 'owner',
-  select: 'name',
-  match: { color: 'black' },
-  options: { sort: { name: -1 }}
-}).exec((err: any, res: IActor[]) => {});
-query3.find().populate('owner', 'name', null, {sort: { name: -1 }}).exec((err: any, res: IActor[]) => {});
+query3
+    .findOne()
+    .populate("owner")
+    .exec((err: any, res: IActor[]) => {});
+query3
+    .find()
+    .populate({
+        path: "owner",
+        select: "name",
+        match: { color: "black" },
+        options: { sort: { name: -1 } },
+    })
+    .exec((err: any, res: IActor[]) => {});
+query3
+    .find()
+    .populate("owner", "name", null, { sort: { name: -1 } })
+    .exec((err: any, res: IActor[]) => {});
 
-query3.read('primary');
-query3.read('p');
-query3.read('primaryPreferred');
-query3.read('pp');
-query3.read('secondary');
-query3.read('s');
-query3.read('secondaryPreferred');
-query3.read('sp');
-query3.read('nearest');
-query3.read('n');
-query3.read('s', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }]);
-query3.remove({ artist: 'Anne Murray' }, (err: any, res: IActor[]) => {});
-query3.select('a b -c');
-query3.select({a: 1, b: 1, c: 0});
-query3.select('+path');
-query3.where('tags').size(0);
+query3.read("primary");
+query3.read("p");
+query3.read("primaryPreferred");
+query3.read("pp");
+query3.read("secondary");
+query3.read("s");
+query3.read("secondaryPreferred");
+query3.read("sp");
+query3.read("nearest");
+query3.read("n");
+query3.read("s", [
+    { dc: "sf", s: 1 },
+    { dc: "ma", s: 2 },
+]);
+query3.remove({ artist: "Anne Murray" }, (err: any, res: IActor[]) => {});
+query3.select("a b -c");
+query3.select({ a: 1, b: 1, c: 0 });
+query3.select("+path");
+query3.where("tags").size(0);
 query3.skip(100).limit(20);
 query3.slaveOk();
 query3.slaveOk(true);
 query3.slaveOk(false);
-query3.slice('comments', -5);
-query3.slice('comments', [10, 5])
-query3.where('comments').slice(5);
-query3.where('comments').slice([-10, 5]);
+query3.slice("comments", -5);
+query3.slice("comments", [10, 5]);
+query3.where("comments").slice(5);
+query3.where("comments").slice([-10, 5]);
 query3.snapshot();
 query3.snapshot(true);
 query3.snapshot(false);
-query3.sort({ field: 'asc', test: -1 });
-query3.sort('field -test');
-Model.find({ name: /^hello/ }).stream({ transform: JSON.stringify }).pipe(fs.createWriteStream('./test.json'));
+query3.sort({ field: "asc", test: -1 });
+query3.sort("field -test");
+Model.find({ name: /^hello/ })
+    .stream({ transform: JSON.stringify })
+    .pipe(fs.createWriteStream("./test.json"));
 var stream = Model.find({ name: /^hello/ }).stream();
 stream
-  .on('data', (doc: IActor) => {})
-  .on('error', (err: any) => {})
-  .on('close', () => {});
+    .on("data", (doc: IActor) => {})
+    .on("error", (err: any) => {})
+    .on("close", () => {});
 
 query3.tailable();
 query3.tailable(false);
 var AdvQuery = query3.toConstructor();
-query3.update({ title: 'words' });
-query3.update({ $set: { title: 'words' }});
-query3.update({ name: /^match/ }, { $set: { arr: [] }}, { multi: true }, (err: any, row: number, raw: any) => {});
+query3.update({ title: "words" });
+query3.update({ $set: { title: "words" } });
+query3.update({ name: /^match/ }, { $set: { arr: [] } }, { multi: true }, (err: any, row: number, raw: any) => {});
 
-query3.where('loc').within({ center: [50,50], radius: 10, unique: true, spherical: true });
-query3.where('loc').within({ box: [[40.73, -73.9], [40.7, -73.988]] });
-query3.where('loc').within({ polygon: [[],[],[],[]] });
-query3.where('loc').within([], [], []); // polygon
-query3.where('loc').within([], []); // box
-query3.where('loc').within({ type: 'LineString', coordinates: [] }); // geometry
+query3.where("loc").within({ center: [50, 50], radius: 10, unique: true, spherical: true });
+query3.where("loc").within({
+    box: [
+        [40.73, -73.9],
+        [40.7, -73.988],
+    ],
+});
+query3.where("loc").within({ polygon: [[], [], [], []] });
+query3.where("loc").within([], [], []); // polygon
+query3.where("loc").within([], []); // box
+query3.where("loc").within({ type: "LineString", coordinates: [] }); // geometry
 
 mongoose.Query.use$geoWithin = false;
 
-
 var ToySchema = new Schema({});
-ToySchema.add({ name: 'string', color: 'string', price: 'number' });
-schema.eachPath(function(path: string, value: any) {});
+ToySchema.add({ name: "string", color: "string", price: "number" });
+schema.eachPath(function (path: string, value: any) {});
 schema.index({ first: 1, last: -1 });
 schema.indexes();
-schema.method('meow', function() {
-  console.log('meeeeeoooooooooooow');
+schema.method("meow", function () {
+    console.log("meeeeeoooooooooooow");
 });
-var Kitty = mongoose.model<IActor>('Kitty', schema);
-var fizz: any = new Kitty({ name: 'kitty' });
+var Kitty = mongoose.model<IActor>("Kitty", schema);
+var fizz: any = new Kitty({ name: "kitty" });
 fizz.meow();
 schema.method({
-  purr: function() {},
-  scratch: function() {},
+    purr: function () {},
+    scratch: function () {},
 });
-schema.path('name');
-schema.path('name', Number);
-schema.pathType('name');
-schema.plugin(function() {});
-schema.post('save', function(doc: IActor) {});
-schema.pre('save', function(next: () => void) {});
+schema.path("name");
+schema.path("name", Number);
+schema.pathType("name");
+schema.plugin(function () {});
+schema.post("save", function (doc: IActor) {});
+schema.pre("save", function (next: () => void) {});
 schema.requiredPaths();
-schema.static('findByName', function(name: string, callback: () => void) {});
-schema.virtual('display_name')
-  .get(function(): string { return this.name; })
-  .set((value: string): void => {});
+schema.static("findByName", function (name: string, callback: () => void) {});
+schema
+    .virtual("display_name")
+    .get(function (): string {
+        return this.name;
+    })
+    .set((value: string): void => {});
 
-var id: mongoose.Types.ObjectId = new mongoose.Types.ObjectId('foo');
+var id: mongoose.Types.ObjectId = new mongoose.Types.ObjectId("foo");
 var id: mongoose.Types.ObjectId = new mongoose.Types.ObjectId();
 var id2: mongoose.Types.ObjectId = new mongoose.Types.ObjectId(123);
 var id2: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromTime(123);
-var id2: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString('foo');
-var isValid:boolean = mongoose.Types.ObjectId.isValid('570d350b67b1ae0600e8bee8');
+var id2: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString("foo");
+var isValid: boolean = mongoose.Types.ObjectId.isValid("570d350b67b1ae0600e8bee8");
 var s = id.toHexString();
 var valid = id.isValid();
 var eq = id.equals(id2);
@@ -401,13 +484,12 @@ function logger(modelName: string, timestamp: string) {
 
 function AwesomeLoggerPlugin(schema: mongoose.Schema, options?: PluginOption) {
     if (options) {
-        schema.pre('save', function (next: Function) {
-            logger(options.modelName, options.timestamp)
-        })
+        schema.pre("save", function (next: Function) {
+            logger(options.modelName, options.timestamp);
+        });
     }
 }
 
-new mongoose.Schema({})
-    .plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', timestamp: 'yyyy/MM/dd'})
+new mongoose.Schema({}).plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", timestamp: "yyyy/MM/dd" });
 
-mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', timestamp: 'yyyy/MM/dd'})
+mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", timestamp: "yyyy/MM/dd" });

--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -11,7 +11,6 @@
 /// <reference types="mongodb" />
 /// <reference types="node" />
 
-
 /*
  * Guidelines for maintaining these definitions:
  * - If you spot an error here or there, please submit a PR.
@@ -79,2879 +78,2985 @@ To find a section, CTRL+F and type "section ___.js"
  */
 
 declare module "mongoose" {
-  import events = require('events');
-  import mongodb = require('mongodb');
-  import stream = require('stream');
-  import mongoose = require('mongoose');
+    import events = require("events");
+    import mongodb = require("mongodb");
+    import stream = require("stream");
+    import mongoose = require("mongoose");
 
-  /*
-   * Some mongoose classes have the same name as the native JS classes
-   * Keep references to native classes using a "Native" prefix
-   */
-  class NativeBuffer extends global.Buffer {}
-  class NativeDate extends global.Date {}
-  class NativeError extends global.Error {}
-
-  /*
-   * section index.js
-   * http://mongoosejs.com/docs/api.html#index-js
-   */
-  export var DocumentProvider: any;
-  // recursive constructor
-  export var Mongoose: new(...args: any[]) => typeof mongoose;
-  type Mongoose = typeof mongoose;
-  export var SchemaTypes: typeof Schema.Types;
-
-  /** Expose connection states for user-land */
-  export var STATES: any;
-  /** The default connection of the mongoose module. */
-  export var connection: Connection;
-  /** The node-mongodb-native driver Mongoose uses. */
-  export var mongo: typeof mongodb;
-  /** The Mongoose version */
-  export var version: string;
-
-  /**
-   * Opens the default mongoose connection.
-   * Options passed take precedence over options included in connection strings.
-   * @returns pseudo-promise wrapper around this
-   */
-  export function connect(uris: string,
-    options?: ConnectionOptions,
-    callback?: (err: mongodb.MongoError) => void): MongooseThenable;
-  export function connect(uris: string,
-    callback?: (err: mongodb.MongoError) => void): MongooseThenable;
-
-  /**
-   * Creates a Connection instance.
-   * Each connection instance maps to a single database. This method is helpful
-   *   when mangaging multiple db connections.
-   * @param uri a mongodb:// URI
-   * @param options options to pass to the driver
-   * @returns the created Connection object
-   */
-  export function createConnection(): Connection;
-  export function createConnection(uri: string,
-    options?: ConnectionOptions
-  ): Connection;
-  export function createConnection(host: string, database_name: string, port?: number,
-    options?: ConnectionOptions
-  ): Connection;
-
-  /**
-   * Disconnects all connections.
-   * @param fn called after all connection close.
-   * @returns pseudo-promise wrapper around this
-   */
-  export function disconnect(fn?: (error: any) => void): MongooseThenable;
-
-  /** Gets mongoose options */
-  export function get(key: string): any;
-
-  /**
-   * Defines a model or retrieves it.
-   * Models defined on the mongoose instance are available to all connection
-   *   created by the same mongoose instance.
-   * @param name model name
-   * @param collection (optional, induced from model name)
-   * @param skipInit whether to skip initialization (defaults to false)
-   */
-  export function model<T extends Document>(name: string, schema?: Schema, collection?: string,
-    skipInit?: boolean): Model<T>;
-  export function model<T extends Document, U extends Model<T>>(
-    name: string,
-    schema?: Schema,
-    collection?: string,
-    skipInit?: boolean
-  ): U;
-
-  /**
-   * Returns an array of model names created on this instance of Mongoose.
-   * Does not include names of models created using connection.model().
-   */
-  export function modelNames(): string[];
-
-  /**
-   * Declares a global plugin executed on all Schemas.
-   * Equivalent to calling .plugin(fn) on each Schema you create.
-   * @param fn plugin callback
-   * @param opts optional options
-   */
-  export function plugin(fn: Function): typeof mongoose;
-  export function plugin<T>(fn: Function, opts: T): typeof mongoose;
-
-  /** Sets mongoose options */
-  export function set(key: string, value: any): void;
-
-  type MongooseThenable = typeof mongoose & {
-    /**
-     * Ability to use mongoose object as a pseudo-promise so .connect().then()
-     * and .disconnect().then() are viable.
+    /*
+     * Some mongoose classes have the same name as the native JS classes
+     * Keep references to native classes using a "Native" prefix
      */
-    then<TRes>(onFulfill?: () => void | TRes | PromiseLike<TRes>,
-      onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
+    class NativeBuffer extends global.Buffer {}
+    class NativeDate extends global.Date {}
+    class NativeError extends global.Error {}
+
+    /*
+     * section index.js
+     * http://mongoosejs.com/docs/api.html#index-js
+     */
+    export var DocumentProvider: any;
+    // recursive constructor
+    export var Mongoose: new (...args: any[]) => typeof mongoose;
+    type Mongoose = typeof mongoose;
+    export var SchemaTypes: typeof Schema.Types;
+
+    /** Expose connection states for user-land */
+    export var STATES: any;
+    /** The default connection of the mongoose module. */
+    export var connection: Connection;
+    /** The node-mongodb-native driver Mongoose uses. */
+    export var mongo: typeof mongodb;
+    /** The Mongoose version */
+    export var version: string;
 
     /**
-     * Ability to use mongoose object as a pseudo-promise so .connect().then()
-     * and .disconnect().then() are viable.
+     * Opens the default mongoose connection.
+     * Options passed take precedence over options included in connection strings.
+     * @returns pseudo-promise wrapper around this
      */
-    catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
-  }
-
-  class CastError extends Error {
-    /**
-     * The Mongoose CastError constructor
-     * @param type The name of the type
-     * @param value The value that failed to cast
-     * @param path The path a.b.c in the doc where this cast error occurred
-     * @param reason The original error that was thrown
-     */
-    constructor(type: string, value: any, path: string, reason?: NativeError);
-  }
-
-  /*
-   * section querystream.js
-   * http://mongoosejs.com/docs/api.html#querystream-js
-   *
-   * QueryStream can only be accessed using query#stream(), we only
-   *   expose its interface here.
-   */
-  class QueryStream extends stream.Stream {
-    /**
-     * Provides a Node.js 0.8 style ReadStream interface for Queries.
-     * @event data emits a single Mongoose document
-     * @event error emits when an error occurs during streaming. This will emit before the close event.
-     * @event close emits when the stream reaches the end of the cursor or an error occurs, or the stream
-     *   is manually destroyed. After this event, no more events are emitted.
-     */
-    constructor(query: Query<any>, options?: {
-      /**
-       * optional function which accepts a mongoose document. The return value
-       * of the function will be emitted on data.
-       */
-      transform?: Function;
-      [other: string]: any;
-    });
+    export function connect(
+        uris: string,
+        options?: ConnectionOptions,
+        callback?: (err: mongodb.MongoError) => void,
+    ): MongooseThenable;
+    export function connect(uris: string, callback?: (err: mongodb.MongoError) => void): MongooseThenable;
 
     /**
-     * Destroys the stream, closing the underlying cursor, which emits the close event.
-     * No more events will be emitted after the close event.
+     * Creates a Connection instance.
+     * Each connection instance maps to a single database. This method is helpful
+     *   when mangaging multiple db connections.
+     * @param uri a mongodb:// URI
+     * @param options options to pass to the driver
+     * @returns the created Connection object
      */
-    destroy(err?: NativeError): void;
-
-    /** Pauses this stream. */
-    pause(): void;
-    /** Pipes this query stream into another stream. This method is inherited from NodeJS Streams. */
-    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
-    /** Resumes this stream. */
-    resume(): void;
-
-    /** Flag stating whether or not this stream is paused. */
-    paused: boolean;
-    /** Flag stating whether or not this stream is readable. */
-    readable: boolean;
-  }
-
-  /*
-   * section connection.js
-   * http://mongoosejs.com/docs/api.html#connection-js
-   *
-   * The Connection class exposed by require('mongoose')
-   *   is actually the driver's NativeConnection class.
-   *   connection.js defines a base class that the native
-   *   versions extend. See:
-   *   http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
-   */
-  abstract class ConnectionBase extends events.EventEmitter {
-    /**
-     * For practical reasons, a Connection equals a Db.
-     * @param base a mongoose instance
-     * @event connecting Emitted when connection.{open,openSet}() is executed on this connection.
-     * @event connected Emitted when this connection successfully connects to the db. May be emitted multiple times in reconnected scenarios.
-     * @event open Emitted after we connected and onOpen is executed on all of this connections models.
-     * @event disconnecting Emitted when connection.close() was executed.
-     * @event disconnected Emitted after getting disconnected from the db.
-     * @event close Emitted after we disconnected and onClose executed on all of this connections models.
-     * @event reconnected Emitted after we connected and subsequently disconnected, followed by successfully another successfull connection.
-     * @event error Emitted when an error occurs on this connection.
-     * @event fullsetup Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
-     * @event all Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
-     */
-    constructor(base: typeof mongoose);
+    export function createConnection(): Connection;
+    export function createConnection(uri: string, options?: ConnectionOptions): Connection;
+    export function createConnection(
+        host: string,
+        database_name: string,
+        port?: number,
+        options?: ConnectionOptions,
+    ): Connection;
 
     /**
-     * Opens the connection to MongoDB.
-     * @param mongodb://uri or the host to which you are connecting
-     * @param database database name
-     * @param port database port
-     * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
-     *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
-     *   See the node-mongodb-native driver instance for options that it understands.
-     *   Options passed take precedence over options included in connection strings.
+     * Disconnects all connections.
+     * @param fn called after all connection close.
+     * @returns pseudo-promise wrapper around this
      */
-    open(connection_string: string, database?: string, port?: number,
-      options?: ConnectionOpenOptions, callback?: (err: any) => void): any;
+    export function disconnect(fn?: (error: any) => void): MongooseThenable;
 
-    /** Helper for dropDatabase() */
-    dropDatabase(callback?: (err: any) => void): Promise<void>;
+    /** Gets mongoose options */
+    export function get(key: string): any;
 
     /**
-     * Opens the connection to a replica set.
-     * @param uris comma-separated mongodb:// URIs
-     * @param database database name if not included in uris
-     * @param options passed to the internal driver
+     * Defines a model or retrieves it.
+     * Models defined on the mongoose instance are available to all connection
+     *   created by the same mongoose instance.
+     * @param name model name
+     * @param collection (optional, induced from model name)
+     * @param skipInit whether to skip initialization (defaults to false)
      */
-    openSet(uris: string, database?: string, options?: ConnectionOpenSetOptions,
-      callback?: (err: any) => void): any;
-
-    /** Closes the connection */
-    close(callback?: (err: any) => void): Promise<void>;
-
-    /**
-     * Retrieves a collection, creating it if not cached.
-     * Not typically needed by applications. Just talk to your collection through your model.
-     * @param name name of the collection
-     * @param options optional collection options
-     */
-    collection(name: string, options?: any): Collection;
-
-    /**
-     * Defines or retrieves a model.
-     * When no collection argument is passed, Mongoose produces a collection name by passing
-     * the model name to the utils.toCollectionName method. This method pluralizes the name.
-     * If you don't like this behavior, either pass a collection name or set your schemas
-     * collection name option.
-     * @param name the model name
-     * @param schema a schema. necessary when defining a model
-     * @param collection name of mongodb collection (optional) if not given it will be induced from model name
-     * @returns The compiled model
-     */
-    model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
-    model<T extends Document, U extends Model<T>>(
-      name: string,
-      schema?: Schema,
-      collection?: string
+    export function model<T extends Document>(
+        name: string,
+        schema?: Schema,
+        collection?: string,
+        skipInit?: boolean,
+    ): Model<T>;
+    export function model<T extends Document, U extends Model<T>>(
+        name: string,
+        schema?: Schema,
+        collection?: string,
+        skipInit?: boolean,
     ): U;
 
     /**
-     * Removes the model named `name` from this connection, if it exists. You can
-     * use this function to clean up any models you created in your tests to
-     * prevent OverwriteModelErrors.
+     * Returns an array of model names created on this instance of Mongoose.
+     * Does not include names of models created using connection.model().
+     */
+    export function modelNames(): string[];
+
+    /**
+     * Declares a global plugin executed on all Schemas.
+     * Equivalent to calling .plugin(fn) on each Schema you create.
+     * @param fn plugin callback
+     * @param opts optional options
+     */
+    export function plugin(fn: Function): typeof mongoose;
+    export function plugin<T>(fn: Function, opts: T): typeof mongoose;
+
+    /** Sets mongoose options */
+    export function set(key: string, value: any): void;
+
+    type MongooseThenable = typeof mongoose & {
+        /**
+         * Ability to use mongoose object as a pseudo-promise so .connect().then()
+         * and .disconnect().then() are viable.
+         */
+        then<TRes>(
+            onFulfill?: () => void | TRes | PromiseLike<TRes>,
+            onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>,
+        ): Promise<TRes>;
+
+        /**
+         * Ability to use mongoose object as a pseudo-promise so .connect().then()
+         * and .disconnect().then() are viable.
+         */
+        catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
+    };
+
+    class CastError extends Error {
+        /**
+         * The Mongoose CastError constructor
+         * @param type The name of the type
+         * @param value The value that failed to cast
+         * @param path The path a.b.c in the doc where this cast error occurred
+         * @param reason The original error that was thrown
+         */
+        constructor(type: string, value: any, path: string, reason?: NativeError);
+    }
+
+    /*
+     * section querystream.js
+     * http://mongoosejs.com/docs/api.html#querystream-js
      *
-     * @param name if string, the name of the model to remove. If regexp, removes all models whose name matches the regexp.
-     * @returns this
+     * QueryStream can only be accessed using query#stream(), we only
+     *   expose its interface here.
      */
-    deleteModel(name: string | RegExp): Connection;
-
-    /** Returns an array of model names created on this connection. */
-    modelNames(): string[];
-
-    /** A hash of the global options that are associated with this connection */
-    config: any;
-
-    /** The mongodb.Db instance, set when the connection is opened */
-    db: mongodb.Db;
-
-    /** A hash of the collections associated with this connection */
-    collections: { [index: string]: Collection };
-
-    /**
-     * Connection ready state
-     * 0 = disconnected
-     * 1 = connected
-     * 2 = connecting
-     * 3 = disconnecting
-     * Each state change emits its associated event name.
-     */
-    readyState: number;
-  }
-
-  interface ConnectionOptionsBase {
-    /** passed to the connection db instance */
-    db?: any;
-    /** passed to the connection server instance(s) */
-    server?: any;
-    /** passed to the connection ReplSet instance */
-    replset?: any;
-    /** username for authentication */
-    user?: string;
-    /** password for authentication */
-    pass?: string;
-    /** options for authentication (see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate) */
-    auth?: any;
-    /** Use ssl connection (needs to have a mongod server with ssl support) (default: true) */
-    ssl?: boolean;
-    /** Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher) */
-    sslValidate?: object;
-    /** Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons. */
-    poolSize?: number;
-    /** Reconnect on error (default: true) */
-    autoReconnect?: boolean;
-    /** TCP KeepAlive on the socket with a X ms delay before start (default: 0). */
-    keepAlive?: number;
-    /** TCP Connection timeout setting (default: 0) */
-    connectTimeoutMS?: number;
-    /** TCP Socket timeout setting (default: 0) */
-    socketTimeoutMS?: number;
-    /** If the database authentication is dependent on another databaseName. */
-    authSource?: string;
-    /** If you're connected to a single server or mongos proxy (as opposed to a replica set),
-     * the MongoDB driver will try to reconnect every reconnectInterval milliseconds for reconnectTries
-     * times, and give up afterward. When the driver gives up, the mongoose connection emits a
-     * reconnectFailed event. (default: 30) */
-    reconnectTries?: number;
-    /** Will wait # milliseconds between retries (default: 1000) */
-    reconnectInterval?: number;
-    /** The name of the replicaset to connect to. */
-    replicaSet?: string;
-    /** The current value of the parameter native_parser */
-    nativeParser?: boolean;
-    /** Auth mechanism */
-    authMechanism?: any;
-    /** Specify a journal write concern (default: false). */
-    journal?: boolean;
-    /** The write concern */
-    w?: number|string;
-    /** The write concern timeout. */
-    wTimeoutMS?: number;
-    /** The ReadPreference mode as listed here: http://mongodb.github.io/node-mongodb-native/2.1/api/ReadPreference.html */
-    readPreference?: string;
-    /** An object representing read preference tags, see: http://mongodb.github.io/node-mongodb-native/2.1/api/ReadPreference.html */
-    readPreferencetags?: object;
-    /** Triggers the server instance to call ismaster (default: true). */
-    monitoring?: boolean;
-    /** The interval of calling ismaster when monitoring is enabled (default: 10000). */
-    haInterval?: number;
-    /** Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit (default: false). */
-    domainsEnabled?: boolean;
-    /** How long driver keeps waiting for servers to come back up (default: Number.MAX_VALUE) */
-    bufferMaxEntries?: number;
-
-    // TODO
-    safe?: any;
-    fsync?: any;
-    rs_name?: any;
-    slaveOk?: any;
-    authdb?: any;
-  }
-
-  /** See the node-mongodb-native driver instance for options that it understands. */
-  interface ConnectionOpenOptions extends ConnectionOptionsBase {
-    /** mongoose-specific options */
-    config?: {
-      /**
-       * set to false to disable automatic index creation for all
-       * models associated with this connection.
-       */
-      autoIndex?: boolean;
-    };
-  }
-
-  /** See the node-mongodb-native driver instance for options that it understands. */
-  interface ConnectionOpenSetOptions extends ConnectionOptionsBase {
-    /**
-     * If true, enables High Availability support for mongos
-     * If connecting to multiple mongos servers, set the mongos option to true.
-     */
-    mongos?: boolean;
-
-    /** sets the underlying driver's promise library (see http://mongodb.github.io/node-mongodb-native/2.1/api/MongoClient.html) */
-    promiseLibrary?: any;
-
-    /** See http://mongoosejs.com/docs/connections.html#use-mongo-client **/
-    useMongoClient?: boolean;
-  }
-
-  interface ConnectionOptions extends
-    ConnectionOpenOptions,
-    ConnectionOpenSetOptions {}
-
-  /*
-   * section drivers/node-mongodb-native/collection.js
-   * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
-   */
-  var Collection: Collection;
-  interface Collection extends CollectionBase {
-    /**
-     * Collection constructor
-     * @param name name of the collection
-     * @param conn A MongooseConnection instance
-     * @param opts optional collection options
-     */
-    new(name: string, conn: Connection, opts?: any): Collection;
-    /** Formatter for debug print args */
-    $format(arg: any): string;
-    /** Debug print helper */
-    $print(name: any, i: any, args: any[]): void;
-    /** Retreives information about this collections indexes. */
-    getIndexes(): any;
-  }
-
-  /*
-   * section drivers/node-mongodb-native/connection.js
-   * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
-   */
-  class Connection extends ConnectionBase {
-    /**
-     * Switches to a different database using the same connection pool.
-     * @param name The database name
-     * @returns New Connection Object
-     */
-    useDb(name: string): Connection;
-
-    /** Expose the possible connection states. */
-    static STATES: any;
-  }
-
-  /*
-   * section error/validation.js
-   * http://mongoosejs.com/docs/api.html#error-validation-js
-   */
-  class ValidationError extends Error {
-    /** Console.log helper */
-    toString(): string;
-  }
-
-  /*
-   * section error.js
-   * http://mongoosejs.com/docs/api.html#error-js
-   */
-  class Error extends global.Error {
-    /**
-     * MongooseError constructor
-     * @param msg Error message
-     */
-    constructor(msg: string);
-
-    /**
-     * The default built-in validator error messages. These may be customized.
-     * As you might have noticed, error messages support basic templating
-     * {PATH} is replaced with the invalid document path
-     * {VALUE} is replaced with the invalid value
-     * {TYPE} is replaced with the validator type such as "regexp", "min", or "user defined"
-     * {MIN} is replaced with the declared min value for the Number.min validator
-     * {MAX} is replaced with the declared max value for the Number.max validator
-     */
-    static messages: any;
-
-    /** For backwards compatibility. Same as mongoose.Error.messages */
-    static Messages: any;
-  }
-
-  interface EachAsyncOptions {
-    /** defaults to 1 */
-    parallel?: number;
-  }
-
-  /*
-   * section querycursor.js
-   * http://mongoosejs.com/docs/api.html#querycursor-js
-   *
-   * Callback signatures are from: http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
-   * QueryCursor can only be accessed by query#cursor(), we only
-   *   expose its interface to enable type-checking.
-   */
-  class QueryCursor<T extends Document> extends stream.Readable {
-    /**
-     * A QueryCursor is a concurrency primitive for processing query results
-     * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
-     * in addition to several other mechanisms for loading documents from MongoDB
-     * one at a time.
-     * Unless you're an advanced user, do not instantiate this class directly.
-     * Use Query#cursor() instead.
-     * @param options query options passed to .find()
-     * @event cursor Emitted when the cursor is created
-     * @event error Emitted when an error occurred
-     * @event data Emitted when the stream is flowing and the next doc is ready
-     * @event end Emitted when the stream is exhausted
-     */
-    constructor(query: Query<T>, options: any);
-
-    /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
-    close(callback?: (error: any, result: any) => void): Promise<any>;
-
-    /**
-     * Execute fn for every document in the cursor. If fn returns a promise,
-     * will wait for the promise to resolve before iterating on to the next one.
-     * Returns a promise that resolves when done.
-     * @param fn Function to be executed for every document in the cursor
-     * @param callback Executed when all docs have been processed
-     */
-    eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): Promise<T>;
-
-    /**
-     * Execute fn for every document in the cursor. If fn returns a promise,
-     * will wait for the promise to resolve before iterating on to the next one.
-     * Returns a promise that resolves when done.
-     * @param fn Function to be executed for every document in the cursor
-     * @param options Async options (e. g. parallel function execution)
-     * @param callback Executed when all docs have been processed
-     */
-    eachAsync(fn: (doc: T) => any, options: EachAsyncOptions, callback?: (err: any) => void): Promise<T>;
-
-    /**
-     * Registers a transform function which subsequently maps documents retrieved
-     * via the streams interface or .next()
-     */
-    map(fn: (doc: T) => T): this;
-
-    /**
-     * Get the next document from this cursor. Will return null when there are
-     * no documents left.
-     */
-    next(callback?: (err: any, doc?: T) => void): Promise<any>;
-  }
-
-  /*
-   * section virtualtype.js
-   * http://mongoosejs.com/docs/api.html#virtualtype-js
-   */
-  class VirtualType {
-    /** This is what mongoose uses to define virtual attributes via Schema.prototype.virtual. */
-    constructor(options: any, name: string);
-    /** Applies getters to value using optional scope. */
-    applyGetters(value: any, scope: any): any;
-    /** Applies setters to value using optional scope. */
-    applySetters(value: any, scope: any): any;
-    /** Defines a getter. */
-    get(fn: Function): this;
-    /** Defines a setter. */
-    set(fn: Function): this;
-  }
-
-  /*
-   * section schema.js
-   * http://mongoosejs.com/docs/api.html#schema-js
-   */
-  class Schema extends events.EventEmitter {
-    /**
-     * Schema constructor.
-     * When nesting schemas, (children in the example above), always declare
-     * the child schema first before passing it into its parent.
-     * @event init Emitted after the schema is compiled into a Model.
-     */
-    constructor(definition?: SchemaDefinition, options?: SchemaOptions);
-
-    /** Adds key path / schema type pairs to this schema. */
-    add(obj: SchemaDefinition, prefix?: string): void;
-
-    /**
-     * Iterates the schemas paths similar to Array.forEach.
-     * @param fn callback function
-     * @returns this
-     */
-    eachPath(fn: (path: string, type: SchemaType) => void): this;
-
-    /**
-     * Gets a schema option.
-     * @param key option name
-     */
-    get(key: string): any;
-
-    /**
-     * Defines an index (most likely compound) for this schema.
-     * @param options Options to pass to MongoDB driver's createIndex() function
-     * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
-     *   expires option into seconds for the expireAfterSeconds in the above link.
-     */
-    index(fields: any, options?: {
-      expires?: string;
-      [other: string]: any;
-    }): this;
-
-    /** Compiles indexes from fields and schema-level indexes */
-    indexes(): any[];
-
-    /**
-     * Loads an ES6 class into a schema. Maps setters + getters, static methods, and
-     * instance methods to schema virtuals, statics, and methods.
-     */
-    loadClass(model: Function): this;
-
-    /**
-     * Adds an instance method to documents constructed from Models compiled from this schema.
-     * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
-     */
-    method(method: string, fn: Function): this;
-    method(methodObj: { [name: string]: Function }): this;
-
-    /**
-     * Gets/sets schema paths.
-     * Sets a path (if arity 2)
-     * Gets a path (if arity 1)
-     */
-    path(path: string): SchemaType;
-    path(path: string, constructor: any): this;
-
-    /**
-     * Returns the pathType of path for this schema.
-     * @returns whether it is a real, virtual, nested, or ad-hoc/undefined path.
-     */
-    pathType(path: string): string;
-
-    /**
-     * Registers a plugin for this schema.
-     * @param plugin callback
-     */
-    plugin(plugin: (schema: Schema) => void): this;
-    plugin<T>(plugin: (schema: Schema, options: T) => void, opts: T): this;
-
-    /**
-     * Defines a post hook for the document
-     * Post hooks fire on the event emitted from document instances of Models compiled
-     *   from this schema.
-     * @param method name of the method to hook
-     * @param fn callback
-     */
-    post<T extends Document>(method: string, fn: (
-      error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void
-    ) => void): this;
-
-    post<T extends Document>(method: string, fn: (
-      doc: T, next: (err?: NativeError) => void
-    ) => void): this;
-
-    /**
-     * Defines a pre hook for the document.
-     */
-    pre(method: string, parallel: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): this;
-    pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): this;
-
-    /**
-     * Adds a method call to the queue.
-     * @param name name of the document method to call later
-     * @param args arguments to pass to the method
-     */
-    queue(name: string, args: any[]): this;
-
-    /**
-     * Removes the given path (or [paths]).
-     */
-    remove(path: string | string[]): void;
-
-    /**
-     * @param invalidate refresh the cache
-     * @returns an Array of path strings that are required by this schema.
-     */
-    requiredPaths(invalidate?: boolean): string[];
-
-    /**
-     * Sets/gets a schema option.
-     * @param key option name
-     * @param value if not passed, the current option value is returned
-     */
-    set(key: string): any;
-    set(key: string, value: any): this;
-
-    /**
-     * Adds static "class" methods to Models compiled from this schema.
-     */
-    static(name: string, fn: Function): this;
-    static(nameObj: { [name: string]: Function }): this;
-
-    /** Creates a virtual type with the given name. */
-    virtual(name: string, options?: any): VirtualType;
-
-    /** Returns the virtual type with the given name. */
-    virtualpath(name: string): VirtualType;
-
-    /** The allowed index types */
-    static indexTypes: string[];
-
-    /**
-     * Reserved document keys.
-     * Keys in this object are names that are rejected in schema declarations
-     * b/c they conflict with mongoose functionality. Using these key name
-     * will throw an error.
-     */
-    static reserved: any;
-
-    /** Object of currently defined methods on this schema. */
-    methods: any;
-    /** Object of currently defined statics on this schema. */
-    statics: any;
-    /** Object of currently defined query helpers on this schema. */
-    query: any;
-    /** The original object passed to the schema constructor */
-    obj: any;
-  }
-
-  // Hook functions: https://github.com/vkarpov15/hooks-fixed
-  interface HookSyncCallback {
-    (next: HookNextFunction, ...hookArgs:any[]): any;
-  }
-
-  interface HookAsyncCallback {
-    (next: HookNextFunction, done: HookDoneFunction, ...hookArgs: any[]): any;
-  }
-
-  interface HookErrorCallback {
-    (error: Error): any;
-  }
-
-  interface HookNextFunction {
-    (error: Error): any;
-    (...hookArgs: any[]): any;
-  }
-
-  interface HookDoneFunction {
-    (error: Error): any;
-    (...hookArgs: any[]): any;
-  }
-
-  interface SchemaOptions {
-    /** defaults to null (which means use the connection's autoIndex option) */
-    autoIndex?: boolean;
-    /** defaults to true */
-    bufferCommands?: boolean;
-    /** defaults to false */
-    capped?: boolean | number | { size?: number; max?: number; autoIndexId?: boolean; };
-    /** no default */
-    collection?: string;
-    /** defaults to "__t" */
-    discriminatorKey?: string;
-    /** defaults to false. */
-    emitIndexErrors?: boolean;
-    /** defaults to true */
-    id?: boolean;
-    /** defaults to true */
-    _id?: boolean;
-    /** controls document#toObject behavior when called manually - defaults to true */
-    minimize?: boolean;
-    read?: string;
-    /** defaults to true. */
-    safe?: boolean | { w?: number | string; wtimeout?: number; j?: boolean };
-    /** defaults to null */
-    shardKey?: boolean;
-    /** defaults to true */
-    strict?: boolean;
-    /** no default */
-    toJSON?: any;
-    /** no default */
-    toObject?: any;
-    /** defaults to 'type' */
-    typeKey?: string;
-    /** defaults to false */
-    useNestedStrict?: boolean;
-    /** defaults to false */
-    usePushEach?: boolean;
-    /** defaults to true */
-    validateBeforeSave?: boolean;
-    /** defaults to "__v" */
-    versionKey?: string|boolean;
-    /** defaults to false */
-    retainKeyOrder?: boolean;
-    /**
-     * skipVersioning allows excluding paths from
-     * versioning (the internal revision will not be
-     * incremented even if these paths are updated).
-     */
-    skipVersioning?: any;
-    /**
-     * If set timestamps, mongoose assigns createdAt
-     * and updatedAt fields to your schema, the type
-     * assigned is Date.
-     */
-    timestamps?: any;
-    /**
-     * Defaults to false. Provides optimistic
-     * concurrency support for `save()`. `versionKey`
-     * must be set if this is true.
-     */
-    optimisticConcurrency?: boolean;
-  }
-
-  /*
-   * Intellisense for Schema definitions
-   */
-  interface SchemaDefinition {
-    [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
-  }
-
-  /*
-   * The standard options available when configuring a schema type:
-   * new Schema({
-   *   name: {
-   *     type: String,
-   *     required: true,
-   *     ...
-   *   }
-   * });
-   *
-   * Note: the properties have Object as a fallback type: | Object
-   *   because this interface does not apply to a schematype that
-   *   does not have a type property. Ex:
-   * new Schema({
-   *   name: {
-   *     first: String,    // since name does not have a "type" property
-   *     last: String      //   first and last can have any valid type
-   *     ...
-   *   }
-   * });
-   *
-   * References:
-   * - http://mongoosejs.com/docs/schematypes.html
-   * - http://mongoosejs.com/docs/api.html#schema_Schema.Types
-   */
-  interface SchemaTypeOpts<T> {
-    /* Common Options for all schema types */
-    type?: T;
-
-    /** Sets a default value for this SchemaType. */
-    default?: SchemaTypeOpts.DefaultFn<T> | T;
-
-    /**
-     * Getters allow you to transform the representation of the data as it travels
-     * from the raw mongodb document to the value that you see.
-     */
-    get?: (value: T, schematype?: this) => T | any;
-
-    /** Declares the index options for this schematype. */
-    index?: SchemaTypeOpts.IndexOpts | boolean | string;
-
-    /**
-     * Adds a required validator to this SchemaType. The validator gets added
-     * to the front of this SchemaType's validators array using unshift().
-     */
-    required?: SchemaTypeOpts.RequiredFn<T> |
-      boolean | [boolean, string] |
-      string | [string, string] |
-      any;
-
-    /**
-     * Sets default select() behavior for this path.
-     * Set to true if this path should always be included in the results, false
-     * if it should be excluded by default. This setting can be overridden at
-     * the query level.
-     */
-    select?: boolean | any;
-
-    /**
-     * Setters allow you to transform the data before it gets to the raw mongodb
-     * document and is set as a value on an actual key.
-     */
-    set?: (value: T, schematype?: this) => T | any;
-
-    /** Declares a sparse index. */
-    sparse?: boolean | any;
-
-    /** Declares a full text index. */
-    text?: boolean | any;
-
-    /**
-     * Adds validator(s) for this document path.
-     * Validators always receive the value to validate as their first argument
-     * and must return Boolean. Returning false means validation failed.
-     */
-    validate?: RegExp | [RegExp, string] |
-      SchemaTypeOpts.ValidateFn<T> | [SchemaTypeOpts.ValidateFn<T>, string] |
-      SchemaTypeOpts.ValidateOpts | SchemaTypeOpts.ValidateOpts[] |
-      any;
-
-    /** Declares an unique index. */
-    unique?: boolean | any;
-
-
-    /* Options for specific schema types (String, Number, Date, etc.) */
-    /** String only - Adds an enum validator */
-    enum?: T[] | SchemaTypeOpts.EnumOpts<T> | any;
-    /** String only - Adds a lowercase setter. */
-    lowercase?: boolean | any;
-    /** String only - Sets a regexp validator. */
-    match?: RegExp | [RegExp, string] | any;
-    /** String only - Sets a maximum length validator. */
-    maxlength?: number | [number, string] | any;
-    /** String only - Sets a minimum length validator. */
-    minlength?: number | [number, string] | any;
-    /** String only - Adds a trim setter. */
-    trim?: boolean | any;
-    /** String only - Adds an uppercase setter. */
-    uppercase?: boolean | any;
-
-    /**
-     * Date, Number only - Sets a minimum number validator.
-     * Sets a minimum date validator.
-     */
-    min?: number | [number, string] |
-      Date | [Date, string] |
-      any;
-
-    /**
-     * Date, Number only - Sets a maximum number validator.
-     * Sets a maximum date validator.
-     */
-    max?: number | [number, string] |
-      Date | [Date, string] |
-      any;
-
-    /**
-     * Date only - Declares a TTL index (rounded to the nearest second)
-     * for Date types only.
-     */
-    expires?: number | string | any;
-
-    /** ObjectId only - Adds an auto-generated ObjectId default if turnOn is true. */
-    auto?: boolean | any;
-
-    [other: string]: any;
-  }
-
-  // Interfaces specific to schema type options should be scoped in this namespace
-  namespace SchemaTypeOpts {
-    interface DefaultFn<T> {
-      (...args: any[]): T;
-    }
-
-    interface RequiredFn<T> {
-      (required: boolean, message?: string): T;
-    }
-
-    interface ValidateFn<T> {
-      (obj: RegExp | Function, message?: string, type?: string): T;
-    }
-
-    interface ValidateOpts {
-      validator?: RegExp | Function,
-      msg?: string,
-      type?: string
-    }
-
-    interface EnumOpts<T> {
-      values?: T[];
-      message?: string;
-    }
-
-    interface IndexOpts {
-      background?: boolean,
-      expires?: number | string
-      sparse?: boolean,
-      type?: string,
-      unique?: boolean,
-    }
-  }
-
-  /*
-   * section document.js
-   * http://mongoosejs.com/docs/api.html#document-js
-   */
-  interface MongooseDocument extends MongooseDocumentOptionals { }
-  class MongooseDocument {
-    /** Checks if a path is set to its default. */
-    $isDefault(path?: string): boolean;
-
-    /**
-     * Takes a populated field and returns it to its unpopulated state.
-     * If the path was not populated, this is a no-op.
-     */
-    depopulate(path: string): void;
-
-    /**
-     * Returns true if the Document stores the same data as doc.
-     * Documents are considered equal when they have matching _ids, unless neither document
-     * has an _id, in which case this function falls back to usin deepEqual().
-     * @param doc a document to compare
-     */
-    equals(doc: MongooseDocument): boolean;
-
-    /**
-     * Explicitly executes population and returns a promise.
-     * Useful for ES2015 integration.
-     * @returns promise that resolves to the document when population is done
-     */
-    execPopulate(): Promise<this>;
-
-    /**
-     * Returns the value of a path.
-     * @param type optionally specify a type for on-the-fly attributes
-     */
-    get(path: string, type?: any): any;
-
-    /**
-     * Initializes the document without setters or marking anything modified.
-     * Called internally after a document is returned from mongodb.
-     * @param doc document returned by mongo
-     * @param fn callback
-     */
-    init(doc: MongooseDocument, fn?: () => void): this;
-    init(doc: MongooseDocument, opts: any, fn?: () => void): this;
-
-    /** Helper for console.log */
-    inspect(options?: any): any;
-
-    /**
-     * Marks a path as invalid, causing validation to fail.
-     * The errorMsg argument will become the message of the ValidationError.
-     * The value argument (if passed) will be available through the ValidationError.value property.
-     * @param path the field to invalidate
-     * @param errorMsg the error which states the reason path was invalid
-     * @param value optional invalid value
-     * @param kind optional kind property for the error
-     * @returns the current ValidationError, with all currently invalidated paths
-     */
-    invalidate(path: string, errorMsg: string | NativeError, value: any, kind?: string): ValidationError | boolean;
-
-    /** Returns true if path was directly set and modified, else false. */
-    isDirectModified(path: string): boolean;
-
-    /** Checks if path was initialized */
-    isInit(path: string): boolean;
-
-    /**
-     * Returns true if this document was modified, else false.
-     * If path is given, checks if a path or any full path containing path as part of its path
-     * chain has been modified.
-     */
-    isModified(path?: string): boolean;
-
-    /** Checks if path was selected in the source query which initialized this document. */
-    isSelected(path: string): boolean;
-
-    /**
-     * Marks the path as having pending changes to write to the db.
-     * Very helpful when using Mixed types.
-     * @param path the path to mark modified
-     */
-    markModified(path: string): void;
-
-    /** Returns the list of paths that have been modified. */
-    modifiedPaths(): string[];
-
-    /**
-     * Populates document references, executing the callback when complete.
-     * If you want to use promises instead, use this function with
-     * execPopulate()
-     * Population does not occur unless a callback is passed or you explicitly
-     * call execPopulate(). Passing the same path a second time will overwrite
-     * the previous path options. See Model.populate() for explaination of options.
-     * @param path The path to populate or an options object
-     * @param names The properties to fetch from the populated document
-     * @param callback When passed, population is invoked
-     */
-    populate(callback: (err: any, res: this) => void): this;
-    populate(path: string, callback?: (err: any, res: this) => void): this;
-    populate(path: string, names: string, callback?: (err: any, res: this) => void): this;
-    populate(options: ModelPopulateOptions | ModelPopulateOptions[], callback?: (err: any, res: this) => void): this;
-
-    /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */
-    populated(path: string): any;
-
-    /**
-     * Sets the value of a path, or many paths.
-     * @param path path or object of key/vals to set
-     * @param val the value to set
-     * @param type optionally specify a type for "on-the-fly" attributes
-     * @param options optionally specify options that modify the behavior of the set
-     */
-    set(path: string, val: any, options?: any): this;
-    set(path: string, val: any, type: any, options?: any): this;
-    set(value: any): this;
-
-    /**
-     * The return value of this method is used in calls to JSON.stringify(doc).
-     * This method accepts the same options as Document#toObject. To apply the
-     * options to every document of your schema by default, set your schemas
-     * toJSON option to the same argument.
-     */
-    toJSON(options?: DocumentToObjectOptions): any;
-
-    /**
-     * Converts this document into a plain javascript object, ready for storage in MongoDB.
-     * Buffers are converted to instances of mongodb.Binary for proper storage.
-     */
-    toObject(options?: DocumentToObjectOptions): any;
-
-    /** Helper for console.log */
-    toString(): string;
-
-    /**
-     * Clears the modified state on the specified path.
-     * @param path the path to unmark modified
-     */
-    unmarkModified(path: string): void;
-
-    /** Sends an update command with this document _id as the query selector.  */
-    update(doc: any, callback?: (err: any, raw: any) => void): Query<any>;
-    update(doc: any, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any>;
-
-    /**
-     * Executes registered validation rules for this document.
-     * @param optional options internal options
-     * @param callback callback called after validation completes, passing an error if one occurred
-     */
-    validate(callback?: (err: any) => void): Promise<void>;
-    validate(optional: any, callback?: (err: any) => void): Promise<void>;
-
-    /**
-     * Executes registered validation rules (skipping asynchronous validators) for this document.
-     * This method is useful if you need synchronous validation.
-     * @param pathsToValidate only validate the given paths
-     * @returns MongooseError if there are errors during validation, or undefined if there is no error.
-     */
-    validateSync(pathsToValidate?: string | string[]): Error | undefined;
-
-    /** Hash containing current validation errors. */
-    errors: any;
-    /** This documents _id. */
-    _id: any;
-    /** Boolean flag specifying if the document is new. */
-    isNew: boolean;
-    /** The documents schema. */
-    schema: Schema;
-  }
-
-  interface MongooseDocumentOptionals {
-    /**
-     * Virtual getter that by default returns the document's _id field cast to a string,
-     * or in the case of ObjectIds, its hexString. This id getter may be disabled by
-     * passing the option { id: false } at schema construction time. If disabled, id
-     * behaves like any other field on a document and can be assigned any value.
-     */
-    id?: any;
-  }
-
-  interface DocumentToObjectOptions {
-    /** apply all getters (path and virtual getters) */
-    getters?: boolean;
-    /** apply virtual getters (can override getters option) */
-    virtuals?: boolean;
-    /** remove empty objects (defaults to true) */
-    minimize?: boolean;
-    /**
-     * A transform function to apply to the resulting document before returning
-     * @param doc The mongoose document which is being converted
-     * @param ret The plain object representation which has been converted
-     * @param options The options in use (either schema options or the options passed inline)
-     */
-    transform?: (doc: any, ret: any, options: any) => any;
-    /** depopulate any populated paths, replacing them with their original refs (defaults to false) */
-    depopulate?: boolean;
-    /** whether to include the version key (defaults to true) */
-    versionKey?: boolean;
-    /**
-     * keep the order of object keys. If this is set to true,
-     * Object.keys(new Doc({ a: 1, b: 2}).toObject()) will
-     * always produce ['a', 'b'] (defaults to false)
-     */
-    retainKeyOrder?: boolean;
-  }
-
-  namespace Types {
-    /*
-      * section types/subdocument.js
-      * http://mongoosejs.com/docs/api.html#types-subdocument-js
-      */
-    class Subdocument extends MongooseDocument {
-      /** Returns the top level document of this sub-document. */
-      ownerDocument(): MongooseDocument;
-
-      /**
-       * Null-out this subdoc
-       * @param callback optional callback for compatibility with Document.prototype.remove
-       */
-      remove(callback?: (err: any) => void): void;
-      remove(options: any, callback?: (err: any) => void): void;
+    class QueryStream extends stream.Stream {
+        /**
+         * Provides a Node.js 0.8 style ReadStream interface for Queries.
+         * @event data emits a single Mongoose document
+         * @event error emits when an error occurs during streaming. This will emit before the close event.
+         * @event close emits when the stream reaches the end of the cursor or an error occurs, or the stream
+         *   is manually destroyed. After this event, no more events are emitted.
+         */
+        constructor(
+            query: Query<any>,
+            options?: {
+                /**
+                 * optional function which accepts a mongoose document. The return value
+                 * of the function will be emitted on data.
+                 */
+                transform?: Function;
+                [other: string]: any;
+            },
+        );
+
+        /**
+         * Destroys the stream, closing the underlying cursor, which emits the close event.
+         * No more events will be emitted after the close event.
+         */
+        destroy(err?: NativeError): void;
+
+        /** Pauses this stream. */
+        pause(): void;
+        /** Pipes this query stream into another stream. This method is inherited from NodeJS Streams. */
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean }): T;
+        /** Resumes this stream. */
+        resume(): void;
+
+        /** Flag stating whether or not this stream is paused. */
+        paused: boolean;
+        /** Flag stating whether or not this stream is readable. */
+        readable: boolean;
     }
 
     /*
-     * section types/array.js
-     * http://mongoosejs.com/docs/api.html#types-array-js
+     * section connection.js
+     * http://mongoosejs.com/docs/api.html#connection-js
+     *
+     * The Connection class exposed by require('mongoose')
+     *   is actually the driver's NativeConnection class.
+     *   connection.js defines a base class that the native
+     *   versions extend. See:
+     *   http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
      */
-    class Array<T> extends global.Array<T> {
-      /**
-       * Atomically shifts the array at most one time per document save().
-       * Calling this mulitple times on an array before saving sends the same command as
-       * calling it once. This update is implemented using the MongoDB $pop method which
-       * enforces this restriction.
-       */
-      $shift(): T;
+    abstract class ConnectionBase extends events.EventEmitter {
+        /**
+         * For practical reasons, a Connection equals a Db.
+         * @param base a mongoose instance
+         * @event connecting Emitted when connection.{open,openSet}() is executed on this connection.
+         * @event connected Emitted when this connection successfully connects to the db. May be emitted multiple times in reconnected scenarios.
+         * @event open Emitted after we connected and onOpen is executed on all of this connections models.
+         * @event disconnecting Emitted when connection.close() was executed.
+         * @event disconnected Emitted after getting disconnected from the db.
+         * @event close Emitted after we disconnected and onClose executed on all of this connections models.
+         * @event reconnected Emitted after we connected and subsequently disconnected, followed by successfully another successfull connection.
+         * @event error Emitted when an error occurs on this connection.
+         * @event fullsetup Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
+         * @event all Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
+         */
+        constructor(base: typeof mongoose);
 
-      /** Alias of pull */
-      remove(...args: any[]): this;
+        /**
+         * Opens the connection to MongoDB.
+         * @param mongodb://uri or the host to which you are connecting
+         * @param database database name
+         * @param port database port
+         * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
+         *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
+         *   See the node-mongodb-native driver instance for options that it understands.
+         *   Options passed take precedence over options included in connection strings.
+         */
+        open(
+            connection_string: string,
+            database?: string,
+            port?: number,
+            options?: ConnectionOpenOptions,
+            callback?: (err: any) => void,
+        ): any;
 
-      /**
-       * Pops the array atomically at most one time per document save().
-       * Calling this mulitple times on an array before saving sends the same command as
-       * calling it once. This update is implemented using the MongoDB $pop method which
-       * enforces this restriction.
-       */
-      $pop(): T;
+        /** Helper for dropDatabase() */
+        dropDatabase(callback?: (err: any) => void): Promise<void>;
 
-      /**
-       * Adds values to the array if not already present.
-       * @returns the values that were added
-       */
-      addToSet(...args: any[]): T[];
+        /**
+         * Opens the connection to a replica set.
+         * @param uris comma-separated mongodb:// URIs
+         * @param database database name if not included in uris
+         * @param options passed to the internal driver
+         */
+        openSet(
+            uris: string,
+            database?: string,
+            options?: ConnectionOpenSetOptions,
+            callback?: (err: any) => void,
+        ): any;
 
-      /**
-       * Return the index of obj or -1 if not found.
-       * @param obj The item to look for
-       */
-      indexOf(obj: any): number;
+        /** Closes the connection */
+        close(callback?: (err: any) => void): Promise<void>;
 
-      /** Helper for console.log */
-      inspect(): any;
+        /**
+         * Retrieves a collection, creating it if not cached.
+         * Not typically needed by applications. Just talk to your collection through your model.
+         * @param name name of the collection
+         * @param options optional collection options
+         */
+        collection(name: string, options?: any): Collection;
 
-      /**
-       * Marks the entire array as modified, which if saved, will store it as a $set
-       * operation, potentially overwritting any changes that happen between when you
-       * retrieved the object and when you save it.
-       * @returns new length of the array
-       */
-      nonAtomicPush(...args: any[]): number;
+        /**
+         * Defines or retrieves a model.
+         * When no collection argument is passed, Mongoose produces a collection name by passing
+         * the model name to the utils.toCollectionName method. This method pluralizes the name.
+         * If you don't like this behavior, either pass a collection name or set your schemas
+         * collection name option.
+         * @param name the model name
+         * @param schema a schema. necessary when defining a model
+         * @param collection name of mongodb collection (optional) if not given it will be induced from model name
+         * @returns The compiled model
+         */
+        model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
+        model<T extends Document, U extends Model<T>>(name: string, schema?: Schema, collection?: string): U;
 
-      /**
-       * Wraps Array#pop with proper change tracking.
-       * marks the entire array as modified which will pass the entire thing to $set
-       * potentially overwritting any changes that happen between when you retrieved
-       * the object and when you save it.
-       */
-      pop(): T;
+        /**
+         * Removes the model named `name` from this connection, if it exists. You can
+         * use this function to clean up any models you created in your tests to
+         * prevent OverwriteModelErrors.
+         *
+         * @param name if string, the name of the model to remove. If regexp, removes all models whose name matches the regexp.
+         * @returns this
+         */
+        deleteModel(name: string | RegExp): Connection;
 
-      /**
-       * Pulls items from the array atomically. Equality is determined by casting
-       * the provided value to an embedded document and comparing using
-       * the Document.equals() function.
-       */
-      pull(...args: any[]): this;
+        /** Returns an array of model names created on this connection. */
+        modelNames(): string[];
 
-      /**
-       * Wraps Array#push with proper change tracking.
-       * @returns new length of the array
-       */
-      push(...args: any[]): number;
+        /** A hash of the global options that are associated with this connection */
+        config: any;
 
-      /** Sets the casted val at index i and marks the array modified. */
-      set(i: number, val: any): this;
+        /** The mongodb.Db instance, set when the connection is opened */
+        db: mongodb.Db;
 
-      /**
-       * Wraps Array#shift with proper change tracking.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      shift(): T;
+        /** A hash of the collections associated with this connection */
+        collections: { [index: string]: Collection };
 
-      /**
-       * Wraps Array#sort with proper change tracking.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      // some lib.d.ts have return type "this" and others have return type "T[]"
-      // which causes errors. Let the inherited array provide the sort() method.
-      //sort(compareFn?: (a: T, b: T) => number): T[];
+        /**
+         * Connection ready state
+         * 0 = disconnected
+         * 1 = connected
+         * 2 = connecting
+         * 3 = disconnecting
+         * Each state change emits its associated event name.
+         */
+        readyState: number;
+    }
 
-      /**
-       * Wraps Array#splice with proper change tracking and casting.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      splice(...args: any[]): T[];
+    interface ConnectionOptionsBase {
+        /** passed to the connection db instance */
+        db?: any;
+        /** passed to the connection server instance(s) */
+        server?: any;
+        /** passed to the connection ReplSet instance */
+        replset?: any;
+        /** username for authentication */
+        user?: string;
+        /** password for authentication */
+        pass?: string;
+        /** options for authentication (see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate) */
+        auth?: any;
+        /** Use ssl connection (needs to have a mongod server with ssl support) (default: true) */
+        ssl?: boolean;
+        /** Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher) */
+        sslValidate?: object;
+        /** Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons. */
+        poolSize?: number;
+        /** Reconnect on error (default: true) */
+        autoReconnect?: boolean;
+        /** TCP KeepAlive on the socket with a X ms delay before start (default: 0). */
+        keepAlive?: number;
+        /** TCP Connection timeout setting (default: 0) */
+        connectTimeoutMS?: number;
+        /** TCP Socket timeout setting (default: 0) */
+        socketTimeoutMS?: number;
+        /** If the database authentication is dependent on another databaseName. */
+        authSource?: string;
+        /** If you're connected to a single server or mongos proxy (as opposed to a replica set),
+         * the MongoDB driver will try to reconnect every reconnectInterval milliseconds for reconnectTries
+         * times, and give up afterward. When the driver gives up, the mongoose connection emits a
+         * reconnectFailed event. (default: 30) */
+        reconnectTries?: number;
+        /** Will wait # milliseconds between retries (default: 1000) */
+        reconnectInterval?: number;
+        /** The name of the replicaset to connect to. */
+        replicaSet?: string;
+        /** The current value of the parameter native_parser */
+        nativeParser?: boolean;
+        /** Auth mechanism */
+        authMechanism?: any;
+        /** Specify a journal write concern (default: false). */
+        journal?: boolean;
+        /** The write concern */
+        w?: number | string;
+        /** The write concern timeout. */
+        wTimeoutMS?: number;
+        /** The ReadPreference mode as listed here: http://mongodb.github.io/node-mongodb-native/2.1/api/ReadPreference.html */
+        readPreference?: string;
+        /** An object representing read preference tags, see: http://mongodb.github.io/node-mongodb-native/2.1/api/ReadPreference.html */
+        readPreferencetags?: object;
+        /** Triggers the server instance to call ismaster (default: true). */
+        monitoring?: boolean;
+        /** The interval of calling ismaster when monitoring is enabled (default: 10000). */
+        haInterval?: number;
+        /** Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit (default: false). */
+        domainsEnabled?: boolean;
+        /** How long driver keeps waiting for servers to come back up (default: Number.MAX_VALUE) */
+        bufferMaxEntries?: number;
 
-      /** Returns a native js Array. */
-      toObject(options?: any): T[];
+        // TODO
+        safe?: any;
+        fsync?: any;
+        rs_name?: any;
+        slaveOk?: any;
+        authdb?: any;
+    }
 
-      /**
-       * Wraps Array#unshift with proper change tracking.
-       * Marks the entire array as modified, which if saved, will store it as a $set operation,
-       * potentially overwritting any changes that happen between when you retrieved the object
-       * and when you save it.
-       */
-      unshift(...args: any[]): number;
+    /** See the node-mongodb-native driver instance for options that it understands. */
+    interface ConnectionOpenOptions extends ConnectionOptionsBase {
+        /** mongoose-specific options */
+        config?: {
+            /**
+             * set to false to disable automatic index creation for all
+             * models associated with this connection.
+             */
+            autoIndex?: boolean;
+        };
+    }
+
+    /** See the node-mongodb-native driver instance for options that it understands. */
+    interface ConnectionOpenSetOptions extends ConnectionOptionsBase {
+        /**
+         * If true, enables High Availability support for mongos
+         * If connecting to multiple mongos servers, set the mongos option to true.
+         */
+        mongos?: boolean;
+
+        /** sets the underlying driver's promise library (see http://mongodb.github.io/node-mongodb-native/2.1/api/MongoClient.html) */
+        promiseLibrary?: any;
+
+        /** See http://mongoosejs.com/docs/connections.html#use-mongo-client **/
+        useMongoClient?: boolean;
+    }
+
+    interface ConnectionOptions extends ConnectionOpenOptions, ConnectionOpenSetOptions {}
+
+    /*
+     * section drivers/node-mongodb-native/collection.js
+     * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
+     */
+    var Collection: Collection;
+    interface Collection extends CollectionBase {
+        /**
+         * Collection constructor
+         * @param name name of the collection
+         * @param conn A MongooseConnection instance
+         * @param opts optional collection options
+         */
+        new (name: string, conn: Connection, opts?: any): Collection;
+        /** Formatter for debug print args */
+        $format(arg: any): string;
+        /** Debug print helper */
+        $print(name: any, i: any, args: any[]): void;
+        /** Retreives information about this collections indexes. */
+        getIndexes(): any;
     }
 
     /*
-      * section types/documentarray.js
-      * http://mongoosejs.com/docs/api.html#types-documentarray-js
-      */
-    class DocumentArray<T extends MongooseDocument> extends Types.Array<T> {
-      /**
-       * Creates a subdocument casted to this schema.
-       * This is the same subdocument constructor used for casting.
-       * @param obj the value to cast to this arrays SubDocument schema
-       */
-      create(obj: any): T;
+     * section drivers/node-mongodb-native/connection.js
+     * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
+     */
+    class Connection extends ConnectionBase {
+        /**
+         * Switches to a different database using the same connection pool.
+         * @param name The database name
+         * @returns New Connection Object
+         */
+        useDb(name: string): Connection;
 
-      /**
-       * Searches array items for the first document with a matching _id.
-       * @returns the subdocument or null if not found.
-       */
-      id(id: ObjectId | string | number | NativeBuffer): T;
-
-      /** Helper for console.log */
-      inspect(): T[];
-
-      /**
-       * Returns a native js Array of plain js objects
-       * @param options optional options to pass to each documents toObject
-       *   method call during conversion
-       */
-      toObject(options?: any): T[];
+        /** Expose the possible connection states. */
+        static STATES: any;
     }
 
     /*
-     * section types/buffer.js
-     * http://mongoosejs.com/docs/api.html#types-buffer-js
+     * section error/validation.js
+     * http://mongoosejs.com/docs/api.html#error-validation-js
      */
-    class Buffer extends global.Buffer {
-      /**
-       * Copies the buffer.
-       * Buffer#copy does not mark target as modified so you must copy
-       * from a MongooseBuffer for it to work as expected. This is a
-       * work around since copy modifies the target, not this.
-       */
-      copy(target: NativeBuffer, ...nodeBufferArgs: any[]): number;
-
-      /** Determines if this buffer is equals to other buffer */
-      equals(other: NativeBuffer): boolean;
-
-      /** Sets the subtype option and marks the buffer modified. */
-      subtype(subtype: number): void;
-
-      /** Converts this buffer to its Binary type representation. */
-      toObject(subtype?: number): mongodb.Binary;
-
-      /** Writes the buffer. */
-      write(string: string, ...nodeBufferArgs: any[]): number;
+    class ValidationError extends Error {
+        /** Console.log helper */
+        toString(): string;
     }
 
     /*
-      * section types/objectid.js
-      * http://mongoosejs.com/docs/api.html#types-objectid-js
-      */
-    var ObjectId: ObjectIdConstructor;
+     * section error.js
+     * http://mongoosejs.com/docs/api.html#error-js
+     */
+    class Error extends global.Error {
+        /**
+         * MongooseError constructor
+         * @param msg Error message
+         */
+        constructor(msg: string);
 
-    // mongodb.ObjectID does not allow mongoose.Types.ObjectId(id). This is
-    //   commonly used in mongoose and is found in an example in the docs:
-    //   http://mongoosejs.com/docs/api.html#aggregate_Aggregate
-    // constructor exposes static methods of mongodb.ObjectID and ObjectId(id)
-    type ObjectIdConstructor = typeof mongodb.ObjectID & {
-      (s?: string | number): mongodb.ObjectID;
-    };
+        /**
+         * The default built-in validator error messages. These may be customized.
+         * As you might have noticed, error messages support basic templating
+         * {PATH} is replaced with the invalid document path
+         * {VALUE} is replaced with the invalid value
+         * {TYPE} is replaced with the validator type such as "regexp", "min", or "user defined"
+         * {MIN} is replaced with the declared min value for the Number.min validator
+         * {MAX} is replaced with the declared max value for the Number.max validator
+         */
+        static messages: any;
 
-    // var objectId: mongoose.Types.ObjectId should reference mongodb.ObjectID not
-    //   the ObjectIdConstructor, so we add the interface below
-    interface ObjectId extends mongodb.ObjectID {}
+        /** For backwards compatibility. Same as mongoose.Error.messages */
+        static Messages: any;
+    }
 
-    class Decimal128 extends mongodb.Decimal128 {}
+    interface EachAsyncOptions {
+        /** defaults to 1 */
+        parallel?: number;
+    }
 
     /*
-      * section types/embedded.js
-      * http://mongoosejs.com/docs/api.html#types-embedded-js
-      */
-    class Embedded extends MongooseDocument {
-      /** Helper for console.log */
-      inspect(): any;
+     * section querycursor.js
+     * http://mongoosejs.com/docs/api.html#querycursor-js
+     *
+     * Callback signatures are from: http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
+     * QueryCursor can only be accessed by query#cursor(), we only
+     *   expose its interface to enable type-checking.
+     */
+    class QueryCursor<T extends Document> extends stream.Readable {
+        /**
+         * A QueryCursor is a concurrency primitive for processing query results
+         * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
+         * in addition to several other mechanisms for loading documents from MongoDB
+         * one at a time.
+         * Unless you're an advanced user, do not instantiate this class directly.
+         * Use Query#cursor() instead.
+         * @param options query options passed to .find()
+         * @event cursor Emitted when the cursor is created
+         * @event error Emitted when an error occurred
+         * @event data Emitted when the stream is flowing and the next doc is ready
+         * @event end Emitted when the stream is exhausted
+         */
+        constructor(query: Query<T>, options: any);
 
-      /**
-       * Marks a path as invalid, causing validation to fail.
-       * @param path the field to invalidate
-       * @param err error which states the reason path was invalid
-       */
-      invalidate(path: string, err: string | NativeError): boolean;
+        /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
+        close(callback?: (error: any, result: any) => void): Promise<any>;
 
-      /** Returns the top level document of this sub-document. */
-      ownerDocument(): MongooseDocument;
-      /** Returns this sub-documents parent document. */
-      parent(): MongooseDocument;
-      /** Returns this sub-documents parent array. */
-      parentArray(): DocumentArray<MongooseDocument>;
+        /**
+         * Execute fn for every document in the cursor. If fn returns a promise,
+         * will wait for the promise to resolve before iterating on to the next one.
+         * Returns a promise that resolves when done.
+         * @param fn Function to be executed for every document in the cursor
+         * @param callback Executed when all docs have been processed
+         */
+        eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): Promise<T>;
 
-      /** Removes the subdocument from its parent array. */
-      remove(options?: {
-        noop?: boolean;
-      }, fn?: (err: any) => void): this;
+        /**
+         * Execute fn for every document in the cursor. If fn returns a promise,
+         * will wait for the promise to resolve before iterating on to the next one.
+         * Returns a promise that resolves when done.
+         * @param fn Function to be executed for every document in the cursor
+         * @param options Async options (e. g. parallel function execution)
+         * @param callback Executed when all docs have been processed
+         */
+        eachAsync(fn: (doc: T) => any, options: EachAsyncOptions, callback?: (err: any) => void): Promise<T>;
 
-      /**
-       * Marks the embedded doc modified.
-       * @param path the path which changed
-       */
-      markModified(path: string): void;
+        /**
+         * Registers a transform function which subsequently maps documents retrieved
+         * via the streams interface or .next()
+         */
+        map(fn: (doc: T) => T): this;
+
+        /**
+         * Get the next document from this cursor. Will return null when there are
+         * no documents left.
+         */
+        next(callback?: (err: any, doc?: T) => void): Promise<any>;
     }
-  }
 
-  /*
-   * section query.js
-   * http://mongoosejs.com/docs/api.html#query-js
-   *
-   * Query<T> is for backwards compatibility. Example: Query<T>.find() returns Query<T[]>.
-   * If later in the query chain a method returns Query<T>, we will need to know type T.
-   * So we save this type as the second type parameter in DocumentQuery. Since people have
-   * been using Query<T>, we set it as an alias of DocumentQuery.
-   */
-  class Query<T> extends DocumentQuery<T, any> {}
-  class DocumentQuery<T, DocType extends Document> extends mquery {
-    /**
-     * Specifies a javascript function or expression to pass to MongoDBs query system.
-     * Only use $where when you have a condition that cannot be met using other MongoDB
-     * operators like $lt. Be sure to read about all of its caveats before using.
-     * @param js javascript string or function
+    /*
+     * section virtualtype.js
+     * http://mongoosejs.com/docs/api.html#virtualtype-js
      */
-    $where(js: string | Function): this;
+    class VirtualType {
+        /** This is what mongoose uses to define virtual attributes via Schema.prototype.virtual. */
+        constructor(options: any, name: string);
+        /** Applies getters to value using optional scope. */
+        applyGetters(value: any, scope: any): any;
+        /** Applies setters to value using optional scope. */
+        applySetters(value: any, scope: any): any;
+        /** Defines a getter. */
+        get(fn: Function): this;
+        /** Defines a setter. */
+        set(fn: Function): this;
+    }
 
-    /**
-     * Specifies an $all query condition.
-     * When called with one argument, the most recent path passed to where() is used.
+    /*
+     * section schema.js
+     * http://mongoosejs.com/docs/api.html#schema-js
      */
-    all(val: number): this;
-    all(path: string, val: number): this;
-
-    /**
-     * Specifies arguments for a $and condition.
-     * @param array array of conditions
-     */
-    and(array: any[]): this;
-
-    /** Specifies the batchSize option. Cannot be used with distinct() */
-    batchSize(val: number): this;
-
-    /**
-     * Specifies a $box condition
-     * @param Upper Right Coords
-     */
-    box(val: any): this;
-    box(lower: number[], upper: number[]): this;
-
-    /** Casts this query to the schema of model, If obj is present, it is cast instead of this query.*/
-    cast(model: any, obj?: any): any;
-
-    /**
-     * Executes the query returning a Promise which will be
-     * resolved with either the doc(s) or rejected with the error.
-     * Like .then(), but only takes a rejection handler.
-     */
-    catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
-
-    /**
-     * DEPRECATED Alias for circle
-     * Specifies a $center or $centerSphere condition.
-     * @deprecated Use circle instead.
-     */
-    center(area: any): this;
-    center(path: string, area: any): this;
-
-    /**
-     * DEPRECATED Specifies a $centerSphere condition
-     * @deprecated Use circle instead.
-     */
-    centerSphere(path: string, val: any): this;
-    centerSphere(val: any): this;
-
-    /** Specifies a $center or $centerSphere condition. */
-    circle(area: any): this;
-    circle(path: string, area: any): this;
-
-    /** Adds a collation to this op (MongoDB 3.4 and up) */
-    collation(value: CollationOptions): this;
-
-    /** Specifies the comment option. Cannot be used with distinct() */
-    comment(val: string): this;
-
-    /**
-     * Specifying this query as a count query. Passing a callback executes the query.
-     * @param criteria mongodb selector
-     */
-    count(callback?: (err: any, count: number) => void): Query<number>;
-    count(criteria: any, callback?: (err: any, count: number) => void): Query<number>;
-
-    /**
-     * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
-     * Streams3-compatible interface, as well as a .next() function.
-     */
-    cursor(options?: any): QueryCursor<DocType>;
-
-    /** Declares or executes a distict() operation. Passing a callback executes the query. */
-    distinct(callback?: (err: any, res: any[]) => void): Query<any[]>;
-    distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
-    distinct(field: string, criteria: any | Query<any>,
-      callback?: (err: any, res: any[]) => void): Query<any[]>;
-
-    /** Specifies an $elemMatch condition */
-    elemMatch(criteria: (elem: Query<any>) => void): this;
-    elemMatch(criteria: any): this;
-    elemMatch(path: string | any | Function, criteria: (elem: Query<any>) => void): this;
-    elemMatch(path: string | any | Function, criteria: any): this;
-
-    /** Specifies the complementary comparison value for paths specified with where() */
-    equals(val: any): this;
-
-    /** Executes the query */
-    exec(callback?: (err: any, res: T) => void): Promise<T>;
-    exec(operation: string | Function, callback?: (err: any, res: T) => void): Promise<T>;
-
-    /** Specifies an $exists condition */
-    exists(val?: boolean): this;
-    exists(path: string, val?: boolean): this;
-
-    /**
-     * Finds documents. When no callback is passed, the query is not executed. When the
-     * query is executed, the result will be an array of documents.
-     * @param criteria mongodb selector
-     */
-    find(callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType>;
-    find(criteria: any,
-      callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType>;
-
-    /**
-     * Declares the query a findOne operation. When executed, the first found document is
-     * passed to the callback. Passing a callback executes the query. The result of the query
-     * is a single document.
-     * @param criteria mongodb selector
-     * @param projection optional fields to return
-     */
-    findOne(callback?: (err: any, res: DocType | null) => void): DocumentQuery<DocType | null, DocType>;
-    findOne(criteria: any,
-      callback?: (err: any, res: DocType | null) => void): DocumentQuery<DocType | null, DocType>;
-
-    /**
-     * Issues a mongodb findAndModify remove command.
-     * Finds a matching document, removes it, passing the found document (if any) to the
-     * callback. Executes immediately if callback is passed.
-     */
-    findOneAndRemove(callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType>;
-    findOneAndRemove(conditions: any,
-      callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType>;
-    findOneAndRemove(conditions: any, options: QueryFindOneAndRemoveOptions,
-      callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType>;
-
-    /**
-     * Issues a mongodb findAndModify update command.
-     * Finds a matching document, updates it according to the update arg, passing any options, and returns
-     * the found document (if any) to the callback. The query executes immediately if callback is passed.
-     */
-    findOneAndUpdate(callback?: (err: any, doc: DocType | null) => void): DocumentQuery<DocType | null, DocType>;
-    findOneAndUpdate(update: any,
-      callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType>;
-    findOneAndUpdate(query: any, update: any,
-      callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType>;
-    findOneAndUpdate(query: any, update: any,
-      options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: DocType, res: any) => void): DocumentQuery<DocType, DocType>;
-    findOneAndUpdate(query: any, update: any, options: QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType>;
-
-    /**
-     * Specifies a $geometry condition. geometry() must come after either intersects() or within().
-     * @param object Must contain a type property which is a String and a coordinates property which
-     *   is an Array. See the examples.
-     */
-    geometry(object: { type: string, coordinates: any[] }): this;
-
-    /**
-     * Returns the current query conditions as a JSON object.
-     * @returns current query conditions
-     */
-    getQuery(): any;
-
-    /**
-     * Returns the current update operations as a JSON object.
-     * @returns current update operations
-     */
-    getUpdate(): any;
-
-    /**
-     * Specifies a $gt query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    gt(val: number): this;
-    gt(path: string, val: number): this;
-
-    /**
-     * Specifies a $gte query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    gte(val: number): this;
-    gte(path: string, val: number): this;
-
-    /**
-     * Sets query hints.
-     * @param val a hint object
-     */
-    hint(val: any): this;
-
-    /**
-     * Specifies an $in query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    in(val: any[]): this;
-    in(path: string, val: any[]): this;
-
-    /** Declares an intersects query for geometry(). MUST be used after where(). */
-    intersects(arg?: any): this;
-
-    /**
-     * Sets the lean option.
-     * Documents returned from queries with the lean option enabled are plain
-     * javascript objects, not MongooseDocuments. They have no save method,
-     * getters/setters or other Mongoose magic applied.
-     * @param bool defaults to true
-     */
-    lean(bool?: boolean | object): Query<object>;
-
-    /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
-    limit(val: number): this;
-
-    /**
-     * Specifies a $lt query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    lt(val: number): this;
-    lt(path: string, val: number): this;
-
-    /**
-     * Specifies a $lte query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    lte(val: number): this;
-    lte(path: string, val: number): this;
-
-    /**
-     * Specifies a $maxDistance query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    maxDistance(val: number): this;
-    maxDistance(path: string, val: number): this;
-
-    /** @deprecated Alias of maxScan */
-    maxscan(val: number): this;
-    /** Specifies the maxScan option. Cannot be used with distinct() */
-    maxScan(val: number): this;
-
-    /**
-     * Merges another Query or conditions object into this one.
-     * When a Query is passed, conditions, field selection and options are merged.
-     */
-    merge(source: any | Query<any>): this;
-
-    /** Specifies a $mod condition */
-    mod(val: number[]): this;
-    mod(path: string, val: number[]): this;
-
-    /**
-     * Specifies a $ne query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    ne(val: any): this;
-    ne(path: string, val: any): this;
-
-    /** Specifies a $near or $nearSphere condition. */
-    near(val: any): this;
-    near(path: string, val: any): this;
-
-    /**
-     * DEPRECATED Specifies a $nearSphere condition
-     * @deprecated Use query.near() instead with the spherical option set to true.
-     */
-    nearSphere(val: any): this;
-    nearSphere(path: string, val: any): this;
-
-    /**
-     * Specifies a $nin query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    nin(val: any[]): this;
-    nin(path: string, val: any[]): this;
-
-    /**
-     * Specifies arguments for a $nor condition.
-     * @param array array of conditions
-     */
-    nor(array: any[]): this;
-
-    /**
-     * Specifies arguments for an $or condition.
-     * @param array array of conditions
-     */
-    or(array: any[]): this;
-
-    /** Specifies a $polygon condition */
-    polygon(...coordinatePairs: number[][]): this;
-    polygon(path: string, ...coordinatePairs: number[][]): this;
-
-    /**
-     * Specifies paths which should be populated with other documents.
-     * Paths are populated after the query executes and a response is received. A separate
-     * query is then executed for each path specified for population. After a response for
-     * each query has also been returned, the results are passed to the callback.
-     * @param path either the path to populate or an object specifying all parameters
-     * @param select Field selection for the population query
-     * @param model The model you wish to use for population. If not specified, populate
-     *   will look up the model by the name in the Schema's ref field.
-     * @param match Conditions for the population query
-     * @param options Options for the population query (sort, etc)
-     */
-    populate(path: string | any, select?: string | any, model?: any,
-      match?: any, options?: any): this;
-    populate(options: ModelPopulateOptions | ModelPopulateOptions[]): this;
-
-    /**
-     * Determines the MongoDB nodes from which to read.
-     * @param pref one of the listed preference options or aliases
-     * @tags optional tags for this query
-     */
-    read(pref: string, tags?: any[]): this;
-
-    /**
-     * Specifies a $regex query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    regex(val: RegExp): this;
-    regex(path: string, val: RegExp): this;
-
-    /**
-     * Declare and/or execute this query as a remove() operation.
-     * The operation is only executed when a callback is passed. To force execution without a callback,
-     * you must first call remove() and then execute it by using the exec() method.
-     * @param criteria mongodb selector
-     */
-    remove(callback?: (err: any) => void): Query<mongodb.WriteOpResult>;
-    remove(criteria: any | Query<any>, callback?: (err: any) => void): Query<mongodb.WriteOpResult>;
-
-    /** Specifies which document fields to include or exclude (also known as the query "projection") */
-    select(arg: string | any): this;
-    /** Determines if field selection has been made. */
-    selected(): boolean;
-    /** Determines if exclusive field selection has been made.*/
-    selectedExclusively(): boolean;
-    /** Determines if inclusive field selection has been made. */
-    selectedInclusively(): boolean;
-    /** Sets query options. */
-    setOptions(options: any): this;
-
-    /**
-     * Specifies a $size query condition.
-     * When called with one argument, the most recent path passed to where() is used.
-     */
-    size(val: number): this;
-    size(path: string, val: number): this;
-
-    /** Specifies the number of documents to skip. Cannot be used with distinct() */
-    skip(val: number): this;
-
-    /**
-     * DEPRECATED Sets the slaveOk option.
-     * @param v defaults to true
-     * @deprecated in MongoDB 2.2 in favor of read preferences.
-     */
-    slaveOk(v?: boolean): this;
-
-    /**
-     * Specifies a $slice projection for an array.
-     * @param val number/range of elements to slice
-     */
-    slice(val: number | number[]): this;
-    slice(path: string, val: number | number[]): this;
-
-    /** Specifies this query as a snapshot query. Cannot be used with distinct() */
-    snapshot(v?: boolean): this;
-
-    /**
-     * Sets the sort order
-     * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
-     * If a string is passed, it must be a space delimited list of path names. The
-     * sort order of each path is ascending unless the path name is prefixed with -
-     * which will be treated as descending.
-     */
-    sort(arg: string | any): this;
-
-    /** Returns a Node.js 0.8 style read stream interface. */
-    stream(options?: { transform?: Function; }): QueryStream;
-
-    /**
-     * Sets the tailable option (for use with capped collections). Cannot be used with distinct()
-     * @param bool defaults to true
-     * @param opts options to set
-     * @param opts.numberOfRetries if cursor is exhausted, retry this many times before giving up
-     * @param opts.tailableRetryInterval if cursor is exhausted, wait this many milliseconds before retrying
-     */
-    tailable(bool?: boolean, opts?: {
-      numberOfRetries?: number;
-      tailableRetryInterval?: number;
-    }): this;
-
-    /** Executes this query and returns a promise */
-    then<TRes>(resolve?: (res: T) => void | TRes | PromiseLike<TRes>,
-      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>;
-
-    /**
-     * Converts this query to a customized, reusable query
-     * constructor with all arguments and options retained.
-     */
-    toConstructor<T>(): new(...args: any[]) => Query<T>;
-    toConstructor<T, Doc extends Document>(): new(...args: any[]) => DocumentQuery<T, Doc>;
-
-    /**
-     * Declare and/or execute this query as an update() operation.
-     * All paths passed that are not $atomic operations will become $set ops.
-     * @param doc the update command
-     */
-    update(callback?: (err: any, affectedRows: number) => void): Query<number>;
-    update(doc: any, callback?: (err: any, affectedRows: number) => void): Query<number>;
-    update(criteria: any, doc: any,
-      callback?: (err: any, affectedRows: number) => void): Query<number>;
-    update(criteria: any, doc: any, options: QueryUpdateOptions,
-      callback?: (err: any, affectedRows: number) => void): Query<number>;
-
-    /** Specifies a path for use with chaining. */
-    where(path?: string | any, val?: any): this;
-
-    /** Defines a $within or $geoWithin argument for geo-spatial queries. */
-    within(val?: any): this;
-    within(coordinate: number[], ...coordinatePairs: number[][]): this;
-
-    /** Flag to opt out of using $geoWithin. */
-    static use$geoWithin: boolean;
-  }
-
-  // https://github.com/aheckmann/mquery
-  // mquery currently does not have a type definition please
-  //   replace it if one is ever created
-  class mquery {}
-
-  interface QueryFindOneAndRemoveOptions {
-    /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
-    sort?: any;
-    /** puts a time limit on the query - requires mongodb >= 2.6.0 */
-    maxTimeMS?: number;
-    /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
-    passRawResult?: boolean;
-  }
-
-  interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
-    /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
-    new?: boolean;
-    /** creates the object if it doesn't exist. defaults to false. */
-    upsert?: boolean;
-    /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
-    fields?: any | string;
-    /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */
-    runValidators?: boolean;
-    /**
-     * if this and upsert are true, mongoose will apply the defaults specified in the model's schema if a new document
-     * is created. This option only works on MongoDB >= 2.4 because it relies on MongoDB's $setOnInsert operator.
-     */
-    setDefaultsOnInsert?: boolean;
-    /**
-     * if set to 'query' and runValidators is on, this will refer to the query in custom validator
-     * functions that update validation runs. Does nothing if runValidators is false.
-     */
-    context?: string;
-  }
-
-  interface QueryUpdateOptions extends ModelUpdateOptions {
-    /**
-     * if set to 'query' and runValidators is on, this will refer to the query
-     * in customvalidator functions that update validation runs. Does nothing
-     * if runValidators is false.
-     */
-    context?: string;
-  }
-
-  interface CollationOptions {
-    locale?: string;
-    caseLevel?: boolean;
-    caseFirst?: string;
-    strength?: number;
-    numericOrdering?: boolean;
-    alternate?: string;
-    maxVariable?: string;
-    backwards?: boolean;
-  }
-
-  namespace Schema {
-    namespace Types {
-      /*
-        * section schema/array.js
-        * http://mongoosejs.com/docs/api.html#schema-array-js
-        */
-      class Array extends SchemaType {
-        /** Array SchemaType constructor */
-        constructor(key: string, cast?: SchemaType, options?: any);
-
+    class Schema extends events.EventEmitter {
         /**
-         * Check if the given value satisfies a required validator. The given value
-         * must be not null nor undefined, and have a non-zero length.
+         * Schema constructor.
+         * When nesting schemas, (children in the example above), always declare
+         * the child schema first before passing it into its parent.
+         * @event init Emitted after the schema is compiled into a Model.
          */
-        checkRequired<T extends { length: number }>(value: T): boolean;
+        constructor(definition?: SchemaDefinition, options?: SchemaOptions);
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/string.js
-        * http://mongoosejs.com/docs/api.html#schema-string-js
-        */
-      class String extends SchemaType {
-        /** String SchemaType constructor. */
-        constructor(key: string, options?: any);
-
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
+        /** Adds key path / schema type pairs to this schema. */
+        add(obj: SchemaDefinition, prefix?: string): void;
 
         /**
-         * Adds an enum validator
-         * @param args enumeration values
+         * Iterates the schemas paths similar to Array.forEach.
+         * @param fn callback function
+         * @returns this
          */
-        enum(args: string | string[] | any): this;
-
-        /** Adds a lowercase setter. */
-        lowercase(): this;
+        eachPath(fn: (path: string, type: SchemaType) => void): this;
 
         /**
-         * Sets a regexp validator. Any value that does not pass regExp.test(val) will fail validation.
-         * @param regExp regular expression to test against
-         * @param message optional custom error message
+         * Gets a schema option.
+         * @param key option name
          */
-        match(regExp: RegExp, message?: string): this;
+        get(key: string): any;
 
         /**
-         * Sets a maximum length validator.
-         * @param value maximum string length
-         * @param message optional custom error message
+         * Defines an index (most likely compound) for this schema.
+         * @param options Options to pass to MongoDB driver's createIndex() function
+         * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
+         *   expires option into seconds for the expireAfterSeconds in the above link.
          */
-        maxlength(value: number, message?: string): this;
+        index(
+            fields: any,
+            options?: {
+                expires?: string;
+                [other: string]: any;
+            },
+        ): this;
+
+        /** Compiles indexes from fields and schema-level indexes */
+        indexes(): any[];
 
         /**
-         * Sets a minimum length validator.
-         * @param value minimum string length
-         * @param message optional custom error message
+         * Loads an ES6 class into a schema. Maps setters + getters, static methods, and
+         * instance methods to schema virtuals, statics, and methods.
          */
-        minlength(value: number, message?: string): this;
-
-        /** Adds a trim setter. The string value will be trimmed when set. */
-        trim(): this;
-        /** Adds an uppercase setter. */
-        uppercase(): this;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-
-      }
-
-      /*
-        * section schema/documentarray.js
-        * http://mongoosejs.com/docs/api.html#schema-documentarray-js
-        */
-      class DocumentArray extends Array {
-        /** SubdocsArray SchemaType constructor */
-        constructor(key: string, schema: Schema, options?: any);
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/number.js
-        * http://mongoosejs.com/docs/api.html#schema-number-js
-        */
-      class Number extends SchemaType {
-        /** Number SchemaType constructor. */
-        constructor(key: string, options?: any);
-
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
+        loadClass(model: Function): this;
 
         /**
-         * Sets a maximum number validator.
-         * @param maximum number
-         * @param message optional custom error message
+         * Adds an instance method to documents constructed from Models compiled from this schema.
+         * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
          */
-        max(maximum: number, message?: string): this;
+        method(method: string, fn: Function): this;
+        method(methodObj: { [name: string]: Function }): this;
 
         /**
-         * Sets a minimum number validator.
-         * @param value minimum number
-         * @param message optional custom error message
+         * Gets/sets schema paths.
+         * Sets a path (if arity 2)
+         * Gets a path (if arity 1)
          */
-        min(value: number, message?: string): this;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/date.js
-        * http://mongoosejs.com/docs/api.html#schema-date-js
-        */
-      class Date extends SchemaType {
-        /** Date SchemaType constructor. */
-        constructor(key: string, options?: any);
+        path(path: string): SchemaType;
+        path(path: string, constructor: any): this;
 
         /**
-         * Check if the given value satisfies a required validator. To satisfy
-         * a required validator, the given value must be an instance of Date.
+         * Returns the pathType of path for this schema.
+         * @returns whether it is a real, virtual, nested, or ad-hoc/undefined path.
          */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
-        /** Declares a TTL index (rounded to the nearest second) for Date types only. */
-        expires(when: number | string): this;
+        pathType(path: string): string;
 
         /**
-         * Sets a maximum date validator.
-         * @param maximum date
-         * @param message optional custom error message
+         * Registers a plugin for this schema.
+         * @param plugin callback
          */
-        max(maximum: NativeDate, message?: string): this;
+        plugin(plugin: (schema: Schema) => void): this;
+        plugin<T>(plugin: (schema: Schema, options: T) => void, opts: T): this;
 
         /**
+         * Defines a post hook for the document
+         * Post hooks fire on the event emitted from document instances of Models compiled
+         *   from this schema.
+         * @param method name of the method to hook
+         * @param fn callback
+         */
+        post<T extends Document>(
+            method: string,
+            fn: (error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void) => void,
+        ): this;
+
+        post<T extends Document>(method: string, fn: (doc: T, next: (err?: NativeError) => void) => void): this;
+
+        /**
+         * Defines a pre hook for the document.
+         */
+        pre(method: string, parallel: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): this;
+        pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): this;
+
+        /**
+         * Adds a method call to the queue.
+         * @param name name of the document method to call later
+         * @param args arguments to pass to the method
+         */
+        queue(name: string, args: any[]): this;
+
+        /**
+         * Removes the given path (or [paths]).
+         */
+        remove(path: string | string[]): void;
+
+        /**
+         * @param invalidate refresh the cache
+         * @returns an Array of path strings that are required by this schema.
+         */
+        requiredPaths(invalidate?: boolean): string[];
+
+        /**
+         * Sets/gets a schema option.
+         * @param key option name
+         * @param value if not passed, the current option value is returned
+         */
+        set(key: string): any;
+        set(key: string, value: any): this;
+
+        /**
+         * Adds static "class" methods to Models compiled from this schema.
+         */
+        static(name: string, fn: Function): this;
+        static(nameObj: { [name: string]: Function }): this;
+
+        /** Creates a virtual type with the given name. */
+        virtual(name: string, options?: any): VirtualType;
+
+        /** Returns the virtual type with the given name. */
+        virtualpath(name: string): VirtualType;
+
+        /** The allowed index types */
+        static indexTypes: string[];
+
+        /**
+         * Reserved document keys.
+         * Keys in this object are names that are rejected in schema declarations
+         * b/c they conflict with mongoose functionality. Using these key name
+         * will throw an error.
+         */
+        static reserved: any;
+
+        /** Object of currently defined methods on this schema. */
+        methods: any;
+        /** Object of currently defined statics on this schema. */
+        statics: any;
+        /** Object of currently defined query helpers on this schema. */
+        query: any;
+        /** The original object passed to the schema constructor */
+        obj: any;
+    }
+
+    // Hook functions: https://github.com/vkarpov15/hooks-fixed
+    interface HookSyncCallback {
+        (next: HookNextFunction, ...hookArgs: any[]): any;
+    }
+
+    interface HookAsyncCallback {
+        (next: HookNextFunction, done: HookDoneFunction, ...hookArgs: any[]): any;
+    }
+
+    interface HookErrorCallback {
+        (error: Error): any;
+    }
+
+    interface HookNextFunction {
+        (error: Error): any;
+        (...hookArgs: any[]): any;
+    }
+
+    interface HookDoneFunction {
+        (error: Error): any;
+        (...hookArgs: any[]): any;
+    }
+
+    interface SchemaOptions {
+        /** defaults to null (which means use the connection's autoIndex option) */
+        autoIndex?: boolean;
+        /** defaults to true */
+        bufferCommands?: boolean;
+        /** defaults to false */
+        capped?: boolean | number | { size?: number; max?: number; autoIndexId?: boolean };
+        /** no default */
+        collection?: string;
+        /** defaults to "__t" */
+        discriminatorKey?: string;
+        /** defaults to false. */
+        emitIndexErrors?: boolean;
+        /** defaults to true */
+        id?: boolean;
+        /** defaults to true */
+        _id?: boolean;
+        /** controls document#toObject behavior when called manually - defaults to true */
+        minimize?: boolean;
+        read?: string;
+        /** defaults to true. */
+        safe?: boolean | { w?: number | string; wtimeout?: number; j?: boolean };
+        /** defaults to null */
+        shardKey?: boolean;
+        /** defaults to true */
+        strict?: boolean;
+        /** no default */
+        toJSON?: any;
+        /** no default */
+        toObject?: any;
+        /** defaults to 'type' */
+        typeKey?: string;
+        /** defaults to false */
+        useNestedStrict?: boolean;
+        /** defaults to false */
+        usePushEach?: boolean;
+        /** defaults to true */
+        validateBeforeSave?: boolean;
+        /** defaults to "__v" */
+        versionKey?: string | boolean;
+        /** defaults to false */
+        retainKeyOrder?: boolean;
+        /**
+         * skipVersioning allows excluding paths from
+         * versioning (the internal revision will not be
+         * incremented even if these paths are updated).
+         */
+        skipVersioning?: any;
+        /**
+         * If set timestamps, mongoose assigns createdAt
+         * and updatedAt fields to your schema, the type
+         * assigned is Date.
+         */
+        timestamps?: any;
+        /**
+         * Defaults to false. Provides optimistic
+         * concurrency support for `save()`. `versionKey`
+         * must be set if this is true.
+         */
+        optimisticConcurrency?: boolean;
+    }
+
+    /*
+     * Intellisense for Schema definitions
+     */
+    interface SchemaDefinition {
+        [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
+    }
+
+    /*
+     * The standard options available when configuring a schema type:
+     * new Schema({
+     *   name: {
+     *     type: String,
+     *     required: true,
+     *     ...
+     *   }
+     * });
+     *
+     * Note: the properties have Object as a fallback type: | Object
+     *   because this interface does not apply to a schematype that
+     *   does not have a type property. Ex:
+     * new Schema({
+     *   name: {
+     *     first: String,    // since name does not have a "type" property
+     *     last: String      //   first and last can have any valid type
+     *     ...
+     *   }
+     * });
+     *
+     * References:
+     * - http://mongoosejs.com/docs/schematypes.html
+     * - http://mongoosejs.com/docs/api.html#schema_Schema.Types
+     */
+    interface SchemaTypeOpts<T> {
+        /* Common Options for all schema types */
+        type?: T;
+
+        /** Sets a default value for this SchemaType. */
+        default?: SchemaTypeOpts.DefaultFn<T> | T;
+
+        /**
+         * Getters allow you to transform the representation of the data as it travels
+         * from the raw mongodb document to the value that you see.
+         */
+        get?: (value: T, schematype?: this) => T | any;
+
+        /** Declares the index options for this schematype. */
+        index?: SchemaTypeOpts.IndexOpts | boolean | string;
+
+        /**
+         * Adds a required validator to this SchemaType. The validator gets added
+         * to the front of this SchemaType's validators array using unshift().
+         */
+        required?: SchemaTypeOpts.RequiredFn<T> | boolean | [boolean, string] | string | [string, string] | any;
+
+        /**
+         * Sets default select() behavior for this path.
+         * Set to true if this path should always be included in the results, false
+         * if it should be excluded by default. This setting can be overridden at
+         * the query level.
+         */
+        select?: boolean | any;
+
+        /**
+         * Setters allow you to transform the data before it gets to the raw mongodb
+         * document and is set as a value on an actual key.
+         */
+        set?: (value: T, schematype?: this) => T | any;
+
+        /** Declares a sparse index. */
+        sparse?: boolean | any;
+
+        /** Declares a full text index. */
+        text?: boolean | any;
+
+        /**
+         * Adds validator(s) for this document path.
+         * Validators always receive the value to validate as their first argument
+         * and must return Boolean. Returning false means validation failed.
+         */
+        validate?:
+            | RegExp
+            | [RegExp, string]
+            | SchemaTypeOpts.ValidateFn<T>
+            | [SchemaTypeOpts.ValidateFn<T>, string]
+            | SchemaTypeOpts.ValidateOpts
+            | SchemaTypeOpts.ValidateOpts[]
+            | any;
+
+        /** Declares an unique index. */
+        unique?: boolean | any;
+
+        /* Options for specific schema types (String, Number, Date, etc.) */
+        /** String only - Adds an enum validator */
+        enum?: T[] | SchemaTypeOpts.EnumOpts<T> | any;
+        /** String only - Adds a lowercase setter. */
+        lowercase?: boolean | any;
+        /** String only - Sets a regexp validator. */
+        match?: RegExp | [RegExp, string] | any;
+        /** String only - Sets a maximum length validator. */
+        maxlength?: number | [number, string] | any;
+        /** String only - Sets a minimum length validator. */
+        minlength?: number | [number, string] | any;
+        /** String only - Adds a trim setter. */
+        trim?: boolean | any;
+        /** String only - Adds an uppercase setter. */
+        uppercase?: boolean | any;
+
+        /**
+         * Date, Number only - Sets a minimum number validator.
          * Sets a minimum date validator.
-         * @param value minimum date
+         */
+        min?: number | [number, string] | Date | [Date, string] | any;
+
+        /**
+         * Date, Number only - Sets a maximum number validator.
+         * Sets a maximum date validator.
+         */
+        max?: number | [number, string] | Date | [Date, string] | any;
+
+        /**
+         * Date only - Declares a TTL index (rounded to the nearest second)
+         * for Date types only.
+         */
+        expires?: number | string | any;
+
+        /** ObjectId only - Adds an auto-generated ObjectId default if turnOn is true. */
+        auto?: boolean | any;
+
+        [other: string]: any;
+    }
+
+    // Interfaces specific to schema type options should be scoped in this namespace
+    namespace SchemaTypeOpts {
+        interface DefaultFn<T> {
+            (...args: any[]): T;
+        }
+
+        interface RequiredFn<T> {
+            (required: boolean, message?: string): T;
+        }
+
+        interface ValidateFn<T> {
+            (obj: RegExp | Function, message?: string, type?: string): T;
+        }
+
+        interface ValidateOpts {
+            validator?: RegExp | Function;
+            msg?: string;
+            type?: string;
+        }
+
+        interface EnumOpts<T> {
+            values?: T[];
+            message?: string;
+        }
+
+        interface IndexOpts {
+            background?: boolean;
+            expires?: number | string;
+            sparse?: boolean;
+            type?: string;
+            unique?: boolean;
+        }
+    }
+
+    /*
+     * section document.js
+     * http://mongoosejs.com/docs/api.html#document-js
+     */
+    interface MongooseDocument extends MongooseDocumentOptionals {}
+    class MongooseDocument {
+        /** Checks if a path is set to its default. */
+        $isDefault(path?: string): boolean;
+
+        /**
+         * Takes a populated field and returns it to its unpopulated state.
+         * If the path was not populated, this is a no-op.
+         */
+        depopulate(path: string): void;
+
+        /**
+         * Returns true if the Document stores the same data as doc.
+         * Documents are considered equal when they have matching _ids, unless neither document
+         * has an _id, in which case this function falls back to usin deepEqual().
+         * @param doc a document to compare
+         */
+        equals(doc: MongooseDocument): boolean;
+
+        /**
+         * Explicitly executes population and returns a promise.
+         * Useful for ES2015 integration.
+         * @returns promise that resolves to the document when population is done
+         */
+        execPopulate(): Promise<this>;
+
+        /**
+         * Returns the value of a path.
+         * @param type optionally specify a type for on-the-fly attributes
+         */
+        get(path: string, type?: any): any;
+
+        /**
+         * Initializes the document without setters or marking anything modified.
+         * Called internally after a document is returned from mongodb.
+         * @param doc document returned by mongo
+         * @param fn callback
+         */
+        init(doc: MongooseDocument, fn?: () => void): this;
+        init(doc: MongooseDocument, opts: any, fn?: () => void): this;
+
+        /** Helper for console.log */
+        inspect(options?: any): any;
+
+        /**
+         * Marks a path as invalid, causing validation to fail.
+         * The errorMsg argument will become the message of the ValidationError.
+         * The value argument (if passed) will be available through the ValidationError.value property.
+         * @param path the field to invalidate
+         * @param errorMsg the error which states the reason path was invalid
+         * @param value optional invalid value
+         * @param kind optional kind property for the error
+         * @returns the current ValidationError, with all currently invalidated paths
+         */
+        invalidate(path: string, errorMsg: string | NativeError, value: any, kind?: string): ValidationError | boolean;
+
+        /** Returns true if path was directly set and modified, else false. */
+        isDirectModified(path: string): boolean;
+
+        /** Checks if path was initialized */
+        isInit(path: string): boolean;
+
+        /**
+         * Returns true if this document was modified, else false.
+         * If path is given, checks if a path or any full path containing path as part of its path
+         * chain has been modified.
+         */
+        isModified(path?: string): boolean;
+
+        /** Checks if path was selected in the source query which initialized this document. */
+        isSelected(path: string): boolean;
+
+        /**
+         * Marks the path as having pending changes to write to the db.
+         * Very helpful when using Mixed types.
+         * @param path the path to mark modified
+         */
+        markModified(path: string): void;
+
+        /** Returns the list of paths that have been modified. */
+        modifiedPaths(): string[];
+
+        /**
+         * Populates document references, executing the callback when complete.
+         * If you want to use promises instead, use this function with
+         * execPopulate()
+         * Population does not occur unless a callback is passed or you explicitly
+         * call execPopulate(). Passing the same path a second time will overwrite
+         * the previous path options. See Model.populate() for explaination of options.
+         * @param path The path to populate or an options object
+         * @param names The properties to fetch from the populated document
+         * @param callback When passed, population is invoked
+         */
+        populate(callback: (err: any, res: this) => void): this;
+        populate(path: string, callback?: (err: any, res: this) => void): this;
+        populate(path: string, names: string, callback?: (err: any, res: this) => void): this;
+        populate(
+            options: ModelPopulateOptions | ModelPopulateOptions[],
+            callback?: (err: any, res: this) => void,
+        ): this;
+
+        /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */
+        populated(path: string): any;
+
+        /**
+         * Sets the value of a path, or many paths.
+         * @param path path or object of key/vals to set
+         * @param val the value to set
+         * @param type optionally specify a type for "on-the-fly" attributes
+         * @param options optionally specify options that modify the behavior of the set
+         */
+        set(path: string, val: any, options?: any): this;
+        set(path: string, val: any, type: any, options?: any): this;
+        set(value: any): this;
+
+        /**
+         * The return value of this method is used in calls to JSON.stringify(doc).
+         * This method accepts the same options as Document#toObject. To apply the
+         * options to every document of your schema by default, set your schemas
+         * toJSON option to the same argument.
+         */
+        toJSON(options?: DocumentToObjectOptions): any;
+
+        /**
+         * Converts this document into a plain javascript object, ready for storage in MongoDB.
+         * Buffers are converted to instances of mongodb.Binary for proper storage.
+         */
+        toObject(options?: DocumentToObjectOptions): any;
+
+        /** Helper for console.log */
+        toString(): string;
+
+        /**
+         * Clears the modified state on the specified path.
+         * @param path the path to unmark modified
+         */
+        unmarkModified(path: string): void;
+
+        /** Sends an update command with this document _id as the query selector.  */
+        update(doc: any, callback?: (err: any, raw: any) => void): Query<any>;
+        update(doc: any, options: ModelUpdateOptions, callback?: (err: any, raw: any) => void): Query<any>;
+
+        /**
+         * Executes registered validation rules for this document.
+         * @param optional options internal options
+         * @param callback callback called after validation completes, passing an error if one occurred
+         */
+        validate(callback?: (err: any) => void): Promise<void>;
+        validate(optional: any, callback?: (err: any) => void): Promise<void>;
+
+        /**
+         * Executes registered validation rules (skipping asynchronous validators) for this document.
+         * This method is useful if you need synchronous validation.
+         * @param pathsToValidate only validate the given paths
+         * @returns MongooseError if there are errors during validation, or undefined if there is no error.
+         */
+        validateSync(pathsToValidate?: string | string[]): Error | undefined;
+
+        /** Hash containing current validation errors. */
+        errors: any;
+        /** This documents _id. */
+        _id: any;
+        /** Boolean flag specifying if the document is new. */
+        isNew: boolean;
+        /** The documents schema. */
+        schema: Schema;
+    }
+
+    interface MongooseDocumentOptionals {
+        /**
+         * Virtual getter that by default returns the document's _id field cast to a string,
+         * or in the case of ObjectIds, its hexString. This id getter may be disabled by
+         * passing the option { id: false } at schema construction time. If disabled, id
+         * behaves like any other field on a document and can be assigned any value.
+         */
+        id?: any;
+    }
+
+    interface DocumentToObjectOptions {
+        /** apply all getters (path and virtual getters) */
+        getters?: boolean;
+        /** apply virtual getters (can override getters option) */
+        virtuals?: boolean;
+        /** remove empty objects (defaults to true) */
+        minimize?: boolean;
+        /**
+         * A transform function to apply to the resulting document before returning
+         * @param doc The mongoose document which is being converted
+         * @param ret The plain object representation which has been converted
+         * @param options The options in use (either schema options or the options passed inline)
+         */
+        transform?: (doc: any, ret: any, options: any) => any;
+        /** depopulate any populated paths, replacing them with their original refs (defaults to false) */
+        depopulate?: boolean;
+        /** whether to include the version key (defaults to true) */
+        versionKey?: boolean;
+        /**
+         * keep the order of object keys. If this is set to true,
+         * Object.keys(new Doc({ a: 1, b: 2}).toObject()) will
+         * always produce ['a', 'b'] (defaults to false)
+         */
+        retainKeyOrder?: boolean;
+    }
+
+    namespace Types {
+        /*
+         * section types/subdocument.js
+         * http://mongoosejs.com/docs/api.html#types-subdocument-js
+         */
+        class Subdocument extends MongooseDocument {
+            /** Returns the top level document of this sub-document. */
+            ownerDocument(): MongooseDocument;
+
+            /**
+             * Null-out this subdoc
+             * @param callback optional callback for compatibility with Document.prototype.remove
+             */
+            remove(callback?: (err: any) => void): void;
+            remove(options: any, callback?: (err: any) => void): void;
+        }
+
+        /*
+         * section types/array.js
+         * http://mongoosejs.com/docs/api.html#types-array-js
+         */
+        class Array<T> extends global.Array<T> {
+            /**
+             * Atomically shifts the array at most one time per document save().
+             * Calling this mulitple times on an array before saving sends the same command as
+             * calling it once. This update is implemented using the MongoDB $pop method which
+             * enforces this restriction.
+             */
+            $shift(): T;
+
+            /** Alias of pull */
+            remove(...args: any[]): this;
+
+            /**
+             * Pops the array atomically at most one time per document save().
+             * Calling this mulitple times on an array before saving sends the same command as
+             * calling it once. This update is implemented using the MongoDB $pop method which
+             * enforces this restriction.
+             */
+            $pop(): T;
+
+            /**
+             * Adds values to the array if not already present.
+             * @returns the values that were added
+             */
+            addToSet(...args: any[]): T[];
+
+            /**
+             * Return the index of obj or -1 if not found.
+             * @param obj The item to look for
+             */
+            indexOf(obj: any): number;
+
+            /** Helper for console.log */
+            inspect(): any;
+
+            /**
+             * Marks the entire array as modified, which if saved, will store it as a $set
+             * operation, potentially overwritting any changes that happen between when you
+             * retrieved the object and when you save it.
+             * @returns new length of the array
+             */
+            nonAtomicPush(...args: any[]): number;
+
+            /**
+             * Wraps Array#pop with proper change tracking.
+             * marks the entire array as modified which will pass the entire thing to $set
+             * potentially overwritting any changes that happen between when you retrieved
+             * the object and when you save it.
+             */
+            pop(): T;
+
+            /**
+             * Pulls items from the array atomically. Equality is determined by casting
+             * the provided value to an embedded document and comparing using
+             * the Document.equals() function.
+             */
+            pull(...args: any[]): this;
+
+            /**
+             * Wraps Array#push with proper change tracking.
+             * @returns new length of the array
+             */
+            push(...args: any[]): number;
+
+            /** Sets the casted val at index i and marks the array modified. */
+            set(i: number, val: any): this;
+
+            /**
+             * Wraps Array#shift with proper change tracking.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            shift(): T;
+
+            /**
+             * Wraps Array#sort with proper change tracking.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            // some lib.d.ts have return type "this" and others have return type "T[]"
+            // which causes errors. Let the inherited array provide the sort() method.
+            //sort(compareFn?: (a: T, b: T) => number): T[];
+
+            /**
+             * Wraps Array#splice with proper change tracking and casting.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            splice(...args: any[]): T[];
+
+            /** Returns a native js Array. */
+            toObject(options?: any): T[];
+
+            /**
+             * Wraps Array#unshift with proper change tracking.
+             * Marks the entire array as modified, which if saved, will store it as a $set operation,
+             * potentially overwritting any changes that happen between when you retrieved the object
+             * and when you save it.
+             */
+            unshift(...args: any[]): number;
+        }
+
+        /*
+         * section types/documentarray.js
+         * http://mongoosejs.com/docs/api.html#types-documentarray-js
+         */
+        class DocumentArray<T extends MongooseDocument> extends Types.Array<T> {
+            /**
+             * Creates a subdocument casted to this schema.
+             * This is the same subdocument constructor used for casting.
+             * @param obj the value to cast to this arrays SubDocument schema
+             */
+            create(obj: any): T;
+
+            /**
+             * Searches array items for the first document with a matching _id.
+             * @returns the subdocument or null if not found.
+             */
+            id(id: ObjectId | string | number | NativeBuffer): T;
+
+            /** Helper for console.log */
+            inspect(): T[];
+
+            /**
+             * Returns a native js Array of plain js objects
+             * @param options optional options to pass to each documents toObject
+             *   method call during conversion
+             */
+            toObject(options?: any): T[];
+        }
+
+        /*
+         * section types/buffer.js
+         * http://mongoosejs.com/docs/api.html#types-buffer-js
+         */
+        class Buffer extends global.Buffer {
+            /**
+             * Copies the buffer.
+             * Buffer#copy does not mark target as modified so you must copy
+             * from a MongooseBuffer for it to work as expected. This is a
+             * work around since copy modifies the target, not this.
+             */
+            copy(target: NativeBuffer, ...nodeBufferArgs: any[]): number;
+
+            /** Determines if this buffer is equals to other buffer */
+            equals(other: NativeBuffer): boolean;
+
+            /** Sets the subtype option and marks the buffer modified. */
+            subtype(subtype: number): void;
+
+            /** Converts this buffer to its Binary type representation. */
+            toObject(subtype?: number): mongodb.Binary;
+
+            /** Writes the buffer. */
+            write(string: string, ...nodeBufferArgs: any[]): number;
+        }
+
+        /*
+         * section types/objectid.js
+         * http://mongoosejs.com/docs/api.html#types-objectid-js
+         */
+        var ObjectId: ObjectIdConstructor;
+
+        // mongodb.ObjectID does not allow mongoose.Types.ObjectId(id). This is
+        //   commonly used in mongoose and is found in an example in the docs:
+        //   http://mongoosejs.com/docs/api.html#aggregate_Aggregate
+        // constructor exposes static methods of mongodb.ObjectID and ObjectId(id)
+        type ObjectIdConstructor = typeof mongodb.ObjectID & {
+            (s?: string | number): mongodb.ObjectID;
+        };
+
+        // var objectId: mongoose.Types.ObjectId should reference mongodb.ObjectID not
+        //   the ObjectIdConstructor, so we add the interface below
+        interface ObjectId extends mongodb.ObjectID {}
+
+        class Decimal128 extends mongodb.Decimal128 {}
+
+        /*
+         * section types/embedded.js
+         * http://mongoosejs.com/docs/api.html#types-embedded-js
+         */
+        class Embedded extends MongooseDocument {
+            /** Helper for console.log */
+            inspect(): any;
+
+            /**
+             * Marks a path as invalid, causing validation to fail.
+             * @param path the field to invalidate
+             * @param err error which states the reason path was invalid
+             */
+            invalidate(path: string, err: string | NativeError): boolean;
+
+            /** Returns the top level document of this sub-document. */
+            ownerDocument(): MongooseDocument;
+            /** Returns this sub-documents parent document. */
+            parent(): MongooseDocument;
+            /** Returns this sub-documents parent array. */
+            parentArray(): DocumentArray<MongooseDocument>;
+
+            /** Removes the subdocument from its parent array. */
+            remove(
+                options?: {
+                    noop?: boolean;
+                },
+                fn?: (err: any) => void,
+            ): this;
+
+            /**
+             * Marks the embedded doc modified.
+             * @param path the path which changed
+             */
+            markModified(path: string): void;
+        }
+    }
+
+    /*
+     * section query.js
+     * http://mongoosejs.com/docs/api.html#query-js
+     *
+     * Query<T> is for backwards compatibility. Example: Query<T>.find() returns Query<T[]>.
+     * If later in the query chain a method returns Query<T>, we will need to know type T.
+     * So we save this type as the second type parameter in DocumentQuery. Since people have
+     * been using Query<T>, we set it as an alias of DocumentQuery.
+     */
+    class Query<T> extends DocumentQuery<T, any> {}
+    class DocumentQuery<T, DocType extends Document> extends mquery {
+        /**
+         * Specifies a javascript function or expression to pass to MongoDBs query system.
+         * Only use $where when you have a condition that cannot be met using other MongoDB
+         * operators like $lt. Be sure to read about all of its caveats before using.
+         * @param js javascript string or function
+         */
+        $where(js: string | Function): this;
+
+        /**
+         * Specifies an $all query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        all(val: number): this;
+        all(path: string, val: number): this;
+
+        /**
+         * Specifies arguments for a $and condition.
+         * @param array array of conditions
+         */
+        and(array: any[]): this;
+
+        /** Specifies the batchSize option. Cannot be used with distinct() */
+        batchSize(val: number): this;
+
+        /**
+         * Specifies a $box condition
+         * @param Upper Right Coords
+         */
+        box(val: any): this;
+        box(lower: number[], upper: number[]): this;
+
+        /** Casts this query to the schema of model, If obj is present, it is cast instead of this query.*/
+        cast(model: any, obj?: any): any;
+
+        /**
+         * Executes the query returning a Promise which will be
+         * resolved with either the doc(s) or rejected with the error.
+         * Like .then(), but only takes a rejection handler.
+         */
+        catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
+
+        /**
+         * DEPRECATED Alias for circle
+         * Specifies a $center or $centerSphere condition.
+         * @deprecated Use circle instead.
+         */
+        center(area: any): this;
+        center(path: string, area: any): this;
+
+        /**
+         * DEPRECATED Specifies a $centerSphere condition
+         * @deprecated Use circle instead.
+         */
+        centerSphere(path: string, val: any): this;
+        centerSphere(val: any): this;
+
+        /** Specifies a $center or $centerSphere condition. */
+        circle(area: any): this;
+        circle(path: string, area: any): this;
+
+        /** Adds a collation to this op (MongoDB 3.4 and up) */
+        collation(value: CollationOptions): this;
+
+        /** Specifies the comment option. Cannot be used with distinct() */
+        comment(val: string): this;
+
+        /**
+         * Specifying this query as a count query. Passing a callback executes the query.
+         * @param criteria mongodb selector
+         */
+        count(callback?: (err: any, count: number) => void): Query<number>;
+        count(criteria: any, callback?: (err: any, count: number) => void): Query<number>;
+
+        /**
+         * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
+         * Streams3-compatible interface, as well as a .next() function.
+         */
+        cursor(options?: any): QueryCursor<DocType>;
+
+        /** Declares or executes a distict() operation. Passing a callback executes the query. */
+        distinct(callback?: (err: any, res: any[]) => void): Query<any[]>;
+        distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
+        distinct(field: string, criteria: any | Query<any>, callback?: (err: any, res: any[]) => void): Query<any[]>;
+
+        /** Specifies an $elemMatch condition */
+        elemMatch(criteria: (elem: Query<any>) => void): this;
+        elemMatch(criteria: any): this;
+        elemMatch(path: string | any | Function, criteria: (elem: Query<any>) => void): this;
+        elemMatch(path: string | any | Function, criteria: any): this;
+
+        /** Specifies the complementary comparison value for paths specified with where() */
+        equals(val: any): this;
+
+        /** Executes the query */
+        exec(callback?: (err: any, res: T) => void): Promise<T>;
+        exec(operation: string | Function, callback?: (err: any, res: T) => void): Promise<T>;
+
+        /** Specifies an $exists condition */
+        exists(val?: boolean): this;
+        exists(path: string, val?: boolean): this;
+
+        /**
+         * Finds documents. When no callback is passed, the query is not executed. When the
+         * query is executed, the result will be an array of documents.
+         * @param criteria mongodb selector
+         */
+        find(callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType>;
+        find(criteria: any, callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType>;
+
+        /**
+         * Declares the query a findOne operation. When executed, the first found document is
+         * passed to the callback. Passing a callback executes the query. The result of the query
+         * is a single document.
+         * @param criteria mongodb selector
+         * @param projection optional fields to return
+         */
+        findOne(callback?: (err: any, res: DocType | null) => void): DocumentQuery<DocType | null, DocType>;
+        findOne(
+            criteria: any,
+            callback?: (err: any, res: DocType | null) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+
+        /**
+         * Issues a mongodb findAndModify remove command.
+         * Finds a matching document, removes it, passing the found document (if any) to the
+         * callback. Executes immediately if callback is passed.
+         */
+        findOneAndRemove(
+            callback?: (error: any, doc: DocType | null, result: any) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+        findOneAndRemove(
+            conditions: any,
+            callback?: (error: any, doc: DocType | null, result: any) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+        findOneAndRemove(
+            conditions: any,
+            options: QueryFindOneAndRemoveOptions,
+            callback?: (error: any, doc: DocType | null, result: any) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+
+        /**
+         * Issues a mongodb findAndModify update command.
+         * Finds a matching document, updates it according to the update arg, passing any options, and returns
+         * the found document (if any) to the callback. The query executes immediately if callback is passed.
+         */
+        findOneAndUpdate(callback?: (err: any, doc: DocType | null) => void): DocumentQuery<DocType | null, DocType>;
+        findOneAndUpdate(
+            update: any,
+            callback?: (err: any, doc: DocType | null, res: any) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+        findOneAndUpdate(
+            query: any,
+            update: any,
+            callback?: (err: any, doc: DocType | null, res: any) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+        findOneAndUpdate(
+            query: any,
+            update: any,
+            options: { upsert: true; new: true } & QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: DocType, res: any) => void,
+        ): DocumentQuery<DocType, DocType>;
+        findOneAndUpdate(
+            query: any,
+            update: any,
+            options: QueryFindOneAndUpdateOptions,
+            callback?: (err: any, doc: DocType | null, res: any) => void,
+        ): DocumentQuery<DocType | null, DocType>;
+
+        /**
+         * Specifies a $geometry condition. geometry() must come after either intersects() or within().
+         * @param object Must contain a type property which is a String and a coordinates property which
+         *   is an Array. See the examples.
+         */
+        geometry(object: { type: string; coordinates: any[] }): this;
+
+        /**
+         * Returns the current query conditions as a JSON object.
+         * @returns current query conditions
+         */
+        getQuery(): any;
+
+        /**
+         * Returns the current update operations as a JSON object.
+         * @returns current update operations
+         */
+        getUpdate(): any;
+
+        /**
+         * Specifies a $gt query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        gt(val: number): this;
+        gt(path: string, val: number): this;
+
+        /**
+         * Specifies a $gte query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        gte(val: number): this;
+        gte(path: string, val: number): this;
+
+        /**
+         * Sets query hints.
+         * @param val a hint object
+         */
+        hint(val: any): this;
+
+        /**
+         * Specifies an $in query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        in(val: any[]): this;
+        in(path: string, val: any[]): this;
+
+        /** Declares an intersects query for geometry(). MUST be used after where(). */
+        intersects(arg?: any): this;
+
+        /**
+         * Sets the lean option.
+         * Documents returned from queries with the lean option enabled are plain
+         * javascript objects, not MongooseDocuments. They have no save method,
+         * getters/setters or other Mongoose magic applied.
+         * @param bool defaults to true
+         */
+        lean(bool?: boolean | object): Query<object>;
+
+        /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
+        limit(val: number): this;
+
+        /**
+         * Specifies a $lt query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        lt(val: number): this;
+        lt(path: string, val: number): this;
+
+        /**
+         * Specifies a $lte query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        lte(val: number): this;
+        lte(path: string, val: number): this;
+
+        /**
+         * Specifies a $maxDistance query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        maxDistance(val: number): this;
+        maxDistance(path: string, val: number): this;
+
+        /** @deprecated Alias of maxScan */
+        maxscan(val: number): this;
+        /** Specifies the maxScan option. Cannot be used with distinct() */
+        maxScan(val: number): this;
+
+        /**
+         * Merges another Query or conditions object into this one.
+         * When a Query is passed, conditions, field selection and options are merged.
+         */
+        merge(source: any | Query<any>): this;
+
+        /** Specifies a $mod condition */
+        mod(val: number[]): this;
+        mod(path: string, val: number[]): this;
+
+        /**
+         * Specifies a $ne query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        ne(val: any): this;
+        ne(path: string, val: any): this;
+
+        /** Specifies a $near or $nearSphere condition. */
+        near(val: any): this;
+        near(path: string, val: any): this;
+
+        /**
+         * DEPRECATED Specifies a $nearSphere condition
+         * @deprecated Use query.near() instead with the spherical option set to true.
+         */
+        nearSphere(val: any): this;
+        nearSphere(path: string, val: any): this;
+
+        /**
+         * Specifies a $nin query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        nin(val: any[]): this;
+        nin(path: string, val: any[]): this;
+
+        /**
+         * Specifies arguments for a $nor condition.
+         * @param array array of conditions
+         */
+        nor(array: any[]): this;
+
+        /**
+         * Specifies arguments for an $or condition.
+         * @param array array of conditions
+         */
+        or(array: any[]): this;
+
+        /** Specifies a $polygon condition */
+        polygon(...coordinatePairs: number[][]): this;
+        polygon(path: string, ...coordinatePairs: number[][]): this;
+
+        /**
+         * Specifies paths which should be populated with other documents.
+         * Paths are populated after the query executes and a response is received. A separate
+         * query is then executed for each path specified for population. After a response for
+         * each query has also been returned, the results are passed to the callback.
+         * @param path either the path to populate or an object specifying all parameters
+         * @param select Field selection for the population query
+         * @param model The model you wish to use for population. If not specified, populate
+         *   will look up the model by the name in the Schema's ref field.
+         * @param match Conditions for the population query
+         * @param options Options for the population query (sort, etc)
+         */
+        populate(path: string | any, select?: string | any, model?: any, match?: any, options?: any): this;
+        populate(options: ModelPopulateOptions | ModelPopulateOptions[]): this;
+
+        /**
+         * Determines the MongoDB nodes from which to read.
+         * @param pref one of the listed preference options or aliases
+         * @tags optional tags for this query
+         */
+        read(pref: string, tags?: any[]): this;
+
+        /**
+         * Specifies a $regex query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        regex(val: RegExp): this;
+        regex(path: string, val: RegExp): this;
+
+        /**
+         * Declare and/or execute this query as a remove() operation.
+         * The operation is only executed when a callback is passed. To force execution without a callback,
+         * you must first call remove() and then execute it by using the exec() method.
+         * @param criteria mongodb selector
+         */
+        remove(callback?: (err: any) => void): Query<mongodb.WriteOpResult>;
+        remove(criteria: any | Query<any>, callback?: (err: any) => void): Query<mongodb.WriteOpResult>;
+
+        /** Specifies which document fields to include or exclude (also known as the query "projection") */
+        select(arg: string | any): this;
+        /** Determines if field selection has been made. */
+        selected(): boolean;
+        /** Determines if exclusive field selection has been made.*/
+        selectedExclusively(): boolean;
+        /** Determines if inclusive field selection has been made. */
+        selectedInclusively(): boolean;
+        /** Sets query options. */
+        setOptions(options: any): this;
+
+        /**
+         * Specifies a $size query condition.
+         * When called with one argument, the most recent path passed to where() is used.
+         */
+        size(val: number): this;
+        size(path: string, val: number): this;
+
+        /** Specifies the number of documents to skip. Cannot be used with distinct() */
+        skip(val: number): this;
+
+        /**
+         * DEPRECATED Sets the slaveOk option.
+         * @param v defaults to true
+         * @deprecated in MongoDB 2.2 in favor of read preferences.
+         */
+        slaveOk(v?: boolean): this;
+
+        /**
+         * Specifies a $slice projection for an array.
+         * @param val number/range of elements to slice
+         */
+        slice(val: number | number[]): this;
+        slice(path: string, val: number | number[]): this;
+
+        /** Specifies this query as a snapshot query. Cannot be used with distinct() */
+        snapshot(v?: boolean): this;
+
+        /**
+         * Sets the sort order
+         * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
+         * If a string is passed, it must be a space delimited list of path names. The
+         * sort order of each path is ascending unless the path name is prefixed with -
+         * which will be treated as descending.
+         */
+        sort(arg: string | any): this;
+
+        /** Returns a Node.js 0.8 style read stream interface. */
+        stream(options?: { transform?: Function }): QueryStream;
+
+        /**
+         * Sets the tailable option (for use with capped collections). Cannot be used with distinct()
+         * @param bool defaults to true
+         * @param opts options to set
+         * @param opts.numberOfRetries if cursor is exhausted, retry this many times before giving up
+         * @param opts.tailableRetryInterval if cursor is exhausted, wait this many milliseconds before retrying
+         */
+        tailable(
+            bool?: boolean,
+            opts?: {
+                numberOfRetries?: number;
+                tailableRetryInterval?: number;
+            },
+        ): this;
+
+        /** Executes this query and returns a promise */
+        then<TRes>(
+            resolve?: (res: T) => void | TRes | PromiseLike<TRes>,
+            reject?: (err: any) => void | TRes | PromiseLike<TRes>,
+        ): Promise<TRes>;
+
+        /**
+         * Converts this query to a customized, reusable query
+         * constructor with all arguments and options retained.
+         */
+        toConstructor<T>(): new (...args: any[]) => Query<T>;
+        toConstructor<T, Doc extends Document>(): new (...args: any[]) => DocumentQuery<T, Doc>;
+
+        /**
+         * Declare and/or execute this query as an update() operation.
+         * All paths passed that are not $atomic operations will become $set ops.
+         * @param doc the update command
+         */
+        update(callback?: (err: any, affectedRows: number) => void): Query<number>;
+        update(doc: any, callback?: (err: any, affectedRows: number) => void): Query<number>;
+        update(criteria: any, doc: any, callback?: (err: any, affectedRows: number) => void): Query<number>;
+        update(
+            criteria: any,
+            doc: any,
+            options: QueryUpdateOptions,
+            callback?: (err: any, affectedRows: number) => void,
+        ): Query<number>;
+
+        /** Specifies a path for use with chaining. */
+        where(path?: string | any, val?: any): this;
+
+        /** Defines a $within or $geoWithin argument for geo-spatial queries. */
+        within(val?: any): this;
+        within(coordinate: number[], ...coordinatePairs: number[][]): this;
+
+        /** Flag to opt out of using $geoWithin. */
+        static use$geoWithin: boolean;
+    }
+
+    // https://github.com/aheckmann/mquery
+    // mquery currently does not have a type definition please
+    //   replace it if one is ever created
+    class mquery {}
+
+    interface QueryFindOneAndRemoveOptions {
+        /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
+        sort?: any;
+        /** puts a time limit on the query - requires mongodb >= 2.6.0 */
+        maxTimeMS?: number;
+        /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
+        passRawResult?: boolean;
+    }
+
+    interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
+        /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
+        new?: boolean;
+        /** creates the object if it doesn't exist. defaults to false. */
+        upsert?: boolean;
+        /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
+        fields?: any | string;
+        /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */
+        runValidators?: boolean;
+        /**
+         * if this and upsert are true, mongoose will apply the defaults specified in the model's schema if a new document
+         * is created. This option only works on MongoDB >= 2.4 because it relies on MongoDB's $setOnInsert operator.
+         */
+        setDefaultsOnInsert?: boolean;
+        /**
+         * if set to 'query' and runValidators is on, this will refer to the query in custom validator
+         * functions that update validation runs. Does nothing if runValidators is false.
+         */
+        context?: string;
+    }
+
+    interface QueryUpdateOptions extends ModelUpdateOptions {
+        /**
+         * if set to 'query' and runValidators is on, this will refer to the query
+         * in customvalidator functions that update validation runs. Does nothing
+         * if runValidators is false.
+         */
+        context?: string;
+    }
+
+    interface CollationOptions {
+        locale?: string;
+        caseLevel?: boolean;
+        caseFirst?: string;
+        strength?: number;
+        numericOrdering?: boolean;
+        alternate?: string;
+        maxVariable?: string;
+        backwards?: boolean;
+    }
+
+    namespace Schema {
+        namespace Types {
+            /*
+             * section schema/array.js
+             * http://mongoosejs.com/docs/api.html#schema-array-js
+             */
+            class Array extends SchemaType {
+                /** Array SchemaType constructor */
+                constructor(key: string, cast?: SchemaType, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. The given value
+                 * must be not null nor undefined, and have a non-zero length.
+                 */
+                checkRequired<T extends { length: number }>(value: T): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/string.js
+             * http://mongoosejs.com/docs/api.html#schema-string-js
+             */
+            class String extends SchemaType {
+                /** String SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /**
+                 * Adds an enum validator
+                 * @param args enumeration values
+                 */
+                enum(args: string | string[] | any): this;
+
+                /** Adds a lowercase setter. */
+                lowercase(): this;
+
+                /**
+                 * Sets a regexp validator. Any value that does not pass regExp.test(val) will fail validation.
+                 * @param regExp regular expression to test against
+                 * @param message optional custom error message
+                 */
+                match(regExp: RegExp, message?: string): this;
+
+                /**
+                 * Sets a maximum length validator.
+                 * @param value maximum string length
+                 * @param message optional custom error message
+                 */
+                maxlength(value: number, message?: string): this;
+
+                /**
+                 * Sets a minimum length validator.
+                 * @param value minimum string length
+                 * @param message optional custom error message
+                 */
+                minlength(value: number, message?: string): this;
+
+                /** Adds a trim setter. The string value will be trimmed when set. */
+                trim(): this;
+                /** Adds an uppercase setter. */
+                uppercase(): this;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/documentarray.js
+             * http://mongoosejs.com/docs/api.html#schema-documentarray-js
+             */
+            class DocumentArray extends Array {
+                /** SubdocsArray SchemaType constructor */
+                constructor(key: string, schema: Schema, options?: any);
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/number.js
+             * http://mongoosejs.com/docs/api.html#schema-number-js
+             */
+            class Number extends SchemaType {
+                /** Number SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /**
+                 * Sets a maximum number validator.
+                 * @param maximum number
+                 * @param message optional custom error message
+                 */
+                max(maximum: number, message?: string): this;
+
+                /**
+                 * Sets a minimum number validator.
+                 * @param value minimum number
+                 * @param message optional custom error message
+                 */
+                min(value: number, message?: string): this;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/date.js
+             * http://mongoosejs.com/docs/api.html#schema-date-js
+             */
+            class Date extends SchemaType {
+                /** Date SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. To satisfy
+                 * a required validator, the given value must be an instance of Date.
+                 */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** Declares a TTL index (rounded to the nearest second) for Date types only. */
+                expires(when: number | string): this;
+
+                /**
+                 * Sets a maximum date validator.
+                 * @param maximum date
+                 * @param message optional custom error message
+                 */
+                max(maximum: NativeDate, message?: string): this;
+
+                /**
+                 * Sets a minimum date validator.
+                 * @param value minimum date
+                 * @param message optional custom error message
+                 */
+                min(value: NativeDate, message?: string): this;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/buffer.js
+             * http://mongoosejs.com/docs/api.html#schema-buffer-js
+             */
+            class Buffer extends SchemaType {
+                /** Buffer SchemaType constructor */
+                constructor(key: string, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. To satisfy a
+                 * required validator, a buffer must not be null or undefined and have
+                 * non-zero length.
+                 */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/boolean.js
+             * http://mongoosejs.com/docs/api.html#schema-boolean-js
+             */
+            class Boolean extends SchemaType {
+                /** Boolean SchemaType constructor. */
+                constructor(path: string, options?: any);
+
+                /**
+                 * Check if the given value satisfies a required validator. For a
+                 * boolean to satisfy a required validator, it must be strictly
+                 * equal to true or to false.
+                 */
+                checkRequired(value: any): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/objectid.js
+             * http://mongoosejs.com/docs/api.html#schema-objectid-js
+             */
+            class ObjectId extends SchemaType {
+                /** ObjectId SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /**
+                 * Adds an auto-generated ObjectId default if turnOn is true.
+                 * @param turnOn auto generated ObjectId defaults
+                 */
+                auto(turnOn: boolean): this;
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+            /*
+             * section schema/decimal128.js
+             * http://mongoosejs.com/docs/api.html#schema-decimal128-js
+             */
+            class Decimal128 extends SchemaType {
+                /** Decimal128 SchemaType constructor. */
+                constructor(key: string, options?: any);
+
+                /** Check if the given value satisfies a required validator. */
+                checkRequired(value: any, doc: MongooseDocument): boolean;
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/mixed.js
+             * http://mongoosejs.com/docs/api.html#schema-mixed-js
+             */
+            class Mixed extends SchemaType {
+                /** Mixed SchemaType constructor. */
+                constructor(path: string, options?: any);
+
+                /** This schema type's name, to defend against minifiers that mangle function names. */
+                static schemaName: string;
+            }
+
+            /*
+             * section schema/embedded.js
+             * http://mongoosejs.com/docs/api.html#schema-embedded-js
+             */
+            class Embedded extends SchemaType {
+                /** Sub-schema schematype constructor */
+                constructor(schema: Schema, key: string, options?: any);
+            }
+        }
+    }
+
+    /*
+     * section aggregate.js
+     * http://mongoosejs.com/docs/api.html#aggregate-js
+     */
+    class Aggregate<T> {
+        /**
+         * Aggregate constructor used for building aggregation pipelines.
+         * Returned when calling Model.aggregate().
+         * @param ops aggregation operator(s) or operator array
+         */
+        constructor(ops?: any | any[], ...args: any[]);
+
+        /** Adds a cursor flag */
+        addCursorFlag(flag: string, value: boolean): this;
+
+        /**
+         * Sets the allowDiskUse option for the aggregation query (ignored for < 2.6.0)
+         * @param value Should tell server it can use hard drive to store data during aggregation.
+         * @param tags optional tags for this query
+         */
+        allowDiskUse(value: boolean, tags?: any[]): this;
+
+        /**
+         * Appends new operators to this aggregate pipeline
+         * @param ops operator(s) to append
+         */
+        append(...ops: any[]): this;
+
+        /** Adds a collation. */
+        collation(options: CollationOptions): this;
+
+        /**
+         * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
+         * Note the different syntax below: .exec() returns a cursor object, and no callback
+         * is necessary.
+         * @param options set the cursor batch size
+         */
+        cursor(options: any): this;
+
+        // If cursor option is on, could return an object
+        /** Executes the aggregate pipeline on the currently bound Model. */
+        exec(callback?: (err: any, result: T) => void): Promise<T> | any;
+
+        /** Execute the aggregation with explain */
+        explain(callback?: (err: any, result: T) => void): Promise<T>;
+
+        /**
+         * Appends a new custom $group operator to this aggregate pipeline.
+         * @param arg $group operator contents
+         */
+        group(arg: any): this;
+
+        /**
+         * Appends a new $limit operator to this aggregate pipeline.
+         * @param num maximum number of records to pass to the next stage
+         */
+        limit(num: number): this;
+
+        /**
+         * Appends new custom $lookup operator(s) to this aggregate pipeline.
+         * @param options to $lookup as described in the above link
+         */
+        lookup(options: any): this;
+
+        /**
+         * Appends a new custom $match operator to this aggregate pipeline.
+         * @param arg $match operator contents
+         */
+        match(arg: any): this;
+
+        /**
+         * Binds this aggregate to a model.
+         * @param model the model to which the aggregate is to be bound
+         */
+        model(model: any): this;
+
+        /**
+         * Appends a new $geoNear operator to this aggregate pipeline.
+         * MUST be used as the first operator in the pipeline.
+         */
+        near(parameters: any): this;
+
+        /**
+         * Appends a new $project operator to this aggregate pipeline.
+         * Mongoose query selection syntax is also supported.
+         * @param arg field specification
+         */
+        project(arg: string | any): this;
+
+        /**
+         * Sets the readPreference option for the aggregation query.
+         * @param pref one of the listed preference options or their aliases
+         * @param tags optional tags for this query
+         */
+        read(pref: string, tags?: any[]): this;
+
+        /**
+         * Appends new custom $sample operator(s) to this aggregate pipeline.
+         * @param size number of random documents to pick
+         */
+        sample(size: number): this;
+
+        /**
+         * Appends a new $skip operator to this aggregate pipeline.
+         * @param num number of records to skip before next stage
+         */
+        skip(num: number): this;
+
+        /**
+         * Appends a new $sort operator to this aggregate pipeline.
+         * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
+         * If a string is passed, it must be a space delimited list of path names. The sort order
+         * of each path is ascending unless the path name is prefixed with - which will be treated
+         * as descending.
+         */
+        sort(arg: string | any): this;
+
+        /** Provides promise for aggregate. */
+        then<TRes>(
+            resolve?: (val: T) => void | TRes | PromiseLike<TRes>,
+            reject?: (err: any) => void | TRes | PromiseLike<TRes>,
+        ): Promise<TRes>;
+
+        /**
+         * Appends new custom $unwind operator(s) to this aggregate pipeline.
+         * Note that the $unwind operator requires the path name to start with '$'.
+         * Mongoose will prepend '$' if the specified field doesn't start '$'.
+         * @param fields the field(s) to unwind
+         */
+        unwind(...fields: string[]): this;
+        /**
+         * Appends new custom $unwind operator(s) to this aggregate pipeline
+         * new in mongodb 3.2
+         */
+        unwind(...opts: { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean }[]): this;
+    }
+
+    /*
+     * section schematype.js
+     * http://mongoosejs.com/docs/api.html#schematype-js
+     */
+    class SchemaType {
+        /** SchemaType constructor */
+        constructor(path: string, options?: any, instance?: string);
+
+        /**
+         * Sets a default value for this SchemaType.
+         * Defaults can be either functions which return the value to use as the
+         * default or the literal value itself. Either way, the value will be cast
+         * based on its schema type before being set during document creation.
+         * @param val the default value
+         */
+        default(val: any): any;
+
+        /** Adds a getter to this schematype. */
+        get(fn: Function): this;
+
+        /**
+         * Declares the index options for this schematype.
+         * Indexes are created in the background by default. Specify background: false to override.
+         */
+        index(options: any | boolean | string): this;
+
+        /**
+         * Adds a required validator to this SchemaType. The validator gets added
+         * to the front of this SchemaType's validators array using unshift().
+         * @param required enable/disable the validator
          * @param message optional custom error message
          */
-        min(value: NativeDate, message?: string): this;
+        required(required: boolean, message?: string): this;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/buffer.js
-        * http://mongoosejs.com/docs/api.html#schema-buffer-js
-        */
-      class Buffer extends SchemaType {
-        /** Buffer SchemaType constructor */
-        constructor(key: string, options?: any);
-
-        /**
-         * Check if the given value satisfies a required validator. To satisfy a
-         * required validator, a buffer must not be null or undefined and have
-         * non-zero length.
-         */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-
-      }
-
-      /*
-        * section schema/boolean.js
-        * http://mongoosejs.com/docs/api.html#schema-boolean-js
-        */
-      class Boolean extends SchemaType {
-        /** Boolean SchemaType constructor. */
-        constructor(path: string, options?: any);
+        /** Sets default select() behavior for this path. */
+        select(val: boolean): this;
+        /** Adds a setter to this schematype. */
+        set(fn: Function): this;
+        /** Declares a sparse index. */
+        sparse(bool: boolean): this;
+        /** Declares a full text index. */
+        text(bool: boolean): this;
+        /** Declares an unique index. */
+        unique(bool: boolean): this;
 
         /**
-         * Check if the given value satisfies a required validator. For a
-         * boolean to satisfy a required validator, it must be strictly
-         * equal to true or to false.
+         * Adds validator(s) for this document path.
+         * Validators always receive the value to validate as their first argument
+         * and must return Boolean. Returning false means validation failed.
+         * @param obj validator
+         * @param errorMsg optional error message
+         * @param type optional validator type
          */
-        checkRequired(value: any): boolean;
+        validate(obj: RegExp | Function | any, errorMsg?: string, type?: string): this;
 
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/objectid.js
-        * http://mongoosejs.com/docs/api.html#schema-objectid-js
-        */
-      class ObjectId extends SchemaType {
-        /** ObjectId SchemaType constructor. */
-        constructor(key: string, options?: any);
-
-        /**
-         * Adds an auto-generated ObjectId default if turnOn is true.
-         * @param turnOn auto generated ObjectId defaults
-         */
-        auto(turnOn: boolean): this;
-
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-      /*
-        * section schema/decimal128.js
-        * http://mongoosejs.com/docs/api.html#schema-decimal128-js
-        */
-      class Decimal128 extends SchemaType {
-        /** Decimal128 SchemaType constructor. */
-        constructor(key: string, options?: any);
-
-        /** Check if the given value satisfies a required validator. */
-        checkRequired(value: any, doc: MongooseDocument): boolean;
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/mixed.js
-        * http://mongoosejs.com/docs/api.html#schema-mixed-js
-        */
-      class Mixed extends SchemaType {
-        /** Mixed SchemaType constructor. */
-        constructor(path: string, options?: any);
-
-        /** This schema type's name, to defend against minifiers that mangle function names. */
-        static schemaName: string;
-      }
-
-      /*
-        * section schema/embedded.js
-        * http://mongoosejs.com/docs/api.html#schema-embedded-js
-        */
-      class Embedded extends SchemaType {
-        /** Sub-schema schematype constructor */
-        constructor(schema: Schema, key: string, options?: any);
-      }
+        /** Name of SchemaType instance. e.g. 'Number' */
+        instance: string;
+        /** Path name */
+        path: string;
+        /** Array containing validators */
+        validators: any[];
+        /** Array containing getters */
+        getters: any[];
+        /** Array containing setters */
+        setters: any[];
+        /** Array containing options for instantiated SchemaType */
+        options: SchemaOptions;
+        /** Default value */
+        defaultValue: any;
     }
-  }
 
-  /*
-   * section aggregate.js
-   * http://mongoosejs.com/docs/api.html#aggregate-js
-   */
-  class Aggregate<T> {
-    /**
-     * Aggregate constructor used for building aggregation pipelines.
-     * Returned when calling Model.aggregate().
-     * @param ops aggregation operator(s) or operator array
-     */
-    constructor(ops?: any | any[], ...args: any[]);
-
-    /** Adds a cursor flag */
-    addCursorFlag(flag: string, value: boolean): this;
-
-    /**
-     * Sets the allowDiskUse option for the aggregation query (ignored for < 2.6.0)
-     * @param value Should tell server it can use hard drive to store data during aggregation.
-     * @param tags optional tags for this query
-     */
-    allowDiskUse(value: boolean, tags?: any[]): this;
-
-    /**
-     * Appends new operators to this aggregate pipeline
-     * @param ops operator(s) to append
-     */
-    append(...ops: any[]): this;
-
-    /** Adds a collation. */
-    collation(options: CollationOptions): this;
-
-    /**
-     * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
-     * Note the different syntax below: .exec() returns a cursor object, and no callback
-     * is necessary.
-     * @param options set the cursor batch size
-     */
-    cursor(options: any): this;
-
-    // If cursor option is on, could return an object
-    /** Executes the aggregate pipeline on the currently bound Model. */
-    exec(callback?: (err: any, result: T) => void): Promise<T> | any;
-
-    /** Execute the aggregation with explain */
-    explain(callback?: (err: any, result: T) => void): Promise<T>;
-
-    /**
-     * Appends a new custom $group operator to this aggregate pipeline.
-     * @param arg $group operator contents
-     */
-    group(arg: any): this;
-
-    /**
-     * Appends a new $limit operator to this aggregate pipeline.
-     * @param num maximum number of records to pass to the next stage
-     */
-    limit(num: number): this;
-
-    /**
-     * Appends new custom $lookup operator(s) to this aggregate pipeline.
-     * @param options to $lookup as described in the above link
-     */
-    lookup(options: any): this;
-
-    /**
-     * Appends a new custom $match operator to this aggregate pipeline.
-     * @param arg $match operator contents
-     */
-    match(arg: any): this;
-
-    /**
-     * Binds this aggregate to a model.
-     * @param model the model to which the aggregate is to be bound
-     */
-    model(model: any): this;
-
-    /**
-     * Appends a new $geoNear operator to this aggregate pipeline.
-     * MUST be used as the first operator in the pipeline.
-     */
-    near(parameters: any): this;
-
-    /**
-     * Appends a new $project operator to this aggregate pipeline.
-     * Mongoose query selection syntax is also supported.
-     * @param arg field specification
-     */
-    project(arg: string | any): this;
-
-    /**
-     * Sets the readPreference option for the aggregation query.
-     * @param pref one of the listed preference options or their aliases
-     * @param tags optional tags for this query
-     */
-    read(pref: string, tags?: any[]): this;
-
-    /**
-     * Appends new custom $sample operator(s) to this aggregate pipeline.
-     * @param size number of random documents to pick
-     */
-    sample(size: number): this;
-
-    /**
-     * Appends a new $skip operator to this aggregate pipeline.
-     * @param num number of records to skip before next stage
-     */
-    skip(num: number): this;
-
-    /**
-     * Appends a new $sort operator to this aggregate pipeline.
-     * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
-     * If a string is passed, it must be a space delimited list of path names. The sort order
-     * of each path is ascending unless the path name is prefixed with - which will be treated
-     * as descending.
-     */
-    sort(arg: string | any): this;
-
-    /** Provides promise for aggregate. */
-    then<TRes>(resolve?: (val: T) =>  void | TRes | PromiseLike<TRes>,
-      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>;
-
-    /**
-     * Appends new custom $unwind operator(s) to this aggregate pipeline.
-     * Note that the $unwind operator requires the path name to start with '$'.
-     * Mongoose will prepend '$' if the specified field doesn't start '$'.
-     * @param fields the field(s) to unwind
-     */
-    unwind(...fields: string[]): this;
-    /**
-     * Appends new custom $unwind operator(s) to this aggregate pipeline
-     * new in mongodb 3.2
-     */
-    unwind(...opts: { path: string, includeArrayIndex?: string, preserveNullAndEmptyArrays?: boolean }[]): this;
-  }
-
-  /*
-   * section schematype.js
-   * http://mongoosejs.com/docs/api.html#schematype-js
-   */
-  class SchemaType {
-    /** SchemaType constructor */
-    constructor(path: string, options?: any, instance?: string);
-
-    /**
-     * Sets a default value for this SchemaType.
-     * Defaults can be either functions which return the value to use as the
-     * default or the literal value itself. Either way, the value will be cast
-     * based on its schema type before being set during document creation.
-     * @param val the default value
-     */
-    default(val: any): any;
-
-    /** Adds a getter to this schematype. */
-    get(fn: Function): this;
-
-    /**
-     * Declares the index options for this schematype.
-     * Indexes are created in the background by default. Specify background: false to override.
-     */
-    index(options: any | boolean | string): this;
-
-    /**
-     * Adds a required validator to this SchemaType. The validator gets added
-     * to the front of this SchemaType's validators array using unshift().
-     * @param required enable/disable the validator
-     * @param message optional custom error message
-     */
-    required(required: boolean, message?: string): this;
-
-    /** Sets default select() behavior for this path. */
-    select(val: boolean): this;
-    /** Adds a setter to this schematype. */
-    set(fn: Function): this;
-    /** Declares a sparse index. */
-    sparse(bool: boolean): this;
-    /** Declares a full text index. */
-    text(bool: boolean): this;
-    /** Declares an unique index. */
-    unique(bool: boolean): this;
-
-    /**
-     * Adds validator(s) for this document path.
-     * Validators always receive the value to validate as their first argument
-     * and must return Boolean. Returning false means validation failed.
-     * @param obj validator
-     * @param errorMsg optional error message
-     * @param type optional validator type
-     */
-    validate(obj: RegExp | Function | any, errorMsg?: string,
-      type?: string): this;
-
-    /** Name of SchemaType instance. e.g. 'Number' */
-    instance: string;
-    /** Path name */
-    path: string;
-    /** Array containing validators */
-    validators: any[];
-    /** Array containing getters */
-    getters: any[];
-    /** Array containing setters */
-    setters: any[];
-    /** Array containing options for instantiated SchemaType */
-    options: SchemaOptions;
-    /** Default value */
-    defaultValue: any;
-  }
-
-  /*
-   * section promise.js
-   * http://mongoosejs.com/docs/api.html#promise-js
-   */
-  /**
-   * To assign your own promise library:
-   *
-   * 1. Typescript does not allow assigning properties of imported modules.
-   *    To avoid compile errors use one of the options below in your code:
-   *
-   *    - (<any>mongoose).Promise = YOUR_PROMISE;
-   *    - require('mongoose').Promise = YOUR_PROMISE;
-   *    - import mongoose = require('mongoose');
-   *      mongoose.Promise = YOUR_PROMISE;
-   *
-   * 2. To assign type definitions for your promise library, you will need
-   *    to have a .d.ts file with the following code when you compile:
-   *
-   *    - import * as Q from 'q';
-   *      declare module 'mongoose' {
-   *        type Promise<T> = Q.promise<T>;
-   *      }
-   *
-   *    - import * as Bluebird from 'bluebird';
-   *      declare module 'mongoose' {
-   *        type Promise<T> = Bluebird<T>;
-   *      }
-   *
-   * Uses global.Promise by default. If you would like to use mongoose default
-   *   mpromise implementation (which is deprecated), you can omit step 1 and
-   *   run npm install @types/mongoose-promise
-   */
-  export var Promise: any;
-  export var PromiseProvider: any;
-
-  /*
-   * section model.js
-   * http://mongoosejs.com/docs/api.html#model-js
-   */
-  export var Model: Model<any>;
-  interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
-    /**
-     * Model constructor
-     * Provides the interface to MongoDB collections as well as creates document instances.
-     * @param doc values with which to create the document
-     * @event error If listening to this event, it is emitted when a document
-     *   was saved without passing a callback and an error occurred. If not
-     *   listening, the event bubbles to the connection used to create this Model.
-     * @event index Emitted after Model#ensureIndexes completes. If an error
-     *   occurred it is passed with the event.
-     * @event index-single-start Emitted when an individual index starts within
-     *   Model#ensureIndexes. The fields and options being used to build the index
-     *   are also passed with the event.
-     * @event index-single-done Emitted when an individual index finishes within
-     *   Model#ensureIndexes. If an error occurred it is passed with the event.
-     *   The fields, options, and index name are also passed.
-     */
-    new(doc?: Partial<T>): T;
-
-    /**
-     * Finds a single document by its _id field. findById(id) is almost*
-     * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.
-     * @param id value of _id to query by
-     * @param projection optional fields to return
-     */
-    findById(id: any | string | number,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findById(id: any | string | number, projection: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findById(id: any | string | number, projection: any, options: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-
-      model<U extends Document>(name: string): Model<U>;
-
-    /**
-     * Creates a Query and specifies a $where condition.
-     * @param argument is a javascript string or anonymous function
-     */
-    $where(argument: string | Function): DocumentQuery<T, T>;
-
-    /**
-     * Performs aggregations on the models collection.
-     * If a callback is passed, the aggregate is executed and a Promise is returned.
-     * If a callback is not passed, the aggregate itself is returned.
-     * @param ... aggregation pipeline operator(s) or operator array
-     */
-    aggregate(...aggregations: any[]): Aggregate<any[]>;
-    aggregate(...aggregationsWithCallback: any[]): Promise<any[]>;
-
-    /** Counts number of matching documents in a database collection. */
-    count(conditions: any, callback?: (err: any, count: number) => void): Query<number>;
-
-    /**
-     * Shortcut for saving one or more documents to the database. MyModel.create(docs)
-     * does new MyModel(doc).save() for every doc in docs.
-     * Triggers the save() hook.
-     */
-    create(docs: any[], callback?: (err: any, res: T[]) => void): Promise<T[]>;
-    create(...docs: any[]): Promise<T>;
-    create(...docsWithCallback: any[]): Promise<T>;
-
-    /**
-     * Adds a discriminator type.
-     * @param name discriminator model name
-     * @param schema discriminator model schema
-     */
-    discriminator<U extends Document>(name: string, schema: Schema): Model<U>;
-
-    /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
-    distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
-    distinct(field: string, conditions: any,
-      callback?: (err: any, res: any[]) => void): Query<any[]>;
-
-    /**
-     * Sends ensureIndex commands to mongo for each index declared in the schema.
-     * @param options internal options
-     * @param cb optional callback
-     */
-    ensureIndexes(callback?: (err: any) => void): Promise<void>;
-    ensureIndexes(options: any, callback?: (err: any) => void): Promise<void>;
-
-    /**
-     * Finds documents.
-     * @param projection optional fields to return
-     */
-    find(callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
-    find(conditions: any, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
-    find(conditions: any, projection?: any | null,
-      callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
-    find(conditions: any, projection?: any | null, options?: any | null,
-      callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
-
-
-
-    /**
-     * Issue a mongodb findAndModify remove command by a document's _id field.
-     * findByIdAndRemove(id, ...) is equivalent to findOneAndRemove({ _id: id }, ...).
-     * Finds a matching document, removes it, passing the found document (if any) to the callback.
-     * Executes immediately if callback is passed, else a Query object is returned.
-     * @param id value of _id to query by
-     */
-    findByIdAndRemove(): DocumentQuery<T | null, T>;
-    findByIdAndRemove(id: any | number | string,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findByIdAndRemove(id: any | number | string, options: {
-      /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
-      sort?: any;
-      /** sets the document fields to return */
-      select?: any;
-    }, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-
-    /**
-     * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
-     * is equivalent to findOneAndUpdate({ _id: id }, ...).
-     * @param id value of _id to query by
-     */
-    findByIdAndUpdate(): DocumentQuery<T | null, T>;
-    findByIdAndUpdate(id: any | number | string, update: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findByIdAndUpdate(id: any | number | string, update: any,
-      options: { upsert: true, new: true } & ModelFindByIdAndUpdateOptions,
-      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
-    findByIdAndUpdate(id: any | number | string, update: any,
-      options: ModelFindByIdAndUpdateOptions,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-
-    /**
-     * Finds one document.
-     * The conditions are cast to their respective SchemaTypes before the command is sent.
-     * @param projection optional fields to return
-     */
-    findOne(conditions?: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findOne(conditions: any, projection: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findOne(conditions: any, projection: any, options: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-
-    /**
-     * Issue a mongodb findAndModify remove command.
-     * Finds a matching document, removes it, passing the found document (if any) to the callback.
-     * Executes immediately if callback is passed else a Query object is returned.
-     */
-    findOneAndRemove(): DocumentQuery<T | null, T>;
-    findOneAndRemove(conditions: any,
-      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-    findOneAndRemove(conditions: any, options: {
-      /**
-       * if multiple docs are found by the conditions, sets the sort order to choose
-       * which doc to update
-       */
-      sort?: any;
-      /** puts a time limit on the query - requires mongodb >= 2.6.0 */
-      maxTimeMS?: number;
-      /** sets the document fields to return */
-      select?: any;
-    }, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
-
-    /**
-     * Issues a mongodb findAndModify update command.
-     * Finds a matching document, updates it according to the update arg, passing any options,
-     * and returns the found document (if any) to the callback. The query executes immediately
-     * if callback is passed else a Query object is returned.
-     */
-    findOneAndUpdate(): DocumentQuery<T | null, T>;
-    findOneAndUpdate(conditions: any, update: any,
-      callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T>;
-    findOneAndUpdate(conditions: any, update: any,
-      options: { upsert: true, new: true } & ModelFindOneAndUpdateOptions,
-      callback?: (err: any, doc: T, res: any) => void): DocumentQuery<T, T>;
-    findOneAndUpdate(conditions: any, update: any,
-      options: ModelFindOneAndUpdateOptions,
-      callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T>;
-
-    /**
-     * geoNear support for Mongoose
-     * @param GeoJSON point or legacy coordinate pair [x,y] to search near
-     * @param options for the qurery
-     * @param callback optional callback for the query
-     */
-    geoNear(point: number[] | {
-      type: string;
-      coordinates: number[]
-    }, options: {
-      /** return the raw object */
-      lean?: boolean;
-      [other: string]: any;
-    }, callback?: (err: any, res: T[], stats: any) => void): DocumentQuery<T[], T>;
-
-    /**
-     * Implements $geoSearch functionality for Mongoose
-     * @param conditions an object that specifies the match condition (required)
-     * @param options for the geoSearch, some (near, maxDistance) are required
-     * @param callback optional callback
-     */
-    geoSearch(conditions: any, options: {
-      /** x,y point to search for */
-      near: number[];
-      /** the maximum distance from the point near that a result can be */
-      maxDistance: number;
-      /** The maximum number of results to return */
-      limit?: number;
-      /** return the raw object instead of the Mongoose Model */
-      lean?: boolean;
-    }, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
-
-    /**
-     * Shortcut for creating a new Document from existing raw data,
-     * pre-saved in the DB. The document returned has no paths marked
-     * as modified initially.
-     */
-    hydrate(obj: any): T;
-
-    /**
-     * Shortcut for validating an array of documents and inserting them into
-     * MongoDB if they're all valid. This function is faster than .create()
-     * because it only sends one operation to the server, rather than one for each
-     * document.
-     * This function does not trigger save middleware.
-     */
-    insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): Promise<T[]>;
-    insertMany(doc: any, callback?: (error: any, doc: T) => void): Promise<T>;
-    insertMany(...docsWithCallback: any[]): Promise<T>;
-
-    /**
-     * Executes a mapReduce command.
-     * @param o an object specifying map-reduce options
-     * @param callbackoptional callback
-     */
-    mapReduce<Key, Value>(
-      o: ModelMapReduceOption<T, Key, Value>,
-      callback?: (err: any, res: any) => void
-    ): Promise<any>;
-
-    /**
-     * Populates document references.
-     * @param docs Either a single document or array of documents to populate.
-     * @param options A hash of key/val (path, options) used for population.
-     * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
-     */
-    populate(docs: any[], options: ModelPopulateOptions | ModelPopulateOptions[],
-      callback?: (err: any, res: T[]) => void): Promise<T[]>;
-    populate<T>(docs: any, options: ModelPopulateOptions | ModelPopulateOptions[],
-      callback?: (err: any, res: T) => void): Promise<T>;
-
-    /** Removes documents from the collection. */
-    remove(conditions: any, callback?: (err: any) => void): Query<void>;
-    deleteOne(conditions: any, callback?: (err: any) => void): Query<void>;
-    deleteMany(conditions: any, callback?: (err: any) => void): Query<void>;
-
-    /**
-     * Updates documents in the database without returning them.
-     * All update values are cast to their appropriate SchemaTypes before being sent.
-     */
-    update(conditions: any, doc: any,
-      callback?: (err: any, raw: any) => void): Query<any>;
-    update(conditions: any, doc: any, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any>;
-    updateOne(conditions: any, doc: any,
-      callback?: (err: any, raw: any) => void): Query<any>;
-    updateOne(conditions: any, doc: any, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any>;
-    updateMany(conditions: any, doc: any,
-      callback?: (err: any, raw: any) => void): Query<any>;
-    updateMany(conditions: any, doc: any, options: ModelUpdateOptions,
-      callback?: (err: any, raw: any) => void): Query<any>;
-
-    /** Creates a Query, applies the passed conditions, and returns the Query. */
-    where(path: string, val?: any): Query<any>;
-  }
-
-  interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
-    /** Signal that we desire an increment of this documents version. */
-    increment(): this;
-
-    /**
-     * Returns another Model instance.
-     * @param name model name
-     */
-    model<T extends Document>(name: string): Model<T>;
-
-    /**
-     * Removes this document from the db.
-     * @param fn optional callback
-     */
-    remove(fn?: (err: any, product: this) => void): Promise<this>;
-
-    /**
-     * Saves this document.
-     * @param options options optional options
-     * @param options.safe overrides schema's safe option
-     * @param options.validateBeforeSave set to false to save without validating.
-     * @param fn optional callback
-     */
-    save(options?: SaveOptions, fn?: (err: any, product: this, numAffected: number) => void): Promise<this>;
-    save(fn?: (err: any, product: this, numAffected: number) => void): Promise<this>;
-
-    /**
-     * Version using default version key. See http://mongoosejs.com/docs/guide.html#versionKey
-     * If you're using another key, you will have to access it using []: doc[_myVersionKey]
-     */
-    __v?: number;
-  }
-
-  interface SaveOptions {
-    safe?: boolean | WriteConcern;
-    validateBeforeSave?: boolean;
-  }
-
-  interface WriteConcern {
-    j?: boolean;
-    w?: number | 'majority' | TagSet;
-    wtimeout?: number;
-  }
-
-  interface TagSet {
-    [k: string]: string;
-  }
-
-  interface ModelProperties {
-    /** Base Mongoose instance the model uses. */
-    base: typeof mongoose;
-
-    /**
-     * If this is a discriminator model, baseModelName is the
-     * name of the base model.
-     */
-    baseModelName: string | undefined;
-
-    /** Collection the model uses. */
-    collection: Collection;
-
-    /** Connection the model uses. */
-    db: Connection;
-
-    /** Registered discriminators for this model. */
-    discriminators: any;
-
-    /** The name of the model */
-    modelName: string;
-
-    /** Schema the model uses. */
-    schema: Schema;
-  }
-
-  interface ModelFindByIdAndUpdateOptions {
-    /** true to return the modified document rather than the original. defaults to false */
-    new?: boolean;
-    /** creates the object if it doesn't exist. defaults to false. */
-    upsert?: boolean;
-    /**
-     * if true, runs update validators on this command. Update validators validate the
-     * update operation against the model's schema.
-     */
-    runValidators?: boolean;
-    /**
-     * if this and upsert are true, mongoose will apply the defaults specified in the model's
-     * schema if a new document is created. This option only works on MongoDB >= 2.4 because
-     * it relies on MongoDB's $setOnInsert operator.
-     */
-    setDefaultsOnInsert?: boolean;
-    /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
-    sort?: any;
-    /** sets the document fields to return */
-    select?: any;
-    /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
-    passRawResult?: boolean;
-    /** overwrites the schema's strict mode option for this update */
-    strict?: boolean;
-    /**
-     * if true, run all setters defined on the associated model's schema for all fields
-     * defined in the query and the update.
-     */
-    runSettersOnQuery?: boolean;
-  }
-
-  interface ModelFindOneAndUpdateOptions extends ModelFindByIdAndUpdateOptions {
-    /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
-    fields?: any | string;
-    /** puts a time limit on the query - requires mongodb >= 2.6.0 */
-    maxTimeMS?: number;
-    /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
-    passRawResult?: boolean;
-  }
-
-  interface ModelPopulateOptions {
-    /** space delimited path(s) to populate */
-    path: string;
-    /** optional fields to select */
-    select?: any;
-    /** optional query conditions to match */
-    match?: any;
-    /** optional name of the model to use for population */
-    model?: string;
-    /** optional query options like sort, limit, etc */
-    options?: any;
-    /** deep populate */
-    populate?: ModelPopulateOptions | ModelPopulateOptions[];
-  }
-
-  interface ModelUpdateOptions {
-    /** safe mode (defaults to value set in schema (true)) */
-    safe?: boolean;
-    /** whether to create the doc if it doesn't match (false) */
-    upsert?: boolean;
-    /** whether multiple documents should be updated (false) */
-    multi?: boolean;
-    /**
-     * If true, runs update validators on this command. Update validators validate
-     * the update operation against the model's schema.
-     */
-    runValidators?: boolean;
-    /**
-     * If this and upsert are true, mongoose will apply the defaults specified in the
-     * model's schema if a new document is created. This option only works on MongoDB >= 2.4
-     * because it relies on MongoDB's $setOnInsert operator.
-     */
-    setDefaultsOnInsert?: boolean;
-    /** overrides the strict option for this update */
-    strict?: boolean;
-    /** disables update-only mode, allowing you to overwrite the doc (false) */
-    overwrite?: boolean;
-    /**
-    * Only update elements that match the arrayFilters conditions in the document or documents that match the query conditions.
-    */
-    arrayFilters?: { [key: string]: any }[];
-    /** other options */
-    [other: string]: any;
-  }
-
-  interface ModelMapReduceOption<T, Key, Val> {
-    map: Function | string;
-    reduce: (key: Key, vals: T[]) => Val;
-    /** query filter object. */
-    query?: any;
-    /** sort input objects using this key */
-    sort?: any;
-    /** max number of documents */
-    limit?: number;
-    /** keep temporary data default: false */
-    keeptemp?: boolean;
-    /** finalize function */
-    finalize?: (key: Key, val: Val) => Val;
-    /** scope variables exposed to map/reduce/finalize during execution */
-    scope?: any;
-    /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
-    jsMode?: boolean;
-    /** provide statistics on job execution time. default: false */
-    verbose?: boolean;
-    readPreference?: string;
-    /** sets the output target for the map reduce job. default: {inline: 1} */
-    out?: {
-      /** the results are returned in an array */
-      inline?: number;
-      /**
-       * {replace: 'collectionName'} add the results to collectionName: the
-       * results replace the collection
-       */
-      replace?: string;
-      /**
-       * {reduce: 'collectionName'} add the results to collectionName: if
-       * dups are detected, uses the reducer / finalize functions
-       */
-      reduce?: string;
-      /**
-       * {merge: 'collectionName'} add the results to collectionName: if
-       * dups exist the new docs overwrite the old
-       */
-      merge?: string;
-    };
-  }
-
-  interface MapReduceResult<Key, Val> {
-    _id: Key;
-    value: Val;
-  }
-
-  /*
-   * section collection.js
-   * http://mongoosejs.com/docs/api.html#collection-js
-   */
-  interface CollectionBase extends mongodb.Collection {
     /*
-      * Abstract methods. Some of these are already defined on the
-      * mongodb.Collection interface so they've been commented out.
-      */
-    ensureIndex(...args: any[]): any;
-    //find(...args: any[]): any;
-    findAndModify(...args: any[]): any;
-    //findOne(...args: any[]): any;
-    getIndexes(...args: any[]): any;
-    //insert(...args: any[]): any;
-    //mapReduce(...args: any[]): any;
-    //save(...args: any[]): any;
-    //update(...args: any[]): any;
+     * section promise.js
+     * http://mongoosejs.com/docs/api.html#promise-js
+     */
+    /**
+     * To assign your own promise library:
+     *
+     * 1. Typescript does not allow assigning properties of imported modules.
+     *    To avoid compile errors use one of the options below in your code:
+     *
+     *    - (<any>mongoose).Promise = YOUR_PROMISE;
+     *    - require('mongoose').Promise = YOUR_PROMISE;
+     *    - import mongoose = require('mongoose');
+     *      mongoose.Promise = YOUR_PROMISE;
+     *
+     * 2. To assign type definitions for your promise library, you will need
+     *    to have a .d.ts file with the following code when you compile:
+     *
+     *    - import * as Q from 'q';
+     *      declare module 'mongoose' {
+     *        type Promise<T> = Q.promise<T>;
+     *      }
+     *
+     *    - import * as Bluebird from 'bluebird';
+     *      declare module 'mongoose' {
+     *        type Promise<T> = Bluebird<T>;
+     *      }
+     *
+     * Uses global.Promise by default. If you would like to use mongoose default
+     *   mpromise implementation (which is deprecated), you can omit step 1 and
+     *   run npm install @types/mongoose-promise
+     */
+    export var Promise: any;
+    export var PromiseProvider: any;
 
-    /** The collection name */
-    collectionName: string;
-    /** The Connection instance */
-    conn: Connection;
-    /** The collection name */
-    name: string;
-  }
+    /*
+     * section model.js
+     * http://mongoosejs.com/docs/api.html#model-js
+     */
+    export var Model: Model<any>;
+    interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
+        /**
+         * Model constructor
+         * Provides the interface to MongoDB collections as well as creates document instances.
+         * @param doc values with which to create the document
+         * @event error If listening to this event, it is emitted when a document
+         *   was saved without passing a callback and an error occurred. If not
+         *   listening, the event bubbles to the connection used to create this Model.
+         * @event index Emitted after Model#ensureIndexes completes. If an error
+         *   occurred it is passed with the event.
+         * @event index-single-start Emitted when an individual index starts within
+         *   Model#ensureIndexes. The fields and options being used to build the index
+         *   are also passed with the event.
+         * @event index-single-done Emitted when an individual index finishes within
+         *   Model#ensureIndexes. If an error occurred it is passed with the event.
+         *   The fields, options, and index name are also passed.
+         */
+        new (doc?: Partial<T>): T;
+
+        /**
+         * Finds a single document by its _id field. findById(id) is almost*
+         * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.
+         * @param id value of _id to query by
+         * @param projection optional fields to return
+         */
+        findById(id: any | string | number, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
+        findById(
+            id: any | string | number,
+            projection: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+        findById(
+            id: any | string | number,
+            projection: any,
+            options: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+
+        model<U extends Document>(name: string): Model<U>;
+
+        /**
+         * Creates a Query and specifies a $where condition.
+         * @param argument is a javascript string or anonymous function
+         */
+        $where(argument: string | Function): DocumentQuery<T, T>;
+
+        /**
+         * Performs aggregations on the models collection.
+         * If a callback is passed, the aggregate is executed and a Promise is returned.
+         * If a callback is not passed, the aggregate itself is returned.
+         * @param ... aggregation pipeline operator(s) or operator array
+         */
+        aggregate(...aggregations: any[]): Aggregate<any[]>;
+        aggregate(...aggregationsWithCallback: any[]): Promise<any[]>;
+
+        /** Counts number of matching documents in a database collection. */
+        count(conditions: any, callback?: (err: any, count: number) => void): Query<number>;
+
+        /**
+         * Shortcut for saving one or more documents to the database. MyModel.create(docs)
+         * does new MyModel(doc).save() for every doc in docs.
+         * Triggers the save() hook.
+         */
+        create(docs: any[], callback?: (err: any, res: T[]) => void): Promise<T[]>;
+        create(...docs: any[]): Promise<T>;
+        create(...docsWithCallback: any[]): Promise<T>;
+
+        /**
+         * Adds a discriminator type.
+         * @param name discriminator model name
+         * @param schema discriminator model schema
+         */
+        discriminator<U extends Document>(name: string, schema: Schema): Model<U>;
+
+        /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
+        distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
+        distinct(field: string, conditions: any, callback?: (err: any, res: any[]) => void): Query<any[]>;
+
+        /**
+         * Sends ensureIndex commands to mongo for each index declared in the schema.
+         * @param options internal options
+         * @param cb optional callback
+         */
+        ensureIndexes(callback?: (err: any) => void): Promise<void>;
+        ensureIndexes(options: any, callback?: (err: any) => void): Promise<void>;
+
+        /**
+         * Finds documents.
+         * @param projection optional fields to return
+         */
+        find(callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
+        find(conditions: any, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
+        find(conditions: any, projection?: any | null, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
+        find(
+            conditions: any,
+            projection?: any | null,
+            options?: any | null,
+            callback?: (err: any, res: T[]) => void,
+        ): DocumentQuery<T[], T>;
+
+        /**
+         * Issue a mongodb findAndModify remove command by a document's _id field.
+         * findByIdAndRemove(id, ...) is equivalent to findOneAndRemove({ _id: id }, ...).
+         * Finds a matching document, removes it, passing the found document (if any) to the callback.
+         * Executes immediately if callback is passed, else a Query object is returned.
+         * @param id value of _id to query by
+         */
+        findByIdAndRemove(): DocumentQuery<T | null, T>;
+        findByIdAndRemove(
+            id: any | number | string,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+        findByIdAndRemove(
+            id: any | number | string,
+            options: {
+                /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
+                sort?: any;
+                /** sets the document fields to return */
+                select?: any;
+            },
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+
+        /**
+         * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
+         * is equivalent to findOneAndUpdate({ _id: id }, ...).
+         * @param id value of _id to query by
+         */
+        findByIdAndUpdate(): DocumentQuery<T | null, T>;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: any,
+            options: { upsert: true; new: true } & ModelFindByIdAndUpdateOptions,
+            callback?: (err: any, res: T) => void,
+        ): DocumentQuery<T, T>;
+        findByIdAndUpdate(
+            id: any | number | string,
+            update: any,
+            options: ModelFindByIdAndUpdateOptions,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+
+        /**
+         * Finds one document.
+         * The conditions are cast to their respective SchemaTypes before the command is sent.
+         * @param projection optional fields to return
+         */
+        findOne(conditions?: any, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
+        findOne(
+            conditions: any,
+            projection: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+        findOne(
+            conditions: any,
+            projection: any,
+            options: any,
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+
+        /**
+         * Issue a mongodb findAndModify remove command.
+         * Finds a matching document, removes it, passing the found document (if any) to the callback.
+         * Executes immediately if callback is passed else a Query object is returned.
+         */
+        findOneAndRemove(): DocumentQuery<T | null, T>;
+        findOneAndRemove(conditions: any, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T>;
+        findOneAndRemove(
+            conditions: any,
+            options: {
+                /**
+                 * if multiple docs are found by the conditions, sets the sort order to choose
+                 * which doc to update
+                 */
+                sort?: any;
+                /** puts a time limit on the query - requires mongodb >= 2.6.0 */
+                maxTimeMS?: number;
+                /** sets the document fields to return */
+                select?: any;
+            },
+            callback?: (err: any, res: T | null) => void,
+        ): DocumentQuery<T | null, T>;
+
+        /**
+         * Issues a mongodb findAndModify update command.
+         * Finds a matching document, updates it according to the update arg, passing any options,
+         * and returns the found document (if any) to the callback. The query executes immediately
+         * if callback is passed else a Query object is returned.
+         */
+        findOneAndUpdate(): DocumentQuery<T | null, T>;
+        findOneAndUpdate(
+            conditions: any,
+            update: any,
+            callback?: (err: any, doc: T | null, res: any) => void,
+        ): DocumentQuery<T | null, T>;
+        findOneAndUpdate(
+            conditions: any,
+            update: any,
+            options: { upsert: true; new: true } & ModelFindOneAndUpdateOptions,
+            callback?: (err: any, doc: T, res: any) => void,
+        ): DocumentQuery<T, T>;
+        findOneAndUpdate(
+            conditions: any,
+            update: any,
+            options: ModelFindOneAndUpdateOptions,
+            callback?: (err: any, doc: T | null, res: any) => void,
+        ): DocumentQuery<T | null, T>;
+
+        /**
+         * geoNear support for Mongoose
+         * @param GeoJSON point or legacy coordinate pair [x,y] to search near
+         * @param options for the qurery
+         * @param callback optional callback for the query
+         */
+        geoNear(
+            point:
+                | number[]
+                | {
+                      type: string;
+                      coordinates: number[];
+                  },
+            options: {
+                /** return the raw object */
+                lean?: boolean;
+                [other: string]: any;
+            },
+            callback?: (err: any, res: T[], stats: any) => void,
+        ): DocumentQuery<T[], T>;
+
+        /**
+         * Implements $geoSearch functionality for Mongoose
+         * @param conditions an object that specifies the match condition (required)
+         * @param options for the geoSearch, some (near, maxDistance) are required
+         * @param callback optional callback
+         */
+        geoSearch(
+            conditions: any,
+            options: {
+                /** x,y point to search for */
+                near: number[];
+                /** the maximum distance from the point near that a result can be */
+                maxDistance: number;
+                /** The maximum number of results to return */
+                limit?: number;
+                /** return the raw object instead of the Mongoose Model */
+                lean?: boolean;
+            },
+            callback?: (err: any, res: T[]) => void,
+        ): DocumentQuery<T[], T>;
+
+        /**
+         * Shortcut for creating a new Document from existing raw data,
+         * pre-saved in the DB. The document returned has no paths marked
+         * as modified initially.
+         */
+        hydrate(obj: any): T;
+
+        /**
+         * Shortcut for validating an array of documents and inserting them into
+         * MongoDB if they're all valid. This function is faster than .create()
+         * because it only sends one operation to the server, rather than one for each
+         * document.
+         * This function does not trigger save middleware.
+         */
+        insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): Promise<T[]>;
+        insertMany(doc: any, callback?: (error: any, doc: T) => void): Promise<T>;
+        insertMany(...docsWithCallback: any[]): Promise<T>;
+
+        /**
+         * Executes a mapReduce command.
+         * @param o an object specifying map-reduce options
+         * @param callbackoptional callback
+         */
+        mapReduce<Key, Value>(
+            o: ModelMapReduceOption<T, Key, Value>,
+            callback?: (err: any, res: any) => void,
+        ): Promise<any>;
+
+        /**
+         * Populates document references.
+         * @param docs Either a single document or array of documents to populate.
+         * @param options A hash of key/val (path, options) used for population.
+         * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
+         */
+        populate(
+            docs: any[],
+            options: ModelPopulateOptions | ModelPopulateOptions[],
+            callback?: (err: any, res: T[]) => void,
+        ): Promise<T[]>;
+        populate<T>(
+            docs: any,
+            options: ModelPopulateOptions | ModelPopulateOptions[],
+            callback?: (err: any, res: T) => void,
+        ): Promise<T>;
+
+        /** Removes documents from the collection. */
+        remove(conditions: any, callback?: (err: any) => void): Query<void>;
+        deleteOne(conditions: any, callback?: (err: any) => void): Query<void>;
+        deleteMany(conditions: any, callback?: (err: any) => void): Query<void>;
+
+        /**
+         * Updates documents in the database without returning them.
+         * All update values are cast to their appropriate SchemaTypes before being sent.
+         */
+        update(conditions: any, doc: any, callback?: (err: any, raw: any) => void): Query<any>;
+        update(
+            conditions: any,
+            doc: any,
+            options: ModelUpdateOptions,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any>;
+        updateOne(conditions: any, doc: any, callback?: (err: any, raw: any) => void): Query<any>;
+        updateOne(
+            conditions: any,
+            doc: any,
+            options: ModelUpdateOptions,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any>;
+        updateMany(conditions: any, doc: any, callback?: (err: any, raw: any) => void): Query<any>;
+        updateMany(
+            conditions: any,
+            doc: any,
+            options: ModelUpdateOptions,
+            callback?: (err: any, raw: any) => void,
+        ): Query<any>;
+
+        /** Creates a Query, applies the passed conditions, and returns the Query. */
+        where(path: string, val?: any): Query<any>;
+    }
+
+    interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
+        /** Signal that we desire an increment of this documents version. */
+        increment(): this;
+
+        /**
+         * Returns another Model instance.
+         * @param name model name
+         */
+        model<T extends Document>(name: string): Model<T>;
+
+        /**
+         * Removes this document from the db.
+         * @param fn optional callback
+         */
+        remove(fn?: (err: any, product: this) => void): Promise<this>;
+
+        /**
+         * Saves this document.
+         * @param options options optional options
+         * @param options.safe overrides schema's safe option
+         * @param options.validateBeforeSave set to false to save without validating.
+         * @param fn optional callback
+         */
+        save(options?: SaveOptions, fn?: (err: any, product: this, numAffected: number) => void): Promise<this>;
+        save(fn?: (err: any, product: this, numAffected: number) => void): Promise<this>;
+
+        /**
+         * Version using default version key. See http://mongoosejs.com/docs/guide.html#versionKey
+         * If you're using another key, you will have to access it using []: doc[_myVersionKey]
+         */
+        __v?: number;
+    }
+
+    interface SaveOptions {
+        safe?: boolean | WriteConcern;
+        validateBeforeSave?: boolean;
+    }
+
+    interface WriteConcern {
+        j?: boolean;
+        w?: number | "majority" | TagSet;
+        wtimeout?: number;
+    }
+
+    interface TagSet {
+        [k: string]: string;
+    }
+
+    interface ModelProperties {
+        /** Base Mongoose instance the model uses. */
+        base: typeof mongoose;
+
+        /**
+         * If this is a discriminator model, baseModelName is the
+         * name of the base model.
+         */
+        baseModelName: string | undefined;
+
+        /** Collection the model uses. */
+        collection: Collection;
+
+        /** Connection the model uses. */
+        db: Connection;
+
+        /** Registered discriminators for this model. */
+        discriminators: any;
+
+        /** The name of the model */
+        modelName: string;
+
+        /** Schema the model uses. */
+        schema: Schema;
+    }
+
+    interface ModelFindByIdAndUpdateOptions {
+        /** true to return the modified document rather than the original. defaults to false */
+        new?: boolean;
+        /** creates the object if it doesn't exist. defaults to false. */
+        upsert?: boolean;
+        /**
+         * if true, runs update validators on this command. Update validators validate the
+         * update operation against the model's schema.
+         */
+        runValidators?: boolean;
+        /**
+         * if this and upsert are true, mongoose will apply the defaults specified in the model's
+         * schema if a new document is created. This option only works on MongoDB >= 2.4 because
+         * it relies on MongoDB's $setOnInsert operator.
+         */
+        setDefaultsOnInsert?: boolean;
+        /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
+        sort?: any;
+        /** sets the document fields to return */
+        select?: any;
+        /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
+        passRawResult?: boolean;
+        /** overwrites the schema's strict mode option for this update */
+        strict?: boolean;
+        /**
+         * if true, run all setters defined on the associated model's schema for all fields
+         * defined in the query and the update.
+         */
+        runSettersOnQuery?: boolean;
+    }
+
+    interface ModelFindOneAndUpdateOptions extends ModelFindByIdAndUpdateOptions {
+        /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
+        fields?: any | string;
+        /** puts a time limit on the query - requires mongodb >= 2.6.0 */
+        maxTimeMS?: number;
+        /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
+        passRawResult?: boolean;
+    }
+
+    interface ModelPopulateOptions {
+        /** space delimited path(s) to populate */
+        path: string;
+        /** optional fields to select */
+        select?: any;
+        /** optional query conditions to match */
+        match?: any;
+        /** optional name of the model to use for population */
+        model?: string;
+        /** optional query options like sort, limit, etc */
+        options?: any;
+        /** deep populate */
+        populate?: ModelPopulateOptions | ModelPopulateOptions[];
+    }
+
+    interface ModelUpdateOptions {
+        /** safe mode (defaults to value set in schema (true)) */
+        safe?: boolean;
+        /** whether to create the doc if it doesn't match (false) */
+        upsert?: boolean;
+        /** whether multiple documents should be updated (false) */
+        multi?: boolean;
+        /**
+         * If true, runs update validators on this command. Update validators validate
+         * the update operation against the model's schema.
+         */
+        runValidators?: boolean;
+        /**
+         * If this and upsert are true, mongoose will apply the defaults specified in the
+         * model's schema if a new document is created. This option only works on MongoDB >= 2.4
+         * because it relies on MongoDB's $setOnInsert operator.
+         */
+        setDefaultsOnInsert?: boolean;
+        /** overrides the strict option for this update */
+        strict?: boolean;
+        /** disables update-only mode, allowing you to overwrite the doc (false) */
+        overwrite?: boolean;
+        /**
+         * Only update elements that match the arrayFilters conditions in the document or documents that match the query conditions.
+         */
+        arrayFilters?: { [key: string]: any }[];
+        /** other options */
+        [other: string]: any;
+    }
+
+    interface ModelMapReduceOption<T, Key, Val> {
+        map: Function | string;
+        reduce: (key: Key, vals: T[]) => Val;
+        /** query filter object. */
+        query?: any;
+        /** sort input objects using this key */
+        sort?: any;
+        /** max number of documents */
+        limit?: number;
+        /** keep temporary data default: false */
+        keeptemp?: boolean;
+        /** finalize function */
+        finalize?: (key: Key, val: Val) => Val;
+        /** scope variables exposed to map/reduce/finalize during execution */
+        scope?: any;
+        /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
+        jsMode?: boolean;
+        /** provide statistics on job execution time. default: false */
+        verbose?: boolean;
+        readPreference?: string;
+        /** sets the output target for the map reduce job. default: {inline: 1} */
+        out?: {
+            /** the results are returned in an array */
+            inline?: number;
+            /**
+             * {replace: 'collectionName'} add the results to collectionName: the
+             * results replace the collection
+             */
+            replace?: string;
+            /**
+             * {reduce: 'collectionName'} add the results to collectionName: if
+             * dups are detected, uses the reducer / finalize functions
+             */
+            reduce?: string;
+            /**
+             * {merge: 'collectionName'} add the results to collectionName: if
+             * dups exist the new docs overwrite the old
+             */
+            merge?: string;
+        };
+    }
+
+    interface MapReduceResult<Key, Val> {
+        _id: Key;
+        value: Val;
+    }
+
+    /*
+     * section collection.js
+     * http://mongoosejs.com/docs/api.html#collection-js
+     */
+    interface CollectionBase extends mongodb.Collection {
+        /*
+         * Abstract methods. Some of these are already defined on the
+         * mongodb.Collection interface so they've been commented out.
+         */
+        ensureIndex(...args: any[]): any;
+        //find(...args: any[]): any;
+        findAndModify(...args: any[]): any;
+        //findOne(...args: any[]): any;
+        getIndexes(...args: any[]): any;
+        //insert(...args: any[]): any;
+        //mapReduce(...args: any[]): any;
+        //save(...args: any[]): any;
+        //update(...args: any[]): any;
+
+        /** The collection name */
+        collectionName: string;
+        /** The Connection instance */
+        conn: Connection;
+        /** The collection name */
+        name: string;
+    }
 }

--- a/types/mongoose/v4/mongoose-tests.ts
+++ b/types/mongoose/v4/mongoose-tests.ts
@@ -1,4 +1,4 @@
-import * as mongoose from 'mongoose';
+import * as mongoose from "mongoose";
 
 // dummy variables
 var cb = function () {};
@@ -15,47 +15,60 @@ var cb = function () {};
  * section index.js
  * http://mongoosejs.com/docs/api.html#index-js
  */
-var connectUri = 'mongodb://user:pass@localhost:port/database';
+var connectUri = "mongodb://user:pass@localhost:port/database";
 mongoose.connect(connectUri).then(cb).catch(cb);
-mongoose.connect(connectUri, {
-  user: 'larry',
-  pass: 'housan',
-  config: {
-    autoIndex: true
-  },
-  mongos: true
-}).then(cb);
+mongoose
+    .connect(connectUri, {
+        user: "larry",
+        pass: "housan",
+        config: {
+            autoIndex: true,
+        },
+        mongos: true,
+    })
+    .then(cb);
 mongoose.connect(connectUri, function (error) {
-  error.stack;
+    error.stack;
 });
 var mongooseConnection: mongoose.Connection = mongoose.createConnection();
-mongoose.createConnection(connectUri).open('');
-mongoose.createConnection(connectUri, {
-  db: {
-    native_parser: true
-  }
-}).open('');
-mongoose.createConnection('localhost', 'database', 3000).open('');
-mongoose.createConnection('localhost', 'database', 3000, {
-  user: 'larry',
-  config: {
-    autoIndex: false
-  }
-}).open('');
+mongoose.createConnection(connectUri).open("");
+mongoose
+    .createConnection(connectUri, {
+        db: {
+            native_parser: true,
+        },
+    })
+    .open("");
+mongoose.createConnection("localhost", "database", 3000).open("");
+mongoose
+    .createConnection("localhost", "database", 3000, {
+        user: "larry",
+        config: {
+            autoIndex: false,
+        },
+    })
+    .open("");
 mongoose.disconnect(cb).then(cb);
-mongoose.get('test');
-mongoose.model('Actor', new mongoose.Schema({
-  name: String
-}), 'collectionName', true).find({});
-mongoose.model('Actor').find({});
+mongoose.get("test");
+mongoose
+    .model(
+        "Actor",
+        new mongoose.Schema({
+            name: String,
+        }),
+        "collectionName",
+        true,
+    )
+    .find({});
+mongoose.model("Actor").find({});
 mongoose.modelNames()[0].toLowerCase();
-new (new mongoose.Mongoose(9, 8, 7)).Mongoose(1, 2, 3).connect('');
-mongoose.plugin(cb, {}).connect('');
-mongoose.set('test', 'value');
-mongoose.set('debug', function(collectionName: any, methodName: any, arg1: any, arg2: any) {});
-mongoose.STATES.hasOwnProperty('');
-mongoose.connection.on('error', cb);
-new mongoose.mongo.MongoError('error').stack;
+new new mongoose.Mongoose(9, 8, 7).Mongoose(1, 2, 3).connect("");
+mongoose.plugin(cb, {}).connect("");
+mongoose.set("test", "value");
+mongoose.set("debug", function (collectionName: any, methodName: any, arg1: any, arg2: any) {});
+mongoose.STATES.hasOwnProperty("");
+mongoose.connection.on("error", cb);
+new mongoose.mongo.MongoError("error").stack;
 mongoose.SchemaTypes.String;
 mongoose.SchemaTypes.ObjectId;
 mongoose.SchemaTypes.Decimal128;
@@ -67,24 +80,26 @@ mongoose.version.toLowerCase();
  * section querystream.js
  * http://mongoosejs.com/docs/api.html#querystream-js
  */
-var querystream = <mongoose.QueryStream> {};
+var querystream = <mongoose.QueryStream>{};
 querystream.destroy(new Error());
 querystream.pause();
-querystream.pipe(process.stdout, {end: true}).end();
+querystream.pipe(process.stdout, { end: true }).end();
 querystream.resume();
 querystream.paused;
 querystream.readable;
 /* inherited properties */
 querystream.getMaxListeners();
 /* practical examples */
-var QSModel = <typeof mongoose.Model> {};
+var QSModel = <typeof mongoose.Model>{};
 var QSStream: mongoose.QueryStream = QSModel.find().stream();
-QSStream.on('data', function (doc: any) {
-  doc.save();
-}).on('error', function (err: any) {
-  throw err;
-}).on('close', cb);
-QSModel.where('created').gte(20000).stream().pipe(process.stdout);
+QSStream.on("data", function (doc: any) {
+    doc.save();
+})
+    .on("error", function (err: any) {
+        throw err;
+    })
+    .on("close", cb);
+QSModel.where("created").gte(20000).stream().pipe(process.stdout);
 
 /*
  * section collection.js
@@ -93,9 +108,9 @@ QSModel.where('created').gte(20000).stream().pipe(process.stdout);
  * section drivers/node-mongodb-native/collection.js
  * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
  */
-var coll1 = <mongoose.Collection> {};
+var coll1 = <mongoose.Collection>{};
 coll1.$format(999).toLowerCase();
-coll1.$print('name', 'i', [1, 2, 3]);
+coll1.$print("name", "i", [1, 2, 3]);
 coll1.getIndexes();
 /* inherited properties */
 coll1.collectionName;
@@ -105,7 +120,7 @@ coll1.ensureIndex();
 coll1.find({});
 coll1.insert({}, {});
 
-var coll2 = new mongoose.Collection('', new mongoose.Connection(mongoose));
+var coll2 = new mongoose.Collection("", new mongoose.Connection(mongoose));
 coll2.$format(999).toLowerCase();
 /* inherited properties */
 coll2.initializeOrderedBulkOp;
@@ -118,41 +133,57 @@ coll2.indexExists;
  * section section drivers/node-mongodb-native/connection.js
  * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
  */
-var conn1: mongoose.Connection = mongoose.createConnection('mongodb://user:pass@localhost:port/database');
+var conn1: mongoose.Connection = mongoose.createConnection("mongodb://user:pass@localhost:port/database");
 conn1 = new mongoose.Connection(mongoose);
-conn1.open('mongodb://localhost/test', 'myDb', 27017, {
-  replset: null,
-  config: {
-    autoIndex: false
-  }
-}, function (err) {}).open('');
-conn1.openSet('mongodb://localhost/test', 'db', {
-  replset: null,
-  mongos: true
-}, function (err) {}).then(cb).catch(cb);
+conn1
+    .open(
+        "mongodb://localhost/test",
+        "myDb",
+        27017,
+        {
+            replset: null,
+            config: {
+                autoIndex: false,
+            },
+        },
+        function (err) {},
+    )
+    .open("");
+conn1
+    .openSet(
+        "mongodb://localhost/test",
+        "db",
+        {
+            replset: null,
+            mongos: true,
+        },
+        function (err) {},
+    )
+    .then(cb)
+    .catch(cb);
 conn1.close().catch(function (err) {});
-conn1.collection('name').$format(999);
-conn1.model('myModel', new mongoose.Schema({}), 'myCol').find();
-conn1.deleteModel('myModel');
+conn1.collection("name").$format(999);
+conn1.model("myModel", new mongoose.Schema({}), "myCol").find();
+conn1.deleteModel("myModel");
 interface IStatics {
-  staticMethod1: (a: number) => string;
+    staticMethod1: (a: number) => string;
 }
 conn1.modelNames()[0].toLowerCase();
-conn1.config.hasOwnProperty('');
+conn1.config.hasOwnProperty("");
 conn1.db.bufferMaxEntries;
-conn1.collections['coll'].$format(999);
+conn1.collections["coll"].$format(999);
 conn1.readyState.toFixed();
-conn1.useDb('myDb').useDb('');
-mongoose.Connection.STATES.hasOwnProperty('');
+conn1.useDb("myDb").useDb("");
+mongoose.Connection.STATES.hasOwnProperty("");
 /* inherited properties */
-conn1.on('data', cb);
-conn1.addListener('close', cb);
+conn1.on("data", cb);
+conn1.addListener("close", cb);
 
 /*
  * section error/validation.js
  * http://mongoosejs.com/docs/api.html#error-validation-js
  */
-var validationError = <mongoose.ValidationError> {};
+var validationError = <mongoose.ValidationError>{};
 validationError.toString().toLowerCase();
 /* inherited properties */
 validationError.stack;
@@ -162,55 +193,72 @@ validationError.message;
  * section error.js
  * http://mongoosejs.com/docs/api.html#error-js
  */
-var mongooseError: mongoose.Error = new mongoose.Error('error');
+var mongooseError: mongoose.Error = new mongoose.Error("error");
 /* inherited properties */
 mongooseError.message;
 mongooseError.name;
 mongooseError.stack;
 /* static properties */
-mongoose.Error.messages.hasOwnProperty('');
-mongoose.Error.Messages.hasOwnProperty('');
+mongoose.Error.messages.hasOwnProperty("");
+mongoose.Error.Messages.hasOwnProperty("");
 
 /*
  * section querycursor.js
  * http://mongoosejs.com/docs/api.html#querycursor-js
  */
-var querycursor = <mongoose.QueryCursor<any>> {};
-querycursor.close(function (error, result) {
-  result.execPopulate();
-}).catch(cb);
-querycursor.eachAsync(function (doc) {
-  doc.execPopulate();
-}, function (err) {}).catch(cb);
+var querycursor = <mongoose.QueryCursor<any>>{};
+querycursor
+    .close(function (error, result) {
+        result.execPopulate();
+    })
+    .catch(cb);
+querycursor
+    .eachAsync(
+        function (doc) {
+            doc.execPopulate();
+        },
+        function (err) {},
+    )
+    .catch(cb);
 querycursor.next(cb).catch(cb);
 /* inherited properties */
 querycursor.pause();
 querycursor.pipe(process.stdout);
 /* practical example */
-var QCModel = mongoose.model('QC', new mongoose.Schema({name: String}));
-QCModel.find({}).cursor({}).on('data', function (doc: any) {
-  doc.depopulate('name');
-}).on('error', function (error: any) {
-  throw error;
-}).close().then(cb).catch(cb);
-querycursor.map(function (doc) {
-  doc.foo = "bar";
-  return doc;
-}).on('data', function (doc: any) {
-  console.log(doc.foo);
-});
-querycursor.map(function (doc) {
-  doc.foo = "bar";
-  return doc;
-}).next(function (error, doc) {
-  console.log(doc.foo);
-});
+var QCModel = mongoose.model("QC", new mongoose.Schema({ name: String }));
+QCModel.find({})
+    .cursor({})
+    .on("data", function (doc: any) {
+        doc.depopulate("name");
+    })
+    .on("error", function (error: any) {
+        throw error;
+    })
+    .close()
+    .then(cb)
+    .catch(cb);
+querycursor
+    .map(function (doc) {
+        doc.foo = "bar";
+        return doc;
+    })
+    .on("data", function (doc: any) {
+        console.log(doc.foo);
+    });
+querycursor
+    .map(function (doc) {
+        doc.foo = "bar";
+        return doc;
+    })
+    .next(function (error, doc) {
+        console.log(doc.foo);
+    });
 
 /*
  * section virtualtype.js
  * http://mongoosejs.com/docs/api.html#virtualtype-js
  */
-var virtualtype: mongoose.VirtualType = new mongoose.VirtualType({}, 'hello');
+var virtualtype: mongoose.VirtualType = new mongoose.VirtualType({}, "hello");
 virtualtype.applyGetters({}, {});
 virtualtype.applySetters({}, {});
 virtualtype.get(cb).get(cb);
@@ -221,217 +269,258 @@ virtualtype.set(cb).set(cb);
  * http://mongoosejs.com/docs/api.html#schema-js
  */
 var schema: mongoose.Schema = new mongoose.Schema({
-  name:    String,
-  binary:  Buffer,
-  living:  Boolean,
-  updated: { type: Date, default: Date.now },
-  age:     { type: Number, min: 18, max: 65 },
-  mixed:   mongoose.Schema.Types.Mixed,
-  _someId: mongoose.Schema.Types.ObjectId,
-  someDecimal:mongoose.Schema.Types.Decimal128,
-  array:      [],
-  ofString:   [String],
-  ofNumber:   [Number],
-  ofDates:    [Date],
-  ofBuffer:   [Buffer],
-  ofBoolean:  [Boolean],
-  ofMixed:    [mongoose.Schema.Types.Mixed],
-  ofObjectId: [mongoose.Schema.Types.ObjectId],
-  nested: {
-    stuff: { type: String, lowercase: true, trim: true }
-  }
+    name: String,
+    binary: Buffer,
+    living: Boolean,
+    updated: { type: Date, default: Date.now },
+    age: { type: Number, min: 18, max: 65 },
+    mixed: mongoose.Schema.Types.Mixed,
+    _someId: mongoose.Schema.Types.ObjectId,
+    someDecimal: mongoose.Schema.Types.Decimal128,
+    array: [],
+    ofString: [String],
+    ofNumber: [Number],
+    ofDates: [Date],
+    ofBuffer: [Buffer],
+    ofBoolean: [Boolean],
+    ofMixed: [mongoose.Schema.Types.Mixed],
+    ofObjectId: [mongoose.Schema.Types.ObjectId],
+    nested: {
+        stuff: { type: String, lowercase: true, trim: true },
+    },
 });
-schema.add({
-  mixedArray: {
-    type: [mongoose.Schema.Types.Mixed],
-    required: true
-  }
-}, 'prefix');
-schema.eachPath(function (path, type) {
-  path.toLowerCase();
-  type.sparse(true);
-}).eachPath(cb);
-schema.get('path');
-schema.index({
-  name: 1,
-  binary: -1
-}).index({}, {});
+schema.add(
+    {
+        mixedArray: {
+            type: [mongoose.Schema.Types.Mixed],
+            required: true,
+        },
+    },
+    "prefix",
+);
+schema
+    .eachPath(function (path, type) {
+        path.toLowerCase();
+        type.sparse(true);
+    })
+    .eachPath(cb);
+schema.get("path");
+schema
+    .index({
+        name: 1,
+        binary: -1,
+    })
+    .index({}, {});
 schema.indexes().slice();
-schema.method('name', cb).method({
-  m1: cb,
-  m2: cb
+schema.method("name", cb).method({
+    m1: cb,
+    m2: cb,
 });
-schema.path('a', mongoose.Schema.Types.Buffer).path('a');
-schema.pathType('m1').toLowerCase();
-schema.plugin(function (schema: mongoose.Schema, opts?: any) {
-  schema.get('path');
-  if (opts) {
-    opts.hasOwnProperty('');
-  }
-}).plugin(cb, {opts: true});
+schema.path("a", mongoose.Schema.Types.Buffer).path("a");
+schema.pathType("m1").toLowerCase();
+schema
+    .plugin(function (schema: mongoose.Schema, opts?: any) {
+        schema.get("path");
+        if (opts) {
+            opts.hasOwnProperty("");
+        }
+    })
+    .plugin(cb, { opts: true });
 
 schema
-.post('save', function (error, doc, next) {
-  error.stack;
-  doc.model;
-  next.apply;
-})
-.post('save', function (doc: mongoose.Document, next: Function) {
-  doc.model;
-  next(new Error());
-})
-.post('save', function (doc: mongoose.Document) {
-  doc.model;
-});
-schema.queue('m1', [1, 2, 3]).queue('m2', [[]]);
-schema.remove('path');
-schema.remove(['path1', 'path2', 'path3']);
+    .post("save", function (error, doc, next) {
+        error.stack;
+        doc.model;
+        next.apply;
+    })
+    .post("save", function (doc: mongoose.Document, next: Function) {
+        doc.model;
+        next(new Error());
+    })
+    .post("save", function (doc: mongoose.Document) {
+        doc.model;
+    });
+schema.queue("m1", [1, 2, 3]).queue("m2", [[]]);
+schema.remove("path");
+schema.remove(["path1", "path2", "path3"]);
 schema.requiredPaths(true)[0].toLowerCase();
-schema.set('key', 999).set('key');
-schema.static('static', cb).static({
-  s1: cb,
-  s2: cb
+schema.set("key", 999).set("key");
+schema.static("static", cb).static({
+    s1: cb,
+    s2: cb,
 });
-schema.virtual('virt', {}).applyGetters({}, {});
-schema.virtualpath('path').applyGetters({}, {});
+schema.virtual("virt", {}).applyGetters({}, {});
+schema.virtualpath("path").applyGetters({}, {});
 /* static properties */
 mongoose.Schema.indexTypes[0].toLowerCase();
-mongoose.Schema.reserved.hasOwnProperty('');
+mongoose.Schema.reserved.hasOwnProperty("");
 /* inherited properties */
-schema.addListener('e', cb);
+schema.addListener("e", cb);
 /* practical examples */
 var animalSchema = new mongoose.Schema({
-  name: String,
-  type: String
+    name: String,
+    type: String,
 });
 animalSchema.methods.findSimilarTypes = function (cb: any) {
-  return this.model('Aminal').find({ type: this.type }, cb);
+    return this.model("Aminal").find({ type: this.type }, cb);
 };
-var Animal: any = mongoose.model('Animal', animalSchema);
-var dog: any = new Animal({type: 'dog'});
-dog['findSimilarTypes'](function (err: any, dogs: any) {
-  console.log(dogs);
+var Animal: any = mongoose.model("Animal", animalSchema);
+var dog: any = new Animal({ type: "dog" });
+dog["findSimilarTypes"](function (err: any, dogs: any) {
+    console.log(dogs);
 });
 new mongoose.Schema({
-  title:  String,
-  author: String,
-  body:   String,
-  comments: [{ body: String, date: Date }],
-  date: { type: Date, default: Date.now },
-  hidden: Boolean,
-  meta: {
-    votes: Number,
-    favs:  Number,
-    text: String
-  },
-  meta2: {
-    text: mongoose.Schema.Types.Number,
-    select: {
-      type: String
-    }
-  }
+    title: String,
+    author: String,
+    body: String,
+    comments: [{ body: String, date: Date }],
+    date: { type: Date, default: Date.now },
+    hidden: Boolean,
+    meta: {
+        votes: Number,
+        favs: Number,
+        text: String,
+    },
+    meta2: {
+        text: mongoose.Schema.Types.Number,
+        select: {
+            type: String,
+        },
+    },
 });
-new mongoose.Schema({ name: { type: String, index: true }});
-new mongoose.Schema({ loc: { type: [Number], index: 'hashed' }});
-new mongoose.Schema({ loc: { type: [Number], index: '2d', sparse: true }});
-new mongoose.Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }}});
-new mongoose.Schema({ date: { type: Date, index: { unique: true, expires: '1d' }}});
-new mongoose.Schema({ born: { type: Date, required: '{PATH} is required!' }});
-new mongoose.Schema({ born: { type: Date, required: function() {
-  return this.age >= 18;
-}}});
-new mongoose.Schema({ state: { type: String, enum: ['opening', 'open', 'closing', 'closed'] }});
-new mongoose.Schema({ state: { type: String, enum: {
-  values: ['opening', 'open', 'closing', 'closed'],
-  message: 'enum validator failed for path `{PATH}` with value `{VALUE}`'
-}}});
-new mongoose.Schema({ name: { type: String, match: /^a/ }});
-new mongoose.Schema({ name: { type: String, match: [
-  /\.html$/, "That file doesn't end in .html ({VALUE})"
-]}});
+new mongoose.Schema({ name: { type: String, index: true } });
+new mongoose.Schema({ loc: { type: [Number], index: "hashed" } });
+new mongoose.Schema({ loc: { type: [Number], index: "2d", sparse: true } });
+new mongoose.Schema({ loc: { type: [Number], index: { type: "2dsphere", sparse: true } } });
+new mongoose.Schema({ date: { type: Date, index: { unique: true, expires: "1d" } } });
+new mongoose.Schema({ born: { type: Date, required: "{PATH} is required!" } });
 new mongoose.Schema({
-  createdAt: {type: Date, expires: 60 * 60 * 24}
+    born: {
+        type: Date,
+        required: function () {
+            return this.age >= 18;
+        },
+    },
 });
-new mongoose.Schema({ createdAt: { type: Date, expires: '1.5h' }});
-new mongoose.Schema({ d: { type: Date, max: new Date('2014-01-01') }});
-new mongoose.Schema({ d: { type: Date, max: [
-  new Date('2014-01-01'),
-  'The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX}).'
-]}});
-new mongoose.Schema({d: {type: Date, min: [
-  new Date('1970-01-01'),
-  'The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN}).'
-]}});
+new mongoose.Schema({ state: { type: String, enum: ["opening", "open", "closing", "closed"] } });
 new mongoose.Schema({
-  integerOnly: {
-    type: Number,
-    get: (v: number) => Math.round(v),
-    set: (v: number) => Math.round(v)
-  }
+    state: {
+        type: String,
+        enum: {
+            values: ["opening", "open", "closing", "closed"],
+            message: "enum validator failed for path `{PATH}` with value `{VALUE}`",
+        },
+    },
 });
-new mongoose.Schema({ name: { type: String, validate: [
-  { validator: () => {return true}, msg: 'uh oh' },
-  { validator: () => {return true}, msg: 'failed' }
-]}});
+new mongoose.Schema({ name: { type: String, match: /^a/ } });
+new mongoose.Schema({ name: { type: String, match: [/\.html$/, "That file doesn't end in .html ({VALUE})"] } });
+new mongoose.Schema({
+    createdAt: { type: Date, expires: 60 * 60 * 24 },
+});
+new mongoose.Schema({ createdAt: { type: Date, expires: "1.5h" } });
+new mongoose.Schema({ d: { type: Date, max: new Date("2014-01-01") } });
+new mongoose.Schema({
+    d: { type: Date, max: [new Date("2014-01-01"), "The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX})."] },
+});
+new mongoose.Schema({
+    d: {
+        type: Date,
+        min: [new Date("1970-01-01"), "The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN})."],
+    },
+});
+new mongoose.Schema({
+    integerOnly: {
+        type: Number,
+        get: (v: number) => Math.round(v),
+        set: (v: number) => Math.round(v),
+    },
+});
+new mongoose.Schema({
+    name: {
+        type: String,
+        validate: [
+            {
+                validator: () => {
+                    return true;
+                },
+                msg: "uh oh",
+            },
+            {
+                validator: () => {
+                    return true;
+                },
+                msg: "failed",
+            },
+        ],
+    },
+});
 new mongoose.Schema({ status: String, photos: [String] }, { optimisticConcurrency: true });
-animalSchema.statics.findByName = function(name: any, cb: any) {
-  return this.find({ name: new RegExp(name, 'i') }, cb);
+animalSchema.statics.findByName = function (name: any, cb: any) {
+    return this.find({ name: new RegExp(name, "i") }, cb);
 };
-Animal['findByName']('fido', function(err: any, animals: any) {
-  console.log(animals);
+Animal["findByName"]("fido", function (err: any, animals: any) {
+    console.log(animals);
 });
-animalSchema.virtual('name.full').get(function () {
-  return this.name.first + ' ' + this.name.last;
+animalSchema.virtual("name.full").get(function () {
+    return this.name.first + " " + this.name.last;
 });
 var childSchema = new mongoose.Schema({ name: String });
 var parentSchema = new mongoose.Schema({
-  children: [childSchema],
-  child: childSchema,
-  name: {
-    index: true,
-    required: true
-  }
+    children: [childSchema],
+    child: childSchema,
+    name: {
+        index: true,
+        required: true,
+    },
 });
 new mongoose.Schema({
-  eggs: {
-    type: Number,
-    min: [6, 'Too few eggs'],
-    max: 12
-  },
-  bacon: {
-    type: Number,
-    required: [true, 'Why no bacon?']
-  },
-  drink: {
-    type: String,
-    enum: ['Coffee', 'Tea']
-  }
+    eggs: {
+        type: Number,
+        min: [6, "Too few eggs"],
+        max: 12,
+    },
+    bacon: {
+        type: Number,
+        required: [true, "Why no bacon?"],
+    },
+    drink: {
+        type: String,
+        enum: ["Coffee", "Tea"],
+    },
 });
 
-(new mongoose.Schema({})).plugin(function (schema: any, options: any) {
-  schema.add({ lastMod: Date })
-  schema.pre('save', function (next: Function) {
-    this.lastMod = new Date
-    next()
-  })
-  if (options && options['index']) {
-    schema.path('lastMod').index(options['index'])
-  }
-}, { index: true }).plugin(function (schema: any, options: any) {
-  schema.add({ lastMod: Date })
-  schema.pre('save', function (next: Function) {
-    this.lastMod = new Date
-    next()
-  })
-  if (options && options['index']) {
-    schema.path('lastMod').index(options['index'])
-  }
-}, {index: true});
+new mongoose.Schema({})
+    .plugin(
+        function (schema: any, options: any) {
+            schema.add({ lastMod: Date });
+            schema.pre("save", function (next: Function) {
+                this.lastMod = new Date();
+                next();
+            });
+            if (options && options["index"]) {
+                schema.path("lastMod").index(options["index"]);
+            }
+        },
+        { index: true },
+    )
+    .plugin(
+        function (schema: any, options: any) {
+            schema.add({ lastMod: Date });
+            schema.pre("save", function (next: Function) {
+                this.lastMod = new Date();
+                next();
+            });
+            if (options && options["index"]) {
+                schema.path("lastMod").index(options["index"]);
+            }
+        },
+        { index: true },
+    );
 
 // plugins
 interface PluginOption {
-  modelName: string;
-  timestamp: string;
+    modelName: string;
+    timestamp: string;
 }
 
 function logger(modelName: string, timestamp: string) {
@@ -439,117 +528,130 @@ function logger(modelName: string, timestamp: string) {
 }
 
 function AwesomeLoggerPlugin(schema: mongoose.Schema, options?: PluginOption) {
-  if (options) {
-      schema.pre('save', function (next: Function) {
-          logger(options.modelName, options.timestamp)
-      })
-  }
+    if (options) {
+        schema.pre("save", function (next: Function) {
+            logger(options.modelName, options.timestamp);
+        });
+    }
 }
 
-new mongoose.Schema({})
-    .plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', timestamp: 'yyyy/MM/dd'})
+new mongoose.Schema({}).plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", timestamp: "yyyy/MM/dd" });
 
-mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, {modelName: 'Executive', timestamp: 'yyyy/MM/dd'})
+mongoose.plugin<PluginOption>(AwesomeLoggerPlugin, { modelName: "Executive", timestamp: "yyyy/MM/dd" });
 
-export default function(schema: mongoose.Schema) {
-  schema.pre('init', function(this: mongoose.Document, next: (err?: Error) => void, data: any): void {
-    data.name = 'Hello world';
-  });
+export default function (schema: mongoose.Schema) {
+    schema.pre("init", function (this: mongoose.Document, next: (err?: Error) => void, data: any): void {
+        data.name = "Hello world";
+    });
 }
 
 /*
  * section document.js
  * http://mongoosejs.com/docs/api.html#document-js
  */
-var doc = <mongoose.MongooseDocument> {};
-doc.$isDefault('path').valueOf();
-doc.depopulate('path');
+var doc = <mongoose.MongooseDocument>{};
+doc.$isDefault("path").valueOf();
+doc.depopulate("path");
 doc.equals(doc).valueOf();
-doc.execPopulate().then(function (arg) {
-  arg.execPopulate();
-}).catch(function (err) {});
-doc.get('path', Number);
+doc.execPopulate()
+    .then(function (arg) {
+        arg.execPopulate();
+    })
+    .catch(function (err) {});
+doc.get("path", Number);
 doc.init(doc, cb).init(doc, {}, cb);
 doc.inspect();
-doc.invalidate('path', new Error('hi'), 999).toString();
-doc.isDirectModified('path').valueOf();
-doc.isInit('path').valueOf();
-doc.isModified('path').valueOf();
-doc.isSelected('path').valueOf();
-doc.markModified('path');
+doc.invalidate("path", new Error("hi"), 999).toString();
+doc.isDirectModified("path").valueOf();
+doc.isInit("path").valueOf();
+doc.isModified("path").valueOf();
+doc.isSelected("path").valueOf();
+doc.markModified("path");
 doc.modifiedPaths()[0].toLowerCase();
 doc.populate(function (err, doc) {
-  doc.populate('path', function (err, doc) {
-    doc.populate({
-      path: 'path',
-      select: 'path',
-      match: {}
+    doc.populate("path", function (err, doc) {
+        doc.populate({
+            path: "path",
+            select: "path",
+            match: {},
+        });
     });
-  });
 });
-doc.populated('path');
-doc.set('path', 999, {}).set({ path: 999 });
+doc.populated("path");
+doc.set("path", 999, {}).set({ path: 999 });
 doc.toJSON({
-  getters: true,
-  virtuals: false
+    getters: true,
+    virtuals: false,
 });
 doc.toObject({
-  transform: function (doc, ret, options) {
-    doc.toObject();
-  }
+    transform: function (doc, ret, options) {
+        doc.toObject();
+    },
 });
 doc.toString().toLowerCase();
-doc.unmarkModified('path');
+doc.unmarkModified("path");
 doc.update(doc, cb).cursor();
-doc.update(doc, {
-  safe: true,
-  upsert: true
-}, cb).cursor();
+doc.update(
+    doc,
+    {
+        safe: true,
+        upsert: true,
+    },
+    cb,
+).cursor();
 doc.validate({}, function (err) {});
 doc.validate().then(null).catch(null);
-var documentValidationError = doc.validateSync(['path1', 'path2']);
+var documentValidationError = doc.validateSync(["path1", "path2"]);
 if (documentValidationError) {
-    documentValidationError.stack
+    documentValidationError.stack;
 }
 /* practical examples */
-var MyModel = mongoose.model('test', new mongoose.Schema({
-  name: {
-    type: String,
-    default: 'Val '
-  }
-}));
+var MyModel = mongoose.model(
+    "test",
+    new mongoose.Schema({
+        name: {
+            type: String,
+            default: "Val ",
+        },
+    }),
+);
 doc = new MyModel();
-doc.$isDefault('name');
-MyModel.findOne().populate('author').exec(function (err, doc) {
-  if (doc) {
-    doc.depopulate('author');
-  }
-});
-doc.populate('path');
-doc.populate({path: 'hello'});
-doc.populate('path', cb)
-doc.populate({path: 'hello'}, cb);
+doc.$isDefault("name");
+MyModel.findOne()
+    .populate("author")
+    .exec(function (err, doc) {
+        if (doc) {
+            doc.depopulate("author");
+        }
+    });
+doc.populate("path");
+doc.populate({ path: "hello" });
+doc.populate("path", cb);
+doc.populate({ path: "hello" }, cb);
 doc.populate(cb);
-doc.populate({path: 'hello'}).execPopulate().catch(cb);
-doc.update({$inc: {wheels:1}}, { w: 1 }, cb);
+doc.populate({ path: "hello" }).execPopulate().catch(cb);
+doc.update({ $inc: { wheels: 1 } }, { w: 1 }, cb);
 
-const ImageSchema = new mongoose.Schema({
-  name: {type: String, required: true},
-  id: {type: Number, unique: true, required: true, index: true},
-}, { id: false });
+const ImageSchema = new mongoose.Schema(
+    {
+        name: { type: String, required: true },
+        id: { type: Number, unique: true, required: true, index: true },
+    },
+    { id: false },
+);
 
 interface ImageDoc extends mongoose.Document {
-  name: string,
-  id: number
+    name: string;
+    id: number;
 }
 
-const ImageModel = mongoose.model<ImageDoc>('image', ImageSchema);
+const ImageModel = mongoose.model<ImageDoc>("image", ImageSchema);
 
-ImageModel.findOne({}, function(err, doc) {
-  if (doc) {
-    doc.name;
-    doc.id;
-  }
+ImageModel.findOne({}, function (err, doc) {
+    if (doc) {
+        doc.name;
+        doc.id;
+    }
 });
 
 /*
@@ -560,7 +662,7 @@ ImageModel.findOne({}, function(err, doc) {
 var subdocument: mongoose.Types.Subdocument = new mongoose.Types.Subdocument();
 subdocument.ownerDocument().errors;
 subdocument.remove({}, function (err) {
-  return 6;
+    return 6;
 });
 /* inherited properties */
 subdocument.execPopulate();
@@ -573,49 +675,49 @@ var mongooseArray: mongoose.Types.Array<string> = new mongoose.Types.Array<strin
 mongooseArray.$shift().toLowerCase();
 mongooseArray.remove().$shift();
 mongooseArray.$pop().toLowerCase();
-mongooseArray.addToSet('hi', 9, 9, '4')[0].toLowerCase();
-mongooseArray.indexOf({name: 'obj'}).toFixed();
+mongooseArray.addToSet("hi", 9, 9, "4")[0].toLowerCase();
+mongooseArray.indexOf({ name: "obj" }).toFixed();
 mongooseArray.inspect();
-mongooseArray.nonAtomicPush(9, 8, 'hi').toFixed();
+mongooseArray.nonAtomicPush(9, 8, "hi").toFixed();
 mongooseArray.pop().toLowerCase();
-mongooseArray.pull(5, 4, 'hi').$shift();
+mongooseArray.pull(5, 4, "hi").$shift();
 mongooseArray.push([]).toFixed();
-mongooseArray.set(1, 'hi').$shift();
+mongooseArray.set(1, "hi").$shift();
 mongooseArray.shift().toLowerCase();
-mongooseArray.sort(function (a, b) {
-  return a.length - b.length;
-}).unshift();
+mongooseArray
+    .sort(function (a, b) {
+        return a.length - b.length;
+    })
+    .unshift();
 mongooseArray.splice(4, 1).unshift();
-mongooseArray.toObject({depopulate: true}).unshift();
-mongooseArray.unshift(2, 4, 'hi').toFixed();
+mongooseArray.toObject({ depopulate: true }).unshift();
+mongooseArray.unshift(2, 4, "hi").toFixed();
 /* inherited properties */
 mongooseArray.concat();
 mongooseArray.length;
 /* practical examples */
 interface MySubEntity extends mongoose.Types.Subdocument {
-  property1: string;
-  property2: string;
+    property1: string;
+    property2: string;
 }
 interface MyEntity extends mongoose.Document {
-  sub: mongoose.Types.Array<MySubEntity>
+    sub: mongoose.Types.Array<MySubEntity>;
 }
-var myEntity = <MyEntity> {};
+var myEntity = <MyEntity>{};
 var subDocArray = myEntity.sub.filter(sd => {
-  sd.property1;
-  sd.property2.toLowerCase();
-  return true;
+    sd.property1;
+    sd.property2.toLowerCase();
+    return true;
 });
-
 
 /*
  * section types/documentarray.js
  * http://mongoosejs.com/docs/api.html#types-documentarray-js
  */
 // The constructor is private api, but we'll use it to test
-var documentArray: mongoose.Types.DocumentArray<mongoose.MongooseDocument> =
-  new mongoose.Types.DocumentArray();
+var documentArray: mongoose.Types.DocumentArray<mongoose.MongooseDocument> = new mongoose.Types.DocumentArray();
 documentArray.create({}).errors;
-documentArray.id(new Buffer('hi'));
+documentArray.id(new Buffer("hi"));
 documentArray.inspect();
 documentArray.toObject({}).length;
 /* inherited from mongoose.Types.Array */
@@ -624,26 +726,26 @@ documentArray.$shift();
 documentArray.concat();
 /* practical example */
 interface MySubEntity1 extends mongoose.Types.Subdocument {
-  property1: string;
-  property2: string;
+    property1: string;
+    property2: string;
 }
 interface MyEntity1 extends mongoose.Document {
-  sub: mongoose.Types.DocumentArray<MySubEntity>
+    sub: mongoose.Types.DocumentArray<MySubEntity>;
 }
-var newEnt = <MyEntity1> {};
+var newEnt = <MyEntity1>{};
 var newSub: MySubEntity1 = newEnt.sub.create({ property1: "example", property2: "example" });
 
 /*
  * section types/buffer.js
  * http://mongoosejs.com/docs/api.html#types-buffer-js
  */
-var mongooseBuffer: mongoose.Types.Buffer = new mongoose.Types.Buffer('hello');
+var mongooseBuffer: mongoose.Types.Buffer = new mongoose.Types.Buffer("hello");
 mongooseBuffer.copy(mongooseBuffer, 1, 2, 3).toFixed();
-mongooseBuffer.copy(new Buffer('hi')).toFixed();
-mongooseBuffer.equals(new Buffer('hi')).valueOf();
+mongooseBuffer.copy(new Buffer("hi")).toFixed();
+mongooseBuffer.equals(new Buffer("hi")).valueOf();
 mongooseBuffer.subtype(123);
 mongooseBuffer.toObject().value();
-mongooseBuffer.write('world', 3, 2, 1).toFixed();
+mongooseBuffer.write("world", 3, 2, 1).toFixed();
 /* inherited properties */
 mongooseBuffer.compare(mongooseBuffer);
 /* inherited static properties */
@@ -653,37 +755,37 @@ mongoose.Types.Buffer.from([1, 2, 3]);
  * section types/decimal128.js
  * http://mongoosejs.com/docs/api.html#types-decimal128-js
  */
-var decimal128: mongoose.Types.Decimal128 = mongoose.Types.Decimal128.fromString('123.45678901234567');
-decimal128 = new mongoose.Types.Decimal128(new Buffer('12345'));
+var decimal128: mongoose.Types.Decimal128 = mongoose.Types.Decimal128.fromString("123.45678901234567");
+decimal128 = new mongoose.Types.Decimal128(new Buffer("12345"));
 /* practical examples */
 export interface ILargeValuesSchema extends mongoose.MongooseDocument {
-  sum: mongoose.Schema.Types.Decimal128;
+    sum: mongoose.Schema.Types.Decimal128;
 }
 export var LargeValuesSchema = new mongoose.Schema({
-  sum: {
-    type: mongoose.Schema.Types.Decimal128,
-    required: true
-  }
+    sum: {
+        type: mongoose.Schema.Types.Decimal128,
+        required: true,
+    },
 });
 
 /*
  * section types/objectid.js
  * http://mongoosejs.com/docs/api.html#types-objectid-js
  */
-var objectId: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString('0x1234');
+var objectId: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString("0x1234");
 objectId = new mongoose.Types.ObjectId(12345);
 objectId = mongoose.Types.ObjectId(12345);
 objectId.getTimestamp();
 /* practical examples */
 export interface IManagerSchema extends mongoose.MongooseDocument {
-  user: mongoose.Schema.Types.ObjectId;
+    user: mongoose.Schema.Types.ObjectId;
 }
 export var ManagerSchema = new mongoose.Schema({
-  user: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
-    required: true
-  }
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+        required: true,
+    },
 });
 
 /*
@@ -691,13 +793,13 @@ export var ManagerSchema = new mongoose.Schema({
  * http://mongoosejs.com/docs/api.html#types-embedded-js
  */
 var embeddedDocument: mongoose.Types.Embedded = new mongoose.Types.Embedded();
-embeddedDocument.inspect().hasOwnProperty('');
-embeddedDocument.invalidate('hi', new Error('bleh')).valueOf();
+embeddedDocument.inspect().hasOwnProperty("");
+embeddedDocument.invalidate("hi", new Error("bleh")).valueOf();
 embeddedDocument.ownerDocument().execPopulate();
 embeddedDocument.parent().execPopulate();
 embeddedDocument.parentArray().$shift();
-embeddedDocument.remove().invalidate('hi', new Error('hi'));
-embeddedDocument.markModified('path');
+embeddedDocument.remove().invalidate("hi", new Error("hi"));
+embeddedDocument.markModified("path");
 /* inherited properties */
 embeddedDocument.execPopulate();
 
@@ -705,182 +807,235 @@ embeddedDocument.execPopulate();
  * section query.js
  * http://mongoosejs.com/docs/api.html#query-js
  */
-var query = <mongoose.Query<mongoose.MongooseDocument[]>> {};
-query.$where('').$where(cb);
-query.all(99).all('path', 99);
-query.and([{ color: 'green' }, { status: 'ok' }]).and([]);
+var query = <mongoose.Query<mongoose.MongooseDocument[]>>{};
+query.$where("").$where(cb);
+query.all(99).all("path", 99);
+query.and([{ color: "green" }, { status: "ok" }]).and([]);
 query.batchSize(100).batchSize(100);
-var lowerLeft = [40.73083, -73.99756]
-var upperRight = [40.741404,  -73.988135]
-query.where('loc').within().box(lowerLeft, upperRight)
-query.box({ ll : lowerLeft, ur : upperRight }).box({});
-var queryModel = mongoose.model('QModel')
-query.cast(new queryModel(), {}).hasOwnProperty('');
+var lowerLeft = [40.73083, -73.99756];
+var upperRight = [40.741404, -73.988135];
+query.where("loc").within().box(lowerLeft, upperRight);
+query.box({ ll: lowerLeft, ur: upperRight }).box({});
+var queryModel = mongoose.model("QModel");
+query.cast(new queryModel(), {}).hasOwnProperty("");
 query.catch(cb).catch(cb);
 query.center({}).center({});
-query.centerSphere({ center: [50, 50], radius: 10 }).centerSphere('path', {});
-query.circle({ center: [50, 50], radius: 10 }).circle('path');
-query.collation({ locale: 'en_US', strength: 1 });
-query.comment('comment').comment('comment');
-query.where({color: 'black'}).count(function (err, count) {
-  count.toFixed();
-}).then(function (res) {
-  res.toFixed();
-}).catch(function (err) {});
+query.centerSphere({ center: [50, 50], radius: 10 }).centerSphere("path", {});
+query.circle({ center: [50, 50], radius: 10 }).circle("path");
+query.collation({ locale: "en_US", strength: 1 });
+query.comment("comment").comment("comment");
+query
+    .where({ color: "black" })
+    .count(function (err, count) {
+        count.toFixed();
+    })
+    .then(function (res) {
+        res.toFixed();
+    })
+    .catch(function (err) {});
 query.cursor().close();
-query.distinct('field', {}, cb);
-query.distinct('field', {});
-query.distinct('field', cb);
-query.distinct('field');
+query.distinct("field", {}, cb);
+query.distinct("field", {});
+query.distinct("field", cb);
+query.distinct("field");
 query.distinct(cb);
 query.distinct();
-query.elemMatch('comment', {
-  author: 'autobot',
-  votes: {$gte: 5}
-}).elemMatch('comment', function (elem) {
-  elem.where('author').equals('autobot');
-  elem.where('votes').gte(5);
-});
-query.where('age').equals(49);
-query.exec('find', function (err, res) {
-  res[0].execPopulate();
-}).then(function (arg) {
-  arg[0].execPopulate();
-}).catch(cb);
-query.where('name').exists().exists('age', false);
-query.find({name: 'aa'}, function (err, res) {
-  res[0].execPopulate();
-}).find();
-query.findOne(function (err, res) {
-  res.execPopulate();
-}).findOne();
-query.findOneAndRemove({name: 'aa'}, {
-  passRawResult: true
-}, function (err, doc) {
-  doc.execPopulate();
-}).findOneAndRemove();
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, {
-
-});
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, {
-  passRawResult: true
-}, cb);
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, cb);
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'});
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, { });
-query.findOneAndUpdate({name: 'aa'}, {name: 'bb'}, { upsert: true, new: true });
-query.findOneAndUpdate({name: 'bb'}, cb);
-query.findOneAndUpdate({name: 'bb'});
+query
+    .elemMatch("comment", {
+        author: "autobot",
+        votes: { $gte: 5 },
+    })
+    .elemMatch("comment", function (elem) {
+        elem.where("author").equals("autobot");
+        elem.where("votes").gte(5);
+    });
+query.where("age").equals(49);
+query
+    .exec("find", function (err, res) {
+        res[0].execPopulate();
+    })
+    .then(function (arg) {
+        arg[0].execPopulate();
+    })
+    .catch(cb);
+query.where("name").exists().exists("age", false);
+query
+    .find({ name: "aa" }, function (err, res) {
+        res[0].execPopulate();
+    })
+    .find();
+query
+    .findOne(function (err, res) {
+        res.execPopulate();
+    })
+    .findOne();
+query
+    .findOneAndRemove(
+        { name: "aa" },
+        {
+            passRawResult: true,
+        },
+        function (err, doc) {
+            doc.execPopulate();
+        },
+    )
+    .findOneAndRemove();
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" }, {});
+query.findOneAndUpdate(
+    { name: "aa" },
+    { name: "bb" },
+    {
+        passRawResult: true,
+    },
+    cb,
+);
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" }, cb);
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" });
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" }, {});
+query.findOneAndUpdate({ name: "aa" }, { name: "bb" }, { upsert: true, new: true });
+query.findOneAndUpdate({ name: "bb" }, cb);
+query.findOneAndUpdate({ name: "bb" });
 query.findOneAndUpdate(cb);
-query.findOneAndUpdate().then(function (doc) {
-  doc.execPopulate();
-}).catch(cb);
-var polyA = [[[ 10, 20 ], [ 10, 40 ], [ 30, 40 ], [ 30, 20 ]]]
-query.where('loc').within().geometry({ type: 'Polygon', coordinates: polyA })
-var polyB = [[ 0, 0 ], [ 1, 1 ]]
-query.where('loc').within().geometry({ type: 'LineString', coordinates: polyB })
-var polyC = [ 0, 0 ]
-query.where('loc').within().geometry({ type: 'Point', coordinates: polyC })
-query.where('loc').intersects().geometry({ type: 'Point', coordinates: polyC })
+query
+    .findOneAndUpdate()
+    .then(function (doc) {
+        doc.execPopulate();
+    })
+    .catch(cb);
+var polyA = [
+    [
+        [10, 20],
+        [10, 40],
+        [30, 40],
+        [30, 20],
+    ],
+];
+query.where("loc").within().geometry({ type: "Polygon", coordinates: polyA });
+var polyB = [
+    [0, 0],
+    [1, 1],
+];
+query.where("loc").within().geometry({ type: "LineString", coordinates: polyB });
+var polyC = [0, 0];
+query.where("loc").within().geometry({ type: "Point", coordinates: polyC });
+query.where("loc").intersects().geometry({ type: "Point", coordinates: polyC });
 query.getQuery();
 query.getUpdate();
-query.find().where('age').gt(21);
-query.find().gt('age', 21);
-query.find().where('age').gte(21);
-query.find().gte('age', 21);
-query.hint({ indexA: 1, indexB: -1}).hint({});
-query.in([1, 2, 3]).in('num', [1, 2, 3]);
-query.where('path').intersects().geometry({
-    type: 'LineString'
-  , coordinates: [[180.0, 11.0], [180, 9.0]]
+query.find().where("age").gt(21);
+query.find().gt("age", 21);
+query.find().where("age").gte(21);
+query.find().gte("age", 21);
+query.hint({ indexA: 1, indexB: -1 }).hint({});
+query.in([1, 2, 3]).in("num", [1, 2, 3]);
+query
+    .where("path")
+    .intersects()
+    .geometry({
+        type: "LineString",
+        coordinates: [
+            [180.0, 11.0],
+            [180, 9.0],
+        ],
+    });
+query.where("path").intersects({
+    type: "LineString",
+    coordinates: [
+        [180.0, 11.0],
+        [180, 9.0],
+    ],
 });
-query.where('path').intersects({
-    type: 'LineString'
-  , coordinates: [[180.0, 11.0], [180, 9.0]]
-});
-query.find().lean().exec(function (err: any, docs: any) {
-  docs[0];
-});
+query
+    .find()
+    .lean()
+    .exec(function (err: any, docs: any) {
+        docs[0];
+    });
 query.limit(20).limit(20);
-query.find().where('age').lt(21);
-query.find().lt('age', 21);
-query.find().where('age').lte(21);
-query.find().lte('age', 21);
-query.maxDistance('path', 21).maxDistance(21);
+query.find().where("age").lt(21);
+query.find().lt("age", 21);
+query.find().where("age").lte(21);
+query.find().lte("age", 21);
+query.maxDistance("path", 21).maxDistance(21);
 query.maxscan(100).maxScan(100);
 query.maxScan(100).maxScan(100);
 query.merge(query).merge({});
 query.mod([1, 2]).mod([5, 6]);
-query.find().where('age').ne(21);
-query.find().ne('age', 21);
-query.where('loc').near({ center: [10, 10] });
-query.where('loc').near({ center: [10, 10], maxDistance: 5 });
-query.where('loc').near({ center: [10, 10], maxDistance: 5, spherical: true });
-query.near('loc', { center: [10, 10], maxDistance: 5 });
-query.where('loc').nearSphere({ center: [10, 10], maxDistance: 5 });
-query.find().where('age').in([20, 21]);
-query.find().in('age', [20, 21]);
-query.nor([{ color: 'green' }, { status: 'ok' }]).nor([]);
-query.or([{ color: 'red' }, { status: 'emergency' }]).or([]);
-query.where('loc').within().polygon([10,20], [13, 25], [7,15]);
-query.polygon('loc', [10,20], [13, 25], [7,15]);
-query.findOne().populate('owner').exec(function (err, kitten) {
-  kitten.execPopulate();
-});
-query.find().populate({
-    path: 'owner'
-  , select: 'name'
-  , match: { color: 'black' }
-  , options: { sort: { name: -1 }}
-}).exec(function (err, kittens) {
-  kittens[0].execPopulate();
-});
-query.find().populate('owner', 'name', null, {sort: { name: -1 }}).exec(function (err, kittens) {
-  kittens[0].execPopulate();
-});
-query.read('primary', []).read('primary');
-query.regex(/re/).regex('path', /re/);
+query.find().where("age").ne(21);
+query.find().ne("age", 21);
+query.where("loc").near({ center: [10, 10] });
+query.where("loc").near({ center: [10, 10], maxDistance: 5 });
+query.where("loc").near({ center: [10, 10], maxDistance: 5, spherical: true });
+query.near("loc", { center: [10, 10], maxDistance: 5 });
+query.where("loc").nearSphere({ center: [10, 10], maxDistance: 5 });
+query.find().where("age").in([20, 21]);
+query.find().in("age", [20, 21]);
+query.nor([{ color: "green" }, { status: "ok" }]).nor([]);
+query.or([{ color: "red" }, { status: "emergency" }]).or([]);
+query.where("loc").within().polygon([10, 20], [13, 25], [7, 15]);
+query.polygon("loc", [10, 20], [13, 25], [7, 15]);
+query
+    .findOne()
+    .populate("owner")
+    .exec(function (err, kitten) {
+        kitten.execPopulate();
+    });
+query
+    .find()
+    .populate({
+        path: "owner",
+        select: "name",
+        match: { color: "black" },
+        options: { sort: { name: -1 } },
+    })
+    .exec(function (err, kittens) {
+        kittens[0].execPopulate();
+    });
+query
+    .find()
+    .populate("owner", "name", null, { sort: { name: -1 } })
+    .exec(function (err, kittens) {
+        kittens[0].execPopulate();
+    });
+query.read("primary", []).read("primary");
+query.regex(/re/).regex("path", /re/);
 query.remove({}, cb);
 query.remove({});
 query.remove(cb);
 query.remove();
-query.select('a b');
-query.select('-c -d');
+query.select("a b");
+query.select("-c -d");
 query.select({ a: 1, b: 1 });
 query.select({ c: 0, d: 0 });
-query.select('+path');
+query.select("+path");
 query.selected();
 query.selectedExclusively();
 query.selectedInclusively();
 query.setOptions({
-  tailable: true,
-  batchSize: true,
-  lean: false
+    tailable: true,
+    batchSize: true,
+    lean: false,
 });
-query.size(0).size('age', 0);
+query.size(0).size("age", 0);
 query.skip(100).skip(100);
 query.slaveOk().slaveOk(false);
-query.slice('comments', 5);
-query.slice('comments', -5);
-query.slice('comments', [10, 5]);
-query.where('comments').slice(5);
-query.where('comments').slice([-10, 5]);
+query.slice("comments", 5);
+query.slice("comments", -5);
+query.slice("comments", [10, 5]);
+query.where("comments").slice(5);
+query.where("comments").slice([-10, 5]);
 query.snapshot().snapshot(true);
-query.sort({ field: 'asc', test: -1 });
-query.sort('field -test');
-query.stream().on('data', function (doc: any) {
-}).on('error', function (err: any) {
-}).on('close', function () {
-});
+query.sort({ field: "asc", test: -1 });
+query.sort("field -test");
+query
+    .stream()
+    .on("data", function (doc: any) {})
+    .on("error", function (err: any) {})
+    .on("close", function () {});
 query.tailable().tailable(false);
 query.then(cb).catch(cb);
-(new (query.toConstructor())(1, 2, 3)).toConstructor();
-query.update({}, doc, {
-
-}, cb);
-query.update({}, doc, {
-
-});
+new (query.toConstructor())(1, 2, 3).toConstructor();
+query.update({}, doc, {}, cb);
+query.update({}, doc, {});
 query.update({}, doc, cb);
 query.update({}, doc);
 query.update(doc, cb);
@@ -888,48 +1043,69 @@ query.update(doc);
 query.update(cb);
 query.update(true);
 query.update();
-query.where('age').gte(21).lte(65)
-  .where('name', /^vonderful/i)
-  .where('friends').slice(10)
-  .exec(cb);
-query.where('path').within().box({})
-query.where('path').within().circle({})
-query.where('path').within().geometry({type: 'c', coordinates: []});
-query.where('loc').within({ center: [50,50], radius: 10, unique: true, spherical: true });
-query.where('loc').within({ box: [[40.73, -73.9], [40.7, -73.988]] });
-query.where('loc').within({ polygon: [[],[],[],[]] });
-query.where('loc').within([], [], []);
-query.where('loc').within([], []);
-query.where('loc').within({ type: 'LineString', coordinates: [] });
+query
+    .where("age")
+    .gte(21)
+    .lte(65)
+    .where("name", /^vonderful/i)
+    .where("friends")
+    .slice(10)
+    .exec(cb);
+query.where("path").within().box({});
+query.where("path").within().circle({});
+query.where("path").within().geometry({ type: "c", coordinates: [] });
+query.where("loc").within({ center: [50, 50], radius: 10, unique: true, spherical: true });
+query.where("loc").within({
+    box: [
+        [40.73, -73.9],
+        [40.7, -73.988],
+    ],
+});
+query.where("loc").within({ polygon: [[], [], [], []] });
+query.where("loc").within([], [], []);
+query.where("loc").within([], []);
+query.where("loc").within({ type: "LineString", coordinates: [] });
 mongoose.Query.use$geoWithin = false;
 /* practical example */
-query.
-  find({
-    occupation: /host/,
-    'name.last': 'Ghost',
-    age: { $gt: 17, $lt: 66 },
-    likes: { $in: ['vaporizing', 'talking'] }
-  }).
-  limit(10).
-  sort({ occupation: -1 }).
-  select({ name: 1, occupation: 1 }).
-  exec(cb).then(cb).catch(cb);
-query.
-  find({ occupation: /host/ }).
-  where('name.last').equals('Ghost').
-  where('age').gt(17).lt(66).
-  where('likes').in(['vaporizing', 'talking']).
-  limit(10).
-  sort('-occupation').
-  select('name occupation').
-  exec(cb).then(cb).catch(cb);
+query
+    .find({
+        occupation: /host/,
+        "name.last": "Ghost",
+        age: { $gt: 17, $lt: 66 },
+        likes: { $in: ["vaporizing", "talking"] },
+    })
+    .limit(10)
+    .sort({ occupation: -1 })
+    .select({ name: 1, occupation: 1 })
+    .exec(cb)
+    .then(cb)
+    .catch(cb);
+query
+    .find({ occupation: /host/ })
+    .where("name.last")
+    .equals("Ghost")
+    .where("age")
+    .gt(17)
+    .lt(66)
+    .where("likes")
+    .in(["vaporizing", "talking"])
+    .limit(10)
+    .sort("-occupation")
+    .select("name occupation")
+    .exec(cb)
+    .then(cb)
+    .catch(cb);
 
 /*
  * section schema/array.js
  * http://mongoosejs.com/docs/api.html#schema-array-js
  */
-var schemaArray: mongoose.Schema.Types.Array = new mongoose.Schema.Types.Array('key', new mongoose.SchemaType('hi'), {});
-schemaArray.checkRequired('hello').valueOf();
+var schemaArray: mongoose.Schema.Types.Array = new mongoose.Schema.Types.Array(
+    "key",
+    new mongoose.SchemaType("hi"),
+    {},
+);
+schemaArray.checkRequired("hello").valueOf();
 /** static properties */
 mongoose.Schema.Types.Array.schemaName.toLowerCase();
 /** inherited properties */
@@ -940,14 +1116,14 @@ schemaArray.instance;
  * section schema/string.js
  * http://mongoosejs.com/docs/api.html#schema-string-js
  */
-var MongoDocument = <mongoose.Document> {};
-var schemastring: mongoose.Schema.Types.String = new mongoose.Schema.Types.String('hello');
+var MongoDocument = <mongoose.Document>{};
+var schemastring: mongoose.Schema.Types.String = new mongoose.Schema.Types.String("hello");
 schemastring.checkRequired(234, MongoDocument).valueOf();
-schemastring.enum(['hi', 'a', 'b']).enum('hi').enum({});
+schemastring.enum(["hi", "a", "b"]).enum("hi").enum({});
 schemastring.lowercase().lowercase();
-schemastring.match(/re/, 'error').match(/re/);
-schemastring.maxlength(999, 'error').maxlength(999);
-schemastring.minlength(999, 'error').minlength(999);
+schemastring.match(/re/, "error").match(/re/);
+schemastring.maxlength(999, "error").maxlength(999);
+schemastring.minlength(999, "error").minlength(999);
 schemastring.trim().trim();
 schemastring.uppercase().uppercase();
 /* static properties */
@@ -960,7 +1136,10 @@ schemastring.instance;
  * section schema/documentarray.js
  * http://mongoosejs.com/docs/api.html#schema-documentarray-js
  */
-var documentarray: mongoose.Schema.Types.DocumentArray = new mongoose.Schema.Types.DocumentArray('key', new mongoose.Schema());
+var documentarray: mongoose.Schema.Types.DocumentArray = new mongoose.Schema.Types.DocumentArray(
+    "key",
+    new mongoose.Schema(),
+);
 /* static properties */
 mongoose.Schema.Types.DocumentArray.schemaName.toLowerCase();
 /* inherited properties */
@@ -971,10 +1150,10 @@ documentarray.instance;
  * section schema/number.js
  * http://mongoosejs.com/docs/api.html#schema-number-js
  */
-var schemanumber: mongoose.Schema.Types.Number = new mongoose.Schema.Types.Number('num', {});
+var schemanumber: mongoose.Schema.Types.Number = new mongoose.Schema.Types.Number("num", {});
 schemanumber.checkRequired(999, MongoDocument).valueOf();
-schemanumber.max(999, 'error').max(999);
-schemanumber.min(999, 'error').min(999);
+schemanumber.max(999, "error").max(999);
+schemanumber.min(999, "error").min(999);
 /* static properties */
 mongoose.Schema.Types.Number.schemaName.toLowerCase();
 /* inherited properties */
@@ -985,11 +1164,11 @@ schemanumber.instance;
  * section schema/date.js
  * http://mongoosejs.com/docs/api.html#schema-date-js
  */
-var schemadate: mongoose.Schema.Types.Date = new mongoose.Schema.Types.Date('99');
+var schemadate: mongoose.Schema.Types.Date = new mongoose.Schema.Types.Date("99");
 schemadate.checkRequired([], MongoDocument).valueOf();
-schemadate.expires(99).expires('now');
-schemadate.max(new Date(), 'error').max(new Date(''));
-schemadate.min(new Date(), 'error').min(new Date(''));
+schemadate.expires(99).expires("now");
+schemadate.max(new Date(), "error").max(new Date(""));
+schemadate.min(new Date(), "error").min(new Date(""));
 /* static properties */
 mongoose.Schema.Types.Date.schemaName.toLowerCase();
 /* inherited properties */
@@ -1000,7 +1179,7 @@ schemadate.instance;
  * section schema/buffer.js
  * http://mongoosejs.com/docs/api.html#schema-buffer-js
  */
-var schemabuffer: mongoose.Schema.Types.Buffer = new mongoose.Schema.Types.Buffer('99');
+var schemabuffer: mongoose.Schema.Types.Buffer = new mongoose.Schema.Types.Buffer("99");
 schemabuffer.checkRequired(999, MongoDocument).valueOf();
 /* static properties */
 mongoose.Schema.Types.Buffer.schemaName.toLowerCase();
@@ -1012,7 +1191,7 @@ schemabuffer.instance;
  * section schema/boolean.js
  * http://mongoosejs.com/docs/api.html#schema-boolean-js
  */
-var schemaboolean: mongoose.Schema.Types.Boolean = new mongoose.Schema.Types.Boolean('99');
+var schemaboolean: mongoose.Schema.Types.Boolean = new mongoose.Schema.Types.Boolean("99");
 schemaboolean.checkRequired(99).valueOf();
 /* static properties */
 mongoose.Schema.Types.Boolean.schemaName.toLowerCase();
@@ -1024,7 +1203,7 @@ schemaboolean.instance;
  * section schema/objectid.js
  * http://mongoosejs.com/docs/api.html#schema-objectid-js
  */
-var schemaobjectid: mongoose.Schema.Types.ObjectId = new mongoose.Schema.Types.ObjectId('99');
+var schemaobjectid: mongoose.Schema.Types.ObjectId = new mongoose.Schema.Types.ObjectId("99");
 schemaobjectid.auto(true).auto(false);
 schemaobjectid.checkRequired(99, MongoDocument).valueOf();
 /* static properties */
@@ -1037,7 +1216,7 @@ schemaobjectid.instance;
  * section schema/mixed.js
  * http://mongoosejs.com/docs/api.html#schema-mixed-js
  */
-var schemamixed: mongoose.Schema.Types.Mixed = new mongoose.Schema.Types.Mixed('99');
+var schemamixed: mongoose.Schema.Types.Mixed = new mongoose.Schema.Types.Mixed("99");
 /* static properties */
 mongoose.Schema.Types.Mixed.schemaName.toLowerCase();
 /* inherited properties */
@@ -1048,8 +1227,7 @@ schemamixed.instance;
  * section schema/embedded.js
  * http://mongoosejs.com/docs/api.html#schema-embedded-js
  */
-var schemaembedded: mongoose.Schema.Types.Embedded =
-  new mongoose.Schema.Types.Embedded(new mongoose.Schema(), '99');
+var schemaembedded: mongoose.Schema.Types.Embedded = new mongoose.Schema.Types.Embedded(new mongoose.Schema(), "99");
 /* inherited properties */
 schemaembedded.sparse(true);
 schemaembedded.instance;
@@ -1059,114 +1237,120 @@ schemaembedded.instance;
  * http://mongoosejs.com/docs/api.html#aggregate-js
  */
 var aggregate: mongoose.Aggregate<Object[]>;
-aggregate = mongoose.model('ex').aggregate({ $match: { age: { $gte: 21 }}});
+aggregate = mongoose.model("ex").aggregate({ $match: { age: { $gte: 21 } } });
 aggregate = new mongoose.Aggregate<Object[]>();
 aggregate = new mongoose.Aggregate<Object[]>({ $project: { a: 1, b: 1 } });
 aggregate = new mongoose.Aggregate<Object[]>({ $project: { a: 1, b: 1 } }, { $skip: 5 });
 aggregate = new mongoose.Aggregate<Object[]>([{ $project: { a: 1, b: 1 } }, { $skip: 5 }]);
-aggregate.addCursorFlag('flag', true).addCursorFlag('', false);
+aggregate.addCursorFlag("flag", true).addCursorFlag("", false);
 aggregate.allowDiskUse(true).allowDiskUse(false, []);
-aggregate.append({ $project: { field: 1 }}, { $limit: 2 });
-aggregate.append([{ $match: { daw: 'Logic Audio X' }} ]);
-aggregate.collation({ locale: 'en_US', strength: 1 });
+aggregate.append({ $project: { field: 1 } }, { $limit: 2 });
+aggregate.append([{ $match: { daw: "Logic Audio X" } }]);
+aggregate.collation({ locale: "en_US", strength: 1 });
 aggregate.cursor({ batchSize: 1000 }).exec().each(cb);
 aggregate.exec().then(cb).catch(cb);
 aggregate.explain(cb).then(cb).catch(cb);
 aggregate.group({ _id: "$department" }).group({ _id: "$department" });
 aggregate.limit(10).limit(10);
 var lookupOpt = {
-  from: 'users', localField:
-  'userId', foreignField: '_id',
-  as: 'users'
+    from: "users",
+    localField: "userId",
+    foreignField: "_id",
+    as: "users",
 };
 aggregate.lookup(lookupOpt).lookup(lookupOpt);
 aggregate.match({
-  department: {$in: [ "sales", "engineering"]}
+    department: { $in: ["sales", "engineering"] },
 });
-aggregate.model(new (mongoose.model('xx'))()).model(null);
+aggregate.model(new (mongoose.model("xx"))()).model(null);
 aggregate.near({
-  near: [40.724, -73.997],
-  distanceField: "dist.calculated",
-  maxDistance: 0.008,
-  query: { type: "public" },
-  includeLocs: "dist.location",
-  uniqueDocs: true,
-  num: 5
+    near: [40.724, -73.997],
+    distanceField: "dist.calculated",
+    maxDistance: 0.008,
+    query: { type: "public" },
+    includeLocs: "dist.location",
+    uniqueDocs: true,
+    num: 5,
 });
 aggregate.project("a b -_id");
-aggregate.project({a: 1, b: 1, _id: 0});
+aggregate.project({ a: 1, b: 1, _id: 0 });
 aggregate.project({
-    newField: '$b.nested'
-  , plusTen: { $add: ['$val', 10]}
-  , sub: {
-    name: '$a'
-  }
-})
-aggregate.project({ salary_k: { $divide: [ "$salary", 1000 ]}});
-aggregate.read('primaryPreferred').read('pp');
+    newField: "$b.nested",
+    plusTen: { $add: ["$val", 10] },
+    sub: {
+        name: "$a",
+    },
+});
+aggregate.project({ salary_k: { $divide: ["$salary", 1000] } });
+aggregate.read("primaryPreferred").read("pp");
 aggregate.sample(3).sample(3);
 aggregate.skip(10).skip(10);
-aggregate.sort({ field: 'asc', test: -1 });
-aggregate.sort('field -test');
+aggregate.sort({ field: "asc", test: -1 });
+aggregate.sort("field -test");
 aggregate.then(cb).catch(cb);
-aggregate.unwind("tags").unwind('tags');
-aggregate.unwind("a", "b", "c").unwind('tag1', 'tag2');
-aggregate.unwind(
-  {
-    path: "tags",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  })
-  .unwind({
-    path: "tags",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  });
-aggregate.unwind(
-  {
-    path: "a",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  }, {
-    path: "b",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  }, {
-    path: "c",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  })
-  .unwind({
-    path: "tag1",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  }, {
-    path: "tag2",
-    includeArrayIndex: "idx",
-    preserveNullAndEmptyArrays: true
-  });
+aggregate.unwind("tags").unwind("tags");
+aggregate.unwind("a", "b", "c").unwind("tag1", "tag2");
+aggregate
+    .unwind({
+        path: "tags",
+        includeArrayIndex: "idx",
+        preserveNullAndEmptyArrays: true,
+    })
+    .unwind({
+        path: "tags",
+        includeArrayIndex: "idx",
+        preserveNullAndEmptyArrays: true,
+    });
+aggregate
+    .unwind(
+        {
+            path: "a",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+        {
+            path: "b",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+        {
+            path: "c",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+    )
+    .unwind(
+        {
+            path: "tag1",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+        {
+            path: "tag2",
+            includeArrayIndex: "idx",
+            preserveNullAndEmptyArrays: true,
+        },
+    );
 
 /*
  * section schematype.js
  * http://mongoosejs.com/docs/api.html#schematype-js
  */
-new mongoose.SchemaType('hello', 9, 'hello' );
+new mongoose.SchemaType("hello", 9, "hello");
 var STSchema = new mongoose.Schema({
-  mixed: mongoose.Schema.Types.Mixed
+    mixed: mongoose.Schema.Types.Mixed,
 });
-var schematype = schema.path('mixed');
-schematype.default('default');
-STSchema.path('born').get(cb).get(cb);
-STSchema.path('name').index(true).index({ unique: true, sparse: true });
-schematype.required(true, 'mess').required(true);
+var schematype = schema.path("mixed");
+schematype.default("default");
+STSchema.path("born").get(cb).get(cb);
+STSchema.path("name").index(true).index({ unique: true, sparse: true });
+schematype.required(true, "mess").required(true);
 schematype.select(true).select(false);
-STSchema.path('name').set(cb).set(cb);
+STSchema.path("name").set(cb).set(cb);
 schematype.sparse(true).sparse(true);
 schematype.text(true).text(true);
 schematype.unique(true).unique(true);
-schematype.validate(/re/)
-  .validate({}, 'error')
-  .validate(cb, 'try', 'tri');
+schematype.validate(/re/).validate({}, "error").validate(cb, "try", "tri");
 schematype.defaultValue;
 schematype.instance;
 schematype.path;
@@ -1181,232 +1365,288 @@ schematype.options;
  */
 var mongopromise = new mongoose.Promise();
 mongopromise = new mongoose.Promise(function (err: any, arg: any) {
-  arg.sparse(true);
-  err.stack;
+    arg.sparse(true);
+    err.stack;
 });
 mongopromise = new mongoose.Promise(function (err: any, arg1: any, arg2: any) {
-  arg1.sparse(true);
-  arg2.sparse(true);
-  err.stack;
+    arg1.sparse(true);
+    arg2.sparse(true);
+    err.stack;
 });
-mongopromise.addBack(function (err: any, arg: any) {
-  err.stack;
-  arg.sparse(true);
-}).addBack(function (err: any, arg1: any, arg2: any) {
-  err.stack;
-  arg1.sparse(true);
-  arg2.sparse(true);
-});
-mongopromise.addCallback(function (arg: any) {
-  arg.sparse(true);
-}).addCallback(function (arg1: any, arg2: any) {
-  arg1.sparse(true);
-  arg2.sparse(true);
-});
-mongopromise.addErrback(function (err: any) {
-  err.stack;
-}).addErrback(function () {});
-mongopromise.catch(function (err: any) {
-  err.stack;
-}).catch(function () {});
+mongopromise
+    .addBack(function (err: any, arg: any) {
+        err.stack;
+        arg.sparse(true);
+    })
+    .addBack(function (err: any, arg1: any, arg2: any) {
+        err.stack;
+        arg1.sparse(true);
+        arg2.sparse(true);
+    });
+mongopromise
+    .addCallback(function (arg: any) {
+        arg.sparse(true);
+    })
+    .addCallback(function (arg1: any, arg2: any) {
+        arg1.sparse(true);
+        arg2.sparse(true);
+    });
+mongopromise
+    .addErrback(function (err: any) {
+        err.stack;
+    })
+    .addErrback(function () {});
+mongopromise
+    .catch(function (err: any) {
+        err.stack;
+    })
+    .catch(function () {});
 mongopromise.end();
 mongopromise.error(999).error([]);
-mongopromise.on('init', function () {}).on('init', function () {});
-mongopromise.reject({}).reject('').reject(new Error('hi'));
-mongopromise.resolve(new Error('hi'), {}).resolve();
-mongopromise.then(function (arg: any) {
-  arg.sparse(true);
-}, function (err: any) {
-  err.stack;
-}).then(function (arg1: any, arg2: any) {
-  arg1.sparse(true);
-  arg2.sparse(true);
-});
-mongopromise.complete(new mongoose.SchemaType('')).complete(
-  new mongoose.SchemaType(''),
-  new mongoose.SchemaType('')
-);
+mongopromise.on("init", function () {}).on("init", function () {});
+mongopromise.reject({}).reject("").reject(new Error("hi"));
+mongopromise.resolve(new Error("hi"), {}).resolve();
+mongopromise
+    .then(
+        function (arg: any) {
+            arg.sparse(true);
+        },
+        function (err: any) {
+            err.stack;
+        },
+    )
+    .then(function (arg1: any, arg2: any) {
+        arg1.sparse(true);
+        arg2.sparse(true);
+    });
+mongopromise.complete(new mongoose.SchemaType("")).complete(new mongoose.SchemaType(""), new mongoose.SchemaType(""));
 /* static properties */
 mongoose.Promise.ES6(function (complete: Function, error: Function) {
-  complete.apply(this);
-  error.apply(this);
+    complete.apply(this);
+    error.apply(this);
 });
 
 /* inherited properties */
 mongopromise.chain(mongopromise);
 mongoose.Promise.FAILURE;
 /* practical example */
-mongoose.model('')
-  .findOne({})
-  .exec()
-  .then(function (arg) {
-    if (arg) {
-      arg.save;
-    }
-    return 1;
-  }).then(function (num) {
-    num.toFixed;
-    return new Promise<string>((resolve, reject) => {
-      resolve('string');
+mongoose
+    .model("")
+    .findOne({})
+    .exec()
+    .then(function (arg) {
+        if (arg) {
+            arg.save;
+        }
+        return 1;
+    })
+    .then(function (num) {
+        num.toFixed;
+        return new Promise<string>((resolve, reject) => {
+            resolve("string");
+        });
+    })
+    .then(function (str) {
+        str.toLowerCase;
+        return mongoose.model("").findOne({}).exec();
+    })
+    .then(function (arg) {
+        if (arg) {
+            arg.save;
+        }
+        return 1;
+    })
+    .catch(function (err) {
+        return 1;
+    })
+    .then(function (arg) {
+        arg.toFixed;
+        return new Promise<{ a: string; b: number }>((resolve, reject) => {
+            resolve({ a: "hi", b: 29 });
+        });
+    })
+    .then(function (arg) {
+        arg.a.toLowerCase;
+        arg.b.toFixed;
     });
-  }).then(function (str) {
-    str.toLowerCase
-    return (mongoose.model('')).findOne({}).exec();
-  }).then(function (arg) {
-    if (arg) {
-      arg.save;
-    }
-    return 1;
-  }).catch(function (err) {
-    return 1;
-  }).then(function (arg) {
-    arg.toFixed;
-    return new Promise<{a: string, b: number}>((resolve, reject) => {
-      resolve({a: 'hi', b: 29});
-    });
-  }).then(function (arg) {
-    arg.a.toLowerCase;
-    arg.b.toFixed;
-  });
 
-mongoose.model('').findOne({})
-  .then(function (arg) {
-    if (arg) {
-      arg.save;
-    }
-    return 2;
-  }).then(function (num) {
-    num.toFixed;
-    return new Promise<string>((resolve, reject) => {
-      resolve('str');
+mongoose
+    .model("")
+    .findOne({})
+    .then(function (arg) {
+        if (arg) {
+            arg.save;
+        }
+        return 2;
+    })
+    .then(function (num) {
+        num.toFixed;
+        return new Promise<string>((resolve, reject) => {
+            resolve("str");
+        });
+    })
+    .then(function (str) {
+        str.toLowerCase;
     });
-  }).then(function (str) {
-    str.toLowerCase;
-  });
 
-mongoose.model('').aggregate()
-  .then(function (arg) {
-    return 2;
-  }).then(function (num) {
-    num.toFixed;
-    return new Promise<string>((resolve, reject) => {
-      resolve('str');
+mongoose
+    .model("")
+    .aggregate()
+    .then(function (arg) {
+        return 2;
+    })
+    .then(function (num) {
+        num.toFixed;
+        return new Promise<string>((resolve, reject) => {
+            resolve("str");
+        });
+    })
+    .then(function (str) {
+        str.toLowerCase;
     });
-  }).then(function (str) {
-    str.toLowerCase;
-  });
 
 /* pluggable promise */
 (<any>mongoose).Promise = Promise;
-require('mongoose').Promise = Promise;
+require("mongoose").Promise = Promise;
 mongoose.Promise.race;
 mongoose.Promise.all;
 
-mongoose.model('').findOne()
-  .exec().then(cb);
+mongoose.model("").findOne().exec().then(cb);
 
 /*
  * section model.js
  * http://mongoosejs.com/docs/api.html#model-js
  */
-var MongoModel = mongoose.model('MongoModel', new mongoose.Schema({
-  name: String,
-  type: {
-    type: mongoose.Schema.Types.Mixed,
-    required: true
-  }
-}), 'myCollection', true);
-MongoModel.find({}).$where('indexOf("val") !== -1').exec(function (err, docs) {
-  docs[0].save();
-  docs[0].__v;
-});
+var MongoModel = mongoose.model(
+    "MongoModel",
+    new mongoose.Schema({
+        name: String,
+        type: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+        },
+    }),
+    "myCollection",
+    true,
+);
+MongoModel.find({})
+    .$where('indexOf("val") !== -1')
+    .exec(function (err, docs) {
+        docs[0].save();
+        docs[0].__v;
+    });
 MongoModel.findById(999, function (err, doc) {
-  var handleSave = function(err: Error, product: mongoose.Document, numAffected: number) {};
-  if (!doc) {
-    return;
-  }
-  doc.increment();
-  doc.save(handleSave).then(cb).catch(cb);
-  doc.save({ validateBeforeSave: false }, handleSave).then(cb).catch(cb);
-  doc.save({ safe: true }, handleSave).then(cb).catch(cb);
-  doc.save({ safe: { w: 2, j: true } }, handleSave).then(cb).catch(cb);
-  doc.save({ safe: { w: 'majority', wtimeout: 10000 } }, handleSave).then(cb).catch(cb);
+    var handleSave = function (err: Error, product: mongoose.Document, numAffected: number) {};
+    if (!doc) {
+        return;
+    }
+    doc.increment();
+    doc.save(handleSave).then(cb).catch(cb);
+    doc.save({ validateBeforeSave: false }, handleSave).then(cb).catch(cb);
+    doc.save({ safe: true }, handleSave).then(cb).catch(cb);
+    doc.save({ safe: { w: 2, j: true } }, handleSave)
+        .then(cb)
+        .catch(cb);
+    doc.save({ safe: { w: "majority", wtimeout: 10000 } }, handleSave)
+        .then(cb)
+        .catch(cb);
 
-  // test if Typescript can infer the types of (err, product, numAffected)
-  doc.save(function(err, product, numAffected) { product.save(); })
-    .then(function(p) { p.save() }).catch(cb);
-  doc.save({ validateBeforeSave: false }, function(err, product, numAffected) {
-    product.save();
-  }).then(function(p) { p.save() }).catch(cb);
+    // test if Typescript can infer the types of (err, product, numAffected)
+    doc.save(function (err, product, numAffected) {
+        product.save();
+    })
+        .then(function (p) {
+            p.save();
+        })
+        .catch(cb);
+    doc.save({ validateBeforeSave: false }, function (err, product, numAffected) {
+        product.save();
+    })
+        .then(function (p) {
+            p.save();
+        })
+        .catch(cb);
 });
-MongoModel = (new MongoModel()).model('MongoModel');
+MongoModel = new MongoModel().model("MongoModel");
 var mongoModel = new MongoModel();
 mongoModel.remove(function (err, product) {
-  if (err) throw(err);
-  MongoModel.findById(product._id, function (err, product) {
-    if (product) {
-      product.id.toLowerCase();
-      product.remove();
-    }
-  });
+    if (err) throw err;
+    MongoModel.findById(product._id, function (err, product) {
+        if (product) {
+            product.id.toLowerCase();
+            product.remove();
+        }
+    });
 });
 mongoModel.save().then(function (product) {
-  product.save().then(cb).catch(cb);
+    product.save().then(cb).catch(cb);
 });
 MongoModel.aggregate(
-    { $group: { _id: null, maxBalance: { $max: '$balance' }}}
-  , { $project: { _id: 0, maxBalance: 1 }}
-  , cb);
+    { $group: { _id: null, maxBalance: { $max: "$balance" } } },
+    { $project: { _id: 0, maxBalance: 1 } },
+    cb,
+);
 MongoModel.aggregate()
-  .group({ _id: null, maxBalance: { $max: '$balance' } })
-  .exec(cb);
-MongoModel.count({ type: 'jungle' }, function (err, count) {
-  count.toFixed();
+    .group({ _id: null, maxBalance: { $max: "$balance" } })
+    .exec(cb);
+MongoModel.count({ type: "jungle" }, function (err, count) {
+    count.toFixed();
 });
-MongoModel.create({
-  type: 'jelly bean'
-}, {
-  type: 'snickers'
-}, cb).then(function (a) {
-  a.save();
-})
-MongoModel.create([{ type: 'jelly bean' }, {
-  type: 'snickers'
-}], function (err, candies) {
-  var jellybean = candies[0];
-  var snickers = candies[1];
-}).then(function (arg) {
-  arg[0].save();
-  arg[1].save();
+MongoModel.create(
+    {
+        type: "jelly bean",
+    },
+    {
+        type: "snickers",
+    },
+    cb,
+).then(function (a) {
+    a.save();
 });
-MongoModel.distinct('url', { clicks: {$gt: 100}}, function (err, result) {
+MongoModel.create(
+    [
+        { type: "jelly bean" },
+        {
+            type: "snickers",
+        },
+    ],
+    function (err, candies) {
+        var jellybean = candies[0];
+        var snickers = candies[1];
+    },
+).then(function (arg) {
+    arg[0].save();
+    arg[1].save();
 });
-MongoModel.distinct('url').exec(cb);
+MongoModel.distinct("url", { clicks: { $gt: 100 } }, function (err, result) {});
+MongoModel.distinct("url").exec(cb);
 MongoModel.ensureIndexes({}, cb);
-MongoModel.find({ name: 'john', age: { $gte: 18 }});
-MongoModel.find({ name: 'john', age: { $gte: 18 }}, function (err, docs) {
-  docs[0].remove();
-  docs[1].execPopulate();
+MongoModel.find({ name: "john", age: { $gte: 18 } });
+MongoModel.find({ name: "john", age: { $gte: 18 } }, function (err, docs) {
+    docs[0].remove();
+    docs[1].execPopulate();
 });
-MongoModel.find({ name: /john/i }, 'name friends', function (err, docs) { })
-MongoModel.find({ name: /john/i }, null, { skip: 10 })
+MongoModel.find({ name: /john/i }, "name friends", function (err, docs) {});
+MongoModel.find({ name: /john/i }, null, { skip: 10 });
 MongoModel.find({ name: /john/i }, null, { skip: 10 }, function (err, docs) {});
 MongoModel.find({ name: /john/i }, null, { skip: 10 }).exec(function (err, docs) {});
 MongoModel.findById(999, function (err, adventure) {});
 MongoModel.findById(999).exec(cb);
-MongoModel.findById(999, 'name length', function (err, adventure) {
-  if (adventure) {
-    adventure.save();
-  }
+MongoModel.findById(999, "name length", function (err, adventure) {
+    if (adventure) {
+        adventure.save();
+    }
 });
-MongoModel.findById(999, 'name length').exec(cb);
-MongoModel.findById(999, '-length').exec(function (err, adventure) {
-  if (adventure) {
-    adventure.addListener('click', cb);
-  }
+MongoModel.findById(999, "name length").exec(cb);
+MongoModel.findById(999, "-length").exec(function (err, adventure) {
+    if (adventure) {
+        adventure.addListener("click", cb);
+    }
 });
-MongoModel.findById(999, 'name', { lean: true }, function (err, doc) {});
-MongoModel.findById(999, 'name').lean().exec(function (err, doc) {});
+MongoModel.findById(999, "name", { lean: true }, function (err, doc) {});
+MongoModel.findById(999, "name")
+    .lean()
+    .exec(function (err, doc) {});
 MongoModel.findByIdAndRemove(999, {}, cb);
 MongoModel.findByIdAndRemove(999, {});
 MongoModel.findByIdAndRemove(999, cb);
@@ -1418,24 +1658,27 @@ MongoModel.findByIdAndUpdate(999, {}, { new: true, upsert: true }, cb);
 MongoModel.findByIdAndUpdate(999, {}, cb);
 MongoModel.findByIdAndUpdate(999, {});
 MongoModel.findByIdAndUpdate();
-MongoModel.findOne({ type: 'iphone' }, function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }).exec(function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }, 'name', function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }, 'name').exec(function (err, adventure) {});
-MongoModel.findOne({ type: 'iphone' }, 'name', { lean: true }, cb);
-MongoModel.findOne({ type: 'iphone' }, 'name', { lean: true }).exec(cb);
-MongoModel.findOne({ type: 'iphone' }).select('name').lean().exec(cb);
+MongoModel.findOne({ type: "iphone" }, function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }).exec(function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }, "name", function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }, "name").exec(function (err, adventure) {});
+MongoModel.findOne({ type: "iphone" }, "name", { lean: true }, cb);
+MongoModel.findOne({ type: "iphone" }, "name", { lean: true }).exec(cb);
+MongoModel.findOne({ type: "iphone" }).select("name").lean().exec(cb);
 interface ModelUser {
-  _id: any;
-  name: string;
-  abctest: string;
+    _id: any;
+    name: string;
+    abctest: string;
 }
-MongoModel.findOne({ type: 'iphone' }).select('name').lean().exec()
-.then(function(doc: ModelUser) {
-  doc._id;
-  doc.name;
-  doc.abctest;
-});
+MongoModel.findOne({ type: "iphone" })
+    .select("name")
+    .lean()
+    .exec()
+    .then(function (doc: ModelUser) {
+        doc._id;
+        doc.name;
+        doc.abctest;
+    });
 MongoModel.findOneAndRemove({}, {}, cb);
 MongoModel.findOneAndRemove({}, {});
 MongoModel.findOneAndRemove({}, cb);
@@ -1447,83 +1690,100 @@ MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true });
 MongoModel.findOneAndUpdate({}, {}, cb);
 MongoModel.findOneAndUpdate({}, {});
 MongoModel.findOneAndUpdate();
-MongoModel.geoNear([1,3], { maxDistance : 5, spherical : true }, function(err, results, stats) {
-   results[0].on('data', cb);
+MongoModel.geoNear([1, 3], { maxDistance: 5, spherical: true }, function (err, results, stats) {
+    results[0].on("data", cb);
 });
-MongoModel.geoNear({ type : "Point", coordinates : [9,9] }, {
-  maxDistance : 5, spherical : true
-}, function(err, results, stats) {
-   console.log(results);
-});
-MongoModel.geoSearch({ type : "house" }, {
-  near: [10, 10], maxDistance: 5
-}, function(err, res) {
-  res[0].remove();
-});
+MongoModel.geoNear(
+    { type: "Point", coordinates: [9, 9] },
+    {
+        maxDistance: 5,
+        spherical: true,
+    },
+    function (err, results, stats) {
+        console.log(results);
+    },
+);
+MongoModel.geoSearch(
+    { type: "house" },
+    {
+        near: [10, 10],
+        maxDistance: 5,
+    },
+    function (err, res) {
+        res[0].remove();
+    },
+);
 MongoModel.hydrate({
-  _id: '54108337212ffb6d459f854c',
-  type: 'jelly bean'
+    _id: "54108337212ffb6d459f854c",
+    type: "jelly bean",
 }).execPopulate();
-MongoModel.insertMany([
-  { name: 'Star Wars' },
-  { name: 'The Empire Strikes Back' }
-], function(error, docs) {});
-MongoModel.insertMany({name: 'Star Wars'}, function(error, doc) {});
-MongoModel.mapReduce({
-  map: cb,
-  reduce: cb
-}, function (err, results) {
-  console.log(results)
-}).then(function (model) {
-  return model.find().where('value').gt(10).exec();
-}).then(function (docs) {
-   console.log(docs);
-}).then(null, cb);
+MongoModel.insertMany([{ name: "Star Wars" }, { name: "The Empire Strikes Back" }], function (error, docs) {});
+MongoModel.insertMany({ name: "Star Wars" }, function (error, doc) {});
+MongoModel.mapReduce(
+    {
+        map: cb,
+        reduce: cb,
+    },
+    function (err, results) {
+        console.log(results);
+    },
+)
+    .then(function (model) {
+        return model.find().where("value").gt(10).exec();
+    })
+    .then(function (docs) {
+        console.log(docs);
+    })
+    .then(null, cb);
 MongoModel.findById(999, function (err, user) {
-  if (!user) {
-    return;
-  }
-  var opts = [
-      { path: 'company', match: { x: 1 }, select: 'name' }
-    , { path: 'notes', options: { limit: 10 }, model: 'override' }
-  ]
-  MongoModel.populate(user, opts, cb);
-  MongoModel.populate(user, opts, function (err, user) {
-    console.log(user);
-  });
+    if (!user) {
+        return;
+    }
+    var opts = [
+        { path: "company", match: { x: 1 }, select: "name" },
+        { path: "notes", options: { limit: 10 }, model: "override" },
+    ];
+    MongoModel.populate(user, opts, cb);
+    MongoModel.populate(user, opts, function (err, user) {
+        console.log(user);
+    });
 });
 MongoModel.find(999, function (err, users) {
-  var opts = [{ path: 'company', match: { x: 1 }, select: 'name' }]
-  var promise = MongoModel.populate(users, opts);
-  promise.then(console.log);
+    var opts = [{ path: "company", match: { x: 1 }, select: "name" }];
+    var promise = MongoModel.populate(users, opts);
+    promise.then(console.log);
 });
-MongoModel.populate({
-  name: 'Indiana Jones',
-  weapon: 389
-}, {
-  path: 'weapon',
-  model: 'Weapon'
-}, cb);
-var users = [{ name: 'Indiana Jones', weapon: 389 }]
-users.push({ name: 'Batman', weapon: 8921 })
-MongoModel.populate(users, { path: 'weapon' }, function (err, users) {
-  users.forEach(cb);
+MongoModel.populate(
+    {
+        name: "Indiana Jones",
+        weapon: 389,
+    },
+    {
+        path: "weapon",
+        model: "Weapon",
+    },
+    cb,
+);
+var users = [{ name: "Indiana Jones", weapon: 389 }];
+users.push({ name: "Batman", weapon: 8921 });
+MongoModel.populate(users, { path: "weapon" }, function (err, users) {
+    users.forEach(cb);
 });
-MongoModel.remove({ title: 'baby born from alien father' }, cb);
-MongoModel.remove({_id: '999'}).exec().then(cb).catch(cb);
+MongoModel.remove({ title: "baby born from alien father" }, cb);
+MongoModel.remove({ _id: "999" }).exec().then(cb).catch(cb);
 MongoModel.update({ age: { $gt: 18 } }, { oldEnough: true }, cb);
-MongoModel.update({ name: 'Tobi' }, { ferret: true }, { multi: true, arrayFilters: [{ element: { $gte: 100 } }] }, cb);
-MongoModel.where('age').gte(21).lte(65).exec(cb);
-MongoModel.where('age').gte(21).lte(65).where('name', /^b/i);
-new (mongoModel.base.model(''))();
+MongoModel.update({ name: "Tobi" }, { ferret: true }, { multi: true, arrayFilters: [{ element: { $gte: 100 } }] }, cb);
+MongoModel.where("age").gte(21).lte(65).exec(cb);
+MongoModel.where("age").gte(21).lte(65).where("name", /^b/i);
+new (mongoModel.base.model(""))();
 mongoModel.baseModelName && mongoModel.baseModelName.toLowerCase();
 mongoModel.collection.$format(99);
 mongoModel.collection.initializeOrderedBulkOp;
 mongoModel.collection.findOne;
-mongoModel.db.openSet('');
+mongoModel.db.openSet("");
 mongoModel.discriminators;
 mongoModel.modelName.toLowerCase();
-MongoModel = mongoModel.base.model('new', mongoModel.schema);
+MongoModel = mongoModel.base.model("new", mongoModel.schema);
 /* inherited properties */
 MongoModel.modelName;
 mongoModel.modelName;
@@ -1531,166 +1791,176 @@ MongoModel.collection;
 mongoModel.collection;
 mongoModel._id;
 mongoModel.execPopulate();
-mongoModel.on('data', cb);
-mongoModel.addListener('event', cb);
+mongoModel.on("data", cb);
+mongoModel.addListener("event", cb);
 MongoModel.findOne({ title: /timex/i })
-  .populate('_creator', 'name')
-  .exec(function (err, story) {
-    if (story) {
-      story.execPopulate();
-    }
-  });
+    .populate("_creator", "name")
+    .exec(function (err, story) {
+        if (story) {
+            story.execPopulate();
+        }
+    });
 MongoModel.find({
-  id: 999
+    id: 999,
 })
-.populate({
-  path: 'fans',
-  match: { age: { $gte: 21 }},
-  select: 'name -_id',
-  options: { limit: 5 }
-})
-.exec();
+    .populate({
+        path: "fans",
+        match: { age: { $gte: 21 } },
+        select: "name -_id",
+        options: { limit: 5 },
+    })
+    .exec();
 /* practical example */
 interface Location extends mongoose.Document {
-  name: string;
-  address: string;
-  rating: number;
-  facilities: string[];
-  coords: number[];
-  openingTimes: any[];
-  reviews: any[];
-};
+    name: string;
+    address: string;
+    rating: number;
+    facilities: string[];
+    coords: number[];
+    openingTimes: any[];
+    reviews: any[];
+}
 const locationSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  address: String,
-  rating: { type: Number, "default": 0, min: 0, max: 5 },
-  facilities: [String],
-  coords: { type: [Number], index: "2dsphere" },
-  openingTimes: [mongoose.Schema.Types.Mixed],
-  reviews: [mongoose.SchemaTypes.Mixed]
+    name: { type: String, required: true },
+    address: String,
+    rating: { type: Number, default: 0, min: 0, max: 5 },
+    facilities: [String],
+    coords: { type: [Number], index: "2dsphere" },
+    openingTimes: [mongoose.Schema.Types.Mixed],
+    reviews: [mongoose.SchemaTypes.Mixed],
 });
 var LocModel = mongoose.model<Location>("Location", locationSchema);
 LocModel.findById(999)
-  .select("-reviews -rating")
-  .exec(function (err, location) {
-    if (!location) {
-      return;
-    }
-    location.name = 'blah';
-    location.address = 'blah';
-    location.reviews.forEach(review => {});
-    location.facilities.forEach(facility => {
-      facility.toLowerCase();
+    .select("-reviews -rating")
+    .exec(function (err, location) {
+        if (!location) {
+            return;
+        }
+        location.name = "blah";
+        location.address = "blah";
+        location.reviews.forEach(review => {});
+        location.facilities.forEach(facility => {
+            facility.toLowerCase();
+        });
     });
-  });
 LocModel.find()
-  .select('-reviews -rating')
-  .exec(function (err, locations) {
-    locations.forEach(location => {
-      location.name = 'blah';
-      location.address = 'blah';
-      location.reviews.forEach(review => {});
-      location.facilities.forEach(facility => {
-        facility.toLowerCase();
-      });
+    .select("-reviews -rating")
+    .exec(function (err, locations) {
+        locations.forEach(location => {
+            location.name = "blah";
+            location.address = "blah";
+            location.reviews.forEach(review => {});
+            location.facilities.forEach(facility => {
+                facility.toLowerCase();
+            });
+        });
     });
-  });
-LocModel.find({}).$where('')
-  .exec(function (err, locations) {
-    locations[0].name;
-    locations[1].openingTimes;
-  });
-LocModel.count({})
-  .exec(function (err, count) {
+LocModel.find({})
+    .$where("")
+    .exec(function (err, locations) {
+        locations[0].name;
+        locations[1].openingTimes;
+    });
+LocModel.count({}).exec(function (err, count) {
     count.toFixed();
-  });
-LocModel.distinct('')
-  .select('-review')
-  .exec(function (err, distinct) {
-    distinct.concat;
-  })
-  .then(cb).catch(cb);
-LocModel.findByIdAndRemove()
-  .exec(function (err, doc) {
+});
+LocModel.distinct("")
+    .select("-review")
+    .exec(function (err, distinct) {
+        distinct.concat;
+    })
+    .then(cb)
+    .catch(cb);
+LocModel.findByIdAndRemove().exec(function (err, doc) {
     if (!doc) {
-      return;
+        return;
     }
     doc.addListener;
     doc.openingTimes;
-  });
+});
 LocModel.findByIdAndUpdate()
-  .select({})
-  .exec(function (err, location) {
-    if (location) {
-      location.reviews;
-    }
-  });
+    .select({})
+    .exec(function (err, location) {
+        if (location) {
+            location.reviews;
+        }
+    });
 LocModel.findOne({}, function (err, doc) {
-  if (doc) {
-    doc.openingTimes;
-  }
-});
-LocModel.findOneAndRemove()
-  .exec(function (err, location) {
-    if (location) {
-      location.name;
+    if (doc) {
+        doc.openingTimes;
     }
-  });
-LocModel.findOneAndUpdate().exec().then(function (arg) {
-  if (arg) {
-    arg.openingTimes;
-  }
 });
-LocModel.geoSearch({}, {
-  near: [1, 2],
-  maxDistance: 22
-}, function (err, res) { res[0].openingTimes; });
+LocModel.findOneAndRemove().exec(function (err, location) {
+    if (location) {
+        location.name;
+    }
+});
+LocModel.findOneAndUpdate()
+    .exec()
+    .then(function (arg) {
+        if (arg) {
+            arg.openingTimes;
+        }
+    });
+LocModel.geoSearch(
+    {},
+    {
+        near: [1, 2],
+        maxDistance: 22,
+    },
+    function (err, res) {
+        res[0].openingTimes;
+    },
+);
 interface IStatics {
-  staticMethod2: (a: number) => string;
+    staticMethod2: (a: number) => string;
 }
 interface MyDocument extends mongoose.Document {
-  prop: string;
-  method: () => void;
+    prop: string;
+    method: () => void;
 }
 interface MyModel extends mongoose.Model<MyDocument> {
-  staticProp: string;
-  staticMethod: () => void;
+    staticProp: string;
+    staticMethod: () => void;
 }
 interface ModelStruct {
-  doc: MyDocument;
-  model: MyModel;
-  method1: (callback: (model: MyModel, doc: MyDocument) => void) => MyModel;
+    doc: MyDocument;
+    model: MyModel;
+    method1: (callback: (model: MyModel, doc: MyDocument) => void) => MyModel;
 }
-var modelStruct1 = <ModelStruct> {};
+var modelStruct1 = <ModelStruct>{};
 var myModel1: MyModel;
 var myDocument1: MyDocument;
-modelStruct1.method1(function (myModel1, myDocument1) {
-  myModel1.staticProp;
-  myModel1.staticMethod();
-  myDocument1.prop;
-  myDocument1.method();
-}).staticProp.toLowerCase();
+modelStruct1
+    .method1(function (myModel1, myDocument1) {
+        myModel1.staticProp;
+        myModel1.staticMethod();
+        myDocument1.prop;
+        myDocument1.method();
+    })
+    .staticProp.toLowerCase();
 var mySchema = new mongoose.Schema({});
-export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>('Final', mySchema);
+export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>("Final", mySchema);
 Final.findOne(function (err: any, doc: MyDocument) {
-  doc.save();
-  doc.remove();
-  doc.model('');
+    doc.save();
+    doc.remove();
+    doc.model("");
 });
-export var Final2: MyModel = mongoose.model<MyDocument, MyModel>('Final2', mySchema);
+export var Final2: MyModel = mongoose.model<MyDocument, MyModel>("Final2", mySchema);
 Final2.staticMethod();
 Final2.staticProp;
 var final2 = new Final2();
 final2.prop;
-final2.method;interface ibase extends mongoose.Document {
-  username: string;
+final2.method;
+interface ibase extends mongoose.Document {
+    username: string;
 }
 interface extended extends ibase {
-  email: string;
+    email: string;
 }
-const base: mongoose.Model<ibase> = mongoose.model<ibase>('testfour')
-const extended: mongoose.Model<extended> = base.discriminator<extended>('extendedS', schema);
+const base: mongoose.Model<ibase> = mongoose.model<ibase>("testfour");
+const extended: mongoose.Model<extended> = base.discriminator<extended>("extendedS", schema);
 const x = new extended({
-  username: 'hi',     // required in baseSchema
-  email: 'beddiw',    // required in extededSchema
+    username: "hi", // required in baseSchema
+    email: "beddiw", // required in extededSchema
 });


### PR DESCRIPTION
# Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

# Background

`Document.prototype.parent()` exists and returns the parent Document if `this` is a Subdocument or a populated document, and `undefined` otherwise: https://mongoosejs.com/docs/api/document.html#document_Document-parent.

Instead, this was only defined on `Embedded.prototype` and missing on `Document.prototype` (where it can return `undefined | Document`) and on `Subdocument.prototype` (where it always returns its parent `Document`).

This all constrasts with mongoose 4, which only defined `.prototype.parent()` on `Subdocument` and `EmbeddedDocument`: https://mongoosejs.com/docs/4.x/docs/api.html#types_subdocument_Subdocument-parent. So it seems these types just didn't get updated for mongoose 5.

 # Changes

### a5d60a9 refactor(mongoose): reformat with prettier

I'm kind of confused about this repo. What's the point of using prettier if all the code in the repo isn't always automatically already formatted with prettier? But anyway, here is a reformatting of types/mongoose in a separate commit so the actual changes can be easily reviewed.

### 4d6142b fix(mongoose): add Document and Subdocument .parent()

The fix. As mentioned above, the types were correct for mongoose 3 and 4, since this was a mongoose 5 change.

# Notes

Locally, there are 6 type errors in `types/mongoose/test/query.ts` **on master**... I'm not sure how that's possible, but this PR doesn't introduce any new failures. 🤷🏼‍♂️ (Update: looks like this passes in CI. Huh.)