### PR TITLE
fix(cheerio): Add optional startIndex and endIndex to Element

### DIFF
--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -67,8 +67,6 @@ tagEl.endIndex - tagEl.startIndex;
 commentEl.endIndex - commentEl.startIndex;
 textEl.endIndex - textEl.startIndex;
 
-$.
-
 /**
  * Selectors
  */

--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -58,13 +58,13 @@ const indicesHTMLRoot = cheerio.load(indicesHTML, {
   withEndIndices: true,
 });
 
-const tagEl = indicesHTMLRoot('*')['0'];
-const commentEl = tagEl.firstChild;
-const textEl = commentEl.nextSibling;
+const tagEl = indicesHTMLRoot('*')['0'] as cheerio.TagElement;
+const commentEl = tagEl.firstChild as cheerio.CommentElement;
+const textEl = tagEl.lastChild as cheerio.TextElement;
 
-tagEl.endIndex - tagEl.startIndex;
-commentEl.endIndex - commentEl.startIndex;
-textEl.endIndex - textEl.startIndex;
+tagEl.endIndex! - tagEl.startIndex!;
+commentEl.endIndex! - commentEl.startIndex!;
+textEl.endIndex! - textEl.startIndex!;
 
 /**
  * Selectors

--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -58,7 +58,7 @@ const indicesHTMLRoot = cheerio.load(indicesHTML, {
   withEndIndices: true,
 });
 
-const tagEl = indicesHTMLRoot('*')['0'] as cheerio.TagElement;
+const tagEl = indicesHTMLRoot('*')[0] as cheerio.TagElement;
 const commentEl = tagEl.firstChild as cheerio.CommentElement;
 const textEl = tagEl.lastChild as cheerio.TextElement;
 

--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -47,7 +47,6 @@ $ = cheerio.load(html, {
 
 const [$ele1] = Array.from($('.class'));
 
-
 /**
  * Start and end indicies for all tags
  */
@@ -60,7 +59,7 @@ const indicesHTMLRoot = cheerio.load(indicesHTML, {
 });
 
 const tagEl = indicesHTMLRoot('*')['0'];
-const commentEl = indicesHTMLRoot.firstChild;
+const commentEl = tagEl.firstChild;
 const textEl = commentEl.nextSibling;
 
 tagEl.endIndex - tagEl.startIndex;

--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -47,6 +47,28 @@ $ = cheerio.load(html, {
 
 const [$ele1] = Array.from($('.class'));
 
+
+/**
+ * Start and end indicies for all tags
+ */
+
+const indicesHTML = `<div id="fruits"><!-- This is a pear -->Pear</div>`;
+
+const indicesHTMLRoot = cheerio.load(indicesHTML, {
+  withStartIndices: true,
+  withEndIndices: true,
+});
+
+const tagEl = indicesHTMLRoot('*')['0'];
+const commentEl = indicesHTMLRoot.firstChild;
+const textEl = commentEl.nextSibling;
+
+tagEl.endIndex - tagEl.startIndex;
+commentEl.endIndex - commentEl.startIndex;
+textEl.endIndex - textEl.startIndex;
+
+$.
+
 /**
  * Selectors
  */

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -47,6 +47,7 @@ declare namespace cheerio {
         nodeValue: string;
         data?: string;
         startIndex?: number;
+        endIndex?: number;
     }
 
     interface CommentElement {

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -25,6 +25,8 @@ declare namespace cheerio {
         prev: Element | null;
         parent: Element;
         data?: string;
+        startIndex?: number;
+        endIndex?: number;
     }
 
     interface TagElement {
@@ -56,6 +58,8 @@ declare namespace cheerio {
         prev: Element | null;
         parent: Element;
         data?: string;
+        startIndex?: number;
+        endIndex?: number;
     }
 
     type AttrFunction = (el: Element, i: number, currentValue: string) => any;


### PR DESCRIPTION
Cheerio offers source location depending on the parser, as used in the [tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cheerio/cheerio-tests.ts#L39) but the `TagElement` interface does not document the existence of the possible endIndex.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cheeriojs/cheerio/blob/main/Readme.md

This also adds `startIndex` and `endIndex` to `TextElement` and `CommentElement` which were also missing.