### PR TITLE
@ckeditor/ckeditor5-core: writable command `value`

### DIFF
--- a/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
@@ -34,7 +34,7 @@ PluginArray.forEach(plugin => plugin.pluginName);
 const editor = new MyEditor(document.createElement("div"));
 const editorState: "initializing" | "ready" | "destroyed" = editor.state;
 // $ExpectError
-editor.state = null;
+editor.state = editorState;
 editor.focus();
 editor.destroy().then(() => {});
 editor.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
@@ -62,6 +62,7 @@ const myPlugin = new MyPlugin(editor);
 const promise = myPlugin.init?.();
 promise != null && promise.then(() => {});
 myPlugin.myMethod();
+myPlugin.isEnabled = true;
 
 class MyEmptyEditor extends Editor {
     static builtinPlugins = [MyPlugin];
@@ -87,6 +88,14 @@ command.destroy();
 command.execute();
 
 command.refresh();
+
+command.value = "foo";
+delete command.value;
+
+command.isEnabled = false;
+command.isEnabled = true;
+// $ExpectError
+delete command.isEnabled;
 
 /**
  * Context

--- a/types/ckeditor__ckeditor5-core/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/command.d.ts
@@ -6,9 +6,9 @@ import * as engine from "@ckeditor/ckeditor5-engine";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export default class Command implements Emitter, Observable {
-    readonly value?: unknown;
+    value?: unknown;
     readonly editor: Editor;
-    readonly isEnabled: boolean;
+    isEnabled: boolean;
 
     constructor(editor: Editor);
     clearForceDisabled(id: string): void;

--- a/types/ckeditor__ckeditor5-core/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugin.d.ts
@@ -11,7 +11,7 @@ export default class Plugin implements Emitter, Observable {
     static readonly requires?: Array<typeof Plugin>;
 
     readonly editor: Editor;
-    readonly isEnabled: boolean;
+    isEnabled: boolean;
 
     constructor(editor: Editor);
     afterInit?(): Promise<any> | void;


### PR DESCRIPTION
Remove the `readonly` flag for the `value` and `isEnabled` property of `Command`.
Remove the `readonly` flag for the `isEnabled` property of `Plugin`.

Closes #52759

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/9af274efaf0ed5e8488aa305975dae85220e32b9/packages/ckeditor5-link/src/linkcommand.js#L67-L86
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.