### PR TITLE
@wordpress/date packages date and dateI18n function params type issue…

### DIFF
--- a/types/wordpress__date/index.d.ts
+++ b/types/wordpress__date/index.d.ts
@@ -41,21 +41,30 @@ export interface DateSettings {
  *
  * @param dateFormat - PHP-style formatting string. See {@link https://php.net/date }.
  * @param [dateValue] - Date object or string, parsable by moment.js.
+ * @param [timezone] - Timezone to output result in or a
+ *                     UTC offset. Defaults to timezone from
+ *                     site. Notice: `boolean` is effectively
+ *                     deprecated, but still supported for
+ *                     backward compatibility reasons
  *
  * @returns - Formatted date.
  */
-export function date(dateFormat: string, dateValue?: MomentInput): string;
+export function date(dateFormat: string, dateValue?: MomentInput, timezone?: string|boolean|undefined): string;
 
 /**
  * Formats a date (like `date_i18n()` in PHP).
  *
  * @param dateFormat - PHP-style formatting string. See {@link https://php.net/date }.
  * @param [dateValue] - Date object or string, parsable by moment.js.
- * @param [gmt=false] - `true` for GMT/UTC, `false` for site's timezone.
+ * @param [timezone] - Timezone to output result in or a
+ *                     UTC offset. Defaults to timezone from
+ *                     site. Notice: `boolean` is effectively
+ *                     deprecated, but still supported for
+ *                     backward compatibility reasons
  *
  * @returns - Formatted date.
  */
-export function dateI18n(dateFormat: string, dateValue?: MomentInput, gmt?: boolean): string;
+export function dateI18n(dateFormat: string, dateValue?: MomentInput, timezone?: string|boolean|undefined): string;
 
 /**
  * Formats a date. Does not alter the date's timezone.

--- a/types/wordpress__date/index.d.ts
+++ b/types/wordpress__date/index.d.ts
@@ -49,7 +49,7 @@ export interface DateSettings {
  *
  * @returns - Formatted date.
  */
-export function date(dateFormat: string, dateValue?: MomentInput, timezone?: string|boolean|undefined): string;
+export function date(dateFormat: string, dateValue?: MomentInput, timezone?: string|boolean): string;
 
 /**
  * Formats a date (like `date_i18n()` in PHP).
@@ -64,7 +64,7 @@ export function date(dateFormat: string, dateValue?: MomentInput, timezone?: str
  *
  * @returns - Formatted date.
  */
-export function dateI18n(dateFormat: string, dateValue?: MomentInput, timezone?: string|boolean|undefined): string;
+export function dateI18n(dateFormat: string, dateValue?: MomentInput, timezone?: string|boolean): string;
 
 /**
  * Formats a date. Does not alter the date's timezone.


### PR DESCRIPTION
For [@wordpress/date](https://github.com/WordPress/gutenberg/blob/trunk/packages/date) package, date, and dateI18n functions have a third param that does not exist in Typed, so added it. documentations links below. 

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/WordPress/gutenberg/blob/trunk/packages/date/src/index.js#L431>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.