### PR TITLE
[ws] add once/off overloads for WebSocket

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -106,6 +106,24 @@ declare class WebSocket extends events.EventEmitter {
     on(event: 'unexpected-response', listener: (this: WebSocket, request: http.ClientRequest, response: http.IncomingMessage) => void): this;
     on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
+    once(event: 'close', listener: (this: WebSocket, code: number, reason: string) => void): this;
+    once(event: 'error', listener: (this: WebSocket, err: Error) => void): this;
+    once(event: 'upgrade', listener: (this: WebSocket, request: http.IncomingMessage) => void): this;
+    once(event: 'message', listener: (this: WebSocket, data: WebSocket.Data) => void): this;
+    once(event: 'open' , listener: (this: WebSocket) => void): this;
+    once(event: 'ping' | 'pong', listener: (this: WebSocket, data: Buffer) => void): this;
+    once(event: 'unexpected-response', listener: (this: WebSocket, request: http.ClientRequest, response: http.IncomingMessage) => void): this;
+    once(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
+
+    off(event: 'close', listener: (this: WebSocket, code: number, reason: string) => void): this;
+    off(event: 'error', listener: (this: WebSocket, err: Error) => void): this;
+    off(event: 'upgrade', listener: (this: WebSocket, request: http.IncomingMessage) => void): this;
+    off(event: 'message', listener: (this: WebSocket, data: WebSocket.Data) => void): this;
+    off(event: 'open' , listener: (this: WebSocket) => void): this;
+    off(event: 'ping' | 'pong', listener: (this: WebSocket, data: Buffer) => void): this;
+    off(event: 'unexpected-response', listener: (this: WebSocket, request: http.ClientRequest, response: http.IncomingMessage) => void): this;
+    off(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
+
     addListener(event: 'close', listener: (code: number, message: string) => void): this;
     addListener(event: 'error', listener: (err: Error) => void): this;
     addListener(event: 'upgrade', listener: (request: http.IncomingMessage) => void): this;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -173,6 +173,16 @@ import * as url from 'url';
     }, { once: true });
 }
 
+{
+    const ws = new WebSocket('ws://www.host.com/path');
+    const eventHandler: Parameters<typeof ws.once>[1] = () => {};
+    const event = '';
+    const errorHandler = (err: Error) => {
+        ws.off(event, eventHandler);
+    };
+    ws.once('error', errorHandler);
+}
+
 function f() {
     const ws = new WebSocket('ws://www.host.com/path');
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2f6c3ecbd21289ccd0c83a90cc29354ba7f10f3c/types/ws/index.d.ts#L100-L107
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `once`/`off` overloads are just carbon copies of the `on` overloads above.