### PR TITLE
fix(remarkable): invalid preset value

### DIFF
--- a/types/remarkable/index.d.ts
+++ b/types/remarkable/index.d.ts
@@ -4,7 +4,6 @@
 //                 Richard Lea <https://github.com/chigix>
 //                 Lilian Saget-Lethias <https://github.com/bios21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import Remarkable = require("./lib");
 

--- a/types/remarkable/lib/index.d.ts
+++ b/types/remarkable/lib/index.d.ts
@@ -29,7 +29,7 @@ declare class Remarkable {
      * Remarkable offers some "presets" as a convenience to quickly enable/disable
      * active syntax rules and options for common use cases.
      */
-    constructor(preset: "commonmark" | "full" | "remarkable", options?: Remarkable.Options);
+    constructor(preset: "commonmark" | "full" | "default", options?: Remarkable.Options);
 
     /**
      * `"# Remarkable rulezz!"` => `"<h1>Remarkable rulezz!</h1>"`

--- a/types/remarkable/remarkable-tests.ts
+++ b/types/remarkable/remarkable-tests.ts
@@ -13,6 +13,12 @@ export class RemarkableTest {
         md.render("# Remarkable rulezz!");
     }
 
+    presets() {
+        new Remarkable("commonmark");
+        new Remarkable("default");
+        new Remarkable("full");
+    }
+
     defineOptionsInContructor() {
         const md = new Remarkable({
             html: false,


### PR DESCRIPTION
This fixes runtime error as wrong string alias is used in the
definition. It should read `default`, not `remarkable`.
Tests amended.

https://github.com/jonschlinkert/remarkable/blob/58b6945f203ca7a0bb5a0785df90a3a6a8b9e59c/lib/index.js#L24-L28

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes