### PR TITLE
[nova-editor-node] Add new showInputPalette option added in Nova 6

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -963,7 +963,7 @@ interface Workspace {
     ): void;
     showInputPalette(
         message: string,
-        options?: { placeholder?: string },
+        options?: { placeholder?: string; value?: string },
         callback?: (value: string | null) => void,
     ): void;
     showChoicePalette(

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -333,3 +333,17 @@ treeView.onDidExpandElement(element => {});
 treeView.onDidCollapseElement(element => {});
 
 treeView.onDidChangeVisibility(() => {});
+
+/// https://novadocs.panic.com/api-reference/text-editor/
+
+nova.workspace.showInputPalette('This is an input');
+
+nova.workspace.showInputPalette('This is an input', {
+    placeholder: "Help text"
+});
+
+nova.workspace.showInputPalette('This is an input', {
+    placeholder: "Help text",
+    // after 6.0
+    value: "Default value"
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - Release notes: https://nova.app/releases#v6
    - New API docs: https://docs.nova.app/api-reference/workspace/#showinputpalettemessage-options-callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

~~There are two commits in this PR, [the first one](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52516/commits/e2dd5f8569e04126509bde213718a82c0ad897dc) which adds the new API option to the type definition, and [a second one](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52516/commits/dafdf4d4a3c1028baa0a0f2492c2c84cf402529b) which runs the Prettier command on the files for this package.
Let me know and I can drop the second commit if needed.~~

I've dropped the commit with the Prettier formatting as it introduced Linting errors in the tests.