### PR TITLE
fix(rename): correct `parse` input param and outcomes

### DIFF
--- a/types/rename/index.d.ts
+++ b/types/rename/index.d.ts
@@ -3,17 +3,19 @@
 // Definitions by: Aankhen <https://github.com/Aankhen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = Rename;
+export = rename;
 
-declare function Rename(filepath: string | Rename.FileObject, transformer: Rename.Transformer): Rename.FilePath;
+declare function rename(filepath: string | rename.FileObject, transformer: rename.Transformer): rename.FilePath;
 
-declare namespace Rename {
-    interface FileObject { // using package's terminology
+declare namespace rename {
+    interface FileObject {
+        // using package's terminology
         dirname?: string;
         basename?: string;
         extname?: string;
         path?: string;
-        hash?: string;          // not populated by package
+        hash?: string; // not populated by package
+        origin?: string;
     }
 
     interface Specification {
@@ -30,7 +32,14 @@ declare namespace Rename {
     type Transformer = ((spec: FileObject) => FilePath)
         | FilePath;
 
-    function parse(filename: string): FileObject;
+    interface ParsedFileObject {
+        dirname: string;
+        extname: string;
+        basename: string;
+        origin: string;
+    }
+
+    function parse(filename: string | Partial<ParsedFileObject>): ParsedFileObject;
 
     function stringify(obj: FileObject): string;
 }

--- a/types/rename/rename-tests.ts
+++ b/types/rename/rename-tests.ts
@@ -38,9 +38,8 @@ rename({
         suffix: '-${hash}'
     });
 
-rename.parse();                 // $ExpectError
-rename.parse({});               // $ExpectError
-rename.parse("p.js");
+rename.parse("p.js"); // $ExpectType ParsedFileObject
+rename.parse({ dirname: '.'}); // $ExpectType ParsedFileObject
 
 rename.stringify();             // $ExpectError
 


### PR DESCRIPTION
- `parse` takes either a string or an object
- `parse` returns object with 4 known properties only
- 'Rename' to 'rename' internally (to match JS naming conventions)
- tests amended

https://github.com/popomore/rename#renameparse

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).