### PR TITLE
[Faker] faker.address.nearbyGPSCoordinate accepts `number[]` as coordinates

### DIFF
--- a/types/faker/faker-tests.ts
+++ b/types/faker/faker-tests.ts
@@ -45,6 +45,7 @@ resultStr = faker.address.ordinalDirection();
 resultStr = faker.address.ordinalDirection(true);
 resultStrArr = faker.address.nearbyGPSCoordinate();
 resultStrArr = faker.address.nearbyGPSCoordinate(['0', '0'], 0, true);
+resultStrArr = faker.address.nearbyGPSCoordinate([0, 0], 0, true);
 resultStr = faker.address.timeZone();
 
 resultStr = faker.commerce.color();

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -41,7 +41,11 @@ declare namespace Faker {
             direction(useAbbr?: boolean): string;
             cardinalDirection(useAbbr?: boolean): string;
             ordinalDirection(useAbbr?: boolean): string;
-            nearbyGPSCoordinate(coordinate?: ReadonlyArray<string>, radius?: number, isMetric?: boolean): string[];
+            nearbyGPSCoordinate(
+                coordinate?: ReadonlyArray<number | string>,
+                radius?: number,
+                isMetric?: boolean,
+            ): string[];
             timeZone(): string;
         };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
As the [code shows](https://github.com/Marak/faker.js/blob/master/lib/address.js#L349-L399), coordinates are passed straight to `coordinateWithOffset` where they are converted using `degreesToRadians` without being casted.
Javascript cast them automatically, so while `string[]` is ok, `number[]` would likely be better. 
In an effort to preserve backward compatibility I'm just adding the `number[]` option here.
