### PR TITLE
[google.visualization] Add YearLabel to CalendarOptions / Fix TableOptions

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -72,7 +72,10 @@ function test_calendarChart() {
     var options = {
         title: "Test Calendar",
         height: 350,
-        colorAxis: { colors: ['red', 'white', 'green'], values: [-250, 0, 250] }
+        colorAxis: { colors: ['red', 'white', 'green'], values: [-250, 0, 250] },
+        calendar: {
+            yearLabel: { color: 'black', bold: true, italic: false }
+        }
     };
 
     var container = document.getElementById('chart_div');

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1164,7 +1164,7 @@ declare namespace google {
             cssClassNames?: CssClassNames;
             firstRowNumber?: number;
             frozenColumns?: number;
-            height?: string;
+            height?: string | number;
             page?: string;
             pageSize?: number;
             pagingButtons?: number | 'both' | 'prev' | 'next' | 'auto';
@@ -1175,7 +1175,7 @@ declare namespace google {
             sortAscending?: boolean;
             sortColumn?: number;
             startPage?: number;
-            width?: string;
+            width?: string | number;
         }
 
         export interface CssClassNames {

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1396,6 +1396,7 @@ declare namespace google {
                 underMonthSpace?: number;
                 underYearSpace?: number;
                 unusedMonthOutlineColor?: ChartStrokeOpacity;
+                yearLabel?: ChartTextStyle;
             };
             colorAxis?: {
                 colors?: string[];


### PR DESCRIPTION
If changing an existing definition:

[ X ] Provide a URL to documentation or source code which provides context for the suggested changes: 

- YearLabel isn't documented in the configuration property list but is shown used in other places of the documentation. 
https://developers.google.com/chart/interactive/docs/gallery/calendar#configuration-options

- Table width and height accepts Number or String, e.g. '90%'. Documentation says string, definition says number. Either actually work.
https://developers.google.com/chart/interactive/docs/gallery/table#configuration-options