### PR TITLE
fix(bootstrap): correct global export and `string` in constructor

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -4,11 +4,10 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Martin Badin <https://github.com/martin-badin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 /// <reference types="jquery" />
 
-export as namespace Bootstrap;
+export as namespace bootstrap;
 
 import Alert from "./js/dist/alert";
 import Button from "./js/dist/button";

--- a/types/bootstrap/js/dist/base-component.d.ts
+++ b/types/bootstrap/js/dist/base-component.d.ts
@@ -4,7 +4,7 @@
  * @link https://github.com/twbs/bootstrap/blob/main/js/src/base-component.js
  */
 export default class BaseComponent {
-    constructor(element: Element);
+    constructor(element: string | Element);
 
     /**
      * Destroys an element's.

--- a/types/bootstrap/js/dist/carousel.d.ts
+++ b/types/bootstrap/js/dist/carousel.d.ts
@@ -1,7 +1,7 @@
 import BaseComponent from "./base-component";
 
 declare class Carousel extends BaseComponent {
-    constructor(element: Element, options?: Partial<Carousel.Options>);
+    constructor(element: string | Element, options?: Partial<Carousel.Options>);
 
     /**
      * Cycles through the carousel items from left to right.

--- a/types/bootstrap/js/dist/collapse.d.ts
+++ b/types/bootstrap/js/dist/collapse.d.ts
@@ -3,7 +3,7 @@
 import BaseComponent from './base-component';
 
 declare class Collapse extends BaseComponent {
-    constructor(element: Element, options?: Partial<Collapse.Options>);
+    constructor(element: string | Element, options?: Partial<Collapse.Options>);
 
     /**
      * Toggles a collapsible element to shown or hidden. Returns to the caller

--- a/types/bootstrap/js/dist/dropdown.d.ts
+++ b/types/bootstrap/js/dist/dropdown.d.ts
@@ -2,7 +2,7 @@ import * as Popper from "@popperjs/core";
 import BaseComponent from "./base-component";
 
 declare class Dropdown extends BaseComponent {
-    constructor(element: Element, options?: Partial<Dropdown.Options>);
+    constructor(element: string | Element, options?: Partial<Dropdown.Options>);
 
     /**
      * Toggles the dropdown menu of a given navbar or tabbed navigation.

--- a/types/bootstrap/js/dist/modal.d.ts
+++ b/types/bootstrap/js/dist/modal.d.ts
@@ -1,7 +1,7 @@
 import BaseComponent from './base-component';
 
 declare class Modal extends BaseComponent {
-    constructor(element: Element, options?: Partial<Modal.Options>);
+    constructor(element: string | Element, options?: Partial<Modal.Options>);
 
     /**
      * Manually toggles a modal. Returns to the caller before the modal has

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -3,7 +3,7 @@ import BaseComponent from "./base-component";
 import Tooltip from "./tooltip";
 
 declare class Popover extends BaseComponent {
-    constructor(element: Element, options?: Partial<Popover.Options>);
+    constructor(element: string | Element, options?: Partial<Popover.Options>);
 
     /**
      * Reveals an element’s popover. Returns to the caller before the

--- a/types/bootstrap/js/dist/scrollspy.d.ts
+++ b/types/bootstrap/js/dist/scrollspy.d.ts
@@ -1,7 +1,7 @@
 import BaseComponent from './base-component';
 
 declare class ScrollSpy extends BaseComponent {
-    constructor(element: Element, options?: Partial<ScrollSpy.Options>);
+    constructor(element: string | Element, options?: Partial<ScrollSpy.Options>);
 
     /**
      * When using scrollspy in conjunction with adding or removing of

--- a/types/bootstrap/js/dist/toast.d.ts
+++ b/types/bootstrap/js/dist/toast.d.ts
@@ -1,7 +1,7 @@
 import BaseComponent from './base-component';
 
 declare class Toast extends BaseComponent {
-    constructor(element: Element, options?: Partial<Toast.Options>);
+    constructor(element: string | Element, options?: Partial<Toast.Options>);
 
     /**
      * Reveals an element’s toast. Returns to the caller before the toast has actually

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -2,7 +2,7 @@ import * as Popper from "@popperjs/core";
 import BaseComponent from "./base-component";
 
 declare class Tooltip extends BaseComponent {
-    constructor(element: Element, options?: Partial<Tooltip.Options>);
+    constructor(element: string | Element, options?: Partial<Tooltip.Options>);
 
     /**
      * Reveals an element’s tooltip. Returns to the caller before the

--- a/types/bootstrap/test/global-script.ts
+++ b/types/bootstrap/test/global-script.ts
@@ -1,0 +1,10 @@
+// test global script usage
+
+const modal = new bootstrap.Modal("#myModal");
+const dropdown = new bootstrap.Dropdown('[data-bs-toggle="dropdown"]');
+
+// ctor
+new bootstrap.Alert("#alert");
+new bootstrap.Alert(document.querySelector("#alert")!);
+new bootstrap.Modal("#myModal", {});
+new bootstrap.Modal(document.querySelector("#myModal")!, {});

--- a/types/bootstrap/tsconfig.json
+++ b/types/bootstrap/tsconfig.json
@@ -24,6 +24,7 @@
         "test/carousel-tests.ts",
         "test/collapse-tests.ts",
         "test/dropdown-tests.ts",
+        "test/global-script.ts",
         "test/modal-tests.ts",
         "test/offcanvas-tests.ts",
         "test/popover-tests.ts",


### PR DESCRIPTION
Invalid export for usage in global script (non-ESM).

https://getbootstrap.com/docs/5.0/migration/#javascript

Invalid (missing) parameter for constructors:
https://github.com/twbs/bootstrap/blob/main/js/src/base-component.js#L21

Thanks!

/cc @cjbarth

Fixes #52334

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).