### PR TITLE
[nw.js] Set NWJS_Helpers.win.window type as Window

### DIFF
--- a/types/nw.js/index.d.ts
+++ b/types/nw.js/index.d.ts
@@ -828,7 +828,7 @@ declare global {
             /**
              * Get the corresponding DOM window object of the native window.
              */
-            window: Object;
+            window: Window;
 
             /**
              * Get or set left offset from window to screen.

--- a/types/nw.js/nw.js-tests.ts
+++ b/types/nw.js/nw.js-tests.ts
@@ -334,6 +334,16 @@ nw.Window.open('popup.html', {}, function (win) {
         win = null;
     });
 
+    // Listen for window click event
+    win.window.addEventListener('on', function () {
+        // Create div element notifying of click
+        var el = win.window.document.createElement('div');
+        el.innerText = 'Window clicked!';
+
+        // Append it to the body
+        win.window.document.body.append(el);
+    });
+
     // Listen to main window's close event
     nw.Window.get().on('close', function () {
         // Hide the window to give user the feeling of closing immediately


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nwjs.readthedocs.io/en/latest/References/Window/#winwindow
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Setting the type of the window property of NWJS_Helpers.win as Object makes it so none of the properties of the window object can be accessed without causing problems.