### PR TITLE
Create type definitions for webos-service

### DIFF
--- a/types/webos-service/activity-manager.d.ts
+++ b/types/webos-service/activity-manager.d.ts
@@ -1,0 +1,70 @@
+import { Service } from "./service";
+import { Subscription } from "./subscription";
+
+export interface Type {
+    readonly explicit?: boolean;
+    readonly foreground?: boolean;
+    readonly persist?: boolean;
+}
+
+export interface Activity {
+    readonly description: string;
+    readonly name: string;
+    readonly type?: Type;
+}
+
+export interface ActivitySpec {
+    readonly activity: Activity;
+    readonly replace?: boolean;
+    readonly start?: boolean;
+    readonly subscribe?: boolean;
+}
+
+export interface CreateDummyCallback {
+    activity: { name: string };
+    isDummyActivity: boolean;
+}
+
+export class ActivityManager {
+    readonly idleTimeout: number;
+
+    readonly service: Service;
+
+    exitOnTimeout: boolean;
+
+    useDummyActivity: boolean;
+
+    constructor(service: Service, idleTimeout: number);
+
+    adopt(activity: Record<string, any>, callback?: (payload: Record<string, any>) => void): void;
+
+    complete(
+        activity: Record<string, any>,
+        options?: Record<string, any>,
+        callback?: (payload: Record<string, any>) => void,
+    ): boolean | void;
+
+    create(spec: string | Record<string, any>, callback: (payload: any) => void): void;
+
+    private readonly _activities: { [id: string]: Subscription };
+
+    private _counter: number;
+
+    private _dummyActivityId: number;
+
+    private _idleTimer: NodeJS.Timeout | null;
+
+    private _add(id: string, activity: Subscription): void;
+
+    private _createActual(activitySpec: ActivitySpec, callback?: (payload: any) => void): void;
+
+    private _createDummy(jobId: string, callback?: (payload: CreateDummyCallback) => void): void;
+
+    private _createInternal(jobId: string, callback?: (payload: any) => void): void;
+
+    private _remove(id: string): void;
+
+    private _startTimer(): void;
+
+    private _stopTimer(): void;
+}

--- a/types/webos-service/index.d.ts
+++ b/types/webos-service/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for non-npm package webos-service 0.4
+// Project: https://github.com/webosose/nodejs-module-webos-service
+// Definitions by: Alexandre Macabies <https://github.com/zopieux>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace WebosService;
+
+import { ActivityManager } from "./activity-manager";
+import { Message } from "./message";
+import { Method } from "./method";
+import { Service } from "./service";
+import { Subscription } from "./subscription";
+
+export { ActivityManager, Message, Method, Service, Subscription };

--- a/types/webos-service/message.d.ts
+++ b/types/webos-service/message.d.ts
@@ -1,0 +1,32 @@
+import { ActivityManager } from "./activity-manager";
+import { Service } from "./service";
+
+export class Message {
+    readonly activityManager: ActivityManager;
+
+    readonly category: string;
+
+    readonly handle: any;
+
+    readonly isSubscription: boolean;
+
+    readonly ls2Message: any;
+
+    readonly method: string;
+
+    readonly payload: Record<string, any>;
+
+    readonly sender: string;
+
+    readonly service: Service;
+
+    readonly token: string;
+
+    readonly uniqueToken: string;
+
+    constructor(message: any, handle: any, activityManager: ActivityManager, service: Service);
+
+    cancel(response: Record<string, any>): void;
+
+    respond(response: Record<string, any>): boolean;
+}

--- a/types/webos-service/method.d.ts
+++ b/types/webos-service/method.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="node" />
+
+import { Message } from "./message";
+import { EventEmitter } from "events";
+
+export class Method extends EventEmitter {
+    readonly description: Record<string, any>;
+
+    readonly name: string;
+
+    constructor(methodName: string, description: Record<string, any>);
+
+    on(event: "request" | "cancel", listener: (message: Message) => void): this;
+
+    on(event: string, listener: () => void): this;
+}

--- a/types/webos-service/service.d.ts
+++ b/types/webos-service/service.d.ts
@@ -1,0 +1,87 @@
+import { ActivityManager } from "./activity-manager";
+import { Message } from "./message";
+import { Method } from "./method";
+import { Subscription } from "./subscription";
+
+export interface ServiceOptions {
+    // Idle time in seconds before exiting.
+    readonly idleTimer?: number;
+    // Prevents registering 'info' & 'quit' methods.
+    readonly noBuiltinMethods?: boolean;
+}
+
+export class Service {
+    readonly activityManager: ActivityManager;
+
+    readonly busId: string;
+
+    readonly cancelHandlers: Record<string, any>;
+
+    readonly handlers: Record<string, any>;
+
+    readonly idleTimer: number;
+
+    readonly methods: { [category: string]: { [methodName: string]: Method } };
+
+    readonly noBuiltinMethods: boolean;
+
+    readonly subscriptions: { [id: string]: Message };
+
+    cleanupUnifiedDone: boolean;
+
+    handle: any;
+
+    hasPublicMethods: boolean;
+
+    privateHandle: any;
+
+    publicHandle: any;
+
+    sendingHandle: any;
+
+    useACG: boolean;
+
+    constructor(busId: string, activityManager?: ActivityManager, options?: ServiceOptions);
+
+    call(uri: string, args: Record<string, any>, callback: (message: Message) => void): void;
+
+    cancelSubscription(handle: any, ls2Message: any): void;
+
+    cleanupUnified(): void;
+
+    idIsPrivileged(id: string): boolean;
+
+    info(message: Message): void;
+
+    quit(message: Message): void;
+
+    register(
+        name: string,
+        requestCallback?: (message: Message) => void,
+        cancelCallback?: (message: Message) => void,
+        description?: Record<string, any>,
+    ): Method;
+
+    registerPrivate(
+        name: string,
+        requestCallback?: (message: Message) => void,
+        cancelCallback?: (message: Message) => void,
+        description?: Record<string, any>,
+    ): Method;
+
+    subscribe(uri: string, args: Record<string, any>): Subscription;
+
+    private readonly __serviceMainUnified: any;
+
+    private _dispatch(handle: any, ls2Message: any): void;
+
+    private _register(
+        privateBus: boolean,
+        name: string,
+        requestCallback?: (message: Message) => void,
+        cancelCallback?: (message: Message) => void,
+        description?: Record<string, any>,
+    ): Method;
+
+    private _registerBuiltInMethods(privateBus: boolean): void;
+}

--- a/types/webos-service/subscription.d.ts
+++ b/types/webos-service/subscription.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="node" />
+
+import { EventEmitter } from "events";
+
+export class Subscription extends EventEmitter {
+    readonly args: Record<string, any>;
+
+    readonly handle: any;
+
+    readonly request: any;
+
+    readonly uri: string;
+
+    constructor(handle: any, uri: string, args: Record<string, any>);
+
+    cancel(): void;
+}

--- a/types/webos-service/tsconfig.json
+++ b/types/webos-service/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webos-service-tests.ts"
+    ]
+}

--- a/types/webos-service/tslint.json
+++ b/types/webos-service/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/webos-service/webos-service-tests.ts
+++ b/types/webos-service/webos-service-tests.ts
@@ -1,0 +1,4 @@
+const service = new WebosService.Service("test"); // $ExpectType Service
+service.activityManager; // $ExpectType ActivityManager
+const sub = service.subscribe("test", {}); // $ExpectType Subscription
+sub.uri; // $ExpectType string


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Note the upstream package is from a corporate entity which does not follow common practice over semantic versioning. https://github.com/webosose/nodejs-module-webos-service has tags of the form `submissions/4` so I chose an arbitrary version `0.4` to fit the semantic versioning check. If you know of a saner way of doing this, please share. 