### PR TITLE
[gifencoder]: added missing definitions for encoder.setTransparent() and encoder.out

### DIFF
--- a/types/gifencoder/gifencoder-tests.ts
+++ b/types/gifencoder/gifencoder-tests.ts
@@ -1,5 +1,5 @@
-import GIFEncoder = require('gifencoder');
-import fs = require('fs');
+import GIFEncoder = require("gifencoder");
+import fs = require("fs");
 
 declare const pngFileStream: NodeJS.ReadableStream;
 
@@ -7,37 +7,40 @@ const encoder = new GIFEncoder(854, 480);
 
 const stream = pngFileStream
     .pipe(encoder.createWriteStream({ repeat: -1, delay: 500, quality: 10 }))
-    .pipe(fs.createWriteStream('myanimated.gif'));
+    .pipe(fs.createWriteStream("myanimated.gif"));
 
-stream.on('finish', () => {
+stream.on("finish", () => {
     // Process generated GIF
 });
 
 // stream the results as they are available into myanimated.gif
-encoder.createReadStream().pipe(fs.createWriteStream('myanimated.gif'));
+encoder.createReadStream().pipe(fs.createWriteStream("myanimated.gif"));
 
 encoder.start();
 encoder.setRepeat(0); // 0 for repeat, -1 for no-repeat
 encoder.setDelay(500); // frame delay in ms
 encoder.setQuality(10); // image quality. 10 is default.
+encoder.setTransparent(0x000000);
 
 // use node-canvas
 declare const canvas: HTMLCanvasElement;
-const ctx = canvas.getContext('2d')!;
+const ctx = canvas.getContext("2d")!;
 
 // red rectangle
-ctx.fillStyle = '#ff0000';
+ctx.fillStyle = "#ff0000";
 ctx.fillRect(0, 0, 320, 240);
 encoder.addFrame(ctx);
 
 // green rectangle
-ctx.fillStyle = '#00ff00';
+ctx.fillStyle = "#00ff00";
 ctx.fillRect(0, 0, 320, 240);
 encoder.addFrame(ctx);
 
 // blue rectangle
-ctx.fillStyle = '#0000ff';
+ctx.fillStyle = "#0000ff";
 ctx.fillRect(0, 0, 320, 240);
 encoder.addFrame(ctx);
 
 encoder.finish();
+
+const image = encoder.out.getData();

--- a/types/gifencoder/index.d.ts
+++ b/types/gifencoder/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for gifencoder 2.0
 // Project: https://github.com/eugeneware/gifencoder#readme
 // Definitions by: Carlos Precioso <https://github.com/cprecioso>
+//                 Almeida <https://github.com/almeidx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-import { Readable, Transform } from 'stream';
+import { Readable, Transform } from "stream";
 
 declare class GIFEncoder {
     constructor(width: number, height: number);
@@ -19,8 +20,11 @@ declare class GIFEncoder {
     ): void;
     setDelay(/** frame delay in ms */ delay: number): void;
     setQuality(/** image quality. 10 is default */ quality: number): void;
+    setTransparent(color: number | string): void;
     addFrame(ctx: CanvasRenderingContext2D): void;
     finish(): void;
+
+    out: GIFEncoder.ByteArray;
 }
 
 declare namespace GIFEncoder {
@@ -31,6 +35,11 @@ declare namespace GIFEncoder {
         delay: number;
         /** image quality. 10 is default */
         quality: number;
+    }
+
+    interface ByteArray {
+        data: number[];
+        getData(): Buffer;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [`encoder.out`](https://github.com/eugeneware/gifencoder/blob/18f84bdef2eb6bae1097d5f1a7e0306552dc3b59/lib/GIFEncoder.js#L69)
  - [`encoder.setTransparent`](https://github.com/eugeneware/gifencoder/blob/18f84bdef2eb6bae1097d5f1a7e0306552dc3b59/lib/GIFEncoder.js#L178)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
