### PR TITLE
bpmn-moodle - The `fromXML` method could answer with a Promise instead of a callback function

### DIFF
--- a/types/bpmn-moddle/index.d.ts
+++ b/types/bpmn-moddle/index.d.ts
@@ -1060,6 +1060,43 @@ declare namespace BPMNModdle {
             options: Option,
             done: ImportFn
         ): void;
+
+        /**
+         * Instantiates a BPMN model tree from a given xml string.
+         *
+         * @param xmlStr
+         * XML string
+         */
+        fromXML(xmlStr: string): Promise<Definitions>;
+
+        /**
+         * Instantiates a BPMN model tree from a given xml string.
+         *
+         * @param xmlStr
+         * XML string
+         *
+         * @param options
+         * Options to pass to the underlying reader
+         */
+        fromXML(xmlStr: string, options: Option): Promise<Definitions>;
+
+        /**
+         * Instantiates a BPMN model tree from a given xml string.
+         *
+         * @param xmlStr
+         * XML string
+         *
+         * @param typeName
+         * Name of the root element
+         *
+         * @param options
+         * Options to pass to the underlying reader
+         */
+        fromXML(
+            xmlStr: string,
+            typeName: string,
+            options: Option,
+        ): Promise<Definitions>;
     }
 }
 

--- a/types/bpmn-moddle/index.d.ts
+++ b/types/bpmn-moddle/index.d.ts
@@ -1066,19 +1066,11 @@ declare namespace BPMNModdle {
          *
          * @param xmlStr
          * XML string
-         */
-        fromXML(xmlStr: string): Promise<Definitions>;
-
-        /**
-         * Instantiates a BPMN model tree from a given xml string.
-         *
-         * @param xmlStr
-         * XML string
          *
          * @param options
          * Options to pass to the underlying reader
          */
-        fromXML(xmlStr: string, options: Option): Promise<Definitions>;
+        fromXML(xmlStr: string, options?: Option): Promise<Definitions>;
 
         /**
          * Instantiates a BPMN model tree from a given xml string.


### PR DESCRIPTION
The `fromXML` method could answer with a Promise instead of a callback function

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bpmn-io/bpmn-moddle (the sample is using the Promise form)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
