### PR TITLE
allow boolean true to keep controlbar buttons

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -1983,25 +1983,25 @@ declare namespace videojs {
     };
 
     interface ControlBarOptions extends ComponentOptions {
-        volumePanel?: VolumePanelOptions | false;
-        playToggle?: false;
-        captionsButton?: false;
-        chaptersButton?: false;
-        subtitlesButton?: false;
-        remainingTimeDisplay?: false;
-        progressControl?: ProgressControlOptions | false;
-        fullscreenToggle?: false;
-        playbackRateMenuButton?: false;
-        pictureInPictureToggle?: false;
-        currentTimeDisplay?: false;
-        timeDivider?: false;
-        durationDisplay?: false;
-        liveDisplay?: false;
-        seekToLive?: false;
-        customControlSpacer?: false;
-        descriptionsButton?: false;
-        subsCapsButton?: false;
-        audioTrackButton?: false;
+        volumePanel?: VolumePanelOptions | boolean;
+        playToggle?: boolean;
+        captionsButton?: boolean;
+        chaptersButton?: boolean;
+        subtitlesButton?: boolean;
+        remainingTimeDisplay?: boolean;
+        progressControl?: ProgressControlOptions | boolean;
+        fullscreenToggle?: boolean;
+        playbackRateMenuButton?: boolean;
+        pictureInPictureToggle?: boolean;
+        currentTimeDisplay?: boolean;
+        timeDivider?: boolean;
+        durationDisplay?: boolean;
+        liveDisplay?: boolean;
+        seekToLive?: boolean;
+        customControlSpacer?: boolean;
+        descriptionsButton?: boolean;
+        subsCapsButton?: boolean;
+        audioTrackButton?: boolean;
     }
 
     /**

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -1,5 +1,7 @@
 import videojs, { VideoJsPlayer, VideoJsPlayerOptions } from 'video.js';
 
+const audioElement = document.createElement('audio');
+
 const playerOptions: VideoJsPlayerOptions = {
     autoplay: 'muted',
     bigPlayButton: false,
@@ -8,6 +10,7 @@ const playerOptions: VideoJsPlayerOptions = {
         playToggle: false,
         captionsButton: false,
         chaptersButton: false,
+        pictureInPictureToggle: audioElement.tagName !== "AUDIO"
     },
     height: 10,
     loop: true,


### PR DESCRIPTION
2 months ago when #51136 was merged we lost the ability to keep controlBar buttons with a boolean `true`. This restores that