### PR TITLE
styled-components: Add displayName prop to withConfig

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -142,6 +142,7 @@ type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof Re
 // Config to be used with withConfig
 export interface StyledConfig<O extends object = {}> {
     // TODO: Add all types from the original StyledComponentWrapperProperties
+    displayName?: string,
     shouldForwardProp?: (prop: keyof O, defaultValidatorFn: (prop: keyof O) => boolean) => boolean;
 }
 

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -142,7 +142,7 @@ type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof Re
 // Config to be used with withConfig
 export interface StyledConfig<O extends object = {}> {
     // TODO: Add all types from the original StyledComponentWrapperProperties
-    displayName?: string,
+    displayName?: string;
     shouldForwardProp?: (prop: keyof O, defaultValidatorFn: (prop: keyof O) => boolean) => boolean;
 }
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -337,6 +337,16 @@ const SomeButton: React.FC = () => <Button type="submit">I am a button</Button>;
  */
 
 /**
+ * displayName
+ */
+
+styled('div').withConfig({
+    displayName: "TestDisplayName",
+})`
+ color: red;
+`;
+
+/**
  * shouldForwardProp
  */
 


### PR DESCRIPTION
Adds the `displayName` prop to be accepted by `withConfig`. 

[Here is the line of code showing where withConfig is defined](https://github.com/styled-components/styled-components/blob/legacy-v5/packages/styled-components/src/constructors/constructWithOptions.js#L22-L24). There are [other props which are accepted by withConfig](https://github.com/styled-components/styled-components/blob/legacy-v5/packages/styled-components/src/models/StyledComponent.js#L179-L185), but I was unsure if those other props are intended to be set via `withConfig` and so I have omitted them for now. 


-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
