### PR TITLE
[chai, chai-as-promised] Fix chai-related types to allow Symbols for property names

### DIFF
--- a/types/chai-as-promised/chai-as-promised-tests.ts
+++ b/types/chai-as-promised/chai-as-promised-tests.ts
@@ -10,6 +10,11 @@ class TestClass {}
 var thenableNum: PromiseLike<number> = Promise.resolve(3);
 thenableNum = chai.expect(thenableNum).to.eventually.equal(3);
 thenableNum = chai.expect(thenableNum).to.eventually.have.property('foo');
+thenableNum = chai.expect(thenableNum).to.eventually.have.property(Symbol.for('bar'));
+thenableNum = chai.expect(thenableNum).to.eventually.have.ownProperty('foo');
+thenableNum = chai.expect(thenableNum).to.eventually.have.ownProperty(Symbol.for('bar'));
+thenableNum = chai.expect(thenableNum).to.eventually.have.ownPropertyDescriptor('foo');
+thenableNum = chai.expect(thenableNum).to.eventually.have.ownPropertyDescriptor(Symbol.for('bar'));
 thenableNum = chai.expect(thenableNum).to.become(3);
 thenableNum = chai.expect(thenableNum).to.be.fulfilled;
 thenableNum = chai.expect(thenableNum).to.be.rejected;

--- a/types/chai-as-promised/index.d.ts
+++ b/types/chai-as-promised/index.d.ts
@@ -188,16 +188,16 @@ declare namespace Chai {
     }
 
     interface PromisedProperty {
-        (name: string, value?: any, message?: string): PromisedAssertion;
+        (name: string | Symbol, value?: any, message?: string): PromisedAssertion;
     }
 
     interface PromisedOwnProperty {
-        (name: string, message?: string): PromisedAssertion;
+        (name: string | Symbol, message?: string): PromisedAssertion;
     }
 
     interface PromisedOwnPropertyDescriptor {
-        (name: string, descriptor: PropertyDescriptor, message?: string): PromisedAssertion;
-        (name: string, message?: string): PromisedAssertion;
+        (name: string | Symbol, descriptor: PropertyDescriptor, message?: string): PromisedAssertion;
+        (name: string | Symbol, message?: string): PromisedAssertion;
     }
 
     interface PromisedLength extends PromisedLanguageChains, PromisedNumericComparison {

--- a/types/chai-as-promised/index.d.ts
+++ b/types/chai-as-promised/index.d.ts
@@ -188,16 +188,16 @@ declare namespace Chai {
     }
 
     interface PromisedProperty {
-        (name: string | Symbol, value?: any, message?: string): PromisedAssertion;
+        (name: string | symbol, value?: any, message?: string): PromisedAssertion;
     }
 
     interface PromisedOwnProperty {
-        (name: string | Symbol, message?: string): PromisedAssertion;
+        (name: string | symbol, message?: string): PromisedAssertion;
     }
 
     interface PromisedOwnPropertyDescriptor {
-        (name: string | Symbol, descriptor: PropertyDescriptor, message?: string): PromisedAssertion;
-        (name: string | Symbol, message?: string): PromisedAssertion;
+        (name: string | symbol, descriptor: PropertyDescriptor, message?: string): PromisedAssertion;
+        (name: string | symbol, message?: string): PromisedAssertion;
     }
 
     interface PromisedLength extends PromisedLanguageChains, PromisedNumericComparison {

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -556,6 +556,7 @@ function empty() {
 
 function property() {
     expect('test').to.have.property('length');
+    expect('test').to.have.property(Symbol.for('length'));
     'test'.should.have.property('length');
     expect(4).to.not.have.property('length');
     (4).should.not.have.property('length');
@@ -594,6 +595,7 @@ function nestedProperty() {
 
 function property2() {
     expect('test').to.have.property('length', 4);
+    expect('test').to.have.property(Symbol.for('length'), 4);
     'test'.should.have.property('length', 4);
     expect('asd').to.have.property('constructor', String);
     'asd'.should.have.property('constructor', String);
@@ -640,6 +642,7 @@ function own() {
 
 function ownProperty() {
     expect('test').to.have.ownProperty('length');
+    expect('test').to.have.ownProperty(Symbol.for('length'));
     'test'.should.have.ownProperty('length');
     expect('test').to.haveOwnProperty('length');
     'test'.should.haveOwnProperty('length');
@@ -654,6 +657,7 @@ function ownProperty() {
     ({length: 12}).should.not.have.ownProperty('length', 'blah');
 
     expect('test').to.have.own.property('length');
+    expect('test').to.have.own.property(Symbol.for('length'));
     'test'.should.have.own.property('length');
     expect({length: 12}).to.have.own.property('length');
     ({length: 12}).should.have.own.property('length');
@@ -680,6 +684,7 @@ function ownProperty() {
 
 function ownPropertyDescriptor() {
     expect('test').to.have.ownPropertyDescriptor('length');
+    expect('test').to.have.ownPropertyDescriptor(Symbol.for('length'));
     expect('test').to.have.ownPropertyDescriptor('length', {
         enumerable: false,
         configurable: false,

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -341,13 +341,13 @@ declare namespace Chai {
     }
 
     interface Property {
-        (name: string, value: any, message?: string): Assertion;
-        (name: string, message?: string): Assertion;
+        (name: string | Symbol, value: any, message?: string): Assertion;
+        (name: string | Symbol, message?: string): Assertion;
     }
 
     interface OwnPropertyDescriptor {
-        (name: string, descriptor: PropertyDescriptor, message?: string): Assertion;
-        (name: string, message?: string): Assertion;
+        (name: string | Symbol, descriptor: PropertyDescriptor, message?: string): Assertion;
+        (name: string | Symbol, message?: string): Assertion;
     }
 
     interface Length extends LanguageChains, NumericComparison {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -341,13 +341,13 @@ declare namespace Chai {
     }
 
     interface Property {
-        (name: string | Symbol, value: any, message?: string): Assertion;
-        (name: string | Symbol, message?: string): Assertion;
+        (name: string | symbol, value: any, message?: string): Assertion;
+        (name: string | symbol, message?: string): Assertion;
     }
 
     interface OwnPropertyDescriptor {
-        (name: string | Symbol, descriptor: PropertyDescriptor, message?: string): Assertion;
-        (name: string | Symbol, message?: string): Assertion;
+        (name: string | symbol, descriptor: PropertyDescriptor, message?: string): Assertion;
+        (name: string | symbol, message?: string): Assertion;
     }
 
     interface Length extends LanguageChains, NumericComparison {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _See below_
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

It's possible in chai to use `Symbol`s when expecting or asserting properties, even though this is not correctly reflected in their docs yet (see https://www.chaijs.com/api/bdd/#method_property )

This is however totally valid and actually does work today, compare e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#parameters