### PR TITLE
[cache-manager-ioredis] add ambient namespace declaration

### DIFF
--- a/types/cache-manager-ioredis/cache-manager-ioredis-tests.ts
+++ b/types/cache-manager-ioredis/cache-manager-ioredis-tests.ts
@@ -1,6 +1,8 @@
 import cacheManager = require("cache-manager");
 import redisStore = require("cache-manager-ioredis");
 
+import { RedisSingleNodeStore } from "cache-manager-ioredis";
+
 const redisCache = cacheManager.caching({
     store: redisStore,
     host: 'localhost', // default value
@@ -36,3 +38,7 @@ clusterCache.store.getClient();
 const memoryCache = cacheManager.caching({ store: 'memory', max: 100, ttl: 60 });
 
 cacheManager.multiCaching([redisCache, memoryCache]);
+
+function getStore(): RedisSingleNodeStore {
+  return redisCache.store;
+}

--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -6,7 +6,7 @@
 import * as IORedis from "ioredis";
 import { Store, CachingConfig, CacheOptions, Cache } from 'cache-manager';
 
-declare var CacheManagerIORedis: CacheManagerIORedis.RedisStoreConstructor;
+declare const CacheManagerIORedis: CacheManagerIORedis.RedisStoreConstructor;
 export = CacheManagerIORedis;
 
 declare module 'cache-manager' {

--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -6,9 +6,8 @@
 import * as IORedis from "ioredis";
 import { Store, CachingConfig, CacheOptions, Cache } from 'cache-manager';
 
-declare const methods: CacheManagerIORedis.RedisStoreConstructor;
-export = methods;
-export { };
+declare var CacheManagerIORedis: CacheManagerIORedis.RedisStoreConstructor;
+export = CacheManagerIORedis;
 
 declare module 'cache-manager' {
     function caching(IConfig: CacheManagerIORedis.RedisStoreClusterConfig): CacheManagerIORedis.ClusterCache;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test cache-manager-ioredis`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: No reference URL.
its declaration uses namespaces to define its CacheManagerIORedis. For the TypeScript compiler to see this CacheManagerIORedis, so add ambient namespace declaration. 

fix after, i can use this, example
``` typescript
import { RedisSingleNodeStore } from "cache-manager-ioredis";

function getStore(): RedisSingleNodeStore {
  return redisCache.store;
}
```