### PR TITLE
react: add `csp` string attribute to IframeHTMLAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2040,6 +2040,7 @@ declare namespace React {
         allow?: string;
         allowFullScreen?: boolean;
         allowTransparency?: boolean;
+        csp?: string;
         /** @deprecated */
         frameBorder?: number | string;
         height?: number | string;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -32,6 +32,7 @@ const testCases = [
     <input value={['one', 'two'] as string[]} />,
     <input value={['one', 'two']} />,
     <input enterKeyHint="done" />,
+    <iframe csp="default-src 'none';"></iframe>,
     // $ExpectError
     <input enterKeyHint="don" />,
     <video disableRemotePlayback />

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -2854,6 +2854,7 @@ declare namespace React {
     interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean;
         allowTransparency?: boolean;
+        csp?: string;
         frameBorder?: number | string;
         height?: number | string;
         marginHeight?: number;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -2042,6 +2042,7 @@ declare namespace React {
         allow?: string;
         allowFullScreen?: boolean;
         allowTransparency?: boolean;
+        csp?: string;
         /** @deprecated */
         frameBorder?: number | string;
         height?: number | string;


### PR DESCRIPTION
The `csp` attribute (https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/csp) was missing from the `IframeHTMLAttributes` interface, so e.g. the `<iframe csp="…">` TSX template would not compile. I added the missing `csp` attribute to the `IframeHTMLAttributes` interface in v17, v16 and v15 as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/csp
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.