### PR TITLE
Fix ArangoDB exists() annotation

### DIFF
--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -659,7 +659,7 @@ declare namespace ArangoDB {
         document(
             selectors: ReadonlyArray<string | DocumentLike>
         ): Array<Document<T>>;
-        exists(name: string): boolean;
+        exists(name: string): DocumentMetadata | false;
         firstExample(example: Partial<Document<T>>): Document<T> | null;
         getResponsibleShard(document: DocumentLike): string;
         insert(data: DocumentData<T>, options?: InsertOptions): InsertResult<T>;


### PR DESCRIPTION
Type annotation for `exists()` function in `@types/arangodb` can either return `false` if the document is missing, or Document metadata (_id, _key, _rev) if it exists. Type annotation currently only lists boolean as possible return value.

See ArangoDB [source code](https://github.com/arangodb/arangodb/blob/devel/js/client/modules/%40arangodb/arango-collection.js#L800-L813) and [documentation](https://www.arangodb.com/docs/stable/data-modeling-documents-document-methods.html#exists).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/arangodb/arangodb/blob/devel/js/client/modules/%40arangodb/arango-collection.js#L800-L813)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
