### PR TITLE
[sharedb] Re-export `Snapshot` and `LocalPresence`

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -130,7 +130,7 @@ declare namespace sharedb {
     }
 
     type DBQueryMethod = (collection: string, query: any, fields: ProjectionFields | undefined, options: any, callback: DBQueryCallback) => void;
-    type DBQueryCallback = (err: Error | null, snapshots: ShareDB.Snapshot[], extra?: any) => void;
+    type DBQueryCallback = (err: Error | null, snapshots: Snapshot[], extra?: any) => void;
 
     abstract class PubSub {
         private static shallowCopy(obj: any): any;
@@ -158,7 +158,7 @@ declare namespace sharedb {
     abstract class MilestoneDB {
         close(callback?: BasicCallback): void;
         getMilestoneSnapshot(collection: string, id: string, version: number, callback?: BasicCallback): void;
-        saveMilestoneSnapshot(collection: string, snapshot: ShareDB.Snapshot, callback?: BasicCallback): void;
+        saveMilestoneSnapshot(collection: string, snapshot: Snapshot, callback?: BasicCallback): void;
         getMilestoneSnapshotAtOrBeforeTime(collection: string, id: string, timestamp: number, callback?: BasicCallback): void;
         getMilestoneSnapshotAtOrAfterTime(collection: string, id: string, timestamp: number, callback?: BasicCallback): void;
     }
@@ -174,6 +174,7 @@ declare namespace sharedb {
         createSubscribeQuery(collectionName: string, query: string, options: {results?: ShareDB.Query[]}, callback: (err: Error, results: any) => any): ShareDB.Query;
     }
     type Doc = ShareDB.Doc;
+    type Snapshot = ShareDB.Snapshot;
     type Query = ShareDB.Query;
     type Error = ShareDB.Error;
     type Op = ShareDB.Op;
@@ -237,7 +238,7 @@ declare namespace sharedb {
         interface DocContext extends BaseContext {
             collection: string;
             id: string;
-            snapshot: ShareDB.Snapshot;
+            snapshot: Snapshot;
         }
 
         interface OpContext extends BaseContext {
@@ -260,7 +261,7 @@ declare namespace sharedb {
 
         interface ReadSnapshotsContext extends BaseContext {
             collection: string;
-            snapshots: ShareDB.Snapshot[];
+            snapshots: Snapshot[];
             snapshotType: SnapshotType;
         }
 
@@ -306,7 +307,7 @@ interface SubmitRequest {
     maxRetries: number | null;
     retries: number;
 
-    snapshot: ShareDB.Snapshot | null;
+    snapshot: sharedb.Snapshot | null;
     ops: any[];
     channels: string[] | null;
 }

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -19,8 +19,10 @@ export class Connection {
     getDocPresence(collection: string, id: string): Presence;
 }
 export type Doc<T = any> = ShareDB.Doc<T>;
+export type Snapshot<T = any> = ShareDB.Snapshot<T>;
 export type Query<T = any> = ShareDB.Query<T>;
 export type Presence<T = any> = ShareDB.Presence<T>;
+export type LocalPresence<T = any> = ShareDB.LocalPresence<T>;
 export type Error = ShareDB.Error;
 export type Op = ShareDB.Op;
 export type AddNumOp = ShareDB.AddNumOp;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -308,7 +308,7 @@ function startClient(callback) {
 
     doc.submitOp([{insert: 'foo', attributes: {bold: true}}], {source: {deep: true}});
 
-    connection.fetchSnapshot('examples', 'foo', 123, (error, snapshot) => {
+    connection.fetchSnapshot('examples', 'foo', 123, (error, snapshot: ShareDBClient.Snapshot) => {
         if (error) throw error;
         console.log(snapshot.data);
     });


### PR DESCRIPTION
Since `sharedb/lib/sharedb` isn't a real module, importing types from
that module doesn't work correctly (which is presumably why all the
other classes are also re-exported).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.