### PR TITLE
node-forge: add missing "sha512" in hmac algorithm type

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -756,7 +756,7 @@ declare module "node-forge" {
 
     namespace hmac {
 
-      type Algorithm = "sha1" | "md5" | "sha256";
+      type Algorithm = "sha1" | "md5" | "sha256" | "sha512";
 
       interface HMAC {
           digest(): util.ByteBuffer;

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -429,3 +429,31 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
 {
     publicKeyRsa.n.bitLength();
 }
+
+{
+  const hmac = forge.hmac.create();
+  hmac.start('md5', 'Jefe');
+  hmac.update('what do ya want for nothing?');
+  const ret = hmac.digest().toHex();
+}
+
+{
+  const hmac = forge.hmac.create();
+  hmac.start('sha1', 'Jefe');
+  hmac.update('what do ya want for nothing?');
+  const ret = hmac.digest().toHex();
+}
+
+{
+  const hmac = forge.hmac.create();
+  hmac.start('sha256', 'Jefe');
+  hmac.update('what do ya want for nothing?');
+  const ret = hmac.digest().toHex();
+}
+
+{
+  const hmac = forge.hmac.create();
+  hmac.start('sha512', 'Jefe');
+  hmac.update('what do ya want for nothing?');
+  const ret = hmac.digest().toHex();
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge/commit/dc980d8465fca06ec1ef97bf92f6024bbcb51452
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

