### PR TITLE
[postcss-reporter] Update to postcss-reporter v7

### DIFF
--- a/types/postcss-reporter/index.d.ts
+++ b/types/postcss-reporter/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for postcss-reporter 6.0
+// Type definitions for postcss-reporter 7.0
 // Project: https://github.com/postcss/postcss-reporter#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
 
-import { Plugin, ResultMessage } from 'postcss';
+import { PluginCreator, Message } from 'postcss';
 
 declare namespace postcssReporter {
     /**
@@ -22,7 +23,7 @@ declare namespace postcssReporter {
          * - accepts an object containing a messages array and a source string
          * - returns the string to report
          */
-        formatter?: (input: { messages: ResultMessage[]; source: string }) => string;
+        formatter?: (input: { messages: Message[]; source: string }) => string;
         /**
          * If plugins is empty (as it is by default),
          * the reporter will log messages from every PostCSS plugin.
@@ -33,7 +34,7 @@ declare namespace postcssReporter {
          * Provide a filter function. It receives the message object and returns a truthy or falsy value,
          * indicating whether that particular message should be reported or not.
          */
-        filter?: (message: ResultMessage) => boolean;
+        filter?: (message: Message) => boolean;
         /**
          * If true, not pass any messages into other plugins, or the whatever runner you use, for logging.
          * @default false
@@ -44,12 +45,6 @@ declare namespace postcssReporter {
          * @default false
          */
         throwError?: boolean;
-        /**
-         * By default, messages without line/column positions will be grouped at the beginning of the output.
-         * To put them at the end, instead, use "last". To not bother sorting these, use "any".
-         * @default 'first'
-         */
-        positionless?: 'first' | 'last' | 'any';
     }
 
     /**
@@ -71,9 +66,15 @@ declare namespace postcssReporter {
          * @default false
          */
         noPlugin?: boolean;
+        /**
+         * By default, messages without line/column positions will be grouped at the beginning of the output.
+         * To put them at the end, instead, use "last". To not bother sorting these, use "any".
+         * @default 'first'
+         */
+        positionless?: 'first' | 'last' | 'any';
     }
 
-    type PostCSSReporter = Plugin<Options>;
+    type PostCSSReporter = PluginCreator<Options>;
 }
 
 declare const postcssReporter: postcssReporter.PostCSSReporter;

--- a/types/postcss-reporter/lib/formatter.d.ts
+++ b/types/postcss-reporter/lib/formatter.d.ts
@@ -1,5 +1,5 @@
-import { ResultMessage } from 'postcss';
+import { Message } from 'postcss';
 import { DefaultOptions } from '../index';
 
-declare function formatter(options?: DefaultOptions): (input?: { messages: ResultMessage[]; source: string }) => string;
+declare function formatter(options?: DefaultOptions): (input: { messages: Message[]; source: string }) => string;
 export = formatter;

--- a/types/postcss-reporter/package.json
+++ b/types/postcss-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "^7.0.27"
+        "postcss": "^8.2.10"
     }
 }

--- a/types/postcss-reporter/postcss-reporter-tests.ts
+++ b/types/postcss-reporter/postcss-reporter-tests.ts
@@ -2,7 +2,6 @@
 
 import reporter = require('postcss-reporter');
 import formatter = require('postcss-reporter/lib/formatter');
-import { ResultMessage } from 'postcss';
 reporter({
     formatter: input => {
         return `${input.source} produced ${input.messages.length} messages`;
@@ -35,9 +34,10 @@ const basicMessages = [
 const myFormatter = formatter({
     noIcon: true,
     noPlugin: true,
+    positionless: 'last'
 });
 // Defaults
-myFormatter();
+myFormatter({ messages: [], source: 'test' });
 
 const warningLog = myFormatter({
     messages: basicMessages,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postcss/postcss-reporter/blob/24ce038eb3058ee8e2081c69baacab9d7e3b17ec/lib/formatter.js#L12-L18
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The change in 7.0 is the upgrade to postcss 8. This impact the postcss types being used, because type names in postcss have changed.
Other changes in the types are about fixing some existing mistakes in type definitions:
- the argument of the formatter is not optional
- `positionless` is an option supported by the  default formatter