### PR TITLE
Add index type to Namespace in argparse.

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -260,12 +260,14 @@ class CustomAction1 extends Action {
         super(options);
     }
     call(parser: ArgumentParser, namespace: Namespace, values: string | string[], optionString: string | null) {
+        namespace[this.dest] = values;
         console.log("custom action 1");
     }
 }
 
 class CustomAction2 extends Action {
     call(parser: ArgumentParser, namespace: Namespace, values: string | string[], optionString: string | null) {
+        namespace.custom = values;
         console.log("custom action 2");
     }
 }

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -26,6 +26,7 @@ export class ArgumentParser extends ArgumentGroup {
 // tslint:disable-next-line:no-unnecessary-class
 export class Namespace {
     constructor(options: object);
+    [key: string]: any;
 }
 
 export class SubParser {


### PR DESCRIPTION
The Namespace class is intended to have options stored on it. As such it should be indexable without casting to any.

Relates to #29597

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/argparse/blob/70fc26eb5a9a829d6ddcceb6b4c87802218227fd/argparse.js#L110 and see places where `setattr` and etc. are called on a namespace.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.