### PR TITLE
Make some braintree-web/apple-pay methods static according to apple p…

### DIFF
--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -77,6 +77,8 @@ export class ApplePaySession {
 
     static canMakePaymentsWithActiveCard(merchantIdentifier: string): boolean;
 
+    static supportsVersion(version: number): boolean;
+
     completeMerchantValidation(merchantSession: any): void;
 
     abort(): void;
@@ -95,8 +97,6 @@ export class ApplePaySession {
     ): void;
 
     completeShippingMethodSelection(status: ApplePayStatusCodes, newTotal: any, newLineItems: any): void;
-
-    static supportsVersion(version: number): boolean;
 
     oncancel: (event: any) => void;
 

--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -73,9 +73,9 @@ export interface ApplePayPayload {
 export class ApplePaySession {
     constructor(version: number, request: ApplePayPaymentRequest);
 
-    canMakePayments(): boolean;
+    static canMakePayments(): boolean;
 
-    canMakePaymentsWithActiveCard(merchantIdentifier: string): boolean;
+    static canMakePaymentsWithActiveCard(merchantIdentifier: string): boolean;
 
     completeMerchantValidation(merchantSession: any): void;
 
@@ -96,7 +96,7 @@ export class ApplePaySession {
 
     completeShippingMethodSelection(status: ApplePayStatusCodes, newTotal: any, newLineItems: any): void;
 
-    supportsVersion(version: number): boolean;
+    static supportsVersion(version: number): boolean;
 
     oncancel: (event: any) => void;
 

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -316,7 +316,7 @@ braintree.client.create(
         );
 
         braintree.ApplePaySession.canMakePayments(); // boolean
-        braintree.ApplePaySession.canMakePaymentsWithActiveCard(); // boolean
+        braintree.ApplePaySession.canMakePaymentsWithActiveCard('merchantIdentifier'); // boolean
         braintree.ApplePaySession.supportsVersion(3); // boolean
 
         braintree.applePay.create(

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -315,6 +315,10 @@ braintree.client.create(
             },
         );
 
+        braintree.ApplePaySession.canMakePayments(); // boolean
+        braintree.ApplePaySession.canMakePaymentsWithActiveCard(); // boolean
+        braintree.ApplePaySession.supportsVersion(3); // boolean
+
         braintree.applePay.create(
             { client: clientInstance },
             (createErr?: braintree.BraintreeError, applePayInstance?: braintree.ApplePay) => {


### PR DESCRIPTION
Adding missing static type definition for ApplePaySession which determines support for API and Payments according to Apple pay documentation https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

