### PR TITLE
koa router params type and prettier

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -17,7 +17,6 @@
 
  =============================================== */
 
-
 import * as Koa from "koa";
 
 declare namespace Router {
@@ -48,7 +47,7 @@ declare namespace Router {
         /**
          * url params
          */
-        params: any;
+        params: { [key: string]: string };
         /**
          * the router instance
          */
@@ -60,15 +59,19 @@ declare namespace Router {
         _matchedRouteName: string | undefined;
     }
 
-    export type RouterContext<StateT = any, CustomT = {}> =
-        Koa.ParameterizedContext<StateT, CustomT & IRouterParamContext<StateT, CustomT>>;
+    export type RouterContext<StateT = any, CustomT = {}> = Koa.ParameterizedContext<
+        StateT,
+        CustomT & IRouterParamContext<StateT, CustomT>
+    >;
 
     // For backward compatibility IRouterContext needs to be an interface
     // But it's deprecated - please use `RouterContext` instead
     export interface IRouterContext extends RouterContext {}
 
-    export type IMiddleware<StateT = any, CustomT = {}> =
-        Koa.Middleware<StateT, CustomT & IRouterParamContext<StateT, CustomT>>
+    export type IMiddleware<StateT = any, CustomT = {}> = Koa.Middleware<
+        StateT,
+        CustomT & IRouterParamContext<StateT, CustomT>
+    >;
 
     export interface IParamMiddleware<STateT = any, CustomT = {}> {
         (param: string, ctx: RouterContext<STateT, CustomT>, next: () => Promise<any>): any;
@@ -129,7 +132,12 @@ declare namespace Router {
         path: string;
 
         constructor(path: string | RegExp, methods: string[], middleware: Router.IMiddleware, opts?: ILayerOptions);
-        constructor(path: string | RegExp, methods: string[], middleware: Array<Router.IMiddleware>, opts?: ILayerOptions);
+        constructor(
+            path: string | RegExp,
+            methods: string[],
+            middleware: Array<Router.IMiddleware>,
+            opts?: ILayerOptions,
+        );
 
         /**
          * Returns whether request `path` matches route.
@@ -201,12 +209,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     get<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -225,12 +233,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     post<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -249,12 +257,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     put<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -273,12 +281,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     link<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -297,12 +305,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     unlink<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -321,12 +329,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     delete<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -345,12 +353,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     del<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -369,12 +377,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     head<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -393,12 +401,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     options<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -417,12 +425,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     patch<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -441,12 +449,12 @@ declare class Router<StateT = any, CustomT = {}> {
         name: string,
         path: string | RegExp,
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
     all<T, U>(
         path: string | RegExp | (string | RegExp)[],
         middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>,
     ): Router<StateT & T, CustomT & U>;
 
     /**
@@ -469,9 +477,7 @@ declare class Router<StateT = any, CustomT = {}> {
      * an `Allow` header containing the allowed methods, as well as responding
      * with `405 Method Not Allowed` and `501 Not Implemented` as appropriate.
      */
-    allowedMethods(
-        options?: Router.IRouterAllowedMethodsOptions
-    ): Router.IMiddleware<StateT, CustomT>;
+    allowedMethods(options?: Router.IRouterAllowedMethodsOptions): Router.IMiddleware<StateT, CustomT>;
 
     /**
      * Redirect `source` to `destination` URL with optional 30x status `code`.

--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -47,7 +47,7 @@ declare namespace Router {
         /**
          * url params
          */
-        params: { [key: string]: string };
+        params: Record<string, string>;
         /**
          * the router instance
          */


### PR DESCRIPTION
koa router params should always return string.

I think this should not be any


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ZijianHe/koa-router/blob/49498ff35138edb218b90b58dd99dfe9b53ae916/lib/layer.js#L74-L85
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
