### PR TITLE
fix(find-in-files): access literal objects as first parameter

### DIFF
--- a/types/find-in-files/find-in-files-tests.ts
+++ b/types/find-in-files/find-in-files-tests.ts
@@ -1,20 +1,36 @@
-import { find, findSync, FindResult } from 'find-in-files';
+import { find, findSync } from 'find-in-files';
 
-const main = async () => {
-    // FindResult interface should be exported
-    const files: FindResult = await find(/foo/, 'foo', /foo/);
-    // Third argument is optional
+(async () => {
+    // $ExpectType FindResult
+    await find(/foo/, 'foo', /foo/);
+    // $ExpectType FindResult
     await find(/foo/, 'foo');
-    // First argument can be a string
+    // $ExpectType FindResult
     await find('foo', 'foo');
-    // Sync version
+    // $ExpectType FindResult
     findSync('foo', 'foo');
-
-    // Incorrect param
-    // $ExpectError
-    await find(3, 'foo', /foo/);
-
-    return files;
-};
-
-export default main;
+    // $ExpectType FindResult
+    await find(/version/, './node_modules/find-in-files');
+    // $ExpectType FindResult
+    await find('version', './node_modules/find-in-files');
+    // $ExpectType FindResult
+    await find(
+        {
+            term: 'version',
+            flags: 'gi',
+        },
+        './node_modules/find-in-files',
+    );
+    // $ExpectType FindResult
+    findSync(/version/, './node_modules/find-in-files');
+    // $ExpectType FindResult
+    findSync('version', './node_modules/find-in-files');
+    // $ExpectType FindResult
+    findSync(
+        {
+            term: 'version',
+            flags: 'gi',
+        },
+        './node_modules/find-in-files',
+    );
+})();

--- a/types/find-in-files/index.d.ts
+++ b/types/find-in-files/index.d.ts
@@ -11,5 +11,18 @@ export interface FindResult {
     };
 }
 
-export function find(pattern: string | RegExp, directory: string, fileFilter?: string | RegExp): Promise<FindResult>;
-export function findSync(pattern: string | RegExp, directory: string, fileFilter?: string | RegExp): FindResult;
+export interface RegexControlOptions {
+    term: string;
+    flags: string;
+}
+
+export function find(
+    pattern: string | RegExp | RegexControlOptions,
+    directory: string,
+    fileFilter?: string | RegExp,
+): Promise<FindResult>;
+export function findSync(
+    pattern: string | RegExp | RegexControlOptions,
+    directory: string,
+    fileFilter?: string | RegExp,
+): FindResult;


### PR DESCRIPTION
The first param can be a literal object:

```js
await find({
    term: 'version',
    flags: 'gi'
}, './node_modules/find-in-files');
```

https://github.com/kaesetoast/find-in-files#example

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).