### PR TITLE
build: Revert force double quotes through prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json.schemastore.org/prettierrc",
     "arrowParens": "avoid",
-    "singleQuote": false,
+    "singleQuote": true,
     "trailingComma": "all",
     "tabWidth": 4,
     "printWidth": 120


### PR DESCRIPTION
Reverts #51436 to avoid unnecessary PR like #52790 which only creates noise changing single to dbl quotes. Also it's not true, that `dslint` is forcing dbl quotes, as otherwise, all the builds would be failing by now. Actually the `quotemark` rule in dtslint is disabled! See https://github.com/microsoft/dtslint/blob/master/dtslint.json#L115. See description of this rule: https://palantir.github.io/tslint/rules/quotemark/

Some more fruitful explanation can be also found in discussion at #51436