### PR TITLE
node-netstat tests can't depend on node:stream

### DIFF
--- a/types/node-netstat/node-netstat-tests.ts
+++ b/types/node-netstat/node-netstat-tests.ts
@@ -1,5 +1,5 @@
 import nodeNetstat = require("node-netstat");
-import { Stream } from "node:stream";
+import { Stream } from "stream";
 
 const mockLine =
     "tcp6       0      0  ffff::ffff:ffff:.00000 ffff::ffff:ffff:.00000 ESTABLISHED 000000 000000    000      0 0x000 0x00000000";


### PR DESCRIPTION
That reference isn't supported yet. This PR changes it to just "stream".