### PR TITLE
Add types for meteor mdg:validation-error

### DIFF
--- a/types/meteor-mdg-validation-error/index.d.ts
+++ b/types/meteor-mdg-validation-error/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="meteor"/>
 
 // tslint:disable-next-line no-single-declare-module
-declare module 'meteor/mdg:validation-error' {
+declare module "meteor/mdg:validation-error" {
     interface ValidationErrorDetail {
         name: string;
         type: string;

--- a/types/meteor-mdg-validation-error/index.d.ts
+++ b/types/meteor-mdg-validation-error/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for non-npm package Atmosphere package mdg:validation-error 0.5
+// Project: https://github.com/meteor/validation-error
+// Definitions by: ToastHawaii <https://github.com/ToastHawaii>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+/// <reference types="meteor"/>
+
+// tslint:disable-next-line no-single-declare-module
+declare module 'meteor/mdg:validation-error' {
+    interface ValidationErrorDetail {
+        name: string;
+        type: string;
+        [name: string]: any;
+    }
+    class ValidationError extends Meteor.Error {
+        /**
+         * @param errors The "details" property of the ValidationError must be an array of objects containing at least two properties. The "name" and "type" properties are required.
+         */
+        constructor(errors: ValidationErrorDetail[], message?: string);
+        /** Static method checking if a given Meteor.Error is an instance of ValidationError. */
+        static is(err: any): err is ValidationError;
+        /**  Universal validation error code to be use in applications and packages. */
+        static ERROR_CODE: string;
+        /**  Default validation error message that can be changed globally. */
+        static DEFAULT_MESSAGE: string;
+    }
+}

--- a/types/meteor-mdg-validation-error/meteor-mdg-validation-error-tests.ts
+++ b/types/meteor-mdg-validation-error/meteor-mdg-validation-error-tests.ts
@@ -1,0 +1,17 @@
+// Tests based on https://github.com/meteor/validation-error/blob/master/validation-error-tests.js
+
+import { ValidationError } from "meteor/mdg:validation-error";
+
+// $ExpectError
+new ValidationError([{ name: 'name' }]);
+
+const error = new ValidationError([{
+    name: 'name',
+    type: 'required'
+}], 'Name is required');
+
+// $ExpectType string | number
+error.error;
+
+// $ExpectType string
+error.message;

--- a/types/meteor-mdg-validation-error/tsconfig.json
+++ b/types/meteor-mdg-validation-error/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "DOM"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/meteor-mdg-validation-error/tsconfig.json
+++ b/types/meteor-mdg-validation-error/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/meteor-mdg-validation-error/tsconfig.json
+++ b/types/meteor-mdg-validation-error/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "meteor-mdg-validation-error-tests.ts"
+    ]
+}

--- a/types/meteor-mdg-validation-error/tslint.json
+++ b/types/meteor-mdg-validation-error/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
