### PR TITLE
Fixed carfinality parameter type for edmond-blossom

### DIFF
--- a/types/edmonds-blossom/edmonds-blossom-tests.ts
+++ b/types/edmonds-blossom/edmonds-blossom-tests.ts
@@ -5,3 +5,4 @@ const data = [
       [1, 2, 5]
     ];
 blossom(data); // $ExpectType number[]
+blossom(data, true); // $ExpectType number[]

--- a/types/edmonds-blossom/index.d.ts
+++ b/types/edmonds-blossom/index.d.ts
@@ -4,4 +4,4 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 export = blossom;
-declare function blossom(edges: number[][], maxCardinality?: number): number[];
+declare function blossom(edges: number[][], maxCardinality?: boolean): number[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

The only place where this variable is used in the library itself looks like this:

```Javascript
      if (!this.maxCardinality) {
```
https://github.com/mattkrick/EdmondsBlossom/blob/master/app/blossom.js#L84

And in tests, when it is provided, the value is always `true`:

```Javascript
    var result = blossom(data, true);
```
https://github.com/mattkrick/EdmondsBlossom/blob/master/spec/blossomSpec.js#L48