### PR TITLE
Create type definitions for `zdf`

### DIFF
--- a/types/zdf/index.d.ts
+++ b/types/zdf/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for zdf 1.2
+// Project: https://github.com/MauriceConrad/zdf-mediathek#readme
+// Definitions by: Christian Koop <https://github.com/SpraxDev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ZdfInfoMeta {
+    readonly title: string;
+    readonly teasertext: string;
+    readonly preview: string;
+}
+
+export interface ZdfInfo {
+    readonly info: ZdfInfoMeta;
+
+    readonly files: Array<{ uri: string, quality: string }>;
+    readonly stream: string[];
+}
+
+export interface ZdfProgress {
+    readonly parts: number;
+    readonly all: number;
+    readonly length: number;
+    readonly total: number;
+    readonly time: number;
+}
+
+/**
+ * Fetches show info, mp4 files and a list of all ts-files for a given show
+ *
+ * @param url The show URL (without https://) from https://www.zdf.de
+ * @param handle Called when the data has been fetched
+ * @param handleInfo Called when the data has been fetched (only contains the show info)
+ */
+export function getSources(
+    url: string,
+    handle: (result: ZdfInfo) => void,
+    handleInfo?: (result: ZdfInfoMeta) => void
+): void;
+
+/**
+ * Downloads all HD streams and merges them into one file.
+ * If provided with an URL, it calls `#getSources` to fetch the required data itself.
+ *
+ * @param url The show URL (without https://) from https://www.zdf.de (May only be undefined if `streamInfo` is provided)
+ * @param output The path to be used for the finished file (Default: `__dirname + '/output.ts'`)
+ * @param handle Called every time one of the streams has been downloaded (Download is done when `progress.parts == progress.all`
+ * @param streamInfo Can be used instead of an URL if you e.g. already called `#getSources`
+ */
+export function downloadStream(
+    url: string | undefined,
+    output: string | undefined,
+    handle: (progress: ZdfProgress) => void,
+    streamInfo?: ZdfInfo
+): void;

--- a/types/zdf/tsconfig.json
+++ b/types/zdf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "zdf-tests.ts"
+    ]
+}

--- a/types/zdf/tslint.json
+++ b/types/zdf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/zdf/zdf-tests.ts
+++ b/types/zdf/zdf-tests.ts
@@ -1,0 +1,21 @@
+import * as zdf from "zdf";
+
+// $ExpectType void
+zdf.getSources(
+    "",
+    (
+        result // $ExpectType ZdfInfo
+    ) => {},
+    (
+        result // $ExpectType ZdfInfoMeta
+    ) => {}
+);
+
+// $ExpectType void
+zdf.downloadStream(
+    "",
+    undefined,
+    (
+        progress // $ExpectType ZdfProgress
+    ) => {}
+);


### PR DESCRIPTION
I'm adding some type definitions for [https://www.npmjs.com/package/zdf](https://www.npmjs.com/package/zdf).

- - -

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.