### PR TITLE
Add types for chai-datetime

### DIFF
--- a/types/chai-datetime/chai-datetime-tests.ts
+++ b/types/chai-datetime/chai-datetime-tests.ts
@@ -80,3 +80,55 @@ function test_withinDate(){
     date.should.be.withinDate(fromDate, toDate);
     assert.withinDate(date, fromDate, toDate);
 }
+
+function test_beforeOrEqualDate(){
+    const date1: Date = new Date(2014, 1, 1);
+    const date2: Date = new Date(2014, 1, 2);
+
+    expect(date1).to.be.beforeOrEqualDate(date1);
+    date1.should.be.beforeOrEqualDate(date1);
+    assert.beforeOrEqualDate(date1, date1);
+
+    expect(date1).to.be.beforeOrEqualDate(date2);
+    date1.should.be.beforeOrEqualDate(date2);
+    assert.beforeOrEqualDate(date1, date2);
+}
+
+function test_afterOrEqualDate(){
+    const date1: Date = new Date(2014, 1, 2);
+    const date2: Date = new Date(2014, 1, 1);
+
+    expect(date1).to.be.afterOrEqualDate(date1);
+    date1.should.be.afterOrEqualDate(date1);
+    assert.afterOrEqualDate(date1, date1);
+
+    expect(date1).to.be.afterOrEqualDate(date2);
+    date1.should.be.afterOrEqualDate(date2);
+    assert.afterOrEqualDate(date1, date2);
+}
+
+function test_beforeOrEqualTime(){
+    const date1: Date = new Date(2014, 1, 1, 0, 0, 30);
+    const date2: Date = new Date(2014, 1, 1, 0, 2, 30);
+
+    expect(date1).to.be.beforeOrEqualTime(date1);
+    date1.should.be.beforeOrEqualTime(date1);
+    assert.beforeOrEqualTime(date1, date1);
+
+    expect(date1).to.be.beforeOrEqualTime(date2);
+    date1.should.be.beforeOrEqualTime(date2);
+    assert.beforeOrEqualTime(date1, date2);
+}
+
+function test_afterOrEqualTime(){
+    const date1: Date = new Date(2014, 1, 1, 0, 2, 30);
+    const date2: Date = new Date(2014, 1, 1, 0, 0, 30);
+
+    expect(date1).to.be.afterOrEqualTime(date1);
+    date1.should.be.afterOrEqualTime(date1);
+    assert.afterOrEqualTime(date1, date1);
+
+    expect(date1).to.be.afterOrEqualTime(date2);
+    date1.should.be.afterOrEqualTime(date2);
+    assert.afterOrEqualTime(date1, date2);
+}

--- a/types/chai-datetime/index.d.ts
+++ b/types/chai-datetime/index.d.ts
@@ -14,34 +14,42 @@ declare global {
     namespace Chai {
         interface Assertion {
             afterDate(date: Date): Assertion;
+            afterOrEqualDate(date: Date): Assertion;
+            afterOrEqualTime(date: Date): Assertion;
+            afterTime(date: Date): Assertion;
             beforeDate(date: Date): Assertion;
+            beforeOrEqualDate(date: Date): Assertion;
+            beforeOrEqualTime(date: Date): Assertion;
+            beforeTime(date: Date): Assertion;
             closeToTime(date: Date, deltaInSeconds: number): Assertion;
             equalDate(date: Date): Assertion;
-            withinDate(dateFrom: Date, dateTo: Date): Assertion;
-            afterTime(date: Date): Assertion;
-            beforeTime(date: Date): Assertion;
             equalTime(date: Date): Assertion;
+            withinDate(dateFrom: Date, dateTo: Date): Assertion;
             withinTime(dateFrom: Date, dateTo: Date): Assertion;
         }
 
         interface Assert {
-            equalTime(val: Date, exp: Date, msg?: string): void;
-            notEqualTime(val: Date, exp: Date, msg?: string): void;
+            afterDate(val: Date, exp: Date, msg?: string): void;
+            afterOrEqualDate(val: Date, exp: Date, msg?: string): void;
+            afterOrEqualTime(val: Date, exp: Date, msg?: string): void;
+            afterTime(val: Date, exp: Date, msg?: string): void;
+            beforeDate(val: Date, exp: Date, msg?: string): void;
+            beforeOrEqualDate(val: Date, exp: Date, msg?: string): void;
+            beforeOrEqualTime(val: Date, exp: Date, msg?: string): void;
             beforeTime(val: Date, exp: Date, msg?: string): void;
             closeToTime(val: Date, exp: Date, deltaInSeconds: number, msg?: string): void;
-            notBeforeTime(val: Date, exp: Date, msg?: string): void;
-            afterTime(val: Date, exp: Date, msg?: string): void;
-            notAfterTime(val: Date, exp: Date, msg?: string): void;
-            withinTime(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
-            notWithinTime(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
             equalDate(val: Date, exp: Date, msg?: string): void;
-            notEqualDate(val: Date, exp: Date, msg?: string): void;
-            beforeDate(val: Date, exp: Date, msg?: string): void;
-            notBeforeDate(val: Date, exp: Date, msg?: string): void;
-            afterDate(val: Date, exp: Date, msg?: string): void;
+            equalTime(val: Date, exp: Date, msg?: string): void;
             notAfterDate(val: Date, exp: Date, msg?: string): void;
-            withinDate(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
+            notAfterTime(val: Date, exp: Date, msg?: string): void;
+            notBeforeDate(val: Date, exp: Date, msg?: string): void;
+            notBeforeTime(val: Date, exp: Date, msg?: string): void;
+            notEqualDate(val: Date, exp: Date, msg?: string): void;
+            notEqualTime(val: Date, exp: Date, msg?: string): void;
             notWithinDate(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
+            notWithinTime(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
+            withinDate(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
+            withinTime(val: Date, expFrom: Date, expTo: Date, msg?: string): void;
         }
     }
 


### PR DESCRIPTION
Adds types for methods `afterOrEqualDate()`, `afterOrEqualTime()`, `beforeOrEqualDate()`, `beforeOrEqualTime()`. Types themselves were also sorted alphabetically for better overview.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mguterl/chai-datetime & https://github.com/mguterl/chai-datetime/issues/42
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
