### PR TITLE
[pino-http] Add raw pino logger typing

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -16,7 +16,10 @@ declare function PinoHttp(opts?: PinoHttp.Options, stream?: DestinationStream): 
 declare function PinoHttp(stream?: DestinationStream): PinoHttp.HttpLogger;
 
 declare namespace PinoHttp {
-    type HttpLogger = (req: IncomingMessage, res: ServerResponse, next?: () => void) => void;
+    interface HttpLogger {
+        (req: IncomingMessage, res: ServerResponse, next?: () => void): void;
+        logger: Logger;
+    }
     type ReqId = number | string | object;
 
     /**

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -21,6 +21,7 @@ function handle_with_next(req: http.IncomingMessage, res: http.ServerResponse, n
 }
 
 pinoHttp({ logger });
+pinoHttp({ logger }).logger = logger;
 pinoHttp({ genReqId: req => req.statusCode || 200 });
 pinoHttp({ genReqId: req => 'foo' });
 pinoHttp({ genReqId: req => Buffer.allocUnsafe(16) });


### PR DESCRIPTION
The default export of the pino-http module is a factory function which, when called, outputs a middleware function. This middleware function actually has a custom property attached to it ("logger") which equals the raw pino logger object used by the middleware. This can be seen here: https://github.com/pinojs/pino-http/blob/master/logger.js#L61

Previously this property was not typed so I have added that typing. I've also added a test and ensured all the tests pass with the new change.