### PR TITLE
hapi__hapi: Add `onPostResponse` Ext type.

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -2476,7 +2476,8 @@ export type RouteRequestExtType = 'onPreAuth'
     | 'onPostAuth'
     | 'onPreHandler'
     | 'onPostHandler'
-    | 'onPreResponse';
+    | 'onPreResponse'
+    | 'onPostResponse';
 
 export type ServerRequestExtType =
     RouteRequestExtType

--- a/types/hapi__hapi/test/route/ext.ts
+++ b/types/hapi__hapi/test/route/ext.ts
@@ -17,6 +17,11 @@ server.route({
                     return h.continue;
                 },
             }],
+            onPostResponse: {
+                method(_request, h) {
+                    return h.continue;
+                },
+            }
         }
     }
 });


### PR DESCRIPTION
Hapi supports `onPostResponse` extensions as of 19.2.0, unfortunately the types for hapi do not recognize this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hapi/pull/4073
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
