### PR TITLE
add(svg-outline-stroke): new definition

### DIFF
--- a/types/svg-outline-stroke/index.d.ts
+++ b/types/svg-outline-stroke/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for svg-outline-stroke 1.3
+// Project: https://github.com/elrumordelaluz/outline-stroke#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+/**
+ * Transform svg strokes into filled paths
+ */
+declare function outlineStroke(input: string | Buffer, params?: outlineStroke.Options): Promise<string>;
+
+declare namespace outlineStroke {
+    interface Options {
+        alphaMax?: number;
+        background?: string;
+        blackOnWhite?: boolean;
+        color?: string;
+        optCurve?: boolean;
+        optTolerance?: number;
+        threshold?: number;
+        turdSize?: number;
+        turnPolicy?: string;
+    }
+}
+export = outlineStroke;

--- a/types/svg-outline-stroke/index.d.ts
+++ b/types/svg-outline-stroke/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for svg-outline-stroke 1.3
 // Project: https://github.com/elrumordelaluz/outline-stroke#readme
-// Definitions by: Piotr Błażejewicz <https://github.com/me>
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 

--- a/types/svg-outline-stroke/svg-outline-stroke-tests.ts
+++ b/types/svg-outline-stroke/svg-outline-stroke-tests.ts
@@ -1,0 +1,17 @@
+import outlineStroke = require("svg-outline-stroke");
+
+const strokedSVG = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <line x1="32" y1="16" x2="32" y2="48" fill="none" stroke="#202020" stroke-miterlimit="10" stroke-width="2"/>
+  <line x1="48" y1="32" x2="16" y2="32" fill="none" stroke="#202020" stroke-miterlimit="10" stroke-width="2"/>
+</svg>`;
+
+outlineStroke(strokedSVG).then(outlined => {
+    console.log(outlined);
+});
+outlineStroke(strokedSVG, {}).then(outlined => {
+    console.log(outlined);
+});
+outlineStroke(Buffer.from(strokedSVG), { color: "#bada55" }).then(outlined => {
+    console.log(outlined);
+});

--- a/types/svg-outline-stroke/tsconfig.json
+++ b/types/svg-outline-stroke/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg-outline-stroke-tests.ts"
+    ]
+}

--- a/types/svg-outline-stroke/tslint.json
+++ b/types/svg-outline-stroke/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://github.com/elrumordelaluz/outline-stroke#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.