### PR TITLE
[types/@chrome] Convert declarativeNetRequest enum keys to allcaps

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9855,50 +9855,50 @@ declare namespace chrome.declarativeNetRequest {
 
     /** This describes the resource type of the network request. */
     export enum ResourceType {
-        MainFrame = "main_frame",
-        SubFrame = "sub_frame",
-        Stylesheet = "stylesheet",
-        Script = "script",
-        Image = "image",
-        Font = "font",
-        Object = "object",
-        XmlHttpRequest = "xmlhttprequest",
-        Ping = "ping",
-        CspReport = "csp_report",
-        Media = "media",
-        WebSocket = "websocket",
-        Other = "other"
+        MAIN_FRAME = "main_frame",
+        SUB_FRAME = "sub_frame",
+        STYLESHEET = "stylesheet",
+        SCRIPT = "script",
+        IMAGE = "image",
+        FONT = "font",
+        OBJECT = "object",
+        XML_HTTP_REQUEST = "xmlhttprequest",
+        PING = "ping",
+        CSP_REPORT = "csp_report",
+        MEDIA = "media",
+        WEB_SOCKET = "websocket",
+        OTHER = "other"
     }
 
     /** Describes the kind of action to take if a given RuleCondition matches. */
     export enum RuleActionType {
-        Block= "block",
-        Redirect = "redirect",
-        Allow = "allow",
-        UpgradeScheme = "upgradeScheme",
-        ModifyHeaders = "modifyHeaders",
-        AllowAllRequests = "allowAllRequests"
+        BLOCK = "block",
+        REDIRECT = "redirect",
+        ALLOW = "allow",
+        UPGRADE_SCHEME = "upgradeScheme",
+        MODIFY_HEADERS = "modifyHeaders",
+        ALLOW_ALL_REQUESTS = "allowAllRequests"
     }
 
     /** Describes the reason why a given regular expression isn't supported. */
     export enum UnsupportedRegexReason {
-        SyntaxError = "syntaxError",
-        MemoryLimitExceeded = "memoryLimitExceeded"
+        SYNTAX_ERROR = "syntaxError",
+        MEMORY_LIMIT_EXCEEDED = "memoryLimitExceeded"
     }
 
     /** TThis describes whether the request is first or third party to the frame in which it originated.
      * A request is said to be first party if it has the same domain (eTLD+1) as the frame in which the request originated.
      */
     export enum DomainType {
-        FirstParty = "firstParty",
-        ThirdParty = "thirdParty"
+        FIRST_PARTY = "firstParty",
+        THIRD_PARTY = "thirdParty"
     }
 
     /** This describes the possible operations for a "modifyHeaders" rule. */
     export enum HeaderOperation {
-        Append = "append",
-        Set = "set",
-        Remove = "remove"
+        APPEND = "append",
+        SET = "set",
+        REMOVE = "remove"
     }
 
     export interface RequestDetails {


### PR DESCRIPTION
* Fixes issue #52844

- [✓] Provide a URL to documentation or source code which provides context for the suggested changes:
See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52844
The enums added to the declarativeNetRequest API weren't exported correctly, making it impossible to use them with the API. Converting them to all caps should correct it.
