### PR TITLE
[mini-css-extract-plugin] fix chunkFilename type to match output.chunkFilename

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -42,7 +42,7 @@ declare namespace MiniCssExtractPlugin {
         /**
          * Works like [`output.chunkFilename`](https://webpack.js.org/configuration/output/#outputchunkfilename).
          */
-        chunkFilename?: string;
+        chunkFilename?: Required<Configuration>['output']['chunkFilename'];
         /**
          * For projects where CSS ordering has been mitigated through consistent
          * use of scoping or naming conventions, the CSS order warnings can be

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -74,6 +74,16 @@ configuration = {
     // ...
     plugins: [
         new MiniCssExtractPlugin({
+            filename: "style.css",
+            chunkFilename: ({ chunk }) => (chunk?.name ? `${chunk.name.replace("/js/", "/css/")}.css` : "unknown"),
+        }),
+    ],
+};
+
+configuration = {
+    // ...
+    plugins: [
+        new MiniCssExtractPlugin({
             filename: "styles.css",
             chunkFilename: "style.css",
             ignoreOrder: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/plugins/mini-css-extract-plugin/#chunkfilename
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
