### PR TITLE
[@types/d3-zoom] fix wheelDelta type

### DIFF
--- a/types/d3-zoom/d3-zoom-tests.ts
+++ b/types/d3-zoom/d3-zoom-tests.ts
@@ -167,17 +167,15 @@ touchableFn = svgZoom.touchable();
 
 // wheelDelta() ----------------------------------------------------------------
 
-// chainable
-svgZoom = svgZoom.wheelDelta(function(d, i, group) {
-    // Cast d3 event to D3ZoomEvent to be used in filter logic
-    const e = event as WheelEvent;
+// chainable with function
+svgZoom = svgZoom.wheelDelta(function(this: SVGRectElement, e) {
     const that: SVGRectElement = this;
-    const datum: SVGDatum = d;
-    const index: number = i;
-    const g: SVGRectElement[] | ArrayLike<SVGRectElement> = group;
 
     return -e.deltaY * (e.deltaMode ? 100 : 1) / 600;
 });
+
+// chainable with number
+svgZoom = svgZoom.wheelDelta(1);
 
 let wheelDeltaFn: (this: SVGRectElement, d: SVGDatum, index: number, group: SVGRectElement[]) => number;
 wheelDeltaFn = svgZoom.wheelDelta();

--- a/types/d3-zoom/index.d.ts
+++ b/types/d3-zoom/index.d.ts
@@ -231,10 +231,10 @@ export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datu
      * The scale factor transform.k is multiplied by 2Δ; for example, a Δ of +1 doubles the scale factor, Δ of -1 halves the scale factor.
      *
      * @param delta Wheel delta function which is invoked in the wheel event handler of each element to which the zoom behavior was applied,
-     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * in order, being passed the wheel event that triggered the handler,
      * with this as the current DOM element. The function returns a numeric value.
      */
-    wheelDelta(delta: ValueFn<ZoomRefElement, Datum, number>): this;
+     wheelDelta(delta: ((event: WheelEvent) => number) | number): this;
 
     /**
      * Return the current extent accessor, which defaults to [[0, 0], [width, height]] where width is the client width of the element and height is its client height;

--- a/types/d3-zoom/index.d.ts
+++ b/types/d3-zoom/index.d.ts
@@ -234,7 +234,7 @@ export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datu
      * in order, being passed the wheel event that triggered the handler,
      * with this as the current DOM element. The function returns a numeric value.
      */
-     wheelDelta(delta: ((event: WheelEvent) => number) | number): this;
+    wheelDelta(delta: ((event: WheelEvent) => number) | number): this;
 
     /**
      * Return the current extent accessor, which defaults to [[0, 0], [width, height]] where width is the client width of the element and height is its client height;


### PR DESCRIPTION
D3's zoom wheelDelta function was incorrectly typed as a ValueFn which passes through the d3 datum object. In fact, this function takes a callback which is passed a WheelEvent and expects a number value for wheelDelta to be returned. Additionally it can also take a static number as an argument. See `wheelDelta`'s [documentation](https://github.com/d3/d3-zoom#zoom_wheelDelta) and [source code](https://github.com/d3/d3-zoom/blob/master/src/zoom.js#L397)

I have tested this in my own code which consumes d3.zoom() and confirmed that the callback does indeed take a WheelEvent, and tested a module augmentation which corrects this in the same manner here.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-zoom/blob/master/src/zoom.js#L34
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
