### PR TITLE
Remove body-parser deprecation label

### DIFF
--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -16,7 +16,6 @@ import * as http from 'http';
 
 // for docs go to https://github.com/expressjs/body-parser/tree/1.19.0#body-parser
 
-/** @deprecated */
 declare function bodyParser(
     options?: bodyParser.OptionsJson & bodyParser.OptionsText & bodyParser.OptionsUrlencoded,
 ): NextHandleFunction;


### PR DESCRIPTION
See mentions in [Issue #428](https://github.com/expressjs/body-parser/issues/428) of the [expressjs/body-parser](https://github.com/expressjs/express) repo.

Since the body-parser repo does not mention any deprecation or pause of development...was this an error?
Apologies if this PR is a waste of time, but could shed some light to a lot of people's confusion.