### PR TITLE
[@types/carbon-components-react]: Update types to match 7.33.x

### DIFF
--- a/types/carbon-components-react/OTHER_FILES.txt
+++ b/types/carbon-components-react/OTHER_FILES.txt
@@ -1,4 +1,5 @@
 lib/components/AccordionItem/AccordionItem.d.ts
+lib/components/FeatureFlags/index.d.ts
 lib/components/Notification/a11yIconWarningSolid.d.ts
 lib/components/ListBox/next/index.d.ts
 lib/components/ListBox/next/ListBoxSelection.d.ts

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -183,9 +183,21 @@ const secondaryButtonT3 = (
 // CodeSnippet
 
 let codeSnippetType: CodeSnippetType = "inline";
-const inlineCodeSnippet = (<CodeSnippet type="inline" onClick={(e) => e.preventDefault()}>code</CodeSnippet>);
-const multiCodeSnippet = (<CodeSnippet type="multi" onBlur={(e) => e.preventDefault()}>code</CodeSnippet>)
-const codeSnippetTypeIsVariable = (<CodeSnippet type={codeSnippetType} onClick={(e) => e.preventDefault()}>code</CodeSnippet>);
+const inlineCodeSnippet = (
+    <CodeSnippet type="inline" onClick={e => e.preventDefault()}>
+        code
+    </CodeSnippet>
+);
+const multiCodeSnippet = (
+    <CodeSnippet type="multi" maxCollapsedNumberOfRows={10} minExpandedNumberOfRows={3} onBlur={e => e.preventDefault()}>
+        code
+    </CodeSnippet>
+);
+const codeSnippetTypeIsVariable = (
+    <CodeSnippet type={codeSnippetType} onClick={e => e.preventDefault()}>
+        code
+    </CodeSnippet>
+);
 
 interface Row1 extends DataTableRow {
     rowProp: string;

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -37,6 +37,7 @@ export * from "./lib/components/DatePicker";
 export * from "./lib/components/DatePickerInput";
 export * from "./lib/components/Dropdown";
 export * from "./lib/components/ErrorBoundary";
+export * from "./lib/components/ExpandableSearch";
 export * from "./lib/components/FileUploader";
 export * from "./lib/components/FluidForm/FluidForm"; // context is not exported from index
 export * from "./lib/components/Form";
@@ -153,6 +154,7 @@ export { default as DatePicker } from "./lib/components/DatePicker";
 export { default as DatePickerInput } from "./lib/components/DatePickerInput";
 export { default as Dropdown } from "./lib/components/Dropdown";
 export { ErrorBoundary, ErrorBoundaryContext } from "./lib/components/ErrorBoundary";
+export { default as ExpandableSearch } from "./lib/components/ExpandableSearch";
 export {
     default as FileUploader,
     Filename,

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbon-components-react 7.31
+// Type definitions for carbon-components-react 7.33
 // Project: https://github.com/carbon-design-system/carbon/tree/master/packages/react
 // Definitions by: Kyle Albert <https://github.com/kalbert312>
 //                 Sebastien Gregoire <https://github.com/sgregoire>

--- a/types/carbon-components-react/lib/components/Accordion/Accordion.d.ts
+++ b/types/carbon-components-react/lib/components/Accordion/Accordion.d.ts
@@ -4,7 +4,7 @@ import { ReactAttr } from "../../../typings/shared";
 export interface AccordionProps extends ReactAttr<HTMLUListElement> {
     align?: "end" | "start";
     disabled?: boolean;
-    size?: "sm" | "xl";
+    size?: "sm" | "md" | "lg" | "xl";
 }
 
 declare const Accordion: React.FC<AccordionProps>;

--- a/types/carbon-components-react/lib/components/Button/Button.d.ts
+++ b/types/carbon-components-react/lib/components/Button/Button.d.ts
@@ -25,6 +25,7 @@ export interface ButtonKindProps {
 
 // these props are not passed to the general createElement call
 interface ButtonBaseIsolatedProps {
+    dangerDescription?: string;
     hasIconOnly?: boolean;
     iconDescription?: string;
     isSelected?: boolean;

--- a/types/carbon-components-react/lib/components/Checkbox/Checkbox.d.ts
+++ b/types/carbon-components-react/lib/components/Checkbox/Checkbox.d.ts
@@ -9,7 +9,9 @@ export interface CheckboxProps extends Omit<ReactInputAttr, ExcludedAttributes> 
     id: string,
     indeterminate?: boolean,
     labelText: NonNullable<React.ReactNode>,
-    onChange?(checked: boolean, id: string, event: React.ChangeEvent<HTMLInputElement>): void,
+    onChange?:
+        | ((evt: React.ChangeEvent<HTMLInputElement>, data: { checked: boolean, id: string }) => void) // variant when "enable-2021-release" feature flag is enabled
+        | ((checked: boolean, id: string, event: React.ChangeEvent<HTMLInputElement>) => void);
     wrapperClassName?: string,
 }
 

--- a/types/carbon-components-react/lib/components/CodeSnippet/CodeSnippet.d.ts
+++ b/types/carbon-components-react/lib/components/CodeSnippet/CodeSnippet.d.ts
@@ -6,7 +6,8 @@ interface SharedProps {
     copyLabel?: string,
     copyButtonDescription?: string,
     disabled?: boolean,
-    feedback?: CopyProps["feedback"],
+    feedback?: string,
+    feedbackTimeout?: number;
     hideCopyButton?: boolean,
     light?: boolean,
     showLessText?: string,
@@ -15,16 +16,26 @@ interface SharedProps {
 }
 
 export interface CodeSnippetDivProps extends SharedProps, Omit<ReactDivAttr, "children"> {
-    type?: 'single' | 'multi' | null;
+    type?: "single" | null;
+}
+
+export interface CodeSnippetMultiProps extends SharedProps, Omit<ReactDivAttr, "children"> {
+    maxCollapsedNumberOfRows?: number;
+    maxExpandedNumberOfRows?: number;
+    minCollapsedNumberOfRows?: number;
+    minExpandedNumberOfRows?: number;
+    type: "multi";
 }
 
 export interface CodeSnippetInlineProps extends SharedProps, Omit<CopyProps, "children" | "type"> {
     type: "inline",
 }
 
-export type CodeSnippetType = CodeSnippetDivProps["type"] | CodeSnippetInlineProps["type"];
+export type CodeSnippetType = CodeSnippetDivProps["type"] | CodeSnippetInlineProps["type"] | CodeSnippetMultiProps["type"];
 
 declare function CodeSnippet(props: FCProps<CodeSnippetInlineProps>): FCReturn;
+// tslint:disable:unified-signatures
+declare function CodeSnippet(props: FCProps<CodeSnippetMultiProps>): FCReturn;
 // tslint:disable:unified-signatures
 declare function CodeSnippet(props: FCProps<CodeSnippetDivProps>): FCReturn;
 

--- a/types/carbon-components-react/lib/components/ComboBox/ComboBox.d.ts
+++ b/types/carbon-components-react/lib/components/ComboBox/ComboBox.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { InternationalProps, ReactInputAttr, VerticalDirection } from "../../../typings/shared";
+import { InternationalProps, ReactInputAttr, VerticalDirection, FCReturn } from "../../../typings/shared";
 import { ListBoxProps } from "../ListBox";
 import { ListBoxMenuIconTranslationKey } from "../ListBox/ListBoxMenuIcon";
 import { ListBoxSelectionTranslationKey } from "../ListBox/ListBoxSelection";
@@ -25,6 +25,7 @@ export interface ComboBoxProps<ItemType = string, CustomElementProps = Extract<I
     light?: boolean;
     onChange?(data: { selectedItem: ItemType | null | undefined }): void,
     onInputChange?(inputValue?: string): void,
+    onToggleClick?(evt: React.MouseEvent<HTMLButtonElement>): void,
     placeholder: string,
     selectedItem?: ItemType | null,
     shouldFilterItem?(data: { item: ItemType, itemToString?: ComboBoxProps<ItemType>["itemToString"], inputValue?: string }): void,
@@ -35,6 +36,6 @@ export interface ComboBoxProps<ItemType = string, CustomElementProps = Extract<I
     warnText?: React.ReactNode;
 }
 
-declare class ComboBox<T = string> extends React.Component<ComboBoxProps<T>> { }
+declare function ComboBox<T = string>(props: ComboBoxProps<T>): FCReturn;
 
 export default ComboBox;

--- a/types/carbon-components-react/lib/components/ComposedModal/ComposedModal.d.ts
+++ b/types/carbon-components-react/lib/components/ComposedModal/ComposedModal.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactDivAttr, CarbonSize } from "../../../typings/shared";
+import { ReactDivAttr } from "../../../typings/shared";
 import { ButtonProps } from "../Button";
 
 // ComposedModal
@@ -13,7 +13,7 @@ export interface ComposedModalProps extends Omit<ReactDivAttr, ExcludedAttribute
     preventCloseOnClickOutside?: boolean,
     selectedPrimaryFocus?: string,
     selectorsFloatingMenus?: string,
-    size?: CarbonSize,
+    size?: "xs" | "sm" | "md" | "lg";
 }
 
 declare class ComposedModal extends React.Component<ComposedModalProps> { }

--- a/types/carbon-components-react/lib/components/ContentSwitcher/ContentSwitcher.d.ts
+++ b/types/carbon-components-react/lib/components/ContentSwitcher/ContentSwitcher.d.ts
@@ -5,11 +5,14 @@ import { SwitchOnKeyDownData } from "../Switch";
 export type ContentSwitcherOnChangeData = Omit<SwitchOnKeyDownData, "key"> & Partial<Pick<SwitchOnKeyDownData, "key">>;
 
 export interface ContentSwitcherProps extends Omit<ReactDivAttr, "onChange" | "role"> {
+    /**
+     * @deprecated
+     */
     light?: boolean,
     onChange?(data: ContentSwitcherOnChangeData): void,
     selectedIndex?: number,
     selectionMode?: "automatic" | "manual";
-    size?: "sm" | "xl";
+    size?: "sm" | "md" | "lg" | "xl";
 }
 
 declare class ContentSwitcher extends React.Component<ContentSwitcherProps> {}

--- a/types/carbon-components-react/lib/components/ContextMenu/ContextMenuOption.d.ts
+++ b/types/carbon-components-react/lib/components/ContextMenu/ContextMenuOption.d.ts
@@ -16,6 +16,7 @@ type ExcludedPropKeys =
 export interface ContextMenuOptionProps extends Omit<ReactLIAttr, ExcludedPropKeys> {
     disabled?: boolean;
     indented?: boolean; // set by context menu parent component
+    kind?: "danger" | "default";
     label: string;
     level?: number; // set by context menu parent component
     onClick?(evt: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>): void;

--- a/types/carbon-components-react/lib/components/DatePickerInput/DatePickerInput.d.ts
+++ b/types/carbon-components-react/lib/components/DatePickerInput/DatePickerInput.d.ts
@@ -15,7 +15,7 @@ export interface DatePickerInputProps extends Omit<ReactInputAttr, ExcludedAttri
     labelText: NonNullable<React.ReactNode>,
     openCalendar?: React.MouseEventHandler,
     pattern?: string,
-    size?: Extract<CarbonInputSize, "sm" | "xl">,
+    size?: "sm" | "md" | "lg" | "xl",
     warn?: boolean;
     warnText?: React.ReactNode,
 }

--- a/types/carbon-components-react/lib/components/ExpandableSearch/ExpandableSearch.d.ts
+++ b/types/carbon-components-react/lib/components/ExpandableSearch/ExpandableSearch.d.ts
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { SearchProps } from "../Search";
+
+type ExcludedPropKeys = "onBlur" | "onFocus" | "ref";
+export interface ExpandableSearchProps extends Omit<SearchProps, ExcludedPropKeys> { }
+
+declare const ExpandableSearch: React.FC<ExpandableSearchProps>;
+
+export default ExpandableSearch;

--- a/types/carbon-components-react/lib/components/ExpandableSearch/index.d.ts
+++ b/types/carbon-components-react/lib/components/ExpandableSearch/index.d.ts
@@ -1,0 +1,5 @@
+import ExpandableSearch from "./ExpandableSearch";
+
+export * from "./ExpandableSearch";
+
+export default ExpandableSearch;

--- a/types/carbon-components-react/lib/components/FeatureFlags/index.d.ts
+++ b/types/carbon-components-react/lib/components/FeatureFlags/index.d.ts
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+// TODO: import FeatureFlagScope related things from @types/carbon__feature-flags when available
+export type FeatureFlagRecord = Record<string, boolean>;
+
+export declare class FeatureFlagScope {
+    constructor(flags?: FeatureFlagRecord);
+
+    add(name: string, enabled: boolean): void;
+    checkForFlag(name: string): void;
+    enable(name: string): void;
+    enabled(name: string): boolean;
+    disable(name: string): void;
+    merge(flags: FeatureFlagRecord): void;
+    mergeWithScope(scope: FeatureFlagScope): void;
+}
+
+export interface FeatureFlagsProps {
+    children?: React.ReactNode;
+    flags?: FeatureFlagRecord;
+}
+
+export declare const FeatureFlags: React.FC<FeatureFlagsProps>;
+
+export declare function useFeatureFlag(flag: string): boolean;
+
+export declare function useFeatureFlags(): FeatureFlagScope;

--- a/types/carbon-components-react/lib/components/FormGroup/FormGroup.d.ts
+++ b/types/carbon-components-react/lib/components/FormGroup/FormGroup.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface FormGroupProps extends React.FieldsetHTMLAttributes<HTMLFieldSetElement> {
+    hasMargin?: boolean;
     invalid?: boolean,
     legendText: NonNullable<React.ReactNode>,
     message?: boolean,

--- a/types/carbon-components-react/lib/components/Link/Link.d.ts
+++ b/types/carbon-components-react/lib/components/Link/Link.d.ts
@@ -4,7 +4,7 @@ import { ReactAnchorAttr } from "../../../typings/shared";
 export interface LinkProps extends ReactAnchorAttr { // this is a <p> element when disabled but accounting for it is useless
     disabled?: boolean,
     inline?: boolean,
-    size?: "sm" | "lg",
+    size?: "sm" | "md" | "lg",
     visited?: boolean,
 }
 

--- a/types/carbon-components-react/lib/components/ListBox/ListBoxMenuItem.d.ts
+++ b/types/carbon-components-react/lib/components/ListBox/ListBoxMenuItem.d.ts
@@ -1,12 +1,16 @@
 import * as React from "react";
-import { ReactDivAttr } from "../../../typings/shared";
+import { ReactDivAttr, ForwardRefReturn } from "../../../typings/shared";
 
 export interface ListBoxMenuItemProps extends ReactDivAttr {
     isActive?: boolean, // required but has default value
     isHighlighted?: boolean, // required but has default value
 }
 
-export interface ListBoxMenuItemComponent extends React.FC<ListBoxMenuItemProps> { }
+export interface ListBoxMenuItemForwardedRef {
+    menuItemOptionRef?: React.Ref<HTMLDivElement>;
+}
+
+export interface ListBoxMenuItemComponent extends ForwardRefReturn<ListBoxMenuItemForwardedRef, ListBoxMenuItemProps> { }
 
 declare const ListBoxMenuItem: ListBoxMenuItemComponent;
 

--- a/types/carbon-components-react/lib/components/ListBox/ListBoxPropTypes.d.ts
+++ b/types/carbon-components-react/lib/components/ListBox/ListBoxPropTypes.d.ts
@@ -1,2 +1,2 @@
-export type ListBoxSize = "sm" | "xl";
+export type ListBoxSize = "sm" | "md" | "lg" | "xl";
 export type ListBoxType = "default" | "inline";

--- a/types/carbon-components-react/lib/components/ListBox/next/ListBoxSelection.d.ts
+++ b/types/carbon-components-react/lib/components/ListBox/next/ListBoxSelection.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { ListBoxSelectionProps } from "../ListBoxSelection";
+import { ReactButtonAttr } from "../../../../typings/shared";
 
-declare const ListBoxSelection: React.FC<ListBoxSelectionProps>;
+type ExcludedButtonPropKeys = "aria-label" | "className" | "onClick" | "onKeyDown" | "tabIndex" | "title" | "type";
+export interface ListBoxSelectionNextProps extends ListBoxSelectionProps, Omit<ReactButtonAttr, ExcludedButtonPropKeys> { }
+
+declare const ListBoxSelection: React.FC<ListBoxSelectionNextProps>;
 
 export default ListBoxSelection;

--- a/types/carbon-components-react/lib/components/ListBox/next/ListBoxTrigger.d.ts
+++ b/types/carbon-components-react/lib/components/ListBox/next/ListBoxTrigger.d.ts
@@ -2,8 +2,11 @@ import * as React from "react";
 import { InternationalProps, ReactButtonAttr } from "../../../../typings/shared";
 import { ListBoxMenuIconTranslationKey } from "../ListBoxMenuIcon";
 
-export interface ListBoxTriggerProps extends ReactButtonAttr, InternationalProps<ListBoxMenuIconTranslationKey> {
-    isOpen: boolean,
+type ExcludedButtonPropKeys = "aria-label" | "className" | "tabIndex" | "title" | "type";
+export interface ListBoxTriggerProps
+    extends Omit<ReactButtonAttr, ExcludedButtonPropKeys>,
+        InternationalProps<ListBoxMenuIconTranslationKey> {
+    isOpen: boolean;
 }
 
 declare const ListBoxTrigger: React.FC<ListBoxTriggerProps>;

--- a/types/carbon-components-react/lib/components/Modal/Modal.d.ts
+++ b/types/carbon-components-react/lib/components/Modal/Modal.d.ts
@@ -34,7 +34,7 @@ export interface ModalProps extends Omit<ReactDivAttr, ExcludedAttributes> {
     secondaryButtonText?: React.ReactNode,
     selectorPrimaryFocus?: string,
     selectorsFloatingMenus?: readonly string[],
-    size?: CarbonSize,
+    size?: "xs" | "sm" | "md" | "lg";
     shouldSubmitOnEnter?: boolean,
 }
 

--- a/types/carbon-components-react/lib/components/Notification/Notification.d.ts
+++ b/types/carbon-components-react/lib/components/Notification/Notification.d.ts
@@ -44,7 +44,8 @@ export interface ToastNotificationProps extends Omit<ReactDivAttr, "title"> {
     kind?: NotificationKind; // required but has default value
     lowContrast?: boolean,
     notificationType?: NotificationType,
-    onCloseButtonClick?(e: React.MouseEvent<HTMLButtonElement>): void,
+    onClose?(evt: React.MouseEvent<HTMLButtonElement>): boolean;
+    onCloseButtonClick?(evt: React.MouseEvent<HTMLButtonElement>): void,
     statusIconDescription?: string,
     subtitle?: React.ReactNode,
     timeout?: number;
@@ -62,6 +63,7 @@ export interface InlineNotificationProps extends Omit<ReactDivAttr, "title"> {
     kind: NotificationKind;
     lowContrast?: boolean,
     notificationType?: NotificationType,
+    onClose?(evt: React.MouseEvent<HTMLButtonElement>): boolean;
     onCloseButtonClick?(e: React.MouseEvent<HTMLButtonElement>): void,
     statusIconDescription?: string,
     subtitle?: React.ReactNode,

--- a/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
+++ b/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import {
     InternationalProps,
     ReactInputAttr,
-    CarbonInputSize, ForwardRefReturn
+    ForwardRefReturn
 } from "../../../typings/shared";
 
 export type NumberInputTranslationKey = "decrement.number" | "increment.number";
@@ -22,7 +22,7 @@ export interface NumberInputProps extends Omit<ReactInputAttr, ExcludedAttribute
     isMobile?: boolean,
     label?: React.ReactNode,
     light?: boolean,
-    size?: Extract<CarbonInputSize, "sm" | "xl">,
+    size?: "sm" | "md" | "lg" | "xl",
     value: number | '',
     warn?: boolean,
     warnText?: React.ReactNode,

--- a/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
+++ b/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
@@ -31,7 +31,7 @@ export interface OverflowMenuProps extends Omit<ReactButtonAttr, ExcludedAttribu
     open?: boolean,
     renderIcon?: any,
     selectorPrimaryFocus?: string,
-    size?: "sm" | "xl",
+    size?: "sm" | "md" | "lg" | "xl",
 }
 
 declare class OverflowMenuComponent extends React.Component<OverflowMenuProps> { }

--- a/types/carbon-components-react/lib/components/Search/Search.d.ts
+++ b/types/carbon-components-react/lib/components/Search/Search.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactInputAttr, CarbonInputSize, SizingProps } from "../../../typings/shared";
+import { ReactInputAttr } from "../../../typings/shared";
 
 type ExcludedAttributes = "defaultValue" | "ref" | "size" | "value";
 
@@ -11,11 +11,11 @@ export interface SearchProps extends Omit<ReactInputAttr, ExcludedAttributes> {
      * @deprecated
      */
     placeHolderText?: string,
-    size?: CarbonInputSize,
+    size?: "sm" | "lg" | "xl",
     /**
      * @deprecated
      */
-    small?: SizingProps["small"],
+    small?: boolean,
     value?: string | number,
     light?: boolean,
 }

--- a/types/carbon-components-react/lib/components/Select/Select.d.ts
+++ b/types/carbon-components-react/lib/components/Select/Select.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ForwardRefReturn, CarbonInputSize } from "../../../typings/shared";
+import { ForwardRefReturn } from "../../../typings/shared";
 
 type ExcludedAttributes = "aria-invalid" | "id" | "ref" | "size";
 
@@ -18,7 +18,7 @@ export interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectE
     labelText?: React.ReactNode,
     light?: boolean,
     noLabel?: boolean,
-    size?: Extract<CarbonInputSize, "sm" | "xl">,
+    size?: "sm" | "md" | "lg" | "xl",
     warn?: boolean;
     warnText?: React.ReactNode;
 }

--- a/types/carbon-components-react/lib/components/Tag/Tag.d.ts
+++ b/types/carbon-components-react/lib/components/Tag/Tag.d.ts
@@ -17,7 +17,8 @@ export type TagTypeName =
 export declare const types: TagTypeName[];
 
 interface SharedProps {
-    size?: "sm";
+    disabled?: boolean;
+    size?: "sm" | "md";
     type?: TagTypeName,
 }
 

--- a/types/carbon-components-react/lib/components/TextInput/TextInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/TextInput.d.ts
@@ -2,11 +2,11 @@ import * as React from "react";
 import ControlledPasswordInput from "./ControlledPasswordInput";
 import PasswordInput from "./PasswordInput";
 import { TextInputSharedProps } from "./props";
-import { ForwardRefReturn, CarbonInputSize } from "../../../typings/shared";
+import { ForwardRefReturn } from "../../../typings/shared";
 
 export interface TextInputProps extends TextInputSharedProps {
     inline?: boolean,
-    size?: Extract<CarbonInputSize, "sm" | "xl">,
+    size?: "sm" | "md" | "lg" | "xl",
     warn?: boolean,
     warnText?: React.ReactNode,
 }

--- a/types/carbon-components-react/lib/components/Tile/Tile.d.ts
+++ b/types/carbon-components-react/lib/components/Tile/Tile.d.ts
@@ -22,22 +22,27 @@ export declare class ClickableTile extends React.Component<ClickableTileProps> {
 
 // SelectableTile
 
-type SelectedTileExcludedAttributes = "onChange" | "onClick" | "onKeyDown";
-
-export interface SelectableTileProps extends Omit<ReactLabelAttr, SelectedTileExcludedAttributes> {
+export interface SelectableTileProps extends Omit<ReactLabelAttr, "onChange"> {
+    disabled?: boolean;
+    /**
+     * @deprecated
+     */
     handleClick?(e: React.MouseEvent<HTMLLabelElement>): void,
+    /**
+     * @deprecated
+     */
     handleKeyDown?(e: React.KeyboardEvent<HTMLLabelElement>): void,
     /**
      * @deprecated
      */
     iconDescription?: string,
     light?: boolean,
-    onChange(e: React.KeyboardEvent<HTMLLabelElement> | React.MouseEvent<HTMLLabelElement>): void,
+    onChange?(e: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLLabelElement> | React.KeyboardEvent<HTMLLabelElement>): void,
     selected?: boolean,
     value: string | number,
 }
 
-export declare class SelectableTile extends React.Component<SelectableTileProps> { }
+export declare const SelectableTile: React.FC<SelectableTileProps>;
 
 // ExpandableTile
 

--- a/types/carbon-components-react/lib/components/TimePicker/TimePicker.d.ts
+++ b/types/carbon-components-react/lib/components/TimePicker/TimePicker.d.ts
@@ -8,7 +8,7 @@ export interface TimePickerProps extends Omit<ReactInputAttr, "id" | "size"> {
     invalidText?: React.ReactNode,
     labelText?: React.ReactNode,
     light?: boolean,
-    size?: "sm" | "xl",
+    size?: "sm" | "md" | "lg" | "xl",
 }
 
 declare class TimePicker extends React.Component<TimePickerProps> { }

--- a/types/carbon-components-react/lib/components/Toggle/Toggle.d.ts
+++ b/types/carbon-components-react/lib/components/Toggle/Toggle.d.ts
@@ -11,7 +11,7 @@ export interface ToggleProps extends Omit<ReactInputAttr, ExcludedAttributes> {
     labelText?: string,
     onChange?(event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>): void,
     onToggle?(checked: boolean, id: ToggleProps["id"], event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>): void,
-    size?: "sm",
+    size?: "sm" | "md",
     toggled?: boolean,
 }
 

--- a/types/carbon-components-react/lib/components/TooltipIcon/TooltipIcon.d.ts
+++ b/types/carbon-components-react/lib/components/TooltipIcon/TooltipIcon.d.ts
@@ -6,7 +6,7 @@ export interface TooltipIconProps extends Omit<ReactButtonAttr, ExcludedAttribut
     align?: TooltipAlignment,
     children: NonNullable<React.ReactNode>,
     direction?: Direction, // required but has default value, should be bottom/top but the prop type has left/right
-    tooltipText: string,
+    tooltipText: NonNullable<React.ReactNode>;
 }
 
 declare const TooltipIcon: React.FC<TooltipIconProps>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/v10.33.0/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Components to add/update/check based on diff against 7.31:
- [x] Accordion
- [x] BreadcrumbItem
- [x] Button
- [x] Checkbox
- [x] CodeSnippet
- [x] ComboBox
- [x] ComposedModal
- [x] ContentSwitcher
- [x] ContextMenu components
- [x] DataTable/TableToolbarSearch
- [x] DatePickerInput
- [x] Dropdown
- [x] ExpandableSearch
- [x] FeatureFlags hook
- [x] FileUploader
- [x] FormGroup
- [x] Link
- [x] ListBox components
- [x] Modal
- [x] MultiSelect components
- [x] NumberInput
- [x] OverflowMenu
- [x] RadioTile
- [x] Search
- [x] Select
- [x] Tab
- [x] Tag
- [x] TextInput
- [x] Tile
- [x] TimePicker
- [x] Toggle
- [x] TooltipIcon
- [x] UIShell components
