### PR TITLE
Lodash: fix typo in function name (merge => mergeWith)

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1807,7 +1807,7 @@ declare module "../index" {
          *   'vegetables': ['carrot']
          * };
          *
-         * _.merge(object, other, customizer);
+         * _.mergeWith(object, other, customizer);
          * // => { 'fruits': ['apple', 'banana'], 'vegetables': ['beet', 'carrot'] }
          */
         mergeWith<TObject, TSource>(object: TObject, source: TSource, customizer: MergeWithCustomizer): TObject & TSource;


### PR DESCRIPTION
Hi, this can helps as it's misleading
