### PR TITLE
mui-datatables add style overrides for Material UI

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1120,54 +1120,168 @@ export default MUIDataTable;
 
 declare module '@material-ui/core/styles/overrides' {
     interface ComponentNameToClassKey {
-        MUIDataTable: 'root' | 'paper' | 'tableRoot' | 'responsiveScroll' | 'caption' | 'liveAnnounce';
+        MUIDataTable:
+            | 'root'
+            | 'caption'
+            | 'liveAnnounce'
+            | 'paper'
+            | 'responsiveScroll'
+            | 'tableRoot'
+            ;
 
-        MUIDataTableBody: 'root' | 'emptyTitle';
+        MUIDataTableBody:
+            | 'root'
+            | 'emptyTitle'
+            | 'lastSimpleCell'
+            | 'lastStackedCell'
+            ;
 
-        MUIDataTableBodyCell: 'root' | 'cellHide' | 'cellStacked' | 'responsiveStacked';
+        MUIDataTableBodyCell:
+            | 'root'
+            | 'cellHide'
+            | 'cellStackedSmall'
+            | 'responsiveStackedSmall'
+            | 'responsiveStackedSmallParent'
+            | 'simpleCell'
+            | 'simpleHeader'
+            | 'stackedCommon'
+            | 'stackedCommonAlways'
+            | 'stackedHeader'
+            | 'stackedParent'
+            | 'stackedParentAlways'
+            ;
 
-        MUIDataTableBodyRow: 'root' | 'hover' | 'responsiveStacked';
+        MUIDataTableBodyRow:
+            | 'root'
+            | 'hoverCursor'
+            | 'responsiveSimple'
+            | 'responsiveStacked'
+            ;
 
         MUIDataTableFilter:
             | 'root'
+            | 'checkbox'
+            | 'checkboxFormControl'
+            | 'checkboxFormControlLabel'
+            | 'checkboxFormGroup'
+            | 'checkboxIcon'
+            | 'checkboxListTitle'
+            | 'checked'
+            | 'filtersSelected'
+            | 'gridListTile'
             | 'header'
-            | 'title'
             | 'noMargin'
             | 'reset'
             | 'resetLink'
-            | 'filtersSelected'
-            | 'checkboxListTitle'
-            | 'checkboxFormGroup'
-            | 'checkboxFormControl'
-            | 'checkboxFormControlLabel'
-            | 'checkboxIcon'
-            | 'checkbox'
-            | 'checked'
-            | 'selectRoot'
-            | 'selectFormControl'
-            | 'textFieldRoot'
-            | 'textFieldFormControl';
+            | 'title'
+            ;
 
         MUIDataTableFilterList: 'root' | 'chip';
 
-        MUIDataTableHead: 'main' | 'responsiveStacked';
+        MUIDataTableFooter: 'root';
 
-        MUIDataTableHeadCell: 'root' | 'fixedHeader' | 'tooltip' | 'mypopper' | 'data' | 'sortAction' | 'sortActive' | 'toolButton';
+        MUIDataTableHead:
+            | 'main'
+            | 'responsiveSimple'
+            | 'responsiveStacked'
+            | 'responsiveStackedAlways'
+            ;
+
+        MUIDataTableHeadCell:
+            | 'root'
+            | 'contentWrapper'
+            | 'data'
+            | 'dragCursor'
+            | 'fixedHeader'
+            | 'hintIconAlone'
+            | 'hintIconWithSortIcon'
+            | 'mypopper'
+            | 'sortAction'
+            | 'sortActive'
+            | 'sortLabelRoot'
+            | 'toolButton'
+            | 'tooltip'
+            ;
 
         MUIDataTableHeadRow: 'root';
 
-        MUIDataTablePagination: 'root' | 'toolbar' | 'selectRoot';
+        MUIDataTableJumpToPage:
+            | 'root'
+            | 'caption'
+            | 'input'
+            | 'select'
+            | 'selectIcon'
+            | 'selectRoot'
+            ;
+
+        MUIDataTablePagination:
+            | 'root'
+            | '@media screen and (max-width: 400px)'
+            | 'navContainer'
+            | 'selectRoot'
+            | 'tableCellContainer'
+            | 'toolbar'
+            ;
 
         MUIDataTableResize: 'root' | 'resizer';
 
-        MUIDataTableSearch: 'main' | 'searchIcon' | 'searchText' | 'clearIcon';
+        MUIDataTableSearch:
+            | 'clearIcon'
+            | 'main'
+            | 'searchIcon'
+            | 'searchText'
+            ;
 
-        MUIDataTableSelectCell: 'root' | 'fixedHeader' | 'icon' | 'expanded' | 'hide' | 'headerCell' | 'checkboxRoot' | 'checked' | 'disabled';
+        MUIDataTableSelectCell:
+            | 'root'
+            | 'checkboxRoot'
+            | 'checked'
+            | 'disabled'
+            | 'expandDisabled'
+            | 'expanded'
+            | 'fixedHeader'
+            | 'fixedLeft'
+            | 'headerCell'
+            | 'hide'
+            | 'icon'
+            ;
 
-        MUIDataTableToolbar: 'root' | 'left' | 'actions' | 'titleRoot' | 'titleText' | 'icon' | 'iconActive' | 'filterPaper' | 'searchIcon' | 'spacer';
+        MUIDataTableToolbar:
+            | 'root'
+            | '@media screen and (max-width: 480px)'
+            | "[theme.breakpoints.down('sm')]"
+            | "[theme.breakpoints.down('xs')]"
+            | 'actions'
+            | 'filterCloseIcon'
+            | 'filterPaper'
+            | 'fullWidthActions'
+            | 'fullWidthLeft'
+            | 'fullWidthRoot'
+            | 'fullWidthTitleText'
+            | 'icon'
+            | 'iconActive'
+            | 'left'
+            | 'searchIcon'
+            | 'titleRoot'
+            | 'titleText'
+            ;
 
-        MUIDataTableToolbarSelect: 'root' | 'title' | 'iconButton' | 'deleteIcon';
+        MUIDataTableToolbarSelect:
+            | 'root'
+            | 'deleteIcon'
+            | 'iconButton'
+            | 'title'
+            ;
 
-        MUIDataTableViewCol: 'root' | 'title' | 'formGroup' | 'formControl' | 'checkbox' | 'checkboxRoot' | 'checked' | 'label';
+        MUIDataTableViewCol:
+            | 'root'
+            | 'checkbox'
+            | 'checkboxRoot'
+            | 'checked'
+            | 'formControl'
+            | 'formGroup'
+            | 'label'
+            | 'title'
+            ;
     }
 }

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -11,6 +11,7 @@
 // Minimum TypeScript Version: 3.5
 
 import * as React from 'react';
+import { ComponentNameToClassKey } from '@material-ui/core/styles/overrides';
 
 export type Display = boolean | 'true' | 'false' | 'excluded';
 export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom';
@@ -1116,3 +1117,57 @@ export const DebounceTableSearch: React.ComponentType<DebouncedMUIDataTableSearc
 export function debounceSearchRender(debounceWait?: number): MUIDataTableOptions['customSearchRender'];
 
 export default MUIDataTable;
+
+declare module '@material-ui/core/styles/overrides' {
+    interface ComponentNameToClassKey {
+        MUIDataTable: 'root' | 'paper' | 'tableRoot' | 'responsiveScroll' | 'caption' | 'liveAnnounce';
+
+        MUIDataTableBody: 'root' | 'emptyTitle';
+
+        MUIDataTableBodyCell: 'root' | 'cellHide' | 'cellStacked' | 'responsiveStacked';
+
+        MUIDataTableBodyRow: 'root' | 'hover' | 'responsiveStacked';
+
+        MUIDataTableFilter:
+            | 'root'
+            | 'header'
+            | 'title'
+            | 'noMargin'
+            | 'reset'
+            | 'resetLink'
+            | 'filtersSelected'
+            | 'checkboxListTitle'
+            | 'checkboxFormGroup'
+            | 'checkboxFormControl'
+            | 'checkboxFormControlLabel'
+            | 'checkboxIcon'
+            | 'checkbox'
+            | 'checked'
+            | 'selectRoot'
+            | 'selectFormControl'
+            | 'textFieldRoot'
+            | 'textFieldFormControl';
+
+        MUIDataTableFilterList: 'root' | 'chip';
+
+        MUIDataTableHead: 'main' | 'responsiveStacked';
+
+        MUIDataTableHeadCell: 'root' | 'fixedHeader' | 'tooltip' | 'mypopper' | 'data' | 'sortAction' | 'sortActive' | 'toolButton';
+
+        MUIDataTableHeadRow: 'root';
+
+        MUIDataTablePagination: 'root' | 'toolbar' | 'selectRoot';
+
+        MUIDataTableResize: 'root' | 'resizer';
+
+        MUIDataTableSearch: 'main' | 'searchIcon' | 'searchText' | 'clearIcon';
+
+        MUIDataTableSelectCell: 'root' | 'fixedHeader' | 'icon' | 'expanded' | 'hide' | 'headerCell' | 'checkboxRoot' | 'checked' | 'disabled';
+
+        MUIDataTableToolbar: 'root' | 'left' | 'actions' | 'titleRoot' | 'titleText' | 'icon' | 'iconActive' | 'filterPaper' | 'searchIcon' | 'spacer';
+
+        MUIDataTableToolbarSelect: 'root' | 'title' | 'iconButton' | 'deleteIcon';
+
+        MUIDataTableViewCol: 'root' | 'title' | 'formGroup' | 'formControl' | 'checkbox' | 'checkboxRoot' | 'checked' | 'label';
+    }
+}

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,5 +1,6 @@
 import MUIDataTable, { ExpandButton, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState } from 'mui-datatables';
 import * as React from 'react';
+import { createMuiTheme } from '@material-ui/core';
 
 interface Props extends Omit<MUIDataTableProps, 'columns'> {
     columns?: MUIDataTableColumn[];
@@ -229,3 +230,16 @@ const disabledOptions: MUIDataTableOptions = {
 };
 
 <MuiCustomTable title="Disabled Buttons" data={Todos} options={disabledOptions} />;
+
+const MuiTheme = createMuiTheme({
+    overrides: {
+        MUIDataTable: {
+            root: {
+                fontWeight: 300
+            }
+        },
+        MUIDataTableBody: {
+            emptyTitle: {}
+        }
+    }
+});

--- a/types/mui-datatables/package.json
+++ b/types/mui-datatables/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@material-ui/core": ">=4"
+       "@material-ui/core": "^4.11.3",
+       "@material-ui/types": "5.1.0"
     }
 }

--- a/types/mui-datatables/package.json
+++ b/types/mui-datatables/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@material-ui/core": ">=3"
+        "@material-ui/core": ">=4"
     }
 }

--- a/types/mui-datatables/package.json
+++ b/types/mui-datatables/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@material-ui/core": ">=3"
+    }
+}


### PR DESCRIPTION
This continues the work started in #35297 to allow for overriding styles when creating a theme with Material UI.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Example for `MUIDataTableHead`: https://github.com/gregnb/mui-datatables/blob/7558e7393b6ee4b21c9481613429efcdbe7a6ddc/src/components/TableHead.js#L27
