### PR TITLE
ActionCable: Update the subscription's signature

### DIFF
--- a/types/actioncable/actioncable-tests.ts
+++ b/types/actioncable/actioncable-tests.ts
@@ -1,7 +1,3 @@
-interface HelloChannel extends ActionCable.Channel {
-  hello(world: string, name?: string): void;
-}
-
 App = {};
 App.cable = ActionCable.createConsumer();
 const helloChannel = App.cable.subscriptions.create('NetworkChannel', {
@@ -17,7 +13,7 @@ const helloChannel = App.cable.subscriptions.create('NetworkChannel', {
   hello(world: string, name: string = 'John Doe'): void {
     console.log(`Hello, ${world}! name[${name}]`);
   }
-}) as HelloChannel;
+});
 
 helloChannel.hello('World');
 

--- a/types/actioncable/index.d.ts
+++ b/types/actioncable/index.d.ts
@@ -13,7 +13,7 @@ declare module ActionCable {
   }
 
   interface Subscriptions {
-    create(channel: string|ChannelNameWithParams, obj?: CreateMixin): Channel;
+    create<T extends CreateMixin>(channel: string|ChannelNameWithParams, obj?: T): Channel & T;
   }
 
   interface Cable {


### PR DESCRIPTION
When a new channel subscription is created with custom methods in the
`CreateMixin`, those methods are available in the resulting channel.

This commit uses a generic to extend the `CreateMixin` and merge it with
the resulting `Channel`.

Doing this saves us from having to extend the `Channel` interface
manually.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rails/rails/blob/0d91d4aa07cd69d97e8390176d43a93a862cca0a/actioncable/app/javascript/action_cable/subscription.js#L59-L74
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
