### PR TITLE
[matrix-js-sdk] fix: fields on EventContentType being optional

### DIFF
--- a/types/matrix-js-sdk/index.d.ts
+++ b/types/matrix-js-sdk/index.d.ts
@@ -1091,8 +1091,8 @@ export interface CreateClientOption {
 export function createClient(ops: string | CreateClientOption): MatrixClient;
 
 export interface EventContentType {
-    body: string;
-    msgtype: MsgType;
+    body?: string;
+    msgtype?: MsgType;
 }
 
 export interface UnsignedType {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

By looking at the sdk code it can happen very well that these fields are undefined. However, it's a bit unlucky, when we know e.g. the type of an event is `m.room.message` that these values will be set. I intend to create an updated version where you could pass some generics to `MatrixEvent` so its fields will be better types.
