### PR TITLE
[node]: Use tuples to infer callback parameters for setTimeout, setInterval and setImmediate

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -47,15 +47,15 @@ declare var console: Console;
 declare var __filename: string;
 declare var __dirname: string;
 
-declare function setTimeout(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
+declare function setTimeout<T extends any[]>(callback: (...args: T) => void, ms?: number, ...args: T): NodeJS.Timeout;
 declare namespace setTimeout {
     function __promisify__(ms: number): Promise<void>;
-    function __promisify__<T>(ms: number, value: T): Promise<T>;
+    function __promisify__<T>(ms: number, value: T, options?: TimerOptions): Promise<T>;
 }
 declare function clearTimeout(timeoutId: NodeJS.Timeout): void;
-declare function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
+declare function setInterval<T extends any[]>(callback: (...args: T) => void, ms?: number, ...args: T): NodeJS.Timeout;
 declare function clearInterval(intervalId: NodeJS.Timeout): void;
-declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
+declare function setImmediate<T extends any[]>(callback: (...args: T) => void, ...args: T): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;
     function __promisify__<T>(value: T): Promise<T>;

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -17,15 +17,15 @@ declare module 'timers' {
         signal?: AbortSignal;
     }
 
-    function setTimeout(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
+    function setTimeout<T extends any[]>(callback: (...args: T) => void, ms?: number, ...args: T): NodeJS.Timeout;
     namespace setTimeout {
         function __promisify__(ms: number): Promise<void>;
         function __promisify__<T>(ms: number, value: T, options?: TimerOptions): Promise<T>;
     }
     function clearTimeout(timeoutId: NodeJS.Timeout): void;
-    function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
+    function setInterval<T extends any[]>(callback: (...args: T) => void, ms?: number, ...args: T): NodeJS.Timeout;
     function clearInterval(intervalId: NodeJS.Timeout): void;
-    function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
+    function setImmediate<T extends any[]>(callback: (...args: T) => void, ...args: T): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;
         function __promisify__<T>(value: T, options?: TimerOptions): Promise<T>;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

Use tuples to infer callback parameters for setTimeout, setInterval and setImmediate.

```ts
setTimeout((param1 /*a number*/,param2 /*a string*/, param3 /*a boolean*/) => {
    //...
}, 1000, 1234, 'this is a string', true);

setTimeout((a /* An error is thrown*/) => {
    //...
}, 1000); // argument for parameter `a` wasn't passed. so throw an error if used in the callback.

setTimeout(() => {
    //... still works
}, 1000);

setTimeout(() => {
    //....
}, 12312, 12321); // An error is thrown, should be used inside the callback as a parameter.
```

If passing a BigInt, it is required to use 'es2020' or above as target. 
The PR might be a breaking change.