### PR TITLE
cytoscape: add blob-promise output option

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -377,6 +377,15 @@ cy.png({
   maxWidth: 100,
   maxHeight: 100
 });
+// $ExpectType Promise<Blob>
+cy.png({
+  output: 'blob-promise',
+  bg: oneOf('#ffffff', undefined),
+  full: true,
+  scale: 2,
+  maxWidth: 100,
+  maxHeight: 100
+});
 
 aliases(cy.jpg, cy.jpeg);
 // $ExpectType string
@@ -392,6 +401,16 @@ cy.jpg({
 // $ExpectType Blob
 cy.jpg({
   output: 'blob',
+  bg: oneOf('#ffffff', undefined),
+  full: true,
+  scale: 2,
+  maxWidth: 100,
+  maxHeight: 100,
+  quality: 0.5
+});
+// $ExpectType Promise<Blob>
+cy.jpg({
+  output: 'blob-promise',
   bg: oneOf('#ffffff', undefined),
   full: true,
   scale: 2,

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1151,6 +1151,13 @@ declare namespace cytoscape {
         output?: "blob";
     }
 
+    interface ExportBlobPromiseOptions extends ExportOptions {
+        /**
+         * output Whether the output should be 'base64uri' (default), 'base64', 'blob', or 'blob-promise'.
+         */
+        output?: "blob-promise";
+    }
+
     interface ExportJpgOptions extends ExportOptions {
         /**
          * quality Specifies the quality of the image from 0
@@ -1163,6 +1170,8 @@ declare namespace cytoscape {
     }
     interface ExportJpgBlobOptions extends ExportJpgOptions, ExportBlobOptions {
     }
+    interface ExportJpgBlobPromiseOptions extends ExportJpgOptions, ExportBlobPromiseOptions {
+    }
 
     interface CoreExport {
         /**
@@ -1170,18 +1179,21 @@ declare namespace cytoscape {
          */
         png(options?: ExportStringOptions): string;
         png(options?: ExportBlobOptions): Blob;
+        png(options?: ExportBlobPromiseOptions): Promise<Blob>;
 
         /**
          * Export the current graph view as a JPG image in Base64 representation.
          */
         jpg(options?: ExportJpgStringOptions): string;
         jpg(options?: ExportJpgBlobOptions): Blob;
+        jpg(options?: ExportJpgBlobPromiseOptions): Promise<Blob>;
 
         /**
          * Export the current graph view as a JPG image in Base64 representation.
          */
         jpeg(options?: ExportJpgStringOptions): string;
         jpeg(options?: ExportJpgBlobOptions): Blob;
+        jpeg(options?: ExportJpgBlobPromiseOptions): Promise<Blob>;
 
         /**
          * Export the graph as JSON, the same format used at initialisation.

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1166,10 +1166,13 @@ declare namespace cytoscape {
          */
         quality?: number;
     }
+
     interface ExportJpgStringOptions extends ExportJpgOptions, ExportStringOptions {
     }
+
     interface ExportJpgBlobOptions extends ExportJpgOptions, ExportBlobOptions {
     }
+
     interface ExportJpgBlobPromiseOptions extends ExportJpgOptions, ExportBlobPromiseOptions {
     }
 


### PR DESCRIPTION
Adds missing 'blob-promise' output option to cy.png() and cy.jpeg().
From the documentation (https://js.cytoscape.org/#cy.png):

output - Whether the output should be 'base64uri' (default), 'base64', 'blob', or 'blob-promise' (a promise that resolves to the blob is returned)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
    The existing type definitions does not follow the recommended code style (prettier).  
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://js.cytoscape.org/#cy.png
    - https://js.cytoscape.org/#cy.png
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

