### PR TITLE
fix(jest-when): update When to accept generic function argument

### DIFF
--- a/types/jest-when/example-module.ts
+++ b/types/jest-when/example-module.ts
@@ -1,0 +1,1 @@
+export const toBeMocked = (hello = "world") => hello;

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -1,9 +1,10 @@
 // Type definitions for jest-when 2.7
 // Project: https://github.com/timkindberg/jest-when#readme
-// Definitions by: Alden Taylor <https://github.com/aldentaylor>
-//                 Trung Dang <https://github.com/immanuel192>
-//                 Gregor Stamać <https://github.com/gstamac>
-//                 Valentin Stern <https://github.com/sehsyha>
+// Definitions by: Alden Taylor <https://github.com/aldentaylor>,
+//                 Trung Dang <https://github.com/immanuel192>,
+//                 Gregor Stamać <https://github.com/gstamac>,
+//                 Valentin Stern <https://github.com/sehsyha>,
+//                 Nicholas Hehr <https://github.com/hipsterbrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -23,7 +23,7 @@ export interface WhenMock<T = any, Y extends any[] = any>
   mockImplementationOnce(fn?: (...args: Y) => T): this;
 }
 
-export type When = <T, Y extends any[]>(fn: jest.MockInstance<T, Y>) => WhenMock<T, Y>;
+export type When = <T, Y extends any[]>(fn: ((...args: Y) => T) | jest.MockInstance<T, Y>) => WhenMock<T, Y>;
 
 export const when: When;
 export function resetAllWhenMocks(): void;

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -1,4 +1,7 @@
 import { when, resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
+import { toBeMocked } from './example-module';
+
+jest.mock('./example-module');
 
 describe('mock-when test', () => {
     it('basic usage:', () => {
@@ -178,5 +181,13 @@ describe('mock-when test', () => {
       fn2(1);
 
       expect(verifyAllWhenMocksCalled).not.toThrow();
+    });
+
+    it('allows mocked modules', () => {
+      when(toBeMocked)
+        .calledWith('another one')
+        .mockReturnValue('another one');
+
+      expect(toBeMocked('another one')).toEqual('another one');
     });
 });


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

Updating the types for `When` to fix a common pain point when mocking modules in Jest, described here: https://hipsterbrown.com/musings/musing/typed-jest-mocks/

By adding support for a generic function argument, the types for an imported mocked function can be used to infer the generic type args for `WhenMock`. 