### PR TITLE
New @ckeditor/ckeditor5-cloud-services v27

### DIFF
--- a/types/ckeditor__ckeditor5-cloud-services/ckeditor__ckeditor5-cloud-services-tests.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/ckeditor__ckeditor5-cloud-services-tests.ts
@@ -1,0 +1,22 @@
+import * as CloudServices from "@ckeditor/ckeditor5-cloud-services";
+import { Editor } from "@ckeditor/ckeditor5-core";
+import Token from "@ckeditor/ckeditor5-cloud-services/src/token/token";
+
+class MyEditor extends Editor {}
+
+const instance = new CloudServices.CloudServices(new MyEditor());
+instance.uploadUrl = "foo";
+let token: Token = instance.token!;
+token = instance.getTokenFor("foo");
+instance
+    .registerTokenUrl(() => "foo")
+    .then(t => {
+        token = t;
+    });
+instance.tokenUrl = "foo";
+instance.tokenUrl = () => "foo";
+
+const core = new CloudServices.CloudServicesCore(new MyEditor());
+token = core.createToken("foo");
+token = core.createToken("foo", { autoRefresh: true, initValue: "bar" });
+core.createUploadGateway(token, "foo");

--- a/types/ckeditor__ckeditor5-cloud-services/index.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for @ckeditor/ckeditor5-cloud-services 27.0
+// Project: https://ckeditor.com/docs/ckeditor5/latest/api/cloud-services.html
+// Definitions by: Federico Panico <https://github.com/fedemp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.2
+export { default as CloudServices } from "./src/cloudservices";
+export { default as CloudServicesCore } from "./src/cloudservicescore";

--- a/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
@@ -1,0 +1,49 @@
+import { ContextPlugin } from "@ckeditor/ckeditor5-core";
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import Token from "./token/token";
+import * as engine from "@ckeditor/ckeditor5-engine";
+
+export default class CloudServices extends ContextPlugin implements Emitter, Observable {
+    token: Token | null;
+    tokenUrl?: string | (() => string);
+    uploadUrl: string;
+
+    getTokenFor(tokenUrl: string): Token;
+    registerTokenUrl(tokenUrl: string | (() => string)): Promise<Token>;
+
+    on: (
+        event: string,
+        callback: (info: EventInfo<Emitter>, data: engine.view.observer.DomEventData) => void,
+        options?: { priority: PriorityString | number },
+    ) => void;
+    once(
+        event: string,
+        callback: (info: EventInfo, data: engine.view.observer.DomEventData) => void,
+        options?: { priority: PriorityString | number },
+    ): void;
+    off(event: string, callback?: (info: EventInfo, data: engine.view.observer.DomEventData) => void): void;
+    listenTo(
+        emitter: Emitter,
+        event: string,
+        callback: (info: EventInfo, data: engine.view.observer.DomEventData) => void,
+        options?: { priority?: PriorityString | number },
+    ): void;
+    stopListening(
+        emitter?: Emitter,
+        event?: string,
+        callback?: (info: EventInfo, data: engine.view.observer.DomEventData) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+}
+
+export interface CloudServicesConfig {
+    bundleVersion?: string;
+    tokenUrl: string | (() => string);
+    uploadUrl: string;
+    webSocketUrl?: string;
+}

--- a/types/ckeditor__ckeditor5-cloud-services/src/cloudservicescore.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/cloudservicescore.d.ts
@@ -1,0 +1,12 @@
+import { ContextPlugin } from "@ckeditor/ckeditor5-core";
+import Token from "./token/token";
+import UploadGateway from "./uploadgateway/uploadgateway";
+
+export default class CloudServicesCore extends ContextPlugin {
+    static pluginName: "CloudServicesCore";
+    createToken(
+        tokenUrlOrRefreshToken: string | (() => string),
+        options?: { initValue?: string; autoRefresh?: boolean },
+    ): Token;
+    createUploadGateway(token: Token, apiAddress: string): UploadGateway;
+}

--- a/types/ckeditor__ckeditor5-cloud-services/src/token/token.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/token/token.d.ts
@@ -1,0 +1,24 @@
+import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+
+export default class Token implements Observable {
+    value: string;
+
+    constructor(
+        tokenUrlOrRefreshToken: string | (() => string),
+        options: { initValue?: string; autoRefresh?: boolean },
+    );
+    destroy(): void;
+    init(): Promise<Token>;
+    refreshToken(): Promise<Token>;
+
+    static create(
+        tokenUrlOrRefreshToken: string | (() => string),
+        options: { initValue?: string; autoRefresh?: boolean },
+    ): Promise<Token>;
+
+    set(option: Record<string, unknown>): void;
+    set(name: string, value: unknown): void;
+    bind(...bindProperties: string[]): BindChain;
+    unbind(...unbindProperties: string[]): void;
+    decorate(methodName: string): void;
+}

--- a/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/fileuploader.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/fileuploader.d.ts
@@ -1,0 +1,41 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import Token from "../token/token";
+import * as engine from "@ckeditor/ckeditor5-engine";
+
+export default class FileUploader implements Emitter {
+    file: Blob;
+
+    constructor(fileOrData: string | Blob, token: Token, apiAddress: string);
+    abort(): void;
+    onError(callback: (event: unknown, data: unknown) => void): FileUploader;
+    onProgress(callback: (event: unknown, data: unknown) => void): FileUploader;
+    send(): Promise<unknown>;
+
+    on: (
+        event: string,
+        callback: (info: EventInfo<Emitter>, data: engine.view.observer.DomEventData) => void,
+        options?: { priority: PriorityString | number },
+    ) => void;
+    once(
+        event: string,
+        callback: (info: EventInfo, data: engine.view.observer.DomEventData) => void,
+        options?: { priority: PriorityString | number },
+    ): void;
+    off(event: string, callback?: (info: EventInfo, data: engine.view.observer.DomEventData) => void): void;
+    listenTo(
+        emitter: Emitter,
+        event: string,
+        callback: (info: EventInfo, data: engine.view.observer.DomEventData) => void,
+        options?: { priority?: PriorityString | number },
+    ): void;
+    stopListening(
+        emitter?: Emitter,
+        event?: string,
+        callback?: (info: EventInfo, data: engine.view.observer.DomEventData) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+}

--- a/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/uploadgateway.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/uploadgateway.d.ts
@@ -1,0 +1,7 @@
+import Token from "../token/token";
+import FileUploader from "./fileuploader";
+
+export default class UploadGateway {
+    constructor(token: Token, apiAddress: string);
+    upload(fileOrData: string | Blob): FileUploader;
+}

--- a/types/ckeditor__ckeditor5-cloud-services/tsconfig.json
+++ b/types/ckeditor__ckeditor5-cloud-services/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ckeditor/*": [
+                "ckeditor__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-cloud-services-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-cloud-services/tslint.json
+++ b/types/ckeditor__ckeditor5-cloud-services/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.