### PR TITLE
[three]OrbitControls/TrackballControls: Change the attribute type of keys from number to string

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -43,7 +43,7 @@ export class OrbitControls {
     autoRotateSpeed: number;
 
     enableKeys: boolean;
-    keys: { LEFT: number; UP: number; RIGHT: number; BOTTOM: number };
+    keys: { LEFT: string; UP: string; RIGHT: string; BOTTOM: string };
     mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
     touches: { ONE: TOUCH; TWO: TOUCH };
 

--- a/types/three/examples/jsm/controls/TrackballControls.d.ts
+++ b/types/three/examples/jsm/controls/TrackballControls.d.ts
@@ -20,7 +20,7 @@ export class TrackballControls extends EventDispatcher {
     dynamicDampingFactor: number;
     minDistance: number;
     maxDistance: number;
-    keys: number[];
+    keys: string[];
     mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
 
     target: Vector3;


### PR DESCRIPTION
Three.js r127

OrbitControls/TrackballControls: Replace `Event.keyCode` with `Event.code`.



<br>

[OrbitControls.js](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/controls/OrbitControls.js)

```diff
-    this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+    this.keys = { LEFT: 'ArrowLeft', UP: 'ArrowUp', RIGHT: 'ArrowRight', BOTTOM: 'ArrowDown' };
```



[TrackballControls.js](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/controls/TrackballControls.js)

```diff
-	this.keys = [ 65 /*A*/, 83 /*S*/, 68 /*D*/ ];
+	this.keys = [ 'KeyA' /*A*/, 'KeyS' /*S*/, 'KeyD' /*D*/ ];
```



<br>

so...



changing an existing definition:

- [ ] https://github.com/DefinitelyTyped/DefinitelyTyped/edit/master/types/three/examples/jsm/controls/OrbitControls.d.ts

  ```diff
  -    keys: { LEFT: number; UP: number; RIGHT: number; BOTTOM: number };
  +    keys: { LEFT: string; UP: string; RIGHT: string; BOTTOM: string };
  ```

  

- [ ] https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/three/examples/jsm/controls/TrackballControls.d.ts

  ```diff
  -    keys: number[];
  +    keys: string[];
  ```

  

