### PR TITLE
[@types/mongodb]: add BulkWriteError and alias MongoBulkWriteError

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -344,6 +344,13 @@ export class MongoWriteConcernError extends MongoError {
     result?: object;
 }
 
+/**
+ * An error indicating an unsuccessful Bulk Write
+ * @see https://mongodb.github.io/node-mongodb-native/3.6/api/BulkWriteError.html
+ */
+export class BulkWriteError extends MongoError {}
+export { BulkWriteError as MongoBulkWriteError};
+
 /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html#.connect */
 export interface MongoClientOptions
     extends DbCreateOptions,

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -349,7 +349,7 @@ export class MongoWriteConcernError extends MongoError {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/BulkWriteError.html
  */
 export class BulkWriteError extends MongoError {}
-export { BulkWriteError as MongoBulkWriteError};
+export { BulkWriteError as MongoBulkWriteError };
 
 /** @see https://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html#.connect */
 export interface MongoClientOptions


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jira.mongodb.org/browse/NODE-2306
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Adding missing declarations of classes `MongoBulkWriteError` & `BulkWriteError`, present in `mongodb@>=3.3.5`.

Pure addition of missing error classes not referenced anywhere in other typings AFAIK, so I don't know if I really have to add tests.
