### PR TITLE
[jaeger-client] Update jaeger-client typings for v3.18

### DIFF
--- a/types/jaeger-client/index.d.ts
+++ b/types/jaeger-client/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: jgeth <https://github.com/jgeth>
 //                 tsachis <https://github.com/tsachi>
 //                 MiLk <https://github.com/MiLk>
+//                 doochik <https://github.com/doochik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/jaeger-client/index.d.ts
+++ b/types/jaeger-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jaeger-client 3.15
+// Type definitions for jaeger-client 3.18
 // Project: https://github.com/jaegertracing/jaeger-client-node#readme
 // Definitions by: jgeth <https://github.com/jgeth>
 //                 tsachis <https://github.com/tsachi>
@@ -6,7 +6,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+// This extracts the core definitions from express to prevent a circular dependency between express and serve-static
+/// <reference types="node" />
+
 // opentracing requires typescript version ^2.1
+import { SocketOptions, SocketType } from "dgram";
 import * as opentracing from "opentracing";
 import * as prometheus from "prom-client";
 
@@ -44,6 +48,7 @@ export interface ReporterConfig {
     logSpans?: boolean;
     agentHost?: string;
     agentPort?: number;
+    agentSocketType?: SocketType | SocketOptions;
     collectorEndpoint?: string;
     username?: string;
     password?: string;
@@ -79,6 +84,7 @@ export interface TracingOptions {
     metrics?: PrometheusMetricsFactory;
     logger?: Logger;
     tags?: any;
+    traceId128bit?: boolean;
 }
 
 export interface Injector {
@@ -106,7 +112,7 @@ export function initTracerFromEnv(
 ): JaegerTracer;
 
 export class PrometheusMetricsFactory {
-    constructor(client: typeof prometheus, serviceName: string);
+    constructor(client: typeof prometheus, serviceName?: string);
     createCounter(name: string, tags: {}): Counter;
     createGauge(name: string, tags: {}): Gauge;
 }

--- a/types/jaeger-client/package.json
+++ b/types/jaeger-client/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "opentracing": "~0.14.3",
-        "prom-client": "~11.3.0"
+        "prom-client": "~11.3.0 || ^12.0.0 || ^13.0.0"
     }
 }


### PR DESCRIPTION
1. `agentSocketType` and traceId128bit was added at v3.17.0
https://github.com/jaegertracing/jaeger-client-node/releases/tag/v3.17.0
2. `serviceName` at `PrometheusMetricsFactory` must be optional.
https://github.com/jaegertracing/jaeger-client-node/blob/4c739a26d57c615fb4ac53eae921b9fd5ca53df2/src/metrics/prometheus.js#L57
3. Add support for actual prom-client versions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
