### PR TITLE
[nodegit] Add types for Repository#createCommitWithSignature and friends

### DIFF
--- a/types/nodegit/commit.d.ts
+++ b/types/nodegit/commit.d.ts
@@ -8,6 +8,7 @@ import { Object } from './object';
 import { Tree } from './tree';
 import { TreeEntry } from './tree-entry';
 import { Diff } from './diff';
+import { Error } from './error';
 
 export interface HistoryEventEmitter extends EventEmitter {
     start(): void;
@@ -26,6 +27,15 @@ export class Commit {
     static createWithSignature(repo: Repository, commitContent: string, signature: string, signatureField: string): Promise<Oid>;
 
     amend(updateRef: string, author: Signature, committer: Signature, messageEncoding: string, message: string, tree: Tree | Oid): Promise<Oid>;
+    amendWithSignature(
+        updateRef: string,
+        author: Signature,
+        committer: Signature,
+        messageEncoding: string,
+        message: string,
+        tree: Tree | Oid,
+        onSignature: (data: string) => Promise<{code: Error.CODE, field?: string, signedData: string}> | {code: Error.CODE, field?: string, signedData: string}
+    ): Promise<Oid>;
     author(): Signature;
     committer(): Signature;
 
@@ -121,4 +131,9 @@ export class Commit {
      *
      */
     body(): string;
+
+    getSignature(field?: string): Promise<{
+        signature: string
+        signedData: string
+    }>;
 }

--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -22,6 +22,7 @@ import { StatusFile } from './status-file';
 import { StatusOptions } from './status-options';
 import { DiffLine } from './diff-line';
 import { Treebuilder } from './tree-builder';
+import { Error } from './error';
 
 export interface RepositoryInitOptions {
     description: string;
@@ -147,6 +148,15 @@ export class Repository {
      */
     getHeadCommit(): Promise<Commit>;
     createCommit(updateRef: string, author: Signature, committer: Signature, message: string, Tree: Tree | Oid | string, parents: Array<string | Commit | Oid>, callback?: Function): Promise<Oid>;
+    createCommitWithSignature(
+        updateRef: string,
+        author: Signature,
+        committer: Signature,
+        message: string,
+        Tree: Tree | Oid | string,
+        parents: Array<string | Commit | Oid>,
+        onSignature: (data: string) => Promise<{code: Error.CODE, field?: string, signedData: string}> | {code: Error.CODE, field?: string, signedData: string}
+    ): Promise<Oid>;
     /**
      * Creates a new commit on HEAD from the list of passed in files
      */

--- a/types/nodegit/tag.d.ts
+++ b/types/nodegit/tag.d.ts
@@ -3,11 +3,21 @@ import { Oid } from './oid';
 import { Object } from './object';
 import { Signature } from './signature';
 import { Strarray } from './str-array';
+import { Error } from './error';
 
 export class Tag {
     static annotationCreate(repo: Repository, tagName: string, target: Object, tagger: Signature, message: string): Promise<Oid>;
     static create(repo: Repository, tagName: string, target: Object, tagger: Signature, message: string, force: number): Promise<Oid>;
     static createLightweight(repo: Repository, tagName: string, target: Object, force: number): Promise<Oid>;
+    static createWithSignature(
+        repo: Repository,
+        tagName: string,
+        target: Oid | string,
+        tagger: Signature,
+        message: string | undefined | null,
+        force: number,
+        signingCallback: (data: string) => Promise<{code: Error.CODE, field?: string, signedData: string}> | {code: Error.CODE, field?: string, signedData: string}
+    ): Promise<Oid>;
     static delete(repo: Repository, tagName: string): Promise<number>;
     static list(repo: Repository): Promise<any[]>;
     static listMatch(pattern: string, repo: Repository): Promise<any[]>;


### PR DESCRIPTION
This adds types for
* Commit#getSignature
* Commit#amendWithSignature
* Repository#createCommitWithSignature
* Tag.createWithSignature

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * [Commit#getSignature](https://www.nodegit.org/api/commit/#getSignature). This returns a Promise even though the documentation states it's a synchronous method.
  * [Commit#amendWithSignature](https://www.nodegit.org/api/commit/#amendWithSignature)
  * [Repository#createCommitWithSignature](https://www.nodegit.org/api/repository/#createCommitWithSignature)
  * [Tag.createWithSignature](https://www.nodegit.org/api/tag/#createWithSignature)

Can't quite figure out how to create tests for these as they need a signed object. Would appreciate any help regarding with this.