### PR TITLE
Update mui-datatables customHeadLabelRender def

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -205,6 +205,11 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
     label?: string;
 }
 
+export interface CustomHeadLabelRenderOptions extends MUIDataTableColumnState {
+    index: number;
+    colPos: number;
+}
+
 export interface MUIDataTableColumnOptions {
     /**
      * Function that returns a string or React component.
@@ -232,7 +237,7 @@ export interface MUIDataTableColumnOptions {
      * Used for creating a custom header to a column.
      * This method only affects the display in the table's header, other areas of the table (such as the View Columns popover), will use the column's label.
      */
-    customHeadLabelRender?: (dataIndex: number, rowIndex: number) => string | React.ReactNode;
+    customHeadLabelRender?: (options: CustomHeadLabelRenderOptions) => string | React.ReactNode;
     /**
      * These options only affect the filter chips that display after filter are selected.
      * To modify the filters themselves, see filterOptions.

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -51,8 +51,8 @@ const MuiCustomTable: React.FC<Props> = props => {
             name: 'amount',
             label: 'Amount',
             options: {
-                customHeadLabelRender: (dataIndex: number, rowIndex: number) => {
-                    return <p>Some customize Header</p>;
+                customHeadLabelRender: (options) => {
+                    return <p>Some customize Header - {options.name}</p>;
                 },
             },
         },


### PR DESCRIPTION
The signature for `customHeadLabelRender` has changed quite a bit and is outdated for the version that's supported, 3.7

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blob/7558e7393b6ee4b21c9481613429efcdbe7a6ddc/src/components/TableHead.js#L163
