### PR TITLE
New @ckeditor/ckeditor5-alignment v27

### DIFF
--- a/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
+++ b/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
@@ -1,0 +1,34 @@
+import { Alignment } from "@ckeditor/ckeditor5-alignment";
+import { Editor } from "@ckeditor/ckeditor5-core";
+import * as utils from "@ckeditor/ckeditor5-alignment/src/utils";
+import { Locale } from "@ckeditor/ckeditor5-utils";
+import AlignmentCommand from "@ckeditor/ckeditor5-alignment/src/alignmentcommand";
+
+class MyEditor extends Editor {}
+
+let bool = true;
+
+new Alignment(new MyEditor());
+Alignment.requires.map(Plugin => {
+    new Plugin(new MyEditor());
+    if (Plugin.pluginName === "AlignmentUI" || Plugin.pluginName === "AlignmentEditing") {
+    }
+});
+Alignment.requires.length === 2;
+
+bool = utils.isDefault("left", new Locale());
+bool = utils.isSupported("left");
+utils.supportedOptions.length === 4;
+const normalizedOptions = utils.normalizeAlignmentOptions(["foo"]);
+if (typeof normalizedOptions !== "string") {
+    const str: string = normalizedOptions[0].name;
+}
+
+// $ExpectError
+utils.normalizeAlignmentOptions([{ name: "foo", className: "bar" }]);
+utils.normalizeAlignmentOptions([{ name: "left", className: "bar" }]);
+
+const command = new AlignmentCommand(new MyEditor());
+// $ExpectError
+command.execute("foo");
+command.execute();

--- a/types/ckeditor__ckeditor5-alignment/index.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for @ckeditor/ckeditor5-alignment 27.0
+// Project: https://ckeditor.com/docs/ckeditor5/latest/api/alignment.html
+// Definitions by: Federico Panico <https://github.com/fedemp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.2
+export { default as Alignment } from "./src/alignment";
+export { default as AlignmentEditing } from "./src/alignmentediting";
+export { default as AlignmentUI } from "./src/alignmentui";

--- a/types/ckeditor__ckeditor5-alignment/src/alignment.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignment.d.ts
@@ -1,0 +1,12 @@
+import { Plugin } from "@ckeditor/ckeditor5-core";
+import AlignmentEditing, { AlignmentFormat } from "./alignmentediting";
+import AlignmentUI from "./alignmentui";
+
+export default class Alignment extends Plugin {
+    static readonly requires: [typeof AlignmentEditing, typeof AlignmentUI];
+    static readonly pluginName: "Alignment";
+}
+
+export interface AlignmentConfig {
+    options: Array<string | AlignmentFormat>;
+}

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
@@ -1,0 +1,5 @@
+import { Command } from "@ckeditor/ckeditor5-core";
+
+export default class AlignmentCommand extends Command {
+    execute(): void;
+}

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
@@ -1,0 +1,11 @@
+import { Plugin } from "@ckeditor/ckeditor5-core";
+
+export default class AlignmentEditing extends Plugin {
+    static readonly pluginName: "AlignmentEditing";
+    init(): void;
+}
+
+export interface AlignmentFormat {
+    className: string;
+    name: "left" | "right" | "center" | "justify";
+}

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
@@ -1,0 +1,12 @@
+import { Plugin } from "@ckeditor/ckeditor5-core";
+
+export default class AlignmentUI extends Plugin {
+    readonly localizedOptionTitles: {
+        left: string;
+        right: string;
+        center: string;
+        justify: string;
+    };
+    static readonly pluginName: "AlignmentUI";
+    init(): void;
+}

--- a/types/ckeditor__ckeditor5-alignment/src/utils.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/utils.d.ts
@@ -1,0 +1,8 @@
+import { Locale } from "@ckeditor/ckeditor5-utils";
+import { AlignmentFormat } from "./alignmentediting";
+
+export const supportedOptions: ["left", "right", "center", "justify"];
+
+export function isDefault(alignment: string, locale: Locale): boolean;
+export function isSupported(option: string): boolean;
+export function normalizeAlignmentOptions(configuredOptions: Array<string | AlignmentFormat>): AlignmentFormat[];

--- a/types/ckeditor__ckeditor5-alignment/tsconfig.json
+++ b/types/ckeditor__ckeditor5-alignment/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ckeditor/*": [
+                "ckeditor__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-alignment-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-alignment/tslint.json
+++ b/types/ckeditor__ckeditor5-alignment/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/ckeditor__ckeditor5-core/src/editor/editorconfig.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorconfig.d.ts
@@ -1,10 +1,9 @@
+import { AlignmentConfig } from "@ckeditor/ckeditor5-alignment/src/alignment";
 import { AutosaveConfig } from "@ckeditor/ckeditor5-autosave/src/autosave";
 import { ExportPdfConfig } from "@ckeditor/ckeditor5-export-pdf/src/exportpdf";
 import { ExportWordConfig } from "@ckeditor/ckeditor5-export-word/src/exportword";
 import Plugin from "../plugin";
 
-// TODO: import {Alignment} from "@ckeditor/ckeditor5-alignment/src/alignment"
-type Alignment = any;
 // TODO: import {CKFinderConfig} from "@ckeditor/ckeditor5-ckfinder/src/ckfinder";
 type CKFinderConfig = any;
 // TODO: import {CloudServicesConfig} from "@ckeditor/ckeditor5-cloud-services/src/cloudservices";
@@ -60,7 +59,7 @@ type WordCountConfig = any;
 type TextPartLanguageOption = any;
 
 export interface EditorConfig {
-    alignment?: Alignment;
+    alignment?: AlignmentConfig;
     autosave?: AutosaveConfig;
     balloonToolbar?: string[] | { items: string[]; shouldNotGroupWhenFull?: boolean };
     blockToolbar?: string[] | { items: string[]; shouldNotGroupWhenFull?: boolean };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.