### PR TITLE
fix(webpack-dev-server): add missing `listeningApp` property to `WebpackDevServer`

### DIFF
--- a/types/poi/index.d.ts
+++ b/types/poi/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/egoist/poi/
 // Definitions by: c4605 <https://github.com/bolasblack>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 3.8
 
 import { ICompiler, Configuration as WebpackConfig } from "webpack";
 import { Configuration as WebpackDevServerConfig } from "webpack-dev-server";

--- a/types/react-dev-utils/index.d.ts
+++ b/types/react-dev-utils/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://github.com/facebook/create-react-app#readme
 // Definitions by: ark120202 <https://github.com/ark120202>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 3.8
 
 export {};

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -355,6 +355,7 @@ declare module 'webpack' {
 }
 
 declare class WebpackDevServer {
+    listeningApp: WebpackDevServer.ListeningApp;
     sockets: NodeJS.EventEmitter[];
 
     constructor(webpack: webpack.Compiler | webpack.MultiCompiler, config?: WebpackDevServer.Configuration);

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -12,7 +12,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 William Artero <https://github.com/wwmoraes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 3.8
 
 import * as webpack from 'webpack';
 import * as httpProxyMiddleware from 'http-proxy-middleware';

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -78,6 +78,11 @@ const config: WebpackDevServer.Configuration = {
     publicPath: '/assets/',
     headers: { 'X-Custom-Header': 'yes' },
     open: true,
+
+    // https://webpack.js.org/configuration/dev-server/#devserveronlistening
+    onListening(server) {
+        const { port } = server.listeningApp.address();
+    },
 };
 
 const c2: WebpackDevServer.Configuration = {

--- a/types/webpack-shell-plugin/index.d.ts
+++ b/types/webpack-shell-plugin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/1337programming/webpack-shell-plugin
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 3.8
 
 import { Plugin } from 'webpack';
 


### PR DESCRIPTION
As documented on https://webpack.js.org/configuration/dev-server/#devserveronlistening, the following is valid:

```ts
devServer: {
  onListening(server) {
    const { port } = server.listeningApp.address();
    console.log('Listening on port:', port);
  },
}
```

<img width="779" alt="Screen Shot 2021-05-01 at 8 55 37 PM" src="https://user-images.githubusercontent.com/113730/116798625-50424b80-aafa-11eb-8171-a8a9375bf037.png">

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Webpack documentation](https://webpack.js.org/configuration/dev-server/#devserveronlistening)
- _N/A_ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
