### PR TITLE
Fix Typing For Vertices.mean - Returns single vector, instead of array<vector>

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -2968,7 +2968,7 @@ declare namespace Matter {
          * @param {vertices} vertices
          * @return {vector} The average point
          */
-        static mean(vertices: Array<Vector>): Array<Vector>;
+        static mean(vertices: Array<Vector>): Vector;
 
         /**
          * Sorts the input vertices into clockwise order in place.


### PR DESCRIPTION
Please fill in this template.

- [y] Use a meaningful title for the pull request. Include the name of the package modified.
- [-] Test the change in your own code. (Compile and run.)
- [-] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [y] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [y] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/liabru/matter-js/blob/826ed46829ced96b7fb310e219b24a62afe46712/src/geometry/Vertices.js#L105
