### PR TITLE
fix(number-to-words): UMD support and input type fix

### DIFF
--- a/types/number-to-words/index.d.ts
+++ b/types/number-to-words/index.d.ts
@@ -3,15 +3,19 @@
 // Definitions by: Frederick Fogerty <https://github.com/frederickfogerty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export as namespace numberToWords;
+
 /**
  * Converts an integer into a string with an ordinal postfix. If number is decimal, the decimals will be removed.
  */
-export function toOrdinal(number: number): string;
+export function toOrdinal(number: string | number): string;
+
 /**
  * Converts an integer into words. If number is decimal, the decimals will be removed.
  */
-export function toWords(number: number): string;
+export function toWords(number: string | number): string;
+
 /**
  * Converts a number into ordinal words. If number is decimal, the decimals will be removed.
  */
-export function toWordsOrdinal(number: number): string;
+export function toWordsOrdinal(number: string | number): string;

--- a/types/number-to-words/number-to-words-tests.ts
+++ b/types/number-to-words/number-to-words-tests.ts
@@ -1,7 +1,10 @@
-import * as converter from 'number-to-words';
+import numberToWords = require("number-to-words");
 
-converter.toOrdinal(21);
+numberToWords.toOrdinal(21); // $ExpectType string
+numberToWords.toOrdinal("21"); // $ExpectType string
 
-converter.toWords(13);
+numberToWords.toWords(13); // $ExpectType string
+numberToWords.toWords("13"); // $ExpectType string
 
-converter.toWordsOrdinal(21);
+numberToWords.toWordsOrdinal(21); // $ExpectType string
+numberToWords.toWordsOrdinal("21"); // $ExpectType string


### PR DESCRIPTION
- this library suppots string numeric values as inputs. It's event
  documented in the source code:
https://github.com/marlun78/number-to-words/blob/master/numberToWords.js#L146
- add proper UMD support to use in the browsers:
https://github.com/marlun78/number-to-words/blob/master/numberToWords.js#L252-L259
- tests amended

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.