### PR TITLE
[aws-lambda] Add AppSyncBatchResolverHandler

### DIFF
--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -1,4 +1,9 @@
-import { AppSyncIdentityCognito, AppSyncIdentityIAM, AppSyncResolverHandler } from 'aws-lambda';
+import {
+    AppSyncIdentityCognito,
+    AppSyncIdentityIAM,
+    AppSyncResolverHandler,
+    AppSyncBatchResolverHandler
+} from 'aws-lambda';
 
 declare let objectOrNull: {} | null;
 declare let prevResultOrNull: { result: { [key: string]: any } } | null;
@@ -13,6 +18,19 @@ interface TestEntity {
     name: string;
     check: boolean;
 }
+
+const batchHandler: AppSyncBatchResolverHandler<TestArguments, TestEntity> = async (event) => {
+    array = event;
+    str = event[0].id;
+    str = event[0].query;
+    return [
+        {
+            id: '',
+            name: '',
+            check: true,
+        }
+    ];
+};
 
 const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event, context) => {
     str = event.arguments.id;

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -1,6 +1,7 @@
 import { Handler } from '../handler';
 
 export type AppSyncResolverHandler<T, V> = Handler<AppSyncResolverEvent<T>, V | V[]>;
+export type AppSyncBatchResolverHandler<T, V> = Handler<T[], V[]>;
 
 export interface AppSyncResolverEventHeaders {
     [name: string]: string | undefined;


### PR DESCRIPTION
AppSync supports batch-invoking Lambda function.

This PR adds `AppSyncBatchResolverHandler<T, V>` type which represent the shape of functions to be batch-invoked.

* A request payload is `T[]`, a batch  of single request `T`.
* A response payload is `V[]`, a list of single response `V`.

Refer https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-lambda.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
