### PR TITLE
[@types/chrome] Make argument in chrome.devtools.inspectedWindow.eval optional

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2028,7 +2028,7 @@ declare namespace chrome.devtools.inspectedWindow {
      */
     export function eval<T>(
         expression: string,
-        options: EvalOptions,
+        options?: EvalOptions,
         callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
     ): void;
     /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -568,6 +568,12 @@ chrome.devtools.network.getHAR((harLog: chrome.devtools.network.HARLog) => {
     console.log('harLog: ', harLog);
 });
 
+function testDevtools() {
+    chrome.devtools.inspectedWindow.eval('1+1', undefined, result => {
+        console.log(result);
+    });
+}
+
 function testAssistiveWindow() {
     chrome.input.ime.setAssistiveWindowProperties({
         contextID: 0,


### PR DESCRIPTION
In @types/chrome, there is a function `chrome.devtools.inspectedWindow.eval()`

According to [the docs](https://developer.chrome.com/docs/extensions/reference/devtools_inspectedWindow/#method-eval), the second argument "options" should be optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/devtools_inspectedWindow/#method-eval
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.