### PR TITLE
Update tap definitions from v14.10 to v15.0

### DIFF
--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -41,6 +41,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
     addAssert(name: string, length: number, fn: (...args: any[]) => boolean): boolean;
     comment(message: string, ...args: any[]): void;
     bailout(message?: string): void;
+
     beforeEach(fn: (done: () => void, childTest: Test) => void | Promise<void>): void;
     afterEach(fn: (done: () => void, childTest: Test) => void | Promise<void>): void;
 
@@ -61,25 +62,36 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     // Assertions
 
-    // Verifies that the object is truthy.
+    /**
+     * Verifies that the object is truthy.
+     */
     ok: Assertions.Basic;
 
-
-    // Verifies that the object is not truthy.
+    /**
+     * Verifies that the object is not truthy.
+     */
     notOk: Assertions.Basic;
-    
 
-    // If the object is an error, then the assertion fails.
-    // Note: if an error is encountered unexpectedly, it's often better to simply throw it. The Test object will handle this as a failure.
+    /**
+     * If the object is an error, then the assertion fails.
+     * 
+     * Note: if an error is encountered unexpectedly,
+     * it's often better to simply throw it. The Test object will handle this as a failure.
+     */
     error: Assertions.Basic;
     
 
-    // Verify that the event emitter emits the named event before the end of the test.
+    /**
+     * Verify that the event emitter emits the named event before the end of the test.
+     */
     emits(eventEmitter: EventEmitter, event: string, message?: string, extra?: Options.Assert): void;
 
-    // Verifies that the promise (or promise-returning function) rejects. If an expected error is provided, then also verify that the rejection matches the expected error.
-    // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
-    // Instead, it returns a Promise that resolves when it is completed.
+    /**
+     * Verifies that the promise (or promise-returning function) rejects.
+     * 
+     * If an expected error is provided,
+     * then also verify that the rejection matches the expected error.
+     */
     rejects(
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         expectedError: Error,
@@ -92,18 +104,22 @@ declare class Test extends DeprecatedAssertionSynonyms {
         extra?: Options.Assert,
     ): Promise<void>;
 
-    // Verifies that the promise (or promise-returning function) resolves, making no expectation about the value that the promise resolves to.
-    // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
-    // Instead, it returns a Promise that resolves when it is completed.
+    /**
+     * Verifies that the promise (or promise-returning function) resolves,
+     * making no expectation about the value that the promise resolves to.
+     */
     resolves(
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         message?: string,
         extra?: Options.Assert,
     ): Promise<void>;
 
-    // Verifies that the promise (or promise-returning function) resolves, and furthermore that the value of the promise matches the wanted pattern using match.
-    // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
-    // Instead, it returns a Promise that resolves when it is completed.
+    /**
+     * Verifies that the promise (or promise-returning function) resolves
+     * and that the value of the promise matches the wanted pattern using t.match.
+     * 
+     * @see match
+     */
     resolveMatch(
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         wanted: string | RegExp | { [key: string]: RegExp },
@@ -121,39 +137,49 @@ declare class Test extends DeprecatedAssertionSynonyms {
     ): Promise<void>;
 
     // As of version 11, tap supports saving and then comparing against "snapshot" strings. This is a powerful technique for testing programs that generate output, but it comes with some caveats.
-    matchSnapshot(output: any, message?: string, extra?: Options.Assert): boolean;
 
-    // Expect the function to throw an error. If an expected error is provided, then also verify that the thrown error matches the expected error.
-    // If the expected error is an object, then it's matched against the thrown error using t.match(er, expectedError). If it's a function, then the error is asserted to be a member of that class.
-    // If the function has a name, and the message is not provided, then the function name will be used as the message.
-    // If the function is not provided, then this will be treated as a todo test.
-    // Caveat: if you pass a extra object to t.throws, then you MUST also pass in an expected error, or else it will read the diag object as the expected error, and get upset when your thrown error
-    // doesn't match {skip:true} or whatever.
-    // For example, this will not work as expected:
-    // // anti-example, do not use!
-    // t.throws(function() {throw new Error('x')}, { skip: true })
-    // But this is fine:
-    // // this example is ok to use.
-    // // note the empty 'expected error' object.
-    // // since it has no fields, it'll only verify that the thrown thing is
-    // // an object, not the value of any properties
-    // t.throws(function() {throw new Error('x')}, {}, { skip: true })
-    // The expected error is tested against the throw error using t.match, so regular expressions and the like are fine. If the expected error is an Error object, then the stack field is ignored,
-    // since that will generally never match.
+    // this function does not exist anymore? atleast, it's not documented. - zkldi
+    // matchSnapshot(output: any, message?: string, extra?: Options.Assert): boolean;
+
+    /**
+     * Expect the function to throw an error.
+     * If an expected error is provided, then also verify that the thrown error
+     * matches the expected error.
+     * 
+     * If the function has a name, and the message is not provided,
+     * then the function name will be used as the message.
+     * 
+     * If the function is not provided, then this will be treated as a todo test.
+     */
     throws: Assertions.Throws;
 
-    // Verify that the provided function does not throw.
-    // If the function has a name, and the message is not provided, then the function name will be used as the message.
-    // If the function is not provided, then this will be treated as a todo test.
-    // Note: if an error is encountered unexpectedly, it's often better to simply throw it. The Test object will handle this as a failure.
+    /**
+     * Verify that the provided function does not throw.
+     * 
+     * If the function has a name, and the message is not provided,
+     * then the function name will be used as the message.
+     * 
+     * If the function is not provided, then this will be treated as a todo test.
+     * 
+     * Note: If an error is encountered unexpectedly,
+     * it's often better to simply throw it. The Test object will handle this as a failure.
+     */
     doesNotThrow: Assertions.DoesNotThrow;
 
-    // Expect the function to throw an uncaught exception at some point in the future, before the test ends. If the test ends without having thrown the expected error, then the test fails.
-    // This is useful for verifying that an error thrown in some part of your code will not be handled, which would normally result in a program crash, and verify behavior in those scenarios.
-    // If the error is thrown synchronously, or within a promise, then the t.throws() or t.rejects() methods are more appropriate.
-    // If called multiple times, then the uncaught exception errors must be emitted in the order called.
-    // Note: This method will not properly link a thrown error to the correct test object in some cases involving native modules on Node version 8, because the async_hooks module does not track
-    // the execution context ID across native boundaries.
+    /**
+     * Expect the function to throw an uncaught exception at some point in the future,
+     * before the test ends.
+     * If the test ends without having thrown the expected error, then the test fails.
+     * 
+     * If the error is thrown synchronously, or within a promise,
+     * then the t.throws() or t.rejects() methods are more appropriate.
+     * 
+     * If called multiple times, then the uncaught exception errors must be emitted in the order called.
+     * 
+     * This method will NOT properly link a thrown error to the correct test object
+     * in some cases involving native modules on Node version 8.
+     * @see {@link https://node-tap.org/docs/api/asserts/#texpectuncaughtexceptionfn-expectederror-message-extra}
+     */
     expectUncaughtException(
         fn?: (...args: any[]) => any,
         expectedError?: Error,
@@ -161,32 +187,57 @@ declare class Test extends DeprecatedAssertionSynonyms {
         extra?: Options.Assert,
     ): boolean;
 
-    // Verify that the object found is exactly the same (that is, ===) to the object that is wanted.
+    /**
+     * Verify that the object found is exactly the same (that is, ===)
+     * to the object that is wanted.
+     */
     equal: Assertions.Equal;
 
-    // Inverse of t.equal().
-    // Verify that the object found is not exactly the same (that is, !==) as the object that is wanted.
+    /**
+     * Inverse of t.equal().
+     * 
+     * Verify that the object found is not exactly the same (that is, !==)
+     * as the object that is wanted.
+     */
     not: Assertions.NotEqual;
 
-    // Verify that the found object is deeply equivalent to the wanted object. Use non-strict equality for scalars (ie, ==). See: tcompare
+    /**
+     * Verify that the found object is deeply equivalent to the wanted object.
+     * 
+     * Uses non-strict equality for scalars (ie, ==).
+     */
     same: Assertions.Equal;
 
-    // Inverse of t.same().
-    // Verify that the found object is not deeply equivalent to the unwanted object. Uses non-strict inequality (ie, !=) for scalars.
+    /**
+     * Inverse of t.same().
+     * 
+     * Verify that the found object is not deeply equivalent to the unwanted object.
+     * Uses non-strict inequality (ie, !=) for scalars.
+     */
     notSame: Assertions.NotEqual;
 
-    // Strict version of t.same().
-    // Verify that the found object is deeply equivalent to the wanted object. Use strict equality for scalars (ie, ===).
+    /**
+     * Strict version of t.same().
+     * 
+     * Verify that the found object is deeply equivalent to the wanted object.
+     * Uses strict equality for scalars (ie, ===).
+     */
     strictSame: Assertions.Equal;
 
-    // Inverse of t.strictSame().
-    // Verify that the found object is not deeply equivalent to the unwanted object. Use strict equality for scalars (ie, ===).
+    /**
+     * Inverse of t.strictSame().
+     * 
+     * Verify that the found object is not deeply equivalent to the unwanted object.
+     * Uses strict equality for scalars (ie, ===).
+     */
     strictNotSame: Assertions.NotEqual;
 
-    // Verify that the found object contains all of the provided fields, and that they are of the same type and value as the pattern provided.
-    // This does not do advanced/loose matching based on constructor, regexp patterns, and so on, like t.match() does. You may specify key: undefined in the pattern to ensure that a field is not
-    // defined in the found object, but it will not differentiate between a missing property and a property set to undefined.
-    // Note that t.has(), the un-strict version of this function, is an alias for t.match().
+    /**
+     * Verify that the found object contains all of the provided fields,
+     * and that they are of the same type and value as the pattern provided.
+     * 
+     * @see has
+     */
     hasStrict: Assertions.Match;
 
     /**
@@ -195,9 +246,10 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * If pattern is a regular expression, and found is a string, then verify that the string matches the pattern.
      * If the pattern is a string, and found is a string, then verify that the pattern occurs within the string somewhere.
      * If pattern is an object, then verify that all of the (enumerable) fields in the pattern match the corresponding fields in the object using this same algorithm.
-     * @example {x:/a[sdf]{3}/} would successfully match {x:'asdf',y:'z'}.
      * 
      * This is useful when you want to verify that an object has a certain set of required fields, but additional fields are ok.
+     * 
+     * @example {x:/a[sdf]{3}/} would successfully match {x:'asdf',y:'z'}.
      */
     match: Assertions.Match;
 
@@ -210,16 +262,24 @@ declare class Test extends DeprecatedAssertionSynonyms {
      */
     has: Assertions.Match;
 
-    // Inverse of match()
-    // Verify that the found object does not match the pattern provided.
+    /**
+     * Inverse of match().
+     * 
+     * Verify that the found object does not match the pattern provided.
+     */
     notMatch: Assertions.Match;
 
-    // Verify that the object is of the type provided.
-    // Type can be a string that matches the typeof value of the object, or the string name of any constructor in the object's prototype chain, or a constructor function in the
-    // object's prototype chain. For example, all the following will pass:
-    // t.type(new Date(), 'object');
-    // t.type(new Date(), 'Date');
-    // t.type(new Date(), Date);
+    /**
+     * Verify that the object is of the type provided.
+     * 
+     * Type can be a string that matches the typeof value of the object,
+     * or the string name of any constructor in the object's prototype chain,
+     * or a constructor function in the object's prototype chain.
+     * 
+     * @example type(new Date(), "object") - true
+     * @example type(new Date(), "Date") - true
+     * @example type(new Date(), Date) - true
+     */
     type: Assertions.Type;
 }
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -63,17 +63,52 @@ declare class Test extends DeprecatedAssertionSynonyms {
      */
     plan(n: number, comment?: string): void;
 
+    /**
+     * Call when tests are done running. This is not necessary if t.plan() was used, 
+     * or if the test function returns a Promise.
+     * 
+     * If you call t.end() explicitly more than once, an error will be raised.
+     */
     end(): void;
 
+    /**
+     * Create a subtest.
+     * 
+     * Returns a Promise which resolves with the parent when the child test is completed.
+     * @param name - The name for this subtest.
+     * @param extra - Any options this subtest should adhere to.
+     * @param cb - The function containing the sub-tests. If not present, the test
+     * will automatically be marked as a todo.
+     */
     test(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
+
+    /**
+     * Create a subtest.
+     * 
+     * Returns a Promise which resolves with the parent when the child test is completed.
+     * @param name - The name for this subtest.
+     * @param cb - The function containing the sub-tests. If not present, the test
+     * will automatically be marked as a todo.
+     */
     test(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
 
+    /**
+     * Exactly the same as t.test(), but adds todo: true in the options.
+     */
     todo(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     todo(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
 
+    /**
+     * Exactly the same as t.test(), but adds skip: true in the options.
+     */
     skip(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     skip(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
 
+    /**
+     * Exactly the same as t.test(), but adds only: true in the options.
+     * 
+     * @see {@link https://node-tap.org/docs/api/only}
+     */
     only(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     only(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
 
@@ -103,8 +138,8 @@ declare class Test extends DeprecatedAssertionSynonyms {
      */
     bailout(reason?: string): void;
 
-    beforeEach(fn: (done: () => void, childTest: Test) => void | Promise<void>): void;
-    afterEach(fn: (done: () => void, childTest: Test) => void | Promise<void>): void;
+    beforeEach(fn: () => void | Promise<void>): void;
+    afterEach(fn: () => void | Promise<void>): void;
 
     cleanSnapshot: (s: string) => string;
     formatSnapshot: (obj: any) => string;

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -139,8 +139,6 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     done(): void;
 
-    assertAt
-
     /**
      * Return true if everything so far is ok.
      */
@@ -375,8 +373,12 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     // As of version 11, tap supports saving and then comparing against "snapshot" strings. This is a powerful technique for testing programs that generate output, but it comes with some caveats.
 
-    // this function does not exist anymore? atleast, it's not documented. - zkldi
-    // matchSnapshot(output: any, message?: string, extra?: Options.Assert): boolean;
+    /**
+     * Checks if the output in data matches the data with this snapshot name.
+     * 
+     * @see {@link https://node-tap.org/docs/api/snapshot-testing/}
+     */
+    matchSnapshot(output: any, message?: string, extra?: Options.Assert): boolean;
 
     /**
      * Expect the function to throw an error.
@@ -514,15 +516,6 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * @example type(new Date(), Date) - true
      */
     type: Assertions.Type;
-
-    // this is not in the documentation anymore?
-    
-    /**
-     * Checks if the output in data matches the data with this snapshot name.
-     * 
-     * @see {@link https://node-tap.org/docs/api/snapshot-testing/}
-     */
-    matchSnapshot: (data: any, snapshotName: string) => boolean;
 }
 
 /**

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -309,10 +309,6 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * then the t.throws() or t.rejects() methods are more appropriate.
      * 
      * If called multiple times, then the uncaught exception errors must be emitted in the order called.
-     * 
-     * This method will NOT properly link a thrown error to the correct test object
-     * in some cases involving native modules on Node version 8.
-     * @see {@link https://node-tap.org/docs/api/asserts/#texpectuncaughtexceptionfn-expectederror-message-extra}
      */
     expectUncaughtException(
         fn?: (...args: any[]) => any,

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -61,7 +61,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * 
      * This may only be called before running any asserts or child tests.
      */
-    plan(n: number, comment?: string): void;
+    plan(n: number): void;
 
     end(): void;
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for tap 14.10
+// Type definitions for tap 15.0.1
 // Project: https://github.com/tapjs/node-tap
 // Definitions by: Tomas Della Vedova <https://github.com/delvedor>
 //                 Ulf Winkelvos <https://github.com/uwinkelvos>
+//                 zkldi <https://github.com/zkldi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TODO: can be removed as soon as https://github.com/tapjs/node-tap/pull/607 is merged
@@ -12,7 +13,7 @@ import { EventEmitter } from 'events';
 declare const tap: Tap;
 export = tap;
 
-declare class Test {
+declare class Test extends DeprecatedAssertionSynonyms {
     constructor(options?: Options.Test);
     tearDown(fn: () => void | Promise<void>): void;
     teardown(fn: () => void | Promise<void>): void;
@@ -62,19 +63,16 @@ declare class Test {
 
     // Verifies that the object is truthy.
     ok: Assertions.Basic;
-    true: Assertions.Basic;
-    assert: Assertions.Basic;
+
 
     // Verifies that the object is not truthy.
     notOk: Assertions.Basic;
-    false: Assertions.Basic;
-    assertNot: Assertions.Basic;
+    
 
     // If the object is an error, then the assertion fails.
     // Note: if an error is encountered unexpectedly, it's often better to simply throw it. The Test object will handle this as a failure.
     error: Assertions.Basic;
-    ifErr: Assertions.Basic;
-    ifError: Assertions.Basic;
+    
 
     // Verify that the event emitter emits the named event before the end of the test.
     emits(eventEmitter: EventEmitter, event: string, message?: string, extra?: Options.Assert): void;
@@ -143,14 +141,12 @@ declare class Test {
     // The expected error is tested against the throw error using t.match, so regular expressions and the like are fine. If the expected error is an Error object, then the stack field is ignored,
     // since that will generally never match.
     throws: Assertions.Throws;
-    throw: Assertions.Throws;
 
     // Verify that the provided function does not throw.
     // If the function has a name, and the message is not provided, then the function name will be used as the message.
     // If the function is not provided, then this will be treated as a todo test.
     // Note: if an error is encountered unexpectedly, it's often better to simply throw it. The Test object will handle this as a failure.
     doesNotThrow: Assertions.DoesNotThrow;
-    notThrow: Assertions.DoesNotThrow;
 
     // Expect the function to throw an uncaught exception at some point in the future, before the test ends. If the test ends without having thrown the expected error, then the test fails.
     // This is useful for verifying that an error thrown in some part of your code will not be handled, which would normally result in a program crash, and verify behavior in those scenarios.
@@ -167,68 +163,25 @@ declare class Test {
 
     // Verify that the object found is exactly the same (that is, ===) to the object that is wanted.
     equal: Assertions.Equal;
-    equals: Assertions.Equal;
-    isEqual: Assertions.Equal;
-    is: Assertions.Equal;
-    strictEqual: Assertions.Equal;
-    strictEquals: Assertions.Equal;
-    strictIs: Assertions.Equal;
-    isStrict: Assertions.Equal;
-    isStrictly: Assertions.Equal;
 
     // Inverse of t.equal().
     // Verify that the object found is not exactly the same (that is, !==) as the object that is wanted.
-    notEqual: Assertions.NotEqual;
-    notEquals: Assertions.NotEqual;
-    inequal: Assertions.NotEqual;
-    notStrictEqual: Assertions.NotEqual;
-    notStrictEquals: Assertions.NotEqual;
-    isNotEqual: Assertions.NotEqual;
-    isNot: Assertions.NotEqual;
-    doesNotEqual: Assertions.NotEqual;
-    isInequal: Assertions.NotEqual;
+    not: Assertions.NotEqual;
 
     // Verify that the found object is deeply equivalent to the wanted object. Use non-strict equality for scalars (ie, ==). See: tcompare
     same: Assertions.Equal;
-    equivalent: Assertions.Equal;
-    looseEqual: Assertions.Equal;
-    looseEquals: Assertions.Equal;
-    deepEqual: Assertions.Equal;
-    deepEquals: Assertions.Equal;
-    isLoose: Assertions.Equal;
-    looseIs: Assertions.Equal;
 
     // Inverse of t.same().
     // Verify that the found object is not deeply equivalent to the unwanted object. Uses non-strict inequality (ie, !=) for scalars.
     notSame: Assertions.NotEqual;
-    inequivalent: Assertions.NotEqual;
-    looseInequal: Assertions.NotEqual;
-    notDeep: Assertions.NotEqual;
-    deepInequal: Assertions.NotEqual;
-    notLoose: Assertions.NotEqual;
-    looseNot: Assertions.NotEqual;
 
     // Strict version of t.same().
     // Verify that the found object is deeply equivalent to the wanted object. Use strict equality for scalars (ie, ===).
     strictSame: Assertions.Equal;
-    strictEquivalent: Assertions.Equal;
-    strictDeepEqual: Assertions.Equal;
-    sameStrict: Assertions.Equal;
-    deepIs: Assertions.Equal;
-    isDeeply: Assertions.Equal;
-    isDeep: Assertions.Equal;
-    strictDeepEquals: Assertions.Equal;
 
     // Inverse of t.strictSame().
     // Verify that the found object is not deeply equivalent to the unwanted object. Use strict equality for scalars (ie, ===).
     strictNotSame: Assertions.NotEqual;
-    strictInequivalent: Assertions.NotEqual;
-    strictDeepInequal: Assertions.NotEqual;
-    notSameStrict: Assertions.NotEqual;
-    deepNot: Assertions.NotEqual;
-    notDeeply: Assertions.NotEqual;
-    strictDeepInequals: Assertions.NotEqual;
-    notStrictSame: Assertions.NotEqual;
 
     // Verify that the found object contains all of the provided fields, and that they are of the same type and value as the pattern provided.
     // This does not do advanced/loose matching based on constructor, regexp patterns, and so on, like t.match() does. You may specify key: undefined in the pattern to ensure that a field is not
@@ -236,37 +189,30 @@ declare class Test {
     // Note that t.has(), the un-strict version of this function, is an alias for t.match().
     hasStrict: Assertions.Match;
 
-    // Verify that the found object matches the pattern provided.
-    // If pattern is a regular expression, and found is a string, then verify that the string matches the pattern.
-    // If the pattern is a string, and found is a string, then verify that the pattern occurs within the string somewhere.
-    // If pattern is an object, then verify that all of the (enumerable) fields in the pattern match the corresponding fields in the object using this same algorithm. For example, the pattern
-    // // {x:/a[sdf]{3}/} would successfully match {x:'asdf',y:'z'}.
-    // This is useful when you want to verify that an object has a certain set of required fields, but additional fields are ok.
-    // See tcompare for the full details on how this works.
+    /**
+     * Verify that the found object matches the pattern provided.
+     * 
+     * If pattern is a regular expression, and found is a string, then verify that the string matches the pattern.
+     * If the pattern is a string, and found is a string, then verify that the pattern occurs within the string somewhere.
+     * If pattern is an object, then verify that all of the (enumerable) fields in the pattern match the corresponding fields in the object using this same algorithm.
+     * @example {x:/a[sdf]{3}/} would successfully match {x:'asdf',y:'z'}.
+     * 
+     * This is useful when you want to verify that an object has a certain set of required fields, but additional fields are ok.
+     */
     match: Assertions.Match;
+
+    /**
+     * Verify that the found object contains all of the provided fields, and that they coerce to the same values, even if the types do not match.
+     * 
+     * This does not do advanced/loose matching based on constructor, regexp patterns, and so on, like t.match() does.
+     * You may specify key: undefined in the pattern to ensure that a field is not defined in the found object,
+     * but it will not differentiate between a missing property and a property set to undefined.
+     */
     has: Assertions.Match;
-    hasFields: Assertions.Match;
-    matches: Assertions.Match;
-    similar: Assertions.Match;
-    like: Assertions.Match;
-    isLike: Assertions.Match;
-    includes: Assertions.Match;
-    include: Assertions.Match;
-    contains: Assertions.Match;
 
     // Inverse of match()
     // Verify that the found object does not match the pattern provided.
     notMatch: Assertions.Match;
-    dissimilar: Assertions.Match;
-    unsimilar: Assertions.Match;
-    notSimilar: Assertions.Match;
-    unlike: Assertions.Match;
-    isUnlike: Assertions.Match;
-    notLike: Assertions.Match;
-    isNotLike: Assertions.Match;
-    doesNotHave: Assertions.Match;
-    isNotSimilar: Assertions.Match;
-    isDissimilar: Assertions.Match;
 
     // Verify that the object is of the type provided.
     // Type can be a string that matches the typeof value of the object, or the string name of any constructor in the object's prototype chain, or a constructor function in the
@@ -275,8 +221,318 @@ declare class Test {
     // t.type(new Date(), 'Date');
     // t.type(new Date(), Date);
     type: Assertions.Type;
+}
+
+/**
+ * Tap v15 deprecates **ALL** synonyms for assertions.
+ */
+declare class DeprecatedAssertionSynonyms {
+    /**
+     * @deprecated use ok() instead.
+     */
+    true: Assertions.Basic;
+    /**
+     * @deprecated use ok() instead.
+     */
+    assert: Assertions.Basic;
+
+    /**
+     * @deprecated use notOk() instead.
+     */
+     false: Assertions.Basic;
+     /**
+      * @deprecated use assertNot() instead.
+      */
+     assertNot: Assertions.Basic;
+
+     /**
+     * @deprecated use error() instead.
+     */
+    ifErr: Assertions.Basic;
+    /**
+     * @deprecated use error() instead.
+     */
+    ifError: Assertions.Basic;
+
+    /**
+     * @deprecated use doesNotThrow() instead.
+     */
+     notThrow: Assertions.DoesNotThrow;
+
+     /**
+     * @deprecated use throws() instead.
+     */
+    throw: Assertions.Throws;
+
+    /**
+     * @deprecated use equal() instead.
+     */
+     equals: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     isEqual: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     is: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     strictEqual: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     strictEquals: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     strictIs: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     isStrict: Assertions.Equal;
+     /**
+      * @deprecated use equal() instead.
+      */
+     isStrictly: Assertions.Equal;
+
+     /**
+     * @deprecated use not() instead.
+     */
+    notEqual: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    notEquals: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    inequal: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    notStrictEqual: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    notStrictEquals: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    isNotEqual: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    isNot: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    doesNotEqual: Assertions.NotEqual;
+    /**
+     * @deprecated use not() instead.
+     */
+    isInequal: Assertions.NotEqual;
+
+    /**
+         * @deprecated use same() instead.
+         */
+    equivalent: Assertions.Equal;
+    /**
+     * @deprecated use same() instead.
+     */
+    looseEqual: Assertions.Equal;
+    /**
+     * @deprecated use same() instead.
+     */
+    looseEquals: Assertions.Equal;
+    /**
+     * @deprecated use same() instead.
+     */
+    deepEqual: Assertions.Equal;
+    /**
+     * @deprecated use same() instead.
+     */
+    deepEquals: Assertions.Equal;
+    /**
+     * @deprecated use same() instead.
+     */
+    isLoose: Assertions.Equal;
+    /**
+     * @deprecated use same() instead.
+     */
+    looseIs: Assertions.Equal;
+
+        /**
+     * @deprecated use notSame() instead.
+     */
+         inequivalent: Assertions.NotEqual;
+         /**
+          * @deprecated use notSame() instead.
+          */
+         looseInequal: Assertions.NotEqual;
+         /**
+          * @deprecated use notSame() instead.
+          */
+         notDeep: Assertions.NotEqual;
+         /**
+          * @deprecated use notSame() instead.
+          */
+         deepInequal: Assertions.NotEqual;
+         /**
+          * @deprecated use notSame() instead.
+          */
+         notLoose: Assertions.NotEqual;
+         /**
+          * @deprecated use notSame() instead.
+          */
+         looseNot: Assertions.NotEqual;
+
+    /**
+     * @deprecated use strictSame() instead.
+     */
+     strictEquivalent: Assertions.Equal;
+     /**
+      * @deprecated use strictSame() instead.
+      */
+     strictDeepEqual: Assertions.Equal;
+     /**
+      * @deprecated use strictSame() instead.
+      */
+     sameStrict: Assertions.Equal;
+     /**
+      * @deprecated use strictSame() instead.
+      */
+     deepIs: Assertions.Equal;
+     /**
+      * @deprecated use strictSame() instead.
+      */
+     isDeeply: Assertions.Equal;
+     /**
+      * @deprecated use strictSame() instead.
+      */
+     isDeep: Assertions.Equal;
+     /**
+      * @deprecated use strictSame() instead.
+      */
+     strictDeepEquals: Assertions.Equal;
+
+    /**
+     * @deprecated use strictNotSame() instead.
+     */
+     strictInequivalent: Assertions.NotEqual;
+     /**
+      * @deprecated use strictNotSame() instead.
+      */
+     strictDeepInequal: Assertions.NotEqual;
+     /**
+      * @deprecated use strictNotSame() instead.
+      */
+     notSameStrict: Assertions.NotEqual;
+     /**
+      * @deprecated use strictNotSame() instead.
+      */
+     deepNot: Assertions.NotEqual;
+     /**
+      * @deprecated use strictNotSame() instead.
+      */
+     notDeeply: Assertions.NotEqual;
+     /**
+      * @deprecated use strictNotSame() instead.
+      */
+     strictDeepInequals: Assertions.NotEqual;
+     /**
+      * @deprecated use strictNotSame() instead.
+      */
+     notStrictSame: Assertions.NotEqual;
+
+         /**
+     * @deprecated use match() instead.
+     */
+    matches: Assertions.Match;
+    /**
+     * @deprecated use match() instead.
+     */
+    similar: Assertions.Match;
+    /**
+     * @deprecated use match() instead.
+     */
+    like: Assertions.Match;
+    /**
+     * @deprecated use match() instead.
+     */
+    isLike: Assertions.Match;
+    /**
+     * @deprecated use match() instead.
+     */
+    isSimilar: Assertions.Match;
+
+    /**
+     * @deprecated use notMatch() instead.
+     */
+     dissimilar: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     unsimilar: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     notSimilar: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     unlike: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     isUnlike: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     notLike: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     isNotLike: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     doesNotHave: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     isNotSimilar: Assertions.Match;
+     /**
+      * @deprecated use notMatch() instead.
+      */
+     isDissimilar: Assertions.Match;
+
+    /**
+     * @deprecated use type() instead.
+     */
     isa: Assertions.Type;
+    /**
+     * @deprecated use type() instead.
+     */
     isA: Assertions.Type;
+
+    /**
+     * @deprecated use has() instead.
+     */
+    hasFields: Assertions.Match;
+    /**
+     * @deprecated use has() instead.
+     */
+    includes: Assertions.Match;
+    /**
+     * @deprecated use has() instead.
+     */
+    include: Assertions.Match;
+    /**
+     * @deprecated use has() instead.
+     */
+    contains: Assertions.Match;
 }
 
 declare namespace Options {
@@ -353,7 +609,7 @@ interface Mocha {
 
 // Little hack to simulate the Test class on the tap export
 interface TestConstructor {
-    new (options?: Options.Test): Test;
+    new(options?: Options.Test): Test;
     prototype: Test;
 }
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -138,10 +138,10 @@ declare class Test extends DeprecatedAssertionSynonyms {
      */
     bailout(reason?: string): void;
 
-    before(fn: () => void | Promise<void>): void;
+    before(fn: () => any | Promise<any>): void;
 
-    beforeEach(fn: () => void | Promise<void>): void;
-    afterEach(fn: () => void | Promise<void>): void;
+    beforeEach(fn: () => any | Promise<any>): void;
+    afterEach(fn: () => any | Promise<any>): void;
 
     cleanSnapshot: (s: string) => string;
     formatSnapshot: (obj: any) => string;

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -15,32 +15,93 @@ export = tap;
 
 declare class Test extends DeprecatedAssertionSynonyms {
     constructor(options?: Options.Test);
+
+    /**
+     * Run the supplied function when t.end() is called, or when t.plan is met.
+     * 
+     * This function can return a promise to support async actions.
+     * @see {@link https://node-tap.org/docs/api/test-lifecycle-events}
+     * @param fn 
+     */
     tearDown(fn: () => void | Promise<void>): void;
     teardown(fn: () => void | Promise<void>): void;
+
+    /**
+     * Fail the test with a timeout error if it goes longer than the specified number of ms.
+     * 
+     * Call t.setTimeout(0) to remove the timeout setting.
+     * 
+     * When this is called on the top-level tap object, it sets the runners timeout value
+     * to the specified value for that test process as well.
+     */
     setTimeout(n: number): void;
+
     endAll(): void;
+
+    /**
+     * When an uncaught exception is raised in the context of a test,
+     * then this method is used to handle the error. It fails the test,
+     * and prints out appropriate information about the stack, message, current test,
+     * and so on.
+     * 
+     * Generally, you never need to worry about this directly.
+     */
     threw(error: Error, extra?: Error, proxy?: Test): void;
+
+    /**
+     * Sets a pragma switch for a set of boolean keys in the argument.
+     * 
+     * The only pragma currently supported by the TAP parser is strict,
+     * which tells the parser to treat non-TAP output as a failure.
+     */
     pragma(set: Options.Pragma): void;
+
+    /**
+     * Specify that a given number of tests are going to be run.
+     * 
+     * This may only be called before running any asserts or child tests.
+     */
     plan(n: number, comment?: string): void;
+
     end(): void;
+
     test(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     test(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
+
     todo(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     todo(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
+
     skip(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     skip(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
+
     only(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
     only(name: string, extra?: Options.Test, cb?: (t: Test) => Promise<void> | void): Promise<void>;
+
     current(): Test;
+
     stdin(name: string, extra?: Options.Bag): Promise<void>;
+
     spawn(cmd: string, args: string, options?: Options.Bag, name?: string, extra?: Options.Spawn): Promise<void>;
+
     done(): void;
+
+    /**
+     * Return true if everything so far is ok.
+     */
     passing(): boolean;
+
     pass(message?: string, extra?: Options.Assert): boolean;
+
     fail(message?: string, extra?: Options.Assert): boolean;
+
     addAssert(name: string, length: number, fn: (...args: any[]) => boolean): boolean;
+
     comment(message: string, ...args: any[]): void;
-    bailout(message?: string): void;
+
+    /**
+     * Use this when things are severely broken, and cannot be reasonably handled. Immediately terminates the entire test run.
+     */
+    bailout(reason?: string): void;
 
     beforeEach(fn: (done: () => void, childTest: Test) => void | Promise<void>): void;
     afterEach(fn: (done: () => void, childTest: Test) => void | Promise<void>): void;
@@ -48,19 +109,57 @@ declare class Test extends DeprecatedAssertionSynonyms {
     cleanSnapshot: (s: string) => string;
     formatSnapshot: (obj: any) => string;
 
+    /**
+     * Create a fixture object to specify hard links and symbolic links
+     * in the fixture definition object passed to t.testdir().
+     */
     fixture(type: 'symlink' | 'link', content: string): Fixture.Instance;
     fixture(type: 'file', content: string | Buffer): Fixture.Instance;
     fixture(type: 'dir', content: Fixture.Spec): Fixture.Instance;
 
+    /**
+     * Create a fresh directory with the specified fixtures,
+     * which is deleted on test teardown. Returns the directory name.
+     * 
+     * @see {@link https://node-tap.org/docs/api/fixtures/}
+     */
     testdir(spec?: Fixture.Spec): string;
+
+
     readonly testdirName: string;
 
+    /**
+     * This is an object which is inherited by child tests, and is a handy place to put
+     * various contextual information.
+     * 
+     * t.context will only be inherited by child tests if it is an object.
+     * 
+     * This typically will be used with lifecycle events, such as beforeEach or afterEach.
+     * @see {@link https://node-tap.org/docs/api/test-lifecycle-events}
+     */
     context: any;
+    
+    /**
+     * This is a read-only property set to the string value provided
+     * as the name argument to t.test(), or an empty string if no name is provided.
+     */
     readonly name: string;
+
+    /**
+     * Set to true to only run child tests that have only: true
+     * set in their options (or are run with t.only(), which is the same thing).
+     */
     runOnly: boolean;
+
+    /**
+     * If you set the t.jobs property to a number greater than 1,
+     * then it will enable parallel execution of all of this test's children.
+     */
     jobs: number;
 
-    // Assertions
+    // ----
+    // Assertions below this line!
+    // ----
 
     /**
      * Verifies that the object is truthy.

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -61,7 +61,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * 
      * This may only be called before running any asserts or child tests.
      */
-    plan(n: number): void;
+    plan(n: number, comment?: string): void;
 
     end(): void;
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -184,7 +184,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * If this function returns a promise, it will wait for the promise to
      * resolve, before running any tests.
      */
-    before(fn: () => any | Promise<any>): void;
+    before(fn: () => any): void;
 
     /**
      * Before any child test (or any children of any child tests, etc.) the
@@ -194,16 +194,14 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * doneness. Thus, async functions automatically end when all of their
      * awaited Promises are complete.
      */
-    beforeEach(fn: () => any | Promise<any>): void;
-    beforeEach(fn: (childTest: any) => any | Promise<any>): void;
+    beforeEach(fn: (() => any) | ((childTest: any) => any)): void;
 
     /**
      * This is called after each child test (or any children of any child tests,
      * on down the tree). Like beforeEach, it's called with the child test
      * object, and can return a Promise to perform asynchronous operations.
      */
-    afterEach(fn: () => any | Promise<any>): void;
-    afterEach(fn: (childTest: any) => any | Promise<any>): void;
+    afterEach(fn: (() => any) | ((childTest: any) => any)): void;
 
     /**
      * Formats a string from a snapshot. This can be used to remove variables
@@ -288,9 +286,8 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * @param mocks - The key/value pairs of paths (relative to the current test)
      * and the value that should be returned when anything in the loaded module requires
      * those modules.
-     * @param ModuleType - The type of the module that be exported. Defaults to any.
      */
-    mock<ModuleType = any>(modulePath: string, mocks: Record<string, any>): ModuleType;
+    mock(modulePath: string, mocks: Record<string, any>): any;
 
     // ----
     // Assertions below this line!

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -362,16 +362,20 @@ declare class Test extends DeprecatedAssertionSynonyms {
         extra?: Options.Assert,
     ): Promise<void>;
 
-    // Verifies that the promise (or promise-returning function) resolves, and furthermore that the value of the promise matches the snapshot.
-    // Note: since promises always reject and resolve asynchronously, this assertion is implemented asynchronously. As such, it does not return a boolean to indicate its passing status.
-    // Instead, it returns a Promise that resolves when it is completed.
+    /**
+     * Verifies that the promise (or promise-returning function) resolves, and
+     * furthermore that the value of the promise matches the snapshot.
+     * 
+     * Note: since promises always reject and resolve asynchronously, this
+     * assertion is implemented asynchronously. As such, it does not return a
+     * boolean to indicate its passing status. Instead, it returns a Promise
+     * that resolves when it is completed.
+     */
     resolveMatchSnapshot(
         promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
         message?: string,
         extra?: Options.Assert,
     ): Promise<void>;
-
-    // As of version 11, tap supports saving and then comparing against "snapshot" strings. This is a powerful technique for testing programs that generate output, but it comes with some caveats.
 
     // WARN: This is not described in the documentation formally anymore?
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -373,6 +373,8 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     // As of version 11, tap supports saving and then comparing against "snapshot" strings. This is a powerful technique for testing programs that generate output, but it comes with some caveats.
 
+    // WARN: This is not described in the documentation formally anymore?
+
     /**
      * Checks if the output in data matches the data with this snapshot name.
      * 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -56,7 +56,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
     readonly testdirName: string;
 
     context: any;
-    name: string;
+    readonly name: string;
     runOnly: boolean;
     jobs: number;
 

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -138,6 +138,8 @@ declare class Test extends DeprecatedAssertionSynonyms {
      */
     bailout(reason?: string): void;
 
+    before(fn: () => void | Promise<void>): void;
+
     beforeEach(fn: () => void | Promise<void>): void;
     afterEach(fn: () => void | Promise<void>): void;
 
@@ -191,6 +193,20 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * then it will enable parallel execution of all of this test's children.
      */
     jobs: number;
+
+    // TODO: Investigate whether - using generics - this could
+    // return the type of module provided unioned with the mocks?
+
+    /**
+     * 
+     * @param modulePath - The string path to the module that is being required,
+     * relative to the current test file.
+     * @param mocks - The key/value pairs of paths (relative to the current test)
+     * and the value that should be returned when anything in the loaded module requires
+     * those modules.
+     * @param ModuleType - The type of the module that be exported. Defaults to any.
+     */
+    mock<ModuleType = any>(modulePath: string, mocks: Record<string, any>): ModuleType;
 
     // ----
     // Assertions below this line!

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -256,7 +256,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * @see {@link https://node-tap.org/docs/api/test-lifecycle-events}
      */
     context: any;
-    
+
     /**
      * This is a read-only property set to the string value provided
      * as the name argument to t.test(), or an empty string if no name is provided.
@@ -314,7 +314,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * it's often better to simply throw it. The Test object will handle this as a failure.
      */
     error: Assertions.Basic;
-    
+
 
     /**
      * Verify that the event emitter emits the named event before the end of the test.
@@ -540,15 +540,15 @@ declare class DeprecatedAssertionSynonyms {
     /**
      * @deprecated use notOk() instead.
      */
-     false: Assertions.Basic;
-     /**
-      * @deprecated use assertNot() instead.
-      */
-     assertNot: Assertions.Basic;
-
-     /**
-     * @deprecated use error() instead.
+    false: Assertions.Basic;
+    /**
+     * @deprecated use assertNot() instead.
      */
+    assertNot: Assertions.Basic;
+
+    /**
+    * @deprecated use error() instead.
+    */
     ifErr: Assertions.Basic;
     /**
      * @deprecated use error() instead.
@@ -558,49 +558,49 @@ declare class DeprecatedAssertionSynonyms {
     /**
      * @deprecated use doesNotThrow() instead.
      */
-     notThrow: Assertions.DoesNotThrow;
+    notThrow: Assertions.DoesNotThrow;
 
-     /**
-     * @deprecated use throws() instead.
-     */
+    /**
+    * @deprecated use throws() instead.
+    */
     throw: Assertions.Throws;
 
     /**
      * @deprecated use equal() instead.
      */
-     equals: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     isEqual: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     is: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     strictEqual: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     strictEquals: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     strictIs: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     isStrict: Assertions.Equal;
-     /**
-      * @deprecated use equal() instead.
-      */
-     isStrictly: Assertions.Equal;
-
-     /**
-     * @deprecated use not() instead.
+    equals: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
      */
+    isEqual: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
+     */
+    is: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
+     */
+    strictEqual: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
+     */
+    strictEquals: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
+     */
+    strictIs: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
+     */
+    isStrict: Assertions.Equal;
+    /**
+     * @deprecated use equal() instead.
+     */
+    isStrictly: Assertions.Equal;
+
+    /**
+    * @deprecated use not() instead.
+    */
     notEqual: Assertions.NotEqual;
     /**
      * @deprecated use not() instead.
@@ -664,92 +664,92 @@ declare class DeprecatedAssertionSynonyms {
      */
     looseIs: Assertions.Equal;
 
-        /**
+    /**
+ * @deprecated use notSame() instead.
+ */
+    inequivalent: Assertions.NotEqual;
+    /**
      * @deprecated use notSame() instead.
      */
-         inequivalent: Assertions.NotEqual;
-         /**
-          * @deprecated use notSame() instead.
-          */
-         looseInequal: Assertions.NotEqual;
-         /**
-          * @deprecated use notSame() instead.
-          */
-         notDeep: Assertions.NotEqual;
-         /**
-          * @deprecated use notSame() instead.
-          */
-         deepInequal: Assertions.NotEqual;
-         /**
-          * @deprecated use notSame() instead.
-          */
-         notLoose: Assertions.NotEqual;
-         /**
-          * @deprecated use notSame() instead.
-          */
-         looseNot: Assertions.NotEqual;
+    looseInequal: Assertions.NotEqual;
+    /**
+     * @deprecated use notSame() instead.
+     */
+    notDeep: Assertions.NotEqual;
+    /**
+     * @deprecated use notSame() instead.
+     */
+    deepInequal: Assertions.NotEqual;
+    /**
+     * @deprecated use notSame() instead.
+     */
+    notLoose: Assertions.NotEqual;
+    /**
+     * @deprecated use notSame() instead.
+     */
+    looseNot: Assertions.NotEqual;
 
     /**
      * @deprecated use strictSame() instead.
      */
-     strictEquivalent: Assertions.Equal;
-     /**
-      * @deprecated use strictSame() instead.
-      */
-     strictDeepEqual: Assertions.Equal;
-     /**
-      * @deprecated use strictSame() instead.
-      */
-     sameStrict: Assertions.Equal;
-     /**
-      * @deprecated use strictSame() instead.
-      */
-     deepIs: Assertions.Equal;
-     /**
-      * @deprecated use strictSame() instead.
-      */
-     isDeeply: Assertions.Equal;
-     /**
-      * @deprecated use strictSame() instead.
-      */
-     isDeep: Assertions.Equal;
-     /**
-      * @deprecated use strictSame() instead.
-      */
-     strictDeepEquals: Assertions.Equal;
+    strictEquivalent: Assertions.Equal;
+    /**
+     * @deprecated use strictSame() instead.
+     */
+    strictDeepEqual: Assertions.Equal;
+    /**
+     * @deprecated use strictSame() instead.
+     */
+    sameStrict: Assertions.Equal;
+    /**
+     * @deprecated use strictSame() instead.
+     */
+    deepIs: Assertions.Equal;
+    /**
+     * @deprecated use strictSame() instead.
+     */
+    isDeeply: Assertions.Equal;
+    /**
+     * @deprecated use strictSame() instead.
+     */
+    isDeep: Assertions.Equal;
+    /**
+     * @deprecated use strictSame() instead.
+     */
+    strictDeepEquals: Assertions.Equal;
 
     /**
      * @deprecated use strictNotSame() instead.
      */
-     strictInequivalent: Assertions.NotEqual;
-     /**
-      * @deprecated use strictNotSame() instead.
-      */
-     strictDeepInequal: Assertions.NotEqual;
-     /**
-      * @deprecated use strictNotSame() instead.
-      */
-     notSameStrict: Assertions.NotEqual;
-     /**
-      * @deprecated use strictNotSame() instead.
-      */
-     deepNot: Assertions.NotEqual;
-     /**
-      * @deprecated use strictNotSame() instead.
-      */
-     notDeeply: Assertions.NotEqual;
-     /**
-      * @deprecated use strictNotSame() instead.
-      */
-     strictDeepInequals: Assertions.NotEqual;
-     /**
-      * @deprecated use strictNotSame() instead.
-      */
-     notStrictSame: Assertions.NotEqual;
-
-         /**
-     * @deprecated use match() instead.
+    strictInequivalent: Assertions.NotEqual;
+    /**
+     * @deprecated use strictNotSame() instead.
      */
+    strictDeepInequal: Assertions.NotEqual;
+    /**
+     * @deprecated use strictNotSame() instead.
+     */
+    notSameStrict: Assertions.NotEqual;
+    /**
+     * @deprecated use strictNotSame() instead.
+     */
+    deepNot: Assertions.NotEqual;
+    /**
+     * @deprecated use strictNotSame() instead.
+     */
+    notDeeply: Assertions.NotEqual;
+    /**
+     * @deprecated use strictNotSame() instead.
+     */
+    strictDeepInequals: Assertions.NotEqual;
+    /**
+     * @deprecated use strictNotSame() instead.
+     */
+    notStrictSame: Assertions.NotEqual;
+
+    /**
+* @deprecated use match() instead.
+*/
     matches: Assertions.Match;
     /**
      * @deprecated use match() instead.
@@ -771,43 +771,43 @@ declare class DeprecatedAssertionSynonyms {
     /**
      * @deprecated use notMatch() instead.
      */
-     dissimilar: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     unsimilar: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     notSimilar: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     unlike: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     isUnlike: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     notLike: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     isNotLike: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     doesNotHave: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     isNotSimilar: Assertions.Match;
-     /**
-      * @deprecated use notMatch() instead.
-      */
-     isDissimilar: Assertions.Match;
+    dissimilar: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    unsimilar: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    notSimilar: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    unlike: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    isUnlike: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    notLike: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    isNotLike: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    doesNotHave: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    isNotSimilar: Assertions.Match;
+    /**
+     * @deprecated use notMatch() instead.
+     */
+    isDissimilar: Assertions.Match;
 
     /**
      * @deprecated use type() instead.

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for tap 15.0.1
+// Type definitions for tap 15.0
 // Project: https://github.com/tapjs/node-tap
 // Definitions by: Tomas Della Vedova <https://github.com/delvedor>
 //                 Ulf Winkelvos <https://github.com/uwinkelvos>
@@ -8,7 +8,7 @@
 // TODO: can be removed as soon as https://github.com/tapjs/node-tap/pull/607 is merged
 
 /// <reference types="node" />
-import { EventEmitter } from 'events';
+import { EventEmitter } from "events";
 
 declare const tap: Tap;
 export = tap;
@@ -18,19 +18,19 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Run the supplied function when t.end() is called, or when t.plan is met.
-     * 
+     *
      * This function can return a promise to support async actions.
      * @see {@link https://node-tap.org/docs/api/test-lifecycle-events}
-     * @param fn 
+     * @param fn
      */
     tearDown(fn: () => void | Promise<void>): void;
     teardown(fn: () => void | Promise<void>): void;
 
     /**
      * Fail the test with a timeout error if it goes longer than the specified number of ms.
-     * 
+     *
      * Call t.setTimeout(0) to remove the timeout setting.
-     * 
+     *
      * When this is called on the top-level tap object, it sets the runners timeout value
      * to the specified value for that test process as well.
      */
@@ -46,14 +46,14 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * then this method is used to handle the error. It fails the test,
      * and prints out appropriate information about the stack, message, current test,
      * and so on.
-     * 
+     *
      * Generally, you never need to worry about this directly.
      */
     threw(error: Error, extra?: Error, proxy?: Test): void;
 
     /**
      * Sets a pragma switch for a set of boolean keys in the argument.
-     * 
+     *
      * The only pragma currently supported by the TAP parser is strict,
      * which tells the parser to treat non-TAP output as a failure.
      */
@@ -61,22 +61,22 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Specify that a given number of tests are going to be run.
-     * 
+     *
      * This may only be called before running any asserts or child tests.
      */
     plan(n: number, comment?: string): void;
 
     /**
-     * Call when tests are done running. This is not necessary if t.plan() was used, 
+     * Call when tests are done running. This is not necessary if t.plan() was used,
      * or if the test function returns a Promise.
-     * 
+     *
      * If you call t.end() explicitly more than once, an error will be raised.
      */
     end(): void;
 
     /**
      * Create a subtest.
-     * 
+     *
      * Returns a Promise which resolves with the parent when the child test is completed.
      * @param name - The name for this subtest.
      * @param extra - Any options this subtest should adhere to.
@@ -87,7 +87,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Create a subtest.
-     * 
+     *
      * Returns a Promise which resolves with the parent when the child test is completed.
      * @param name - The name for this subtest.
      * @param cb - The function containing the sub-tests. If not present, the test
@@ -109,7 +109,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Exactly the same as t.test(), but adds only: true in the options.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/only}
      */
     only(name: string, cb?: (t: Test) => Promise<void> | void): Promise<void>;
@@ -119,7 +119,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Parse standard input as if it was a child test named /dev/stdin.
-     * 
+     *
      * Returns a Promise which resolves with the parent when the input stream is
      * completed.
      */
@@ -129,10 +129,10 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * Sometimes, instead of running a child test directly inline, you might
      * want to run a TAP producting test as a child process, and treat its
      * standard output as the TAP stream.
-     * 
-     * Returns a Promise which resolves with the parent when the child process 
+     *
+     * Returns a Promise which resolves with the parent when the child process
      * is completed.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/advanced/#tspawncommand-arguments-options-name}
      */
     spawn(cmd: string, args: string, options?: Options.Bag, name?: string, extra?: Options.Spawn): Promise<void>;
@@ -150,12 +150,12 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * This is used for creating assertion methods on the Test class.
-     * 
+     *
      * @param name The name of the assertion method.
      * @param length The amount of arguments the assertion has.
      * @param fn The code to be ran when this assertion is called.
-     * 
-     * @example 
+     *
+     * @example
      * // Add an assertion that a string is in Title Case
      * // It takes one argument (the string to be tested)
      * t.Test.prototype.addAssert('titleCase', 1, function (str, message, extra) {
@@ -166,7 +166,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
      *     // this.pass(message) or this.fail(message, extra)
      *     return this.equal(str, tc, message, extra)
      * })
-     * 
+     *
      * t.titleCase('This Passes')
      * t.titleCase('however, tHis tOTaLLy faILS')
      */
@@ -189,7 +189,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
     /**
      * Before any child test (or any children of any child tests, etc.) the
      * supplied function is called with the test object that it's prefixing.
-     * 
+     *
      * If the function returns a Promise, then that is used as the indication of
      * doneness. Thus, async functions automatically end when all of their
      * awaited Promises are complete.
@@ -208,9 +208,9 @@ declare class Test extends DeprecatedAssertionSynonyms {
     /**
      * Formats a string from a snapshot. This can be used to remove variables
      * and replace them with sentinel values.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/snapshot-testing/}
-     * 
+     *
      * @example
      * t.cleanSnapshot = s => {
      *     return s.replace(/ time=[0-9]+$/g, ' time={time}')
@@ -220,9 +220,9 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Formats the data argument of any snapshot into this string.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/snapshot-testing/}
-     * 
+     *
      * @example t.formatSnapshot = object => JSON.stringify(object)
      */
     formatSnapshot: (obj: any) => string;
@@ -231,27 +231,26 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * Create a fixture object to specify hard links and symbolic links
      * in the fixture definition object passed to t.testdir().
      */
-    fixture(type: 'symlink' | 'link', content: string): Fixture.Instance;
-    fixture(type: 'file', content: string | Buffer): Fixture.Instance;
-    fixture(type: 'dir', content: Fixture.Spec): Fixture.Instance;
+    fixture(type: "symlink" | "link", content: string): Fixture.Instance;
+    fixture(type: "file", content: string | Buffer): Fixture.Instance;
+    fixture(type: "dir", content: Fixture.Spec): Fixture.Instance;
 
     /**
      * Create a fresh directory with the specified fixtures,
      * which is deleted on test teardown. Returns the directory name.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/fixtures/}
      */
     testdir(spec?: Fixture.Spec): string;
-
 
     readonly testdirName: string;
 
     /**
      * This is an object which is inherited by child tests, and is a handy place to put
      * various contextual information.
-     * 
+     *
      * t.context will only be inherited by child tests if it is an object.
-     * 
+     *
      * This typically will be used with lifecycle events, such as beforeEach or afterEach.
      * @see {@link https://node-tap.org/docs/api/test-lifecycle-events}
      */
@@ -281,9 +280,9 @@ declare class Test extends DeprecatedAssertionSynonyms {
     /**
      * Takes a path to a module and returns the specified module in context of the
      * mocks provided.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/mocks/}
-     * 
+     *
      * @param modulePath - The string path to the module that is being required,
      * relative to the current test file.
      * @param mocks - The key/value pairs of paths (relative to the current test)
@@ -309,12 +308,11 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * If the object is an error, then the assertion fails.
-     * 
+     *
      * Note: if an error is encountered unexpectedly,
      * it's often better to simply throw it. The Test object will handle this as a failure.
      */
     error: Assertions.Basic;
-
 
     /**
      * Verify that the event emitter emits the named event before the end of the test.
@@ -323,7 +321,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Verifies that the promise (or promise-returning function) rejects.
-     * 
+     *
      * If an expected error is provided,
      * then also verify that the rejection matches the expected error.
      */
@@ -352,7 +350,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
     /**
      * Verifies that the promise (or promise-returning function) resolves
      * and that the value of the promise matches the wanted pattern using t.match.
-     * 
+     *
      * @see match
      */
     resolveMatch(
@@ -365,7 +363,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
     /**
      * Verifies that the promise (or promise-returning function) resolves, and
      * furthermore that the value of the promise matches the snapshot.
-     * 
+     *
      * Note: since promises always reject and resolve asynchronously, this
      * assertion is implemented asynchronously. As such, it does not return a
      * boolean to indicate its passing status. Instead, it returns a Promise
@@ -381,7 +379,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Checks if the output in data matches the data with this snapshot name.
-     * 
+     *
      * @see {@link https://node-tap.org/docs/api/snapshot-testing/}
      */
     matchSnapshot(output: any, message?: string, extra?: Options.Assert): boolean;
@@ -390,22 +388,22 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * Expect the function to throw an error.
      * If an expected error is provided, then also verify that the thrown error
      * matches the expected error.
-     * 
+     *
      * If the function has a name, and the message is not provided,
      * then the function name will be used as the message.
-     * 
+     *
      * If the function is not provided, then this will be treated as a todo test.
      */
     throws: Assertions.Throws;
 
     /**
      * Verify that the provided function does not throw.
-     * 
+     *
      * If the function has a name, and the message is not provided,
      * then the function name will be used as the message.
-     * 
+     *
      * If the function is not provided, then this will be treated as a todo test.
-     * 
+     *
      * Note: If an error is encountered unexpectedly,
      * it's often better to simply throw it. The Test object will handle this as a failure.
      */
@@ -415,10 +413,10 @@ declare class Test extends DeprecatedAssertionSynonyms {
      * Expect the function to throw an uncaught exception at some point in the future,
      * before the test ends.
      * If the test ends without having thrown the expected error, then the test fails.
-     * 
+     *
      * If the error is thrown synchronously, or within a promise,
      * then the t.throws() or t.rejects() methods are more appropriate.
-     * 
+     *
      * If called multiple times, then the uncaught exception errors must be emitted in the order called.
      */
     expectUncaughtException(
@@ -436,7 +434,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Inverse of t.equal().
-     * 
+     *
      * Verify that the object found is not exactly the same (that is, !==)
      * as the object that is wanted.
      */
@@ -444,14 +442,14 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Verify that the found object is deeply equivalent to the wanted object.
-     * 
+     *
      * Uses non-strict equality for scalars (ie, ==).
      */
     same: Assertions.Equal;
 
     /**
      * Inverse of t.same().
-     * 
+     *
      * Verify that the found object is not deeply equivalent to the unwanted object.
      * Uses non-strict inequality (ie, !=) for scalars.
      */
@@ -459,7 +457,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Strict version of t.same().
-     * 
+     *
      * Verify that the found object is deeply equivalent to the wanted object.
      * Uses strict equality for scalars (ie, ===).
      */
@@ -467,7 +465,7 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Inverse of t.strictSame().
-     * 
+     *
      * Verify that the found object is not deeply equivalent to the unwanted object.
      * Uses strict equality for scalars (ie, ===).
      */
@@ -476,27 +474,27 @@ declare class Test extends DeprecatedAssertionSynonyms {
     /**
      * Verify that the found object contains all of the provided fields,
      * and that they are of the same type and value as the pattern provided.
-     * 
+     *
      * @see has
      */
     hasStrict: Assertions.Match;
 
     /**
      * Verify that the found object matches the pattern provided.
-     * 
+     *
      * If pattern is a regular expression, and found is a string, then verify that the string matches the pattern.
      * If the pattern is a string, and found is a string, then verify that the pattern occurs within the string somewhere.
      * If pattern is an object, then verify that all of the (enumerable) fields in the pattern match the corresponding fields in the object using this same algorithm.
-     * 
+     *
      * This is useful when you want to verify that an object has a certain set of required fields, but additional fields are ok.
-     * 
+     *
      * @example {x:/a[sdf]{3}/} would successfully match {x:'asdf',y:'z'}.
      */
     match: Assertions.Match;
 
     /**
      * Verify that the found object contains all of the provided fields, and that they coerce to the same values, even if the types do not match.
-     * 
+     *
      * This does not do advanced/loose matching based on constructor, regexp patterns, and so on, like t.match() does.
      * You may specify key: undefined in the pattern to ensure that a field is not defined in the found object,
      * but it will not differentiate between a missing property and a property set to undefined.
@@ -505,18 +503,18 @@ declare class Test extends DeprecatedAssertionSynonyms {
 
     /**
      * Inverse of match().
-     * 
+     *
      * Verify that the found object does not match the pattern provided.
      */
     notMatch: Assertions.Match;
 
     /**
      * Verify that the object is of the type provided.
-     * 
+     *
      * Type can be a string that matches the typeof value of the object,
      * or the string name of any constructor in the object's prototype chain,
      * or a constructor function in the object's prototype chain.
-     * 
+     *
      * @example type(new Date(), "object") - true
      * @example type(new Date(), "Date") - true
      * @example type(new Date(), Date) - true
@@ -547,8 +545,8 @@ declare class DeprecatedAssertionSynonyms {
     assertNot: Assertions.Basic;
 
     /**
-    * @deprecated use error() instead.
-    */
+     * @deprecated use error() instead.
+     */
     ifErr: Assertions.Basic;
     /**
      * @deprecated use error() instead.
@@ -561,8 +559,8 @@ declare class DeprecatedAssertionSynonyms {
     notThrow: Assertions.DoesNotThrow;
 
     /**
-    * @deprecated use throws() instead.
-    */
+     * @deprecated use throws() instead.
+     */
     throw: Assertions.Throws;
 
     /**
@@ -599,8 +597,8 @@ declare class DeprecatedAssertionSynonyms {
     isStrictly: Assertions.Equal;
 
     /**
-    * @deprecated use not() instead.
-    */
+     * @deprecated use not() instead.
+     */
     notEqual: Assertions.NotEqual;
     /**
      * @deprecated use not() instead.
@@ -636,8 +634,8 @@ declare class DeprecatedAssertionSynonyms {
     isInequal: Assertions.NotEqual;
 
     /**
-         * @deprecated use same() instead.
-         */
+     * @deprecated use same() instead.
+     */
     equivalent: Assertions.Equal;
     /**
      * @deprecated use same() instead.
@@ -665,8 +663,8 @@ declare class DeprecatedAssertionSynonyms {
     looseIs: Assertions.Equal;
 
     /**
- * @deprecated use notSame() instead.
- */
+     * @deprecated use notSame() instead.
+     */
     inequivalent: Assertions.NotEqual;
     /**
      * @deprecated use notSame() instead.
@@ -748,8 +746,8 @@ declare class DeprecatedAssertionSynonyms {
     notStrictSame: Assertions.NotEqual;
 
     /**
-* @deprecated use match() instead.
-*/
+     * @deprecated use match() instead.
+     */
     matches: Assertions.Match;
     /**
      * @deprecated use match() instead.
@@ -893,7 +891,7 @@ declare namespace Assertions {
 
 declare namespace Fixture {
     interface Instance {
-        type: 'symlink' | 'link' | 'file' | 'dir';
+        type: "symlink" | "link" | "file" | "dir";
         content: string | Buffer | Spec;
     }
 
@@ -910,7 +908,7 @@ interface Mocha {
 
 // Little hack to simulate the Test class on the tap export
 interface TestConstructor {
-    new(options?: Options.Test): Test;
+    new (options?: Options.Test): Test;
     prototype: Test;
 }
 

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -231,6 +231,12 @@ interface MockModule {
 tap.test("lifecycle", t => {
     t.before(() => true);
     t.before(async () => true);
+
+    t.beforeEach(() => true);
+    t.beforeEach(async () => true);
+
+    t.afterEach(() => true);
+    t.afterEach(async () => true);
 })
 
 tap.test("mocks", t => {

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -234,9 +234,11 @@ tap.test("lifecycle", t => {
 
     t.beforeEach(() => true);
     t.beforeEach(async () => true);
+    t.beforeEach(async (childTest: any) => childTest.foo);
 
     t.afterEach(() => true);
     t.afterEach(async () => true);
+    t.afterEach(async (childTest: any) => childTest.foo);
 })
 
 tap.test("mocks", t => {

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -228,6 +228,11 @@ interface MockModule {
     }
 }
 
+tap.test("lifecycle", t => {
+    t.before(() => true);
+    t.before(async () => true);
+})
+
 tap.test("mocks", t => {
     const genericMockModule = tap.mock<MockModule>("../my-module", {
         "fs": {

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -1,22 +1,22 @@
-import { EventEmitter } from 'events';
-import * as tap from 'tap';
+import { EventEmitter } from "events";
+import * as tap from "tap";
 
 tap.pass();
 
-tap.test('all-assertions', t => {
+tap.test("all-assertions", t => {
     const obj: any = {};
     const found: any = 1;
     const wanted: any = 1;
     const notWanted: any = 1;
-    const fn: (stuff: any) => void = () => { };
+    const fn: (stuff: any) => void = () => {};
     const expectedError: Error = new Error();
     const eventEmitter: EventEmitter = new EventEmitter();
-    const pattern: RegExp | string | { [key: string]: RegExp } = 'pattern';
+    const pattern: RegExp | string | { [key: string]: RegExp } = "pattern";
 
-    const message = 'message';
+    const message = "message";
     const extra = {
         todo: false,
-        skip: 'skip',
+        skip: "skip",
         diagnostic: true,
         extra_stuff: false,
     };
@@ -39,9 +39,9 @@ tap.test('all-assertions', t => {
     t.ifErr(expectedError);
     t.ifError(expectedError);
 
-    t.emits(eventEmitter, 'event', message, extra);
-    t.emits(eventEmitter, 'event', message);
-    t.emits(eventEmitter, 'event');
+    t.emits(eventEmitter, "event", message, extra);
+    t.emits(eventEmitter, "event", message);
+    t.emits(eventEmitter, "event");
 
     t.matchSnapshot(found, message, extra);
     t.matchSnapshot(found, message);
@@ -165,21 +165,21 @@ tap.test('all-assertions', t => {
     t.isNotSimilar(found, pattern);
     t.isDissimilar(found, pattern);
 
-    t.type(new Date(), 'object', message, extra);
-    t.type(new Date(), 'object', message);
-    t.type(new Date(), 'object');
-    t.isa(new Date(), 'Date');
+    t.type(new Date(), "object", message, extra);
+    t.type(new Date(), "object", message);
+    t.type(new Date(), "object");
+    t.isa(new Date(), "Date");
     t.isA(new Date(), Date);
 });
 
-tap.test('async test', async t => {
+tap.test("async test", async t => {
     const wanted: any = 1;
     const expectedError: Error = new Error();
 
-    const message = 'message';
+    const message = "message";
     const extra = {
         todo: false,
-        skip: 'skip',
+        skip: "skip",
         diagnostic: true,
         extra_stuff: false,
     };
@@ -225,7 +225,7 @@ interface MockModule {
     fs: {
         readFile: () => string;
         writeFile: () => string;
-    }
+    };
 }
 
 tap.test("lifecycle", t => {
@@ -239,51 +239,51 @@ tap.test("lifecycle", t => {
     t.afterEach(() => true);
     t.afterEach(async () => true);
     t.afterEach(async (childTest: any) => childTest.foo);
-})
+});
 
 tap.test("mocks", t => {
     const genericMockModule = tap.mock<MockModule>("../my-module", {
-        "fs": {
+        fs: {
             readFile: () => false,
-        }
+        },
     });
 
     genericMockModule.fs.readFile;
     genericMockModule.fs.writeFile;
 
     const anyMockModule = tap.mock("../my-module", {
-        "fs": {
+        fs: {
             readFile: () => false,
-        }
+        },
     });
 
     anyMockModule.any.thing;
 });
 
-tap.only('only', t => {
+tap.only("only", t => {
     t.pass();
 });
 
-tap.skip('skip', t => {
+tap.skip("skip", t => {
     t.pass();
 });
 
-tap.test('test with options', { only: true, skip: true, todo: true, timeout: 1000 }, t => {
+tap.test("test with options", { only: true, skip: true, todo: true, timeout: 1000 }, t => {
     t.pass();
 });
 
 const topLevelDir = tap.testdir();
 
-tap.test('testdir', t => {
+tap.test("testdir", t => {
     const cwd = t.testdir({
-        'demo.jpg': Buffer.from('a jpg'),
-        'package.json': JSON.stringify({
-            name: 'pj',
+        "demo.jpg": Buffer.from("a jpg"),
+        "package.json": JSON.stringify({
+            name: "pj",
         }),
         src: {
-            'index.js': 'yay',
-            hardlinked: t.fixture('link', '../target'),
-            softlinked: t.fixture('symlink', '../target'),
+            "index.js": "yay",
+            hardlinked: t.fixture("link", "../target"),
+            softlinked: t.fixture("symlink", "../target"),
         },
         target: {},
     });
@@ -291,13 +291,13 @@ tap.test('testdir', t => {
     t.equals(cwd, t.testdirName);
 });
 
-tap.test('fixture', t => {
+tap.test("fixture", t => {
     // fairly infrequent vs testdir() sugar
-    t.fixture('dir', {});
-    t.fixture('file', 'content');
-    t.fixture('file', Buffer.from('content'));
+    t.fixture("dir", {});
+    t.fixture("file", "content");
+    t.fixture("file", Buffer.from("content"));
 
     // much more common, as sugar does not exist
-    t.fixture('link', 'target');
-    t.fixture('symlink', 'target');
+    t.fixture("link", "target");
+    t.fixture("symlink", "target");
 });

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -221,6 +221,32 @@ tap.test('async test', async t => {
     await t.resolveMatchSnapshot(promiseProvider);
 });
 
+interface MockModule {
+    fs: {
+        readFile: () => string;
+        writeFile: () => string;
+    }
+}
+
+tap.test("mocks", t => {
+    const genericMockModule = tap.mock<MockModule>("../my-module", {
+        "fs": {
+            readFile: () => false,
+        }
+    });
+
+    genericMockModule.fs.readFile;
+    genericMockModule.fs.writeFile;
+
+    const anyMockModule = tap.mock("../my-module", {
+        "fs": {
+            readFile: () => false,
+        }
+    });
+
+    anyMockModule.any.thing;
+});
+
 tap.only('only', t => {
     t.pass();
 });

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -8,7 +8,7 @@ tap.test('all-assertions', t => {
     const found: any = 1;
     const wanted: any = 1;
     const notWanted: any = 1;
-    const fn: (stuff: any) => void = () => {};
+    const fn: (stuff: any) => void = () => { };
     const expectedError: Error = new Error();
     const eventEmitter: EventEmitter = new EventEmitter();
     const pattern: RegExp | string | { [key: string]: RegExp } = 'pattern';

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -221,13 +221,6 @@ tap.test("async test", async t => {
     await t.resolveMatchSnapshot(promiseProvider);
 });
 
-interface MockModule {
-    fs: {
-        readFile: () => string;
-        writeFile: () => string;
-    };
-}
-
 tap.test("lifecycle", t => {
     t.before(() => true);
     t.before(async () => true);
@@ -242,15 +235,6 @@ tap.test("lifecycle", t => {
 });
 
 tap.test("mocks", t => {
-    const genericMockModule = tap.mock<MockModule>("../my-module", {
-        fs: {
-            readFile: () => false,
-        },
-    });
-
-    genericMockModule.fs.readFile;
-    genericMockModule.fs.writeFile;
-
     const anyMockModule = tap.mock("../my-module", {
         fs: {
             readFile: () => false,


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://node-tap.org/changelog/#150---2021-03-30>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This pull request updates tap definitions to the newest version. This is a breaking change, but I am not certain as for how many people still depend on 14.x.x. and as for whether to keep the old types.

Although this update is a breaking change, the changes are fairly minor, only affecting two function calls called in a non-standard manner.

This pull request also changes the formatting of comments in the type definitions from // to JSDoc, which allows things like intellisense to properly interpret comments for the types.

