### PR TITLE
Add types for es-aggregate-error

### DIFF
--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -1,0 +1,1 @@
+import S from "es-aggregate-error";

--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -1,1 +1,23 @@
-import S from "es-aggregate-error";
+import AggregateError from "es-aggregate-error";
+
+const oneError = new RangeError("hi!");
+const otherError = new EvalError("oops");
+
+new AggregateError(); // $ExpectError
+new AggregateError("this is not an error"); // $ExpectError
+AggregateError([oneError, otherError], "this is two kinds of errors"); // $ExpectError
+
+new AggregateError([]); // $ExpectType AggregateError
+new AggregateError([oneError, otherError]); // $ExpectType AggregateError
+
+// $ExpectType AggregateError
+const error = new AggregateError([oneError, otherError], "this is two kinds of errors");
+
+AggregateError.shim; // $ExpectType () => void
+AggregateError.shim(); // $ExpectType: void
+
+error.errors; // $ExpectType: Array<unknown>
+error.name; // $ExpectType: "AggregateError"
+error.message; // $ExpectType: string
+
+error.name = "something else"; // $ExpectError

--- a/types/es-aggregate-error/index.d.ts
+++ b/types/es-aggregate-error/index.d.ts
@@ -3,37 +3,16 @@
 // Definitions by: AverageHelper <https://github.com/AverageHelper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
+/// <reference types="node" />
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+declare class AggregateError extends Error implements NodeJS.ErrnoException {
+    readonly errors: unknown[];
+    readonly name: "AggregateError";
+    readonly message: string;
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+    constructor(errors: unknown[], message?: string);
+
+    static shim(): void;
 }
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    function foo(): void;
-}
+export = AggregateError;

--- a/types/es-aggregate-error/index.d.ts
+++ b/types/es-aggregate-error/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for es-aggregate-error 1.0
+// Project: https://github.com/es-shims/AggregateError#readme
+// Definitions by: AverageHelper <https://github.com/AverageHelper>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/es-aggregate-error/index.d.ts
+++ b/types/es-aggregate-error/index.d.ts
@@ -6,11 +6,11 @@
 /// <reference types="node" />
 
 declare class AggregateError extends Error implements NodeJS.ErrnoException {
-    readonly errors: unknown[];
+    readonly errors: ReadonlyArray<unknown>;
     readonly name: "AggregateError";
     readonly message: string;
 
-    constructor(errors: unknown[], message?: string);
+    constructor(errors: ReadonlyArray<unknown>, message?: string);
 
     static shim(): void;
 }

--- a/types/es-aggregate-error/tsconfig.json
+++ b/types/es-aggregate-error/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "esModuleInterop": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "es-aggregate-error-tests.ts"
+    ]
+}

--- a/types/es-aggregate-error/tslint.json
+++ b/types/es-aggregate-error/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add types for [es-shims/AggregateError](https://github.com/es-shims/AggregateError)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
