### PR TITLE
[pino-multi-stream] Allow silent level for streams

### DIFF
--- a/types/pino-multi-stream/index.d.ts
+++ b/types/pino-multi-stream/index.d.ts
@@ -7,7 +7,7 @@
 import {
     LoggerOptions as PinoLoggerOptions,
     Logger as PinoLogger,
-    Level as PinoLevel,
+    LevelWithSilent as PinoLevel,
     DestinationStream as PinoDestinationStream,
     stdSerializers as pinoStdSerializers
 } from 'pino';

--- a/types/pino-multi-stream/pino-multi-stream-tests.ts
+++ b/types/pino-multi-stream/pino-multi-stream-tests.ts
@@ -9,7 +9,8 @@ const streams: pinoms.Streams = [
     { level: 'fatal', stream: fs.createWriteStream('/tmp/fatal.stream.out') },
     { stream: pino.destination() },
     { stream: pinoms.prettyStream() },
-    { stream: pinoms.prettyStream({ prettyPrint: { colorize: true } }) }
+    { stream: pinoms.prettyStream({ prettyPrint: { colorize: true } }) },
+    { level: 'silent', stream: pino.destination()} // "silent" stream
 ];
 const opts: pinoms.MultiStreamOptions = {
     dedupe: true


### PR DESCRIPTION
Pino allows `silent` level in logger options: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7e51c23cd081b605ec5ba1c0f1cfe5c800cf7037/types/pino/index.d.ts#L270

Also it is supported in multistream's `LoggerOptions` https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7e51c23cd081b605ec5ba1c0f1cfe5c800cf7037/types/pino-multi-stream/index.d.ts#L18  which extends those Pino's `LoggerOptions` (first link in description)


