### PR TITLE
Cytoscape Stylesheet - text-rotation 'autorotate'

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -50,6 +50,7 @@ const showAllStyle: cytoscape.Stylesheet[] = [
   {
     selector: 'edge',
     css: {
+      'text-rotation': 'autorotate',
       'target-arrow-shape': 'triangle',
       'curve-style': 'taxi',
       'source-endpoint': 'outside-to-node',

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -4218,7 +4218,7 @@ declare namespace cytoscape {
              *  * The special value none can be used to denote 0deg.
              *  * Rotations works best with left- to - right text.
              */
-            "text-rotation": PropertyValue<SingularType, number>;
+            "text-rotation": PropertyValue<SingularType, number | 'autorotate'>;
 
             /**
              * (For the source label of an edge.)


### PR DESCRIPTION
Typing does not include option for special value, description above typing already included a description for this.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://js.cytoscape.org/#style/labels](https://js.cytoscape.org/#style/labels)
And typing description just above change.

