### PR TITLE
Fix return type of istanbul-reports create

### DIFF
--- a/types/istanbul-reports/index.d.ts
+++ b/types/istanbul-reports/index.d.ts
@@ -5,9 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import { Node, Visitor } from 'istanbul-lib-report';
+import { Node, ReportBase } from 'istanbul-lib-report';
 
-export function create<T extends keyof ReportOptions>(name: T, options?: Partial<ReportOptions[T]>): Visitor;
+export function create<T extends keyof ReportOptions>(name: T, options?: Partial<ReportOptions[T]>): ReportBase;
 
 export interface FileOptions {
     file: string;

--- a/types/istanbul-reports/istanbul-reports-tests.ts
+++ b/types/istanbul-reports/istanbul-reports-tests.ts
@@ -1,3 +1,4 @@
+import * as report from 'istanbul-lib-report';
 import { create } from 'istanbul-reports';
 
 create('clover');
@@ -57,3 +58,6 @@ create('text-lcov', { projectRoot: 'foo' });
 
 create('text-summary');
 create('text-summary', { file: 'foo' });
+
+const context = report.createContext({});
+create('html').execute(context);


### PR DESCRIPTION
The function returns an instance of ReportBase, rather than a visitor.
https://github.com/istanbuljs/istanbuljs/blob/c1559005b3bb318da01f505740adb0e782aaf14e/packages/istanbul-reports/index.js#L22
creates the instance, which is dynamically required based on `lib`.
For example, the `html` reporter extends `ReportBase` here:
https://github.com/istanbuljs/istanbuljs/blob/c1559005b3bb318da01f505740adb0e782aaf14e/packages/istanbul-reports/lib/html/index.js#L253

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See code links above
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

