### PR TITLE
Created type definitions for easy-soap-request

### DIFF
--- a/types/easy-soap-request/easy-soap-request-tests.ts
+++ b/types/easy-soap-request/easy-soap-request-tests.ts
@@ -1,0 +1,38 @@
+import soapRequest, { Response } from "easy-soap-request";
+
+// minimal required options
+// $ExpectType Promise<Response>
+const promise = soapRequest({
+    url: 'http://example.com/soap',
+    xml: '<xml></xml>',
+});
+// response
+promise.then((response: Response) => {});
+
+// all posible options
+// $ExpectType Promise<Response>
+soapRequest({
+    url: 'http://example.com/soap',
+    xml: '<xml></xml>',
+    timeout: 100000,
+    headers: {
+        SoapAction: 'test',
+    },
+    maxBodyLength: 100,
+    maxContentLength: 100,
+    method: 'PUT',
+    proxy: {
+        host: 'http://proxy.example.com',
+        port: 1080,
+    },
+    extraOpts: {
+        // test some axios options
+        maxRedirects: 1,
+        decompress: false,
+        socketPath: null,
+    }
+});
+
+// Missing required options
+// $ExpectError
+soapRequest({});

--- a/types/easy-soap-request/easy-soap-request-tests.ts
+++ b/types/easy-soap-request/easy-soap-request-tests.ts
@@ -3,8 +3,8 @@ import soapRequest, { Response } from "easy-soap-request";
 // minimal required options
 // $ExpectType Promise<Response>
 const promise = soapRequest({
-    url: 'http://example.com/soap',
-    xml: '<xml></xml>',
+    url: "http://example.com/soap",
+    xml: "<xml></xml>",
 });
 // response
 promise.then((response: Response) => {});
@@ -12,17 +12,17 @@ promise.then((response: Response) => {});
 // all posible options
 // $ExpectType Promise<Response>
 soapRequest({
-    url: 'http://example.com/soap',
-    xml: '<xml></xml>',
+    url: "http://example.com/soap",
+    xml: "<xml></xml>",
     timeout: 100000,
     headers: {
-        SoapAction: 'test',
+        SoapAction: "test",
     },
     maxBodyLength: 100,
     maxContentLength: 100,
-    method: 'PUT',
+    method: "PUT",
     proxy: {
-        host: 'http://proxy.example.com',
+        host: "http://proxy.example.com",
         port: 1080,
     },
     extraOpts: {
@@ -30,7 +30,7 @@ soapRequest({
         maxRedirects: 1,
         decompress: false,
         socketPath: null,
-    }
+    },
 });
 
 // Missing required options

--- a/types/easy-soap-request/easy-soap-request-tests.ts
+++ b/types/easy-soap-request/easy-soap-request-tests.ts
@@ -1,4 +1,5 @@
-import soapRequest, { Response } from "easy-soap-request";
+// import { Response } from "easy-soap-request";
+import soapRequest = require("easy-soap-request");
 
 // minimal required options
 // $ExpectType Promise<Response>
@@ -6,8 +7,6 @@ const promise = soapRequest({
     url: "http://example.com/soap",
     xml: "<xml></xml>",
 });
-// response
-promise.then((response: Response) => {});
 
 // all posible options
 // $ExpectType Promise<Response>

--- a/types/easy-soap-request/index.d.ts
+++ b/types/easy-soap-request/index.d.ts
@@ -1,0 +1,71 @@
+// Type definitions for easy-soap-request 4.1
+// Project: https://github.com/circa10a/easy-soap-request
+// Definitions by: Steven Snoeijen <https://github.com/stevensnoeijen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { AxiosProxyConfig, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
+
+export interface Options {
+    /**
+     * HTTP request method
+     * @default 'POST'
+     */
+    method?: string;
+
+    /**
+     * endpoint URL
+     */
+    url: string;
+
+    /**
+     * HTTP headers, can be string or object
+     */
+    headers?: object | string;
+
+    /**
+     *  SOAP envelope, can be read from file or passed as string
+     */
+    xml: string;
+
+    /**
+     * Milliseconds before timing out request
+     * @default 10000
+     */
+    timeout?: number;
+
+    /**
+     * Object with proxy configuration
+     */
+    proxy?: AxiosProxyConfig;
+
+    /**
+     * Limit body size being sent(bytes)
+     * @default Infinity
+     */
+    maxBodyLength?: number;
+
+    /**
+     * Limit content size being sent(bytes)
+     * @default Infinity
+     */
+    maxContentLength?: number;
+
+    /**
+     * Object of additional axios parameters.
+     */
+    extraOpts?: AxiosRequestConfig;
+}
+
+export interface Response {
+    response: {
+        headers: any;
+        body: any;
+        statusCode: number;
+    };
+}
+
+/**
+ * @returns parsed from a AxiosResponse
+ * @throws {any|AxiosError} response from AxiosError.response.data
+ */
+ export default function soapRequest(options: Options): Promise<Response>;

--- a/types/easy-soap-request/index.d.ts
+++ b/types/easy-soap-request/index.d.ts
@@ -68,4 +68,6 @@ export interface Response {
  * @returns parsed from a AxiosResponse
  * @throws {any|AxiosError} response from AxiosError.response.data
  */
-export default function soapRequest(options: Options): Promise<Response>;
+function soapRequest(options: Options): Promise<Response>;
+
+export = soapRequest

--- a/types/easy-soap-request/index.d.ts
+++ b/types/easy-soap-request/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steven Snoeijen <https://github.com/stevensnoeijen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { AxiosProxyConfig, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
+import { AxiosProxyConfig, AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
 
 export interface Options {
     /**
@@ -68,4 +68,4 @@ export interface Response {
  * @returns parsed from a AxiosResponse
  * @throws {any|AxiosError} response from AxiosError.response.data
  */
- export default function soapRequest(options: Options): Promise<Response>;
+export default function soapRequest(options: Options): Promise<Response>;

--- a/types/easy-soap-request/index.d.ts
+++ b/types/easy-soap-request/index.d.ts
@@ -5,7 +5,7 @@
 
 import { AxiosProxyConfig, AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
 
-export interface Options {
+interface Options {
     /**
      * HTTP request method
      * @default 'POST'
@@ -56,7 +56,7 @@ export interface Options {
     extraOpts?: AxiosRequestConfig;
 }
 
-export interface Response {
+interface Response {
     response: {
         headers: any;
         body: any;
@@ -68,6 +68,6 @@ export interface Response {
  * @returns parsed from a AxiosResponse
  * @throws {any|AxiosError} response from AxiosError.response.data
  */
-function soapRequest(options: Options): Promise<Response>;
+declare function soapRequest(options: Options): Promise<Response>;
 
-export = soapRequest
+export = soapRequest;

--- a/types/easy-soap-request/package.json
+++ b/types/easy-soap-request/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "axios": "^0.21.1",
+        "@types/node": "^14.14.41"
+    }
+}

--- a/types/easy-soap-request/package.json
+++ b/types/easy-soap-request/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "axios": "^0.21.1",
-        "@types/node": "^14.14.41"
+        "axios": "^0.21.1"
     }
 }

--- a/types/easy-soap-request/tsconfig.json
+++ b/types/easy-soap-request/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "easy-soap-request-tests.ts"
+    ]
+}

--- a/types/easy-soap-request/tslint.json
+++ b/types/easy-soap-request/tslint.json
@@ -1,14 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": [
-            true,
-            {
-                "mode": "code",
-                "errors": [
-                    [ "NeedsExportEquals", false ]
-                ]
-            }
-        ]
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/easy-soap-request/tslint.json
+++ b/types/easy-soap-request/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "no-redundant-jsdoc": false,
         "npm-naming": [
             true,
             {

--- a/types/easy-soap-request/tslint.json
+++ b/types/easy-soap-request/tslint.json
@@ -1,0 +1,15 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc": false,
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [ "NeedsExportEquals", false ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.