### PR TITLE
Add type defs for saml package v1.0

### DIFF
--- a/types/saml/index.d.ts
+++ b/types/saml/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for saml 0.13
+// Type definitions for saml 1.0
 // Project: https://github.com/auth0/node-saml#readme
-// Definitions by: Eric Heikes <https://github.com/eheikes>
+// Definitions by: Eric Heikes <https://github.com/eheikes>, Eva Sarafianou <https://github.com/esarafianou>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -13,7 +13,7 @@ export interface KeyInfoProvider {
     getKeyInfo(key: string, prefix: string): string;
 }
 
-export interface SamlOpts {
+export interface SamlSignedOpts {
     authnContextClassRef?: string;
     attributes?: SamlAttributes;
     audiences?: string | string[];
@@ -27,7 +27,7 @@ export interface SamlOpts {
     inResponseTo?: string;
     issuer?: string;
     key: Buffer;
-    keyEncryptionAlgorighm?: string; // sic https://github.com/auth0/node-xml-encryption/issues/17
+    keyEncryptionAlgorithm?: string;
     keyInfoProvider?: KeyInfoProvider;
     lifetimeInSeconds?: number;
     nameIdentifier?: string;
@@ -43,10 +43,41 @@ export interface SamlOpts {
     xpathToNodeBeforeSignature?: string;
 }
 
+export interface SamlUnassignedOpts {
+    authnContextClassRef?: string;
+    attributes?: SamlAttributes;
+    audiences?: string | string[];
+    cert?: Buffer;
+    digestAlgorithm?: string;
+    encryptionAlgorithm?: string;
+    encryptionCert?: Buffer;
+    encryptionPublicKey?: Buffer;
+    holderOfKeyProofSecret?: string;
+    includeAttributeNameFormat?: boolean;
+    inResponseTo?: string;
+    issuer?: string;
+    key?: Buffer;
+    keyEncryptionAlgorithm?: string;
+    keyInfoProvider?: KeyInfoProvider;
+    lifetimeInSeconds?: number;
+    nameIdentifier?: string;
+    nameIdentifierFormat?: string;
+    prefix?: string;
+    recipient?: string;
+    sessionIndex?: string;
+    signatureAlgorithm?: string;
+    signatureNamespacePrefix?: string;
+    subjectConfirmationMethod?: string;
+    typedAttributes?: boolean;
+    uid?: string;
+    xpathToNodeBeforeSignature?: string;
+}
 export namespace Saml11 {
-    function create(opts: SamlOpts, cb?: (err: Error | null, result: any[], proofSecret: Buffer) => void): any;
+    function create(opts: SamlSignedOpts, cb?: (err: Error | null, result: any[], proofSecret: Buffer) => void): any;
+    function createUnsignedAssertion(opts: SamlUnassignedOpts, cb?: (err: Error | null, result: any[], proofSecret: Buffer) => void): any;
 }
 
 export namespace Saml20 {
-    function create(opts: SamlOpts, cb?: (err: Error | null, signed: string) => void): any;
+    function create(opts: SamlUnassignedOpts, cb?: (err: Error | null, signed: string) => void): any;
+    function createUnsignedAssertion(opts: SamlUnassignedOpts, cb?: (err: Error | null, signed: string) => void): any;
 }

--- a/types/saml/saml-tests.ts
+++ b/types/saml/saml-tests.ts
@@ -1,4 +1,4 @@
-import { KeyInfoProvider, Saml11, Saml20, SamlAttributes, SamlOpts } from 'saml';
+import { KeyInfoProvider, Saml11, Saml20, SamlAttributes, SamlSignedOpts, SamlUnassignedOpts } from 'saml';
 
 Saml11.create({
     cert: Buffer.from('certificate'),
@@ -22,12 +22,50 @@ Saml11.create(
     () => {}
 );
 
+Saml11.createUnsignedAssertion({}, () => {});
+
+Saml11.createUnsignedAssertion(
+    {
+        cert: Buffer.from('certificate'),
+        key: Buffer.from('key'),
+        issuer: 'urn:issuer',
+        lifetimeInSeconds: 600,
+        audiences: 'urn:myapp',
+        attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+        },
+        nameIdentifier: 'foo',
+        sessionIndex: '_faed468a-15a0-4668-aed6-3d9c478cc8fa',
+    },
+    () => {}
+);
+
 Saml20.create({
     cert: Buffer.from('certificate'),
     key: Buffer.from('key'),
 });
 
 Saml20.create(
+    {
+        cert: Buffer.from('certificate'),
+        key: Buffer.from('key'),
+        issuer: 'urn:issuer',
+        lifetimeInSeconds: 600,
+        audiences: 'urn:myapp',
+        attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+        },
+        nameIdentifier: 'foo',
+        sessionIndex: '_faed468a-15a0-4668-aed6-3d9c478cc8fa',
+    },
+    () => {}
+);
+
+Saml20.createUnsignedAssertion({}, () => {});
+
+Saml20.createUnsignedAssertion(
     {
         cert: Buffer.from('certificate'),
         key: Buffer.from('key'),


### PR DESCRIPTION
Adds type definitions for saml package version 1.0

## Changes: 
1. `saml11.createUnsignedAssertion()` and `saml11.createUnsignedAssertion()` were added in version 0.15: https://github.com/auth0/node-saml/blob/v1.0.0/CHANGELOG.md#0150-2020-10-01 
2. Version 1.0.0  fixes typo in config property from `keyEncryptionAlgorighm` to `keyEncryptionAlgorithm` consumed by new xml-encryption library version. https://github.com/auth0/node-saml/blob/v1.0.0/CHANGELOG.md#-breaking-changes




Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-saml/blob/v1.0.0/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.