### PR TITLE
relay-test-utils: add type signature of MockFunctions.queuePendingOperation

### DIFF
--- a/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
+++ b/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
@@ -12,6 +12,7 @@ import {
     Variables,
     OptimisticUpdate,
     MissingFieldHandler,
+    GraphQLTaggedNode,
 } from 'relay-runtime';
 
 export type OperationMockResolver = (operation: OperationDescriptor) => GraphQLResponse | Error | null;
@@ -34,6 +35,7 @@ export interface MockFunctions {
     resolve: (request: ConcreteRequest | OperationDescriptor, payload: GraphQLResponse) => void;
     getAllOperations: () => ReadonlyArray<OperationDescriptor>;
     findOperation: (findFn: (operation: OperationDescriptor) => boolean) => OperationDescriptor;
+    queuePendingOperation: (query: GraphQLTaggedNode, variables: Variables) => void;
     getMostRecentOperation: () => OperationDescriptor;
     resolveMostRecentOperation: (
         payload: GraphQLResponse | ((operation: OperationDescriptor) => GraphQLResponse | void),

--- a/types/relay-test-utils/relay-test-utils-tests.tsx
+++ b/types/relay-test-utils/relay-test-utils-tests.tsx
@@ -8,6 +8,8 @@ environment.mock.resolveMostRecentOperation(operation => {
     MockPayloadGenerator.generate(operation);
 });
 
+environment.mock.queuePendingOperation(graphql``, {foo: 'bar'});
+
 function Test() {
     return <div />;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://relay.dev/docs/guides/testing-relay-components/#relaymockenvironment-api-overview