### PR TITLE
modify slice params  in  prosemirror-model

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -159,6 +159,12 @@ export class Fragment<S extends Schema = any> {
    * object with two separate positions is returned.
    */
   findDiffEnd(other: ProsemirrorNode<S>): { a: number; b: number } | null | undefined;
+
+  // : (number, ?number) → {index: number, offset: number}
+  // Find the index and inner offset corresponding to a given relative
+  // position in this fragment. The result object will be reused
+  // (overwritten) the next time the function is called. (Not public.)
+  findIndex(pos: number, round?: number ): { index: number; offset: number };
   /**
    * Return a debugging string that describes this fragment.
    */
@@ -599,7 +605,7 @@ declare class ProsemirrorNode<S extends Schema = any> {
    * Cut out the part of the document between the given positions, and
    * return it as a `Slice` object.
    */
-  slice(from: number, to?: number): Slice<S>;
+  slice(from: number, to?: number,includeParents?:boolean): Slice<S>;
   /**
    * Replace the part of the document between the given positions with
    * the given slice. The slice must 'fit', meaning its open sides


### PR DESCRIPTION
add findInde method in Fragment

Please fill in this template.

- [ ] Fix types in `prosemirro-model`.

Select one of these and delete the others:

his`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] About fragment code: https://github.com/ProseMirror/prosemirror-model/blob/master/src/fragment.js
- [ ] About model code: https://github.com/ProseMirror/prosemirror-model/blob/master/src/node.js

