### PR TITLE
Improve jitsi-meet typings (event, constructor)

### DIFF
--- a/types/jitsi-meet/index.d.ts
+++ b/types/jitsi-meet/index.d.ts
@@ -707,6 +707,10 @@ export interface JitsiMeetExternalAPI extends TypedEventEmitter<ExternalAPIEvent
     dispose(): void;
 }
 
+export interface JitsiMeetExternalAPIConstructor {
+    new(domain: string, options?: ExternalAPIOptions): JitsiMeetExternalAPI;
+}
+
 // this helps with `import type Jitsi` declarations as sometimes babel can get upset that the implementation is loaded
 // at runtime
 export as namespace Jitsi

--- a/types/jitsi-meet/index.d.ts
+++ b/types/jitsi-meet/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package jitsi-meet 2.0
 // Project: https://github.com/jitsi/jitsi-meet
 // Definitions by: Tom Price <https://github.com/tomtom5152>
+//                 Philipp Katz <https://github.com/qqilihq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.1
 
@@ -604,6 +605,7 @@ export interface ExternalAPIEventCallbacks {
     participantRoleChanged: (e: ParticipantRoleChangedEvent) => void;
     passwordRequired: () => void;
     videoConferenceJoined: (e: VideoConferenceJoinedEvent) => void;
+    videoConferenceLeft: (e: VideoConferenceLeftEvent) => void;
     videoAvailabilityChanged: (e: VideoAvailabilityChangedEvent) => void;
     videoMuteStatusChanged: (e: VideoMuteStatusChangedEvent) => void;
     videoQualityChanged: (e: VideoQualityChangedEvent) => void;

--- a/types/jitsi-meet/jitsi-meet-tests.ts
+++ b/types/jitsi-meet/jitsi-meet-tests.ts
@@ -5,6 +5,7 @@ import {
     InterfaceConfig,
     JitsiMeetExternalAPI, RecordingMode,
     RecordingOptions, VideoConferenceJoinedEvent,
+    JitsiMeetExternalAPIConstructor
 } from 'jitsi-meet/index';
 
 /**
@@ -329,44 +330,43 @@ const options: ExternalAPIOptions = {
     },
 };
 
-// These current don't work due to the implementation being dynamically loaded at runtime.
-// They are kept here as an example test for future use should Jitsi publish as module rather than dynamic loading.
-//
-// const api = new JitsiMeetExternalAPI('typescript', options)
-//
-// api.captureLargeVideoScreenshot().then()
-// api.getAvailableDevices().then()
-// api.getCurrentDevices().then()
-// let getParticipantsInfo: any = api.getParticipantsInfo()
-// let getVideoQuality: any = api.getVideoQuality()
-// api.isDeviceListAvailable().then()
-// api.isMultipleAudioInputSupported().then()
-// api.pinParticipant('typescript')
-// api.resizeLargeVideo(1440,  1080)
-// api.setAudioInputDevice('mic', 'atype')
-// api.setAudioOutputDevice('speaker', 'atype')
-// api.setLargeVideoParticipant('typescript')
-// api.setVideoInputDevice('camera', 'vtype')
-// api.startRecording({
-//     mode: 'stream',
-//     dropboxToken: 'drop',
-//     shouldShare: false,
-//     rtmpStreamKey: 'rtmp',
-//     rtmpBroadcastID: 'rtmp',
-//     youtubeStreamKey: 'youtube',
-//     youtubeBroadcastID: 'youtube',
-// })
-// api.stopRecording('file')
-// api.executeCommand('toggleTileView')
-// let getNumberOfParticipants: number = api.getNumberOfParticipants()
-// let getAvatarURL: string = api.getAvatarURL('typescript')
-// let getDisplayName: string = api.getDisplayName('typescript')
-// let getEmail: string = api.getEmail('typescript')
-// let getIFrame: HTMLIFrameElement = api.getIFrame()
-// api.isAudioMuted().then()
-// api.isVideoMuted().then()
-// api.isAudioAvailable().then()
-// api.isVideoAvailable().then()
-// api.dispose()
-//
-// api.addListener('videoConferenceJoined', (e: VideoConferenceJoinedEvent) => {})
+const JitsiMeetExternalAPI = (window as any).JitsiMeetExternalAPI as JitsiMeetExternalAPIConstructor;
+
+const api = new JitsiMeetExternalAPI('typescript', options);
+
+api.captureLargeVideoScreenshot().then();
+api.getAvailableDevices().then();
+api.getCurrentDevices().then();
+const getParticipantsInfo: any = api.getParticipantsInfo();
+const getVideoQuality: any = api.getVideoQuality();
+api.isDeviceListAvailable().then();
+api.isMultipleAudioInputSupported().then();
+api.pinParticipant('typescript');
+api.resizeLargeVideo(1440,  1080);
+api.setAudioInputDevice('mic', 'atype');
+api.setAudioOutputDevice('speaker', 'atype');
+api.setLargeVideoParticipant('typescript');
+api.setVideoInputDevice('camera', 'vtype');
+api.startRecording({
+    mode: 'stream',
+    dropboxToken: 'drop',
+    shouldShare: false,
+    rtmpStreamKey: 'rtmp',
+    rtmpBroadcastID: 'rtmp',
+    youtubeStreamKey: 'youtube',
+    youtubeBroadcastID: 'youtube',
+});
+api.stopRecording('file');
+api.executeCommand('toggleTileView');
+const getNumberOfParticipants: number = api.getNumberOfParticipants();
+const getAvatarURL: string = api.getAvatarURL('typescript');
+const getDisplayName: string = api.getDisplayName('typescript');
+const getEmail: string = api.getEmail('typescript');
+const getIFrame: HTMLIFrameElement = api.getIFrame();
+api.isAudioMuted().then();
+api.isVideoMuted().then();
+api.isAudioAvailable().then();
+api.isVideoAvailable().then();
+api.dispose();
+
+api.addListener('videoConferenceJoined', (e: VideoConferenceJoinedEvent) => {});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#videoconferenceleft
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Besides adding the missing event `videoconferenceleft`, I added a constructor interface for the `JitsiMeetExternalAPI`. This will at least give a signature for the constructor, which improves the previous state as described in the tests:

> These current don't work due to the implementation being dynamically loaded at runtime. They are kept here as an example test for future use should Jitsi publish as module rather than dynamic loading.

I am currently using it as follows:

```
const JitsiMeetExternalAPI = (window as any).JitsiMeetExternalAPI as JitsiMeetExternalAPIConstructor;
```

Still not super-beautiful, but at least I have a properly typed constructor this way.

Hope this makes sense :-)
