### PR TITLE
fix(react): React.forwardRef return type should have 'children' props

### DIFF
--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -798,7 +798,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P>;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<PropsWithChildren<P>> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -358,6 +358,11 @@ const ForwardRef3 = React.forwardRef(
 <ForwardRef3 ref={divFnRef}/>;
 <ForwardRef3 ref={divRef}/>;
 
+const ForwardRefWithChildren = React.forwardRef((props: React.PropsWithChildren<{}>, ref?: React.Ref<HTMLDivElement>) => <div ref={ref}>{props.children}</div>);
+const ForwardRefWithChildren1 = React.forwardRef<{}, HTMLDivElement>((props, ref) => <div ref={ref}>{props.children}</div>);
+<ForwardRefWithChildren>test</ForwardRefWithChildren>;
+<ForwardRefWithChildren1>test</ForwardRefWithChildren1>;
+
 const { Profiler } = React;
 
 // 'id' is missing


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

