### PR TITLE
[iobroker] disallow setting non-primitives, allow settings states without val

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ioBroker 3.2
+// Type definitions for ioBroker 3.3
 // Project: https://github.com/ioBroker/ioBroker, http://iobroker.net
 // Definitions by: AlCalzone <https://github.com/AlCalzone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,6 +11,9 @@
 /// <reference types="node" />
 /// <reference path="./objects.d.ts" />
 import * as fs from 'fs';
+export {}; // avoids exporting AtLeastOne into the global scope
+
+type AtLeastOne<T, U = {[K in keyof T]-?: T[K] }> = { [K in keyof U]: {[P in K]: U[P]} }[keyof U];
 
 declare global {
     namespace ioBroker {
@@ -28,7 +31,7 @@ declare global {
 
         interface State {
             /** The value of the state. */
-            val: string | number | boolean | any[] | Record<string, any> | null;
+            val: string | number | boolean | null;
 
             /** Direction flag: false for desired value and true for actual value. Default: false. */
             ack: boolean;
@@ -54,7 +57,8 @@ declare global {
             /** Optional comment */
             c?: string;
         }
-        type SettableState = Partial<Omit<State, 'val'>> & Pick<State, 'val'>;
+
+        type SettableState = AtLeastOne<State>;
 
         type Session = any; // TODO: implement
 
@@ -748,24 +752,24 @@ declare global {
             // tslint:disable:unified-signatures
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -773,41 +777,41 @@ declare global {
             /** Writes a value into the states DB. */
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack?: boolean,
             ): SetStatePromise;
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options?: unknown,
             ): SetStatePromise;
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStatePromise;
             /** Writes a value into the states DB only if it has changed. */
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -815,41 +819,41 @@ declare global {
             /** Writes a value into the states DB only if it has changed. */
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack?: boolean,
             ): SetStateChangedPromise;
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options?: unknown,
             ): SetStateChangedPromise;
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStateChangedPromise;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -857,41 +861,41 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack?: boolean,
             ): SetStatePromise;
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options?: unknown,
             ): SetStatePromise;
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStatePromise;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -899,17 +903,17 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack?: boolean,
             ): SetStateChangedPromise;
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 options?: unknown,
             ): SetStateChangedPromise;
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState | null,
+                state: State | State["val"] | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStateChangedPromise;

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -29,9 +29,11 @@ declare global {
             sensor_reports_error = 0x84,
         }
 
+        type StateValue = string | number | boolean | null;
+
         interface State {
             /** The value of the state. */
-            val: string | number | boolean | null;
+            val: StateValue;
 
             /** Direction flag: false for desired value and true for actual value. Default: false. */
             ack: boolean;
@@ -752,24 +754,24 @@ declare global {
             // tslint:disable:unified-signatures
             setState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -777,41 +779,41 @@ declare global {
             /** Writes a value into the states DB. */
             setStateAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack?: boolean,
             ): SetStatePromise;
             setStateAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options?: unknown,
             ): SetStatePromise;
             setStateAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStatePromise;
             /** Writes a value into the states DB only if it has changed. */
             setStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -819,41 +821,41 @@ declare global {
             /** Writes a value into the states DB only if it has changed. */
             setStateChangedAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack?: boolean,
             ): SetStateChangedPromise;
             setStateChangedAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options?: unknown,
             ): SetStateChangedPromise;
             setStateChangedAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStateChangedPromise;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -861,41 +863,41 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignStateAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack?: boolean,
             ): SetStatePromise;
             setForeignStateAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options?: unknown,
             ): SetStatePromise;
             setForeignStateAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStatePromise;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -903,17 +905,17 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChangedAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack?: boolean,
             ): SetStateChangedPromise;
             setForeignStateChangedAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 options?: unknown,
             ): SetStateChangedPromise;
             setForeignStateChangedAsync(
                 id: string,
-                state: State | State["val"] | SettableState,
+                state: State | StateValue | SettableState,
                 ack: boolean,
                 options: unknown,
             ): SetStateChangedPromise;

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -543,6 +543,38 @@ adapter.setForeignStateChanged("id", ["an", "array"]);
 adapter.setStateChangedAsync("id", ["an", "array"]);
 // $ExpectError
 adapter.setForeignStateChangedAsync("id", ["an", "array"]);
+// $ExpectError
+adapter.setState("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setForeignState("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setStateAsync("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setForeignStateAsync("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setStateChanged("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setForeignStateChanged("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setStateChangedAsync("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setForeignStateChangedAsync("id", {val: {an: "object"}});
+// $ExpectError
+adapter.setState("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setForeignState("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setStateAsync("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setForeignStateAsync("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setStateChanged("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setForeignStateChanged("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setStateChangedAsync("id", {val: ["an", "array"]});
+// $ExpectError
+adapter.setForeignStateChangedAsync("id", {val: ["an", "array"]});
 
 // Allow alias states
 adapter.getObjectAsync("id").then(obj => obj && obj.type === "state" && obj.common.alias && obj.common.alias.id.toUpperCase());

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -492,9 +492,11 @@ const folderObj: ioBroker.FolderObject = {
     native: {},
 };
 
-// Repro from https://github.com/ioBroker/ioBroker.js-controller/issues/782
-// $ExpectError
+// This used to be an error: https://github.com/ioBroker/ioBroker.js-controller/issues/782
+// With JS-Controller 3.3 it no longer is.
 adapter.setState('id', { ack: false });
+// $ExpectError
+adapter.setState('id', {});
 
 // null is a valid state value
 adapter.setState("id", null);
@@ -507,6 +509,40 @@ adapter.setStateChangedAsync("id", null);
 adapter.setForeignStateChangedAsync("id", null);
 adapter.delBinaryState("id");
 adapter.delBinaryStateAsync("id").then(() => null);
+
+// Objects and arrays are not valid state values
+// $ExpectError
+adapter.setState("id", {an: "object"});
+// $ExpectError
+adapter.setForeignState("id", {an: "object"});
+// $ExpectError
+adapter.setStateAsync("id", {an: "object"});
+// $ExpectError
+adapter.setForeignStateAsync("id", {an: "object"});
+// $ExpectError
+adapter.setStateChanged("id", {an: "object"});
+// $ExpectError
+adapter.setForeignStateChanged("id", {an: "object"});
+// $ExpectError
+adapter.setStateChangedAsync("id", {an: "object"});
+// $ExpectError
+adapter.setForeignStateChangedAsync("id", {an: "object"});
+// $ExpectError
+adapter.setState("id", ["an", "array"]);
+// $ExpectError
+adapter.setForeignState("id", ["an", "array"]);
+// $ExpectError
+adapter.setStateAsync("id", ["an", "array"]);
+// $ExpectError
+adapter.setForeignStateAsync("id", ["an", "array"]);
+// $ExpectError
+adapter.setStateChanged("id", ["an", "array"]);
+// $ExpectError
+adapter.setForeignStateChanged("id", ["an", "array"]);
+// $ExpectError
+adapter.setStateChangedAsync("id", ["an", "array"]);
+// $ExpectError
+adapter.setForeignStateChangedAsync("id", ["an", "array"]);
 
 // Allow alias states
 adapter.getObjectAsync("id").then(obj => obj && obj.type === "state" && obj.common.alias && obj.common.alias.id.toUpperCase());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ioBroker/ioBroker.js-controller/blob/5623364759f8d024ef8913d3b0ed9a8bac63c2b1/lib/adapter.js#L1760-L1772, https://github.com/ioBroker/ioBroker.js-controller/blob/5623364759f8d024ef8913d3b0ed9a8bac63c2b1/lib/adapter.js#L6095
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
