### PR TITLE
fix(random-words): narrow input types and function returns

### DIFF
--- a/types/random-words/index.d.ts
+++ b/types/random-words/index.d.ts
@@ -12,10 +12,10 @@ declare function words(
         join: string;
     },
 ): string;
-declare function words(options: words.Options | number): string | string[];
+declare function words(options: words.Options | number): string[];
 
 declare namespace words {
-    let wordList: string[];
+    const wordList: string[];
 
     interface Options {
         exactly?: number;

--- a/types/random-words/random-words-tests.ts
+++ b/types/random-words/random-words-tests.ts
@@ -1,25 +1,25 @@
-import randomWords = require('random-words');
+import randomWords = require("random-words");
 
 randomWords(); // $ExpectType string
 
-randomWords(5); // $ExpectType string | string[]
+randomWords(5); // $ExpectType string[]
 
-randomWords({ min: 3, max: 10 }); // $ExpectType string | string[]
-randomWords({ exactly: 2 }); // $ExpectType string | string[]
+randomWords({ min: 3, max: 10 }); // $ExpectType string[]
+randomWords({ exactly: 2 }); // $ExpectType string[]
 
-randomWords({ exactly: 5, join: ' ' }); // $ExpectType string
+randomWords({ exactly: 5, join: " " }); // $ExpectType string
 
-randomWords({ exactly: 5, join: '' }); // $ExpectType string
+randomWords({ exactly: 5, join: "" }); // $ExpectType string
 
-randomWords({ exactly: 5, maxLength: 4 }); // $ExpectType string | string[]
+randomWords({ exactly: 5, maxLength: 4 }); // $ExpectType string[]
 
-randomWords({ exactly: 5, wordsPerString: 2 }); // $ExpectType string | string[]
+randomWords({ exactly: 5, wordsPerString: 2 }); // $ExpectType string[]
 
-randomWords({ exactly: 5, wordsPerString: 2, separator: '-' }); // $ExpectType string | string[]
+randomWords({ exactly: 5, wordsPerString: 2, separator: "-" }); // $ExpectType string[]
 
-randomWords({ exactly: 5, wordsPerString: 2, formatter: word => word.toUpperCase() }); // $ExpectType string | string[]
+randomWords({ exactly: 5, wordsPerString: 2, formatter: word => word.toUpperCase() }); // $ExpectType string[]
 
-// $ExpectType string | string[]
+// $ExpectType string[]
 randomWords({
     exactly: 5,
     wordsPerString: 2,


### PR DESCRIPTION
- never outputs a string, if 'exactly' (or derived) property is used
- never outpus a string, if no parameters are used
- otuputs a string if join option is used

https://github.com/punkave/random-words/blob/master/index.js

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).