### PR TITLE
update(bootstrap): 'alert' nullable support for `getInstance`

### DIFF
--- a/types/bootstrap/js/dist/alert.d.ts
+++ b/types/bootstrap/js/dist/alert.d.ts
@@ -1,22 +1,19 @@
-import BaseComponent from './base-component';
+import BaseComponent from "./base-component";
 
 declare class Alert extends BaseComponent {
+    static NAME: "alert";
+    static jQueryInterface: Alert.jQueryInterface;
+    /**
+     * Static method which allows you to get the alert instance associated to a
+     * DOM element, you can use it like this: getInstance(alert)
+     */
+    static getInstance(element: Element): Alert | null;
     /**
      * Closes an alert by removing it from the DOM. If the .fade and .show
      * classes are present on the element, the alert will fade out before it
      * is removed.
      */
     close(): void;
-
-    /**
-     * Static method which allows you to get the alert instance associated to a
-     * DOM element, you can use it like this: getInstance(alert)
-     */
-    static getInstance(element: Element): Alert;
-
-    static jQueryInterface: Alert.jQueryInterface;
-
-    // static NAME: 'alert';
 }
 
 declare namespace Alert {
@@ -24,16 +21,16 @@ declare namespace Alert {
         /**
          * Fires immediately when the close instance method is called.
          */
-        close = 'close.bs.alert',
+        close = "close.bs.alert",
 
         /**
          * Fired when the alert has been closed and CSS transitions have
          * completed.
          */
-        closed = 'closed.bs.alert',
+        closed = "closed.bs.alert",
     }
 
-    type jQueryInterface = (config?: 'close' | 'dispose') => void;
+    type jQueryInterface = (config?: "close" | "dispose") => void;
 }
 
 export default Alert;

--- a/types/bootstrap/test/alert-tests.ts
+++ b/types/bootstrap/test/alert-tests.ts
@@ -1,16 +1,18 @@
-import { Alert } from 'bootstrap';
-import * as $ from 'jquery';
+import { Alert } from "bootstrap";
+import * as $ from "jquery";
 
 const element = new Element();
 
 // $ExpectType Alert
-new Alert(element);
+const alert = new Alert(element);
+alert.close();
+alert.dispose();
 
-// $ExpectType Alert
-Alert.getInstance(element);
+// $ExpectType void | undefined
+Alert.getInstance(element)?.close();
 
-// $ExpectType string
-Alert.VERSION;
+Alert.VERSION; // $ExpectType string
+Alert.NAME; // $ExpectType "alert"
 
 element.addEventListener(Alert.Events.close, event => {
     // do something…
@@ -21,7 +23,7 @@ element.addEventListener(Alert.Events.closed, event => {
 });
 
 // $ExpectType void
-$('.alert').alert();
+$(".alert").alert();
 
 // $ExpectType void
-$('.alert').alert('close');
+$(".alert").alert("close");


### PR DESCRIPTION
Alert.getInstance retursn null if instance was alrady disposed.
This change allows to use either usuall guards checks or just use
optional chaining properly. Here is JS code that works same in TS after
this change:

```js
bootstrap.Modal.getInstance(document.querySelector("#exampleModalSm"))?.show()
```
https://github.com/twbs/bootstrap/blob/58b1be927f43c779377e478df2d119f2ddf956ca/js/src/dom/data.js#L35-L41

- minor style changes for Alert
- test amended

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).