### PR TITLE
nova-editor: Allow passing editor into command invoking

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -107,6 +107,7 @@ interface CommandsRegistry {
     register(name: string, callable: (...params: any[]) => void): Disposable;
     register<T>(name: string, callable: (this: T, ...params: any[]) => void, thisValue: T): Disposable;
     invoke(name: string, ...arguments: Transferrable[]): Promise<unknown>;
+    invoke(name: string, textEditor: TextEditor, ...arguments: Transferrable[]): Promise<unknown>;
 }
 
 /// https://docs.nova.app/api-reference/completion-context/

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -52,6 +52,8 @@ nova.commands.register(
 );
 
 nova.commands.invoke('apexskier.bar', 'foo');
+// You're allowed to pass an editor in your own extension's commands
+nova.commands.invoke('apexskier.bar', editor, 'foo');
 
 // after 3.4: $ExpectType unknown
 nova.config.get('test');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   * https://github.com/apexskier/nova-typescript/pull/202/checks?check_run_id=2426834001
   * https://devforum.nova.app/t/commandsregistry-arguments-documentation/719
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
