### PR TITLE
bitcore-lib-cash: Signature related improvements

### DIFF
--- a/types/bitcore-lib-cash/bitcore-lib-cash-tests.ts
+++ b/types/bitcore-lib-cash/bitcore-lib-cash-tests.ts
@@ -28,7 +28,14 @@ const tx = new bitcore.Transaction()
     .from(utxo)
     .change('bitcoinAddress')
     .addData(Buffer.from(''))
-    .sign('bitcoinAddressPrivateKey');
+    .sign('bitcoinAddressPrivateKey')
+    .sign('bitcoinAddressPrivateKey2',
+        bitcore.crypto.Signature.SIGHASH_ALL | bitcore.crypto.Signature.SIGHASH_FORKID
+    )
+    .sign('bitcoinAddressPrivateKey3',
+        null,
+        'schnorr'
+    );
 
 tx.verify();
 

--- a/types/bitcore-lib-cash/index.d.ts
+++ b/types/bitcore-lib-cash/index.d.ts
@@ -39,7 +39,8 @@ export namespace crypto {
     class Signature {
         static fromDER(sig: Buffer): Signature;
         static fromString(data: string): Signature;
-        SIGHASH_ALL: number;
+        static SIGHASH_ALL: number;
+        static SIGHASH_FORKID: number;
         toString(): string;
     }
 
@@ -293,7 +294,7 @@ export class Transaction {
     fee(amount: number): this;
     feePerKb(amount: number): this;
     feePerByte(amount: number): this;
-    sign(privateKey: Array<PrivateKey | string> | PrivateKey | string, sigtype?: number, signingMethod?: string): this;
+    sign(privateKey: Array<PrivateKey | string> | PrivateKey | string, sigtype?: number | null, signingMethod?: string): this;
     getSignatures(
         privKey: PrivateKey | string,
         sigtype?: number,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Proof of static SIGHASH](https://github.com/bitpay/bitcore/blob/77bae4049f78a4bbaec85a884e9ed25ec85930cf/packages/bitcore-lib-cash/lib/crypto/signature.js#L430) and [Proof that setting SIGHASH arg to null/undefined uses the default ALL|FORKID: transaction.sign](https://github.com/bitpay/bitcore/blob/77bae4049f78a4bbaec85a884e9ed25ec85930cf/packages/bitcore-lib-cash/lib/transaction/transaction.js#L1078) calls [getSignatures](https://github.com/bitpay/bitcore/blob/77bae4049f78a4bbaec85a884e9ed25ec85930cf/packages/bitcore-lib-cash/lib/transaction/transaction.js#L1098), also used [here](https://github.com/simpleledger/BitcoinFilesJS/blob/d36aa7b76b3cc137ae600fe08e73573874a13f9d/lib/bfp.ts#L395)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
