### PR TITLE
[jsrsasign] Added gracePeriod to verifyJWT

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -1,4 +1,4 @@
-import { KJUR, KEYUTIL, b64toBA, b64tohex } from 'jsrsasign';
+import { KJUR, KEYUTIL, b64toBA, b64tohex, RSAKey } from 'jsrsasign';
 
 const ec = new KJUR.crypto.ECDSA({ curve: 'secp256r1' });
 ec.generateKeyPairHex();
@@ -31,3 +31,7 @@ b64tohex('ZXhhbXBsZQ=='); // $ExpectType string
 
 KJUR.jws.JWS.sign(null, { alg: 'HS256' }, 'payload', { utf8: '123abc' });
 KJUR.jws.JWS.sign(null, { alg: 'HS256' }, 'payload', '123abc');
+
+KJUR.jws.JWS.verifyJWT('', new RSAKey(), {});
+KJUR.jws.JWS.verifyJWT('', '', {});
+KJUR.jws.JWS.verifyJWT('', '', { gracePeriod: 1 });

--- a/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
+++ b/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
@@ -363,6 +363,7 @@ declare namespace jsrsasign.KJUR.jws {
                 jti?: string;
                 sub?: string[];
                 verifyAt?: string | number;
+                gracePeriod?: number;
             },
         ): boolean;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://kjur.github.io/jsrsasign/api/symbols/KJUR.jws.JWS.html#.verifyJWT

> Clock of JWT generator or verifier can be fast or slow. If these clocks are very different, JWT validation may fail. To avoid such case, 'jsrsasign' supports 'acceptField.gracePeriod' parameter which specifies acceptable time difference of those clocks in seconds. So if you want to accept slow or fast in 2 hours, you can specify acceptField.gracePeriod = 2 * 60 * 60;. "gracePeriod" is zero by default. "gracePeriod" is supported since jsrsasign 5.0.12.

@ffflorian 