### PR TITLE
fix(randomatic): allow numeric input

### DIFF
--- a/types/randomatic/index.d.ts
+++ b/types/randomatic/index.d.ts
@@ -1,15 +1,22 @@
 // Type definitions for randomatic 3.1
 // Project: https://github.com/jonschlinkert/randomatic
 // Definitions by: Frelia <https://github.com/execfera>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function randomatic(p: string, l?: number, options?: {
-  chars?: string;
-  exclude?: string | string[];
-}): string;
+/**
+ * Generate randomized strings of a specified length using simple character sequences. The original generate-password.
+ */
+declare function randomatic(pattern: string, length?: number, options?: randomatic.Options): string;
+declare function randomatic(length: number): string;
 
 declare namespace randomatic {
-  const isCrypto: boolean;
+    const isCrypto: boolean;
+
+    interface Options {
+        chars?: string;
+        exclude?: string | string[];
+    }
 }
 
 export = randomatic;

--- a/types/randomatic/randomatic-tests.ts
+++ b/types/randomatic/randomatic-tests.ts
@@ -1,5 +1,6 @@
-import * as randomize from 'randomatic';
+import randomize = require('randomatic');
 
 randomize('*', 10); // $ExpectedType string
 randomize('?', 20, { chars: 'jonschlinkert' }); // $ExpectedType string
 randomize('*', 20, { exclude: '0oOiIlL1' }); // $ExpectedType string
+randomize(10); // $ExpectTYpe string


### PR DESCRIPTION
This package generates random string of the lenght of the single
parameter:

```js
randomatic(10); // `wjL)g!SrK$'`
```

This fixes usage on this use-case:
https://github.com/jonschlinkert/randomatic/blob/master/index.js#L55

- tests amended
- maintainer added

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes