### PR TITLE
Fixed express-mysql-session import of express-session causing tslint to freak out

### DIFF
--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -5,11 +5,12 @@
 //                 Ionaru <https://github.com/Ionaru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as express from 'express';
 import * as expressSession from 'express-session';
 
 export = MySQLStore;
 
-declare function MySQLStore(session: typeof expressSession.session): typeof MySQLStoreClass;
+declare function MySQLStore(session: typeof express.RequestHandler): typeof MySQLStoreClass;
 
 declare namespace MySQLStore {
     interface Options {

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -5,11 +5,11 @@
 //                 Ionaru <https://github.com/Ionaru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import expressSession, { Store } from 'express-session';
+import * as expressSession from 'express-session';
 
 export = MySQLStore;
 
-declare function MySQLStore(session: typeof expressSession): typeof MySQLStoreClass;
+declare function MySQLStore(session: typeof expressSession.session): typeof MySQLStoreClass;
 
 declare namespace MySQLStore {
     interface Options {
@@ -37,7 +37,7 @@ declare namespace MySQLStore {
     type MySQLStore = MySQLStoreClass;
 }
 
-declare class MySQLStoreClass extends Store {
+declare class MySQLStoreClass extends expressSession.Store {
     constructor(options: MySQLStore.Options, connection?: any, callback?: (error: any) => void);
 
     setDefaultOptions(): void;

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -5,12 +5,11 @@
 //                 Ionaru <https://github.com/Ionaru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as express from 'express';
-import * as expressSession from 'express-session';
+import expressSession = require('express-session');
 
 export = MySQLStore;
 
-declare function MySQLStore(session: typeof express.RequestHandler): typeof MySQLStoreClass;
+declare function MySQLStore(session: typeof expressSession): typeof MySQLStoreClass;
 
 declare namespace MySQLStore {
     interface Options {

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -5,7 +5,7 @@
 //                 Ionaru <https://github.com/Ionaru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as expressSession from 'express-session';
+import expressSession, { Store } from 'express-session';
 
 export = MySQLStore;
 
@@ -37,7 +37,7 @@ declare namespace MySQLStore {
     type MySQLStore = MySQLStoreClass;
 }
 
-declare class MySQLStoreClass extends expressSession.Store {
+declare class MySQLStoreClass extends Store {
     constructor(options: MySQLStore.Options, connection?: any, callback?: (error: any) => void);
 
     setDefaultOptions(): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/expressjs/session>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

EDIT: It seems that the import was correct, but the way it was being imported (using * as ident) was causing tslint to freak out.
