### PR TITLE
`react-image-fallback` Types: Allow `src`/`fallbackImage` Props to be Undefined Values

### DIFF
--- a/types/react-image-fallback/index.d.ts
+++ b/types/react-image-fallback/index.d.ts
@@ -17,7 +17,7 @@ export default class ReactImageFallback extends React.Component<
 
 export interface ReactImageFallbackProps {
     src?: string;
-    fallbackImage: string | React.ReactElement | string[] | (string | undefined)[] | React.ReactElement[];
+    fallbackImage: string | React.ReactElement | string[] | Array<string | undefined> | React.ReactElement[];
     initialImage?: string | React.ReactElement;
     onLoad?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
     onError?: (event: React.SyntheticEvent<HTMLImageElement>) => void;

--- a/types/react-image-fallback/index.d.ts
+++ b/types/react-image-fallback/index.d.ts
@@ -16,8 +16,8 @@ export default class ReactImageFallback extends React.Component<
     > { }
 
 export interface ReactImageFallbackProps {
-    src: string;
-    fallbackImage: string | React.ReactElement | string[] | React.ReactElement[];
+    src?: string;
+    fallbackImage: string | React.ReactElement | string[] | (string | undefined)[] | React.ReactElement[];
     initialImage?: string | React.ReactElement;
     onLoad?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
     onError?: (event: React.SyntheticEvent<HTMLImageElement>) => void;

--- a/types/react-image-fallback/react-image-fallback-tests.tsx
+++ b/types/react-image-fallback/react-image-fallback-tests.tsx
@@ -9,7 +9,7 @@ class ReactImageFallbackSimple extends React.Component<ReactImageFallbackProps> 
     }
 }
 
-class ReactImageFallbackSimple extends React.Component<ReactImageFallbackProps> {
+class ReactImageFallbackWithUndefineds extends React.Component<ReactImageFallbackProps> {
     render() {
         return <ReactImageFallback
             src={undefined}

--- a/types/react-image-fallback/react-image-fallback-tests.tsx
+++ b/types/react-image-fallback/react-image-fallback-tests.tsx
@@ -9,6 +9,14 @@ class ReactImageFallbackSimple extends React.Component<ReactImageFallbackProps> 
     }
 }
 
+class ReactImageFallbackSimple extends React.Component<ReactImageFallbackProps> {
+    render() {
+        return <ReactImageFallback
+            src={undefined}
+            fallbackImage={[undefined, "my-backup.png"]} />;
+    }
+}
+
 class ReactImageFallbackWithOptionals extends React.Component<ReactImageFallbackProps> {
     onLoad(event: React.SyntheticEvent<HTMLImageElement>) {
     }


### PR DESCRIPTION
When using these props, the values for `src` and `fallbackImage` array elements could be taken from an API response object that could be undefined:

```jsx
<ReactImageFallback
  src={artworkResponseObject?.mainImgUrl}
  fallbackImage={[
    artworkResponseObject?.fallbackImgUrl,
    localPlaceholderSvgImg,
  ]}
/>
```

As the object `artworkResponseObject` could return undefined at some stage, allowing the props to be undefined would remove the error messages without having to add a default `|| ''` empty string to each line

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.