### PR TITLE
[@types/google-protobuf] Add proto3 optional to google-protobuf types

### DIFF
--- a/types/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
@@ -90,6 +90,11 @@ export class CodeGeneratorResponse extends jspb.Message {
   getError(): string | undefined;
   setError(value: string): CodeGeneratorResponse;
 
+  hasSupportedFeatures(): boolean;
+  clearSupportedFeatures(): CodeGeneratorResponse;
+  getSupportedFeatures(): number | undefined;
+  setSupportedFeatures(value: number): CodeGeneratorResponse;
+
   clearFileList(): CodeGeneratorResponse;
   getFileList(): Array<CodeGeneratorResponse.File>;
   setFileList(value: Array<CodeGeneratorResponse.File>): CodeGeneratorResponse;
@@ -108,7 +113,13 @@ export class CodeGeneratorResponse extends jspb.Message {
 export namespace CodeGeneratorResponse {
   export type AsObject = {
     error?: string,
+    supportedFeatures?: number,
     fileList: Array<File.AsObject>,
+  }
+
+  export enum Feature {
+    FEATURE_NONE = 0,
+    FEATURE_PROTO3_OPTIONAL = 1,
   }
 
   export class File extends jspb.Message {

--- a/types/google-protobuf/google/protobuf/descriptor_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/descriptor_pb.d.ts
@@ -324,6 +324,11 @@ export class FieldDescriptorProto extends jspb.Message {
   getOptions(): FieldOptions | undefined;
   setOptions(value?: FieldOptions): FieldDescriptorProto;
 
+  hasProto3Optional(): boolean;
+  clearProto3Optional(): FieldDescriptorProto;
+  getProto3Optional(): boolean | undefined;
+  setProto3Optional(value: boolean): FieldDescriptorProto;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
   static toObject(includeInstance: boolean, msg: FieldDescriptorProto): FieldDescriptorProto.AsObject;
@@ -346,6 +351,7 @@ export namespace FieldDescriptorProto {
     oneofIndex?: number,
     jsonName?: string,
     options?: FieldOptions.AsObject,
+    proto3Optional?: boolean,
   }
 
   export enum Type {

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for google-protobuf 3.7
+// Type definitions for google-protobuf 3.15
 // Project: https://github.com/google/google-protobuf
 // Definitions by: Marcus Longmuir <https://github.com/marcuslongmuir>
 //                 Chaitanya Kamatham <https://github.com/kamthamc>


### PR DESCRIPTION
Add the new proto3 optional presence typing information to the
google-protobuf types.Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
