### PR TITLE
ActionCable: Support contextual methods.

### DIFF
--- a/types/actioncable/actioncable-tests.ts
+++ b/types/actioncable/actioncable-tests.ts
@@ -15,6 +15,8 @@ const helloChannel = App.cable.subscriptions.create('NetworkChannel', {
   }
 });
 
+// Methods introduced in the mixin param are available in the channel
+// subscription instance.
 helloChannel.hello('World');
 
 const channelParams: ActionCable.ChannelNameWithParams = {
@@ -33,5 +35,10 @@ const channelWithParams = App.cable.subscriptions.create(channelParams, {
   },
   received(obj: Object): void {
     console.log(obj);
+  },
+  bye(): void {
+    // Methods introduced in the mixin param can read channel methods.
+    this.unsubscribe();
+    console.log('Goodbye!');
   }
 });

--- a/types/actioncable/index.d.ts
+++ b/types/actioncable/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/rails/rails/tree/master/actioncable/app/assets/javascripts
 // Definitions by: Vincent Zhu <https://github.com/zhu1230>
 //                 Jared Szechy <https://github.com/szechyjs>
+//                 David Mejorado <https://github.com/davidmh>
 // Definitions: https://github.com/zhu1230/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -13,7 +14,7 @@ declare module ActionCable {
   }
 
   interface Subscriptions {
-    create<T extends CreateMixin>(channel: string|ChannelNameWithParams, obj?: T): Channel & T;
+    create<T extends CreateMixin>(channel: string|ChannelNameWithParams, obj?: T & ThisType<Channel>): Channel & T;
   }
 
   interface Cable {


### PR DESCRIPTION
This is a follow-up for #52421. Returning an extended type caused the
contextual methods from `Channel` to be dropped.

This commit brings back support to reference methods through `this`.

I've added a test here and also tested against the codebase showing the
original problem in: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52421#issuecomment-828503478

cc: @rmosolgo

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52421
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.