### PR TITLE
Added missing request object in the WebSocket.Server addListener("connection") method.

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -271,7 +271,7 @@ declare namespace WebSocket {
         off(event: 'close' | 'listening', cb: (this: Server) => void): this;
         off(event: string | symbol, listener: (this: Server, ...args: any[]) => void): this;
 
-        addListener(event: 'connection', cb: (client: WebSocket) => void): this;
+        addListener(event: 'connection', cb: (client: WebSocket, request: http.IncomingMessage) => void): this;
         addListener(event: 'error', cb: (err: Error) => void): this;
         addListener(event: 'headers', cb: (headers: string[], request: http.IncomingMessage) => void): this;
         addListener(event: 'close' | 'listening', cb: () => void): this;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -85,6 +85,22 @@ import * as url from 'url';
 }
 
 {
+    const wss = new WebSocket.Server();
+
+    wss.addListener('connection', (client, request) => {
+        request.socket.remoteAddress;
+
+        // $ExpectError
+        request.aborted === 10;
+
+        client.terminate();
+        request.destroy();
+    });
+
+    wss.close();
+}
+
+{
     new WebSocket.Server({ noServer: true, perMessageDeflate: false });
     new WebSocket.Server({ noServer: true, perMessageDeflate: { } });
     new WebSocket.Server({


### PR DESCRIPTION
Fixed the http.IncomingMessage request object missing on the
WebSocket.Server addListener("connection") method.

I'm not fluent in this. I just noticed that the request object is present in "once" and "on" but not in "addListener". It seems to be there e.g. I may use it in my code.

I sadly do not understand these tests, otherwise, I would add one.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/fc7e27d12ad0af90ce05302afc85c292024000b4/lib/websocket-server.js#L330
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

