### PR TITLE
Add `cert`, `key`, and `pfx` options to webpack-livereload-plugin types

### DIFF
--- a/types/webpack-livereload-plugin/index.d.ts
+++ b/types/webpack-livereload-plugin/index.d.ts
@@ -4,7 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 import { Plugin, Stats } from 'webpack';
+import { ServerOptions } from 'https'
 import webpack = require('webpack');
+
 declare class LiveReloadPlugin extends Plugin {
     readonly isRunning: boolean;
     constructor(options?: LiveReloadPlugin.Options);
@@ -20,7 +22,7 @@ declare class LiveReloadPlugin extends Plugin {
 }
 
 declare namespace LiveReloadPlugin {
-    interface Options {
+    interface Options extends Pick<ServerOptions, 'cert' | 'key' | 'pfx'> {
         /**
          * protocol for livereload `<script>` src attribute value
          * @default protocol of the page, either `http` or `https`

--- a/types/webpack-livereload-plugin/index.d.ts
+++ b/types/webpack-livereload-plugin/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 import { Plugin, Stats } from 'webpack';
-import { ServerOptions } from 'https'
+import { ServerOptions } from 'https';
 import webpack = require('webpack');
 
 declare class LiveReloadPlugin extends Plugin {

--- a/types/webpack-livereload-plugin/webpack-livereload-plugin-tests.ts
+++ b/types/webpack-livereload-plugin/webpack-livereload-plugin-tests.ts
@@ -6,9 +6,12 @@ const plugins: Plugin[] = [
     new LiveReloadPlugin({}),
     new LiveReloadPlugin({
         appendScriptTag: true,
+        cert: '',
         delay: 100,
         hostname: 'localhost',
         ignore: /\.css$/,
+        key: '',
+        pfx: '',
         port: 9999,
         protocol: 'https',
         useSourceHash: true,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/statianzo/webpack-livereload-plugin#https

This adds the `cert`, `key`, and `pfx` options to the `webpack-livereload-plugin` definitions.  These are not directly used by the plugin but are passed through to tiny-lr when creating the server.

**NOTE:** the types for these come from `https` which I think depends on `@types/node`.  Does that mean we need to add `@types/node` as a dependency?  I haven't contributed to DefinitelyTyped much, so I'm not sure.