### PR TITLE
Update the LeafletDraw types of EditOptions.remove

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -167,7 +167,7 @@ declare module 'leaflet' {
              *
              * Default value: null
              */
-            remove?: any;
+            remove?: boolean | null;
         }
 
         class Draw extends Control {

--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -167,7 +167,7 @@ declare module 'leaflet' {
              *
              * Default value: null
              */
-            remove?: null | false;
+            remove?: any;
         }
 
         class Draw extends Control {


### PR DESCRIPTION
Control.DrawConstructorOptions.EditOptions type is updated to allow boolean enable.

remove?: null | false; 

type error when trying to enable a disabled remove option.

```
let fullOptions: Control.DrawConstructorOptions = {
      .
      .
      edit: {
        .
        remove: true,
```

![image](https://user-images.githubusercontent.com/7958115/117413321-766d4e80-af33-11eb-9c0e-c79a0502907d.png)

Current hack to avoid this error, `{ remove: true as any }` or `fullOptions['remove'] = true`;

----------------------------------------------------------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
