### PR TITLE
[@types/listr] Skip function can return Promise that resolves to same types as direct return value

### DIFF
--- a/types/listr/index.d.ts
+++ b/types/listr/index.d.ts
@@ -31,7 +31,7 @@ declare namespace Listr {
     interface ListrTask<Ctx = ListrContext> {
         title: string;
         task: (ctx: Ctx, task: ListrTaskWrapper<Ctx>) => void | ListrTaskResult<Ctx>;
-        skip?: (ctx: Ctx) => void | boolean | string | Promise<void | boolean | string>;
+        skip?: (ctx: Ctx) => void | boolean | string | Promise<boolean | string>;
         enabled?: (ctx: Ctx) => boolean | Promise<boolean> | Observable<boolean>;
     }
 

--- a/types/listr/index.d.ts
+++ b/types/listr/index.d.ts
@@ -31,7 +31,7 @@ declare namespace Listr {
     interface ListrTask<Ctx = ListrContext> {
         title: string;
         task: (ctx: Ctx, task: ListrTaskWrapper<Ctx>) => void | ListrTaskResult<Ctx>;
-        skip?: (ctx: Ctx) => void | boolean | string | Promise<boolean | string>;
+        skip?: (ctx: Ctx) => void | boolean | string | Promise<undefined | boolean | string>;
         enabled?: (ctx: Ctx) => boolean | Promise<boolean> | Observable<boolean>;
     }
 
@@ -39,7 +39,7 @@ declare namespace Listr {
         title: string;
         output?: string;
         task: (ctx: Ctx, task: ListrTaskWrapper<Ctx>) => void | ListrTaskResult<Ctx>;
-        skip: (ctx: Ctx) => void | boolean | string | Promise<boolean>;
+        skip: (ctx: Ctx) => void | boolean | string | Promise<undefined | boolean | string>;
         subtasks: ReadonlyArray<ListrTaskWrapper<Ctx>>;
         state: string;
         check: (ctx: Ctx) => void;

--- a/types/listr/index.d.ts
+++ b/types/listr/index.d.ts
@@ -31,7 +31,7 @@ declare namespace Listr {
     interface ListrTask<Ctx = ListrContext> {
         title: string;
         task: (ctx: Ctx, task: ListrTaskWrapper<Ctx>) => void | ListrTaskResult<Ctx>;
-        skip?: (ctx: Ctx) => void | boolean | string | Promise<boolean>;
+        skip?: (ctx: Ctx) => void | boolean | string | Promise<void | boolean | string>;
         enabled?: (ctx: Ctx) => boolean | Promise<boolean> | Observable<boolean>;
     }
 

--- a/types/listr/listr-tests.ts
+++ b/types/listr/listr-tests.ts
@@ -203,3 +203,15 @@ const tasks9 = new Listr(
         renderer: 'default',
     }
 );
+
+const tasks10 = new Listr([
+   {
+        title: 'Skipped with Promise that resolves to string',
+        skip: async () => {
+            if (Math.random() > 0.5) {
+                return 'Reason for skipping';
+            }
+        },
+        task: () => 'Foo',
+    }
+]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

Documentation: https://www.npmjs.com/package/listr#skipping-tasks. The wording isn't very precise, but you _can_ return a `Promise` that resolves to a `string`.