### PR TITLE
[@types/node] Fix ProcessEnv

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -84,7 +84,7 @@ declare module 'process' {
             }
 
             // Alias for compatibility
-            interface ProcessEnv extends Dict<string> {}
+            interface ProcessEnv extends Dict<string | number | boolean> {}
 
             interface HRTime {
                 (time?: [number, number]): [number, number];

--- a/types/node/test/path.ts
+++ b/types/node/test/path.ts
@@ -85,7 +85,7 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+process.env["PATH"]; // $ExpectType string | number | boolean | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -679,7 +679,7 @@ declare namespace NodeJS {
     }
 
     interface ProcessEnv {
-        [key: string]: string | undefined;
+        [key: string]: string | number | boolean | undefined;
     }
 
     interface WriteStream extends Socket {

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -758,7 +758,7 @@ declare namespace NodeJS {
     }
 
     interface ProcessEnv {
-        [key: string]: string | undefined;
+        [key: string]: string | number | undefined;
     }
 
     interface HRTime {

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -79,7 +79,7 @@ declare module 'worker_threads' {
          * were passed as CLI options to the script.
          */
         argv?: any[];
-        env?: NodeJS.Dict<string> | typeof SHARE_ENV;
+        env?: NodeJS.Dict<string | number | boolean> | typeof SHARE_ENV;
         eval?: boolean;
         workerData?: any;
         stdin?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

https://github.com/nodejs/node/blob/master/src/node_env_var.cc

```cc
if (env->options()->pending_deprecation && !value->IsString() &&
      !value->IsNumber() && !value->IsBoolean() &&
      env->EmitProcessEnvWarning()) 
```

https://nodejs.org/dist/latest-v15.x/docs/api/deprecations.html#DEP0104

> When assigning a non-string property to process.env, the assigned value is implicitly converted to a string. This behavior is deprecated if the assigned value is not a string, boolean, or number. In the future, such assignment might result in a thrown error. Please convert the property to a string before assigning it to process.env.

So the three types of string, number, and boolean are allowed
