### PR TITLE
[pg] Re-export 'DatabaseError' from 'pg-protocol'

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pg 7.14
+// Type definitions for pg 8.6
 // Project: http://github.com/brianc/node-postgres
 // Definitions by: Phips Peter <https://github.com/pspeter3>, Ravi van Rooijen <https://github.com/HoldYourWaffle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -294,3 +294,5 @@ export const defaults: Defaults & ClientConfig;
 import * as Pg from '.';
 
 export const native: typeof Pg | null;
+
+export { DatabaseError } from 'pg-protocol';

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "pg-types": "^2.2.0",
-        "pg-protocol": "^1.2.0"
+        "pg-protocol": "*"
     }
 }

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -1,4 +1,4 @@
-import { types, Client, CustomTypesConfig, QueryArrayConfig, Pool } from 'pg';
+import { types, Client, CustomTypesConfig, QueryArrayConfig, Pool, DatabaseError } from 'pg';
 import TypeOverrides = require('pg/lib/type-overrides');
 import { NoticeMessage } from 'pg-protocol/dist/messages';
 
@@ -277,7 +277,16 @@ pool.end().then(() => console.log('pool has ended'));
 
 (async () => {
     const client = await pool.connect();
-    await client.query('SELECT NOW()');
+    try {
+        await client.query('SELECT NOW()');
+    } catch (err) {
+        if (err instanceof DatabaseError) {
+            if (err.position !== undefined) {
+                const position: string = err.position;
+                console.log(position);
+            }
+        }
+    }
     client.release();
 })();
 


### PR DESCRIPTION
Added in 'pg' v8.6.0
- ChangeLog entry: https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#pg860
- Commit: https://github.com/brianc/node-postgres/commit/4b229275cfe41ca17b7d69bd39f91ada0068a5d0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
