### PR TITLE
sinon: update tests to use new types

### DIFF
--- a/types/sinon/package.json
+++ b/types/sinon/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@sinonjs/fake-timers": "^7.0.4"
+        "@sinonjs/fake-timers": "^7.0.5"
     }
 }

--- a/types/sinon/package.json
+++ b/types/sinon/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@sinonjs/fake-timers": "^7.0.5"
+        "@sinonjs/fake-timers": "^7.1.0"
     }
 }

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -431,9 +431,11 @@ function testTypedSpy() {
 }
 
 function testInstanceSpy() {
-    const obj: {
-        foo(arg: number): string;
-    } = <any>{};
+    const obj = {
+        foo(arg: number): string {
+            return "xyz";
+        },
+    };
 
     const spy = sinon.spy(obj); // $ExpectType SinonSpiedInstance<{ foo(arg: number): string; }>
 

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -1,11 +1,11 @@
-import sinon = require('sinon');
+import sinon = require("sinon");
 
 function testSandbox() {
     const obj = {};
 
     sinon.createSandbox({
         injectInto: obj,
-        properties: ['spy', 'stub'],
+        properties: ["spy", "stub"],
         useFakeTimers: true,
         useFakeServer: true,
     });
@@ -24,9 +24,9 @@ function testSandbox() {
     const sb = sinon.createSandbox();
 
     sb.fake.returns(42);
-    sb.match(/foo/).test('foo');
+    sb.match(/foo/).test("foo");
 
-    sb.assert.pass('foo');
+    sb.assert.pass("foo");
     sb.clock.tick(1000);
     sb.spy();
     sb.stub();
@@ -44,7 +44,7 @@ function testSandbox() {
     xhr.restore();
 
     const server = sb.useFakeServer();
-    server.respondWith('foo');
+    server.respondWith("foo");
 
     sb.restore();
     sb.reset();
@@ -68,10 +68,10 @@ function testSandbox() {
         set setter(val) {},
     };
 
-    sb.replace(replaceMe, 'prop', 10);
-    sb.replace(replaceMe, 'method', sb.spy());
-    sb.replaceGetter(replaceMe, 'getter', () => 14);
-    sb.replaceSetter(replaceMe, 'setter', v => {});
+    sb.replace(replaceMe, "prop", 10);
+    sb.replace(replaceMe, "method", sb.spy());
+    sb.replaceGetter(replaceMe, "getter", () => 14);
+    sb.replaceSetter(replaceMe, "setter", v => {});
 
     const cls = class {
         foo(arg1: string, arg2: number): number {
@@ -90,8 +90,8 @@ function testSandbox() {
 
     const stubInstance = sb.createStubInstance(cls);
     const privateFooStubbedInstance = sb.createStubInstance(PrivateFoo);
-    stubInstance.foo.calledWith('foo', 1);
-    stubInstance.foo.calledWith('foo');
+    stubInstance.foo.calledWith("foo", 1);
+    stubInstance.foo.calledWith("foo");
     privateFooStubbedInstance.foo.calledWith();
     const clsFoo: sinon.SinonStub<[string, number], number> = stubInstance.foo;
     const privateFooFoo: sinon.SinonStub<[], void> = privateFooStubbedInstance.foo;
@@ -126,11 +126,11 @@ function testFakeServer() {
 function testXHR() {
     const xhr = new sinon.FakeXMLHttpRequest();
     const headers = xhr.getAllResponseHeaders();
-    const header = xhr.getResponseHeader('foo');
+    const header = xhr.getResponseHeader("foo");
 
-    xhr.setResponseHeaders({ 'Content-Type': 'text/html' });
-    xhr.setResponseBody('foo');
-    xhr.respond(200, { 'Content-Type': 'foo' }, 'bar');
+    xhr.setResponseHeaders({ "Content-Type": "text/html" });
+    xhr.setResponseBody("foo");
+    xhr.respond(200, { "Content-Type": "foo" }, "bar");
     xhr.error();
 
     sinon.FakeXMLHttpRequest.useFilters = true;
@@ -154,10 +154,10 @@ function testClock() {
     clock.setImmediate(fn);
     clock.requestAnimationFrame(fn);
 
-    // TODO (43081j): uncomment theses when sinon#371 lands
-    // now = clock.setTimeout(fnWithArgs, 0, 1234, 'abc');
-    // now = clock.setInterval(fnWithArgs, 0, 1234, 'abc');
-    // now = clock.setImmediate(fnWithArgs, 1234, 'abc');
+    now = clock.setTimeout(fnWithArgs, 0, 1234, "abc");
+    now = clock.setInterval(fnWithArgs, 0, 1234, "abc");
+
+    clock.setImmediate(fnWithArgs, 1234, "abc"); // $ExpectType NodeTimer
 
     let timer = clock.setTimeout(fn, 0);
     clock.clearTimeout(timer);
@@ -172,9 +172,9 @@ function testClock() {
     clock.nextTick(fn);
 
     clock.tick(1);
-    clock.tick('00:10');
+    clock.tick("00:10");
     clock.tickAsync(500).then(val => val.toExponential());
-    clock.tickAsync('500').then(val => val.toExponential());
+    clock.tickAsync("500").then(val => val.toExponential());
 
     clock.next();
     clock.nextAsync().then(val => val.toExponential());
@@ -197,7 +197,7 @@ function testExpectation() {
     const obj = {};
 
     let ex = sinon.expectation.create();
-    ex = sinon.expectation.create('some name');
+    ex = sinon.expectation.create("some name");
 
     ex.atLeast(5).atMost(10);
     ex.never();
@@ -205,8 +205,8 @@ function testExpectation() {
     ex.twice();
     ex.thrice();
     ex.exactly(5);
-    ex.withArgs('a', 'b');
-    ex.withExactArgs('a', 'b');
+    ex.withArgs("a", "b");
+    ex.withExactArgs("a", "b");
     ex.on(obj);
     ex.verify();
     ex.restore();
@@ -217,56 +217,56 @@ function testMatch() {
     const fn = () => {};
 
     sinon.match(5).test(5);
-    sinon.match('str').test('foo');
-    sinon.match(/foo/).test('foo');
+    sinon.match("str").test("foo");
+    sinon.match(/foo/).test("foo");
     sinon.match({ a: 5, b: 6 }).test({});
-    sinon.match(v => true).test('foo');
-    sinon.match(v => true, 'some message').test('foo');
-    sinon.match.any.test('foo');
-    sinon.match.defined.test('foo');
-    sinon.match.truthy.test('foo');
-    sinon.match.falsy.test('foo');
-    sinon.match.bool.test('foo');
-    sinon.match.number.test('foo');
-    sinon.match.string.test('foo');
-    sinon.match.object.test('foo');
+    sinon.match(v => true).test("foo");
+    sinon.match(v => true, "some message").test("foo");
+    sinon.match.any.test("foo");
+    sinon.match.defined.test("foo");
+    sinon.match.truthy.test("foo");
+    sinon.match.falsy.test("foo");
+    sinon.match.bool.test("foo");
+    sinon.match.number.test("foo");
+    sinon.match.string.test("foo");
+    sinon.match.object.test("foo");
     sinon.match.func.test(fn);
     sinon.match.map.test(
         new Map([
-            ['a', 1],
-            ['b', 2],
+            ["a", 1],
+            ["b", 2],
         ]),
     );
     sinon.match.set.test(new Set([1, 2, 3]));
     sinon.match.array.test([1, 2, 3]);
-    sinon.match.regexp.test('foo');
-    sinon.match.date.test('foo');
-    sinon.match.symbol.test('foo');
+    sinon.match.regexp.test("foo");
+    sinon.match.date.test("foo");
+    sinon.match.symbol.test("foo");
     sinon.match.in([1, 2, 3]).test(1);
     sinon.match.same(obj);
-    sinon.match.typeOf('string').test('foo');
-    sinon.match.instanceOf(fn).test('foo');
-    sinon.match.has('prop').test(obj);
-    sinon.match.has('prop', 123).test(obj);
-    sinon.match.hasOwn('prop').test(obj);
-    sinon.match.hasOwn('prop', 123).test(obj);
-    sinon.match.hasNested('prop.foo.bar').test(obj);
-    sinon.match.hasNested('prop.foo.bar', 123).test(obj);
-    sinon.match.every(sinon.match.number).test([1, 2, 'three']);
-    sinon.match.some(sinon.match.number).test([1, 2, 'three']);
-    sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
-    sinon.match.array.startsWith([{ a: 'b' }]).test([]);
-    sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
-    sinon.match.array.contains([{ a: 'b' }]).test([]);
+    sinon.match.typeOf("string").test("foo");
+    sinon.match.instanceOf(fn).test("foo");
+    sinon.match.has("prop").test(obj);
+    sinon.match.has("prop", 123).test(obj);
+    sinon.match.hasOwn("prop").test(obj);
+    sinon.match.hasOwn("prop", 123).test(obj);
+    sinon.match.hasNested("prop.foo.bar").test(obj);
+    sinon.match.hasNested("prop.foo.bar", 123).test(obj);
+    sinon.match.every(sinon.match.number).test([1, 2, "three"]);
+    sinon.match.some(sinon.match.number).test([1, 2, "three"]);
+    sinon.match.array.deepEquals([{ a: "b" }]).test([]);
+    sinon.match.array.startsWith([{ a: "b" }]).test([]);
+    sinon.match.array.deepEquals([{ a: "b" }]).test([]);
+    sinon.match.array.contains([{ a: "b" }]).test([]);
     sinon.match.map
         .deepEquals(
             new Map([
-                ['a', true],
-                ['b', false],
+                ["a", true],
+                ["b", false],
             ]),
         )
         .test(new Map());
-    sinon.match.map.contains(new Map([['a', true]])).test(new Map());
+    sinon.match.map.contains(new Map([["a", true]])).test(new Map());
 }
 
 function testFake() {
@@ -275,14 +275,14 @@ function testFake() {
 
     fake = sinon.fake(() => true);
     fake = sinon.fake.returns(5);
-    fake = sinon.fake.throws('foo');
-    fake = sinon.fake.throws(new Error('foo'));
-    fake = sinon.fake.resolves('foo');
-    fake = sinon.fake.rejects('foo');
+    fake = sinon.fake.throws("foo");
+    fake = sinon.fake.throws(new Error("foo"));
+    fake = sinon.fake.resolves("foo");
+    fake = sinon.fake.rejects("foo");
     fake = sinon.fake.yields(1, 2, fn);
     fake = sinon.fake.yieldsAsync(1, 2, fn);
 
-    fake.calledWith('foo');
+    fake.calledWith("foo");
 }
 
 function testAssert() {
@@ -291,8 +291,8 @@ function testAssert() {
     const obj = {};
 
     sinon.assert.fail();
-    sinon.assert.fail('foo');
-    sinon.assert.pass('foo');
+    sinon.assert.fail("foo");
+    sinon.assert.pass("foo");
     sinon.assert.notCalled(spy);
     sinon.assert.called(spy);
     sinon.assert.calledOnce(spy);
@@ -303,33 +303,33 @@ function testAssert() {
     sinon.assert.calledOn(spy, obj);
     sinon.assert.calledOn(spy.firstCall, obj);
     sinon.assert.alwaysCalledOn(spy, obj);
-    sinon.assert.alwaysCalledWith(spy, 'a', 'b', 'c');
-    sinon.assert.neverCalledWith(spy, 'a', 'b', 'c');
-    sinon.assert.calledWithExactly(spy, 'a', 'b', 'c');
-    sinon.assert.calledOnceWithExactly(spy, 'a', 'b', 'c');
-    sinon.assert.alwaysCalledWithExactly(spy, 'a', 'b', 'c');
-    sinon.assert.calledWithMatch(spy, 'a', 'b', 'c');
-    sinon.assert.calledWithMatch(spy.firstCall, 'a', 'b', 'c');
-    sinon.assert.calledOnceWithMatch(spy, 'a', 'b', 'c');
-    sinon.assert.calledOnceWithMatch(spy.firstCall, 'a', 'b', 'c');
-    sinon.assert.alwaysCalledWithMatch(spy, 'a', 'b', 'c');
-    sinon.assert.neverCalledWithMatch(spy, 'a', 'b', 'c');
+    sinon.assert.alwaysCalledWith(spy, "a", "b", "c");
+    sinon.assert.neverCalledWith(spy, "a", "b", "c");
+    sinon.assert.calledWithExactly(spy, "a", "b", "c");
+    sinon.assert.calledOnceWithExactly(spy, "a", "b", "c");
+    sinon.assert.alwaysCalledWithExactly(spy, "a", "b", "c");
+    sinon.assert.calledWithMatch(spy, "a", "b", "c");
+    sinon.assert.calledWithMatch(spy.firstCall, "a", "b", "c");
+    sinon.assert.calledOnceWithMatch(spy, "a", "b", "c");
+    sinon.assert.calledOnceWithMatch(spy.firstCall, "a", "b", "c");
+    sinon.assert.alwaysCalledWithMatch(spy, "a", "b", "c");
+    sinon.assert.neverCalledWithMatch(spy, "a", "b", "c");
     sinon.assert.calledWithNew(spy);
     sinon.assert.calledWithNew(spy.firstCall);
     sinon.assert.threw(spy);
     sinon.assert.threw(spy.firstCall);
-    sinon.assert.threw(spy, 'foo error');
-    sinon.assert.threw(spy.firstCall, 'foo error');
-    sinon.assert.threw(spy, new Error('foo'));
-    sinon.assert.threw(spy.firstCall, new Error('foo'));
+    sinon.assert.threw(spy, "foo error");
+    sinon.assert.threw(spy.firstCall, "foo error");
+    sinon.assert.threw(spy, new Error("foo"));
+    sinon.assert.threw(spy.firstCall, new Error("foo"));
     sinon.assert.alwaysThrew(spy);
-    sinon.assert.alwaysThrew(spy, 'foo error');
-    sinon.assert.alwaysThrew(spy, new Error('foo'));
-    sinon.assert.match('a', 'b');
+    sinon.assert.alwaysThrew(spy, "foo error");
+    sinon.assert.alwaysThrew(spy, new Error("foo"));
+    sinon.assert.match("a", "b");
     sinon.assert.match(1, 1 + 1);
-    sinon.assert.match({ a: 1 }, { b: 2, c: 'abc' });
+    sinon.assert.match({ a: 1 }, { b: 2, c: "abc" });
     sinon.assert.expose(obj);
-    sinon.assert.expose(obj, { prefix: 'blah' });
+    sinon.assert.expose(obj, { prefix: "blah" });
     sinon.assert.expose(obj, { includeFail: true });
 
     const typedSpy = sinon.spy((arg1: string, arg2: boolean) => 123);
@@ -343,37 +343,37 @@ function testAssert() {
     sinon.assert.calledOn(typedSpy, obj);
     sinon.assert.calledOn(typedSpy.firstCall, obj);
     sinon.assert.alwaysCalledOn(typedSpy, obj);
-    sinon.assert.alwaysCalledWith(typedSpy, 'a', 'b', 'c'); // $ExpectError
-    sinon.assert.alwaysCalledWith(typedSpy, 'a', true);
-    sinon.assert.neverCalledWith(typedSpy, 'a', false);
-    sinon.assert.neverCalledWith(typedSpy, 'a', 'b'); // $ExpectError
-    sinon.assert.calledWithExactly(typedSpy, 'a', true);
-    sinon.assert.calledWithExactly(typedSpy, 'a', 'b'); // $ExpectError
-    sinon.assert.alwaysCalledWithExactly(typedSpy, 'a', true);
-    sinon.assert.alwaysCalledWithExactly(typedSpy, 'a', 1); // $ExpectError
-    sinon.assert.calledWithMatch(typedSpy, 'a', true);
-    sinon.assert.calledWithMatch(typedSpy.firstCall, 'a', true);
-    sinon.assert.calledWithMatch(typedSpy.firstCall, 'a', 2); // $ExpectError
-    sinon.assert.alwaysCalledWithMatch(typedSpy, 'a', true);
-    sinon.assert.alwaysCalledWithMatch(typedSpy, 'a', 2); // $ExpectError
-    sinon.assert.neverCalledWithMatch(typedSpy, 'a', true);
-    sinon.assert.neverCalledWithMatch(typedSpy, 'a', 2); // $ExpectError
+    sinon.assert.alwaysCalledWith(typedSpy, "a", "b", "c"); // $ExpectError
+    sinon.assert.alwaysCalledWith(typedSpy, "a", true);
+    sinon.assert.neverCalledWith(typedSpy, "a", false);
+    sinon.assert.neverCalledWith(typedSpy, "a", "b"); // $ExpectError
+    sinon.assert.calledWithExactly(typedSpy, "a", true);
+    sinon.assert.calledWithExactly(typedSpy, "a", "b"); // $ExpectError
+    sinon.assert.alwaysCalledWithExactly(typedSpy, "a", true);
+    sinon.assert.alwaysCalledWithExactly(typedSpy, "a", 1); // $ExpectError
+    sinon.assert.calledWithMatch(typedSpy, "a", true);
+    sinon.assert.calledWithMatch(typedSpy.firstCall, "a", true);
+    sinon.assert.calledWithMatch(typedSpy.firstCall, "a", 2); // $ExpectError
+    sinon.assert.alwaysCalledWithMatch(typedSpy, "a", true);
+    sinon.assert.alwaysCalledWithMatch(typedSpy, "a", 2); // $ExpectError
+    sinon.assert.neverCalledWithMatch(typedSpy, "a", true);
+    sinon.assert.neverCalledWithMatch(typedSpy, "a", 2); // $ExpectError
     sinon.assert.calledWithNew(typedSpy);
     sinon.assert.calledWithNew(typedSpy.firstCall);
     sinon.assert.threw(typedSpy);
     sinon.assert.threw(typedSpy.firstCall);
-    sinon.assert.threw(typedSpy, 'foo error');
-    sinon.assert.threw(typedSpy.firstCall, 'foo error');
-    sinon.assert.threw(typedSpy, new Error('foo'));
-    sinon.assert.threw(typedSpy.firstCall, new Error('foo'));
+    sinon.assert.threw(typedSpy, "foo error");
+    sinon.assert.threw(typedSpy.firstCall, "foo error");
+    sinon.assert.threw(typedSpy, new Error("foo"));
+    sinon.assert.threw(typedSpy.firstCall, new Error("foo"));
     sinon.assert.alwaysThrew(typedSpy);
-    sinon.assert.alwaysThrew(typedSpy, 'foo error');
-    sinon.assert.alwaysThrew(typedSpy, new Error('foo'));
-    sinon.assert.match('a', 'b');
+    sinon.assert.alwaysThrew(typedSpy, "foo error");
+    sinon.assert.alwaysThrew(typedSpy, new Error("foo"));
+    sinon.assert.match("a", "b");
     sinon.assert.match(1, 1 + 1);
-    sinon.assert.match({ a: 1 }, { b: 2, c: 'abc' });
+    sinon.assert.match({ a: 1 }, { b: 2, c: "abc" });
     sinon.assert.expose(obj);
-    sinon.assert.expose(obj, { prefix: 'blah' });
+    sinon.assert.expose(obj, { prefix: "blah" });
     sinon.assert.expose(obj, { includeFail: true });
 }
 
@@ -393,52 +393,52 @@ function testTypedSpy() {
     };
 
     const instance = new cls();
-    const spy = sinon.spy(instance, 'foo');
+    const spy = sinon.spy(instance, "foo");
 
-    spy.calledWith(5, 'x');
-    spy.calledWith(sinon.match(5), 'x');
-    spy.calledWithExactly(5, 'x');
-    spy.calledWithExactly(5, sinon.match('x'));
-    spy.calledOnceWith(5, 'x');
-    spy.calledOnceWith(sinon.match(5), 'x');
-    spy.notCalledWith(5, 'x');
-    spy.notCalledWith(sinon.match(5), 'x');
+    spy.calledWith(5, "x");
+    spy.calledWith(sinon.match(5), "x");
+    spy.calledWithExactly(5, "x");
+    spy.calledWithExactly(5, sinon.match("x"));
+    spy.calledOnceWith(5, "x");
+    spy.calledOnceWith(sinon.match(5), "x");
+    spy.notCalledWith(5, "x");
+    spy.notCalledWith(sinon.match(5), "x");
     spy.returned(5);
     spy.returned(sinon.match(5));
 
-    spy.withArgs(sinon.match(5), 'x').calledWith(5, 'x');
-    spy.alwaysCalledWith(sinon.match(5), 'x');
-    spy.alwaysCalledWith(5, 'x');
-    spy.alwaysCalledWithExactly(sinon.match(5), 'x');
-    spy.alwaysCalledWithExactly(5, 'x');
-    spy.neverCalledWith(sinon.match(5), 'x');
-    spy.neverCalledWith(5, 'x');
+    spy.withArgs(sinon.match(5), "x").calledWith(5, "x");
+    spy.alwaysCalledWith(sinon.match(5), "x");
+    spy.alwaysCalledWith(5, "x");
+    spy.alwaysCalledWithExactly(sinon.match(5), "x");
+    spy.alwaysCalledWithExactly(5, "x");
+    spy.neverCalledWith(sinon.match(5), "x");
+    spy.neverCalledWith(5, "x");
 
-    const stub = sinon.stub(instance, 'foo');
+    const stub = sinon.stub(instance, "foo");
 
-    stub.withArgs(5, 'x').returns(3);
-    stub.withArgs(sinon.match(5), 'x').returns(5);
+    stub.withArgs(5, "x").returns(3);
+    stub.withArgs(sinon.match(5), "x").returns(5);
 
-    const accessorSpy = sinon.spy(instance, 'accessorTest', ['get', 'set']);
+    const accessorSpy = sinon.spy(instance, "accessorTest", ["get", "set"]);
     accessorSpy.get.returned(5);
     accessorSpy.set.calledWith(55);
 
-    const getterSpy = sinon.spy(instance, 'getterTest', ['get']);
+    const getterSpy = sinon.spy(instance, "getterTest", ["get"]);
     getterSpy.get.returned(5);
 
-    const setterSpy = sinon.spy(instance, 'setterTest', ['set']);
+    const setterSpy = sinon.spy(instance, "setterTest", ["set"]);
     setterSpy.set.calledWith(100);
 }
 
 function testInstanceSpy() {
     const obj: {
-        foo(arg: number): string
-    } = <any> {};
+        foo(arg: number): string;
+    } = <any>{};
 
     const spy = sinon.spy(obj); // $ExpectType SinonSpiedInstance<{ foo(arg: number): string; }>
 
     spy.foo.calledWith(5);
-    spy.foo.returns('bar'); // $ExpectError
+    spy.foo.returns("bar"); // $ExpectError
 }
 
 function testSpy() {
@@ -456,12 +456,12 @@ function testSpy() {
     const instance = new obj();
 
     const spy = sinon.spy(); // $ExpectType SinonSpy<any[], any>
-    const spyTwo = sinon.spy().named('spyTwo');
+    const spyTwo = sinon.spy().named("spyTwo");
 
-    const methodSpy = sinon.spy(instance, 'foo'); // $ExpectType SinonSpy<[], void>
+    const methodSpy = sinon.spy(instance, "foo"); // $ExpectType SinonSpy<[], void>
     methodSpy.wrappedMethod; // $ExpectType () => void
 
-    const methodSpy2 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined> || SinonSpy<[p1?: string | undefined], string | undefined>
+    const methodSpy2 = sinon.spy(instance, "foobar"); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined> || SinonSpy<[p1?: string | undefined], string | undefined>
     methodSpy2.wrappedMethod; // $ExpectType (p1?: string | undefined) => string | undefined
 
     methodSpy.calledBefore(methodSpy2);
@@ -487,7 +487,7 @@ function testSpy() {
 
     const fnSpy = sinon.spy(fn); // $ExpectType SinonSpy<[string, number], boolean> || SinonSpy<[arg: string, arg2: number], boolean>
     fn = fnSpy; // Should be assignable to original function
-    fnSpy('a', 1); // $ExpectType boolean
+    fnSpy("a", 1); // $ExpectType boolean
     fnSpy.args; // $ExpectType [string, number][] || [arg: string, arg2: number][]
     fnSpy.returnValues; // $ExpectType boolean[]
 
@@ -499,43 +499,43 @@ function testSpy() {
     spy.calledImmediatelyBefore(spyTwo);
     spy.calledImmediatelyAfter(spyTwo);
     spy.calledWithNew();
-    spy.withArgs('a', 1).calledBefore(spyTwo);
+    spy.withArgs("a", 1).calledBefore(spyTwo);
     spy.alwaysCalledOn(instance);
-    spy.alwaysCalledWith('a', 1);
-    spy.alwaysCalledWith('a');
-    spy.alwaysCalledWithExactly('a', 1);
-    spy.alwaysCalledWithMatch('foo');
-    spy.neverCalledWith('b', 2);
-    spy.neverCalledWith('b');
-    spy.neverCalledWithMatch('foo', 'bar');
+    spy.alwaysCalledWith("a", 1);
+    spy.alwaysCalledWith("a");
+    spy.alwaysCalledWithExactly("a", 1);
+    spy.alwaysCalledWithMatch("foo");
+    spy.neverCalledWith("b", 2);
+    spy.neverCalledWith("b");
+    spy.neverCalledWithMatch("foo", "bar");
     spy.alwaysThrew();
-    spy.alwaysThrew('foo');
-    spy.alwaysThrew(new Error('foo'));
-    spy.alwaysReturned('foo');
-    spy.invokeCallback('a', 'b');
+    spy.alwaysThrew("foo");
+    spy.alwaysThrew(new Error("foo"));
+    spy.alwaysReturned("foo");
+    spy.invokeCallback("a", "b");
     spy.calledOn(instance);
-    spy.calledWith('a', 2);
-    spy.calledWithExactly('a', 2);
-    spy.calledOnceWith('a', 2);
-    spy.calledOnceWithExactly('a', 2);
-    spy.calledWithMatch('bar', 2);
-    spy.notCalledWith('a', 2);
-    spy.notCalledWithMatch('a', 2);
+    spy.calledWith("a", 2);
+    spy.calledWithExactly("a", 2);
+    spy.calledOnceWith("a", 2);
+    spy.calledOnceWithExactly("a", 2);
+    spy.calledWithMatch("bar", 2);
+    spy.notCalledWith("a", 2);
+    spy.notCalledWithMatch("a", 2);
     spy.returned(true);
-    spy.returned('foo');
+    spy.returned("foo");
     spy.returned(2);
     spy.threw();
-    spy.threw('foo');
-    spy.threw(new Error('foo'));
+    spy.threw("foo");
+    spy.threw(new Error("foo"));
     spy.callArg(1);
     spy.callArgOn(1, instance);
-    spy.callArgOn(1, instance, 'a', 2);
-    spy.callArgWith(1, 'a', 2);
-    spy.callArgOnWith(1, instance, 'a', 2);
-    spy.yield('a', 2);
-    spy.yieldOn(instance, 'a', 2);
-    spy.yieldTo('prop', 'a', 2);
-    spy.yieldToOn('prop', instance, 'a', 2);
+    spy.callArgOn(1, instance, "a", 2);
+    spy.callArgWith(1, "a", 2);
+    spy.callArgOnWith(1, instance, "a", 2);
+    spy.yield("a", 2);
+    spy.yieldOn(instance, "a", 2);
+    spy.yieldTo("prop", "a", 2);
+    spy.yieldToOn("prop", instance, "a", 2);
 
     let call = spy.firstCall;
     call = spy.secondCall;
@@ -562,10 +562,10 @@ function testStub() {
             return 1;
         }
         promiseFunc() {
-            return Promise.resolve('foo');
+            return Promise.resolve("foo");
         }
         promiseLikeFunc() {
-            return Promise.resolve('foo') as PromiseLike<string>;
+            return Promise.resolve("foo") as PromiseLike<string>;
         }
         unresolvableReturnFunc(): any {
             return Promise.resolve();
@@ -580,15 +580,15 @@ function testStub() {
 
     const spy: sinon.SinonSpy = stub;
 
-    const promiseStub = sinon.stub(instance, 'promiseFunc');
-    promiseStub.resolves('test');
+    const promiseStub = sinon.stub(instance, "promiseFunc");
+    promiseStub.resolves("test");
     promiseStub.resolves(123); // $ExpectError
 
-    const promiseUnresolvableReturn = sinon.stub(instance, 'unresolvableReturnFunc');
-    promiseUnresolvableReturn.resolves(['anything', 123, true]);
+    const promiseUnresolvableReturn = sinon.stub(instance, "unresolvableReturnFunc");
+    promiseUnresolvableReturn.resolves(["anything", 123, true]);
 
-    const promiseLikeStub = sinon.stub(instance, 'promiseLikeFunc');
-    promiseLikeStub.resolves('test');
+    const promiseLikeStub = sinon.stub(instance, "promiseLikeFunc");
+    promiseLikeStub.resolves("test");
 
     sinon.stub(instance);
 
@@ -598,70 +598,70 @@ function testStub() {
 
     stub.returns(true);
     stub.returns(5);
-    stub.returns('foo');
+    stub.returns("foo");
     stub.returnsArg(1);
     stub.returnsThis();
     stub.resolves();
-    stub.resolves('foo');
+    stub.resolves("foo");
     stub.resolvesArg(1);
     stub.resolvesThis();
     stub.throws();
-    stub.throws('err');
-    stub.throws(new Error('err'));
+    stub.throws("err");
+    stub.throws(new Error("err"));
     stub.throwsArg(1);
-    stub.throwsException('err');
-    stub.throwsException(new Error('err'));
+    stub.throwsException("err");
+    stub.throwsException(new Error("err"));
     stub.rejects();
-    stub.rejects('TypeError');
+    stub.rejects("TypeError");
     stub.rejects(1234);
     stub.callsArg(1);
     stub.callThrough();
     stub.callsArgOn(1, instance);
-    stub.callsArgWith(1, 'a', 2);
+    stub.callsArgWith(1, "a", 2);
     stub.callsArgAsync(1);
     stub.callsArgOnAsync(1, instance);
-    stub.callsArgWithAsync(1, 'a', 2);
-    stub.callsArgOnWithAsync(1, instance, 'a', 2);
+    stub.callsArgWithAsync(1, "a", 2);
+    stub.callsArgOnWithAsync(1, instance, "a", 2);
     stub.callsFake((s1, s2, s3) => {});
     stub.callsFake(() => {});
     stub.get(() => true);
     stub.set(v => {});
     stub.onCall(1).returns(true);
-    stub.onFirstCall().resolves('foo');
-    stub.onSecondCall().resolves('foo');
-    stub.onThirdCall().resolves('foo');
-    stub.value('foo');
-    stub.yields('a', 2);
-    stub.yieldsOn(instance, 'a', 2);
-    stub.yieldsRight('a', 2);
-    stub.yieldsTo('foo', 'a', 2);
-    stub.yieldsToOn('foo', instance, 'a', 2);
-    stub.yieldsAsync('a', 2);
-    stub.yieldsOnAsync(instance, 'a', 2);
-    stub.yieldsToAsync('foo', 'a', 2);
-    stub.yieldsToOnAsync('foo', instance, 'a', 2);
-    stub.withArgs('a', 2).returns(true);
+    stub.onFirstCall().resolves("foo");
+    stub.onSecondCall().resolves("foo");
+    stub.onThirdCall().resolves("foo");
+    stub.value("foo");
+    stub.yields("a", 2);
+    stub.yieldsOn(instance, "a", 2);
+    stub.yieldsRight("a", 2);
+    stub.yieldsTo("foo", "a", 2);
+    stub.yieldsToOn("foo", instance, "a", 2);
+    stub.yieldsAsync("a", 2);
+    stub.yieldsOnAsync(instance, "a", 2);
+    stub.yieldsToAsync("foo", "a", 2);
+    stub.yieldsToOnAsync("foo", instance, "a", 2);
+    stub.withArgs("a", 2).returns(true);
 
     // Type-safe stubs
-    const stub2 = sinon.stub(instance, 'foo').named('namedStub');
+    const stub2 = sinon.stub(instance, "foo").named("namedStub");
     instance.foo = stub2; // Should be assignable to original
     stub2.returns(true); // $ExpectError
     stub2.returns(5);
-    stub2.returns('foo'); // $ExpectError
+    stub2.returns("foo"); // $ExpectError
     stub2.callsFake((arg: string) => 1);
     stub2.callsFake((arg: number) => 1); // $ExpectError
-    stub2.callsFake((arg: string) => 'a'); // $ExpectError
+    stub2.callsFake((arg: string) => "a"); // $ExpectError
     stub2.onCall(1).returns(2);
-    stub2.withArgs('a', 2).returns('true'); // $ExpectError
-    stub2.withArgs('a').returns(1);
-    stub2.withArgs('a').returns('a'); // $ExpectError
+    stub2.withArgs("a", 2).returns("true"); // $ExpectError
+    stub2.withArgs("a").returns(1);
+    stub2.withArgs("a").returns("a"); // $ExpectError
 
-    const stub3 = sinon.stub(instance, 'fooDeep').named('namedStubDeep');
+    const stub3 = sinon.stub(instance, "fooDeep").named("namedStubDeep");
     stub3.calledWith({ s: sinon.match.string });
 
-    const pStub = sinon.stub(instance, 'promiseFunc');
+    const pStub = sinon.stub(instance, "promiseFunc");
     pStub.resolves();
-    pStub.resolves('foo');
+    pStub.resolves("foo");
     pStub.resolves(1); // $ExpectError
 }
 
@@ -674,9 +674,9 @@ function testTypedStub() {
     let stub: sinon.SinonStub<[number, string], boolean> = sinon.stub();
     let stub2 = sinon.stub<[number, string], boolean>();
     const foo = new Foo();
-    stub = sinon.stub(foo, 'bar');
-    stub2 = sinon.stub(foo, 'bar');
-    const result: boolean = stub(42, 'qux');
+    stub = sinon.stub(foo, "bar");
+    stub2 = sinon.stub(foo, "bar");
+    const result: boolean = stub(42, "qux");
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
         bar: sinon.stub(),
     };
@@ -686,13 +686,13 @@ function testMock() {
     const obj = {};
     const mock = sinon.mock(obj);
 
-    mock.expects('method').atLeast(2).atMost(5);
+    mock.expects("method").atLeast(2).atMost(5);
     mock.restore();
     mock.verify();
 }
 
 function testAddBehavior() {
-    sinon.addBehavior('returnsNum', (fake, n) => {
+    sinon.addBehavior("returnsNum", (fake, n) => {
         fake.returns(n);
     });
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

This just uncomments some tests i temporarily disabled while waiting for sinon to merge a PR on their end.

one curiosity is that we now use `typeof globalThis.setTimeout` for example, which is a node timer in node (an object) and a number in browsers.

so a test like this (in browsers) won't work:

```ts
const num = clock.setTimeout(fn, 1000);

num = clock.setImmediate(fn); // This is a node-only function, there is no setImmediate in browsers. so you can get a node timer in a browser, according to the types
```