### PR TITLE
fix(stylus): expose Renderer for client and types consumption

### DIFF
--- a/types/stylus/index.d.ts
+++ b/types/stylus/index.d.ts
@@ -8,8 +8,22 @@
 
 import { EventEmitter } from 'events';
 
+import Renderer = require('./lib/renderer');
+
 declare var stylus: Stylus.Static;
 export = stylus;
+
+declare namespace stylus  {
+    interface RenderOptions {
+        globals?: Stylus.Dictionary<any>;
+        functions?: Stylus.Dictionary<any>;
+        imports?: string[];
+        paths?: string[];
+        filename?: string;
+        Evaluator?: typeof Stylus.Evaluator;
+    }
+    type RenderCallback = (err: Error, css: string, js: string) => void;
+}
 
 declare namespace Stylus {
     export interface Static {
@@ -17,7 +31,7 @@ declare namespace Stylus {
          * Return a new `Renderer` for the given `str` and `options`.
          */
         (str: string): Renderer;
-        (str: string, options: RenderOptions): Renderer;
+        (str: string, options: stylus.RenderOptions): Renderer;
 
         /**
          * Library version.
@@ -58,8 +72,8 @@ declare namespace Stylus {
         /**
          * Render the given `str` with `options` and callback `fn(err, css)`.
          */
-        render(str: string, callback: RenderCallback): void;
-        render(str: string, options: RenderOptions, callback: RenderCallback): void;
+        render(str: string, callback: stylus.RenderCallback): void;
+        render(str: string, options: stylus.RenderOptions, callback: stylus.RenderCallback): void;
 
         /**
          * Return a url() function with the given `options`.
@@ -635,83 +649,6 @@ declare namespace Stylus {
     }
 
     export class Compiler {
-    }
-
-    export class Renderer extends EventEmitter {
-        options: RenderOptions;
-        str: string;
-        events: any;
-
-        constructor(str: string);
-        constructor(str: string, options: RenderOptions);
-
-        /**
-         * Parse and evaluate AST, then callback `fn(err, css, js)`.
-         */
-        render(callback: RenderCallback): void;
-
-        /**
-         * Parse and evaluate AST and return the result.
-         */
-        render(): string;
-
-        /**
-         * Get dependencies of the compiled file.
-         */
-        deps(filename?: string): string[];
-
-        /**
-         * Set option `key` to `val`.
-         */
-        set(key: string, val: any): this;
-
-        /**
-         * Get option `key`.
-         */
-        get(key: string): any;
-
-        /**
-         * Include the given `path` to the lookup paths array.
-         */
-        include(path: string): this;
-
-        /**
-         * Use the given `fn`.
-         *
-         * This allows for plugins to alter the renderer in
-         * any way they wish, exposing paths etc.
-         */
-        use(fn: (renderer: Renderer) => any): this;
-
-        /**
-         * Define function or global var with the given `name`. Optionally
-         * the function may accept full expressions, by setting `raw`
-         * to `true`.
-         */
-        define(name: string, fn: (...args: any[]) => any): this;
-        define(name: string, node: Nodes.Node): this;
-        define(name: string, val: any): this;
-        define(name: string, fn: (...args: any[]) => any, raw: boolean): this;
-        define(name: string, node: Nodes.Node, raw: boolean): this;
-        define(name: string, val: any, raw: boolean): this;
-
-        /**
-         * Import the given `file`.
-         */
-        import(file: string): this;
-
-        //#region EventEmitter Members
-        addListener(event: string, listener: (...args: any[]) => any): this;
-        on(event: string, listener: (...args: any[]) => any): this;
-        once(event: string, listener: (...args: any[]) => any): this;
-        removeListener(event: string, listener: (...args: any[]) => any): this;
-        removeAllListeners(event?: string): this;
-        setMaxListeners(n: number): this;
-        getMaxListeners(): number;
-        listeners(event: string): Array<(...args: any[]) => any>;
-        emit(event: string, ...args: any[]): boolean;
-        listenerCount(type: string): number;
-        //#endregion
     }
 
     //#endregion
@@ -1408,17 +1345,6 @@ declare namespace Stylus {
     export interface Dictionary<T> {
         [key: string]: T;
     }
-
-    export interface RenderOptions {
-        globals?: Dictionary<any>;
-        functions?: Dictionary<any>;
-        imports?: string[];
-        paths?: string[];
-        filename?: string;
-        Evaluator?: typeof Evaluator;
-    }
-
-    export type RenderCallback = (err: Error, css: string, js: string) => void;
 
     export interface UrlOptions {
         limit?: number | false | null;

--- a/types/stylus/lib/renderer.d.ts
+++ b/types/stylus/lib/renderer.d.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from "events";
+import { RenderOptions, RenderCallback } from "..";
+import stylus = require("..");
+
+// TODO: rewrite this to proper import in futures
+declare type Node = typeof stylus["nodes"]["Node"];
+
+declare class Renderer extends EventEmitter {
+    options: RenderOptions;
+    str: string;
+    events: any;
+
+    constructor(str: string);
+    constructor(str: string, options: RenderOptions);
+
+    /**
+     * Parse and evaluate AST, then callback `fn(err, css, js)`.
+     */
+    render(callback: RenderCallback): void;
+
+    /**
+     * Parse and evaluate AST and return the result.
+     */
+    render(): string;
+
+    /**
+     * Get dependencies of the compiled file.
+     */
+    deps(filename?: string): string[];
+
+    /**
+     * Set option `key` to `val`.
+     */
+    set(key: string, val: any): this;
+
+    /**
+     * Get option `key`.
+     */
+    get(key: string): any;
+
+    /**
+     * Include the given `path` to the lookup paths array.
+     */
+    include(path: string): this;
+
+    /**
+     * Use the given `fn`.
+     *
+     * This allows for plugins to alter the renderer in
+     * any way they wish, exposing paths etc.
+     */
+    use(fn: (renderer: Renderer) => any): this;
+
+    /**
+     * Define function or global var with the given `name`. Optionally
+     * the function may accept full expressions, by setting `raw`
+     * to `true`.
+     */
+    define(name: string, fn: (...args: any[]) => any): this;
+    define(name: string, node: Node): this;
+    define(name: string, val: any): this;
+    define(name: string, fn: (...args: any[]) => any, raw: boolean): this;
+    define(name: string, node: Node, raw: boolean): this;
+    define(name: string, val: any, raw: boolean): this;
+
+    /**
+     * Import the given `file`.
+     */
+    import(file: string): this;
+
+    //#region EventEmitter Members
+    addListener(event: string, listener: (...args: any[]) => any): this;
+    on(event: string, listener: (...args: any[]) => any): this;
+    once(event: string, listener: (...args: any[]) => any): this;
+    removeListener(event: string, listener: (...args: any[]) => any): this;
+    removeAllListeners(event?: string): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    listeners(event: string): Array<(...args: any[]) => any>;
+    emit(event: string, ...args: any[]): boolean;
+    listenerCount(type: string): number;
+}
+
+export = Renderer;

--- a/types/stylus/stylus-tests.ts
+++ b/types/stylus/stylus-tests.ts
@@ -5,6 +5,12 @@
  */
 
 import stylus = require("stylus");
+import Renderer = require("stylus/lib/renderer");
+
+// $ExpectType typeof Renderer
+Renderer;
+// $ExpectType string
+new Renderer("str", {}).render();
 
 const str = "This is a stylus test";
 


### PR DESCRIPTION
- move to submodule to allow proper import (for now separate file)
- correst namespacing to put interfacese and types for export
- amend tests

https://github.com/stylus/stylus/blob/dev/lib/renderer.js#L25

/cc @NomNes

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).