### PR TITLE
[jest] Fix jsdoc @example syntax for toMatchObject

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -970,7 +970,7 @@ declare namespace jest {
          *   }
          * };
          *
-         * expect(desiredHouse).toMatchObject<House>(...standardHouse, kitchen: {area: 20}) // wherein standardHouse is some base object of type House
+         * expect(desiredHouse).toMatchObject<House>({...standardHouse, kitchen: {area: 20}}) // wherein standardHouse is some base object of type House
          */
         // tslint:disable-next-line: no-unnecessary-generics
         toMatchObject<E extends {} | any[]>(expected: E): R;


### PR DESCRIPTION
## Changing an existing definition
URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/expect#tomatchobjectobject
