### PR TITLE
Allow extending xast children using module augmentation

### DIFF
--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -12,18 +12,36 @@ import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } fro
 export { UnistNode as Node };
 
 /**
- * Node in xast containing other nodes.
- * Its content is limited to only other xast content.
- */
-export interface Parent extends UnistParent {
-    children: Array<Element | Text | Comment | Doctype | Instruction | Cdata>;
-}
-
-/**
  * Node in xast containing a value.
  */
 export interface Literal extends UnistLiteral {
     value: string;
+}
+
+/**
+ * This map registers valid children for a xast root node.
+ *
+ * For example to register a custom node type as a valid xast rppt child:
+ *
+ * ```ts
+ * interface Custom extends Node {
+ *   type: 'custom';
+ * }
+ *
+ * declare module 'xast' {
+ *   interface RootChildMap {
+ *     custom: Custom;
+ *   }
+ * }
+ * ```
+ */
+export interface RootChildMap {
+    cdata: Cdata;
+    comment: Comment;
+    doctype: Doctype;
+    element: Element;
+    instruction: Instruction;
+    text: Text;
 }
 
 /**
@@ -34,14 +52,40 @@ export interface Literal extends UnistLiteral {
  * therefore a root should have exactly one element child when representing a
  * whole document.
  */
-export interface Root extends Parent {
+export interface Root extends UnistParent {
     type: 'root';
+    children: Array<RootChildMap[keyof RootChildMap]>;
+}
+
+/**
+ * This map registers valid children for a xast element node.
+ *
+ * For example to register a custom node type as a valid xast element child:
+ *
+ * ```ts
+ * interface Custom extends Node {
+ *   type: 'custom';
+ * }
+ *
+ * declare module 'xast' {
+ *   interface ElementChildMap {
+ *     custom: Custom;
+ *   }
+ * }
+ * ```
+ */
+export interface ElementChildMap {
+    element: Element;
+    text: Text;
+    comment: Comment;
+    instruction: Instruction;
+    cdata: Cdata;
 }
 
 /**
  * An XML element.
  */
-export interface Element extends Parent {
+export interface Element extends UnistParent {
     type: 'element';
     /**
      * The element's qualified name.
@@ -51,7 +95,7 @@ export interface Element extends Parent {
      * Information associated with the element.
      */
     attributes?: Attributes;
-    children: Array<Element | Text | Comment | Instruction | Cdata>;
+    children: Array<ElementChildMap[keyof ElementChildMap]>;
 }
 
 /**

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -10,6 +10,7 @@
 import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
 
 export { UnistNode as Node };
+export { UnistParent as Parent };
 
 /**
  * Node in xast containing a value.

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -1,5 +1,5 @@
-import { Data, Point, Position } from 'unist';
-import { Parent, Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
+import { Data, Node, Point, Position } from 'unist';
+import { Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
 
 const data: Data = {
     string: 'string',
@@ -69,16 +69,9 @@ const instruction: Instruction = {
     value: 'value',
 };
 
-const element: Element = getElement();
+let element: Element = getElement();
 
-const parent: Parent = {
-    type: 'parent',
-    data,
-    position,
-    children: [getElement(), docType, comment, text, instruction, cdata],
-};
-
-const root: Root = {
+let root: Root = {
     type: 'root',
     data,
     position,
@@ -99,3 +92,50 @@ function getElement(): Element {
         children: [element, comment, text, cdata, instruction],
     };
 }
+
+// Test custom xast node registration
+interface Custom extends Node {
+    type: 'custom';
+}
+
+declare module 'xast' {
+    interface RootChildMap {
+        custom: Custom;
+    }
+
+    interface ElementChildMap {
+        custom: Custom;
+    }
+}
+
+root = {
+    type: 'root',
+    data,
+    position,
+    children: [{ type: 'custom' }],
+};
+
+element = {
+    type: 'element',
+    name: 'foo',
+    data,
+    position,
+    children: [{ type: 'custom' }],
+};
+
+root = {
+    type: 'root',
+    data,
+    position,
+    // $ExpectError
+    children: [{ type: 'invalid' }],
+};
+
+element = {
+    type: 'element',
+    name: 'foo',
+    data,
+    position,
+    // $ExpectError
+    children: [{ type: 'invalid' }],
+};

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -1,5 +1,5 @@
 import { Data, Node, Point, Position } from 'unist';
-import { Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
+import { Parent, Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
 
 const data: Data = {
     string: 'string',
@@ -70,6 +70,13 @@ const instruction: Instruction = {
 };
 
 let element: Element = getElement();
+
+const parent: Parent = {
+    type: 'parent',
+    data,
+    position,
+    children: [getElement(), docType, comment, text, instruction, cdata],
+};
 
 let root: Root = {
     type: 'root',


### PR DESCRIPTION
This is an idea based on syntax-tree/xastscript#8.

The idea is to use an approach similar to [`HTMLElementTagNameMap`](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L19398-L19518). Each parent node is accompanied by an interface named `<name>ChildMap`. Only elements registered in this map may be used as children for the parent node they belong to. The jsdocs contain examples of how to register custom nodes. The same principle could be applied to other unist packages.

This could be taken a step further by making `unist#Parent` generic.

```ts
// unist
export interface Parent<ChildMap = Record<string, Node>> extends Node {
  children: Array<ChildMap[keyof ChildMap]>;
}

// xast
export interface Root extends UnistParent<RootChildMap> {
    type: 'root';
}
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: syntax-tree/xastscript#8
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
