### PR TITLE
fix(mousetrap): correct path for extensions

### DIFF
--- a/types/mousetrap/OTHER_FILES.txt
+++ b/types/mousetrap/OTHER_FILES.txt
@@ -1,2 +1,2 @@
-extensions/global.d.ts
-extensions/pause.d.ts
+plugins/global-bind/mousetrap-global-bind.d.ts
+plugins/pause/mousetrap-pause.d.ts

--- a/types/mousetrap/plugins/global-bind/mousetrap-global-bind.d.ts
+++ b/types/mousetrap/plugins/global-bind/mousetrap-global-bind.d.ts
@@ -1,4 +1,4 @@
-import { ExtendedKeyboardEvent, MousetrapStatic } from "../";
+import { ExtendedKeyboardEvent, MousetrapStatic } from "../../";
 
 /** https://craig.is/killing/mice#extensions.global */
 

--- a/types/mousetrap/plugins/pause/mousetrap-pause.d.ts
+++ b/types/mousetrap/plugins/pause/mousetrap-pause.d.ts
@@ -1,4 +1,4 @@
-import { MousetrapStatic, MousetrapInstance } from "../";
+import { MousetrapStatic, MousetrapInstance } from "../..";
 
 /** https://craig.is/killing/mice#extensions.pause */
 

--- a/types/mousetrap/plugins/pause/mousetrap-pause.d.ts
+++ b/types/mousetrap/plugins/pause/mousetrap-pause.d.ts
@@ -1,4 +1,4 @@
-import { MousetrapStatic, MousetrapInstance } from "../..";
+import { MousetrapStatic, MousetrapInstance } from "../../";
 
 /** https://craig.is/killing/mice#extensions.pause */
 

--- a/types/redux-shortcuts/redux-shortcuts-tests.ts
+++ b/types/redux-shortcuts/redux-shortcuts-tests.ts
@@ -4,6 +4,7 @@ import {
     mousetrap,
     Mousetrap
 } from "redux-shortcuts";
+import "mousetrap/plugins/global-bind/mousetrap-global-bind";
 
 import { Dispatch, ActionCreator, Action, AnyAction } from "redux";
 


### PR DESCRIPTION
The path should read 'plugins', not 'extensions'.

/cc @doberkofler

Fixes #52437


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).