### PR TITLE
[codemirror] Fix mode indent() API to take three arguments.

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1497,10 +1497,11 @@ declare namespace CodeMirror {
         copyState?: (state: T) => T;
 
         /**
-         * The indentation method should inspect the given state object, and optionally the textAfter string, which contains the text on
-         * the line that is being indented, and return an integer, the amount of spaces to indent.
+         * Returns the number of spaces of indentation that should be used if a newline were added after the given state. Optionally
+         * this can use the textAfter string (which is the text after the current position) or the line string, which is the whole
+         * text of the line.
          */
-        indent?: (state: T, textAfter: string) => number;
+        indent?: (state: T, textAfter: string, line: string) => number;
 
         /** The four below strings are used for working with the commenting addon. */
         /**


### PR DESCRIPTION
It's been that way since 2011 (https://github.com/codemirror/CodeMirror/commit/894db1e0d03f390b8d3446f5ba9f468642932eb3) but hasn't been documented properly :/

Also update the .getMode() API to return a Mode object (since that's the whole point).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/codemirror/CodeMirror/commit/894db1e0d03f390b8d3446f5ba9f468642932eb3
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.