### PR TITLE
Fix prop misspelling for rn-material-ui-textfield

### DIFF
--- a/types/rn-material-ui-textfield/index.d.ts
+++ b/types/rn-material-ui-textfield/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for rn-material-ui-textfield 1.0
+// Type definitions for rn-material-ui-textfield 1.0.1
 // Project: https://github.com/gabrieldonadel/rn-material-ui-textfield#readme
 // Definitions by: Craig Duckett <https://github.com/craigwduckett>
+//                 Gabriel Donadel Dall'Agnol <https://github.com/gabrieldonadel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';

--- a/types/rn-material-ui-textfield/index.d.ts
+++ b/types/rn-material-ui-textfield/index.d.ts
@@ -68,7 +68,7 @@ export interface TextFieldProps extends TextInputProps {
     labelOffset?: LabelOffset;
     containerStyle?: StyleProp<ViewStyle>;
     inputContainerStyle?: StyleProp<ViewStyle>;
-    abelTextStyle?: StyleProp<TextStyle>;
+    labelTextStyle?: StyleProp<TextStyle>;
     titleTextStyle?: StyleProp<TextStyle>;
     affixTextStyle?: StyleProp<TextStyle>;
     formatText?(text: string): string;

--- a/types/rn-material-ui-textfield/index.d.ts
+++ b/types/rn-material-ui-textfield/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rn-material-ui-textfield 1.0.1
+// Type definitions for rn-material-ui-textfield 1.0
 // Project: https://github.com/gabrieldonadel/rn-material-ui-textfield#readme
 // Definitions by: Craig Duckett <https://github.com/craigwduckett>
 //                 Gabriel Donadel Dall'Agnol <https://github.com/gabrieldonadel>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gabrieldonadel/rn-material-ui-textfield/issues/23#issuecomment-833824882
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.