### PR TITLE
[react-syntax-highlighter] Export createElement and update SyntaxHighlighterProps

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-syntax-highlighter 13.5
+// Type definitions for react-syntax-highlighter 15.4
 // Project: https://github.com/conorhastings/react-syntax-highlighter
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>
 //                 Guo Yunhe <https://github.com/guoyunhe>
@@ -20,6 +20,13 @@ declare module 'react-syntax-highlighter' {
         showLineNumbers?: boolean;
         startingLineNumber?: number;
         lineNumberStyle?: any;
+        showInlineLineNumbers?: boolean;
+        lineNumberContainerStyle?: any;
+        wrapLines?: boolean;
+        wrapLongLines?: boolean;
+        renderer?: any;
+        PreTag?: any;
+        CodeTag?: any;
         [spread: string]: any;
     }
 
@@ -31,6 +38,8 @@ declare module 'react-syntax-highlighter' {
     export { default as PrismAsync } from 'react-syntax-highlighter/dist/esm/prism-async';
     export { default as PrismLight } from 'react-syntax-highlighter/dist/esm/prism-light';
     export { default as Prism } from 'react-syntax-highlighter/dist/esm/prism';
+
+    export { default as createElement } from 'react-syntax-highlighter/dist/esm/create-element';
 }
 
 // esm start
@@ -82,6 +91,11 @@ declare module 'react-syntax-highlighter/dist/esm/prism' {
     import * as React from 'react';
     import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {}
+}
+
+declare module 'react-syntax-highlighter/dist/esm/create-element' {
+    function createElement(props: any): JSX.Element;
+    export default createElement;
 }
 
 declare module 'react-syntax-highlighter/dist/esm/styles/hljs' {

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
-import SyntaxHighlighter, { Light as LightHighlighter, SyntaxHighlighterProps } from "react-syntax-highlighter";
+import SyntaxHighlighter, {
+    createElement,
+    Light as LightHighlighter,
+    SyntaxHighlighterProps
+} from "react-syntax-highlighter";
 import PrismSyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism";
 import PrismLightHighlighter from "react-syntax-highlighter/dist/cjs/prism-light";
 import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
@@ -150,4 +154,69 @@ function lineTagPropsFunction() {
     });
 
     return <PrismLightHighlighter lineProps={lineProps} />;
+}
+
+function syntaxHighlighterProps(): JSX.Element {
+    const codeString: string = `class CPP {
+    private year: number;
+    public constructor(private version: string) {
+        this.year = Number(version.match(/.+\d+$/));
+    }
+    public version(): string {
+        return this.version;
+    }
+}
+`;
+    const lineProps: lineTagPropsFunction = (lineNumber: number) => ({
+        className: "some-classname",
+        style: {
+            opacity: 0
+        },
+        onMouseOver: (event: React.MouseEvent<HTMLElement>) => lineNumber * 5
+    });
+
+    // implement a custom renderer that renders lines as tr elements with the
+    // line numbers and the code snippet in their own td tags
+    const renderer = (props: any): JSX.Element[] => {
+        const  { rows, stylesheet, useInlineStyles } = props;
+        return rows.map((row: any, i: number) => {
+            const { children } = row;
+            return (
+                <tr key={`line-${i}`}>
+                    <td>{i}</td>
+                    <td>{children.map((child: any, j: number) => {
+                        return createElement({
+                            node: child,
+                            stylesheet,
+                            useInlineStyles,
+                            key: `code-segment-${i}-${j}`,
+                        });
+                    })}</td>
+                </tr>
+            );
+        });
+    };
+
+    return (
+        <SyntaxHighlighter
+            language="javascript"
+            style={docco}
+            customStyle={{className: "custom-class"}}
+            lineProps={{className: "line-class"}}
+            codeTagProps={{className: "code-tag-class"}}
+            useInlineStyles={true}
+            showLineNumbers={false}
+            startingLineNumber={1}
+            lineNumberStyle={{className: "line-number-class"}}
+            showInlineLineNumbers={true}
+            lineNumberContainerStyle={{className: "line-number-container-class"}}
+            wrapLines={true}
+            wrapLongLines={true}
+            renderer={renderer}
+            PreTag="table"
+            CodeTag="tbody"
+        >
+            {codeString}
+        </SyntaxHighlighter>
+    );
 }


### PR DESCRIPTION
This PR updates the react-syntax-highlighter package to: 
1.  Export the `createElement` function [defined](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/create-element.js) and [exported](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/index.js#L11) in the original library.
2. g the most recent SyntaxHighlighterProps as described in the [readme](https://github.com/react-syntax-highlighter/react-syntax-highlighter#props)

The type definitions as they exist rely heavily on the any type; in order to not block people from using these supposed-to-be-exported functionality, I followed that pattern rather than trying to refine the existing definitions.
____________________

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    1. createElement added to the public API as of [828e944](https://github.com/react-syntax-highlighter/react-syntax-highlighter/commit/828e944f28656878c61c2976e67fdad4527af072)
    2. see the [readme](https://github.com/react-syntax-highlighter/react-syntax-highlighter#props) for currently documented accepted SyntaxHighlighterProps.  Since these span many releases (the props types have not been updated since 2019 in #40753) so I'm referring to the readme to aggregate

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
