### PR TITLE
fix(escape-html): allow null, undefined, no arg

### DIFF
--- a/types/escape-html/escape-html-tests.ts
+++ b/types/escape-html/escape-html-tests.ts
@@ -6,3 +6,7 @@ const fullName = 'John "Johnny" Smith';
 
 console.dir(`<input name="full_name" value="${escapeHtml(fullName)}">`);
 console.dir(`<textarea name="desc">${escapeHtml(desc)}</textarea>`);
+
+console.log("no arg", escapeHtml())
+console.log("null", escapeHtml(null))
+console.log("undefined", escapeHtml(undefined))

--- a/types/escape-html/escape-html-tests.ts
+++ b/types/escape-html/escape-html-tests.ts
@@ -7,6 +7,6 @@ const fullName = 'John "Johnny" Smith';
 console.dir(`<input name="full_name" value="${escapeHtml(fullName)}">`);
 console.dir(`<textarea name="desc">${escapeHtml(desc)}</textarea>`);
 
-console.log("no arg", escapeHtml())
-console.log("null", escapeHtml(null))
-console.log("undefined", escapeHtml(undefined))
+console.log("no arg", escapeHtml());
+console.log("null", escapeHtml(null));
+console.log("undefined", escapeHtml(undefined));

--- a/types/escape-html/index.d.ts
+++ b/types/escape-html/index.d.ts
@@ -20,6 +20,6 @@
  * *Note* when using the escaped value within a tag, it is only suitable as the value of an attribute,
  * where the value is quoted with either a double quote character (`"`) or a single quote character (`'`).
  */
-declare function escapeHTML(text?: string | null | undefined): string;
+declare function escapeHTML(text?: string | null): string;
 
 export = escapeHTML;

--- a/types/escape-html/index.d.ts
+++ b/types/escape-html/index.d.ts
@@ -20,6 +20,6 @@
  * *Note* when using the escaped value within a tag, it is only suitable as the value of an attribute,
  * where the value is quoted with either a double quote character (`"`) or a single quote character (`'`).
  */
-declare function escapeHTML(text: string): string;
+declare function escapeHTML(text?: string | null | undefined): string;
 
 export = escapeHTML;


### PR DESCRIPTION
This function's parameters are more permissive than the current type
definition:

```js
> const escape = require('escape-html')
undefined
> escape()
'undefined'
> escape(undefined)
'undefined'
> escape(null)
'null'
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/component/escape-html/blob/b42947eefa79efff01b3fe988c4c7e7b051ec8d8/index.js#L34
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.