### PR TITLE
add(leaflet) Add the protected properties on DivOverlay that allow for subclassing

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -16,7 +16,7 @@ export as namespace L;
 import * as geojson from 'geojson';
 
 export class Class {
-    static extend(props: any): {new(...args: any[]): any} & typeof Class;
+    static extend(props: any): { new(...args: any[]): any } & typeof Class;
     static include(props: any): any & typeof Class;
     static mergeOptions(props: any): any & typeof Class;
 
@@ -148,7 +148,7 @@ export type LatLngExpression = LatLng | LatLngLiteral | LatLngTuple;
 
 export function latLng(latitude: number, longitude: number, altitude?: number): LatLng;
 
-export function latLng(coords: LatLngTuple | [number, number, number] | LatLngLiteral | {lat: number, lng: number, alt?: number}): LatLng;
+export function latLng(coords: LatLngTuple | [number, number, number] | LatLngLiteral | { lat: number, lng: number, alt?: number }): LatLng;
 
 export class LatLngBounds {
     constructor(southWest: LatLngExpression, northEast: LatLngExpression);
@@ -210,7 +210,7 @@ export type PointExpression = Point | PointTuple;
 
 export function point(x: number, y: number, round?: boolean): Point;
 
-export function point(coords: PointTuple | {x: number, y: number}): Point;
+export function point(coords: PointTuple | { x: number, y: number }): Point;
 
 export type BoundsLiteral = [PointTuple, PointTuple];
 
@@ -711,7 +711,7 @@ export interface InteractiveLayerOptions extends LayerOptions {
 
 export class Layer extends Evented {
     constructor(options?: LayerOptions);
-    addTo(map: Map|LayerGroup): this;
+    addTo(map: Map | LayerGroup): this;
     remove(): this;
     removeFrom(map: Map): this;
     getPane(name?: string): HTMLElement | undefined;
@@ -739,7 +739,7 @@ export class Layer extends Evented {
     // Extension methods
     onAdd(map: Map): this;
     onRemove(map: Map): this;
-    getEvents?(): {[name: string]: LeafletEventHandlerFn};
+    getEvents?(): { [name: string]: LeafletEventHandlerFn };
     getAttribution?(): string | null;
     beforeAdd?(map: Map): this;
 
@@ -1389,7 +1389,7 @@ export interface ControlOptions {
 }
 
 export class Control extends Class {
-    static extend<T extends object>(props: T): {new(...args: any[]): T} & typeof Control;
+    static extend<T extends object>(props: T): { new(...args: any[]): T } & typeof Control;
     constructor(options?: ControlOptions);
     getPosition(): ControlPosition;
     setPosition(position: ControlPosition): this;
@@ -1492,6 +1492,10 @@ export abstract class DivOverlay extends Layer {
     bringToBack(): this;
 
     options: DivOverlayOptions;
+
+    protected _initLayout(): void;
+    protected _container: HTMLElement | undefined;
+    protected _contentNode: HTMLElement | undefined;
 }
 
 export interface PopupOptions extends DivOverlayOptions {
@@ -1685,11 +1689,11 @@ export namespace DomEvent {
 
     function on(el: HTMLElement, types: string, fn: EventHandlerFn, context?: any): typeof DomEvent;
 
-    function on(el: HTMLElement, eventMap: {[eventName: string]: EventHandlerFn}, context?: any): typeof DomEvent;
+    function on(el: HTMLElement, eventMap: { [eventName: string]: EventHandlerFn }, context?: any): typeof DomEvent;
 
     function off(el: HTMLElement, types: string, fn: EventHandlerFn, context?: any): typeof DomEvent;
 
-    function off(el: HTMLElement, eventMap: {[eventName: string]: EventHandlerFn}, context?: any): typeof DomEvent;
+    function off(el: HTMLElement, eventMap: { [eventName: string]: EventHandlerFn }, context?: any): typeof DomEvent;
 
     function stopPropagation(ev: PropagableEvent): typeof DomEvent;
 
@@ -1707,11 +1711,11 @@ export namespace DomEvent {
 
     function addListener(el: HTMLElement, types: string, fn: EventHandlerFn, context?: any): typeof DomEvent;
 
-    function addListener(el: HTMLElement, eventMap: {[eventName: string]: EventHandlerFn}, context?: any): typeof DomEvent;
+    function addListener(el: HTMLElement, eventMap: { [eventName: string]: EventHandlerFn }, context?: any): typeof DomEvent;
 
     function removeListener(el: HTMLElement, types: string, fn: EventHandlerFn, context?: any): typeof DomEvent;
 
-    function removeListener(el: HTMLElement, eventMap: {[eventName: string]: EventHandlerFn}, context?: any): typeof DomEvent;
+    function removeListener(el: HTMLElement, eventMap: { [eventName: string]: EventHandlerFn }, context?: any): typeof DomEvent;
 }
 
 export interface DefaultMapPanes {
@@ -1773,7 +1777,7 @@ export class Map extends Evented {
      * Name of the pane or the pane as HTML-Element
      */
     getPane(pane: string | HTMLElement): HTMLElement | undefined;
-    getPanes(): {[name: string]: HTMLElement} & DefaultMapPanes;
+    getPanes(): { [name: string]: HTMLElement } & DefaultMapPanes;
     getContainer(): HTMLElement;
     whenReady(fn: () => void, context?: any): this;
 

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -1,5 +1,4 @@
 import * as L from 'leaflet';
-import { Popup } from 'leaflet';
 
 const latLngLiteral: L.LatLngLiteral = { lat: 12, lng: 13 };
 const latLngTuple: L.LatLngTuple = [12, 13];
@@ -819,19 +818,16 @@ export class ExtendedTileLayer extends L.TileLayer {
     }
 }
 
-export class ExtendedPopup extends Popup {
+export class ExtendedPopup extends L.Popup {
     _initLayout() {
         const prefix = 'leaflet-popup';
-        const container = this._container = L.DomUtil.create('div',
-            prefix + ' ' + (this.options.className || '') +
-            ' leaflet-zoom-animated');
+        const container = this._container = L.DomUtil.create('div', `${prefix} ${this.options.className} leaflet-zoom-animated`);
 
-        const wrapper = L.DomUtil.create('div', prefix + '-content-wrapper', container);
-        this._contentNode = L.DomUtil.create('div', prefix + '-content', wrapper);
+        const wrapper = L.DomUtil.create('div', `${prefix}-content-wrapper`, container);
+        this._contentNode = L.DomUtil.create('div', `${prefix}-content`, wrapper);
 
         L.DomEvent.disableClickPropagation(container);
         L.DomEvent.disableScrollPropagation(this._contentNode);
         L.DomEvent.on(container, 'contextmenu', L.DomEvent.stopPropagation);
     }
 }
-

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -1,4 +1,5 @@
 import * as L from 'leaflet';
+import { Popup } from 'leaflet';
 
 const latLngLiteral: L.LatLngLiteral = { lat: 12, lng: 13 };
 const latLngTuple: L.LatLngTuple = [12, 13];
@@ -376,7 +377,7 @@ videoOverlay = L.videoOverlay(videoElement, videoOverlayBounds, {
     autoplay: true
 });
 
-const eventHandler = () => { };
+const eventHandler = () => {};
 const leafletMouseEvent: L.LeafletMouseEvent = {} as L.LeafletMouseEvent;
 const leafletKeyboardEvent: L.LeafletKeyboardEvent = {} as L.LeafletKeyboardEvent;
 const leafletEvent: L.LeafletEvent = {} as L.LeafletEvent;
@@ -817,3 +818,20 @@ export class ExtendedTileLayer extends L.TileLayer {
         }
     }
 }
+
+export class ExtendedPopup extends Popup {
+    _initLayout() {
+        const prefix = 'leaflet-popup';
+        const container = this._container = L.DomUtil.create('div',
+            prefix + ' ' + (this.options.className || '') +
+            ' leaflet-zoom-animated');
+
+        const wrapper = L.DomUtil.create('div', prefix + '-content-wrapper', container);
+        this._contentNode = L.DomUtil.create('div', prefix + '-content', wrapper);
+
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.disableScrollPropagation(this._contentNode);
+        L.DomEvent.on(container, 'contextmenu', L.DomEvent.stopPropagation);
+    }
+}
+


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/blob/master/src/layer/DivOverlay.js#L45

DivOverlay is the base class for Popup and Tooltip and to create custom ones, you need to provide the `_container`, `_contentNode` and `_initLayout` methods. You can see this in the source code link above where DivOverlay calls the `_initLayout` method which doesn't exist in either DivOverlay itself or the base Layer class. Adding these three definitions allows a developer to now do

```
export class ExtendedPopup extends L.Popup {
    _initLayout() {
        const prefix = 'leaflet-popup';
        const container = this._container = L.DomUtil.create('div',
            prefix + ' ' + (this.options.className || '') +
            ' leaflet-zoom-animated');

        const wrapper = L.DomUtil.create('div', prefix + '-content-wrapper', container);
        this._contentNode = L.DomUtil.create('div', prefix + '-content', wrapper);

        L.DomEvent.disableClickPropagation(container);
        L.DomEvent.disableScrollPropagation(this._contentNode);
        L.DomEvent.on(container, 'contextmenu', L.DomEvent.stopPropagation);
    }
}
```

similar to the ExtendedTileLayer functionality already in the repo.

Also: first time contributor, so be gentle :P 
