### PR TITLE
node: Add smart stream.pipeline overloads for [async] iterables

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -224,7 +224,7 @@ function testUtilTypes(
         object; // $ExpectType Boolean
     }
     if (util.types.isBoxedPrimitive(object)) {
-        object; // $ExpectType String | Number | Boolean | BigInt | Symbol
+        object; // $ExpectType String | Number | Boolean | Symbol | BigInt
     }
     if (util.types.isDataView(object)) {
         object; // $ExpectType DataView

--- a/types/node/ts3.6/tsconfig.json
+++ b/types/node/ts3.6/tsconfig.json
@@ -7,7 +7,8 @@
         "module": "commonjs",
         "target": "esnext",
         "lib": [
-            "es6",
+            "es2018",
+            "ES2018.AsyncGenerator",
             "dom"
         ],
         "noImplicitAny": true,


### PR DESCRIPTION
These overloads and their supporting types cover _most_ use cases mentioned in the docs:

* Iterables, AsyncIterables, and functions as sources
* Functions as transforms and destinations
* Promise-returns in the callback and promisify versions

It does not cover using an AbortSignal.

I'm disappointed by the tests I had to write—in my own code, on TypeScript 4.2.3, all the types are automatic and don't have to be specified at all. The tests for ts3.5 or ts3.6 or so failed to pick up the proper parameter type in the destination function, so I had to explicitly declare that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: // https://nodejs.org/api/stream.html#stream_stream_pipeline_source_transforms_destination_callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **No, these features were already in v14.**
