### PR TITLE
postcss-safe-parser: Update typings for version 5.0.x (postcss 8.x)

### DIFF
--- a/types/postcss-safe-parser/index.d.ts
+++ b/types/postcss-safe-parser/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for postcss-safe-parser 4.0
+// Type definitions for postcss-safe-parser 5.0
 // Project: https://github.com/postcss/postcss-safe-parser#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Fabian van der Veen <https://github.com/fvanderveen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6
 
 import { Parser } from 'postcss';
 

--- a/types/postcss-safe-parser/package.json
+++ b/types/postcss-safe-parser/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "^7.0.30"
+        "postcss": "^8.1.0"
     }
 }

--- a/types/postcss-safe-parser/postcss-safe-parser-tests.ts
+++ b/types/postcss-safe-parser/postcss-safe-parser-tests.ts
@@ -1,5 +1,5 @@
 import safe = require('postcss-safe-parser');
-import postcss = require('postcss');
+import postcss from "postcss";
 
 const badCss = 'a {';
 

--- a/types/postcss-safe-parser/tsconfig.json
+++ b/types/postcss-safe-parser/tsconfig.json
@@ -1,8 +1,9 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "ES6",
         "lib": [
-            "es6"
+            "es2018"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
API of this package hasn't changed, but the API of PostCSS 7.x => 8.x has,
making the current package no longer valid for postcss-safe-parser 5.0.x
when using PostCSS 8.x.

I had to bump the typescript version of these types to 3.6+, as 3.5 does not support the current (8.x) postcss typings as these use `Promise<Type>['finally']`, for example; which seems to have been introduced for `.d.ts` files in 3.6.

The typings in PostCSS have also changed, from `export =` to `export default` => https://github.com/postcss/postcss/blob/main/lib/postcss.d.ts#L443

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postcss/postcss/blob/main/lib/postcss.d.ts#L203 (Interface of Parser has changed wrt PostCSS 7.x)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.