### PR TITLE
[@types/estree]: Add support for es2022 PropertyDefinition and PrivateIdentifier nodes

### DIFF
--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -98,7 +98,8 @@ declare var variableDeclaratorOrExpression: ESTree.VariableDeclaration | ESTree.
 declare var variableDeclaratorOrPattern: ESTree.VariableDeclaration | ESTree.Pattern;
 declare var literalOrIdentifier: ESTree.Literal | ESTree.Identifier;
 declare var blockStatementOrExpression: ESTree.BlockStatement | ESTree.Expression;
-declare var identifierOrExpression: ESTree.Identifier | ESTree.PrivateIdentifier | ESTree.Expression;
+declare var identifierOrExpression: ESTree.Identifier | ESTree.Expression;
+declare var privateIdentifierOrExpression: ESTree.PrivateIdentifier | ESTree.Expression;
 declare var any: any;
 declare var string: string;
 declare var boolean: boolean;
@@ -189,7 +190,7 @@ var propertyOrSpread: ESTree.Property | ESTree.SpreadElement
 
 string = property.type;
 if (property.type === 'Property') {
-    identifierOrExpression = property.key;
+    privateIdentifierOrExpression = property.key;
     expressionOrPattern = property.value;
     string = property.kind;
 }
@@ -237,7 +238,7 @@ expressionOrSpread = callExpression.arguments[0];
 // MemberExpression
 var memberExpression: ESTree.MemberExpression;
 expressionOrSuper = memberExpression.object;
-identifierOrExpression = memberExpression.property;
+privateIdentifierOrExpression = memberExpression.property;
 boolean = memberExpression.computed;
 
 // ChainExpression
@@ -246,7 +247,7 @@ var memberExpressionOrCallExpression = chainExpression.expression;
 boolean = memberExpressionOrCallExpression.optional;
 if (memberExpressionOrCallExpression.type === 'MemberExpression') {
   expressionOrSuper = memberExpressionOrCallExpression.object;
-  identifierOrExpression = memberExpressionOrCallExpression.property;
+  privateIdentifierOrExpression = memberExpressionOrCallExpression.property;
   boolean = memberExpressionOrCallExpression.computed;
 } else {
   expressionOrSuper = memberExpressionOrCallExpression.callee;

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -32,6 +32,7 @@ declare var thisExpression: ESTree.ThisExpression;
 declare var arrayExpression: ESTree.ArrayExpression;
 declare var objectExpression: ESTree.ObjectExpression;
 declare var property: ESTree.Property | ESTree.SpreadElement;
+declare var propertyDefinition: ESTree.PropertyDefinition;
 declare var functionExpression: ESTree.FunctionExpression;
 declare var sequenceExpression: ESTree.SequenceExpression;
 declare var unaryExpression: ESTree.UnaryExpression;
@@ -49,6 +50,7 @@ declare var pattern: ESTree.Pattern;
 declare var switchCase: ESTree.SwitchCase;
 declare var catchClause: ESTree.CatchClause;
 declare var identifier: ESTree.Identifier;
+declare var privateIdentifier: ESTree.PrivateIdentifier;
 declare var literal: ESTree.Literal;
 declare var simpleLiteral: ESTree.SimpleLiteral;
 declare var regExpLiteral: ESTree.RegExpLiteral;
@@ -96,7 +98,7 @@ declare var variableDeclaratorOrExpression: ESTree.VariableDeclaration | ESTree.
 declare var variableDeclaratorOrPattern: ESTree.VariableDeclaration | ESTree.Pattern;
 declare var literalOrIdentifier: ESTree.Literal | ESTree.Identifier;
 declare var blockStatementOrExpression: ESTree.BlockStatement | ESTree.Expression;
-declare var identifierOrExpression: ESTree.Identifier | ESTree.Expression;
+declare var identifierOrExpression: ESTree.Identifier | ESTree.PrivateIdentifier | ESTree.Expression;
 declare var any: any;
 declare var string: string;
 declare var boolean: boolean;
@@ -187,9 +189,9 @@ var propertyOrSpread: ESTree.Property | ESTree.SpreadElement
 
 string = property.type;
 if (property.type === 'Property') {
-  expression = property.key;
-  expressionOrPattern = property.value;
-  string = property.kind;
+    identifierOrExpression = property.key;
+    expressionOrPattern = property.value;
+    string = property.kind;
 }
 
 // FunctionExpression
@@ -301,6 +303,9 @@ expression = awaitExpression.argument;
 switch (node.type) {
   case 'Identifier':
     identifier = node;
+    break;
+  case 'PrivateIdentifier':
+    privateIdentifier = node;
     break;
   case 'Literal':
     literal = node;
@@ -491,6 +496,9 @@ switch (node.type) {
     break;
   case 'MethodDefinition':
     methodDefinition = node
+    break;
+  case 'PropertyDefinition':
+    propertyDefinition = node
     break;
 
   // narrowing of ModuleDeclaration

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -251,7 +251,7 @@ export interface ObjectExpression extends BaseExpression {
   properties: Array<Property | SpreadElement>;
 }
 
-interface PrivateIdentifier extends BaseNode {
+export interface PrivateIdentifier extends BaseNode {
     type: "PrivateIdentifier";
     name: string;
 }

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -37,7 +37,7 @@ interface BaseNode extends BaseNodeWithoutComments {
 
 export type Node =
     Identifier | Literal | Program | Function | SwitchCase | CatchClause |
-    VariableDeclarator | Statement | Expression | Property |
+    VariableDeclarator | Statement | Expression | PrivateIdentifier | Property | PropertyDefinition |
     AssignmentProperty | Super | TemplateElement | SpreadElement | Pattern |
     ClassBody | Class | MethodDefinition | ModuleDeclaration | ModuleSpecifier;
 
@@ -251,14 +251,27 @@ export interface ObjectExpression extends BaseExpression {
   properties: Array<Property | SpreadElement>;
 }
 
+interface PrivateIdentifier extends BaseNode {
+    type: "PrivateIdentifier";
+    name: string;
+}
+
 export interface Property extends BaseNode {
   type: "Property";
-  key: Expression;
+  key: Expression | PrivateIdentifier;
   value: Expression | Pattern; // Could be an AssignmentProperty
   kind: "init" | "get" | "set";
   method: boolean;
   shorthand: boolean;
   computed: boolean;
+}
+
+export interface PropertyDefinition extends BaseNode {
+    type: "PropertyDefinition";
+    key: Expression | PrivateIdentifier;
+    value: Expression | null;
+    computed: boolean;
+    static: boolean;
 }
 
 export interface FunctionExpression extends BaseFunction, BaseExpression {
@@ -332,7 +345,7 @@ export interface NewExpression extends BaseCallExpression {
 export interface MemberExpression extends BaseExpression, BasePattern {
   type: "MemberExpression";
   object: Expression | Super;
-  property: Expression;
+  property: Expression | PrivateIdentifier;
   computed: boolean;
   optional: boolean;
 }
@@ -484,12 +497,12 @@ interface BaseClass extends BaseNode {
 
 export interface ClassBody extends BaseNode {
   type: "ClassBody";
-  body: Array<MethodDefinition>;
+  body: Array<MethodDefinition | PropertyDefinition>;
 }
 
 export interface MethodDefinition extends BaseNode {
   type: "MethodDefinition";
-  key: Expression;
+  key: Expression | PrivateIdentifier;
   value: FunctionExpression;
   kind: "constructor" | "method" | "get" | "set";
   computed: boolean;

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -269,7 +269,7 @@ export interface Property extends BaseNode {
 export interface PropertyDefinition extends BaseNode {
     type: "PropertyDefinition";
     key: Expression | PrivateIdentifier;
-    value: Expression | null;
+    value?: Expression | null;
     computed: boolean;
     static: boolean;
 }


### PR DESCRIPTION
[@types/estree]: Add support for es2022 PropertyDefinition and PrivateIdentifier nodes

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
URL to the spec: https://github.com/estree/estree/blob/master/es2022.md