### PR TITLE
Enable inferring types when using assert function for custom format

### DIFF
--- a/types/convict/convict-tests.ts
+++ b/types/convict/convict-tests.ts
@@ -53,6 +53,18 @@ convict({
     },
 });
 
+interface Foo {
+    a: string;
+    b?: number;
+}
+// $ExpectType Config<{ foo: Foo; }>
+convict({
+    foo: {
+        format(val): asserts val is Foo {},
+        default: { a: "a" },
+    },
+});
+
 convict.addFormats({
     prime: {
         validate(val) {

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -78,7 +78,7 @@ declare namespace convict {
          * If omitted, format will be set to the value of Object.prototype.toString.call
          * for the default value
          */
-        format?: PredefinedFormat | any[] | ((val: any) => void);
+        format?: PredefinedFormat | any[] | ((val: any) => asserts val is T) | ((val: any) => void);
         env?: string;
         arg?: string;
         sensitive?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/convict#user-content-custom-format-checking>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.