### PR TITLE
[@types/eslint] Add 12 and 2021 to ParserOptions's ecmaVersion

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1,7 +1,7 @@
 import { Comment, WhileStatement } from "estree";
 import { AST, SourceCode, Rule, Linter, ESLint, CLIEngine, RuleTester, Scope } from "eslint";
 import { ESLintRules } from "eslint/rules";
-import * as _noUnusedExpressions from 'eslint/lib/rules/no-unused-expressions';
+import * as _noUnusedExpressions from "eslint/lib/rules/no-unused-expressions";
 
 const SOURCE = `var foo = bar;`;
 

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -443,7 +443,7 @@ linter.verify(SOURCE, {}, { reportUnusedDisableDirectives: true });
 linter.verify(SOURCE, {}, { preprocess: input => input.split(" ") });
 linter.verify(SOURCE, {}, { postprocess: problemList => problemList[0] });
 
-linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6 } }, "test.js");
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2021 } }, "test.js");
 linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }, "test.js");
 linter.verify(
     SOURCE,

--- a/types/eslint/helpers.d.ts
+++ b/types/eslint/helpers.d.ts
@@ -1,3 +1,3 @@
-type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends ((
-    ..._: infer Result
-) => any) ? Result : never;
+type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends (..._: infer Result) => any
+    ? Result
+    : never;

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -553,7 +553,7 @@ export namespace Linter {
     }
 
     interface ParserOptions {
-        ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
+        ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021;
         sourceType?: "script" | "module";
         ecmaFeatures?: {
             globalReturn?: boolean;

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface BestPractices extends Linter.RulesRecord {
     /**
@@ -7,18 +7,20 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.22.0
      * @see https://eslint.org/docs/rules/accessor-pairs
      */
-    'accessor-pairs': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            setWithoutGet: boolean;
-            /**
-             * @default false
-             */
-            getWithoutSet: boolean;
-        }>
-    ]>;
+    "accessor-pairs": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                setWithoutGet: boolean;
+                /**
+                 * @default false
+                 */
+                getWithoutSet: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce `return` statements in callbacks of array methods.
@@ -26,14 +28,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0-alpha-1
      * @see https://eslint.org/docs/rules/array-callback-return
      */
-    'array-callback-return': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowImplicit: boolean;
-        }>
-    ]>;
+    "array-callback-return": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowImplicit: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce the use of variables within the scope they are defined.
@@ -41,7 +45,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.1.0
      * @see https://eslint.org/docs/rules/block-scoped-var
      */
-    'block-scoped-var': Linter.RuleEntry<[]>;
+    "block-scoped-var": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce that class methods utilize `this`.
@@ -49,11 +53,13 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.4.0
      * @see https://eslint.org/docs/rules/class-methods-use-this
      */
-    'class-methods-use-this': Linter.RuleEntry<[
-        Partial<{
-            exceptMethods: string[];
-        }>
-    ]>;
+    "class-methods-use-this": Linter.RuleEntry<
+        [
+            Partial<{
+                exceptMethods: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum cyclomatic complexity allowed in a program.
@@ -61,19 +67,22 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/complexity
      */
-    'complexity': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 20
-             */
-            max: number;
-            /**
-             * @deprecated
-             * @default 20
-             */
-            maximum: number;
-        }> | number
-    ]>;
+    complexity: Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 20
+                   */
+                  max: number;
+                  /**
+                   * @deprecated
+                   * @default 20
+                   */
+                  maximum: number;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to require `return` statements to either always or never specify values.
@@ -81,14 +90,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/consistent-return
      */
-    'consistent-return': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            treatUndefinedAsUnspecified: boolean;
-        }>
-    ]>;
+    "consistent-return": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                treatUndefinedAsUnspecified: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent brace style for all control statements.
@@ -96,9 +107,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/curly
      */
-    'curly': Linter.RuleEntry<[
-        'all' | 'multi' | 'multi-line' | 'multi-or-nest' | 'consistent'
-    ]>;
+    curly: Linter.RuleEntry<["all" | "multi" | "multi-line" | "multi-or-nest" | "consistent"]>;
 
     /**
      * Rule to require `default` cases in `switch` statements.
@@ -106,14 +115,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.6.0
      * @see https://eslint.org/docs/rules/default-case
      */
-    'default-case': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default '^no default$'
-             */
-            commentPattern: string;
-        }>
-    ]>;
+    "default-case": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default '^no default$'
+                 */
+                commentPattern: string;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent newlines before and after dots.
@@ -121,9 +132,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.21.0
      * @see https://eslint.org/docs/rules/dot-location
      */
-    'dot-location': Linter.RuleEntry<[
-        'object' | 'property'
-    ]>;
+    "dot-location": Linter.RuleEntry<["object" | "property"]>;
 
     /**
      * Rule to enforce dot notation whenever possible.
@@ -131,15 +140,17 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/dot-notation
      */
-    'dot-notation': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            allowKeywords: boolean;
-            allowPattern: string;
-        }>
-    ]>;
+    "dot-notation": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                allowKeywords: boolean;
+                allowPattern: string;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require the use of `===` and `!==`.
@@ -147,17 +158,19 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/eqeqeq
      */
-    'eqeqeq': Linter.RuleEntry<[
-        'always',
-        Partial<{
-            /**
-             * @default 'always'
-             */
-            null: 'always' | 'never' | 'ignore';
-        }>
-    ]> | Linter.RuleEntry<[
-        'smart' | 'allow-null'
-    ]>;
+    eqeqeq:
+        | Linter.RuleEntry<
+              [
+                  "always",
+                  Partial<{
+                      /**
+                       * @default 'always'
+                       */
+                      null: "always" | "never" | "ignore";
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<["smart" | "allow-null"]>;
 
     /**
      * Rule to require `for-in` loops to include an `if` statement.
@@ -165,7 +178,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/guard-for-in
      */
-    'guard-for-in': Linter.RuleEntry<[]>;
+    "guard-for-in": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce a maximum number of classes per file.
@@ -173,9 +186,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 5.0.0-alpha.3
      * @see https://eslint.org/docs/rules/max-classes-per-file
      */
-    'max-classes-per-file': Linter.RuleEntry<[
-        number
-    ]>;
+    "max-classes-per-file": Linter.RuleEntry<[number]>;
 
     /**
      * Rule to disallow the use of `alert`, `confirm`, and `prompt`.
@@ -183,7 +194,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.5
      * @see https://eslint.org/docs/rules/no-alert
      */
-    'no-alert': Linter.RuleEntry<[]>;
+    "no-alert": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `arguments.caller` or `arguments.callee`.
@@ -191,7 +202,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/no-caller
      */
-    'no-caller': Linter.RuleEntry<[]>;
+    "no-caller": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow lexical declarations in case clauses.
@@ -202,7 +213,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.9.0
      * @see https://eslint.org/docs/rules/no-case-declarations
      */
-    'no-case-declarations': Linter.RuleEntry<[]>;
+    "no-case-declarations": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow division operators explicitly at the beginning of regular expressions.
@@ -210,7 +221,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.1.0
      * @see https://eslint.org/docs/rules/no-div-regex
      */
-    'no-div-regex': Linter.RuleEntry<[]>;
+    "no-div-regex": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `else` blocks after `return` statements in `if` statements.
@@ -218,14 +229,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-else-return
      */
-    'no-else-return': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            allowElseIf: boolean;
-        }>
-    ]>;
+    "no-else-return": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                allowElseIf: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow empty functions.
@@ -233,14 +246,25 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0
      * @see https://eslint.org/docs/rules/no-empty-function
      */
-    'no-empty-function': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default []
-             */
-            allow: Array<'functions' | 'arrowFunctions' | 'generatorFunctions' | 'methods' | 'generatorMethods' | 'getters' | 'setters' | 'constructors'>;
-        }>
-    ]>;
+    "no-empty-function": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default []
+                 */
+                allow: Array<
+                    | "functions"
+                    | "arrowFunctions"
+                    | "generatorFunctions"
+                    | "methods"
+                    | "generatorMethods"
+                    | "getters"
+                    | "setters"
+                    | "constructors"
+                >;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow empty destructuring patterns.
@@ -251,7 +275,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.7.0
      * @see https://eslint.org/docs/rules/no-empty-pattern
      */
-    'no-empty-pattern': Linter.RuleEntry<[]>;
+    "no-empty-pattern": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `null` comparisons without type-checking operators.
@@ -259,7 +283,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-eq-null
      */
-    'no-eq-null': Linter.RuleEntry<[]>;
+    "no-eq-null": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `eval()`.
@@ -267,14 +291,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/no-eval
      */
-    'no-eval': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowIndirect: boolean;
-        }>
-    ]>;
+    "no-eval": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowIndirect: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow extending native types.
@@ -282,11 +308,13 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.1.4
      * @see https://eslint.org/docs/rules/no-extend-native
      */
-    'no-extend-native': Linter.RuleEntry<[
-        Partial<{
-            exceptions: string[];
-        }>
-    ]>;
+    "no-extend-native": Linter.RuleEntry<
+        [
+            Partial<{
+                exceptions: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow unnecessary calls to `.bind()`.
@@ -294,7 +322,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.8.0
      * @see https://eslint.org/docs/rules/no-extra-bind
      */
-    'no-extra-bind': Linter.RuleEntry<[]>;
+    "no-extra-bind": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary labels.
@@ -302,7 +330,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0-rc.0
      * @see https://eslint.org/docs/rules/no-extra-label
      */
-    'no-extra-label': Linter.RuleEntry<[]>;
+    "no-extra-label": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow fallthrough of `case` statements.
@@ -313,14 +341,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/no-fallthrough
      */
-    'no-fallthrough': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 'falls?\s?through'
-             */
-            commentPattern: string;
-        }>
-    ]>;
+    "no-fallthrough": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 'falls?\s?through'
+                 */
+                commentPattern: string;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow leading or trailing decimal points in numeric literals.
@@ -328,7 +358,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/no-floating-decimal
      */
-    'no-floating-decimal': Linter.RuleEntry<[]>;
+    "no-floating-decimal": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow assignments to native objects or read-only global variables.
@@ -339,11 +369,13 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.3.0
      * @see https://eslint.org/docs/rules/no-global-assign
      */
-    'no-global-assign': Linter.RuleEntry<[
-        Partial<{
-            exceptions: string[];
-        }>
-    ]>;
+    "no-global-assign": Linter.RuleEntry<
+        [
+            Partial<{
+                exceptions: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow shorthand type conversions.
@@ -351,26 +383,28 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.0.0-rc-2
      * @see https://eslint.org/docs/rules/no-implicit-coercion
      */
-    'no-implicit-coercion': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            boolean: boolean;
-            /**
-             * @default true
-             */
-            number: boolean;
-            /**
-             * @default true
-             */
-            string: boolean;
-            /**
-             * @default []
-             */
-            allow: Array<'~' | '!!' | '+' | '*'>;
-        }>
-    ]>;
+    "no-implicit-coercion": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                boolean: boolean;
+                /**
+                 * @default true
+                 */
+                number: boolean;
+                /**
+                 * @default true
+                 */
+                string: boolean;
+                /**
+                 * @default []
+                 */
+                allow: Array<"~" | "!!" | "+" | "*">;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow variable and `function` declarations in the global scope.
@@ -378,7 +412,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0-alpha-1
      * @see https://eslint.org/docs/rules/no-implicit-globals
      */
-    'no-implicit-globals': Linter.RuleEntry<[]>;
+    "no-implicit-globals": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `eval()`-like methods.
@@ -386,7 +420,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/no-implied-eval
      */
-    'no-implied-eval': Linter.RuleEntry<[]>;
+    "no-implied-eval": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `this` keywords outside of classes or class-like objects.
@@ -394,7 +428,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.0.0-rc-2
      * @see https://eslint.org/docs/rules/no-invalid-this
      */
-    'no-invalid-this': Linter.RuleEntry<[]>;
+    "no-invalid-this": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of the `__iterator__` property.
@@ -402,7 +436,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-iterator
      */
-    'no-iterator': Linter.RuleEntry<[]>;
+    "no-iterator": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow labeled statements.
@@ -410,18 +444,20 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-labels
      */
-    'no-labels': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowLoop: boolean;
-            /**
-             * @default false
-             */
-            allowSwitch: boolean;
-        }>
-    ]>;
+    "no-labels": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowLoop: boolean;
+                /**
+                 * @default false
+                 */
+                allowSwitch: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow unnecessary nested blocks.
@@ -429,7 +465,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-lone-blocks
      */
-    'no-lone-blocks': Linter.RuleEntry<[]>;
+    "no-lone-blocks": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow function declarations that contain unsafe references inside loop statements.
@@ -437,7 +473,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-loop-func
      */
-    'no-loop-func': Linter.RuleEntry<[]>;
+    "no-loop-func": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow magic numbers.
@@ -445,26 +481,28 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.7.0
      * @see https://eslint.org/docs/rules/no-magic-numbers
      */
-    'no-magic-numbers': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default []
-             */
-            ignore: number[];
-            /**
-             * @default false
-             */
-            ignoreArrayIndexes: boolean;
-            /**
-             * @default false
-             */
-            enforceConst: boolean;
-            /**
-             * @default false
-             */
-            detectObjects: boolean;
-        }>
-    ]>;
+    "no-magic-numbers": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default []
+                 */
+                ignore: number[];
+                /**
+                 * @default false
+                 */
+                ignoreArrayIndexes: boolean;
+                /**
+                 * @default false
+                 */
+                enforceConst: boolean;
+                /**
+                 * @default false
+                 */
+                detectObjects: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow multiple spaces.
@@ -472,18 +510,20 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/no-multi-spaces
      */
-    'no-multi-spaces': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            ignoreEOLComments: boolean;
-            /**
-             * @default { Property: true }
-             */
-            exceptions: Record<string, boolean>;
-        }>
-    ]>;
+    "no-multi-spaces": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                ignoreEOLComments: boolean;
+                /**
+                 * @default { Property: true }
+                 */
+                exceptions: Record<string, boolean>;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow multiline strings.
@@ -491,7 +531,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-multi-str
      */
-    'no-multi-str': Linter.RuleEntry<[]>;
+    "no-multi-str": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `new` operators outside of assignments or comparisons.
@@ -499,7 +539,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/no-new
      */
-    'no-new': Linter.RuleEntry<[]>;
+    "no-new": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `new` operators with the `Function` object.
@@ -507,7 +547,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/no-new-func
      */
-    'no-new-func': Linter.RuleEntry<[]>;
+    "no-new-func": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `new` operators with the `String`, `Number`, and `Boolean` objects.
@@ -515,7 +555,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/no-new-wrappers
      */
-    'no-new-wrappers': Linter.RuleEntry<[]>;
+    "no-new-wrappers": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow octal literals.
@@ -526,7 +566,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/no-octal
      */
-    'no-octal': Linter.RuleEntry<[]>;
+    "no-octal": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow octal escape sequences in string literals.
@@ -534,7 +574,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-octal-escape
      */
-    'no-octal-escape': Linter.RuleEntry<[]>;
+    "no-octal-escape": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow reassigning `function` parameters.
@@ -542,18 +582,20 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.18.0
      * @see https://eslint.org/docs/rules/no-param-reassign
      */
-    'no-param-reassign': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            props: boolean;
-            /**
-             * @default []
-             */
-            ignorePropertyModificationsFor: string[];
-        }>
-    ]>;
+    "no-param-reassign": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                props: boolean;
+                /**
+                 * @default []
+                 */
+                ignorePropertyModificationsFor: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow the use of the `__proto__` property.
@@ -561,7 +603,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-proto
      */
-    'no-proto': Linter.RuleEntry<[]>;
+    "no-proto": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow variable redeclaration.
@@ -572,14 +614,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-redeclare
      */
-    'no-redeclare': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            builtinGlobals: boolean;
-        }>
-    ]>;
+    "no-redeclare": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                builtinGlobals: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow certain properties on certain objects.
@@ -587,16 +631,21 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.5.0
      * @see https://eslint.org/docs/rules/no-restricted-properties
      */
-    'no-restricted-properties': Linter.RuleEntry<[
-        ...Array<{
-            object: string;
-            property?: string;
-            message?: string;
-        } | {
-            property: string;
-            message?: string;
-        }>
-    ]>;
+    "no-restricted-properties": Linter.RuleEntry<
+        [
+            ...Array<
+                | {
+                      object: string;
+                      property?: string;
+                      message?: string;
+                  }
+                | {
+                      property: string;
+                      message?: string;
+                  }
+            >
+        ]
+    >;
 
     /**
      * Rule to disallow assignment operators in `return` statements.
@@ -604,9 +653,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-return-assign
      */
-    'no-return-assign': Linter.RuleEntry<[
-        'except-parens' | 'always'
-    ]>;
+    "no-return-assign": Linter.RuleEntry<["except-parens" | "always"]>;
 
     /**
      * Rule to disallow unnecessary `return await`.
@@ -614,7 +661,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.10.0
      * @see https://eslint.org/docs/rules/no-return-await
      */
-    'no-return-await': Linter.RuleEntry<[]>;
+    "no-return-await": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `javascript:` urls.
@@ -622,7 +669,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-script-url
      */
-    'no-script-url': Linter.RuleEntry<[]>;
+    "no-script-url": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow assignments where both sides are exactly the same.
@@ -633,7 +680,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0-rc.0
      * @see https://eslint.org/docs/rules/no-self-assign
      */
-    'no-self-assign': Linter.RuleEntry<[]>;
+    "no-self-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow comparisons where both sides are exactly the same.
@@ -641,7 +688,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-self-compare
      */
-    'no-self-compare': Linter.RuleEntry<[]>;
+    "no-self-compare": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow comma operators.
@@ -649,7 +696,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.5.1
      * @see https://eslint.org/docs/rules/no-sequences
      */
-    'no-sequences': Linter.RuleEntry<[]>;
+    "no-sequences": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow throwing literals as exceptions.
@@ -657,7 +704,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.15.0
      * @see https://eslint.org/docs/rules/no-throw-literal
      */
-    'no-throw-literal': Linter.RuleEntry<[]>;
+    "no-throw-literal": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unmodified loop conditions.
@@ -665,7 +712,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0-alpha-2
      * @see https://eslint.org/docs/rules/no-unmodified-loop-condition
      */
-    'no-unmodified-loop-condition': Linter.RuleEntry<[]>;
+    "no-unmodified-loop-condition": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unused expressions.
@@ -673,22 +720,24 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.1.0
      * @see https://eslint.org/docs/rules/no-unused-expressions
      */
-    'no-unused-expressions': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowShortCircuit: boolean;
-            /**
-             * @default false
-             */
-            allowTernary: boolean;
-            /**
-             * @default false
-             */
-            allowTaggedTemplates: boolean;
-        }>
-    ]>;
+    "no-unused-expressions": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowShortCircuit: boolean;
+                /**
+                 * @default false
+                 */
+                allowTernary: boolean;
+                /**
+                 * @default false
+                 */
+                allowTaggedTemplates: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow unused labels.
@@ -699,7 +748,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.0.0-rc.0
      * @see https://eslint.org/docs/rules/no-unused-labels
      */
-    'no-unused-labels': Linter.RuleEntry<[]>;
+    "no-unused-labels": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary calls to `.call()` and `.apply()`.
@@ -707,7 +756,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/no-useless-call
      */
-    'no-useless-call': Linter.RuleEntry<[]>;
+    "no-useless-call": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary `catch` clauses.
@@ -718,7 +767,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 5.11.0
      * @see https://eslint.org/docs/rules/no-useless-catch
      */
-    'no-useless-catch': Linter.RuleEntry<[]>;
+    "no-useless-catch": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary concatenation of literals or template literals.
@@ -726,7 +775,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 1.3.0
      * @see https://eslint.org/docs/rules/no-useless-concat
      */
-    'no-useless-concat': Linter.RuleEntry<[]>;
+    "no-useless-concat": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary escape characters.
@@ -737,7 +786,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 2.5.0
      * @see https://eslint.org/docs/rules/no-useless-escape
      */
-    'no-useless-escape': Linter.RuleEntry<[]>;
+    "no-useless-escape": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow redundant return statements.
@@ -745,7 +794,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.9.0
      * @see https://eslint.org/docs/rules/no-useless-return
      */
-    'no-useless-return': Linter.RuleEntry<[]>;
+    "no-useless-return": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `void` operators.
@@ -753,7 +802,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.8.0
      * @see https://eslint.org/docs/rules/no-void
      */
-    'no-void': Linter.RuleEntry<[]>;
+    "no-void": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow specified warning terms in comments.
@@ -761,18 +810,20 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.4.4
      * @see https://eslint.org/docs/rules/no-warning-comments
      */
-    'no-warning-comments': Linter.RuleEntry<[
-        {
-            /**
-             * @default ["todo", "fixme", "xxx"]
-             */
-            terms: string[];
-            /**
-             * @default 'start'
-             */
-            location: 'start' | 'anywhere';
-        }
-    ]>;
+    "no-warning-comments": Linter.RuleEntry<
+        [
+            {
+                /**
+                 * @default ["todo", "fixme", "xxx"]
+                 */
+                terms: string[];
+                /**
+                 * @default 'start'
+                 */
+                location: "start" | "anywhere";
+            },
+        ]
+    >;
 
     /**
      * Rule to disallow `with` statements.
@@ -783,7 +834,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/no-with
      */
-    'no-with': Linter.RuleEntry<[]>;
+    "no-with": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce using named capture group in regular expression.
@@ -791,7 +842,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 5.15.0
      * @see https://eslint.org/docs/rules/prefer-named-capture-group
      */
-    'prefer-named-capture-group': Linter.RuleEntry<[]>;
+    "prefer-named-capture-group": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require using Error objects as Promise rejection reasons.
@@ -799,14 +850,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.14.0
      * @see https://eslint.org/docs/rules/prefer-promise-reject-errors
      */
-    'prefer-promise-reject-errors': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowEmptyReject: boolean;
-        }>
-    ]>;
+    "prefer-promise-reject-errors": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowEmptyReject: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce the consistent use of the radix argument when using `parseInt()`.
@@ -814,9 +867,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/radix
      */
-    'radix': Linter.RuleEntry<[
-        'always' | 'as-needed'
-    ]>;
+    radix: Linter.RuleEntry<["always" | "as-needed"]>;
 
     /**
      * Rule to disallow async functions which have no `await` expression.
@@ -824,7 +875,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 3.11.0
      * @see https://eslint.org/docs/rules/require-await
      */
-    'require-await': Linter.RuleEntry<[]>;
+    "require-await": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce the use of `u` flag on RegExp.
@@ -832,7 +883,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 5.3.0
      * @see https://eslint.org/docs/rules/require-unicode-regexp
      */
-    'require-unicode-regexp': Linter.RuleEntry<[]>;
+    "require-unicode-regexp": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require `var` declarations be placed at the top of their containing scope.
@@ -840,7 +891,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.8.0
      * @see https://eslint.org/docs/rules/vars-on-top
      */
-    'vars-on-top': Linter.RuleEntry<[]>;
+    "vars-on-top": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require parentheses around immediate `function` invocations.
@@ -848,15 +899,17 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/wrap-iife
      */
-    'wrap-iife': Linter.RuleEntry<[
-        'outside' | 'inside' | 'any',
-        Partial<{
-            /**
-             * @default false
-             */
-            functionPrototypeMethods: boolean;
-        }>
-    ]>;
+    "wrap-iife": Linter.RuleEntry<
+        [
+            "outside" | "inside" | "any",
+            Partial<{
+                /**
+                 * @default false
+                 */
+                functionPrototypeMethods: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow “Yoda” conditions.
@@ -864,13 +917,15 @@ export interface BestPractices extends Linter.RulesRecord {
      * @since 0.7.1
      * @see https://eslint.org/docs/rules/yoda
      */
-    'yoda': Linter.RuleEntry<[
-        'never',
-        Partial<{
-            exceptRange: boolean;
-            onlyEquality: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'always'
-    ]>;
+    yoda:
+        | Linter.RuleEntry<
+              [
+                  "never",
+                  Partial<{
+                      exceptRange: boolean;
+                      onlyEquality: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<["always"]>;
 }

--- a/types/eslint/rules/deprecated.d.ts
+++ b/types/eslint/rules/deprecated.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface Deprecated extends Linter.RulesRecord {
     /**
@@ -8,96 +8,101 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 4.0.0, use [`indent`](https://eslint.org/docs/rules/indent) instead.
      * @see https://eslint.org/docs/rules/indent-legacy
      */
-    'indent-legacy': Linter.RuleEntry<[
-        number | 'tab',
-        Partial<{
-            /**
-             * @default 0
-             */
-            SwitchCase: number;
-            /**
-             * @default 1
-             */
-            VariableDeclarator: Partial<{
+    "indent-legacy": Linter.RuleEntry<
+        [
+            number | "tab",
+            Partial<{
+                /**
+                 * @default 0
+                 */
+                SwitchCase: number;
                 /**
                  * @default 1
                  */
-                var: number | 'first';
+                VariableDeclarator:
+                    | Partial<{
+                          /**
+                           * @default 1
+                           */
+                          var: number | "first";
+                          /**
+                           * @default 1
+                           */
+                          let: number | "first";
+                          /**
+                           * @default 1
+                           */
+                          const: number | "first";
+                      }>
+                    | number
+                    | "first";
                 /**
                  * @default 1
                  */
-                let: number | 'first';
+                outerIIFEBody: number;
                 /**
                  * @default 1
                  */
-                const: number | 'first';
-            }> | number | 'first';
-            /**
-             * @default 1
-             */
-            outerIIFEBody: number;
-            /**
-             * @default 1
-             */
-            MemberExpression: number | 'off';
-            /**
-             * @default { parameters: 1, body: 1 }
-             */
-            FunctionDeclaration: Partial<{
+                MemberExpression: number | "off";
+                /**
+                 * @default { parameters: 1, body: 1 }
+                 */
+                FunctionDeclaration: Partial<{
+                    /**
+                     * @default 1
+                     */
+                    parameters: number | "first" | "off";
+                    /**
+                     * @default 1
+                     */
+                    body: number;
+                }>;
+                /**
+                 * @default { parameters: 1, body: 1 }
+                 */
+                FunctionExpression: Partial<{
+                    /**
+                     * @default 1
+                     */
+                    parameters: number | "first" | "off";
+                    /**
+                     * @default 1
+                     */
+                    body: number;
+                }>;
+                /**
+                 * @default { arguments: 1 }
+                 */
+                CallExpression: Partial<{
+                    /**
+                     * @default 1
+                     */
+                    arguments: number | "first" | "off";
+                }>;
                 /**
                  * @default 1
                  */
-                parameters: number | 'first' | 'off';
+                ArrayExpression: number | "first" | "off";
                 /**
                  * @default 1
                  */
-                body: number;
-            }>;
-            /**
-             * @default { parameters: 1, body: 1 }
-             */
-            FunctionExpression: Partial<{
+                ObjectExpression: number | "first" | "off";
                 /**
                  * @default 1
                  */
-                parameters: number | 'first' | 'off';
+                ImportDeclaration: number | "first" | "off";
                 /**
-                 * @default 1
+                 * @default false
                  */
-                body: number;
-            }>;
-            /**
-             * @default { arguments: 1 }
-             */
-            CallExpression: Partial<{
+                flatTernaryExpressions: boolean;
+                ignoredNodes: string[];
                 /**
-                 * @default 1
+                 * @default false
                  */
-                arguments: number | 'first' | 'off';
-            }>;
-            /**
-             * @default 1
-             */
-            ArrayExpression: number | 'first' | 'off';
-            /**
-             * @default 1
-             */
-            ObjectExpression: number | 'first' | 'off';
-            /**
-             * @default 1
-             */
-            ImportDeclaration: number | 'first' | 'off';
-            /**
-             * @default false
-             */
-            flatTernaryExpressions: boolean;
-            ignoredNodes: string[];
-            /**
-             * @default false
-             */
-            ignoreComments: boolean;
-        }>
-    ]>;
+                ignoreComments: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow newlines around directives.
@@ -106,9 +111,7 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 4.0.0, use [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) instead.
      * @see https://eslint.org/docs/rules/lines-around-directive
      */
-    'lines-around-directive': Linter.RuleEntry<[
-        'always' | 'never'
-    ]>;
+    "lines-around-directive": Linter.RuleEntry<["always" | "never"]>;
 
     /**
      * Rule to require or disallow an empty line after variable declarations.
@@ -117,9 +120,7 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 4.0.0, use [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) instead.
      * @see https://eslint.org/docs/rules/newline-after-var
      */
-    'newline-after-var': Linter.RuleEntry<[
-        'always' | 'never'
-    ]>;
+    "newline-after-var": Linter.RuleEntry<["always" | "never"]>;
 
     /**
      * Rule to require an empty line before `return` statements.
@@ -128,7 +129,7 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 4.0.0, use [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) instead.
      * @see https://eslint.org/docs/rules/newline-before-return
      */
-    'newline-before-return': Linter.RuleEntry<[]>;
+    "newline-before-return": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow shadowing of variables inside of `catch`.
@@ -137,7 +138,7 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 5.1.0, use [`no-shadow`](https://eslint.org/docs/rules/no-shadow) instead.
      * @see https://eslint.org/docs/rules/no-catch-shadow
      */
-    'no-catch-shadow': Linter.RuleEntry<[]>;
+    "no-catch-shadow": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow reassignment of native objects.
@@ -146,11 +147,13 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 3.3.0, use [`no-global-assign`](https://eslint.org/docs/rules/no-global-assign) instead.
      * @see https://eslint.org/docs/rules/no-native-reassign
      */
-    'no-native-reassign': Linter.RuleEntry<[
-        Partial<{
-            exceptions: string[];
-        }>
-    ]>;
+    "no-native-reassign": Linter.RuleEntry<
+        [
+            Partial<{
+                exceptions: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow negating the left operand in `in` expressions.
@@ -159,7 +162,7 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 3.3.0, use [`no-unsafe-negation`](https://eslint.org/docs/rules/no-unsafe-negation) instead.
      * @see https://eslint.org/docs/rules/no-negated-in-lhs
      */
-    'no-negated-in-lhs': Linter.RuleEntry<[]>;
+    "no-negated-in-lhs": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow spacing between function identifiers and their applications.
@@ -168,7 +171,7 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 3.3.0, use [`func-call-spacing`](https://eslint.org/docs/rules/func-call-spacing) instead.
      * @see https://eslint.org/docs/rules/no-spaced-func
      */
-    'no-spaced-func': Linter.RuleEntry<[]>;
+    "no-spaced-func": Linter.RuleEntry<[]>;
 
     /**
      * Rule to suggest using `Reflect` methods where applicable.
@@ -177,11 +180,13 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 3.9.0
      * @see https://eslint.org/docs/rules/prefer-reflect
      */
-    'prefer-reflect': Linter.RuleEntry<[
-        Partial<{
-            exceptions: string[];
-        }>
-    ]>;
+    "prefer-reflect": Linter.RuleEntry<
+        [
+            Partial<{
+                exceptions: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require JSDoc comments.
@@ -190,32 +195,34 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 5.10.0
      * @see https://eslint.org/docs/rules/require-jsdoc
      */
-    'require-jsdoc': Linter.RuleEntry<[
-        Partial<{
-            require: Partial<{
-                /**
-                 * @default true
-                 */
-                FunctionDeclaration: boolean;
-                /**
-                 * @default false
-                 */
-                MethodDefinition: boolean;
-                /**
-                 * @default false
-                 */
-                ClassDeclaration: boolean;
-                /**
-                 * @default false
-                 */
-                ArrowFunctionExpression: boolean;
-                /**
-                 * @default false
-                 */
-                FunctionExpression: boolean;
-            }>;
-        }>
-    ]>;
+    "require-jsdoc": Linter.RuleEntry<
+        [
+            Partial<{
+                require: Partial<{
+                    /**
+                     * @default true
+                     */
+                    FunctionDeclaration: boolean;
+                    /**
+                     * @default false
+                     */
+                    MethodDefinition: boolean;
+                    /**
+                     * @default false
+                     */
+                    ClassDeclaration: boolean;
+                    /**
+                     * @default false
+                     */
+                    ArrowFunctionExpression: boolean;
+                    /**
+                     * @default false
+                     */
+                    FunctionExpression: boolean;
+                }>;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce valid JSDoc comments.
@@ -224,35 +231,37 @@ export interface Deprecated extends Linter.RulesRecord {
      * @deprecated since 5.10.0
      * @see https://eslint.org/docs/rules/valid-jsdoc
      */
-    'valid-jsdoc': Linter.RuleEntry<[
-        Partial<{
-            prefer: Record<string, string>;
-            preferType: Record<string, string>;
-            /**
-             * @default true
-             */
-            requireReturn: boolean;
-            /**
-             * @default true
-             */
-            requireReturnType: boolean;
-            /**
-             * @remarks
-             * Also accept for regular expression pattern
-             */
-            matchDescription: string;
-            /**
-             * @default true
-             */
-            requireParamDescription: boolean;
-            /**
-             * @default true
-             */
-            requireReturnDescription: boolean;
-            /**
-             * @default true
-             */
-            requireParamType: boolean;
-        }>
-    ]>;
+    "valid-jsdoc": Linter.RuleEntry<
+        [
+            Partial<{
+                prefer: Record<string, string>;
+                preferType: Record<string, string>;
+                /**
+                 * @default true
+                 */
+                requireReturn: boolean;
+                /**
+                 * @default true
+                 */
+                requireReturnType: boolean;
+                /**
+                 * @remarks
+                 * Also accept for regular expression pattern
+                 */
+                matchDescription: string;
+                /**
+                 * @default true
+                 */
+                requireParamDescription: boolean;
+                /**
+                 * @default true
+                 */
+                requireReturnDescription: boolean;
+                /**
+                 * @default true
+                 */
+                requireParamType: boolean;
+            }>,
+        ]
+    >;
 }

--- a/types/eslint/rules/ecmascript-6.d.ts
+++ b/types/eslint/rules/ecmascript-6.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface ECMAScript6 extends Linter.RulesRecord {
     /**
@@ -7,17 +7,19 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.8.0
      * @see https://eslint.org/docs/rules/arrow-body-style
      */
-    'arrow-body-style': Linter.RuleEntry<[
-        'as-needed',
-        Partial<{
-            /**
-             * @default false
-             */
-            requireReturnForObjectLiteral: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'always' | 'never'
-    ]>;
+    "arrow-body-style":
+        | Linter.RuleEntry<
+              [
+                  "as-needed",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      requireReturnForObjectLiteral: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<["always" | "never"]>;
 
     /**
      * Rule to require parentheses around arrow function arguments.
@@ -25,17 +27,19 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/arrow-parens
      */
-    'arrow-parens': Linter.RuleEntry<[
-        'always'
-    ]> | Linter.RuleEntry<[
-        'as-needed',
-        Partial<{
-            /**
-             * @default false
-             */
-            requireForBlockBody: boolean;
-        }>
-    ]>;
+    "arrow-parens":
+        | Linter.RuleEntry<["always"]>
+        | Linter.RuleEntry<
+              [
+                  "as-needed",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      requireForBlockBody: boolean;
+                  }>,
+              ]
+          >;
 
     /**
      * Rule to enforce consistent spacing before and after the arrow in arrow functions.
@@ -43,7 +47,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/arrow-spacing
      */
-    'arrow-spacing': Linter.RuleEntry<[]>;
+    "arrow-spacing": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require `super()` calls in constructors.
@@ -54,7 +58,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 0.24.0
      * @see https://eslint.org/docs/rules/constructor-super
      */
-    'constructor-super': Linter.RuleEntry<[]>;
+    "constructor-super": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce consistent spacing around `*` operators in generator functions.
@@ -62,24 +66,45 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 0.17.0
      * @see https://eslint.org/docs/rules/generator-star-spacing
      */
-    'generator-star-spacing': Linter.RuleEntry<[
-        Partial<{
-            before: boolean;
-            after: boolean;
-            named: Partial<{
-                before: boolean;
-                after: boolean;
-            }> | 'before' | 'after' | 'both' | 'neither';
-            anonymous: Partial<{
-                before: boolean;
-                after: boolean;
-            }> | 'before' | 'after' | 'both' | 'neither';
-            method: Partial<{
-                before: boolean;
-                after: boolean;
-            }> | 'before' | 'after' | 'both' | 'neither';
-        }> | 'before' | 'after' | 'both' | 'neither'
-    ]>;
+    "generator-star-spacing": Linter.RuleEntry<
+        [
+            | Partial<{
+                  before: boolean;
+                  after: boolean;
+                  named:
+                      | Partial<{
+                            before: boolean;
+                            after: boolean;
+                        }>
+                      | "before"
+                      | "after"
+                      | "both"
+                      | "neither";
+                  anonymous:
+                      | Partial<{
+                            before: boolean;
+                            after: boolean;
+                        }>
+                      | "before"
+                      | "after"
+                      | "both"
+                      | "neither";
+                  method:
+                      | Partial<{
+                            before: boolean;
+                            after: boolean;
+                        }>
+                      | "before"
+                      | "after"
+                      | "both"
+                      | "neither";
+              }>
+            | "before"
+            | "after"
+            | "both"
+            | "neither",
+        ]
+    >;
 
     /**
      * Rule to disallow reassigning class members.
@@ -90,7 +115,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/no-class-assign
      */
-    'no-class-assign': Linter.RuleEntry<[]>;
+    "no-class-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow arrow functions where they could be confused with comparisons.
@@ -98,14 +123,16 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-alpha-2
      * @see https://eslint.org/docs/rules/no-confusing-arrow
      */
-    'no-confusing-arrow': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            allowParens: boolean;
-        }>
-    ]>;
+    "no-confusing-arrow": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                allowParens: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow reassigning `const` variables.
@@ -116,7 +143,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/no-const-assign
      */
-    'no-const-assign': Linter.RuleEntry<[]>;
+    "no-const-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow duplicate class members.
@@ -127,7 +154,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.2.0
      * @see https://eslint.org/docs/rules/no-dupe-class-members
      */
-    'no-dupe-class-members': Linter.RuleEntry<[]>;
+    "no-dupe-class-members": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow duplicate module imports.
@@ -135,14 +162,16 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.5.0
      * @see https://eslint.org/docs/rules/no-duplicate-import
      */
-    'no-duplicate-import': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            includeExports: boolean;
-        }>
-    ]>;
+    "no-duplicate-import": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                includeExports: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow `new` operators with the `Symbol` object.
@@ -153,7 +182,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-beta.1
      * @see https://eslint.org/docs/rules/no-new-symbol
      */
-    'no-new-symbol': Linter.RuleEntry<[]>;
+    "no-new-symbol": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow specified modules when loaded by `import`.
@@ -161,20 +190,29 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-alpha-1
      * @see https://eslint.org/docs/rules/no-restricted-imports
      */
-    'no-restricted-imports': Linter.RuleEntry<[
-        ...Array<string | {
-            name: string;
-            importNames?: string[];
-            message?: string;
-        } | Partial<{
-            paths: Array<string | {
-                name: string;
-                importNames?: string[];
-                message?: string;
-            }>;
-            patterns: string[];
-        }>>
-    ]>;
+    "no-restricted-imports": Linter.RuleEntry<
+        [
+            ...Array<
+                | string
+                | {
+                      name: string;
+                      importNames?: string[];
+                      message?: string;
+                  }
+                | Partial<{
+                      paths: Array<
+                          | string
+                          | {
+                                name: string;
+                                importNames?: string[];
+                                message?: string;
+                            }
+                      >;
+                      patterns: string[];
+                  }>
+            >
+        ]
+    >;
 
     /**
      * Rule to disallow `this`/`super` before calling `super()` in constructors.
@@ -185,7 +223,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 0.24.0
      * @see https://eslint.org/docs/rules/no-this-before-super
      */
-    'no-this-before-super': Linter.RuleEntry<[]>;
+    "no-this-before-super": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary computed property keys in object literals.
@@ -193,7 +231,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.9.0
      * @see https://eslint.org/docs/rules/no-useless-computed-key
      */
-    'no-useless-computed-key': Linter.RuleEntry<[]>;
+    "no-useless-computed-key": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary constructors.
@@ -201,7 +239,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-beta.1
      * @see https://eslint.org/docs/rules/no-useless-constructor
      */
-    'no-useless-constructor': Linter.RuleEntry<[]>;
+    "no-useless-constructor": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow renaming import, export, and destructured assignments to the same name.
@@ -209,22 +247,24 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.11.0
      * @see https://eslint.org/docs/rules/no-useless-rename
      */
-    'no-useless-rename': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            ignoreImport: boolean;
-            /**
-             * @default false
-             */
-            ignoreExport: boolean;
-            /**
-             * @default false
-             */
-            ignoreDestructuring: boolean;
-        }>
-    ]>;
+    "no-useless-rename": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                ignoreImport: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreExport: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreDestructuring: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require `let` or `const` instead of `var`.
@@ -232,7 +272,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 0.12.0
      * @see https://eslint.org/docs/rules/no-var
      */
-    'no-var': Linter.RuleEntry<[]>;
+    "no-var": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require or disallow method and property shorthand syntax for object literals.
@@ -240,33 +280,38 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 0.20.0
      * @see https://eslint.org/docs/rules/object-shorthand
      */
-    'object-shorthand': Linter.RuleEntry<[
-        'always' | 'methods',
-        Partial<{
-            /**
-             * @default false
-             */
-            avoidQuotes: boolean;
-            /**
-             * @default false
-             */
-            ignoreConstructors: boolean;
-            /**
-             * @default false
-             */
-            avoidExplicitReturnArrows: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'properties',
-        Partial<{
-            /**
-             * @default false
-             */
-            avoidQuotes: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'never' | 'consistent' | 'consistent-as-needed'
-    ]>;
+    "object-shorthand":
+        | Linter.RuleEntry<
+              [
+                  "always" | "methods",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      avoidQuotes: boolean;
+                      /**
+                       * @default false
+                       */
+                      ignoreConstructors: boolean;
+                      /**
+                       * @default false
+                       */
+                      avoidExplicitReturnArrows: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<
+              [
+                  "properties",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      avoidQuotes: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<["never" | "consistent" | "consistent-as-needed"]>;
 
     /**
      * Rule to require using arrow functions for callbacks.
@@ -274,18 +319,20 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.2.0
      * @see https://eslint.org/docs/rules/prefer-arrow-callback
      */
-    'prefer-arrow-callback': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowNamedFunctions: boolean;
-            /**
-             * @default true
-             */
-            allowUnboundThis: boolean;
-        }>
-    ]>;
+    "prefer-arrow-callback": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowNamedFunctions: boolean;
+                /**
+                 * @default true
+                 */
+                allowUnboundThis: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require `const` declarations for variables that are never reassigned after declared.
@@ -293,18 +340,20 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 0.23.0
      * @see https://eslint.org/docs/rules/prefer-const
      */
-    'prefer-const': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 'any'
-             */
-            destructuring: 'any' | 'all';
-            /**
-             * @default false
-             */
-            ignoreReadBeforeAssign: boolean;
-        }>
-    ]>;
+    "prefer-const": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 'any'
+                 */
+                destructuring: "any" | "all";
+                /**
+                 * @default false
+                 */
+                ignoreReadBeforeAssign: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require destructuring from arrays and/or objects.
@@ -312,24 +361,29 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 3.13.0
      * @see https://eslint.org/docs/rules/prefer-destructuring
      */
-    'prefer-destructuring': Linter.RuleEntry<[
-        Partial<{
-            VariableDeclarator: Partial<{
-                array: boolean;
-                object: boolean;
-            }>;
-            AssignmentExpression: Partial<{
-                array: boolean;
-                object: boolean;
-            }>;
-        } | {
-            array: boolean;
-            object: boolean;
-        }>,
-        Partial<{
-            enforceForRenamedProperties: boolean;
-        }>
-    ]>;
+    "prefer-destructuring": Linter.RuleEntry<
+        [
+            Partial<
+                | {
+                      VariableDeclarator: Partial<{
+                          array: boolean;
+                          object: boolean;
+                      }>;
+                      AssignmentExpression: Partial<{
+                          array: boolean;
+                          object: boolean;
+                      }>;
+                  }
+                | {
+                      array: boolean;
+                      object: boolean;
+                  }
+            >,
+            Partial<{
+                enforceForRenamedProperties: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals.
@@ -337,7 +391,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 3.5.0
      * @see https://eslint.org/docs/rules/prefer-numeric-literals
      */
-    'prefer-numeric-literals': Linter.RuleEntry<[]>;
+    "prefer-numeric-literals": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require rest parameters instead of `arguments`.
@@ -345,7 +399,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-alpha-1
      * @see https://eslint.org/docs/rules/prefer-rest-params
      */
-    'prefer-rest-params': Linter.RuleEntry<[]>;
+    "prefer-rest-params": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require spread operators instead of `.apply()`.
@@ -353,7 +407,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/prefer-spread
      */
-    'prefer-spread': Linter.RuleEntry<[]>;
+    "prefer-spread": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require template literals instead of string concatenation.
@@ -361,7 +415,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.2.0
      * @see https://eslint.org/docs/rules/prefer-template
      */
-    'prefer-template': Linter.RuleEntry<[]>;
+    "prefer-template": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require generator functions to contain `yield`.
@@ -372,7 +426,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/require-yield
      */
-    'require-yield': Linter.RuleEntry<[]>;
+    "require-yield": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce spacing between rest and spread operators and their expressions.
@@ -380,9 +434,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.12.0
      * @see https://eslint.org/docs/rules/rest-spread-spacing
      */
-    'rest-spread-spacing': Linter.RuleEntry<[
-        'never' | 'always'
-    ]>;
+    "rest-spread-spacing": Linter.RuleEntry<["never" | "always"]>;
 
     /**
      * Rule to enforce sorted import declarations within modules.
@@ -390,26 +442,28 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-beta.1
      * @see https://eslint.org/docs/rules/sort-imports
      */
-    'sort-imports': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            ignoreCase: boolean;
-            /**
-             * @default false
-             */
-            ignoreDeclarationSort: boolean;
-            /**
-             * @default false
-             */
-            ignoreMemberSort: boolean;
-            /**
-             * @default ['none', 'all', 'multiple', 'single']
-             */
-            memberSyntaxSortOrder: Array<'none' | 'all' | 'multiple' | 'single'>;
-        }>
-    ]>;
+    "sort-imports": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                ignoreCase: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreDeclarationSort: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreMemberSort: boolean;
+                /**
+                 * @default ['none', 'all', 'multiple', 'single']
+                 */
+                memberSyntaxSortOrder: Array<"none" | "all" | "multiple" | "single">;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require symbol descriptions.
@@ -417,7 +471,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 3.4.0
      * @see https://eslint.org/docs/rules/symbol-description
      */
-    'symbol-description': Linter.RuleEntry<[]>;
+    "symbol-description": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require or disallow spacing around embedded expressions of template strings.
@@ -425,9 +479,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-rc.0
      * @see https://eslint.org/docs/rules/template-curly-spacing
      */
-    'template-curly-spacing': Linter.RuleEntry<[
-        'never' | 'always'
-    ]>;
+    "template-curly-spacing": Linter.RuleEntry<["never" | "always"]>;
 
     /**
      * Rule to require or disallow spacing around the `*` in `yield*` expressions.
@@ -435,10 +487,16 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 2.0.0-alpha-1
      * @see https://eslint.org/docs/rules/yield-star-spacing
      */
-    'yield-star-spacing': Linter.RuleEntry<[
-        Partial<{
-            before: boolean;
-            after: boolean;
-        }> | 'before' | 'after' | 'both' | 'neither'
-    ]>;
+    "yield-star-spacing": Linter.RuleEntry<
+        [
+            | Partial<{
+                  before: boolean;
+                  after: boolean;
+              }>
+            | "before"
+            | "after"
+            | "both"
+            | "neither",
+        ]
+    >;
 }

--- a/types/eslint/rules/index.d.ts
+++ b/types/eslint/rules/index.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 import { BestPractices } from "./best-practices";
 import { Deprecated } from "./deprecated";
@@ -9,6 +9,13 @@ import { StrictMode } from "./strict-mode";
 import { StylisticIssues } from "./stylistic-issues";
 import { Variables } from "./variables";
 
-export interface ESLintRules extends Linter.RulesRecord,
-        PossibleErrors, BestPractices, StrictMode, Variables, NodeJSAndCommonJS,
-        StylisticIssues, ECMAScript6, Deprecated {}
+export interface ESLintRules
+    extends Linter.RulesRecord,
+        PossibleErrors,
+        BestPractices,
+        StrictMode,
+        Variables,
+        NodeJSAndCommonJS,
+        StylisticIssues,
+        ECMAScript6,
+        Deprecated {}

--- a/types/eslint/rules/node-commonjs.d.ts
+++ b/types/eslint/rules/node-commonjs.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface NodeJSAndCommonJS extends Linter.RulesRecord {
     /**
@@ -7,9 +7,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/callback-return
      */
-    'callback-return': Linter.RuleEntry<[
-        string[]
-    ]>;
+    "callback-return": Linter.RuleEntry<[string[]]>;
 
     /**
      * Rule to require `require()` calls to be placed at top-level module scope.
@@ -17,7 +15,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 1.4.0
      * @see https://eslint.org/docs/rules/global-require
      */
-    'global-require': Linter.RuleEntry<[]>;
+    "global-require": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require error handling in callbacks.
@@ -25,9 +23,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.4.5
      * @see https://eslint.org/docs/rules/handle-callback-err
      */
-    'handle-callback-err': Linter.RuleEntry<[
-        string
-    ]>;
+    "handle-callback-err": Linter.RuleEntry<[string]>;
 
     /**
      * Rule to disallow use of the `Buffer()` constructor.
@@ -35,7 +31,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 4.0.0-alpha.0
      * @see https://eslint.org/docs/rules/no-buffer-constructor
      */
-    'no-buffer-constructor': Linter.RuleEntry<[]>;
+    "no-buffer-constructor": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `require` calls to be mixed with regular variable declarations.
@@ -43,18 +39,20 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-mixed-requires
      */
-    'no-mixed-requires': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            grouping: boolean;
-            /**
-             * @default false
-             */
-            allowCall: boolean;
-        }>
-    ]>;
+    "no-mixed-requires": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                grouping: boolean;
+                /**
+                 * @default false
+                 */
+                allowCall: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow `new` operators with calls to `require`.
@@ -62,7 +60,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.6.0
      * @see https://eslint.org/docs/rules/no-new-require
      */
-    'no-new-require': Linter.RuleEntry<[]>;
+    "no-new-require": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow string concatenation when using `__dirname` and `__filename`.
@@ -70,7 +68,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-path-concat
      */
-    'no-path-concat': Linter.RuleEntry<[]>;
+    "no-path-concat": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `process.env`.
@@ -78,7 +76,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/no-process-env
      */
-    'no-process-env': Linter.RuleEntry<[]>;
+    "no-process-env": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `process.exit()`.
@@ -86,7 +84,7 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-process-exit
      */
-    'no-process-exit': Linter.RuleEntry<[]>;
+    "no-process-exit": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow specified modules when loaded by `require`.
@@ -94,18 +92,27 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.6.0
      * @see https://eslint.org/docs/rules/no-restricted-modules
      */
-    'no-restricted-modules': Linter.RuleEntry<[
-        ...Array<string | {
-            name: string;
-            message?: string;
-        } | Partial<{
-            paths: Array<string | {
-                name: string;
-                message?: string;
-            }>;
-            patterns: string[];
-        }>>
-    ]>;
+    "no-restricted-modules": Linter.RuleEntry<
+        [
+            ...Array<
+                | string
+                | {
+                      name: string;
+                      message?: string;
+                  }
+                | Partial<{
+                      paths: Array<
+                          | string
+                          | {
+                                name: string;
+                                message?: string;
+                            }
+                      >;
+                      patterns: string[];
+                  }>
+            >
+        ]
+    >;
 
     /**
      * Rule to disallow synchronous methods.
@@ -113,12 +120,14 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-sync
      */
-    'no-sync': Linter.RuleEntry<[
-        {
-            /**
-             * @default false
-             */
-            allowAtRootLevel: boolean;
-        }
-    ]>;
+    "no-sync": Linter.RuleEntry<
+        [
+            {
+                /**
+                 * @default false
+                 */
+                allowAtRootLevel: boolean;
+            },
+        ]
+    >;
 }

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface PossibleErrors extends Linter.RulesRecord {
     /**
@@ -10,7 +10,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 4.0.0-beta.0
      * @see https://eslint.org/docs/rules/for-direction
      */
-    'for-direction': Linter.RuleEntry<[]>;
+    "for-direction": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce `return` statements in getters.
@@ -21,14 +21,16 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 4.2.0
      * @see https://eslint.org/docs/rules/getter-return
      */
-    'getter-return': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowImplicit: boolean;
-        }>
-    ]>;
+    "getter-return": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowImplicit: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow using an async function as a `Promise` executor.
@@ -39,7 +41,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 5.3.0
      * @see https://eslint.org/docs/rules/no-async-promise-executor
      */
-    'no-async-promise-executor': Linter.RuleEntry<[]>;
+    "no-async-promise-executor": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `await` inside of loops.
@@ -47,7 +49,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 3.12.0
      * @see https://eslint.org/docs/rules/no-await-in-loop
      */
-    'no-await-in-loop': Linter.RuleEntry<[]>;
+    "no-await-in-loop": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow comparing against `-0`.
@@ -58,7 +60,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 3.17.0
      * @see https://eslint.org/docs/rules/no-compare-neg-zero
      */
-    'no-compare-neg-zero': Linter.RuleEntry<[]>;
+    "no-compare-neg-zero": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow assignment operators in conditional statements.
@@ -69,9 +71,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-cond-assign
      */
-    'no-cond-assign': Linter.RuleEntry<[
-        'except-parens' | 'always'
-    ]>;
+    "no-cond-assign": Linter.RuleEntry<["except-parens" | "always"]>;
 
     /**
      * Rule to disallow the use of `console`.
@@ -79,11 +79,13 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/no-console
      */
-    'no-console': Linter.RuleEntry<[
-        Partial<{
-            allow: Array<keyof Console>;
-        }>
-    ]>;
+    "no-console": Linter.RuleEntry<
+        [
+            Partial<{
+                allow: Array<keyof Console>;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow constant expressions in conditions.
@@ -94,14 +96,16 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.4.1
      * @see https://eslint.org/docs/rules/no-constant-condition
      */
-    'no-constant-condition': Linter.RuleEntry<[
-        {
-            /**
-             * @default true
-             */
-            checkLoops: boolean;
-        }
-    ]>;
+    "no-constant-condition": Linter.RuleEntry<
+        [
+            {
+                /**
+                 * @default true
+                 */
+                checkLoops: boolean;
+            },
+        ]
+    >;
 
     /**
      * Rule to disallow control characters in regular expressions.
@@ -112,7 +116,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.1.0
      * @see https://eslint.org/docs/rules/no-control-regex
      */
-    'no-control-regex': Linter.RuleEntry<[]>;
+    "no-control-regex": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `debugger`.
@@ -123,7 +127,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/no-debugger
      */
-    'no-debugger': Linter.RuleEntry<[]>;
+    "no-debugger": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow duplicate arguments in `function` definitions.
@@ -134,7 +138,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.16.0
      * @see https://eslint.org/docs/rules/no-dupe-args
      */
-    'no-dupe-args': Linter.RuleEntry<[]>;
+    "no-dupe-args": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow duplicate keys in object literals.
@@ -145,7 +149,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-dupe-keys
      */
-    'no-dupe-keys': Linter.RuleEntry<[]>;
+    "no-dupe-keys": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow a duplicate case label.
@@ -156,7 +160,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.17.0
      * @see https://eslint.org/docs/rules/no-duplicate-case
      */
-    'no-duplicate-case': Linter.RuleEntry<[]>;
+    "no-duplicate-case": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow empty block statements.
@@ -167,14 +171,16 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/no-empty
      */
-    'no-empty': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowEmptyCatch: boolean;
-        }>
-    ]>;
+    "no-empty": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowEmptyCatch: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow empty character classes in regular expressions.
@@ -185,7 +191,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.22.0
      * @see https://eslint.org/docs/rules/no-empty-character-class
      */
-    'no-empty-character-class': Linter.RuleEntry<[]>;
+    "no-empty-character-class": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow reassigning exceptions in `catch` clauses.
@@ -196,7 +202,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-ex-assign
      */
-    'no-ex-assign': Linter.RuleEntry<[]>;
+    "no-ex-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary boolean casts.
@@ -207,7 +213,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-extra-boolean-cast
      */
-    'no-extra-boolean-cast': Linter.RuleEntry<[]>;
+    "no-extra-boolean-cast": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unnecessary parentheses.
@@ -215,33 +221,35 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.1.4
      * @see https://eslint.org/docs/rules/no-extra-parens
      */
-    'no-extra-parens': Linter.RuleEntry<[
-        'all',
-        Partial<{
-            /**
-             * @default true,
-             */
-            conditionalAssign: boolean;
-            /**
-             * @default true
-             */
-            returnAssign: boolean;
-            /**
-             * @default true
-             */
-            nestedBinaryExpressions: boolean;
-            /**
-             * @default 'none'
-             */
-            ignoreJSX: 'none' | 'all' | 'multi-line' | 'single-line';
-            /**
-             * @default true
-             */
-            enforceForArrowConditionals: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'functions'
-    ]>;
+    "no-extra-parens":
+        | Linter.RuleEntry<
+              [
+                  "all",
+                  Partial<{
+                      /**
+                       * @default true,
+                       */
+                      conditionalAssign: boolean;
+                      /**
+                       * @default true
+                       */
+                      returnAssign: boolean;
+                      /**
+                       * @default true
+                       */
+                      nestedBinaryExpressions: boolean;
+                      /**
+                       * @default 'none'
+                       */
+                      ignoreJSX: "none" | "all" | "multi-line" | "single-line";
+                      /**
+                       * @default true
+                       */
+                      enforceForArrowConditionals: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<["functions"]>;
 
     /**
      * Rule to disallow unnecessary semicolons.
@@ -252,7 +260,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-extra-semi
      */
-    'no-extra-semi': Linter.RuleEntry<[]>;
+    "no-extra-semi": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow reassigning `function` declarations.
@@ -263,7 +271,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-func-assign
      */
-    'no-func-assign': Linter.RuleEntry<[]>;
+    "no-func-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow variable or `function` declarations in nested blocks.
@@ -274,9 +282,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.6.0
      * @see https://eslint.org/docs/rules/no-inner-declarations
      */
-    'no-inner-declarations': Linter.RuleEntry<[
-        'functions' | 'both'
-    ]>;
+    "no-inner-declarations": Linter.RuleEntry<["functions" | "both"]>;
 
     /**
      * Rule to disallow invalid regular expression strings in `RegExp` constructors.
@@ -287,11 +293,13 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.1.4
      * @see https://eslint.org/docs/rules/no-invalid-regexp
      */
-    'no-invalid-regexp': Linter.RuleEntry<[
-        Partial<{
-            allowConstructorFlags: string[];
-        }>
-    ]>;
+    "no-invalid-regexp": Linter.RuleEntry<
+        [
+            Partial<{
+                allowConstructorFlags: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow irregular whitespace.
@@ -302,26 +310,28 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/no-irregular-whitespace
      */
-    'no-irregular-whitespace': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            skipStrings: boolean;
-            /**
-             * @default false
-             */
-            skipComments: boolean;
-            /**
-             * @default false
-             */
-            skipRegExps: boolean;
-            /**
-             * @default false
-             */
-            skipTemplates: boolean;
-        }>
-    ]>;
+    "no-irregular-whitespace": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                skipStrings: boolean;
+                /**
+                 * @default false
+                 */
+                skipComments: boolean;
+                /**
+                 * @default false
+                 */
+                skipRegExps: boolean;
+                /**
+                 * @default false
+                 */
+                skipTemplates: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow characters which are made with multiple code points in character class syntax.
@@ -332,7 +342,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 5.3.0
      * @see https://eslint.org/docs/rules/no-misleading-character-class
      */
-    'no-misleading-character-class': Linter.RuleEntry<[]>;
+    "no-misleading-character-class": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow calling global object properties as functions.
@@ -343,7 +353,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-obj-calls
      */
-    'no-obj-calls': Linter.RuleEntry<[]>;
+    "no-obj-calls": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow use of `Object.prototypes` builtins directly.
@@ -354,7 +364,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 2.11.0
      * @see https://eslint.org/docs/rules/no-prototype-builtins
      */
-    'no-prototype-builtins': Linter.RuleEntry<[]>;
+    "no-prototype-builtins": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow multiple spaces in regular expressions.
@@ -365,7 +375,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-regex-spaces
      */
-    'no-regex-spaces': Linter.RuleEntry<[]>;
+    "no-regex-spaces": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow sparse arrays.
@@ -376,7 +386,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-sparse-arrays
      */
-    'no-sparse-arrays': Linter.RuleEntry<[]>;
+    "no-sparse-arrays": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow template literal placeholder syntax in regular strings.
@@ -384,7 +394,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 3.3.0
      * @see https://eslint.org/docs/rules/no-template-curly-in-string
      */
-    'no-template-curly-in-string': Linter.RuleEntry<[]>;
+    "no-template-curly-in-string": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow confusing multiline expressions.
@@ -395,7 +405,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.24.0
      * @see https://eslint.org/docs/rules/no-unexpected-multiline
      */
-    'no-unexpected-multiline': Linter.RuleEntry<[]>;
+    "no-unexpected-multiline": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unreachable code after `return`, `throw`, `continue`, and `break` statements.
@@ -406,7 +416,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/no-unreachable
      */
-    'no-unreachable': Linter.RuleEntry<[]>;
+    "no-unreachable": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow control flow statements in `finally` blocks.
@@ -417,7 +427,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 2.9.0
      * @see https://eslint.org/docs/rules/no-unsafe-finally
      */
-    'no-unsafe-finally': Linter.RuleEntry<[]>;
+    "no-unsafe-finally": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow negating the left operand of relational operators.
@@ -428,7 +438,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 3.3.0
      * @see https://eslint.org/docs/rules/no-unsafe-negation
      */
-    'no-unsafe-negation': Linter.RuleEntry<[]>;
+    "no-unsafe-negation": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow assignments that can lead to race conditions due to usage of `await` or `yield`.
@@ -439,7 +449,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 5.3.0
      * @see https://eslint.org/docs/rules/require-atomic-updates
      */
-    'require-atomic-updates': Linter.RuleEntry<[]>;
+    "require-atomic-updates": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require calls to `isNaN()` when checking for `NaN`.
@@ -450,7 +460,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/use-isnan
      */
-    'use-isnan': Linter.RuleEntry<[]>;
+    "use-isnan": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce comparing `typeof` expressions against valid strings.
@@ -461,12 +471,14 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 0.5.0
      * @see https://eslint.org/docs/rules/valid-typeof
      */
-    'valid-typeof': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            requireStringLiterals: boolean;
-        }>
-    ]>;
+    "valid-typeof": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                requireStringLiterals: boolean;
+            }>,
+        ]
+    >;
 }

--- a/types/eslint/rules/strict-mode.d.ts
+++ b/types/eslint/rules/strict-mode.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface StrictMode extends Linter.RulesRecord {
     /**
@@ -7,7 +7,5 @@ export interface StrictMode extends Linter.RulesRecord {
      * @since 0.1.0
      * @see https://eslint.org/docs/rules/strict
      */
-    'strict': Linter.RuleEntry<[
-        'safe' | 'global' | 'function' | 'never'
-    ]>;
+    strict: Linter.RuleEntry<["safe" | "global" | "function" | "never"]>;
 }

--- a/types/eslint/rules/stylistic-issues.d.ts
+++ b/types/eslint/rules/stylistic-issues.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface StylisticIssues extends Linter.RulesRecord {
     /**
@@ -7,18 +7,23 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.0.0-alpha.1
      * @see https://eslint.org/docs/rules/array-bracket-newline
      */
-    'array-bracket-newline': Linter.RuleEntry<[
-        'always' | 'never' | 'consistent' | Partial<{
-            /**
-             * @default true
-             */
-            multiline: boolean;
-            /**
-             * @default null
-             */
-            minItems: number | null;
-        }>
-    ]>;
+    "array-bracket-newline": Linter.RuleEntry<
+        [
+            | "always"
+            | "never"
+            | "consistent"
+            | Partial<{
+                  /**
+                   * @default true
+                   */
+                  multiline: boolean;
+                  /**
+                   * @default null
+                   */
+                  minItems: number | null;
+              }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing inside array brackets.
@@ -26,39 +31,45 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.24.0
      * @see https://eslint.org/docs/rules/array-bracket-spacing
      */
-    'array-bracket-spacing': Linter.RuleEntry<[
-        'never',
-        Partial<{
-            /**
-             * @default false
-             */
-            singleValue: boolean;
-            /**
-             * @default false
-             */
-            objectsInArrays: boolean;
-            /**
-             * @default false
-             */
-            arraysInArrays: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'always',
-        Partial<{
-            /**
-             * @default true
-             */
-            singleValue: boolean;
-            /**
-             * @default true
-             */
-            objectsInArrays: boolean;
-            /**
-             * @default true
-             */
-            arraysInArrays: boolean;
-        }>
-    ]>;
+    "array-bracket-spacing":
+        | Linter.RuleEntry<
+              [
+                  "never",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      singleValue: boolean;
+                      /**
+                       * @default false
+                       */
+                      objectsInArrays: boolean;
+                      /**
+                       * @default false
+                       */
+                      arraysInArrays: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<
+              [
+                  "always",
+                  Partial<{
+                      /**
+                       * @default true
+                       */
+                      singleValue: boolean;
+                      /**
+                       * @default true
+                       */
+                      objectsInArrays: boolean;
+                      /**
+                       * @default true
+                       */
+                      arraysInArrays: boolean;
+                  }>,
+              ]
+          >;
 
     /**
      * Rule to enforce line breaks after each array element.
@@ -66,18 +77,23 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.0.0-rc.0
      * @see https://eslint.org/docs/rules/array-element-newline
      */
-    'array-element-newline': Linter.RuleEntry<[
-        'always' | 'never' | 'consistent' | Partial<{
-            /**
-             * @default true
-             */
-            multiline: boolean;
-            /**
-             * @default null
-             */
-            minItems: number | null;
-        }>
-    ]>;
+    "array-element-newline": Linter.RuleEntry<
+        [
+            | "always"
+            | "never"
+            | "consistent"
+            | Partial<{
+                  /**
+                   * @default true
+                   */
+                  multiline: boolean;
+                  /**
+                   * @default null
+                   */
+                  minItems: number | null;
+              }>,
+        ]
+    >;
 
     /**
      * Rule to disallow or enforce spaces inside of blocks after opening block and before closing block.
@@ -85,9 +101,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 1.2.0
      * @see https://eslint.org/docs/rules/block-spacing
      */
-    'block-spacing': Linter.RuleEntry<[
-        'always' | 'never'
-    ]>;
+    "block-spacing": Linter.RuleEntry<["always" | "never"]>;
 
     /**
      * Rule to enforce consistent brace style for blocks.
@@ -95,15 +109,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/brace-style
      */
-    'brace-style': Linter.RuleEntry<[
-        '1tbs' | 'stroustrup' | 'allman',
-        Partial<{
-            /**
-             * @default false
-             */
-            allowSingleLine: boolean;
-        }>
-    ]>;
+    "brace-style": Linter.RuleEntry<
+        [
+            "1tbs" | "stroustrup" | "allman",
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowSingleLine: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce camelcase naming convention.
@@ -111,23 +127,25 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/camelcase
      */
-    'camelcase': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 'always'
-             */
-            properties: 'always' | 'never';
-            /**
-             * @default false
-             */
-            ignoreDestructuring: boolean;
-            /**
-             * @remarks
-             * Also accept for regular expression patterns
-             */
-            allow: string[];
-        }>
-    ]>;
+    camelcase: Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 'always'
+                 */
+                properties: "always" | "never";
+                /**
+                 * @default false
+                 */
+                ignoreDestructuring: boolean;
+                /**
+                 * @remarks
+                 * Also accept for regular expression patterns
+                 */
+                allow: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce or disallow capitalization of the first letter of a comment.
@@ -135,20 +153,22 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.11.0
      * @see https://eslint.org/docs/rules/capitalized-comments
      */
-    'capitalized-comments': Linter.RuleEntry<[
-        'always' | 'never',
-        Partial<{
-            ignorePattern: string;
-            /**
-             * @default false
-             */
-            ignoreInlineComments: boolean;
-            /**
-             * @default false
-             */
-            ignoreConsecutiveComments: boolean;
-        }>
-    ]>;
+    "capitalized-comments": Linter.RuleEntry<
+        [
+            "always" | "never",
+            Partial<{
+                ignorePattern: string;
+                /**
+                 * @default false
+                 */
+                ignoreInlineComments: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreConsecutiveComments: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow trailing commas.
@@ -156,30 +176,36 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.16.0
      * @see https://eslint.org/docs/rules/comma-dangle
      */
-    'comma-dangle': Linter.RuleEntry<[
-        'never' | 'always' | 'always-multiline' | 'only-multiline' | Partial<{
-            /**
-             * @default 'never'
-             */
-            arrays: 'never' | 'always' | 'always-multiline' | 'only-multiline';
-            /**
-             * @default 'never'
-             */
-            objects: 'never' | 'always' | 'always-multiline' | 'only-multiline';
-            /**
-             * @default 'never'
-             */
-            imports: 'never' | 'always' | 'always-multiline' | 'only-multiline';
-            /**
-             * @default 'never'
-             */
-            exports: 'never' | 'always' | 'always-multiline' | 'only-multiline';
-            /**
-             * @default 'never'
-             */
-            functions: 'never' | 'always' | 'always-multiline' | 'only-multiline';
-        }>
-    ]>;
+    "comma-dangle": Linter.RuleEntry<
+        [
+            | "never"
+            | "always"
+            | "always-multiline"
+            | "only-multiline"
+            | Partial<{
+                  /**
+                   * @default 'never'
+                   */
+                  arrays: "never" | "always" | "always-multiline" | "only-multiline";
+                  /**
+                   * @default 'never'
+                   */
+                  objects: "never" | "always" | "always-multiline" | "only-multiline";
+                  /**
+                   * @default 'never'
+                   */
+                  imports: "never" | "always" | "always-multiline" | "only-multiline";
+                  /**
+                   * @default 'never'
+                   */
+                  exports: "never" | "always" | "always-multiline" | "only-multiline";
+                  /**
+                   * @default 'never'
+                   */
+                  functions: "never" | "always" | "always-multiline" | "only-multiline";
+              }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing before and after commas.
@@ -187,18 +213,20 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/comma-spacing
      */
-    'comma-spacing': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            before: boolean;
-            /**
-             * @default true
-             */
-            after: boolean;
-        }>
-    ]>;
+    "comma-spacing": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                before: boolean;
+                /**
+                 * @default true
+                 */
+                after: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent comma style.
@@ -206,12 +234,14 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/comma-style
      */
-    'comma-style': Linter.RuleEntry<[
-        'last' | 'first',
-        Partial<{
-            exceptions: Record<string, boolean>;
-        }>
-    ]>;
+    "comma-style": Linter.RuleEntry<
+        [
+            "last" | "first",
+            Partial<{
+                exceptions: Record<string, boolean>;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing inside computed property brackets.
@@ -219,9 +249,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.23.0
      * @see https://eslint.org/docs/rules/computed-property-spacing
      */
-    'computed-property-spacing': Linter.RuleEntry<[
-        'never' | 'always'
-    ]>;
+    "computed-property-spacing": Linter.RuleEntry<["never" | "always"]>;
 
     /**
      * Rule to enforce consistent naming when capturing the current execution context.
@@ -229,9 +257,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/consistent-this
      */
-    'consistent-this': Linter.RuleEntry<[
-        ...string[]
-    ]>;
+    "consistent-this": Linter.RuleEntry<[...string[]]>;
 
     /**
      * Rule to require or disallow newline at the end of files.
@@ -239,9 +265,11 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.7.1
      * @see https://eslint.org/docs/rules/eol-last
      */
-    'eol-last': Linter.RuleEntry<[
-        'always' | 'never' // | 'unix' | 'windows'
-    ]>;
+    "eol-last": Linter.RuleEntry<
+        [
+            "always" | "never", // | 'unix' | 'windows'
+        ]
+    >;
 
     /**
      * Rule to require or disallow spacing between function identifiers and their invocations.
@@ -249,9 +277,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.3.0
      * @see https://eslint.org/docs/rules/func-call-spacing
      */
-    'func-call-spacing': Linter.RuleEntry<[
-        'never' | 'always'
-    ]>;
+    "func-call-spacing": Linter.RuleEntry<["never" | "always"]>;
 
     /**
      * Rule to require function names to match the name of the variable or property to which they are assigned.
@@ -259,30 +285,36 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.8.0
      * @see https://eslint.org/docs/rules/func-name-matching
      */
-    'func-name-matching': Linter.RuleEntry<[
-        'always' | 'never',
-        Partial<{
-            /**
-             * @default false
-             */
-            considerPropertyDescriptor: boolean;
-            /**
-             * @default false
-             */
-            includeCommonJSModuleExports: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            considerPropertyDescriptor: boolean;
-            /**
-             * @default false
-             */
-            includeCommonJSModuleExports: boolean;
-        }>
-    ]>;
+    "func-name-matching":
+        | Linter.RuleEntry<
+              [
+                  "always" | "never",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      considerPropertyDescriptor: boolean;
+                      /**
+                       * @default false
+                       */
+                      includeCommonJSModuleExports: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<
+              [
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      considerPropertyDescriptor: boolean;
+                      /**
+                       * @default false
+                       */
+                      includeCommonJSModuleExports: boolean;
+                  }>,
+              ]
+          >;
 
     /**
      * Rule to require or disallow named `function` expressions.
@@ -290,12 +322,14 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/func-names
      */
-    'func-names': Linter.RuleEntry<[
-        'always' | 'as-needed' | 'never',
-        Partial<{
-            generators: 'always' | 'as-needed' | 'never';
-        }>
-    ]>;
+    "func-names": Linter.RuleEntry<
+        [
+            "always" | "as-needed" | "never",
+            Partial<{
+                generators: "always" | "as-needed" | "never";
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce the consistent use of either `function` declarations or expressions.
@@ -303,15 +337,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.2.0
      * @see https://eslint.org/docs/rules/func-style
      */
-    'func-style': Linter.RuleEntry<[
-        'expression' | 'declaration',
-        Partial<{
-            /**
-             * @default false
-             */
-            allowArrowFunctions: boolean;
-        }>
-    ]>;
+    "func-style": Linter.RuleEntry<
+        [
+            "expression" | "declaration",
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowArrowFunctions: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent line breaks inside function parentheses.
@@ -319,11 +355,18 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.6.0
      * @see https://eslint.org/docs/rules/function-paren-newline
      */
-    'function-paren-newline': Linter.RuleEntry<[
-        'always' | 'never' | 'multiline' | 'multiline-arguments' | 'consistent' | Partial<{
-            minItems: number;
-        }>
-    ]>;
+    "function-paren-newline": Linter.RuleEntry<
+        [
+            | "always"
+            | "never"
+            | "multiline"
+            | "multiline-arguments"
+            | "consistent"
+            | Partial<{
+                  minItems: number;
+              }>,
+        ]
+    >;
 
     /**
      * Rule to disallow specified identifiers.
@@ -331,9 +374,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.0.0-beta.2
      * @see https://eslint.org/docs/rules/id-blacklist
      */
-    'id-blacklist': Linter.RuleEntry<[
-        ...string[]
-    ]>;
+    "id-blacklist": Linter.RuleEntry<[...string[]]>;
 
     /**
      * Rule to enforce minimum and maximum identifier lengths.
@@ -341,23 +382,25 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 1.0.0
      * @see https://eslint.org/docs/rules/id-length
      */
-    'id-length': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 2
-             */
-            min: number;
-            /**
-             * @default Infinity
-             */
-            max: number;
-            /**
-             * @default 'always'
-             */
-            properties: 'always' | 'never';
-            exceptions: string[];
-        }>
-    ]>;
+    "id-length": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 2
+                 */
+                min: number;
+                /**
+                 * @default Infinity
+                 */
+                max: number;
+                /**
+                 * @default 'always'
+                 */
+                properties: "always" | "never";
+                exceptions: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require identifiers to match a specified regular expression.
@@ -365,23 +408,25 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 1.0.0
      * @see https://eslint.org/docs/rules/id-match
      */
-    'id-match': Linter.RuleEntry<[
-        string,
-        Partial<{
-            /**
-             * @default false
-             */
-            properties: boolean;
-            /**
-             * @default false
-             */
-            onlyDeclarations: boolean;
-            /**
-             * @default false
-             */
-            ignoreDestructuring: boolean;
-        }>
-    ]>;
+    "id-match": Linter.RuleEntry<
+        [
+            string,
+            Partial<{
+                /**
+                 * @default false
+                 */
+                properties: boolean;
+                /**
+                 * @default false
+                 */
+                onlyDeclarations: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreDestructuring: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce the location of arrow function bodies.
@@ -389,9 +434,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.12.0
      * @see https://eslint.org/docs/rules/implicit-arrow-linebreak
      */
-    'implicit-arrow-linebreak': Linter.RuleEntry<[
-        'beside' | 'below'
-    ]>;
+    "implicit-arrow-linebreak": Linter.RuleEntry<["beside" | "below"]>;
 
     /**
      * Rule to enforce consistent indentation.
@@ -399,96 +442,101 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.14.0
      * @see https://eslint.org/docs/rules/indent
      */
-    'indent': Linter.RuleEntry<[
-        number | 'tab',
-        Partial<{
-            /**
-             * @default 0
-             */
-            SwitchCase: number;
-            /**
-             * @default 1
-             */
-            VariableDeclarator: Partial<{
+    indent: Linter.RuleEntry<
+        [
+            number | "tab",
+            Partial<{
+                /**
+                 * @default 0
+                 */
+                SwitchCase: number;
                 /**
                  * @default 1
                  */
-                var: number | 'first';
+                VariableDeclarator:
+                    | Partial<{
+                          /**
+                           * @default 1
+                           */
+                          var: number | "first";
+                          /**
+                           * @default 1
+                           */
+                          let: number | "first";
+                          /**
+                           * @default 1
+                           */
+                          const: number | "first";
+                      }>
+                    | number
+                    | "first";
                 /**
                  * @default 1
                  */
-                let: number | 'first';
+                outerIIFEBody: number;
                 /**
                  * @default 1
                  */
-                const: number | 'first';
-            }> | number | 'first';
-            /**
-             * @default 1
-             */
-            outerIIFEBody: number;
-            /**
-             * @default 1
-             */
-            MemberExpression: number | 'off';
-            /**
-             * @default { parameters: 1, body: 1 }
-             */
-            FunctionDeclaration: Partial<{
+                MemberExpression: number | "off";
+                /**
+                 * @default { parameters: 1, body: 1 }
+                 */
+                FunctionDeclaration: Partial<{
+                    /**
+                     * @default 1
+                     */
+                    parameters: number | "first" | "off";
+                    /**
+                     * @default 1
+                     */
+                    body: number;
+                }>;
+                /**
+                 * @default { parameters: 1, body: 1 }
+                 */
+                FunctionExpression: Partial<{
+                    /**
+                     * @default 1
+                     */
+                    parameters: number | "first" | "off";
+                    /**
+                     * @default 1
+                     */
+                    body: number;
+                }>;
+                /**
+                 * @default { arguments: 1 }
+                 */
+                CallExpression: Partial<{
+                    /**
+                     * @default 1
+                     */
+                    arguments: number | "first" | "off";
+                }>;
                 /**
                  * @default 1
                  */
-                parameters: number | 'first' | 'off';
+                ArrayExpression: number | "first" | "off";
                 /**
                  * @default 1
                  */
-                body: number;
-            }>;
-            /**
-             * @default { parameters: 1, body: 1 }
-             */
-            FunctionExpression: Partial<{
+                ObjectExpression: number | "first" | "off";
                 /**
                  * @default 1
                  */
-                parameters: number | 'first' | 'off';
+                ImportDeclaration: number | "first" | "off";
                 /**
-                 * @default 1
+                 * @default false
                  */
-                body: number;
-            }>;
-            /**
-             * @default { arguments: 1 }
-             */
-            CallExpression: Partial<{
+                flatTernaryExpressions: boolean;
+                ignoredNodes: string[];
                 /**
-                 * @default 1
+                 * @default false
                  */
-                arguments: number | 'first' | 'off';
-            }>;
-            /**
-             * @default 1
-             */
-            ArrayExpression: number | 'first' | 'off';
-            /**
-             * @default 1
-             */
-            ObjectExpression: number | 'first' | 'off';
-            /**
-             * @default 1
-             */
-            ImportDeclaration: number | 'first' | 'off';
-            /**
-             * @default false
-             */
-            flatTernaryExpressions: boolean;
-            ignoredNodes: string[];
-            /**
-             * @default false
-             */
-            ignoreComments: boolean;
-        }>
-    ]>;
+                ignoreComments: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce the consistent use of either double or single quotes in JSX attributes.
@@ -496,9 +544,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 1.4.0
      * @see https://eslint.org/docs/rules/jsx-quotes
      */
-    'jsx-quotes': Linter.RuleEntry<[
-        'prefer-double' | 'prefer-single'
-    ]>;
+    "jsx-quotes": Linter.RuleEntry<["prefer-double" | "prefer-single"]>;
 
     /**
      * Rule to enforce consistent spacing between keys and values in object literal properties.
@@ -506,134 +552,146 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/key-spacing
      */
-    'key-spacing': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            beforeColon: boolean;
-            /**
-             * @default true
-             */
-            afterColon: boolean;
-            /**
-             * @default 'strict'
-             */
-            mode: 'strict' | 'minimum';
-            align: Partial<{
-                /**
-                 * @default false
-                 */
-                beforeColon: boolean;
-                /**
-                 * @default true
-                 */
-                afterColon: boolean;
-                /**
-                 * @default 'colon'
-                 */
-                on: 'value' | 'colon';
-                /**
-                 * @default 'strict'
-                 */
-                mode: 'strict' | 'minimum';
-            }> | 'value' | 'colon';
-        } | {
-            singleLine?: Partial<{
-                /**
-                 * @default false
-                 */
-                beforeColon: boolean;
-                /**
-                 * @default true
-                 */
-                afterColon: boolean;
-                /**
-                 * @default 'strict'
-                 */
-                mode: 'strict' | 'minimum';
-            }>;
-            multiLine?: Partial<{
-                /**
-                 * @default false
-                 */
-                beforeColon: boolean;
-                /**
-                 * @default true
-                 */
-                afterColon: boolean;
-                /**
-                 * @default 'strict'
-                 */
-                mode: 'strict' | 'minimum';
-                align: Partial<{
-                    /**
-                     * @default false
-                     */
-                    beforeColon: boolean;
-                    /**
-                     * @default true
-                     */
-                    afterColon: boolean;
-                    /**
-                     * @default 'colon'
-                     */
-                    on: 'value' | 'colon';
-                    /**
-                     * @default 'strict'
-                     */
-                    mode: 'strict' | 'minimum';
-                }> | 'value' | 'colon';
-            }>;
-        }> | {
-            align: Partial<{
-                /**
-                 * @default false
-                 */
-                beforeColon: boolean;
-                /**
-                 * @default true
-                 */
-                afterColon: boolean;
-                /**
-                 * @default 'colon'
-                 */
-                on: 'value' | 'colon';
-                /**
-                 * @default 'strict'
-                 */
-                mode: 'strict' | 'minimum';
-            }>;
-            singleLine?: Partial<{
-                /**
-                 * @default false
-                 */
-                beforeColon: boolean;
-                /**
-                 * @default true
-                 */
-                afterColon: boolean;
-                /**
-                 * @default 'strict'
-                 */
-                mode: 'strict' | 'minimum';
-            }>;
-            multiLine?: Partial<{
-                /**
-                 * @default false
-                 */
-                beforeColon: boolean;
-                /**
-                 * @default true
-                 */
-                afterColon: boolean;
-                /**
-                 * @default 'strict'
-                 */
-                mode: 'strict' | 'minimum';
-            }>;
-        }
-    ]>;
+    "key-spacing": Linter.RuleEntry<
+        [
+            | Partial<
+                  | {
+                        /**
+                         * @default false
+                         */
+                        beforeColon: boolean;
+                        /**
+                         * @default true
+                         */
+                        afterColon: boolean;
+                        /**
+                         * @default 'strict'
+                         */
+                        mode: "strict" | "minimum";
+                        align:
+                            | Partial<{
+                                  /**
+                                   * @default false
+                                   */
+                                  beforeColon: boolean;
+                                  /**
+                                   * @default true
+                                   */
+                                  afterColon: boolean;
+                                  /**
+                                   * @default 'colon'
+                                   */
+                                  on: "value" | "colon";
+                                  /**
+                                   * @default 'strict'
+                                   */
+                                  mode: "strict" | "minimum";
+                              }>
+                            | "value"
+                            | "colon";
+                    }
+                  | {
+                        singleLine?: Partial<{
+                            /**
+                             * @default false
+                             */
+                            beforeColon: boolean;
+                            /**
+                             * @default true
+                             */
+                            afterColon: boolean;
+                            /**
+                             * @default 'strict'
+                             */
+                            mode: "strict" | "minimum";
+                        }>;
+                        multiLine?: Partial<{
+                            /**
+                             * @default false
+                             */
+                            beforeColon: boolean;
+                            /**
+                             * @default true
+                             */
+                            afterColon: boolean;
+                            /**
+                             * @default 'strict'
+                             */
+                            mode: "strict" | "minimum";
+                            align:
+                                | Partial<{
+                                      /**
+                                       * @default false
+                                       */
+                                      beforeColon: boolean;
+                                      /**
+                                       * @default true
+                                       */
+                                      afterColon: boolean;
+                                      /**
+                                       * @default 'colon'
+                                       */
+                                      on: "value" | "colon";
+                                      /**
+                                       * @default 'strict'
+                                       */
+                                      mode: "strict" | "minimum";
+                                  }>
+                                | "value"
+                                | "colon";
+                        }>;
+                    }
+              >
+            | {
+                  align: Partial<{
+                      /**
+                       * @default false
+                       */
+                      beforeColon: boolean;
+                      /**
+                       * @default true
+                       */
+                      afterColon: boolean;
+                      /**
+                       * @default 'colon'
+                       */
+                      on: "value" | "colon";
+                      /**
+                       * @default 'strict'
+                       */
+                      mode: "strict" | "minimum";
+                  }>;
+                  singleLine?: Partial<{
+                      /**
+                       * @default false
+                       */
+                      beforeColon: boolean;
+                      /**
+                       * @default true
+                       */
+                      afterColon: boolean;
+                      /**
+                       * @default 'strict'
+                       */
+                      mode: "strict" | "minimum";
+                  }>;
+                  multiLine?: Partial<{
+                      /**
+                       * @default false
+                       */
+                      beforeColon: boolean;
+                      /**
+                       * @default true
+                       */
+                      afterColon: boolean;
+                      /**
+                       * @default 'strict'
+                       */
+                      mode: "strict" | "minimum";
+                  }>;
+              },
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing before and after keywords.
@@ -641,22 +699,27 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.0.0-beta.1
      * @see https://eslint.org/docs/rules/keyword-spacing
      */
-    'keyword-spacing': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            before: boolean;
-            /**
-             * @default true
-             */
-            after: boolean;
-            overrides: Record<string, Partial<{
+    "keyword-spacing": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
                 before: boolean;
+                /**
+                 * @default true
+                 */
                 after: boolean;
-            }>>;
-        }>
-    ]>;
+                overrides: Record<
+                    string,
+                    Partial<{
+                        before: boolean;
+                        after: boolean;
+                    }>
+                >;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce position of line comments.
@@ -664,19 +727,21 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.5.0
      * @see https://eslint.org/docs/rules/line-comment-position
      */
-    'line-comment-position': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 'above'
-             */
-            position: 'above' | 'beside';
-            ignorePattern: string;
-            /**
-             * @default true
-             */
-            applyDefaultIgnorePatterns: boolean;
-        }>
-    ]>;
+    "line-comment-position": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 'above'
+                 */
+                position: "above" | "beside";
+                ignorePattern: string;
+                /**
+                 * @default true
+                 */
+                applyDefaultIgnorePatterns: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent linebreak style.
@@ -684,9 +749,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.21.0
      * @see https://eslint.org/docs/rules/linebreak-style
      */
-    'linebreak-style': Linter.RuleEntry<[
-        'unix' | 'windows'
-    ]>;
+    "linebreak-style": Linter.RuleEntry<["unix" | "windows"]>;
 
     /**
      * Rule to require empty lines around comments.
@@ -694,63 +757,65 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.22.0
      * @see https://eslint.org/docs/rules/lines-around-comment
      */
-    'lines-around-comment': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            beforeBlockComment: boolean;
-            /**
-             * @default false
-             */
-            afterBlockComment: boolean;
-            /**
-             * @default false
-             */
-            beforeLineComment: boolean;
-            /**
-             * @default false
-             */
-            afterLineComment: boolean;
-            /**
-             * @default false
-             */
-            allowBlockStart: boolean;
-            /**
-             * @default false
-             */
-            allowBlockEnd: boolean;
-            /**
-             * @default false
-             */
-            allowObjectStart: boolean;
-            /**
-             * @default false
-             */
-            allowObjectEnd: boolean;
-            /**
-             * @default false
-             */
-            allowArrayStart: boolean;
-            /**
-             * @default false
-             */
-            allowArrayEnd: boolean;
-            /**
-             * @default false
-             */
-            allowClassStart: boolean;
-            /**
-             * @default false
-             */
-            allowClassEnd: boolean;
-            ignorePattern: string;
-            /**
-             * @default true
-             */
-            applyDefaultIgnorePatterns: boolean;
-        }>
-    ]>;
+    "lines-around-comment": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                beforeBlockComment: boolean;
+                /**
+                 * @default false
+                 */
+                afterBlockComment: boolean;
+                /**
+                 * @default false
+                 */
+                beforeLineComment: boolean;
+                /**
+                 * @default false
+                 */
+                afterLineComment: boolean;
+                /**
+                 * @default false
+                 */
+                allowBlockStart: boolean;
+                /**
+                 * @default false
+                 */
+                allowBlockEnd: boolean;
+                /**
+                 * @default false
+                 */
+                allowObjectStart: boolean;
+                /**
+                 * @default false
+                 */
+                allowObjectEnd: boolean;
+                /**
+                 * @default false
+                 */
+                allowArrayStart: boolean;
+                /**
+                 * @default false
+                 */
+                allowArrayEnd: boolean;
+                /**
+                 * @default false
+                 */
+                allowClassStart: boolean;
+                /**
+                 * @default false
+                 */
+                allowClassEnd: boolean;
+                ignorePattern: string;
+                /**
+                 * @default true
+                 */
+                applyDefaultIgnorePatterns: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow an empty line between class members.
@@ -758,15 +823,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.9.0
      * @see https://eslint.org/docs/rules/lines-between-class-members
      */
-    'lines-between-class-members': Linter.RuleEntry<[
-        'always' | 'never',
-        Partial<{
-            /**
-             * @default false
-             */
-            exceptAfterSingleLine: boolean;
-        }>
-    ]>;
+    "lines-between-class-members": Linter.RuleEntry<
+        [
+            "always" | "never",
+            Partial<{
+                /**
+                 * @default false
+                 */
+                exceptAfterSingleLine: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum depth that blocks can be nested.
@@ -774,14 +841,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/max-depth
      */
-    'max-depth': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 4
-             */
-            max: number;
-        }>
-    ]>;
+    "max-depth": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 4
+                 */
+                max: number;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum line length.
@@ -789,44 +858,46 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/max-len
      */
-    'max-len': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 80
-             */
-            code: number;
-            /**
-             * @default 4
-             */
-            tabWidth: number;
-            comments: number;
-            ignorePattern: string;
-            /**
-             * @default false
-             */
-            ignoreComments: boolean;
-            /**
-             * @default false
-             */
-            ignoreTrailingComments: boolean;
-            /**
-             * @default false
-             */
-            ignoreUrls: boolean;
-            /**
-             * @default false
-             */
-            ignoreStrings: boolean;
-            /**
-             * @default false
-             */
-            ignoreTemplateLiterals: boolean;
-            /**
-             * @default false
-             */
-            ignoreRegExpLiterals: boolean;
-        }>
-    ]>;
+    "max-len": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 80
+                 */
+                code: number;
+                /**
+                 * @default 4
+                 */
+                tabWidth: number;
+                comments: number;
+                ignorePattern: string;
+                /**
+                 * @default false
+                 */
+                ignoreComments: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreTrailingComments: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreUrls: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreStrings: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreTemplateLiterals: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreRegExpLiterals: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum number of lines per file.
@@ -834,22 +905,25 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.12.0
      * @see https://eslint.org/docs/rules/max-lines
      */
-    'max-lines': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 300
-             */
-            max: number;
-            /**
-             * @default false
-             */
-            skipBlankLines: boolean;
-            /**
-             * @default false
-             */
-            skipComments: boolean;
-        }> | number
-    ]>;
+    "max-lines": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 300
+                   */
+                  max: number;
+                  /**
+                   * @default false
+                   */
+                  skipBlankLines: boolean;
+                  /**
+                   * @default false
+                   */
+                  skipComments: boolean;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum number of line of code in a function.
@@ -857,26 +931,28 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 5.0.0
      * @see https://eslint.org/docs/rules/max-lines-per-function
      */
-    'max-lines-per-function': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 50
-             */
-            max: number;
-            /**
-             * @default false
-             */
-            skipBlankLines: boolean;
-            /**
-             * @default false
-             */
-            skipComments: boolean;
-            /**
-             * @default false
-             */
-            IIFEs: boolean;
-        }>
-    ]>;
+    "max-lines-per-function": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 50
+                 */
+                max: number;
+                /**
+                 * @default false
+                 */
+                skipBlankLines: boolean;
+                /**
+                 * @default false
+                 */
+                skipComments: boolean;
+                /**
+                 * @default false
+                 */
+                IIFEs: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum depth that callbacks can be nested.
@@ -884,14 +960,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.2.0
      * @see https://eslint.org/docs/rules/max-nested-callbacks
      */
-    'max-nested-callbacks': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 10
-             */
-            max: number;
-        }> | number
-    ]>;
+    "max-nested-callbacks": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 10
+                   */
+                  max: number;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum number of parameters in function definitions.
@@ -899,14 +978,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/max-params
      */
-    'max-params': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 3
-             */
-            max: number;
-        }> | number
-    ]>;
+    "max-params": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 3
+                   */
+                  max: number;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum number of statements allowed in function blocks.
@@ -914,18 +996,21 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/max-statements
      */
-    'max-statements': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 10
-             */
-            max: number;
-            /**
-             * @default false
-             */
-            ignoreTopLevelFunctions: boolean;
-        }> | number
-    ]>;
+    "max-statements": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 10
+                   */
+                  max: number;
+                  /**
+                   * @default false
+                   */
+                  ignoreTopLevelFunctions: boolean;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to enforce a maximum number of statements allowed per line.
@@ -933,14 +1018,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.5.0
      * @see https://eslint.org/docs/rules/max-statements-per-line
      */
-    'max-statements-per-line': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 1
-             */
-            max: number;
-        }> | number
-    ]>;
+    "max-statements-per-line": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 1
+                   */
+                  max: number;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to enforce a particular style for multiline comments.
@@ -948,9 +1036,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.10.0
      * @see https://eslint.org/docs/rules/multiline-comment-style
      */
-    'multiline-comment-style': Linter.RuleEntry<[
-        'starred-block' | 'bare-block' | 'separate-lines'
-    ]>;
+    "multiline-comment-style": Linter.RuleEntry<["starred-block" | "bare-block" | "separate-lines"]>;
 
     /**
      * Rule to enforce newlines between operands of ternary expressions.
@@ -958,9 +1044,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.1.0
      * @see https://eslint.org/docs/rules/multiline-ternary
      */
-    'multiline-ternary': Linter.RuleEntry<[
-        'always' | 'always-multiline' | 'never'
-    ]>;
+    "multiline-ternary": Linter.RuleEntry<["always" | "always-multiline" | "never"]>;
 
     /**
      * Rule to require constructor names to begin with a capital letter.
@@ -968,26 +1052,28 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.3-0
      * @see https://eslint.org/docs/rules/new-cap
      */
-    'new-cap': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            newIsCap: boolean;
-            /**
-             * @default true
-             */
-            capIsNew: boolean;
-            newIsCapExceptions: string[];
-            newIsCapExceptionPattern: string;
-            capIsNewExceptions: string[];
-            capIsNewExceptionPattern: string;
-            /**
-             * @default true
-             */
-            properties: boolean;
-        }>
-    ]>;
+    "new-cap": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                newIsCap: boolean;
+                /**
+                 * @default true
+                 */
+                capIsNew: boolean;
+                newIsCapExceptions: string[];
+                newIsCapExceptionPattern: string;
+                capIsNewExceptions: string[];
+                capIsNewExceptionPattern: string;
+                /**
+                 * @default true
+                 */
+                properties: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce or disallow parentheses when invoking a constructor with no arguments.
@@ -995,9 +1081,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/new-parens
      */
-    'new-parens': Linter.RuleEntry<[
-        'always' | 'never'
-    ]>;
+    "new-parens": Linter.RuleEntry<["always" | "never"]>;
 
     /**
      * Rule to require a newline after each call in a method chain.
@@ -1005,14 +1089,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.0.0-rc.0
      * @see https://eslint.org/docs/rules/newline-per-chained-call
      */
-    'newline-per-chained-call': Linter.RuleEntry<[
-        {
-            /**
-             * @default 2
-             */
-            ignoreChainWithDepth: number;
-        }
-    ]>;
+    "newline-per-chained-call": Linter.RuleEntry<
+        [
+            {
+                /**
+                 * @default 2
+                 */
+                ignoreChainWithDepth: number;
+            },
+        ]
+    >;
 
     /**
      * Rule to disallow `Array` constructors.
@@ -1020,7 +1106,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.4.0
      * @see https://eslint.org/docs/rules/no-array-constructor
      */
-    'no-array-constructor': Linter.RuleEntry<[]>;
+    "no-array-constructor": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow bitwise operators.
@@ -1028,15 +1114,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.2
      * @see https://eslint.org/docs/rules/no-bitwise
      */
-    'no-bitwise': Linter.RuleEntry<[
-        Partial<{
-            allow: string[];
-            /**
-             * @default false
-             */
-            int32Hint: boolean;
-        }>
-    ]>;
+    "no-bitwise": Linter.RuleEntry<
+        [
+            Partial<{
+                allow: string[];
+                /**
+                 * @default false
+                 */
+                int32Hint: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow `continue` statements.
@@ -1044,7 +1132,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.19.0
      * @see https://eslint.org/docs/rules/no-continue
      */
-    'no-continue': Linter.RuleEntry<[]>;
+    "no-continue": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow inline comments after code.
@@ -1052,7 +1140,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.10.0
      * @see https://eslint.org/docs/rules/no-inline-comments
      */
-    'no-inline-comments': Linter.RuleEntry<[]>;
+    "no-inline-comments": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `if` statements as the only statement in `else` blocks.
@@ -1060,7 +1148,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.6.0
      * @see https://eslint.org/docs/rules/no-lonely-if
      */
-    'no-lonely-if': Linter.RuleEntry<[]>;
+    "no-lonely-if": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow mixed binary operators.
@@ -1068,25 +1156,27 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.12.0
      * @see https://eslint.org/docs/rules/no-mixed-operators
      */
-    'no-mixed-operators': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default
-             * [
-             *     ["+", "-", "*", "/", "%", "**"],
-             *     ["&", "|", "^", "~", "<<", ">>", ">>>"],
-             *     ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
-             *     ["&&", "||"],
-             *     ["in", "instanceof"]
-             * ]
-             */
-            groups: string[][];
-            /**
-             * @default true
-             */
-            allowSamePrecedence: boolean;
-        }>
-    ]>;
+    "no-mixed-operators": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default
+                 * [
+                 *     ["+", "-", "*", "/", "%", "**"],
+                 *     ["&", "|", "^", "~", "<<", ">>", ">>>"],
+                 *     ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+                 *     ["&&", "||"],
+                 *     ["in", "instanceof"]
+                 * ]
+                 */
+                groups: string[][];
+                /**
+                 * @default true
+                 */
+                allowSamePrecedence: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow mixed spaces and tabs for indentation.
@@ -1097,9 +1187,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.7.1
      * @see https://eslint.org/docs/rules/no-mixed-spaces-and-tabs
      */
-    'no-mixed-spaces-and-tabs': Linter.RuleEntry<[
-        'smart-tabs'
-    ]>;
+    "no-mixed-spaces-and-tabs": Linter.RuleEntry<["smart-tabs"]>;
 
     /**
      * Rule to disallow use of chained assignment expressions.
@@ -1107,7 +1195,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.14.0
      * @see https://eslint.org/docs/rules/no-multi-assign
      */
-    'no-multi-assign': Linter.RuleEntry<[]>;
+    "no-multi-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow multiple empty lines.
@@ -1115,16 +1203,19 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/no-multiple-empty-lines
      */
-    'no-multiple-empty-lines': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 2
-             */
-            max: number;
-            maxEOF: number;
-            maxBOF: number;
-        }> | number
-    ]>;
+    "no-multiple-empty-lines": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default 2
+                   */
+                  max: number;
+                  maxEOF: number;
+                  maxBOF: number;
+              }>
+            | number,
+        ]
+    >;
 
     /**
      * Rule to disallow negated conditions.
@@ -1132,7 +1223,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 1.6.0
      * @see https://eslint.org/docs/rules/no-negated-condition
      */
-    'no-negated-condition': Linter.RuleEntry<[]>;
+    "no-negated-condition": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow nested ternary expressions.
@@ -1140,7 +1231,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.2.0
      * @see https://eslint.org/docs/rules/no-nested-ternary
      */
-    'no-nested-ternary': Linter.RuleEntry<[]>;
+    "no-nested-ternary": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `Object` constructors.
@@ -1148,7 +1239,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-new-object
      */
-    'no-new-object': Linter.RuleEntry<[]>;
+    "no-new-object": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the unary operators `++` and `--`.
@@ -1156,14 +1247,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-plusplus
      */
-    'no-plusplus': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowForLoopAfterthoughts: boolean;
-        }>
-    ]>;
+    "no-plusplus": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowForLoopAfterthoughts: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow specified syntax.
@@ -1171,12 +1264,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 1.4.0
      * @see https://eslint.org/docs/rules/no-restricted-syntax
      */
-    'no-restricted-syntax': Linter.RuleEntry<[
-        ...Array<string | {
-            selector: string;
-            message?: string;
-        }>
-    ]>;
+    "no-restricted-syntax": Linter.RuleEntry<
+        [
+            ...Array<
+                | string
+                | {
+                      selector: string;
+                      message?: string;
+                  }
+            >
+        ]
+    >;
 
     /**
      * Rule to disallow all tabs.
@@ -1184,14 +1282,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.2.0
      * @see https://eslint.org/docs/rules/no-tabs
      */
-    'no-tabs': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowIndentationTabs: boolean;
-        }>
-    ]>;
+    "no-tabs": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowIndentationTabs: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow ternary operators.
@@ -1199,7 +1299,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-ternary
      */
-    'no-ternary': Linter.RuleEntry<[]>;
+    "no-ternary": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow trailing whitespace at the end of lines.
@@ -1207,18 +1307,20 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.7.1
      * @see https://eslint.org/docs/rules/no-trailing-spaces
      */
-    'no-trailing-spaces': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            skipBlankLines: boolean;
-            /**
-             * @default false
-             */
-            ignoreComments: boolean;
-        }>
-    ]>;
+    "no-trailing-spaces": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                skipBlankLines: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreComments: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow dangling underscores in identifiers.
@@ -1226,23 +1328,25 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-underscore-dangle
      */
-    'no-underscore-dangle': Linter.RuleEntry<[
-        Partial<{
-            allow: string[];
-            /**
-             * @default false
-             */
-            allowAfterThis: boolean;
-            /**
-             * @default false
-             */
-            allowAfterSuper: boolean;
-            /**
-             * @default false
-             */
-            enforceInMethodNames: boolean;
-        }>
-    ]>;
+    "no-underscore-dangle": Linter.RuleEntry<
+        [
+            Partial<{
+                allow: string[];
+                /**
+                 * @default false
+                 */
+                allowAfterThis: boolean;
+                /**
+                 * @default false
+                 */
+                allowAfterSuper: boolean;
+                /**
+                 * @default false
+                 */
+                enforceInMethodNames: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow ternary operators when simpler alternatives exist.
@@ -1250,14 +1354,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.21.0
      * @see https://eslint.org/docs/rules/no-unneeded-ternary
      */
-    'no-unneeded-ternary': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            defaultAssignment: boolean;
-        }>
-    ]>;
+    "no-unneeded-ternary": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                defaultAssignment: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow whitespace before properties.
@@ -1265,7 +1371,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.0.0-beta.1
      * @see https://eslint.org/docs/rules/no-whitespace-before-property
      */
-    'no-whitespace-before-property': Linter.RuleEntry<[]>;
+    "no-whitespace-before-property": Linter.RuleEntry<[]>;
 
     /**
      * Rule to enforce the location of single-line statements.
@@ -1273,12 +1379,14 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.17.0
      * @see https://eslint.org/docs/rules/nonblock-statement-body-position
      */
-    'nonblock-statement-body-position': Linter.RuleEntry<[
-        'beside' | 'below' | 'any',
-        Partial<{
-            overrides: Record<string, 'beside' | 'below' | 'any'>;
-        }>
-    ]>;
+    "nonblock-statement-body-position": Linter.RuleEntry<
+        [
+            "beside" | "below" | "any",
+            Partial<{
+                overrides: Record<string, "beside" | "below" | "any">;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent line breaks inside braces.
@@ -1286,33 +1394,41 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.12.0
      * @see https://eslint.org/docs/rules/object-curly-newline
      */
-    'object-curly-newline': Linter.RuleEntry<[
-        | 'always' | 'never'
-        | Partial<{
-                /**
-                 * @default false
-                 */
-                multiline: boolean;
-                minProperties: number;
-                /**
-                 * @default true
-                 */
-                consistent: boolean;
-            }>
-        | Partial<Record<'ObjectExpression' | 'ObjectPattern' | 'ImportDeclaration' | 'ExportDeclaration',
-            | 'always' | 'never'
+    "object-curly-newline": Linter.RuleEntry<
+        [
+            | "always"
+            | "never"
             | Partial<{
-                /**
-                 * @default false
-                 */
-                multiline: boolean;
-                minProperties: number;
-                /**
-                 * @default true
-                 */
-                consistent: boolean;
-            }>>>
-    ]>;
+                  /**
+                   * @default false
+                   */
+                  multiline: boolean;
+                  minProperties: number;
+                  /**
+                   * @default true
+                   */
+                  consistent: boolean;
+              }>
+            | Partial<
+                  Record<
+                      "ObjectExpression" | "ObjectPattern" | "ImportDeclaration" | "ExportDeclaration",
+                      | "always"
+                      | "never"
+                      | Partial<{
+                            /**
+                             * @default false
+                             */
+                            multiline: boolean;
+                            minProperties: number;
+                            /**
+                             * @default true
+                             */
+                            consistent: boolean;
+                        }>
+                  >
+              >,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing inside braces.
@@ -1320,31 +1436,37 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.22.0
      * @see https://eslint.org/docs/rules/object-curly-spacing
      */
-    'object-curly-spacing': Linter.RuleEntry<[
-        'never',
-        {
-            /**
-             * @default false
-             */
-            arraysInObjects: boolean;
-            /**
-             * @default false
-             */
-            objectsInObjects: boolean;
-        }
-    ]> | Linter.RuleEntry<[
-        'always',
-        {
-            /**
-             * @default true
-             */
-            arraysInObjects: boolean;
-            /**
-             * @default true
-             */
-            objectsInObjects: boolean;
-        }
-    ]>;
+    "object-curly-spacing":
+        | Linter.RuleEntry<
+              [
+                  "never",
+                  {
+                      /**
+                       * @default false
+                       */
+                      arraysInObjects: boolean;
+                      /**
+                       * @default false
+                       */
+                      objectsInObjects: boolean;
+                  },
+              ]
+          >
+        | Linter.RuleEntry<
+              [
+                  "always",
+                  {
+                      /**
+                       * @default true
+                       */
+                      arraysInObjects: boolean;
+                      /**
+                       * @default true
+                       */
+                      objectsInObjects: boolean;
+                  },
+              ]
+          >;
 
     /**
      * Rule to enforce placing object properties on separate lines.
@@ -1352,14 +1474,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.10.0
      * @see https://eslint.org/docs/rules/object-property-newline
      */
-    'object-property-newline': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            allowAllPropertiesOnSameLine: boolean;
-        }>
-    ]>;
+    "object-property-newline": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                allowAllPropertiesOnSameLine: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce variables to be declared either together or separately in functions.
@@ -1367,16 +1491,22 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/one-var
      */
-    'one-var': Linter.RuleEntry<[
-        | 'always' | 'never' | 'consecutive'
-        | Partial<{
-                /**
-                 * @default false
-                 */
-                separateRequires: boolean;
-            } & Record<'var' | 'let' | 'const', 'always' | 'never' | 'consecutive'>>
-        | Partial<Record<'initialized' | 'uninitialized', 'always' | 'never' | 'consecutive'>>
-    ]>;
+    "one-var": Linter.RuleEntry<
+        [
+            | "always"
+            | "never"
+            | "consecutive"
+            | Partial<
+                  {
+                      /**
+                       * @default false
+                       */
+                      separateRequires: boolean;
+                  } & Record<"var" | "let" | "const", "always" | "never" | "consecutive">
+              >
+            | Partial<Record<"initialized" | "uninitialized", "always" | "never" | "consecutive">>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow newlines around variable declarations.
@@ -1384,9 +1514,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.0.0-beta.3
      * @see https://eslint.org/docs/rules/one-var-declaration-per-line
      */
-    'one-var-declaration-per-line': Linter.RuleEntry<[
-        'initializations' | 'always'
-    ]>;
+    "one-var-declaration-per-line": Linter.RuleEntry<["initializations" | "always"]>;
 
     /**
      * Rule to require or disallow assignment operator shorthand where possible.
@@ -1394,9 +1522,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.10.0
      * @see https://eslint.org/docs/rules/operator-assignment
      */
-    'operator-assignment': Linter.RuleEntry<[
-        'always' | 'never'
-    ]>;
+    "operator-assignment": Linter.RuleEntry<["always" | "never"]>;
 
     /**
      * Rule to enforce consistent linebreak style for operators.
@@ -1404,12 +1530,14 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.19.0
      * @see https://eslint.org/docs/rules/operator-linebreak
      */
-    'operator-linebreak': Linter.RuleEntry<[
-        'after' | 'before' | 'none',
-        Partial<{
-            overrides: Record<string, 'after' | 'before' | 'none'>;
-        }>
-    ]>;
+    "operator-linebreak": Linter.RuleEntry<
+        [
+            "after" | "before" | "none",
+            Partial<{
+                overrides: Record<string, "after" | "before" | "none">;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow padding within blocks.
@@ -1417,16 +1545,17 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/padded-blocks
      */
-    'padded-blocks': Linter.RuleEntry<[
-        | 'always' | 'never'
-        | Partial<Record<'blocks' | 'classes' | 'switches', 'always' | 'never'>>,
-        {
-            /**
-             * @default false
-             */
-            allowSingleLineBlocks: boolean;
-        }
-    ]>;
+    "padded-blocks": Linter.RuleEntry<
+        [
+            "always" | "never" | Partial<Record<"blocks" | "classes" | "switches", "always" | "never">>,
+            {
+                /**
+                 * @default false
+                 */
+                allowSingleLineBlocks: boolean;
+            },
+        ]
+    >;
 
     /**
      * Rule to require or disallow padding lines between statements.
@@ -1434,11 +1563,15 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.0.0-beta.0
      * @see https://eslint.org/docs/rules/padding-line-between-statements
      */
-    'padding-line-between-statements': Linter.RuleEntry<[
-        ...Array<{
-            blankLine: 'any' | 'never' | 'always';
-        } & Record<'prev' | 'next', string | string[]>>
-    ]>;
+    "padding-line-between-statements": Linter.RuleEntry<
+        [
+            ...Array<
+                {
+                    blankLine: "any" | "never" | "always";
+                } & Record<"prev" | "next", string | string[]>
+            >
+        ]
+    >;
 
     /**
      * Rule to disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead.
@@ -1446,7 +1579,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 5.0.0-alpha.3
      * @see https://eslint.org/docs/rules/prefer-object-spread
      */
-    'prefer-object-spread': Linter.RuleEntry<[]>;
+    "prefer-object-spread": Linter.RuleEntry<[]>;
 
     /**
      * Rule to require quotes around object literal property names.
@@ -1454,33 +1587,38 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/quote-props
      */
-    'quote-props': Linter.RuleEntry<[
-        'always' | 'consistent'
-    ]> | Linter.RuleEntry<[
-        'as-needed',
-        Partial<{
-            /**
-             * @default false
-             */
-            keywords: boolean;
-            /**
-             * @default true
-             */
-            unnecessary: boolean;
-            /**
-             * @default false
-             */
-            numbers: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'consistent-as-needed',
-        Partial<{
-            /**
-             * @default false
-             */
-            keywords: boolean;
-        }>
-    ]>;
+    "quote-props":
+        | Linter.RuleEntry<["always" | "consistent"]>
+        | Linter.RuleEntry<
+              [
+                  "as-needed",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      keywords: boolean;
+                      /**
+                       * @default true
+                       */
+                      unnecessary: boolean;
+                      /**
+                       * @default false
+                       */
+                      numbers: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<
+              [
+                  "consistent-as-needed",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      keywords: boolean;
+                  }>,
+              ]
+          >;
 
     /**
      * Rule to enforce the consistent use of either backticks, double, or single quotes.
@@ -1488,19 +1626,21 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.7
      * @see https://eslint.org/docs/rules/quotes
      */
-    'quotes': Linter.RuleEntry<[
-        'double' | 'single' | 'backtick',
-        Partial<{
-            /**
-             * @default false
-             */
-            avoidEscape: boolean;
-            /**
-             * @default false
-             */
-            allowTemplateLiterals: boolean;
-        }>
-    ]>;
+    quotes: Linter.RuleEntry<
+        [
+            "double" | "single" | "backtick",
+            Partial<{
+                /**
+                 * @default false
+                 */
+                avoidEscape: boolean;
+                /**
+                 * @default false
+                 */
+                allowTemplateLiterals: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow semicolons instead of ASI.
@@ -1508,23 +1648,29 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/semi
      */
-    'semi': Linter.RuleEntry<[
-        'always',
-        Partial<{
-            /**
-             * @default false
-             */
-            omitLastInOneLineBlock: boolean;
-        }>
-    ]> | Linter.RuleEntry<[
-        'never',
-        Partial<{
-            /**
-             * @default 'any'
-             */
-            beforeStatementContinuationChars: 'any' | 'always' | 'never';
-        }>
-    ]>;
+    semi:
+        | Linter.RuleEntry<
+              [
+                  "always",
+                  Partial<{
+                      /**
+                       * @default false
+                       */
+                      omitLastInOneLineBlock: boolean;
+                  }>,
+              ]
+          >
+        | Linter.RuleEntry<
+              [
+                  "never",
+                  Partial<{
+                      /**
+                       * @default 'any'
+                       */
+                      beforeStatementContinuationChars: "any" | "always" | "never";
+                  }>,
+              ]
+          >;
 
     /**
      * Rule to enforce consistent spacing before and after semicolons.
@@ -1532,18 +1678,20 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.16.0
      * @see https://eslint.org/docs/rules/semi-spacing
      */
-    'semi-spacing': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            before: boolean;
-            /**
-             * @default true
-             */
-            after: boolean;
-        }>
-    ]>;
+    "semi-spacing": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                before: boolean;
+                /**
+                 * @default true
+                 */
+                after: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce location of semicolons.
@@ -1551,9 +1699,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.0.0-beta.0
      * @see https://eslint.org/docs/rules/semi-style
      */
-    'semi-style': Linter.RuleEntry<[
-        'last' | 'first'
-    ]>;
+    "semi-style": Linter.RuleEntry<["last" | "first"]>;
 
     /**
      * Rule to require object keys to be sorted.
@@ -1561,23 +1707,25 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.3.0
      * @see https://eslint.org/docs/rules/sort-keys
      */
-    'sort-keys': Linter.RuleEntry<[
-        'asc' | 'desc',
-        Partial<{
-            /**
-             * @default true
-             */
-            caseSensitive: boolean;
-            /**
-             * @default 2
-             */
-            minKeys: number;
-            /**
-             * @default false
-             */
-            natural: boolean;
-        }>
-    ]>;
+    "sort-keys": Linter.RuleEntry<
+        [
+            "asc" | "desc",
+            Partial<{
+                /**
+                 * @default true
+                 */
+                caseSensitive: boolean;
+                /**
+                 * @default 2
+                 */
+                minKeys: number;
+                /**
+                 * @default false
+                 */
+                natural: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require variables within the same declaration block to be sorted.
@@ -1585,14 +1733,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.2.0
      * @see https://eslint.org/docs/rules/sort-vars
      */
-    'sort-vars': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            ignoreCase: boolean;
-        }>
-    ]>;
+    "sort-vars": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                ignoreCase: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing before blocks.
@@ -1600,10 +1750,9 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.9.0
      * @see https://eslint.org/docs/rules/space-before-blocks
      */
-    'space-before-blocks': Linter.RuleEntry<[
-        | 'always' | 'never'
-        | Partial<Record<'functions' | 'keywords' | 'classes', 'always' | 'never' | 'off'>>
-    ]>;
+    "space-before-blocks": Linter.RuleEntry<
+        ["always" | "never" | Partial<Record<"functions" | "keywords" | "classes", "always" | "never" | "off">>]
+    >;
 
     /**
      * Rule to enforce consistent spacing before `function` definition opening parenthesis.
@@ -1611,10 +1760,9 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.18.0
      * @see https://eslint.org/docs/rules/space-before-function-paren
      */
-    'space-before-function-paren': Linter.RuleEntry<[
-        | 'always' | 'never'
-        | Partial<Record<'anonymous' | 'named' | 'asyncArrow', 'always' | 'never' | 'ignore'>>
-    ]>;
+    "space-before-function-paren": Linter.RuleEntry<
+        ["always" | "never" | Partial<Record<"anonymous" | "named" | "asyncArrow", "always" | "never" | "ignore">>]
+    >;
 
     /**
      * Rule to enforce consistent spacing inside parentheses.
@@ -1622,12 +1770,14 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.8.0
      * @see https://eslint.org/docs/rules/space-in-parens
      */
-    'space-in-parens': Linter.RuleEntry<[
-        'never' | 'always',
-        Partial<{
-            exceptions: string[];
-        }>
-    ]>;
+    "space-in-parens": Linter.RuleEntry<
+        [
+            "never" | "always",
+            Partial<{
+                exceptions: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require spacing around infix operators.
@@ -1635,14 +1785,16 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.2.0
      * @see https://eslint.org/docs/rules/space-infix-ops
      */
-    'space-infix-ops': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            int32Hint: boolean;
-        }>
-    ]>;
+    "space-infix-ops": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                int32Hint: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing before or after unary operators.
@@ -1650,19 +1802,21 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.10.0
      * @see https://eslint.org/docs/rules/space-unary-ops
      */
-    'space-unary-ops': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            words: boolean;
-            /**
-             * @default false
-             */
-            nonwords: boolean;
-            overrides: Record<string, boolean>;
-        }>
-    ]>;
+    "space-unary-ops": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default true
+                 */
+                words: boolean;
+                /**
+                 * @default false
+                 */
+                nonwords: boolean;
+                overrides: Record<string, boolean>;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to enforce consistent spacing after the `//` or `/*` in a comment.
@@ -1670,25 +1824,27 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.23.0
      * @see https://eslint.org/docs/rules/spaced-comment
      */
-    'spaced-comment': Linter.RuleEntry<[
-        'always' | 'never',
-        {
-            exceptions: string[];
-            markers: string[];
-            line: {
+    "spaced-comment": Linter.RuleEntry<
+        [
+            "always" | "never",
+            {
                 exceptions: string[];
                 markers: string[];
-            };
-            block: {
-                exceptions: string[];
-                markers: string[];
-                /**
-                 * @default false
-                 */
-                balanced: boolean;
-            };
-        }
-    ]>;
+                line: {
+                    exceptions: string[];
+                    markers: string[];
+                };
+                block: {
+                    exceptions: string[];
+                    markers: string[];
+                    /**
+                     * @default false
+                     */
+                    balanced: boolean;
+                };
+            },
+        ]
+    >;
 
     /**
      * Rule to enforce spacing around colons of switch statements.
@@ -1696,18 +1852,20 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 4.0.0-beta.0
      * @see https://eslint.org/docs/rules/switch-colon-spacing
      */
-    'switch-colon-spacing': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            before: boolean;
-            /**
-             * @default true
-             */
-            after: boolean;
-        }>
-    ]>;
+    "switch-colon-spacing": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                before: boolean;
+                /**
+                 * @default true
+                 */
+                after: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to require or disallow spacing between template tags and their literals.
@@ -1715,9 +1873,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 3.15.0
      * @see https://eslint.org/docs/rules/template-tag-spacing
      */
-    'template-tag-spacing': Linter.RuleEntry<[
-        'never' | 'always'
-    ]>;
+    "template-tag-spacing": Linter.RuleEntry<["never" | "always"]>;
 
     /**
      * Rule to require or disallow Unicode byte order mark (BOM).
@@ -1725,9 +1881,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 2.11.0
      * @see https://eslint.org/docs/rules/unicode-bom
      */
-    'unicode-bom': Linter.RuleEntry<[
-        'never' | 'always'
-    ]>;
+    "unicode-bom": Linter.RuleEntry<["never" | "always"]>;
 
     /**
      * Rule to require parenthesis around regex literals.
@@ -1735,5 +1889,5 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * @since 0.1.0
      * @see https://eslint.org/docs/rules/wrap-regex
      */
-    'wrap-regex': Linter.RuleEntry<[]>;
+    "wrap-regex": Linter.RuleEntry<[]>;
 }

--- a/types/eslint/rules/variables.d.ts
+++ b/types/eslint/rules/variables.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '../index';
+import { Linter } from "../index";
 
 export interface Variables extends Linter.RulesRecord {
     /**
@@ -7,14 +7,16 @@ export interface Variables extends Linter.RulesRecord {
      * @since 1.0.0-rc-1
      * @see https://eslint.org/docs/rules/init-declarations
      */
-    'init-declarations': Linter.RuleEntry<[
-        'always'
-    ]> | Linter.RuleEntry<[
-        'never',
-        Partial<{
-            ignoreForLoopInit: boolean;
-        }>
-    ]>;
+    "init-declarations":
+        | Linter.RuleEntry<["always"]>
+        | Linter.RuleEntry<
+              [
+                  "never",
+                  Partial<{
+                      ignoreForLoopInit: boolean;
+                  }>,
+              ]
+          >;
 
     /**
      * Rule to disallow deleting variables.
@@ -25,7 +27,7 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-delete-var
      */
-    'no-delete-var': Linter.RuleEntry<[]>;
+    "no-delete-var": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow labels that share a name with a variable.
@@ -33,7 +35,7 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-label-var
      */
-    'no-label-var': Linter.RuleEntry<[]>;
+    "no-label-var": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow specified global variables.
@@ -41,12 +43,17 @@ export interface Variables extends Linter.RulesRecord {
      * @since 2.3.0
      * @see https://eslint.org/docs/rules/no-restricted-globals
      */
-    'no-restricted-globals': Linter.RuleEntry<[
-        ...Array<string | {
-            name: string;
-            message?: string;
-        }>
-    ]>;
+    "no-restricted-globals": Linter.RuleEntry<
+        [
+            ...Array<
+                | string
+                | {
+                      name: string;
+                      message?: string;
+                  }
+            >
+        ]
+    >;
 
     /**
      * Rule to disallow variable declarations from shadowing variables declared in the outer scope.
@@ -54,19 +61,21 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-shadow
      */
-    'no-shadow': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            builtinGlobals: boolean;
-            /**
-             * @default 'functions'
-             */
-            hoist: 'functions' | 'all' | 'never';
-            allow: string[];
-        }>
-    ]>;
+    "no-shadow": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                builtinGlobals: boolean;
+                /**
+                 * @default 'functions'
+                 */
+                hoist: "functions" | "all" | "never";
+                allow: string[];
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow identifiers from shadowing restricted names.
@@ -77,7 +86,7 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.1.4
      * @see https://eslint.org/docs/rules/no-shadow-restricted-names
      */
-    'no-shadow-restricted-names': Linter.RuleEntry<[]>;
+    "no-shadow-restricted-names": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of undeclared variables unless mentioned in `global` comments.
@@ -88,14 +97,16 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-undef
      */
-    'no-undef': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default false
-             */
-            typeof: boolean;
-        }>
-    ]>;
+    "no-undef": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                typeof: boolean;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow initializing variables to `undefined`.
@@ -103,7 +114,7 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.6
      * @see https://eslint.org/docs/rules/no-undef-init
      */
-    'no-undef-init': Linter.RuleEntry<[]>;
+    "no-undef-init": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow the use of `undefined` as an identifier.
@@ -111,7 +122,7 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.7.1
      * @see https://eslint.org/docs/rules/no-undefined
      */
-    'no-undefined': Linter.RuleEntry<[]>;
+    "no-undefined": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow unused variables.
@@ -122,29 +133,31 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-unused-vars
      */
-    'no-unused-vars': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default 'all'
-             */
-            vars: 'all' | 'local';
-            varsIgnorePattern: string;
-            /**
-             * @default 'after-used'
-             */
-            args: 'after-used' | 'all' | 'none';
-            /**
-             * @default false
-             */
-            ignoreRestSiblings: boolean;
-            argsIgnorePattern: string;
-            /**
-             * @default 'none'
-             */
-            caughtErrors: 'none' | 'all';
-            caughtErrorsIgnorePattern: string;
-        }>
-    ]>;
+    "no-unused-vars": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default 'all'
+                 */
+                vars: "all" | "local";
+                varsIgnorePattern: string;
+                /**
+                 * @default 'after-used'
+                 */
+                args: "after-used" | "all" | "none";
+                /**
+                 * @default false
+                 */
+                ignoreRestSiblings: boolean;
+                argsIgnorePattern: string;
+                /**
+                 * @default 'none'
+                 */
+                caughtErrors: "none" | "all";
+                caughtErrorsIgnorePattern: string;
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow the use of variables before they are defined.
@@ -152,20 +165,23 @@ export interface Variables extends Linter.RulesRecord {
      * @since 0.0.9
      * @see https://eslint.org/docs/rules/no-use-before-define
      */
-    'no-use-before-define': Linter.RuleEntry<[
-        Partial<{
-            /**
-             * @default true
-             */
-            functions: boolean;
-            /**
-             * @default true
-             */
-            classes: boolean;
-            /**
-             * @default true
-             */
-            variables: boolean;
-        }> | 'nofunc'
-    ]>;
+    "no-use-before-define": Linter.RuleEntry<
+        [
+            | Partial<{
+                  /**
+                   * @default true
+                   */
+                  functions: boolean;
+                  /**
+                   * @default true
+                   */
+                  classes: boolean;
+                  /**
+                   * @default true
+                   */
+                  variables: boolean;
+              }>
+            | "nofunc",
+        ]
+    >;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eslint/eslint/pull/13603
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
