### PR TITLE
fix(sanitize-html): hidden problems fixed and version bump

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sanitize-html 1.27
+// Type definitions for sanitize-html 2.3
 // Project: https://github.com/punkave/sanitize-html
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Afshin Darian <https://github.com/afshin>
@@ -32,7 +32,7 @@ declare namespace sanitize {
 
   // tslint:disable-next-line:interface-name
   interface IDefaults {
-    allowedAttributes: { [index: string]: AllowedAttribute[] };
+    allowedAttributes: Record<string, AllowedAttribute[]>;
     allowedSchemes: string[];
     allowedSchemesByTag: { [index: string]: string[] };
     allowedSchemesAppliedToAttributes: string[];
@@ -53,7 +53,7 @@ declare namespace sanitize {
 
   // tslint:disable-next-line:interface-name
   interface IOptions {
-    allowedAttributes?: { [index: string]: AllowedAttribute[] } | boolean;
+    allowedAttributes?: Record<string, AllowedAttribute[]> | false;
     allowedStyles?: { [index: string]: { [index: string]: RegExp[] } };
     allowedClasses?: { [index: string]: string[] | boolean };
     allowedIframeDomains?: string[];
@@ -63,10 +63,11 @@ declare namespace sanitize {
     allowedSchemesByTag?: { [index: string]: string[] } | boolean;
     allowedSchemesAppliedToAttributes?: string[];
     allowProtocolRelative?: boolean;
-    allowedTags?: string[] | boolean;
+    allowedTags?: string[] | false;
     allowVulnerableTags?: boolean;
     textFilter?: (text: string, tagName: string) => string;
     exclusiveFilter?: (frame: IFrame) => boolean;
+    nestingLimit?: number;
     nonTextTags?: string[];
     selfClosing?: string[];
     transformTags?: { [tagName: string]: string | Transformer };
@@ -81,7 +82,7 @@ declare namespace sanitize {
     enforceHtmlBoundary?: boolean;
   }
 
-  let defaults: IDefaults;
+  const defaults: IDefaults;
 
   function simpleTransform(tagName: string, attribs: Attributes, merge?: boolean): Transformer;
 }

--- a/types/sanitize-html/package.json
+++ b/types/sanitize-html/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "htmlparser2": "^4.1.0"
+    "htmlparser2": "^6.0.0"
   }
 }

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -1,6 +1,7 @@
 import sanitize = require('sanitize-html');
+import { Attributes, IFrame, IOptions } from 'sanitize-html';
 
-const options: sanitize.IOptions = {
+const options: IOptions = {
   allowedTags: sanitize.defaults.allowedTags.concat('h1', 'h2', 'img'),
   allowedAttributes: {
     a: sanitize.defaults.allowedAttributes['a'].concat('rel'),
@@ -22,7 +23,7 @@ const options: sanitize.IOptions = {
   allowedSchemesAppliedToAttributes: [ 'href', 'src', 'cite' ],
     transformTags: {
     a: sanitize.simpleTransform('a', { rel: 'nofollow' }),
-    img: (tagName: string, attribs: sanitize.Attributes) => {
+    img: (tagName: string, attribs: Attributes) => {
       const img = { tagName, attribs };
       img.attribs['alt'] = 'transformed' ;
       return img;
@@ -31,7 +32,7 @@ const options: sanitize.IOptions = {
   textFilter: (text, _) => text,
   allowIframeRelativeUrls: false,
   allowVulnerableTags: true,
-  exclusiveFilter(frame: sanitize.IFrame) {
+  exclusiveFilter(frame: IFrame) {
     return frame.tag === 'a' && !frame.text.trim();
   },
   allowedSchemesByTag: {
@@ -42,7 +43,7 @@ const options: sanitize.IOptions = {
   enforceHtmlBoundary: true,
 };
 
-sanitize.defaults.allowedAttributes; // $ExpectType { [index: string]: AllowedAttribute[]; }
+sanitize.defaults.allowedAttributes; // $ExpectType Record<string, AllowedAttribute[]>
 sanitize.defaults.allowedSchemes; // $ExpectType string[]
 sanitize.defaults.allowedSchemesAppliedToAttributes; // $ExpectType string[]
 sanitize.defaults.allowedSchemesByTag; // $ExpectType { [index: string]: string[]; }
@@ -63,3 +64,9 @@ options.parser = {
 safe = sanitize(unsafe, options);
 
 sanitize(unsafe, sanitize.defaults);
+
+sanitize(unsafe, {
+    allowedTags: false,
+    allowedAttributes: false,
+    nestingLimit: 6,
+});


### PR DESCRIPTION
- bump to recent version
- `allowedAttributes` and `allowedTags` are used with `false` value,
  otherwise implementation fails tryng to access props from iterables on
  booleans, e.g.:
  https://github.com/apostrophecms/sanitize-html/blob/main/index.js#L117
- new option: `nestingLimit`:
https://github.com/apostrophecms/sanitize-html/compare/1.27.4...2.3.://github.com/apostrophecms/sanitize-html/compare/1.27.4...2.3.3

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.