### PR TITLE
redux-first-router:update tests with new redux type

### DIFF
--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -127,7 +127,7 @@ const action: ReduxFirstRouterAction = {
 };
 redirect(action); // $ExpectType Action
 
-// $ExpectType Store<CombinedState<State>, AnyAction> || Store<{ readonly [$CombinedState]?: undefined; } & State, AnyAction>
+// $ExpectType Store<CombinedState<State>, AnyAction> || Store<EmptyObject & State, AnyAction>
 store;
 
 store.getState().location.routesMap; // $ExpectType RoutesMap<Keys, State>


### PR DESCRIPTION
Redux gives a better name to its EmptyObject type now. (The second type still only applies to TS 4.2 and 4.3.)