### PR TITLE
update(xo): v0.39 updates

### DIFF
--- a/types/xo/index.d.ts
+++ b/types/xo/index.d.ts
@@ -1,17 +1,10 @@
-// Type definitions for xo 0.34
+// Type definitions for xo 0.39
 // Project: https://github.com/xojs/xo#readme
-// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Chuah Chee Shian (shian15810) <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import eslint = require('eslint');
-
-/**
- * From T pick a set of properties K
- */
-export type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-};
+import eslint = require("eslint");
 
 // eslint.CLIEngine.getErrorResults without modification
 // eslint.CLIEngine.getFormatter without modification
@@ -38,20 +31,22 @@ export function lintFiles(patterns: string | string[], options?: Options): Resul
 
 export type CLIEngineOptions = Pick<
     eslint.CLIEngine.Options,
-    'baseConfig' | 'cwd' | 'envs' | 'extensions' | 'fix' | 'globals' | 'ignore' | 'parser' | 'plugins' | 'rules'
+    "baseConfig" | "cwd" | "envs" | "extensions" | "fix" | "globals" | "ignore" | "parser" | "plugins" | "rules"
 >;
-export type ESLintOptions = Pick<eslint.Linter.LintOptions, 'filename'>;
-export type ESLintConfig = Pick<eslint.Linter.Config, 'extends' | 'settings'>;
+export type ESLintOptions = Pick<eslint.Linter.LintOptions, "filename">;
+export type ESLintConfig = Pick<eslint.Linter.Config, "extends" | "settings">;
 
 export type Options = {
-    /** Enforce ES2015+ rules. Disabling this will make it not enforce ES2015+ syntax and conventions */
-    esnext?: boolean;
     /** Some paths are ignored by default, including paths in .gitignore and .eslintignore. Additional ignores can be added here */
     ignores?: string[];
     /** Enable rules specific to the Node.js versions within the configured range */
     nodeVersion?: string | boolean;
     /** Format code with Prettier */
     prettier?: boolean;
+    /**
+     *  Print the ESLint configuration for the given file
+     */
+    printConfig?: string;
     /** Set it to false to enforce no-semicolon style. */
     semicolon?: boolean;
     /** Set it to true to get 2-space indentation or specify the number of spaces. */

--- a/types/xo/xo-tests.ts
+++ b/types/xo/xo-tests.ts
@@ -1,21 +1,19 @@
-/// <reference types="node" />
+import xo = require("xo");
+import { Options } from "xo";
 
-import xo = require('xo');
-import path = require('path');
-
-const glob = path.join(__dirname, '..', '*.md');
-
-const options: xo.Options = {};
+const glob = "some/path";
+const options: Options = {};
 
 options.space = 2;
 options.space = true;
 options.space = false;
+options.printConfig = "index.js";
 
 options.webpack = {
     config: {
         resolve: {
             alias: {
-                file2alias: path.resolve(__dirname, process.cwd(), './file2.js'),
+                file2alias: "./file2.js",
             },
         },
     },
@@ -25,57 +23,56 @@ options.webpack = false;
 
 if (options.semicolon === false && !options.prettier) {
     if (options.rules) {
-        options.rules.semi = ['error', 'never'];
-        options.rules['semi-spacing'] = [
-            'error',
+        options.rules.semi = ["error", "never"];
+        options.rules["semi-spacing"] = [
+            "error",
             {
                 before: false,
                 after: true,
             },
         ];
-        options.rules['node/no-unsupported-features/es-builtins'] = ['error', { version: options.nodeVersion }];
-        options.rules['node/no-unsupported-features/es-syntax'] = [
-            'error',
-            { version: options.nodeVersion, ignores: ['modules'] },
+        options.rules["node/no-unsupported-features/es-builtins"] = ["error", { version: options.nodeVersion }];
+        options.rules["node/no-unsupported-features/es-syntax"] = [
+            "error",
+            { version: options.nodeVersion, ignores: ["modules"] },
         ];
-        options.rules['node/no-unsupported-features/node-builtins'] = ['error', { version: options.nodeVersion }];
+        options.rules["node/no-unsupported-features/node-builtins"] = ["error", { version: options.nodeVersion }];
     }
     if (options.plugins) {
-        options.plugins = options.plugins.concat('react');
+        options.plugins = options.plugins.concat("react");
     }
     if (options.prettier && options.plugins) {
-        options.plugins = options.plugins.concat('prettier');
+        options.plugins = options.plugins.concat("prettier");
         if (options.baseConfig) {
-            options.baseConfig.extends = options.baseConfig.extends.concat('prettier');
-            options.baseConfig.extends = options.baseConfig.extends.concat('prettier/unicorn');
+            options.baseConfig.extends = options.baseConfig.extends.concat("prettier");
+            options.baseConfig.extends = options.baseConfig.extends.concat("prettier/unicorn");
         }
     }
 }
 let result = xo.lintText("'use strict'\nconsole.log('unicorn');\n");
 result = xo.lintText("'use strict'\nconsole.log('unicorn');\n", {
-    filename: 'ignored/index.js',
-    ignores: ['ignored/**/*.js'],
+    filename: "ignored/index.js",
+    ignores: ["ignored/**/*.js"],
 });
 xo.lintText("'use strict'\nconsole.log('unicorn');\n", {
-    filename: 'node_modules/ignored/index.js',
+    filename: "node_modules/ignored/index.js",
 });
 result.errorCount; // $ExpectType number
 result.warningCount; // $ExpectType number
 result.results; // LintResult[]
 
 (async () => {
-    const moreExtensionsResults = await xo.lintFiles(glob, { extensions: ['md'] });
-    const { errorCount, results, warningCount } = await xo.lintFiles('**/*', { cwd: 'fixtures/cwd' });
-    const report = await xo.lintFiles('**/*', { cwd: 'fixtures/cwd' });
+    const moreExtensionsResults = await xo.lintFiles(glob, { extensions: ["md"] });
+    const { errorCount, results, warningCount } = await xo.lintFiles("**/*", { cwd: "fixtures/cwd" });
+    const report = await xo.lintFiles("**/*", { cwd: "fixtures/cwd" });
     // only get the error messages
     const errorReport = xo.getErrorResults(result.results);
     // output fixes to disk
     xo.outputFixes(report);
     // tests for the formatter
     let formatter = xo.getFormatter();
-    formatter = xo.getFormatter('compact');
-    formatter = xo.getFormatter('./my/formatter.js');
-    xo.getFormatter('compact')(report.results);
-    // output to console
-    console.log(formatter(report.results));
+    formatter = xo.getFormatter("compact");
+    formatter = xo.getFormatter("./my/formatter.js");
+    xo.getFormatter("compact")(report.results);
+    formatter(report.results); // $ExpectType string
 })();


### PR DESCRIPTION
- drop `esnext` option
- add `printConfig` option
- run DT code format on package to unify style
- amend tests
- make it faster to pass CI and do not depend on Node types for tests.

https://github.com/xojs/xo/compare/v0.34.2...v0.39.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.