### PR TITLE
Don't upgrade rxjs dependents to 7

### DIFF
--- a/types/http-rx/package.json
+++ b/types/http-rx/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "rxjs": ">=6.2.0"
+        "rxjs": "^6.2.0"
     }
 }

--- a/types/yeoman-environment/package.json
+++ b/types/yeoman-environment/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "chalk": "^4.1.0",
-        "rxjs": ">=6.4.0"
+        "rxjs": "^6.4.0"
     }
 }

--- a/types/yeoman-generator/package.json
+++ b/types/yeoman-generator/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "rxjs": ">=6.4.0"
+        "rxjs": "^6.4.0"
     }
 }


### PR DESCRIPTION
rxjs@7 just shipped, and has, at least, [some problems with DOM types](https://github.com/ReactiveX/rxjs/issues/6297). It also seems to only ship types to TS 4.2 and higher.

Keep its DT dependents on rxjs@6 for now.