### PR TITLE
Update sinon to use shipped fake-timers types

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Sinon 9.0
+// Type definitions for Sinon 10.0
 // Project: https://sinonjs.org
 // Definitions by: William Sears <https://github.com/mrbigdog2u>
 //                 Lukas Spieß <https://github.com/lumaxis>

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -775,17 +775,13 @@ declare namespace Sinon {
         (obj: any): SinonMock;
     }
 
-    type SinonTimerId = FakeTimers.TimerId;
-
-    type SinonFakeTimers = FakeTimers.InstalledMethods &
-        FakeTimers.NodeClock &
-        FakeTimers.BrowserClock & {
-            /**
-             * Restore the faked methods.
-             * Call in e.g. tearDown.
-             */
-            restore(): void;
-        };
+    type SinonFakeTimers = FakeTimers.Clock & {
+        /**
+         * Restores the original clock
+         * Identical to uninstall()
+         */
+        restore(): void;
+    };
 
     interface SinonFakeTimersConfig {
         now: number | Date;
@@ -1661,7 +1657,7 @@ declare namespace Sinon {
         expectation: SinonExpectationStatic;
 
         clock: {
-            create(now: number | Date): SinonFakeTimers;
+            create(now: number | Date): FakeTimers.Clock;
         };
 
         FakeXMLHttpRequest: SinonFakeXMLHttpRequestStatic;

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -11,7 +11,7 @@
 //                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as FakeTimers from '@sinonjs/fake-timers';
+import * as FakeTimers from "@sinonjs/fake-timers";
 
 // sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used
@@ -170,7 +170,7 @@ declare namespace Sinon {
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
         extends Pick<
             SinonSpyCallApi<TArgs, TReturnValue>,
-            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, "args">
         > {
         // Properties
         /**
@@ -383,7 +383,7 @@ declare namespace Sinon {
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
 
-        <T, K extends keyof T>(obj: T, method: K, types: Array<'get' | 'set'>): PropertyDescriptor & {
+        <T, K extends keyof T>(obj: T, method: K, types: Array<"get" | "set">): PropertyDescriptor & {
             get: SinonSpy<[], T[K]>;
             set: SinonSpy<[T[K]], void>;
         };
@@ -395,7 +395,7 @@ declare namespace Sinon {
 
     type SinonSpiedMember<T> = T extends (...args: infer TArgs) => infer TReturnValue
         ? SinonSpy<TArgs, TReturnValue>
-         : T;
+        : T;
 
     interface SinonStub<TArgs extends any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
         /**

--- a/types/sinon/package.json
+++ b/types/sinon/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@sinonjs/fake-timers": "^7.0.4"
+    }
+}

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -143,7 +143,7 @@ function testClock() {
     let clock = sinon.clock.create(1000);
     clock = sinon.clock.create(new Date());
 
-    let now: sinon.SinonTimerId = 0;
+    let now: number = 0;
     now = clock.now;
 
     const fn = () => {};
@@ -187,7 +187,6 @@ function testClock() {
     clock.reset();
     clock.runMicrotasks();
     clock.runToFrame();
-    clock.restore();
     clock.uninstall();
     clock.setSystemTime(1000);
     clock.setSystemTime(new Date());

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -143,7 +143,7 @@ function testClock() {
     let clock = sinon.clock.create(1000);
     clock = sinon.clock.create(new Date());
 
-    let now: number = 0;
+    let now = 0;
     now = clock.now;
 
     const fn = () => {};
@@ -154,9 +154,10 @@ function testClock() {
     clock.setImmediate(fn);
     clock.requestAnimationFrame(fn);
 
-    now = clock.setTimeout(fnWithArgs, 0, 1234, 'abc');
-    now = clock.setInterval(fnWithArgs, 0, 1234, 'abc');
-    now = clock.setImmediate(fnWithArgs, 1234, 'abc');
+    // TODO (43081j): uncomment theses when sinon#371 lands
+    // now = clock.setTimeout(fnWithArgs, 0, 1234, 'abc');
+    // now = clock.setInterval(fnWithArgs, 0, 1234, 'abc');
+    // now = clock.setImmediate(fnWithArgs, 1234, 'abc');
 
     let timer = clock.setTimeout(fn, 0);
     clock.clearTimeout(timer);

--- a/types/sinon/tsconfig.json
+++ b/types/sinon/tsconfig.json
@@ -16,9 +16,6 @@
         ],
         "types": [],
         "paths": {
-            "@sinonjs/*": [
-                "sinonjs__*"
-            ]
         },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/fake-timers#help-us-get-our-typescript-definitions-production-ready
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I have:

* Added `@sinonjs/fake-timers` to the dependency whitelist - microsoft/DefinitelyTyped-tools#233
* Pushed a branch to sinon which fixes their JSDoc types - sinonjs/fake-timers#370 (**MUST BE MERGED BEFORE THIS CAN BUILD**)
* Bumped the major version
* Added package.json to depend on `@sinonjs/fake-timers` (the only DT package using it is sinon)

Will also leave some comments where i want feedback.

Draft for now.

**Sinon's own types are a lot weaker than the ones we previously had**, so this will actually introduce _worse_ types but at least they will work. Meanwhile I will contribute up to sinon some better JSDoc types if i can find time, to align with what we used to have.

cc @sandersn hopefully this is what you had in mind in #52294
cc @bcoe 