### PR TITLE
[google-spreadsheet] fix: typo for WorksheetDimensions

### DIFF
--- a/types/google-spreadsheet/index.d.ts
+++ b/types/google-spreadsheet/index.d.ts
@@ -8,7 +8,7 @@
 
 export type WorksheetType = 'GRID' | 'OBJECT';
 
-export type WorksheetDimension = 'ROW' | 'COLUMN';
+export type WorksheetDimension = 'ROWS' | 'COLUMNS';
 
 export type HyperlinkDisplayType = 'LINKED' | 'PLAIN_TEXT';
 


### PR DESCRIPTION

Update in accordance with GoogleAPI and google-spreadsheet documentation 

https://theoephraim.github.io/node-google-spreadsheet/#/classes/google-spreadsheet-worksheet?id=fn-updatedimensionproperties

It's clear there that enum should have ROWS and COLUMNS, not ROW and COLUMN.
