### PR TITLE
fix(stopword): correct literal union value

### DIFF
--- a/types/stopword/index.d.ts
+++ b/types/stopword/index.d.ts
@@ -6,70 +6,79 @@
 
 export as namespace sw;
 
-/**
- * Stopword removal
- *
- * @param text Array string of words
- * @param stopwords Array string of your custom stopwords (default: English stopwords | .en)
- */
-export function removeStopwords(text: string[], stopwords?: string[]): string[];
+declare namespace stopword {
+    interface Stopword {
+        /**
+         * Stopword removal
+         *
+         * @param text Array string of words
+         * @param stopwords Array string of your custom stopwords (default: English stopwords | .en)
+         */
+        removeStopwords: (text: string[], stopwords?: string[]) => string[];
+    }
 
-/**
- * Get array of stopwords according by language code
- */
-export const af: string[];
-export const ar: string[];
-export const bg: string[];
-export const bn: string[];
-export const br: string[];
-export const ca: string[];
-export const cs: string[];
-export const da: string[];
-export const de: string[];
-export const el: string[];
-export const en: string[];
-export const eo: string[];
-export const es: string[];
-export const et: string[];
-export const eu: string[];
-export const fa: string[];
-export const fr: string[];
-export const fi: string[];
-export const ga: string[];
-export const gl: string[];
-export const ha: string[];
-export const he: string[];
-export const hi: string[];
-export const hr: string[];
-export const hu: string[];
-export const hy: string[];
-export const id: string[];
-export const it: string[];
-export const ja: string[];
-export const ko: string[];
-export const la: string;
-export const lgg: string[];
-export const lggo: string[];
-export const lv: string[];
-export const mr: string[];
-export const my: string[];
-export const nl: string[];
-export const no: string[];
-export const pa: string[];
-export const pl: string[];
-export const pt: string[];
-export const ptbr: string[];
-export const ro: string[];
-export const ru: string[];
-export const sk: string[];
-export const sl: string[];
-export const so: string[];
-export const st: string[];
-export const sv: string[];
-export const sw: string[];
-export const th: string[];
-export const tr: string[];
-export const vi: string[];
-export const yo: string[];
-export const zh: string[];
-export const zu: string[];
+    type LanguageCode =
+        | "af"
+        | "ar"
+        | "bg"
+        | "bn"
+        | "br"
+        | "ca"
+        | "cs"
+        | "da"
+        | "de"
+        | "el"
+        | "en"
+        | "eo"
+        | "es"
+        | "et"
+        | "eu"
+        | "fa"
+        | "fi"
+        | "fr"
+        | "ga"
+        | "gl"
+        | "ha"
+        | "he"
+        | "hi"
+        | "hr"
+        | "hu"
+        | "hy"
+        | "id"
+        | "it"
+        | "ja"
+        | "ko"
+        | "la"
+        | "lgg"
+        | "lggo"
+        | "lv"
+        | "mr"
+        | "my"
+        | "nl"
+        | "no"
+        | "pa"
+        | "pl"
+        | "pt"
+        | "ptbr"
+        | "ro"
+        | "ru"
+        | "sk"
+        | "sl"
+        | "so"
+        | "st"
+        | "sv"
+        | "sw"
+        | "th"
+        | "tr"
+        | "vi"
+        | "yo"
+        | "zh"
+        | "zu";
+}
+
+declare const stopword: {
+    [Language in stopword.LanguageCode]: string[];
+} &
+    stopword.Stopword;
+
+export = stopword;

--- a/types/stopword/stopword-tests.ts
+++ b/types/stopword/stopword-tests.ts
@@ -1,7 +1,30 @@
-import sw = require('stopword');
+import sw = require("stopword");
+import { removeStopwords, LanguageCode } from "stopword";
 
-const oldString = 'you can even roll your own custom stopword list'.split(' ');
-const stopwordLangId = sw.id;
+const oldString = "you can even roll your own custom stopword list".split(" ");
+const stopwords = sw.bg; // $ExpectType string[]
 
-sw.removeStopwords(oldString, stopwordLangId); // with custom stopwords
-sw.removeStopwords(oldString); // default stopwords (en)
+sw.removeStopwords(oldString, stopwords); // $ExpectType string[]
+removeStopwords(oldString); // $ExpectType string[]
+
+const customStopwords = ["interesting", "really"];
+sw.removeStopwords(oldString, [...sw.en, ...sw.sv, ...customStopwords]);
+
+// fergiemcdowall/stopword#179
+const getStopwords = (language: string): string[] | undefined => {
+    switch (language) {
+        case "af": {
+            return sw.af;
+        }
+        case "la": {
+            return sw.la;
+        }
+    }
+    return undefined;
+};
+
+const getStopwordsByKey = (language: LanguageCode): string[] | undefined => {
+    return sw[language] || undefined;
+};
+
+getStopwords("asdfasdf"); // $ExpectType string[] | undefined


### PR DESCRIPTION
There was a typo in one of the language code exports in previous update.
To prevent this in feature and ease usage in TypeScript, this moves all
language code into exported union types and changes the export definitio
for a module (backward compatible).
All language code are now just keyed (indexed) type on the module
definition.

Thanks!

/cc @spicemix @fergiemcdowall

Fixes fergiemcdowall/stopword#179

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).