### PR TITLE
Add: CustomEvent Parameters Type

### DIFF
--- a/types/facebook-pixel/index.d.ts
+++ b/types/facebook-pixel/index.d.ts
@@ -33,6 +33,7 @@ declare module facebook.Pixel {
         (eventType:string, eventName:string, parameters:PurchaseParameters):void;
         (eventType:string, eventName:string, parameters:LeadParameters):void;
         (eventType:string, eventName:string, parameters:CompleteRegistrationParameters):void;
+        (eventType:string, eventName:string, parameters:CustomParameters):void;
 
         (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.AddToCartParameters):void;
         (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.PurchaseParameters):void;
@@ -116,6 +117,8 @@ declare module facebook.Pixel {
         content_name?:string;
         status?:boolean;
     }
+
+    type CustomParameters = Record<string,any>;
 }
 
 // For Facebook Tag API using Dynamic Product Ads

--- a/types/facebook-pixel/index.d.ts
+++ b/types/facebook-pixel/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://developers.facebook.com/docs/ads-for-websites/tag-api/
 // Definitions by: Noctis Hsu <https://github.com/noctishsu>
 //                 Victor Hom <https://github.com/VictorHom>
+//                 BC Choi <https://github.com/ninpeng>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare var fbq:facebook.Pixel.Event;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.facebook.com/docs/facebook-pixel/implementation/conversion-tracking/?locale=en_US#custom-events>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


If eventType is 'trackCustom', parameters can use any custom parameters.
So I added the CustomEventParameters Type.

<example usage>
fbq('trackCustom', 'myCustomEvent, { custom_param1: 'facebook_signup', custom_param2: 'normal_signup' });