### PR TITLE
Add ffbinaries

### DIFF
--- a/types/ffbinaries/ffbinaries-tests.ts
+++ b/types/ffbinaries/ffbinaries-tests.ts
@@ -1,0 +1,80 @@
+import ffbinaries = require("ffbinaries");
+
+ffbinaries.downloadBinaries(
+    ["ffmpeg", "ffprobe", "ffplay", "ffserver"],
+    {
+        platform: ffbinaries.detectPlatform(),
+        destination: "./path/to/download",
+        force: true,
+        quiet: true,
+        tickerFn: ({ progress, filename }) => {
+            progress; // $ExpectType number
+            filename; // $ExpectType string
+        },
+        tickerInterval: 1000,
+    },
+    (error, results) => {
+        error; // $ExpectType string | null
+        const result = results[0];
+        switch (result.code) {
+            case "DONE_CLEAN":
+                result.filename;
+                result.path;
+                result.size; // $ExpectType string
+                result.status;
+                break;
+            case "DONE_FROM_CACHE":
+                result.filename;
+                result.path;
+                result.size; // $ExpectError
+                result.status;
+                break;
+            case "FILE_EXISTS":
+                result.filename;
+                result.path;
+                result.size; // $ExpectError
+                result.status;
+                break;
+            default:
+                const _: never = result;
+        }
+    }
+);
+
+const ffmpegLocated = ffbinaries.locateBinariesSync(["ffmpeg"], { ensureExecutable: true, paths: ["."] });
+ffmpegLocated.ffprobe; // $ExpectError
+if (ffmpegLocated.ffmpeg.found) {
+    ffmpegLocated.ffmpeg.isExecutable; // $ExpectType boolean
+    ffmpegLocated.ffmpeg.version; // $ExpectType string
+    ffmpegLocated.ffmpeg.path; // $ExpectType string
+} else {
+    ffmpegLocated.ffmpeg.isExecutable; // $ExpectType false
+    ffmpegLocated.ffmpeg.version; // $ExpectType null
+    ffmpegLocated.ffmpeg.path; // $ExpectType null
+}
+
+const multipleLocated = ffbinaries.locateBinariesSync(["ffmpeg", "ffplay"]);
+multipleLocated.ffmpeg;
+multipleLocated.ffplay;
+
+ffbinaries.locateBinariesSync(["ffmpeg", "not a component"]); // $ExpectError
+
+ffbinaries.getVersionData("1.2.3", (error, data) => {
+    error; // $ExpectType string | null
+    data.bin["osx-64"].ffplay; // $ExpectType string | undefined
+    data.permalink; // $ExpectType string
+    data.version; // $ExpectType string
+});
+
+ffbinaries.listVersions((error, versions) => {
+    error; // $ExpectType string | null
+    versions; // $ExpectType string[]
+});
+
+const _: ffbinaries.Platform[] = ffbinaries.listPlatforms();
+
+const __: ffbinaries.Platform | null = ffbinaries.resolvePlatform("macos");
+
+ffbinaries.getBinaryFilename("ffmpeg", "linux-32"); // $ExpectType string
+
+ffbinaries.clearCache(); // $ExpectType void

--- a/types/ffbinaries/index.d.ts
+++ b/types/ffbinaries/index.d.ts
@@ -1,0 +1,147 @@
+// Type definitions for ffbinaries 1.1
+// Project: https://ffbinaries.com
+// Definitions by: Andrew Branch <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export type Component = "ffmpeg" | "ffprobe" | "ffserver" | "ffplay";
+export interface LocateResultFound {
+    found: true;
+    isExecutable: boolean;
+    path: string;
+    version: string;
+}
+export interface LocateResultNotFound {
+    found: false;
+    isExecutable: false;
+    path: null;
+    version: null;
+}
+export type LocateResult = LocateResultFound | LocateResultNotFound;
+export type Platform = "osx-64" | "linux-32" | "linux-64" | "linux-armel" | "linux-armhf" | "windows-32" | "windows-64";
+
+export interface DownloadOptions {
+    /**
+     * The path where the binaries will be downloaded to. If not provided it will default to `.`.
+     */
+    destination?: string;
+    /**
+     * Defaults to detecting the current platform.
+     */
+    platform?: Platform;
+    /**
+     * Version of ffmpeg to download.
+     */
+    version?: string;
+    /**
+     * Ignore check for existing binaries in the destination and overwrite them if necessary.
+     */
+    force?: boolean;
+    /**
+     * Suppress verbose logs.
+     */
+    quiet?: boolean;
+    /**
+     * A progress-update function, triggered with percentage as argument at an interval until download is completed.
+     */
+    tickerFn?: (tickData: { filename: string; progress: number }) => void;
+    /**
+     * Frequency at which the ticker progress updates are issued (in ms; defaults to `1000`).
+     */
+    tickerInterval?: number;
+}
+
+export interface DownloadResultFileExists {
+    code: "FILE_EXISTS";
+    filename: string;
+    path: string;
+    status: string;
+}
+
+export interface DownloadResultFromCache {
+    code: "DONE_FROM_CACHE";
+    filename: string;
+    path: string;
+    status: string;
+}
+
+export interface DownloadResultClean {
+    code: "DONE_CLEAN";
+    filename: string;
+    path: string;
+    size: string;
+    status: string;
+}
+
+export type DownloadResult = DownloadResultFileExists | DownloadResultFromCache | DownloadResultClean;
+
+export interface VersionData {
+    version: string;
+    permalink: string;
+    bin: {
+        [K in Platform]: {
+            ffmpeg: string;
+            ffprobe: string;
+            ffplay?: string;
+            ffserver?: string;
+        };
+    };
+}
+
+export interface LocateBinariesOptions {
+    /** Locations to check first */
+    paths?: string[];
+    /** Set executable flag on the file if it's missing */
+    ensureExecutable?: boolean;
+}
+
+/**
+ * Downloads and extracts the requested binaries.
+ */
+export function downloadBinaries(callback: (error: string | null, results: DownloadResult[]) => void): void;
+export function downloadBinaries(
+    components: Component | Component[],
+    callback: (error: string | null, results: DownloadResult[]) => void,
+): void;
+export function downloadBinaries(
+    components: Component | Component[],
+    opts: DownloadOptions,
+    callback: (error: string | null, results: DownloadResult[]) => void,
+): void;
+/**
+ * Fetches the full data set without downloading any binaries.
+ */
+export function getVersionData(
+    version: string | null | undefined,
+    callback: (error: string | null, data: VersionData) => void,
+): void;
+/**
+ * Fetches the list of available versions from the API.
+ */
+export function listVersions(callback: (error: string | null, versions: string[]) => void): void;
+/**
+ * Returns the list of available platforms.
+ */
+export function listPlatforms(): Platform[];
+/**
+ * Returns the platform code of the machine as detected by the module.
+ */
+export function detectPlatform(): Platform;
+/**
+ * Resolves input to a platform code (matches aliases).
+ */
+export function resolvePlatform(input: string): Platform | null;
+/**
+ * Resolves a filename of a binary for a given platform (appends ".exe" in Windows).
+ */
+export function getBinaryFilename(component: Component, platform: Platform): string;
+/**
+ * Looks for binaries already existing in the system. Returns object with located binaries, their paths and versions.
+ */
+export function locateBinariesSync<T extends readonly Component[]>(
+    components: T,
+    opts?: LocateBinariesOptions,
+): { [K in T[number]]: LocateResult };
+/**
+ * Purges local cache.
+ */
+export function clearCache(): void;

--- a/types/ffbinaries/index.d.ts
+++ b/types/ffbinaries/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for ffbinaries 1.1
 // Project: https://ffbinaries.com
-// Definitions by: Andrew Branch <https://github.com/me>
+// Definitions by: Andrew Branch <https://github.com/andrewbranch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type Component = "ffmpeg" | "ffprobe" | "ffserver" | "ffplay";

--- a/types/ffbinaries/tsconfig.json
+++ b/types/ffbinaries/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ffbinaries-tests.ts"
+    ]
+}

--- a/types/ffbinaries/tslint.json
+++ b/types/ffbinaries/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
https://github.com/ffbinaries/ffbinaries-node

Note that docs are wrong / out of date about the signature of `downloadBinaries` and vague on the type of callback params. The types here are written against the implementation source code.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
