### PR TITLE
update(svg-parser): missing UMD support

### DIFF
--- a/types/svg-parser/index.d.ts
+++ b/types/svg-parser/index.d.ts
@@ -2,8 +2,8 @@
 // Project: https://github.com/Rich-Harris/svg-parser
 // Definitions by: mrmlnc <https://github.com/mrmlnc>
 //                 Joel Shinness <https://github.com/JoelCodes>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 export interface TextNode {
     type: 'text';
@@ -27,3 +27,5 @@ export interface RootNode {
 }
 
 export function parse(source: string): RootNode;
+
+export as namespace svgParser;

--- a/types/svg-parser/svg-parser-tests.ts
+++ b/types/svg-parser/svg-parser-tests.ts
@@ -1,4 +1,7 @@
-import * as parser from 'svg-parser';
+import { parse } from "svg-parser";
+import svgParser = require("svg-parser");
 
 // $ExpectType RootNode
-parser.parse('<svg></svg>');
+parse("<svg></svg>");
+// $ExpectType RootNode
+svgParser.parse("<svg></svg>");


### PR DESCRIPTION
The package is available for browser usage via global script.
This commit fixes issue adding proper export.
- test amended
- maintainer added

https://unpkg.com/svg-parser@2.0.4/dist/svg-parser.umd.js

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).