### PR TITLE
fix: fix the serialize function definition and add types definition for init function, and ensureAuthenticated middleware

### DIFF
--- a/types/forest-express-mongoose/forest-express-mongoose-tests.ts
+++ b/types/forest-express-mongoose/forest-express-mongoose-tests.ts
@@ -8,7 +8,7 @@ import {
     SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
     collection, CollectionOptions,
 } from 'forest-express-mongoose';
-import * as express from 'express';
+import { RequestHandler } from 'express';
 
 const MY_PUBLIC_ROUTES = PUBLIC_ROUTES;
 
@@ -63,7 +63,7 @@ recordsRemover.remove(['1234', '5678']);
 const recordSerializer = new RecordSerializer(model);
 recordSerializer.serialize([{}, {}]);
 
-let requestHandler: express.RequestHandler;
+let requestHandler: RequestHandler;
 const permissionMiddlewareCreator = new PermissionMiddlewareCreator('users');
 requestHandler = permissionMiddlewareCreator.list();
 requestHandler = permissionMiddlewareCreator.export();
@@ -198,9 +198,3 @@ const complexCollectionOptions: CollectionOptions = {
     }],
 };
 collection('complexCollection', complexCollectionOptions);
-
-const app = express();
-
-app.get('/', (request) => {
-    return recordsGetter.getIdsFromRequest(request);
-});

--- a/types/forest-express-mongoose/forest-express-mongoose-tests.ts
+++ b/types/forest-express-mongoose/forest-express-mongoose-tests.ts
@@ -6,9 +6,26 @@ import {
     RecordGetter, RecordRemover, RecordsCounter, RecordSerializer,
     RecordsGetter, RecordsRemover, RecordUpdater, StatSerialized, StatSerializer,
     SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
-    collection, CollectionOptions,
+    collection, CollectionOptions, LianaOptions, init,
 } from 'forest-express-mongoose';
-import { RequestHandler } from 'express';
+import * as express from 'express';
+import * as mongoose from 'mongoose';
+
+const lianaOptions: LianaOptions = {
+    objectMapping: mongoose,
+    envSecret: 'aSecretKey',
+    authSecret: 'aSecretKey',
+    connections: {
+        'main-connection': mongoose.createConnection('uri'),
+    },
+    includedModels: ['aModel'],
+    excludedModels: ['aModel'],
+    configDir: 'aDirectory',
+};
+
+init(lianaOptions).then((expressApplication: express.Application) => {
+    const expressApp: express.Application = expressApplication;
+});
 
 const MY_PUBLIC_ROUTES = PUBLIC_ROUTES;
 
@@ -61,9 +78,9 @@ const recordsRemover = new RecordsRemover(model);
 recordsRemover.remove(['1234', '5678']);
 
 const recordSerializer = new RecordSerializer(model);
-recordSerializer.serialize([{}, {}]);
+recordSerializer.serialize([{}, {}]).then((statSerialized: StatSerialized) => { });
 
-let requestHandler: RequestHandler;
+let requestHandler: express.RequestHandler;
 const permissionMiddlewareCreator = new PermissionMiddlewareCreator('users');
 requestHandler = permissionMiddlewareCreator.list();
 requestHandler = permissionMiddlewareCreator.export();
@@ -198,3 +215,9 @@ const complexCollectionOptions: CollectionOptions = {
     }],
 };
 collection('complexCollection', complexCollectionOptions);
+
+const app = express();
+
+app.get('/', (request) => {
+    return recordsGetter.getIdsFromRequest(request);
+});

--- a/types/forest-express-mongoose/index.d.ts
+++ b/types/forest-express-mongoose/index.d.ts
@@ -4,7 +4,7 @@
 //                 Guillaume Gautreau <https://github.com/ghusse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { RequestHandler, Response, Request } from "express";
+import { RequestHandler, Response } from "express";
 
 // Everything related to Forest constants
 
@@ -23,7 +23,7 @@ export class RecordGetter extends AbstractRecordTool {
 
 export class RecordsGetter extends AbstractRecordTool {
     getAll(params: Params): Promise<object[]>;
-    getIdsFromRequest(request: Request): Promise<string[]>;
+    getIdsFromRequest(params: Params): Promise<string[]>;
 }
 
 export class RecordsCounter extends AbstractRecordTool {

--- a/types/forest-express-mongoose/index.d.ts
+++ b/types/forest-express-mongoose/index.d.ts
@@ -1,10 +1,31 @@
-// Type definitions for forest-express-mongoose 6.3
+// Type definitions for forest-express-mongoose 7.5
 // Project: http://www.forestadmin.com
 // Definitions by: Steve Bunlon <https://github.com/SteveBunlon>
 //                 Guillaume Gautreau <https://github.com/ghusse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { RequestHandler, Response } from "express";
+import { RequestHandler, Response, Request, NextFunction, Application } from 'express';
+import * as mongoose from 'mongoose';
+
+// Everything related to Forest initialization
+
+export interface LianaOptions {
+    objectMapping: mongoose.Mongoose;
+    envSecret: string;
+    authSecret: string;
+    connections: {
+        [connectionName: string]: mongoose.Connection;
+    };
+    includedModels?: string[];
+    excludedModels?: string[];
+    configDir?: string;
+}
+
+export function init(options: LianaOptions): Promise<Application>;
+
+// Everything related to Forest Authentication
+
+export function ensureAuthenticated(request: Request, response: Response, next: NextFunction): void;
 
 // Everything related to Forest constants
 
@@ -14,7 +35,7 @@ export const PUBLIC_ROUTES: string[];
 
 export class AbstractRecordTool {
     constructor(model: object)
-    serialize(records: object[]): StatSerialized;
+    serialize(records: object[]): Promise<StatSerialized>;
 }
 
 export class RecordGetter extends AbstractRecordTool {
@@ -23,7 +44,7 @@ export class RecordGetter extends AbstractRecordTool {
 
 export class RecordsGetter extends AbstractRecordTool {
     getAll(params: Params): Promise<object[]>;
-    getIdsFromRequest(params: Params): Promise<string[]>;
+    getIdsFromRequest(request: Request): Promise<string[]>;
 }
 
 export class RecordsCounter extends AbstractRecordTool {

--- a/types/forest-express-sequelize/forest-express-sequelize-tests.ts
+++ b/types/forest-express-sequelize/forest-express-sequelize-tests.ts
@@ -8,7 +8,7 @@ import {
     SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
     collection, CollectionOptions
 } from 'forest-express-sequelize';
-import * as express from 'express';
+import { RequestHandler } from 'express';
 
 const MY_PUBLIC_ROUTES = PUBLIC_ROUTES;
 
@@ -63,7 +63,7 @@ recordsRemover.remove(['1234', '5678']);
 const recordSerializer = new RecordSerializer(model);
 recordSerializer.serialize([{}, {}]);
 
-let requestHandler: express.RequestHandler;
+let requestHandler: RequestHandler;
 const permissionMiddlewareCreator = new PermissionMiddlewareCreator('users');
 requestHandler = permissionMiddlewareCreator.list();
 requestHandler = permissionMiddlewareCreator.export();
@@ -198,9 +198,3 @@ const complexCollectionOptions: CollectionOptions = {
     }],
 };
 collection('complexCollection', complexCollectionOptions);
-
-const app = express();
-
-app.get('/', (request) => {
-    return recordsGetter.getIdsFromRequest(request);
-});

--- a/types/forest-express-sequelize/forest-express-sequelize-tests.ts
+++ b/types/forest-express-sequelize/forest-express-sequelize-tests.ts
@@ -6,9 +6,26 @@ import {
     RecordGetter, RecordRemover, RecordsCounter, RecordSerializer,
     RecordsGetter, RecordsRemover, RecordUpdater, StatSerialized, StatSerializer,
     SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
-    collection, CollectionOptions
+    collection, CollectionOptions, LianaOptions, init,
 } from 'forest-express-sequelize';
-import { RequestHandler } from 'express';
+import * as express from 'express';
+import { Sequelize } from 'sequelize';
+
+const lianaOptions: LianaOptions = {
+    objectMapping: Sequelize,
+    envSecret: 'aSecretKey',
+    authSecret: 'aSecretKey',
+    connections: {
+        'main-connection': new Sequelize('uri'),
+    },
+    includedModels: ['aModel'],
+    excludedModels: ['aModel'],
+    configDir: 'aDirectory',
+};
+
+init(lianaOptions).then((expressApplication: express.Application) => {
+    const expressApp: express.Application = expressApplication;
+});
 
 const MY_PUBLIC_ROUTES = PUBLIC_ROUTES;
 
@@ -61,9 +78,9 @@ const recordsRemover = new RecordsRemover(model);
 recordsRemover.remove(['1234', '5678']);
 
 const recordSerializer = new RecordSerializer(model);
-recordSerializer.serialize([{}, {}]);
+recordSerializer.serialize([{}, {}]).then((statSerialized: StatSerialized) => { });
 
-let requestHandler: RequestHandler;
+let requestHandler: express.RequestHandler;
 const permissionMiddlewareCreator = new PermissionMiddlewareCreator('users');
 requestHandler = permissionMiddlewareCreator.list();
 requestHandler = permissionMiddlewareCreator.export();
@@ -198,3 +215,9 @@ const complexCollectionOptions: CollectionOptions = {
     }],
 };
 collection('complexCollection', complexCollectionOptions);
+
+const app = express();
+
+app.get('/', (request) => {
+    return recordsGetter.getIdsFromRequest(request);
+});

--- a/types/forest-express-sequelize/index.d.ts
+++ b/types/forest-express-sequelize/index.d.ts
@@ -4,7 +4,7 @@
 //                 Guillaume Gautreau <https://github.com/ghusse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { RequestHandler, Response, Request } from "express";
+import { RequestHandler, Response } from "express";
 
 // Everything related to Forest constants
 
@@ -23,7 +23,7 @@ export class RecordGetter extends AbstractRecordTool {
 
 export class RecordsGetter extends AbstractRecordTool {
     getAll(params: Params): Promise<object[]>;
-    getIdsFromRequest(request: Request): Promise<string[]>;
+    getIdsFromRequest(params: Params): Promise<string[]>;
 }
 
 export class RecordsCounter extends AbstractRecordTool {

--- a/types/forest-express-sequelize/index.d.ts
+++ b/types/forest-express-sequelize/index.d.ts
@@ -1,10 +1,31 @@
-// Type definitions for forest-express-sequelize 6.3
+// Type definitions for forest-express-sequelize 7.5
 // Project: http://www.forestadmin.com
 // Definitions by: Steve Bunlon <https://github.com/SteveBunlon>
 //                 Guillaume Gautreau <https://github.com/ghusse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { RequestHandler, Response } from "express";
+import { RequestHandler, Response, Request, NextFunction, Application } from 'express';
+import { Sequelize, SequelizeStatic } from 'sequelize';
+
+// Everything related to Forest initialization
+
+export interface LianaOptions {
+    objectMapping: SequelizeStatic;
+    envSecret: string;
+    authSecret: string;
+    connections: {
+        [connectionName: string]: Sequelize;
+    };
+    includedModels?: string[];
+    excludedModels?: string[];
+    configDir?: string;
+}
+
+export function init(options: LianaOptions): Promise<Application>;
+
+// Everything related to Forest Authentication
+
+export function ensureAuthenticated(request: Request, response: Response, next: NextFunction): void;
 
 // Everything related to Forest constants
 
@@ -14,7 +35,7 @@ export const PUBLIC_ROUTES: string[];
 
 export class AbstractRecordTool {
     constructor(model: object)
-    serialize(records: object[]): StatSerialized;
+    serialize(records: object[]): Promise<StatSerialized>;
 }
 
 export class RecordGetter extends AbstractRecordTool {
@@ -23,7 +44,7 @@ export class RecordGetter extends AbstractRecordTool {
 
 export class RecordsGetter extends AbstractRecordTool {
     getAll(params: Params): Promise<object[]>;
-    getIdsFromRequest(params: Params): Promise<string[]>;
+    getIdsFromRequest(request: Request): Promise<string[]>;
 }
 
 export class RecordsCounter extends AbstractRecordTool {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/forestAdmin/forest-express-mongoose/ https://github.com/forestAdmin/forest-express-sequelize/ https://github.com/forestAdmin/forest-express  
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR is about updating missing types for `forest-express-sequelize` and `forest-express-mongoose`. The previous version was for version 6.5 of these packages, the update puts them to the version 7.5. 

Here are the changes:

- Adds the `init` function type, and define its argument type
- Adds the `ensureAuthenticated` (an express middleware) type definition
- Update the `serialize` function, as it is now asynchronous