### PR TITLE
Typing for visibility - display incorrect

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -31,6 +31,7 @@ const showAllStyle: cytoscape.Stylesheet[] = [
   {
     selector: 'node',
     css: {
+      'display': 'element',
       content: 'data(id)',
       'text-valign': 'center',
       'text-halign': 'center',

--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -31,7 +31,7 @@ const showAllStyle: cytoscape.Stylesheet[] = [
   {
     selector: 'node',
     css: {
-      'display': 'element',
+      display: 'element',
       content: 'data(id)',
       'text-valign': 'center',
       'text-halign': 'center',

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -4055,7 +4055,7 @@ declare namespace cytoscape {
              * Whether to display the element; may be element for displayed or none for not displayed.
              * Note that a "display: none" bezier edge does not take up space in its bundle.
              */
-            "display": PropertyValue<SingularType, "none" | "displayed">;
+            "display": PropertyValue<SingularType, "none" | "element">;
             /**
              * Whether the element is visible; may be visible or hidden.
              * Note that a "visibility : hidden" bezier edge still takes up space in its bundle.


### PR DESCRIPTION
According to Cytoscape documents and the description above the typing, options for display are 'none' or 'element'

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://js.cytoscape.org/#style/visibility](https://js.cytoscape.org/#style/visibility)
