### PR TITLE
@types/jasmine fix typings for toHaveBeenCalledWith methods to allow AsymmetricMatcher in properties

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -718,7 +718,7 @@ declare namespace jasmine {
     }
 
     type MatchableArgs<Fn> = Fn extends (...args: infer P) => any
-        ? { [K in keyof P]: P[K] | AsymmetricMatcher<any> }
+        ? { [K in keyof P]: Expected<P[K]> }
         : never;
 
     interface FunctionMatchers<Fn extends Func> extends Matchers<any> {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -928,37 +928,101 @@ describe("A spy, when created manually", () => {
 });
 
 describe("a spy on a typed method", () => {
-    class Test {
-        method(arg: number): string {
-            return "42";
+    describe("method parameter is primitive", () => {
+        class Test {
+            method(arg: number): string {
+                return "42";
+            }
         }
-    }
 
-    let t: Test;
+        let t: Test;
 
-    beforeEach(() => {
-        t = new Test();
+        beforeEach(() => {
+            t = new Test();
+        });
+
+        it("should match only call arguments with the correct type", () => {
+            const spy = spyOn(t, "method");
+            t.method(1);
+
+            expect(t.method).toHaveBeenCalledWith(1);
+            expect(t.method).toHaveBeenCalledWith("1"); // $ExpectError
+            expect(t.method).not.toHaveBeenCalledWith("1"); // $ExpectError
+
+            expect(spy).toHaveBeenCalledWith(1);
+            expect(spy).toHaveBeenCalledWith("1"); // $ExpectError
+            expect(spy).not.toHaveBeenCalledWith("1"); // $ExpectError
+
+            expect(t.method).toHaveBeenCalledOnceWith(1);
+            expect(t.method).toHaveBeenCalledOnceWith("1"); // $ExpectError
+            expect(t.method).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+
+            expect(spy).toHaveBeenCalledOnceWith(1);
+            expect(spy).toHaveBeenCalledOnceWith("1"); // $ExpectError
+            expect(spy).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+        });
     });
 
-    it("should match only call arguments with the correct type", () => {
-        const spy = spyOn(t, "method");
-        t.method(1);
+    describe("method parameter is an object", () => {
+        interface ObjectProperty {
+            prop1: string;
+            prop2: number;
+        }
 
-        expect(t.method).toHaveBeenCalledWith(1);
-        expect(t.method).toHaveBeenCalledWith("1"); // $ExpectError
-        expect(t.method).not.toHaveBeenCalledWith("1"); // $ExpectError
+        interface ObjectParam {
+            prop1: string;
+            prop2: ObjectProperty;
+        }
 
-        expect(spy).toHaveBeenCalledWith(1);
-        expect(spy).toHaveBeenCalledWith("1"); // $ExpectError
-        expect(spy).not.toHaveBeenCalledWith("1"); // $ExpectError
+        class Test {
+            method(arg: ObjectParam): string {
+                return "42";
+            }
+        }
 
-        expect(t.method).toHaveBeenCalledOnceWith(1);
-        expect(t.method).toHaveBeenCalledOnceWith("1"); // $ExpectError
-        expect(t.method).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+        let t: Test;
 
-        expect(spy).toHaveBeenCalledOnceWith(1);
-        expect(spy).toHaveBeenCalledOnceWith("1"); // $ExpectError
-        expect(spy).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+        beforeEach(() => {
+            t = new Test();
+        });
+
+        it("should match only call arguments with the correct type", () => {
+            const spy = spyOn(t, "method");
+            t.method({ prop1: 'prop1', prop2: { prop1: 'deep-prop1', prop2: 10 }});
+
+            expect(t.method).toHaveBeenCalledWith({ prop1: 'prop1', prop2: { prop1: 'deep-prop1', prop2: 10 }});
+            expect(t.method).toHaveBeenCalledWith("1"); // $ExpectError
+            expect(t.method).not.toHaveBeenCalledWith("1"); // $ExpectError
+
+            expect(spy).toHaveBeenCalledWith({ prop1: 'prop1', prop2: { prop1: 'deep-prop1', prop2: 10 }});
+            expect(spy).toHaveBeenCalledWith("1"); // $ExpectError
+            expect(spy).not.toHaveBeenCalledWith("1"); // $ExpectError
+
+            expect(t.method).toHaveBeenCalledOnceWith({ prop1: 'prop1', prop2: { prop1: 'deep-prop1', prop2: 10 }});
+            expect(t.method).toHaveBeenCalledOnceWith("1"); // $ExpectError
+            expect(t.method).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+
+            expect(spy).toHaveBeenCalledOnceWith({ prop1: 'prop1', prop2: { prop1: 'deep-prop1', prop2: 10 }});
+            expect(spy).toHaveBeenCalledOnceWith("1"); // $ExpectError
+            expect(spy).not.toHaveBeenCalledOnceWith("1"); // $ExpectError
+        });
+
+        it("should match arguments using jasmine matchers", () => {
+            const spy = spyOn(t, "method");
+            t.method({ prop1: 'prop1', prop2: { prop1: 'deep-prop1', prop2: 10 }});
+
+            expect(t.method).toHaveBeenCalledWith({ prop1: jasmine.any(String), prop2: { prop1: 'deep-prop1', prop2: jasmine.any(Number) }});
+            expect(t.method).toHaveBeenCalledWith(jasmine.any(Object));
+
+            expect(spy).toHaveBeenCalledWith({ prop1: jasmine.any(String), prop2: { prop1: 'deep-prop1', prop2: jasmine.any(Number) }});
+            expect(spy).toHaveBeenCalledWith(jasmine.any(Object));
+
+            expect(t.method).toHaveBeenCalledOnceWith({ prop1: jasmine.any(String), prop2: { prop1: 'deep-prop1', prop2: jasmine.any(Number) }});
+            expect(t.method).toHaveBeenCalledOnceWith(jasmine.any(Object));
+
+            expect(spy).toHaveBeenCalledOnceWith({ prop1: jasmine.any(String), prop2: { prop1: 'deep-prop1', prop2: jasmine.any(Number) }});
+            expect(spy).toHaveBeenCalledOnceWith(jasmine.any(Object));
+        });
     });
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/3.7/matchers.html


`toHaveBeenCalledWith` methods use the same equality check present in `toEqual` meaning that an AsymmetricMatcher (jasmine.any, jasmine.anything, jasmine.objectContaining, etc) can be used as a value of a property when a parameter is an object.
At the moment if `jasmine.any()` is used there is an error saying that AsymmetricMatcher doesn't match the type of the property. This PR aligns the typings to reflect this capability.
The added unit tests should help prove the above and making it clearer.