### PR TITLE
[xrm] add missing CustomAction parameters types

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -556,7 +556,7 @@ declare namespace Xrm {
 
         /**
          * A reference from a control to the Id of a menu item.
-         * 
+         *
          * Most entities will not return a MenuItemId value. Only the following entities will return this value:
          * BusinessUnit
          * Connection
@@ -577,7 +577,6 @@ declare namespace Xrm {
          * Territory
          */
         MenuItemId: string;
-
     }
 
     /**
@@ -585,14 +584,13 @@ declare namespace Xrm {
      * SelectedControlSelectedItemReferences
      * SelectedControlAllItemReferences
      * SelectedControlUnselectedItemReferences
-     * 
+     *
      * Not to be confused with the more commonly used LookupValue.
-     * 
+     *
      * @see LookupValue
      * @see {@link https://docs.microsoft.com/en-us/previous-versions/dynamicscrm-2016/developers-guide/gg309332(v=crm.8)#remarks}
      */
     interface EntityReference {
-
         /**
          * A string of the GUID Id value for the record.
          */

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -539,6 +539,81 @@ declare namespace Xrm {
         viewType?: "savedquery" | "userquery";
     }
 
+    /**
+     * <CrmParameter> used in RibbonDiffXml actions
+     * @see {@link https://docs.microsoft.com/en-us/previous-versions/dynamicscrm-2016/developers-guide/gg309332(v=crm.8)}
+     */
+    interface CommandProperties {
+        /**
+         * The Id value of the Ribbon control that initiated the event.
+         */
+        SourceControlId: string;
+
+        /**
+         * A string that is sent with the command event when a button is clicked.
+         */
+        CommandValueId: string;
+
+        /**
+         * A reference from a control to the Id of a menu item.
+         * 
+         * Most entities will not return a MenuItemId value. Only the following entities will return this value:
+         * BusinessUnit
+         * Connection
+         * CustomerAddress
+         * Equipment
+         * Goal
+         * InvoiceDetail
+         * Mailbox
+         * MailMergeTemplate
+         * PartnerApplication
+         * QueueItem
+         * QuoteDetail
+         * RoutingRuleItem
+         * SalesOrderDetail
+         * ServiceAppointment
+         * SharePointDocumentLocation
+         * SharePointSite
+         * Territory
+         */
+        MenuItemId: string;
+
+    }
+
+    /**
+     * Some <CrmParameter> values pass an EntityReference object:
+     * SelectedControlSelectedItemReferences
+     * SelectedControlAllItemReferences
+     * SelectedControlUnselectedItemReferences
+     * 
+     * Not to be confused with the more commonly used LookupValue.
+     * 
+     * @see LookupValue
+     * @see {@link https://docs.microsoft.com/en-us/previous-versions/dynamicscrm-2016/developers-guide/gg309332(v=crm.8)#remarks}
+     */
+    interface EntityReference {
+
+        /**
+         * A string of the GUID Id value for the record.
+         */
+        Id: string;
+
+        /**
+         * A string of the value of the Primary field for the record.
+         */
+        Name: string;
+
+        /**
+         * A string representing the unique name of the entity for the record.
+         */
+        TypeName: string;
+
+        /**
+         * @deprecated Use {@link TypeName} instead. The number value for custom entities will typically be different from organization to organization and the number value cannot be used reliably for custom entities.
+         */
+        TypeCode: number;
+    }
+
     namespace Events {
         /**
          * Interface for save event arguments.

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -335,3 +335,12 @@ const gridControlGetSetVisible = (context: Xrm.Events.EventContext) => {
     // setVisible
     gridControl.setVisible(!visibility);
 };
+
+async function ribbonCommand(commandProperties: Xrm.CommandProperties, primaryEntity: Xrm.EntityReference) {
+    if (commandProperties.SourceControlId === "AddExistingRecordFromSubGridAssociated") {
+        await Xrm.Navigation.openAlertDialog({
+            title: `${commandProperties.CommandValueId}`,
+            text: `Thanks for clicking on ${primaryEntity.Name} of type ${primaryEntity.TypeName} and id ${primaryEntity.Id}`,
+        });
+    } 
+}

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -338,9 +338,9 @@ const gridControlGetSetVisible = (context: Xrm.Events.EventContext) => {
 
 async function ribbonCommand(commandProperties: Xrm.CommandProperties, primaryEntity: Xrm.EntityReference) {
     if (commandProperties.SourceControlId === "AddExistingRecordFromSubGridAssociated") {
-        await Xrm.Navigation.openAlertDialog({
+        await Promise.resolve(Xrm.Navigation.openAlertDialog({
             title: `${commandProperties.CommandValueId}`,
             text: `Thanks for clicking on ${primaryEntity.Name} of type ${primaryEntity.TypeName} and id ${primaryEntity.Id}`,
-        });
-    } 
+        }));
+    }
 }


### PR DESCRIPTION
Found some (apparently hidden from Google) docs for these types that are used in `<CrmParameter>`s on `<CustomAction>`s in RibbonXmlDiff .

https://docs.microsoft.com/en-us/previous-versions/dynamicscrm-2016/developers-guide/gg309332(v=crm.8)