### PR TITLE
Implement TypeScript assertions in http-assert types

### DIFF
--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -1,26 +1,115 @@
-import httpAssert = require('http-assert');
-import { HttpError } from 'http-errors';
+import httpAssert = require("http-assert");
+
+declare function unknown(): unknown;
+
+// assert()
+
+(() => {
+    const value = unknown();
+    httpAssert(typeof value === "string");
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown() as string | undefined;
+    httpAssert(value);
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(typeof value === "number", 400);
+
+    // $ExpectType number
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(typeof value === "boolean", 400, "message");
+
+    // $ExpectType boolean
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(value === undefined, 400, { foo: "bar" });
+
+    // $ExpectType undefined
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(value === null, 400, "message", { foo: "bar" });
+
+    // $ExpectType null
+    value;
+})();
+
+// assert.ok()
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(typeof value === "string");
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown() as string | undefined;
+    httpAssert.ok(value);
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(typeof value === "number", 400);
+
+    // $ExpectType number
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(typeof value === "boolean", 400, "message");
+
+    // $ExpectType boolean
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(value === null, 400, "message", { foo: "bar" });
+
+    // $ExpectType null
+    value;
+})();
+
+// Other assertions
 
 const status = 401;
-const message = 'some error message';
+const message = "some error message";
 const options = {};
 
-try {
-    httpAssert.equal('hello', 'hello');
-    httpAssert.notEqual('hello', 'hello', status, message, options);
-    httpAssert.ok(true);
-    httpAssert.ok(true, status, message, options);
-    httpAssert.strictEqual(3, '3');
-    httpAssert.strictEqual(3, '3', status, message, options);
-    httpAssert.notStrictEqual(3, '3');
-    httpAssert.notStrictEqual(3, '3', status, message, options);
-    httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' });
-    httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
-    httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' });
-    httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
-    httpAssert(false, status, message, options);
-} catch (err) {
-    console.log((err as HttpError).status);
-    console.log((err as HttpError).message);
-    console.log((err as HttpError).expose);
-}
+httpAssert.equal("hello", "hello");
+httpAssert.notEqual("hello", "hello", status, message);
+httpAssert.ok(true);
+httpAssert.ok(true, status, message, options);
+httpAssert.strictEqual(3, "3");
+httpAssert.strictEqual(3, "3", status, message, options);
+httpAssert.notStrictEqual(3, "3");
+httpAssert.notStrictEqual(3, "3", status, message, options);
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert(false, status, message, options);

--- a/types/http-assert/package.json
+++ b/types/http-assert/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "types": "index",
+  "typesVersions": {
+    "<=3.6": { "*": ["ts3.6/*"] }
+  }
+}

--- a/types/http-assert/ts3.6/http-assert-tests.ts
+++ b/types/http-assert/ts3.6/http-assert-tests.ts
@@ -1,0 +1,19 @@
+import httpAssert = require("http-assert");
+
+const status = 401;
+const message = "some error message";
+const options = {};
+
+httpAssert.equal("hello", "hello");
+httpAssert.notEqual("hello", "hello", status, message, options);
+httpAssert.ok(true);
+httpAssert.ok(true, status, message, options);
+httpAssert.strictEqual(3, "3");
+httpAssert.strictEqual(3, "3", status, message, options);
+httpAssert.notStrictEqual(3, "3");
+httpAssert.notStrictEqual(3, "3", status, message, options);
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert(false, status, message, options);

--- a/types/http-assert/ts3.6/index.d.ts
+++ b/types/http-assert/ts3.6/index.d.ts
@@ -1,18 +1,10 @@
-// Type definitions for http-assert 1.5
-// Project: https://github.com/jshttp/http-assert
-// Definitions by: jKey Lu <https://github.com/jkeylu>
-//                 Peter Squicciarini <https://github.com/stripedpajamas>
-//                 Alex Bulanov <https://github.com/sapfear>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
 /**
  * @param status the status code
  * @param msg the message of the error, defaulting to node's text for that status code
  * @param opts custom properties to attach to the error object
  */
-declare function assert(value: any, status?: number, msg?: string, opts?: Record<string, any>): asserts value;
-declare function assert(value: any, status?: number, opts?: Record<string, any>): asserts value;
+declare function assert(value: any, status?: number, msg?: string, opts?: {}): void;
+declare function assert(value: any, status?: number, opts?: {}): void;
 
 declare namespace assert {
     /**
@@ -20,21 +12,21 @@ declare namespace assert {
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type Assert = <T>(a: T, b: T, status?: number, msg?: string, opts?: Record<string, any>) => void;
+    type Assert = <T>(a: T, b: T, status?: number, msg?: string, opts?: {}) => void;
 
     /**
      * @param status the status code
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type AssertOK = (a: any, status?: number, msg?: string, opts?: Record<string, any>) => asserts a;
+    type AssertOK = (a: any, status?: number, msg?: string, opts?: {}) => void;
 
     /**
      * @param status the status code
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type AssertEqual = (a: any, b: any, status?: number, msg?: string, opts?: Record<string, any>) => void;
+    type AssertEqual = (a: any, b: any, status?: number, msg?: string, opts?: {}) => void;
 
     const equal: Assert;
     const notEqual: Assert;

--- a/types/http-assert/ts3.6/tsconfig.json
+++ b/types/http-assert/ts3.6/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "http-assert-tests.ts"
+    ]
+}

--- a/types/http-assert/ts3.6/tslint.json
+++ b/types/http-assert/ts3.6/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Because the `asserts` keyword was introduced in TypeScript 3.7, the old types were moved into the `ts3.6` folder.

The try / catch clause was removed from tests, because it wasn’t used for testing the `http-assert` types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
