### PR TITLE
Add new exemptions to npm-naming lint rule

### DIFF
--- a/types/babel__standalone/tslint.json
+++ b/types/babel__standalone/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/contentstack/tslint.json
+++ b/types/contentstack/tslint.json
@@ -1,1 +1,7 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}
+

--- a/types/holderjs/tslint.json
+++ b/types/holderjs/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/pollyjs__adapter-xhr/tslint.json
+++ b/types/pollyjs__adapter-xhr/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/react-responsive/tslint.json
+++ b/types/react-responsive/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/react-sparklines/tslint.json
+++ b/types/react-sparklines/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/sql.js/tslint.json
+++ b/types/sql.js/tslint.json
@@ -6,6 +6,7 @@
         "no-duplicate-imports": false,
         "no-single-declare-module": false,
         "strict-export-declare-modifiers": false,
-        "unified-signatures": false
+        "unified-signatures": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }


### PR DESCRIPTION
[New changes to Typescript](https://github.com/microsoft/TypeScript/pull/42751) make it better at figuring out the type of `module.exports`. Unfortunately, it still gets confused by some bundler outputs, which is what the npm-naming rule uses to compare index.d.ts to find out if the types match the original JS well enough.

This PR adds exemptions to the 7 packages that started failing after the linked Typescript PR was merged.
