### PR TITLE
[ndarray] Prevent return type from shadowing function type

### DIFF
--- a/types/cwise-compiler/index.d.ts
+++ b/types/cwise-compiler/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { CompiledRoutine } from 'cwise-parser';
-import * as ndarray from 'ndarray';
+import { CompiledRoutine } from "cwise-parser";
+import { NdArray } from "ndarray";
 
 declare namespace cwise_compiler {
     interface BlockIndice {
@@ -15,7 +15,7 @@ declare namespace cwise_compiler {
         offset: number[];
         array: number;
     }
-    type ArgType = 'array' | 'offset' | 'shape' | 'scalar' | 'index' | BlockIndice | OffsetArg;
+    type ArgType = "array" | "offset" | "shape" | "scalar" | "index" | BlockIndice | OffsetArg;
     interface UserArgs {
         args: ArgType[];
         pre: CompiledRoutine;
@@ -45,6 +45,8 @@ declare namespace cwise_compiler {
     }
 }
 
-declare function cwise_compiler(user_args: cwise_compiler.UserArgs): (a: ndarray, b: ndarray, ...args: ndarray[]) => ndarray;
+declare function cwise_compiler(
+    user_args: cwise_compiler.UserArgs,
+): (a: NdArray, b: NdArray, ...args: NdArray[]) => NdArray;
 
 export = cwise_compiler;

--- a/types/cwise/cwise-tests.ts
+++ b/types/cwise/cwise-tests.ts
@@ -1,47 +1,89 @@
-import cwise = require('cwise');
-import ndarray = require('ndarray');
-import tape = require('tape');
+import cwise = require("cwise");
+import ndarray = require("ndarray");
+import tape = require("tape");
 
 // basic
-tape("only allow same shape", (t) => {
+tape("only allow same shape", t => {
     const op1 = cwise({
         args: ["array"],
-        body: (a: number) => { a = 1; }
+        body: (a: number) => {
+            a = 1;
+        },
     });
     const op2 = cwise({
         args: ["array", "array"],
-        body: (a: number, b: number) => { a = b; }
+        body: (a: number, b: number) => {
+            a = b;
+        },
     });
     const op3 = cwise({
         args: ["array", "array", "array"],
-        body: (a: number, b: number, c: number) => { a = b + c; }
+        body: (a: number, b: number, c: number) => {
+            a = b + c;
+        },
     });
     const op2block_pos = cwise({
         args: ["array", { blockIndices: 1 }],
-        body: (a: number, b: number[]) => { a = b[1]; }
+        body: (a: number, b: number[]) => {
+            a = b[1];
+        },
     });
     const op2block_neg = cwise({
         args: ["array", { blockIndices: -1 }],
-        body: (a: number, b: number[]) => { a = b[1]; }
+        body: (a: number, b: number[]) => {
+            a = b[1];
+        },
     });
 
-    t.doesNotThrow(() => { op1(ndarray([1, 2, 3], [3])); });
-    t.doesNotThrow(() => { op2(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3])); });
-    t.doesNotThrow(() => { op2(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4, 5, 6], [3, 2])); });
-    t.doesNotThrow(() => { op3(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3])); });
-    t.doesNotThrow(() => { op2block_pos(ndarray([1, 2], [2]), ndarray([1, 2, 3, 4, 5, 6], [3, 2])); });
-    t.doesNotThrow(() => { op2block_neg(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3, 4, 5, 6], [3, 2])); });
+    t.doesNotThrow(() => {
+        op1(ndarray([1, 2, 3], [3]));
+    });
+    t.doesNotThrow(() => {
+        op2(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]));
+    });
+    t.doesNotThrow(() => {
+        op2(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4, 5, 6], [3, 2]));
+    });
+    t.doesNotThrow(() => {
+        op3(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]));
+    });
+    t.doesNotThrow(() => {
+        op2block_pos(ndarray([1, 2], [2]), ndarray([1, 2, 3, 4, 5, 6], [3, 2]));
+    });
+    t.doesNotThrow(() => {
+        op2block_neg(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3, 4, 5, 6], [3, 2]));
+    });
 
-    t.throws(() => { op2(ndarray([1, 2, 3], [3]), ndarray([1, 2], [2])); });
-    t.throws(() => { op2(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3], [3, 1])); });
-    t.throws(() => { op2(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4], [2, 2])); });
-    t.throws(() => { op3(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]), ndarray([1, 2], [2])); });
-    t.throws(() => { op3(ndarray([1, 2, 3], [3]), ndarray([1, 2], [2]), ndarray([1, 2, 3], [3])); });
-    t.throws(() => { op3(ndarray([1, 2], [2]), ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3])); });
-    t.throws(() => { op2block_pos(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3, 4, 5, 6], [3, 2])); });
-    t.throws(() => { op2block_neg(ndarray([1, 2], [2]), ndarray([1, 2, 3, 4, 5, 6], [3, 2])); });
-    t.throws(() => { op2block_pos(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4], [2, 2])); });
-    t.throws(() => { op2block_neg(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4], [2, 2])); });
+    t.throws(() => {
+        op2(ndarray([1, 2, 3], [3]), ndarray([1, 2], [2]));
+    });
+    t.throws(() => {
+        op2(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3], [3, 1]));
+    });
+    t.throws(() => {
+        op2(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4], [2, 2]));
+    });
+    t.throws(() => {
+        op3(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]), ndarray([1, 2], [2]));
+    });
+    t.throws(() => {
+        op3(ndarray([1, 2, 3], [3]), ndarray([1, 2], [2]), ndarray([1, 2, 3], [3]));
+    });
+    t.throws(() => {
+        op3(ndarray([1, 2], [2]), ndarray([1, 2, 3], [3]), ndarray([1, 2, 3], [3]));
+    });
+    t.throws(() => {
+        op2block_pos(ndarray([1, 2, 3], [3]), ndarray([1, 2, 3, 4, 5, 6], [3, 2]));
+    });
+    t.throws(() => {
+        op2block_neg(ndarray([1, 2], [2]), ndarray([1, 2, 3, 4, 5, 6], [3, 2]));
+    });
+    t.throws(() => {
+        op2block_pos(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4], [2, 2]));
+    });
+    t.throws(() => {
+        op2block_neg(ndarray([1, 2, 3, 4, 5, 6], [3, 2]), ndarray([1, 2, 3, 4], [2, 2]));
+    });
 
     t.end();
 });
@@ -58,20 +100,20 @@ class DumbStorage {
         return this.data[i];
     }
     set(i: number, v: number) {
-        return this.data[i] = v;
+        return (this.data[i] = v);
     }
 }
 
-tape("binary", (t) => {
+tape("binary", t => {
     const binary = cwise({
         args: ["array", "array", "scalar", "shape", "index"],
         body(a: number, b: number, t: tape.Test, s: number[], idx: number) {
             if (!(a === 0)) t.fail(`idx:${idx}, shape:${s},a:${a}`);
             a = b + 1001;
-        }
+        },
     });
 
-    function testBinary1D(P: ndarray, Q: ndarray, testName: string) {
+    function testBinary1D(P: ndarray.NdArray, Q: ndarray.NdArray, testName: string) {
         t.equals(P.shape[0], Q.shape[0], testName + "; shape");
         for (let i = 0; i < P.shape[0]; ++i) {
             Q.set(i, i);
@@ -80,7 +122,7 @@ tape("binary", (t) => {
         binary(P, Q, t);
         for (let i = 0; i < P.shape[0]; ++i) {
             if (!(P.get(i) === i + 1001)) {
-                t.fail(`${testName}; encountered ${P.get(i)} instead of ${(i + 1001)} at ${i}`);
+                t.fail(`${testName}; encountered ${P.get(i)} instead of ${i + 1001} at ${i}`);
                 return;
             }
         }
@@ -109,7 +151,7 @@ tape("binary", (t) => {
     const X = ndarray(new Int32Array(64 * 64), [64, 64]);
     const Y = ndarray(new Int32Array(64 * 64), [64, 64]);
 
-    function testBinary2D(P: ndarray, Q: ndarray, testName: string) {
+    function testBinary2D(P: ndarray.NdArray, Q: ndarray.NdArray, testName: string) {
         for (let i = 0; i < X.shape[0]; ++i) {
             for (let j = 0; j < X.shape[1]; ++j) {
                 X.set(i, j, -10000);
@@ -128,7 +170,11 @@ tape("binary", (t) => {
         for (let i = 0; i < P.shape[0]; ++i) {
             for (let j = 0; j < P.shape[1]; ++j) {
                 if (!(P.get(i, j) === i * 1000 + j + 1001)) {
-                    t.fail(`${testName}; encountered ${P.get(i, j)} instead of ${(i * 1000 + j + 1001)} at (" + i + "," + j + ")`);
+                    t.fail(
+                        `${testName}; encountered ${P.get(i, j)} instead of ${
+                            i * 1000 + j + 1001
+                        } at (" + i + "," + j + ")`,
+                    );
                     return;
                 }
             }
@@ -151,8 +197,8 @@ tape("binary", (t) => {
 });
 
 import browserify = require("browserify");
-import * as vm from 'vm';
-import * as path from 'path';
+import * as vm from "vm";
+import * as path from "path";
 
 const cases = ["unary", "binary", "offset", "fill"];
 
@@ -164,7 +210,8 @@ function bundleCasesFrom(i: number) {
     b.ignore("tape");
     b.add(`${__dirname}/${cases[i]}.js`);
     b.transform(path.normalize(__dirname + "/../cwise.js"));
-    tape(cases[i], (t) => { // Without nested tests, the asynchronous nature of bundle causes issues with tape...
+    tape(cases[i], t => {
+        // Without nested tests, the asynchronous nature of bundle causes issues with tape...
         b.bundle((err, src) => {
             if (err) {
                 throw new Error("failed to bundle!");
@@ -181,7 +228,7 @@ function bundleCasesFrom(i: number) {
                 Uint16Array,
                 Uint32Array,
                 Uint8ClampedArray,
-                console: { log: console.log.bind(console) }
+                console: { log: console.log.bind(console) },
             });
             t.end();
         });
@@ -190,12 +237,12 @@ function bundleCasesFrom(i: number) {
 }
 
 // fill
-tape("fill", (t) => {
+tape("fill", t => {
     const fill = cwise({
         args: ["index", "array", "scalar"],
         body(idx, out, f) {
             out = f.apply(undefined, idx);
-        }
+        },
     });
 
     const xlen = 10;
@@ -226,16 +273,16 @@ tape("fill", (t) => {
 });
 
 // offset
-tape("offset", (t) => {
+tape("offset", t => {
     const binary = cwise({
         args: ["array", "array", { offset: [1], array: 1 }, "scalar", "shape", "index"],
         body(a, b, c, t, s, idx) {
             if (!(a === 0)) t.fail(`idx:${idx}, shape:${s},a:${a}`);
             a = c + b + 1000;
-        }
+        },
     });
 
-    function testBinary1D(P: ndarray, Q: ndarray, testName: string) {
+    function testBinary1D(P: ndarray.NdArray, Q: ndarray.NdArray, testName: string) {
         t.equals(P.shape[0], Q.shape[0] - 1, testName + "; shape");
         for (let i = 0; i < P.shape[0]; ++i) {
             Q.set(i, i);
@@ -276,15 +323,15 @@ tape("offset", (t) => {
 
 // unary
 
-tape("unary", (t) => {
+tape("unary", t => {
     const unary = cwise({
         args: ["array"],
         body(a) {
             ++a;
-        }
+        },
     });
 
-    function testUnary1D(arr: ndarray, testName: string) {
+    function testUnary1D(arr: ndarray.NdArray, testName: string) {
         for (let i = 0; i < arr.shape[0]; ++i) {
             arr.set(i, i);
         }
@@ -325,7 +372,7 @@ tape("unary", (t) => {
     testUnary1D(custom_zeros.step(4), "custom_zeros.step(4)");
     testUnary1D(custom_zeros.step(5).lo(10), "custom_zeros.step(5).lo(10)");
 
-    function testUnary2D(arr: ndarray, testName: string) {
+    function testUnary2D(arr: ndarray.NdArray, testName: string) {
         for (let i = 0; i < arr.shape[0]; ++i) {
             for (let j = 0; j < arr.shape[1]; ++j) {
                 arr.set(i, j, i + j * arr.shape[0]);
@@ -335,7 +382,11 @@ tape("unary", (t) => {
         for (let i = 0; i < arr.shape[0]; ++i) {
             for (let j = 0; j < arr.shape[1]; ++j) {
                 if (!(arr.get(i, j) === 1 + i + j * arr.shape[0])) {
-                    t.fail(`${testName}; encountered ${arr.get(i, j)} instead of ${1 + i + j * arr.shape[0]} at (${i},${j})`);
+                    t.fail(
+                        `${testName}; encountered ${arr.get(i, j)} instead of ${
+                            1 + i + j * arr.shape[0]
+                        } at (${i},${j})`,
+                    );
                     return;
                 }
             }

--- a/types/cwise/index.d.ts
+++ b/types/cwise/index.d.ts
@@ -5,13 +5,13 @@
 // TypeScript Version: 2.3
 
 import { ArgType } from "cwise-compiler";
-import * as ndarray from "ndarray";
+import { NdArray } from "ndarray";
 
 declare function cwise(a: string | cwise.UserArgs): cwise.Return;
 
 declare namespace cwise {
-    type Arg = ndarray | ((row: number, col: number) => number) | number[] | any;
-    type Return = (a: ndarray, ...b: Arg[]) => void;
+    type Arg = NdArray | ((row: number, col: number) => number) | number[] | any;
+    type Return = (a: NdArray, ...b: Arg[]) => void;
     interface UserArgs {
         args: ArgType[];
         pre?(a: number, ...args: any[]): void;

--- a/types/gl-texture2d/index.d.ts
+++ b/types/gl-texture2d/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import ndarray = require("ndarray");
+import { NdArray } from "ndarray";
 
 type GLenum = number;
 
@@ -31,15 +31,16 @@ declare class Texture {
     bind(id?: number): number;
     dispose(): void;
     generateMipmap(): void;
-    setPixels(data: InputType | RawObject | ndarray, offset?: [number, number], mipLevel?: GLenum): void;
+    setPixels(data: InputType | RawObject | NdArray, offset?: [number, number], mipLevel?: GLenum): void;
 }
 
-declare function texture2d(gl: WebGLRenderingContext, array: ndarray): Texture;
+declare function texture2d(gl: WebGLRenderingContext, array: NdArray): Texture;
 
 declare function texture2d(
     gl: WebGLRenderingContext,
     input: InputType | RawObject | [number, number],
     format?: GLenum,
-    type?: GLenum): Texture;
+    type?: GLenum,
+): Texture;
 
 export = texture2d;

--- a/types/ndarray-ops/index.d.ts
+++ b/types/ndarray-ops/index.d.ts
@@ -3,217 +3,217 @@
 // Definitions by: Adam Zerella <https://github.com/adamzerella>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import ndarray = require("ndarray");
+import { NdArray } from "ndarray";
 
 ////////////////
 /// Assignment operations
 ////////////////
-export function add(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function addeq(array1: ndarray, array2: ndarray): boolean;
-export function adds(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function addseq(array: ndarray, scalar: number): boolean;
+export function add(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function addeq(array1: NdArray, array2: NdArray): boolean;
+export function adds(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function addseq(array: NdArray, scalar: number): boolean;
 
-export function sub(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function subeq(array1: ndarray, array2: ndarray): boolean;
-export function subs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function subseq(array: ndarray, scalar: number): boolean;
+export function sub(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function subeq(array1: NdArray, array2: NdArray): boolean;
+export function subs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function subseq(array: NdArray, scalar: number): boolean;
 
-export function mul(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function muleq(array1: ndarray, array2: ndarray): boolean;
-export function muls(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function mulseq(array: ndarray, scalar: number): boolean;
+export function mul(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function muleq(array1: NdArray, array2: NdArray): boolean;
+export function muls(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function mulseq(array: NdArray, scalar: number): boolean;
 
-export function div(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function diveq(array1: ndarray, array2: ndarray): boolean;
-export function divs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function divseq(array: ndarray, scalar: number): boolean;
+export function div(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function diveq(array1: NdArray, array2: NdArray): boolean;
+export function divs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function divseq(array: NdArray, scalar: number): boolean;
 
-export function mod(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function modeq(array1: ndarray, array2: ndarray): boolean;
-export function mods(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function modseq(array: ndarray, scalar: number): boolean;
+export function mod(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function modeq(array1: NdArray, array2: NdArray): boolean;
+export function mods(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function modseq(array: NdArray, scalar: number): boolean;
 
-export function band(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function bandeq(array1: ndarray, array2: ndarray): boolean;
-export function bands(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function bandseq(array: ndarray, scalar: number): boolean;
+export function band(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function bandeq(array1: NdArray, array2: NdArray): boolean;
+export function bands(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function bandseq(array: NdArray, scalar: number): boolean;
 
-export function bor(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function boreq(array1: ndarray, array2: ndarray): boolean;
-export function bors(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function borseq(array: ndarray, scalar: number): boolean;
+export function bor(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function boreq(array1: NdArray, array2: NdArray): boolean;
+export function bors(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function borseq(array: NdArray, scalar: number): boolean;
 
-export function bxor(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function bxoreq(array1: ndarray, array2: ndarray): boolean;
-export function bxors(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function bxorseq(array: ndarray, scalar: number): boolean;
+export function bxor(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function bxoreq(array1: NdArray, array2: NdArray): boolean;
+export function bxors(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function bxorseq(array: NdArray, scalar: number): boolean;
 
-export function lshift(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function lshifteq(array1: ndarray, array2: ndarray): boolean;
-export function lshifts(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function lshiftseq(array: ndarray, scalar: number): boolean;
+export function lshift(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function lshifteq(array1: NdArray, array2: NdArray): boolean;
+export function lshifts(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function lshiftseq(array: NdArray, scalar: number): boolean;
 
-export function rshift(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function rshifteq(array1: ndarray, array2: ndarray): boolean;
-export function rshifts(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function rshiftseq(array: ndarray, scalar: number): boolean;
+export function rshift(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function rshifteq(array1: NdArray, array2: NdArray): boolean;
+export function rshifts(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function rshiftseq(array: NdArray, scalar: number): boolean;
 
-export function rrshift(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function rrshifteq(array1: ndarray, array2: ndarray): boolean;
-export function rrshifts(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function rrshiftseq(array: ndarray, scalar: number): boolean;
+export function rrshift(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function rrshifteq(array1: NdArray, array2: NdArray): boolean;
+export function rrshifts(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function rrshiftseq(array: NdArray, scalar: number): boolean;
 
 ////////////////
 /// Unary operations
 ////////////////
-export function not(array1: ndarray, array2: ndarray): ndarray;
-export function noteq(array: ndarray): boolean;
+export function not(array1: NdArray, array2: NdArray): NdArray;
+export function noteq(array: NdArray): boolean;
 
-export function bnot(array1: ndarray, array2: ndarray): ndarray;
-export function bnoteq(array: ndarray): boolean;
+export function bnot(array1: NdArray, array2: NdArray): NdArray;
+export function bnoteq(array: NdArray): boolean;
 
-export function neg(array1: ndarray, array2: ndarray): ndarray;
-export function negeq(array: ndarray): boolean;
+export function neg(array1: NdArray, array2: NdArray): NdArray;
+export function negeq(array: NdArray): boolean;
 
-export function recip(array1: ndarray, array2: ndarray): ndarray;
-export function recipeq(array: ndarray): boolean;
+export function recip(array1: NdArray, array2: NdArray): NdArray;
+export function recipeq(array: NdArray): boolean;
 
 ////////////////
 /// Binary operations
 ////////////////
-export function and(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function ands(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function andeq(array1: ndarray, array2: ndarray): boolean;
-export function andseq(array: ndarray, scalar: number): boolean;
+export function and(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function ands(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function andeq(array1: NdArray, array2: NdArray): boolean;
+export function andseq(array: NdArray, scalar: number): boolean;
 
-export function or(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function ors(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function oreq(array1: ndarray, array2: ndarray): boolean;
-export function orseq(array: ndarray, scalar: number): boolean;
+export function or(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function ors(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function oreq(array1: NdArray, array2: NdArray): boolean;
+export function orseq(array: NdArray, scalar: number): boolean;
 
-export function eq(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function eqs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function eqeq(array1: ndarray, array2: ndarray): boolean;
-export function eqseq(array: ndarray, scalar: number): boolean;
+export function eq(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function eqs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function eqeq(array1: NdArray, array2: NdArray): boolean;
+export function eqseq(array: NdArray, scalar: number): boolean;
 
-export function neq(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function neqs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function neqeq(array1: ndarray, array2: ndarray): boolean;
-export function neqseq(array: ndarray, scalar: number): boolean;
+export function neq(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function neqs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function neqeq(array1: NdArray, array2: NdArray): boolean;
+export function neqseq(array: NdArray, scalar: number): boolean;
 
-export function lt(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function lts(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function lteq(array1: ndarray, array2: ndarray): boolean;
-export function ltseq(array: ndarray, scalar: number): boolean;
+export function lt(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function lts(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function lteq(array1: NdArray, array2: NdArray): boolean;
+export function ltseq(array: NdArray, scalar: number): boolean;
 
-export function gt(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function gts(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function gteq(array1: ndarray, array2: ndarray): boolean;
-export function gtseq(array: ndarray, scalar: number): boolean;
+export function gt(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function gts(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function gteq(array1: NdArray, array2: NdArray): boolean;
+export function gtseq(array: NdArray, scalar: number): boolean;
 
-export function leq(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function leqs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function leqeq(array1: ndarray, array2: ndarray): boolean;
-export function leqseq(array: ndarray, scalar: number): boolean;
+export function leq(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function leqs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function leqeq(array1: NdArray, array2: NdArray): boolean;
+export function leqseq(array: NdArray, scalar: number): boolean;
 
-export function geq(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function geqs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function geqeq(array1: ndarray, array2: ndarray): boolean;
-export function geqseq(array: ndarray, scalar: number): boolean;
+export function geq(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function geqs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function geqeq(array1: NdArray, array2: NdArray): boolean;
+export function geqseq(array: NdArray, scalar: number): boolean;
 
 ////////////////
 /// Math unary operations
 ////////////////
-export function abs(array1: ndarray, array2: ndarray): ndarray;
-export function abseq(array: ndarray): boolean;
+export function abs(array1: NdArray, array2: NdArray): NdArray;
+export function abseq(array: NdArray): boolean;
 
-export function acos(array1: ndarray, array2: ndarray): ndarray;
-export function acoseq(array: ndarray): boolean;
+export function acos(array1: NdArray, array2: NdArray): NdArray;
+export function acoseq(array: NdArray): boolean;
 
-export function asin(array1: ndarray, array2: ndarray): ndarray;
-export function asineq(array: ndarray): boolean;
+export function asin(array1: NdArray, array2: NdArray): NdArray;
+export function asineq(array: NdArray): boolean;
 
-export function atan(array1: ndarray, array2: ndarray): ndarray;
-export function ataneq(array: ndarray): boolean;
+export function atan(array1: NdArray, array2: NdArray): NdArray;
+export function ataneq(array: NdArray): boolean;
 
-export function ceil(array1: ndarray, array2: ndarray): ndarray;
-export function ceileq(array: ndarray): boolean;
+export function ceil(array1: NdArray, array2: NdArray): NdArray;
+export function ceileq(array: NdArray): boolean;
 
-export function cos(array1: ndarray, array2: ndarray): ndarray;
-export function coseq(array: ndarray): boolean;
+export function cos(array1: NdArray, array2: NdArray): NdArray;
+export function coseq(array: NdArray): boolean;
 
-export function exp(array1: ndarray, array2: ndarray): ndarray;
-export function expeq(array: ndarray): boolean;
+export function exp(array1: NdArray, array2: NdArray): NdArray;
+export function expeq(array: NdArray): boolean;
 
-export function floor(array1: ndarray, array2: ndarray): ndarray;
-export function flooreq(array: ndarray): boolean;
+export function floor(array1: NdArray, array2: NdArray): NdArray;
+export function flooreq(array: NdArray): boolean;
 
-export function log(array1: ndarray, array2: ndarray): ndarray;
-export function logeq(array: ndarray): boolean;
+export function log(array1: NdArray, array2: NdArray): NdArray;
+export function logeq(array: NdArray): boolean;
 
-export function round(array1: ndarray, array2: ndarray): ndarray;
-export function roundeq(array: ndarray): boolean;
+export function round(array1: NdArray, array2: NdArray): NdArray;
+export function roundeq(array: NdArray): boolean;
 
-export function sin(array1: ndarray, array2: ndarray): ndarray;
-export function sineq(array: ndarray): boolean;
+export function sin(array1: NdArray, array2: NdArray): NdArray;
+export function sineq(array: NdArray): boolean;
 
-export function sqrt(array1: ndarray, array2: ndarray): ndarray;
-export function sqrteq(array: ndarray): boolean;
+export function sqrt(array1: NdArray, array2: NdArray): NdArray;
+export function sqrteq(array: NdArray): boolean;
 
-export function tan(array1: ndarray, array2: ndarray): ndarray;
-export function taneq(array: ndarray): boolean;
+export function tan(array1: NdArray, array2: NdArray): NdArray;
+export function taneq(array: NdArray): boolean;
 
 ////////////////
 /// Math common operations
 ////////////////
-export function max(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function maxs(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function maxeq(array1: ndarray, array2: ndarray): boolean;
-export function maxseq(array: ndarray, scalar: number): boolean;
+export function max(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function maxs(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function maxeq(array1: NdArray, array2: NdArray): boolean;
+export function maxseq(array: NdArray, scalar: number): boolean;
 
-export function min(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function mins(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function mineq(array1: ndarray, array2: ndarray): boolean;
-export function minseq(array: ndarray, scalar: number): boolean;
+export function min(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function mins(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function mineq(array1: NdArray, array2: NdArray): boolean;
+export function minseq(array: NdArray, scalar: number): boolean;
 
-export function atan2(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function atan2s(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function atan2eq(array1: ndarray, array2: ndarray): boolean;
-export function atan2seq(array: ndarray, scalar: number): boolean;
+export function atan2(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function atan2s(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function atan2eq(array1: NdArray, array2: NdArray): boolean;
+export function atan2seq(array: NdArray, scalar: number): boolean;
 
-export function pow(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function pows(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function poweq(array1: ndarray, array2: ndarray): boolean;
-export function powseq(array: ndarray, scalar: number): boolean;
+export function pow(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function pows(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function poweq(array1: NdArray, array2: NdArray): boolean;
+export function powseq(array: NdArray, scalar: number): boolean;
 
 ////////////////
 /// Math non-common operations
 ////////////////
-export function atan2op(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function atan2ops(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function atan2opeq(array1: ndarray, array2: ndarray): boolean;
-export function atan2opseq(array: ndarray, scalar: number): boolean;
+export function atan2op(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function atan2ops(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function atan2opeq(array1: NdArray, array2: NdArray): boolean;
+export function atan2opseq(array: NdArray, scalar: number): boolean;
 
-export function powop(array1: ndarray, array2: ndarray, array3: ndarray): ndarray;
-export function powops(array1: ndarray, array2: ndarray, scalar: number): ndarray;
-export function powopeq(array1: ndarray, array2: ndarray): boolean;
-export function powopseq(array: ndarray, scalar: number): boolean;
+export function powop(array1: NdArray, array2: NdArray, array3: NdArray): NdArray;
+export function powops(array1: NdArray, array2: NdArray, scalar: number): NdArray;
+export function powopeq(array1: NdArray, array2: NdArray): boolean;
+export function powopseq(array: NdArray, scalar: number): boolean;
 
-export function any(array: ndarray): boolean;
-export function all(array: ndarray): boolean;
-export function sum(array: ndarray): boolean;
-export function prod(array: ndarray): boolean;
-export function norm2squared(array: ndarray): boolean;
-export function norm2(array: ndarray): boolean;
-export function norminf(array: ndarray): boolean;
-export function norm1(array: ndarray): boolean;
-export function sup(array: ndarray): boolean;
-export function inf(array: ndarray): boolean;
-export function argmin(index: number, array: ndarray, shape: ndarray): boolean;
-export function argmax(index: number, array: ndarray, shape: ndarray): boolean;
-export function random(array: ndarray): ndarray;
-export function assign(array: ndarray, array2: ndarray): ndarray;
-export function assigns(array: ndarray, scalar: number): ndarray;
-export function equals(array1: ndarray, array2: ndarray): boolean;
+export function any(array: NdArray): boolean;
+export function all(array: NdArray): boolean;
+export function sum(array: NdArray): boolean;
+export function prod(array: NdArray): boolean;
+export function norm2squared(array: NdArray): boolean;
+export function norm2(array: NdArray): boolean;
+export function norminf(array: NdArray): boolean;
+export function norm1(array: NdArray): boolean;
+export function sup(array: NdArray): boolean;
+export function inf(array: NdArray): boolean;
+export function argmin(index: number, array: NdArray, shape: NdArray): boolean;
+export function argmax(index: number, array: NdArray, shape: NdArray): boolean;
+export function random(array: NdArray): NdArray;
+export function assign(array: NdArray, array2: NdArray): NdArray;
+export function assigns(array: NdArray, scalar: number): NdArray;
+export function equals(array1: NdArray, array2: NdArray): boolean;
 
 export as namespace ops;

--- a/types/ndarray-scratch/index.d.ts
+++ b/types/ndarray-scratch/index.d.ts
@@ -3,36 +3,36 @@
 // Definitions by: Adam Zerella <https://github.com/adamzerella>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import ndarray = require("ndarray");
+import { NdArray } from "ndarray";
 
 /**
  * Allocates a temporary ndarray
  */
-export function malloc(shape: number[], dtype?: string): ndarray;
+export function malloc(shape: number[], dtype?: string): NdArray;
 
 /**
  * Creates a scratch ndarray initialized to `0`
  */
-export function zeros(shape: number[], dtype?: string): ndarray;
+export function zeros(shape: number[], dtype?: string): NdArray;
 
 /**
  * Creates a scratch ndarray initialized to `1`
  */
-export function ones(shape: number[], dtype?: string): ndarray;
+export function ones(shape: number[], dtype?: string): NdArray;
 
 /**
  * Creates a scratch ndarray initialized to `1` if all indices equal, `0` otherwise.
  */
-export function eye(shape: number[], dtype?: string): ndarray;
+export function eye(shape: number[], dtype?: string): NdArray;
 
 /**
  * Releases a temporary ndarray
  */
-export function free(array: ndarray): void;
+export function free(array: NdArray): void;
 
 /**
  * Creates a copy of an ndarray with row-major order.
  */
-export function clone(array: ndarray): ndarray;
+export function clone(array: NdArray): NdArray;
 
 export as namespace pool;

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for ndarray 1.0
 // Project: https://github.com/scijs/ndarray, https://github.com/mikolalysenko/ndarray
-// Definitions by: Giff Song <https://github.com/pawsong>, taoqf <https://github.com/taoqf>
+// Definitions by: Giff Song <https://github.com/pawsong>,
+//                 taoqf <https://github.com/taoqf>
+//                 Axel Bocciarelli <https://github.com/axelboc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -5,36 +5,59 @@
 // TypeScript Version: 2.3
 
 declare function ndarray<T = number>(
-    data: ndarray.Data<T>, shape?: number[], stride?: number[], offset?: number
-): ndarray<T>;
-
-interface ndarray<T = number> {
-    data: ndarray.Data<T>;
-    shape: number[];
-    stride: number[];
-    offset: number;
-    dtype: ndarray.DataType;
-    size: number;
-    order: number[];
-    dimension: number;
-    get(...args: number[]): T;
-    set(...args: number[]): T;
-    index(...args: number[]): T;
-    lo(...args: number[]): ndarray<T>;
-    hi(...args: number[]): ndarray<T>;
-    step(...args: number[]): ndarray<T>;
-    transpose(...args: number[]): ndarray<T>;
-    pick(...args: Array<number | null>): ndarray<T>;
-    reshape(...shapes: number[]): ndarray<T>;
-    T: ndarray<T>;
-}
+    data: ndarray.Data<T>,
+    shape?: number[],
+    stride?: number[],
+    offset?: number,
+): ndarray.NdArray<T>;
 
 declare namespace ndarray {
-    type DataType = 'int8' | 'int16' | 'int32' | 'uint8' | 'uint16' | 'uint32' |
-        'float32' | 'float64' | 'array' | 'uint8_clamped' | 'buffer' | 'generic';
-    type Data<T> = T[] | Int8Array | Int16Array | Int32Array |
-        Uint8Array | Uint16Array | Uint32Array |
-        Float32Array | Float64Array | Uint8ClampedArray;
+    interface NdArray<T = number> {
+        data: Data<T>;
+        shape: number[];
+        stride: number[];
+        offset: number;
+        dtype: DataType;
+        size: number;
+        order: number[];
+        dimension: number;
+        get(...args: number[]): T;
+        set(...args: number[]): T;
+        index(...args: number[]): T;
+        lo(...args: number[]): NdArray<T>;
+        hi(...args: number[]): NdArray<T>;
+        step(...args: number[]): NdArray<T>;
+        transpose(...args: number[]): NdArray<T>;
+        pick(...args: Array<number | null>): NdArray<T>;
+        reshape(...shapes: number[]): NdArray<T>;
+        T: NdArray<T>;
+    }
+
+    type Data<T> =
+        | T[]
+        | Int8Array
+        | Int16Array
+        | Int32Array
+        | Uint8Array
+        | Uint16Array
+        | Uint32Array
+        | Float32Array
+        | Float64Array
+        | Uint8ClampedArray;
+
+    type DataType =
+        | "int8"
+        | "int16"
+        | "int32"
+        | "uint8"
+        | "uint16"
+        | "uint32"
+        | "float32"
+        | "float64"
+        | "array"
+        | "uint8_clamped"
+        | "buffer"
+        | "generic";
 }
 
 export = ndarray;

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -1,4 +1,4 @@
-import ndarray = require('ndarray');
+import ndarray = require("ndarray");
 
 const data = new Int32Array(2 * 2 * 2 + 10);
 const a = ndarray(data, [2, 2, 2], [1, 2, 4], 5);
@@ -11,7 +11,7 @@ console.log(a.stride[0] === 1);
 console.log(a.stride[1] === 2);
 console.log(a.stride[2] === 4);
 console.log(a.offset === 5);
-console.log(a.dtype === 'int32');
+console.log(a.dtype === "int32");
 console.log(a.size === 8);
 console.log(a.order[0] === 0);
 console.log(a.order[1] === 1);

--- a/types/numjs/index.d.ts
+++ b/types/numjs/index.d.ts
@@ -6,14 +6,14 @@
 // TypeScript Version: 2.3
 
 export as namespace nj;
-import * as BaseNdArray from 'ndarray';
+import { Data, DataType, NdArray as BaseNdArray } from "ndarray";
 
-export type NdType<T> = BaseNdArray.DataType | BaseNdArray.Data<T>;
+export type NdType<T> = DataType | Data<T>;
 
 export interface NdArray<T = number> extends BaseNdArray<T> {
     ndim: number;
     T: NdArray<T>;
-    slice(...args: Array<number|number[]>): NdArray<T>;
+    slice(...args: Array<number | number[]>): NdArray<T>;
 
     /**
      * Return a copy of the array collapsed into one dimension using row-major order (C-style)
@@ -155,7 +155,7 @@ export interface NdArray<T = number> extends BaseNdArray<T> {
     fftconvolve(filter: NjArray<T>): NdArray<T>;
 }
 
-export type NdArrayData<T> = BaseNdArray.Data<T>;
+export type NdArrayData<T> = Data<T>;
 export type NjArray<T> = NdArrayData<T> | NdArray<T>;
 export type NjParam<T> = NjArray<T> | number;
 
@@ -310,7 +310,7 @@ export function negative<T = number>(x: NjParam<T>): NdArray<T>;
  * @param [dtype] The type of the output array.
  * @returns Array of ones with the given shape and dtype
  */
-export function ones<T = number>(shape: NdArrayData<T> | number, dtype?: BaseNdArray.DataType): NdArray<T>;
+export function ones<T = number>(shape: NdArrayData<T> | number, dtype?: DataType): NdArray<T>;
 
 /**
  * Raise first array elements to powers from second array, element-wise.
@@ -421,7 +421,7 @@ export function transpose<T = number>(x: NjParam<T>, axes?: number): NdArray<T>;
  * @param [dtype = Array] The type of the output array.
  * @returns Array of zeros with the given shape and dtype
  */
-export function zeros<T = number>(shape: NdArrayData<T> | number, dtype?: BaseNdArray.DataType): NdArray<T>;
+export function zeros<T = number>(shape: NdArrayData<T> | number, dtype?: DataType): NdArray<T>;
 
 export namespace errors {
     function ValueError(message?: string): Error;
@@ -448,7 +448,7 @@ export function diag<T = number>(x: NjArray<T>): NdArray<T>;
  * @param  [dtype=Array]  The type of the output array.
  * @return n x n array with its main diagonal set to one, and all other elements 0
  */
-export function identity<T = number>(n: T, dtype?: BaseNdArray.DataType): NdArray<T>;
+export function identity<T = number>(n: T, dtype?: DataType): NdArray<T>;
 
 /**
  * Join a sequence of arrays along a new axis.
@@ -504,7 +504,7 @@ export namespace images {
     function flip<T = number, O = T>(img: NdArray<T>): NdArray<O>;
 }
 
-export function array<T = number>(arr: NjArray<T>, dtype?: BaseNdArray.DataType): NdArray<T>;
+export function array<T = number>(arr: NjArray<T>, dtype?: DataType): NdArray<T>;
 
 export function int8<T = number>(arr: NjArray<T>): NjArray<Int8Array>;
 


### PR DESCRIPTION
⚠️ **Breaking change!**

I'm renaming the return type of the `ndarray` function from `ndarray` to `NdArray` so that it no longer shadows the type of the function itself. It also felt wrong that the interface wasn't capitalized.

```ts
// BEFORE
import type ndarray from 'ndarray';
function foo(arr: ndarray) { ... }

import * as ndarray = require('ndarray');
function foo(arr: ndarray) { ... }

import ndarray from 'ndarray';
function foo(arr: ndarray): ndarray {
  return ndarray(arr);
}

// AFTER
import type { NdArray } from 'ndarray';
function foo(arr: NdArray) { ... }

import ndarray = require('ndarray');
function foo(arr: ndarray.NdArray) { ... }

import ndarray, { NdArray } from 'ndarray';
function foo(arr: NdArray): NdArray {
  return ndarray(arr);
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/scijs/ndarray/blob/master/ndarray.js