### PR TITLE
[chrome] Added missing `clearAllCachedAuthTokens` method stub

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4057,6 +4057,19 @@ declare namespace chrome.identity {
     export interface SignInChangeEvent extends chrome.events.Event<(account: AccountInfo, signedIn: boolean) => void> { }
 
     /**
+     * Resets the state of the Identity API:
+     *
+     *  * Removes all OAuth2 access tokens from the token cache
+     *  * Removes user's account preferences
+     *  * De-authorizes the user from all auth flows
+     * @since Chrome 87.
+     * @param callback Called when the state has been cleared.
+     * The parameter should be a function that looks like this:
+     * () => {...};
+     */
+    export function clearAllCachedAuthTokens(callback: () => void): void;
+
+    /**
      * Retrieves a list of AccountInfo objects describing the accounts present on the profile.
      * getAccounts is only supported on dev channel.
      * Dev channel only.


### PR DESCRIPTION
This change adds a stub for the newly added `clearAllCachedAuthTokens` method in the Chrome Identity API: https://developer.chrome.com/docs/extensions/reference/identity/#method-clearAllCachedAuthTokens

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/identity/#method-clearAllCachedAuthTokens

