### PR TITLE
[gapi.people] Fix: the results of `connections` and `otherContacts` list are optional

### DIFF
--- a/types/gapi.people/gapi.people-tests.ts
+++ b/types/gapi.people/gapi.people-tests.ts
@@ -76,7 +76,7 @@
       });
 
       request.execute(function(resp) {
-        var connections = resp.connections;
+        var connections = resp.connections || [];
         appendPre('Connections:');
 
         if (connections.length > 0) {
@@ -97,7 +97,7 @@
       });
 
       request.execute(function(resp) {
-        var otherContacts = resp.otherContacts;
+        var otherContacts = resp.otherContacts || [];
         appendPre('Other contacts:');
 
         if (otherContacts.length > 0) {

--- a/types/gapi.people/index.d.ts
+++ b/types/gapi.people/index.d.ts
@@ -51,9 +51,9 @@ declare namespace gapi.client.people {
       }
 
       interface Response {
-        connections: Person[];
-        nextPageToken: string;
-        nextSyncToken: string;
+        connections?: Person[];
+        nextPageToken?: string;
+        nextSyncToken?: string;
       }
     }
   }
@@ -70,9 +70,9 @@ declare namespace gapi.client.people {
     }
 
     interface ListResponse {
-      otherContacts: Person[],
+      otherContacts?: Person[],
       nextPageToken?: string,
-      nextSyncToken: string,
+      nextSyncToken?: string,
     }
 
     function search(parameters: SearchContactsParameters): HttpRequest<SearchContactsResponse>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/people/api/rest/v1/people.connections/list
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

