### PR TITLE
Add string parameter type to `require-all`

### DIFF
--- a/types/require-all/index.d.ts
+++ b/types/require-all/index.d.ts
@@ -11,6 +11,6 @@ interface Options {
     recursive?: true | false;
 }
 
-declare function requireAll(options: Options): {[key: string]: any};
+declare function requireAll(options: string | Options): {[key: string]: any};
 
 export = requireAll;

--- a/types/require-all/require-all-tests.ts
+++ b/types/require-all/require-all-tests.ts
@@ -8,3 +8,5 @@ requireAll({
     map: (name: string, path: string) => name.replace(/_([a-z])/g, `${path}/${name}`),
     resolve: (mClass) => new mClass()
 });
+
+requireAll("./test-directory");


### PR DESCRIPTION
This was always possible in `require-all` 3.0, but it was missing from this definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Context](https://github.com/felixge/node-require-all/tree/v3.0.0#advanced-usage)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.