### PR TITLE
@types/plotly.js Fix `modeBarButtons` argument type

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1556,10 +1556,10 @@ export interface Config {
     /**
      * fully custom mode bar buttons as nested array, where the outer
      * arrays represents button groups, and the inner arrays have
-     * buttons config objects or names of default buttons
+     * button config objects or names of default buttons
      * (see ./components/modebar/buttons.js for more info)
      */
-    modeBarButtons: Array<ModeBarDefaultButtons[] | ModeBarButton[]> | false;
+    modeBarButtons: Array<(ModeBarDefaultButtons | ModeBarButton)[]> | false;
 
     /** add the plotly logo on the end of the mode bar */
     displaylogo: boolean;


### PR DESCRIPTION
`modeBarButtons` type should accept a mix of button config objects or names of default buttons

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).