### PR TITLE
Add types for the WICG File and Directory Entries API

### DIFF
--- a/types/wicg-entries-api/index.d.ts
+++ b/types/wicg-entries-api/index.d.ts
@@ -1,0 +1,75 @@
+// Type definitions for non-npm package File and Directory Entries API 2020.08
+// Project: https://github.com/WICG/entries-api, https://wicg.github.io/entries-api/
+// Definitions by: Henning Kasch <https://github.com/HenningCash>
+//                 Ingvar Stepanyan <https://github.com/RReverser>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class BaseFileSystemEntry {
+    protected constructor();
+
+    readonly isFile: boolean;
+    readonly isDirectory: boolean;
+    readonly name: string;
+    readonly fullPath: string;
+    readonly filesystem: FileSystem;
+
+    getParent(successCallback?: FileSystemEntryCallback, errorCallback?: ErrorCallback): void;
+}
+
+type ErrorCallback = (err: DOMException) => void;
+type FileSystemEntryCallback = (entry: FileSystemEntry) => void;
+type FileSystemEntriesCallback = (entries: FileSystemEntry[]) => void;
+type FileCallback = (file: File) => void;
+
+interface FileSystemFlags {
+    create?: boolean;
+    exclusive?: boolean;
+}
+
+declare global {
+    type FileSystemEntry = FileSystemDirectoryEntry | FileSystemFileEntry;
+
+    interface FileSystemDirectoryEntry extends BaseFileSystemEntry {
+        createReader(): FileSystemDirectoryReader;
+        getFile(
+            path?: string,
+            options?: FileSystemFlags,
+            successCallback?: FileSystemEntryCallback,
+            errorCallback?: ErrorCallback,
+        ): void;
+        getDirectory(
+            path?: string,
+            options?: FileSystemFlags,
+            successCallback?: FileSystemEntryCallback,
+            errorCallback?: ErrorCallback,
+        ): void;
+    }
+
+    interface FileSystemDirectoryReader {
+        readEntries(successCallback: FileSystemEntriesCallback, errorCallback?: ErrorCallback): void;
+    }
+
+    interface FileSystemFileEntry extends BaseFileSystemEntry {
+        file(successCallback: FileCallback, errorCallback?: ErrorCallback): void;
+    }
+
+    interface FileSystem {
+        readonly name: string;
+        readonly root: FileSystemDirectoryEntry;
+    }
+
+    interface File {
+        readonly webkitRelativePath: string;
+    }
+
+    interface HTMLInputElement {
+        webkitdirectory: boolean;
+        readonly webkitEntries: ReadonlyArray<FileSystemEntry>;
+    }
+
+    interface DataTransferItem {
+        webkitGetAsEntry(): FileSystemEntry | null;
+    }
+}
+
+export {};

--- a/types/wicg-entries-api/tsconfig.json
+++ b/types/wicg-entries-api/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+	    "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wicg-entries-api-tests.ts"
+    ]
+}

--- a/types/wicg-entries-api/tslint.json
+++ b/types/wicg-entries-api/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wicg-entries-api/wicg-entries-api-tests.ts
+++ b/types/wicg-entries-api/wicg-entries-api-tests.ts
@@ -1,0 +1,72 @@
+const isDirectoryEntry = (entry: FileSystemEntry): entry is FileSystemDirectoryEntry => entry.isDirectory;
+const isFileEntry = (entry: FileSystemEntry): entry is FileSystemFileEntry => entry.isFile;
+
+const resolveFile = (entry: File) => undefined;
+const resolveEntry = (entry: FileSystemEntry) => undefined;
+const errorHandler = (error: DOMException) => undefined;
+
+const stringifyEntry = (entry: FileSystemEntry): string => {
+    return `
+isFile: ${entry.isFile}
+isDirectory ${entry.isDirectory}
+name: ${entry.name}
+fullPath: ${entry.fullPath}
+filesystem.name: ${entry.filesystem.name}
+    `;
+};
+
+const walkDirectoryReader = (reader: FileSystemDirectoryReader) => {
+    reader.readEntries(entries => {
+        if (entries.length === 0) return;
+        for (const entry of entries) {
+            if (isDirectoryEntry(entry)) {
+                walkDirectoryReader(entry.createReader());
+            }
+            console.log(stringifyEntry(entry));
+        }
+    });
+    reader.readEntries(entries => console.log(entries.length), errorHandler);
+};
+
+const validGetDirectoryCalls = (entry: FileSystemDirectoryEntry) => {
+    entry.getDirectory("dir", { create: false, exclusive: false }, resolveEntry, errorHandler);
+    entry.getDirectory("dir", { create: false }, resolveEntry, errorHandler);
+    entry.getDirectory("dir", { exclusive: false }, resolveEntry, errorHandler);
+    entry.getDirectory("dir", {}, resolveEntry, errorHandler);
+    entry.getDirectory("dir", {}, resolveEntry);
+    entry.getDirectory("dir", {});
+    entry.getDirectory("dir");
+    entry.getDirectory();
+};
+
+const validGetFileCalls = (entry: FileSystemDirectoryEntry) => {
+    entry.getFile("dir", { create: false, exclusive: false }, resolveEntry, errorHandler);
+    entry.getFile("dir", { create: false }, resolveEntry, errorHandler);
+    entry.getFile("dir", { exclusive: false }, resolveEntry, errorHandler);
+    entry.getFile("dir", {}, resolveEntry, errorHandler);
+    entry.getFile("dir", {}, resolveEntry);
+    entry.getFile("dir", {});
+    entry.getFile("dir");
+    entry.getFile();
+};
+
+const validFileCalls = (entry: FileSystemFileEntry) => {
+    entry.file(resolveFile, errorHandler);
+    entry.file(resolveFile);
+};
+
+const readEntriesFromInput = (input: HTMLInputElement) => {
+    for (const entry of input.webkitEntries) {
+        console.log(stringifyEntry(entry));
+    }
+};
+
+const readDataTransferItems = (items: DataTransferItemList) => {
+    // tslint:disable-next-line:prefer-for-of
+    for (let i = 0; i < items.length; i++) {
+        const entry = items[i].webkitGetAsEntry();
+        if (entry !== null) {
+            console.log(stringifyEntry(entry));
+        }
+    }
+};


### PR DESCRIPTION
So there are already types for the WICG File System Access API [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/wicg-file-system-access/index.d.ts). But, atm the more supported FS API in browsers is the "[File and Directory Entries API](https://wicg.github.io/entries-api/)", even if it's no real standard.

Because @RReverser created `@types/wicg-file-system-access`, may I ask you for your opinion on this PR?

--- 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.