### PR TITLE
[eslint][RFC] Update SourceCode with TokenReturnType for accurate typing of filter predicates

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -70,28 +70,44 @@ loc.column; // $ExpectType number
 
 sourceCode.getIndexFromLoc({ line: 0, column: 0 });
 
-sourceCode.getTokenByRangeStart(0); // $ExpectType Comment | Token | null
-sourceCode.getTokenByRangeStart(0, { includeComments: true });
+sourceCode.getTokenByRangeStart(0); // $ExpectType Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: false }); // $ExpectType Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: false as boolean }); // $ExpectType Comment | Token | null
 
-sourceCode.getFirstToken(AST);
+sourceCode.getFirstToken(AST); // $ExpectType Token | null
 sourceCode.getFirstToken(AST, 0);
 sourceCode.getFirstToken(AST, { skip: 0 });
-sourceCode.getFirstToken(AST, t => t.type === "Identifier");
-sourceCode.getFirstToken(AST, { filter: t => t.type === "Identifier" });
+sourceCode.getFirstToken(AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; }) | null
+sourceCode.getFirstToken(AST, { filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier" }); // $ExpectType (Token & { type: "Identifier"; }) | null
 sourceCode.getFirstToken(AST, { skip: 0, filter: t => t.type === "Identifier" });
-sourceCode.getFirstToken(AST, { includeComments: true });
+sourceCode.getFirstToken(AST, { includeComments: true }); // $ExpectType Comment | Token | null
 sourceCode.getFirstToken(AST, { includeComments: true, skip: 0 });
-sourceCode.getFirstToken(AST, { includeComments: true, skip: 0, filter: t => t.type === "Identifier" });
+// prettier-ignore
+sourceCode.getFirstToken(AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
+    includeComments: true,
+    skip: 0,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
 
-sourceCode.getFirstTokens(AST);
-sourceCode.getFirstTokens(AST, 0);
+sourceCode.getFirstTokens(AST); // $ExpectType Token[]
+sourceCode.getFirstTokens(AST, 0); // $ExpectType Token[]
 sourceCode.getFirstTokens(AST, { count: 0 });
-sourceCode.getFirstTokens(AST, t => t.type === "Identifier");
-sourceCode.getFirstTokens(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getFirstTokens(AST, { count: 0, filter: t => t.type === "Identifier" });
-sourceCode.getFirstTokens(AST, { includeComments: true });
-sourceCode.getFirstTokens(AST, { includeComments: true, count: 0 });
-sourceCode.getFirstTokens(AST, { includeComments: true, count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getFirstTokens(AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getFirstTokens(AST, { filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier" }); // $ExpectType (Token & { type: "Identifier"; })[]
+// prettier-ignore
+sourceCode.getFirstTokens(AST, { // $ExpectType (Token & { type: "Identifier"; })[]
+    count: 0,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
+sourceCode.getFirstTokens(AST, { includeComments: true }); //  $ ExpectType (Comment | Token)[]
+sourceCode.getFirstTokens(AST, { includeComments: true, count: 0 }); //  $ ExpectType (Comment | Token)[]
+// prettier-ignore
+sourceCode.getFirstTokens(AST, {// $ExpectType (Token & { type: "Identifier"; })[]
+    includeComments: true,
+    count: 0,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
 
 sourceCode.getLastToken(AST);
 sourceCode.getLastToken(AST, 0);
@@ -161,25 +177,44 @@ sourceCode.getTokensAfter(AST, { includeComments: true, count: 0, filter: t => t
 sourceCode.getTokensAfter(TOKEN, 0);
 sourceCode.getTokensAfter(COMMENT, 0);
 
-sourceCode.getFirstTokenBetween(AST, AST);
+sourceCode.getFirstTokenBetween(AST, AST); // $ExpectType Token | null
 sourceCode.getFirstTokenBetween(AST, AST, 0);
 sourceCode.getFirstTokenBetween(AST, AST, { skip: 0 });
-sourceCode.getFirstTokenBetween(AST, AST, t => t.type === "Identifier");
-sourceCode.getFirstTokenBetween(AST, AST, { filter: t => t.type === "Identifier" });
-sourceCode.getFirstTokenBetween(AST, AST, { skip: 0, filter: t => t.type === "Identifier" });
-sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true });
+sourceCode.getFirstTokenBetween(AST, AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; }) | null
+// prettier-ignore
+sourceCode.getFirstTokenBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
+sourceCode.getFirstTokenBetween(AST, AST, {
+    skip: 0,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
+sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true }); // $ExpectType Comment | Token | null
 sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true, skip: 0 });
-sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true, skip: 0, filter: t => t.type === "Identifier" });
+// prettier-ignore
+sourceCode.getFirstTokenBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
+    includeComments: true,
+    skip: 0,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
 
-sourceCode.getFirstTokensBetween(AST, AST);
+sourceCode.getFirstTokensBetween(AST, AST); // $ExpectType Token[]
 sourceCode.getFirstTokensBetween(AST, AST, 0);
 sourceCode.getFirstTokensBetween(AST, AST, { count: 0 });
-sourceCode.getFirstTokensBetween(AST, AST, t => t.type === "Identifier");
-sourceCode.getFirstTokensBetween(AST, AST, { filter: t => t.type === "Identifier" });
+sourceCode.getFirstTokensBetween(AST, AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; })[]
+// prettier-ignore
+sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; })[]
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
 sourceCode.getFirstTokensBetween(AST, AST, { count: 0, filter: t => t.type === "Identifier" });
-sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true });
+sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
 sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true, count: 0 });
-sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true, count: 0, filter: t => t.type === "Identifier" });
+// prettier-ignore
+sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; })[]
+    includeComments: true,
+    count: 0,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
 
 sourceCode.getLastTokenBetween(AST, AST);
 sourceCode.getLastTokenBetween(AST, AST, 0);
@@ -204,13 +239,17 @@ sourceCode.getLastTokensBetween(AST, AST, { includeComments: true, count: 0, fil
 sourceCode.getTokensBetween(AST, AST);
 sourceCode.getTokensBetween(AST, AST, 0);
 
-sourceCode.getTokens(AST);
+sourceCode.getTokens(AST); // $ExpectType Token[]
 sourceCode.getTokens(AST, 0);
 sourceCode.getTokens(AST, 0, 0);
-sourceCode.getTokens(AST, t => t.type === "Identifier");
-sourceCode.getTokens(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getTokens(AST, { includeComments: true });
-sourceCode.getTokens(AST, { includeComments: true, filter: t => t.type === "Identifier" });
+sourceCode.getTokens(AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getTokens(AST, { filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier" }); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getTokens(AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
+// prettier-ignore
+sourceCode.getTokens(AST, { // $ExpectType (Token & { type: "Identifier"; })[]
+    includeComments: true,
+    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+});
 
 sourceCode.commentsExistBetween(AST, AST);
 sourceCode.commentsExistBetween(TOKEN, TOKEN);

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -167,68 +167,37 @@ export class SourceCode {
     // Inherited methods from TokenStore
     // ---------------------------------
 
-    getTokenByRangeStart(offset: number, options?: { includeComments?: boolean }): AST.Token | ESTree.Comment | null;
+    getTokenByRangeStart(offset: number, options?: { includeComments: false }): AST.Token | null;
+    getTokenByRangeStart(offset: number, options: { includeComments: boolean }): AST.Token | ESTree.Comment | null;
 
-    getFirstToken(node: ESTree.Node, options?: SourceCode.CursorWithSkipOptions): AST.Token | ESTree.Comment | null;
+    getFirstToken: SourceCode.UnaryNodeCursorWithSkipOptions;
 
-    getFirstTokens(node: ESTree.Node, options?: SourceCode.CursorWithCountOptions): Array<AST.Token | ESTree.Comment>;
+    getFirstTokens: SourceCode.UnaryNodeCursorWithCountOptions;
 
-    getLastToken(node: ESTree.Node, options?: SourceCode.CursorWithSkipOptions): AST.Token | ESTree.Comment | null;
+    getLastToken: SourceCode.UnaryNodeCursorWithSkipOptions;
 
-    getLastTokens(node: ESTree.Node, options?: SourceCode.CursorWithCountOptions): Array<AST.Token | ESTree.Comment>;
+    getLastTokens: SourceCode.UnaryNodeCursorWithCountOptions;
 
-    getTokenBefore(
-        node: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | ESTree.Comment | null;
+    getTokenBefore: SourceCode.UnaryCursorWithSkipOptions;
 
-    getTokensBefore(
-        node: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithCountOptions,
-    ): Array<AST.Token | ESTree.Comment>;
+    getTokensBefore: SourceCode.UnaryCursorWithCountOptions;
 
-    getTokenAfter(
-        node: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | ESTree.Comment | null;
+    getTokenAfter: SourceCode.UnaryCursorWithSkipOptions;
 
-    getTokensAfter(
-        node: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithCountOptions,
-    ): Array<AST.Token | ESTree.Comment>;
+    getTokensAfter: SourceCode.UnaryCursorWithCountOptions;
 
-    getFirstTokenBetween(
-        left: ESTree.Node | AST.Token | ESTree.Comment,
-        right: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | ESTree.Comment | null;
+    getFirstTokenBetween: SourceCode.BinaryCursorWithSkipOptions;
 
-    getFirstTokensBetween(
-        left: ESTree.Node | AST.Token | ESTree.Comment,
-        right: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithCountOptions,
-    ): Array<AST.Token | ESTree.Comment>;
+    getFirstTokensBetween: SourceCode.BinaryCursorWithCountOptions;
 
-    getLastTokenBetween(
-        left: ESTree.Node | AST.Token | ESTree.Comment,
-        right: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithSkipOptions,
-    ): AST.Token | ESTree.Comment | null;
+    getLastTokenBetween: SourceCode.BinaryCursorWithSkipOptions;
 
-    getLastTokensBetween(
-        left: ESTree.Node | AST.Token | ESTree.Comment,
-        right: ESTree.Node | AST.Token | ESTree.Comment,
-        options?: SourceCode.CursorWithCountOptions,
-    ): Array<AST.Token | ESTree.Comment>;
+    getLastTokensBetween: SourceCode.BinaryCursorWithCountOptions;
 
-    getTokensBetween(
-        left: ESTree.Node | AST.Token | ESTree.Comment,
-        right: ESTree.Node | AST.Token | ESTree.Comment,
-        padding?: SourceCode.CursorWithCountOptions,
-    ): Array<AST.Token | ESTree.Comment>;
+    getTokensBetween: SourceCode.BinaryCursorWithCountOptions;
 
-    getTokens(node: ESTree.Node, beforeCount?: number, afterCount?: number): AST.Token[];
-    getTokens(node: ESTree.Node, options: SourceCode.CursorWithCountOptions): Array<AST.Token | ESTree.Comment>;
+    getTokens: ((node: ESTree.Node, beforeCount?: number, afterCount?: number) => AST.Token[]) &
+        SourceCode.UnaryNodeCursorWithCountOptions;
 
     commentsExistBetween(
         left: ESTree.Node | AST.Token | ESTree.Comment,
@@ -257,25 +226,205 @@ export namespace SourceCode {
         [nodeType: string]: string[];
     }
 
-    type FilterPredicate = (tokenOrComment: AST.Token | ESTree.Comment) => boolean;
+    interface UnaryNodeCursorWithSkipOptions {
+        <T extends AST.Token>(
+            node: ESTree.Node,
+            options:
+                | ((token: AST.Token) => token is T)
+                | { filter: (token: AST.Token) => token is T; includeComments?: false; skip?: number },
+        ): T | null;
+        <T extends AST.Token | ESTree.Comment>(
+            node: ESTree.Node,
+            options: {
+                filter: (tokenOrComment: AST.Token | ESTree.Comment) => tokenOrComment is T;
+                includeComments: boolean;
+                skip?: number;
+            },
+        ): T | null;
+        (
+            node: ESTree.Node,
+            options?:
+                | { filter?: (token: AST.Token) => boolean; includeComments?: false; skip?: number }
+                | ((token: AST.Token) => boolean)
+                | number,
+        ): AST.Token | null;
+        (
+            node: ESTree.Node,
+            options: {
+                filter?: (token: AST.Token | ESTree.Comment) => boolean;
+                includeComments: boolean;
+                skip?: number;
+            },
+        ): AST.Token | ESTree.Comment | null;
+    }
 
-    type CursorWithSkipOptions =
-        | number
-        | FilterPredicate
-        | {
-              includeComments?: boolean;
-              filter?: FilterPredicate;
-              skip?: number;
-          };
+    interface UnaryNodeCursorWithCountOptions {
+        <T extends AST.Token>(
+            node: ESTree.Node,
+            options:
+                | ((token: AST.Token) => token is T)
+                | { filter: (token: AST.Token) => token is T; includeComments?: false; count?: number },
+        ): T[];
+        <T extends AST.Token | ESTree.Comment>(
+            node: ESTree.Node,
+            options: {
+                filter: (tokenOrComment: AST.Token | ESTree.Comment) => tokenOrComment is T;
+                includeComments: boolean;
+                count?: number;
+            },
+        ): T[];
+        (
+            node: ESTree.Node,
+            options?:
+                | { filter?: (token: AST.Token) => boolean; includeComments?: false; count?: number }
+                | ((token: AST.Token) => boolean)
+                | number,
+        ): AST.Token[];
+        (
+            node: ESTree.Node,
+            options: {
+                filter?: (token: AST.Token | ESTree.Comment) => boolean;
+                includeComments: boolean;
+                count?: number;
+            },
+        ): Array<AST.Token | ESTree.Comment>;
+    }
 
-    type CursorWithCountOptions =
-        | number
-        | FilterPredicate
-        | {
-              includeComments?: boolean;
-              filter?: FilterPredicate;
-              count?: number;
-          };
+    interface UnaryCursorWithSkipOptions {
+        <T extends AST.Token>(
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options:
+                | ((token: AST.Token) => token is T)
+                | { filter: (token: AST.Token) => token is T; includeComments?: false; skip?: number },
+        ): T | null;
+        <T extends AST.Token | ESTree.Comment>(
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter: (tokenOrComment: AST.Token | ESTree.Comment) => tokenOrComment is T;
+                includeComments: boolean;
+                skip?: number;
+            },
+        ): T | null;
+        (
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options?:
+                | { filter?: (token: AST.Token) => boolean; includeComments?: false; skip?: number }
+                | ((token: AST.Token) => boolean)
+                | number,
+        ): AST.Token | null;
+        (
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter?: (token: AST.Token | ESTree.Comment) => boolean;
+                includeComments: boolean;
+                skip?: number;
+            },
+        ): AST.Token | ESTree.Comment | null;
+    }
+
+    interface UnaryCursorWithCountOptions {
+        <T extends AST.Token>(
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options:
+                | ((token: AST.Token) => token is T)
+                | { filter: (token: AST.Token) => token is T; includeComments?: false; count?: number },
+        ): T[];
+        <T extends AST.Token | ESTree.Comment>(
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter: (tokenOrComment: AST.Token | ESTree.Comment) => tokenOrComment is T;
+                includeComments: boolean;
+                count?: number;
+            },
+        ): T[];
+        (
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options?:
+                | { filter?: (token: AST.Token) => boolean; includeComments?: false; count?: number }
+                | ((token: AST.Token) => boolean)
+                | number,
+        ): AST.Token[];
+        (
+            node: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter?: (token: AST.Token | ESTree.Comment) => boolean;
+                includeComments: boolean;
+                count?: number;
+            },
+        ): Array<AST.Token | ESTree.Comment>;
+    }
+
+    interface BinaryCursorWithSkipOptions {
+        <T extends AST.Token>(
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options:
+                | ((token: AST.Token) => token is T)
+                | { filter: (token: AST.Token) => token is T; includeComments?: false; skip?: number },
+        ): T | null;
+        <T extends AST.Token | ESTree.Comment>(
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter: (tokenOrComment: AST.Token | ESTree.Comment) => tokenOrComment is T;
+                includeComments: boolean;
+                skip?: number;
+            },
+        ): T | null;
+        (
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options?:
+                | { filter?: (token: AST.Token) => boolean; includeComments?: false; skip?: number }
+                | ((token: AST.Token) => boolean)
+                | number,
+        ): AST.Token | null;
+        (
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter?: (token: AST.Token | ESTree.Comment) => boolean;
+                includeComments: boolean;
+                skip?: number;
+            },
+        ): AST.Token | ESTree.Comment | null;
+    }
+
+    interface BinaryCursorWithCountOptions {
+        <T extends AST.Token>(
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options:
+                | ((token: AST.Token) => token is T)
+                | { filter: (token: AST.Token) => token is T; includeComments?: false; count?: number },
+        ): T[];
+        <T extends AST.Token | ESTree.Comment>(
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter: (tokenOrComment: AST.Token | ESTree.Comment) => tokenOrComment is T;
+                includeComments: boolean;
+                count?: number;
+            },
+        ): T[];
+        (
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options?:
+                | { filter?: (token: AST.Token) => boolean; includeComments?: false; count?: number }
+                | ((token: AST.Token) => boolean)
+                | number,
+        ): AST.Token[];
+        (
+            left: ESTree.Node | AST.Token | ESTree.Comment,
+            right: ESTree.Node | AST.Token | ESTree.Comment,
+            options: {
+                filter?: (token: AST.Token | ESTree.Comment) => boolean;
+                includeComments: boolean;
+                count?: number;
+            },
+        ): Array<AST.Token | ESTree.Comment>;
+    }
 }
 
 //#endregion


### PR DESCRIPTION
This PR updates the types for SourceCode so that the return type takes `includeComments` and any filter predicates into account.

The types as they're currently defined aren't wrong, but they are overly broad. `includeComments` defaults to false (e.g. [here](https://github.com/eslint/eslint/blob/6791decfc58b7b09cfd0aabd15a3d14148aae073/lib/source-code/token-store/index.js#L78)). Filter predicates do just that. However, if you currently use a type guard in filter, it will have no effect on the resulting type (see modifications to existing test cases).

This PR achieves return type refinement by making these methods generic on their options, and then using a type transformer to compute the actual return type conditioned on the options. If a filter with a predicate is used, then it uses the predicate return type, otherwise it only returns comments if `includeComments` is true.

I called this an RFC for two main reasons.
1. I think this is an improvement because it makes the types more accurate, but it also makes the types more complicated which could
   a. hurt type checking performance
   b. make the type signatures less readable
   I'm open to the argument that slightly more refined types is not worth those two negatives and therefore this shouldn't be checked in.
2. I think this is probably the most elegant way to achieve this, but there might be others and am open to different ways to narrow the return types.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/eslint/eslint/blob/6791decfc58b7b09cfd0aabd15a3d14148aae073/lib/source-code/token-store/index.js#L78>>