### PR TITLE
[pino] fix log formatter arg name

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -510,7 +510,7 @@ declare namespace P {
              * The default shape is { level: number }.
              * The function takes two arguments, the label of the level (e.g. 'info') and the numeric value (e.g. 30).
              */
-            level?: (level: string, number: number) => object;
+            level?: (label: string, number: number) => object;
             /**
              * Changes the shape of the bindings.
              * The default shape is { pid, hostname }.

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -524,7 +524,7 @@ declare namespace P {
              * All arguments passed to the log method, except the message, will be pass to this function.
              * By default it does not change the shape of the log object.
              */
-            log?: (object: object & {err?: Error}) => object;
+            log?: (object: object) => object;
         };
 
         /**

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -524,7 +524,7 @@ declare namespace P {
              * All arguments passed to the log method, except the message, will be pass to this function.
              * By default it does not change the shape of the log object.
              */
-            log?: (object: object) => object;
+            log?: (object: object & {err?: Error}) => object;
         };
 
         /**


### PR DESCRIPTION
`object & {err?: Error}` When used with the default serializers option as per https://github.com/pinojs/pino/blob/master/docs/api.md#serializers-object, log objects will have a top level error object when the prop key `err` is matched and is of type Error.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/pinojs/pino/blob/master/docs/api.md#serializers-object
  - https://github.com/pinojs/pino/blob/master/docs/api.md#level
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
