### PR TITLE
fix(react-dom): Add Document to valid container types

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -6,6 +6,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Josh Rutherford <https://github.com/theruther4d>
 //                 Jessica Franco <https://github.com/Jessidhia>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -53,49 +53,51 @@ export function unstable_renderSubtreeIntoContainer<P>(
     container: Element,
     callback?: (component?: Component<P, ComponentState> | Element) => any): Component<P, ComponentState> | Element | void;
 
+export type Container = Element | Document | DocumentFragment;
+
 export interface Renderer {
     // Deprecated(render): The return value is deprecated.
     // In future releases the render function's return type will be void.
 
     <T extends Element>(
         element: DOMElement<DOMAttributes<T>, T>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): T;
 
     (
         element: Array<DOMElement<DOMAttributes<any>, any>>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Element;
 
     (
         element: SFCElement<any> | Array<SFCElement<any>>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): void;
 
     <P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): T;
 
     (
         element: Array<CElement<any, Component<any, ComponentState>>>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Component<any, ComponentState>;
 
     <P>(
         element: ReactElement<P>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Component<P, ComponentState> | Element | void;
 
     (
         element: ReactElement[],
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Component<any, ComponentState> | Element | void;
 }

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -14,12 +14,14 @@ describe('ReactDOM', () => {
         const rootElement = document.createElement('div');
         ReactDOM.render(React.createElement('div'), rootElement);
         ReactDOM.render(React.createElement('div'), document.createDocumentFragment());
+        ReactDOM.render(React.createElement('div'), document);
     });
 
     it('hydrate', () => {
         const rootElement = document.createElement('div');
         ReactDOM.hydrate(React.createElement('div'), rootElement);
         ReactDOM.hydrate(React.createElement('div'), document.createDocumentFragment());
+        ReactDOM.hydrate(React.createElement('div'), document);
     });
 
     it('unmounts', () => {

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -13,11 +13,13 @@ describe('ReactDOM', () => {
     it('render', () => {
         const rootElement = document.createElement('div');
         ReactDOM.render(React.createElement('div'), rootElement);
+        ReactDOM.render(React.createElement('div'), document.createDocumentFragment());
     });
 
     it('hydrate', () => {
         const rootElement = document.createElement('div');
         ReactDOM.hydrate(React.createElement('div'), rootElement);
+        ReactDOM.hydrate(React.createElement('div'), document.createDocumentFragment());
     });
 
     it('unmounts', () => {

--- a/types/react-dom/v16/index.d.ts
+++ b/types/react-dom/v16/index.d.ts
@@ -6,6 +6,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Josh Rutherford <https://github.com/theruther4d>
 //                 Jessica Franco <https://github.com/Jessidhia>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-dom/v16/index.d.ts
+++ b/types/react-dom/v16/index.d.ts
@@ -53,49 +53,51 @@ export function unstable_renderSubtreeIntoContainer<P>(
     container: Element,
     callback?: (component?: Component<P, ComponentState> | Element) => any): Component<P, ComponentState> | Element | void;
 
+export type Container = Element | Document | DocumentFragment;
+
 export interface Renderer {
     // Deprecated(render): The return value is deprecated.
     // In future releases the render function's return type will be void.
 
     <T extends Element>(
         element: DOMElement<DOMAttributes<T>, T>,
-        container: Element | DocumentFragment | null,
+        container: Container | null,
         callback?: () => void
     ): T;
 
     (
         element: Array<DOMElement<DOMAttributes<any>, any>>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Element;
 
     (
         element: SFCElement<any> | Array<SFCElement<any>>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): void;
 
     <P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): T;
 
     (
         element: Array<CElement<any, Component<any, ComponentState>>>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Component<any, ComponentState>;
 
     <P>(
         element: ReactElement<P>,
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Component<P, ComponentState> | Element | void;
 
     (
         element: ReactElement[],
-        container: Element | DocumentFragment | null,
+        container: Container| null,
         callback?: () => void
     ): Component<any, ComponentState> | Element | void;
 }

--- a/types/react-dom/v16/test/react-dom-tests.tsx
+++ b/types/react-dom/v16/test/react-dom-tests.tsx
@@ -14,12 +14,14 @@ describe('ReactDOM', () => {
         const rootElement = document.createElement('div');
         ReactDOM.render(React.createElement('div'), rootElement);
         ReactDOM.render(React.createElement('div'), document.createDocumentFragment());
+        ReactDOM.render(React.createElement('div'), document);
     });
 
     it('hydrate', () => {
         const rootElement = document.createElement('div');
         ReactDOM.hydrate(React.createElement('div'), rootElement);
         ReactDOM.hydrate(React.createElement('div'), document.createDocumentFragment());
+        ReactDOM.hydrate(React.createElement('div'), document);
     });
 
     it('unmounts', () => {

--- a/types/react-dom/v16/test/react-dom-tests.tsx
+++ b/types/react-dom/v16/test/react-dom-tests.tsx
@@ -13,11 +13,13 @@ describe('ReactDOM', () => {
     it('render', () => {
         const rootElement = document.createElement('div');
         ReactDOM.render(React.createElement('div'), rootElement);
+        ReactDOM.render(React.createElement('div'), document.createDocumentFragment());
     });
 
     it('hydrate', () => {
         const rootElement = document.createElement('div');
         ReactDOM.hydrate(React.createElement('div'), rootElement);
+        ReactDOM.hydrate(React.createElement('div'), document.createDocumentFragment());
     });
 
     it('unmounts', () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - [`Container` in `react@16.9`](https://github.com/facebook/react/blob/v16.9.0/packages/react-dom/src/client/ReactDOMHostConfig.js#L84)
   - [`Container` in `react@17.0`](https://github.com/facebook/react/blob/v17.0.2/packages/react-dom/src/client/ReactDOMHostConfig.js#L109-L111)
   - [CodePen using `document` in a container](https://codepen.io/eps1lon/pen/LYxgOBV) 
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
