### PR TITLE
fix(react-helmet): introduce state export for `peek`

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -10,29 +10,28 @@
 //                 Andriy2 <https://github.com/Andriy2>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
-import * as React from 'react';
+import * as React from "react";
 
 interface OtherElementAttributes {
     [key: string]: string | number | boolean | null | undefined;
 }
 
-type HtmlProps = JSX.IntrinsicElements['html'] & OtherElementAttributes;
+type HtmlProps = JSX.IntrinsicElements["html"] & OtherElementAttributes;
 
-type BodyProps = JSX.IntrinsicElements['body'] & OtherElementAttributes;
+type BodyProps = JSX.IntrinsicElements["body"] & OtherElementAttributes;
 
-type LinkProps = JSX.IntrinsicElements['link'];
+type LinkProps = JSX.IntrinsicElements["link"];
 
-type MetaProps = JSX.IntrinsicElements['meta'];
+type MetaProps = JSX.IntrinsicElements["meta"];
 
 export interface HelmetTags {
-    baseTag: Array<any>;
-    linkTags: Array<HTMLLinkElement>;
-    metaTags: Array<HTMLMetaElement>;
-    noscriptTags: Array<any>;
-    scriptTags: Array<HTMLScriptElement>;
-    styleTags: Array<HTMLStyleElement>;
+    baseTag: any[];
+    linkTags: HTMLLinkElement[];
+    metaTags: HTMLMetaElement[];
+    noscriptTags: any[];
+    scriptTags: HTMLScriptElement[];
+    styleTags: HTMLStyleElement[];
 }
 
 export interface HelmetProps {
@@ -46,16 +45,27 @@ export interface HelmetProps {
     onChangeClientState?: (newState: any, addedTags: HelmetTags, removedTags: HelmetTags) => void;
     link?: LinkProps[];
     meta?: MetaProps[];
-    noscript?: Array<any>;
-    script?: Array<any>;
-    style?: Array<any>;
+    noscript?: any[];
+    script?: any[];
+    style?: any[];
     title?: string;
-    titleAttributes?: Object;
+    titleAttributes?: object;
     titleTemplate?: string;
 }
 
+/**
+ * Used by Helmet.peek()
+ */
+export type HelmetPropsToState = HelmetTags &
+    Pick<
+        HelmetProps,
+        "bodyAttributes" | "defer" | "htmlAttributes" | "onChangeClientState" | "title" | "titleAttributes"
+    > & {
+        encode: Required<HelmetProps["encodeSpecialCharacters"]>;
+    };
+
 declare class Helmet extends React.Component<HelmetProps> {
-    static peek(): HelmetData;
+    static peek(): HelmetPropsToState;
     static rewind(): HelmetData;
     static renderStatic(): HelmetData;
     static canUseDOM: boolean;
@@ -94,7 +104,4 @@ export interface HelmetHTMLElementDatum {
     toComponent(): React.HTMLAttributes<HTMLHtmlElement>;
 }
 
-export const peek: () => HelmetData;
-export const rewind: () => HelmetData;
-export const renderStatic: () => HelmetData;
 export const canUseDOM: boolean;

--- a/types/react-helmet/react-helmet-tests.tsx
+++ b/types/react-helmet/react-helmet-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { Helmet as HelmedNamedExport, HelmetData } from "react-helmet";
-import Helmet from 'react-helmet';
+import Helmet, { Helmet as HelmedNamedExport, HelmetData } from "react-helmet";
 
 const Application = () =>
     <div className="application">
@@ -124,8 +123,9 @@ function HTML() {
 <Helmet htmlAttributes={{ hidden: 42 }} />;
 // $ExpectError
 <Helmet bodyAttributes={{ hidden: 42 }} />;
-
 // $ExpectError
 <Helmet link={[ invalidProp: 'foo' ]} />;
 // $ExpectError
 <Helmet meta={[ invalidProp: 'foo' ]} />;
+
+Helmet.peek(); // $ExpectType HelmetPropsToState

--- a/types/react-helmet/tslint.json
+++ b/types/react-helmet/tslint.json
@@ -1,9 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "array-type": false,
-        "ban-types": false,
-        "no-duplicate-imports": false,
-        "prefer-declare-function": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Fix longstanding problem:
nfl/react-helmet#578

- export state from Helmet as outcome of `peek` method
- remove bogus exports from module level for `peek`, `rewind` and
  `renderStatic`. Those do not exists at runtime or in native package
- remove DT problematic exclusions and update package
- drop 2.8 TS requirement (now uses defaults)
- run DT default formatter (only on the current version)

This specific detail was used to create the shape:
https://github.com/nfl/react-helmet/blob/master/src/HelmetUtils.js#L209
understanding same is being created by internal implementation.

Thanks!
Fixes #52290
Fixes nfl/react-helmet#578

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.