### PR TITLE
[@types/copy-webpack-plugin] fix: don't make webpack as dependencies

### DIFF
--- a/types/copy-webpack-plugin/package.json
+++ b/types/copy-webpack-plugin/package.json
@@ -1,7 +1,12 @@
 {
     "private": true,
-    "dependencies": {
-        "tapable": "^2.0.0",
+    "peerDependencies": {
+        "webpack": ">=4.0.0 <6.0.0"
+    },
+    "devDependencies": {
         "webpack": "^5.1.0"
+    },
+    "dependencies": {
+        "tapable": "^2.0.0"
     }
 }

--- a/types/copy-webpack-plugin/package.json
+++ b/types/copy-webpack-plugin/package.json
@@ -1,8 +1,5 @@
 {
     "private": true,
-    "peerDependencies": {
-        "webpack": ">=4.0.0 <6.0.0"
-    },
     "devDependencies": {
         "webpack": "^5.1.0"
     },


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
---

Using `webpack` as dependencies would fail if something changed on minor update of webpack. Webpack v5.37.0 fail with this error:
```
Type 'CopyPlugin' is not assignable to type '((this: Compiler, compiler: Compiler) => void) | WebpackPluginInstance'.
  Type 'CopyPlugin' is not assignable to type 'WebpackPluginInstance'.
    Types of property 'apply' are incompatible.
      Type '(compiler: import("/home/latipun7/projects/aladine/node_modules/@types/copy-webpack-plugin/node_modules/webpack/types").Compiler) => void' is not assignable to type '(compiler: import("/home/latipun7/projects/aladine/node_modules/webpack/types").Compiler) => void'.
        Types of parameters 'compiler' and 'compiler' are incompatible.
          Type 'import("/home/latipun7/projects/aladine/node_modules/webpack/types").Compiler' is not assignable to type 'import("/home/latipun7/projects/aladine/node_modules/@types/copy-webpack-plugin/node_modules/webpack/types").Compiler'.
            The types of 'hooks.shouldEmit' are incompatible between these types.
              Type 'import("/home/latipun7/projects/aladine/node_modules/tapable/tapable").SyncBailHook<[import("/home/latipun7/projects/aladine/node_modules/webpack/types").Compilation], boolean, import("/home/latipun7/projects/aladine/node_modules/tapable/tapable").UnsetAdditionalOptions>' is not assignable to type 'import("/home/latipun7/projects/aladine/node_modules/tapable/tapable").SyncBailHook<[import("/home/latipun7/projects/aladine/node_modules/@types/copy-webpack-plugin/node_modules/webpack/types").Compilation], boolean, import("/home/latipun7/projects/aladine/node_modules/tapable/tapable").UnsetAdditionalOptions>'.ts(2322)
View Problem (Alt+F8)
No quick fixes available
```
---
Edit: turned out this is my misunderstanding and inexperienced. I'm sorry.
