### PR TITLE
[fs-extra] Make rm types compatible with @types/node@12.x

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -307,7 +307,9 @@ fs.realpath.native('src', { encoding: 'buffer' });
 fs.realpath.native('src', { encoding: null });
 
 async function rmTest() {
+    // $ExpectType void
     await fs.rm('path');
+    // $ExpectType void
     await fs.rm('path', {
         force: true,
         maxRetries: 1,
@@ -317,6 +319,8 @@ async function rmTest() {
 }
 
 async function rmDirTest() {
+    // $ExpectType void
     await fs.rmdir('dir');
+    // $ExpectType void
     await fs.rmdir('dir', { maxRetries: 1, recursive: true, retryDelay: 200 });
 }

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -240,7 +240,13 @@ export namespace realpath {
 export function rename(oldPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 export function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
 
-export function rm(path: PathLike, options?: fs.RmOptions): Promise<void>;
+/**
+ * Asynchronously removes files and directories (modeled on the standard POSIX
+ * `rm` utility).
+ *
+ * Only available in node >= v14.14.0
+ */
+export function rm(path: PathLike, options?: { force?: boolean, maxRetries?: number, recursive?: boolean, retryDelay?: number }): Promise<void>;
 
 /**
  * Asynchronous rmdir - removes the directory specified in {path}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #52097 -- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v12/fs.d.ts doesn't have `fs.RmOptions` (see also: #51677 )
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
