### PR TITLE
fix(sinon): use sinonjs__fake-timers rather than alias

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -11,7 +11,7 @@
 //                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as FakeTimers from '@sinonjs/fake-timers';
+import * as FakeTimers from 'sinonjs__fake-timers';
 
 // sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used

--- a/types/sinon/tsconfig.json
+++ b/types/sinon/tsconfig.json
@@ -15,11 +15,6 @@
             "../"
         ],
         "types": [],
-        "paths": {
-            "@sinonjs/*": [
-                "sinonjs__*"
-            ]
-        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
https://github.com/sinonjs/fake-timers appears to have added types which are incompatible
with the current implementation in DefinitelyTyped.

CC: @fatso83 

Refs: https://github.com/sinonjs/sinon/issues/2353
Refs: https://github.com/sinonjs/sinon/issues/2352

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.