### PR TITLE
[nova-editor-node] Update getParent and openFile, add openNewTextDocument

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -929,6 +929,17 @@ declare class TreeView<E> extends Disposable {
 
 /// https://docs.nova.app/api-reference/workspace/
 
+// The line is optional, unless a column is specified
+declare type FileLocation =
+    | {
+          line?: number;
+          column?: never;
+      }
+    | {
+          line: number;
+          column?: number;
+      };
+
 interface Workspace {
     readonly path: string | null;
     readonly config: Configuration;
@@ -942,32 +953,12 @@ interface Workspace {
     contains(path: string): boolean;
     relativizePath(path: string): string;
     openConfig(identifier?: string): void;
-    openFile(
-        uri: string,
-        options?:
-            | {
-                  line?: number;
-                  column?: never;
-              }
-            | {
-                  line: number;
-                  column?: number; // column requires line
-              },
-    ): Promise<TextEditor | null>;
+    openFile(uri: string, options?: FileLocation): Promise<TextEditor | null>;
     openNewTextDocument(
-        options?:
-            | {
-                  content?: string;
-                  syntax?: string;
-                  line?: number;
-                  column?: never;
-              }
-            | {
-                  content?: string;
-                  syntax?: string;
-                  line: number;
-                  column?: number; // column requires line
-              },
+        options?: {
+            content?: string;
+            syntax?: string;
+        } & FileLocation,
     ): Promise<TextEditor | null>;
     showInformativeMessage(message: string): void;
     showWarningMessage(message: string): void;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -942,7 +942,29 @@ interface Workspace {
     contains(path: string): boolean;
     relativizePath(path: string): string;
     openConfig(identifier?: string): void;
-    openFile(uri: string): Promise<TextEditor | null>;
+    openFile(
+        uri: string,
+        options?: {
+            line?: number,
+            column?: never
+        } | {
+            line: number,
+            column?: number // column requires line
+        }
+    ): Promise<TextEditor | null>;
+    openNewTextDocument(
+        options?: {
+            content?: string,
+            syntax?: string,
+            line?: number,
+            column?: never
+        } | {
+            content?: string,
+            syntax?: string,
+            line: number,
+            column?: number // column requires line
+        }
+    ): Promise<TextEditor | null>;
     showInformativeMessage(message: string): void;
     showWarningMessage(message: string): void;
     showErrorMessage(message: string): void;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -884,7 +884,7 @@ interface TextEditorEdit {
 
 interface TreeDataProvider<E> {
     getChildren(element: E | null): E[] | Promise<E[]>;
-    getParent?(element: E): E;
+    getParent?(element: E): E | null;
     getTreeItem(element: E): TreeItem;
 }
 

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -944,26 +944,30 @@ interface Workspace {
     openConfig(identifier?: string): void;
     openFile(
         uri: string,
-        options?: {
-            line?: number,
-            column?: never
-        } | {
-            line: number,
-            column?: number // column requires line
-        }
+        options?:
+            | {
+                  line?: number;
+                  column?: never;
+              }
+            | {
+                  line: number;
+                  column?: number; // column requires line
+              },
     ): Promise<TextEditor | null>;
     openNewTextDocument(
-        options?: {
-            content?: string,
-            syntax?: string,
-            line?: number,
-            column?: never
-        } | {
-            content?: string,
-            syntax?: string,
-            line: number,
-            column?: number // column requires line
-        }
+        options?:
+            | {
+                  content?: string;
+                  syntax?: string;
+                  line?: number;
+                  column?: never;
+              }
+            | {
+                  content?: string;
+                  syntax?: string;
+                  line: number;
+                  column?: number; // column requires line
+              },
     ): Promise<TextEditor | null>;
     showInformativeMessage(message: string): void;
     showWarningMessage(message: string): void;

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -321,6 +321,9 @@ class MyDataProvider implements TreeDataProvider<{ name: string }> {
     getTreeItem(element: { name: string }): TreeItem {
         throw new Error('Method not implemented.');
     }
+    getParent(element: { name: string }): TreeItem | null {
+        return null;
+    }
 }
 
 // Create the TreeView

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -352,3 +352,24 @@ nova.workspace.showInputPalette('This is an input', {
     // after 6.0
     value: "Default value"
 });
+
+
+/// https://docs.nova.app/api-reference/workspace/
+
+nova.workspace.openFile("file:///tmp/test/txt");
+nova.workspace.openFile("file:///tmp/test/txt", { line: 1 });
+nova.workspace.openFile("file:///tmp/test/txt", { line: 1, column: 2 });
+// $ExpectError
+nova.workspace.openFile("file:///tmp/test/txt", { column: 2 });
+nova.workspace.openNewTextDocument();
+nova.workspace.openNewTextDocument({ content: "<!doctype html>" });
+nova.workspace.openNewTextDocument({ syntax: "html" });
+nova.workspace.openNewTextDocument({ content: "<!doctype html>", syntax: "html" });
+nova.workspace.openNewTextDocument({ line: 1 });
+nova.workspace.openNewTextDocument({ line: 1, column: 2 });
+nova.workspace.openNewTextDocument({ syntax: "html", line: 1 });
+// $ExpectError
+nova.workspace.openNewTextDocument({ syntax: "html", column: 2 });
+nova.workspace.openNewTextDocument({ content: "<!doctype html>", syntax: "html", line: 1, column: 2 });
+
+

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -353,7 +353,6 @@ nova.workspace.showInputPalette('This is an input', {
     value: "Default value"
 });
 
-
 /// https://docs.nova.app/api-reference/workspace/
 
 nova.workspace.openFile("file:///tmp/test/txt");
@@ -371,5 +370,3 @@ nova.workspace.openNewTextDocument({ syntax: "html", line: 1 });
 // $ExpectError
 nova.workspace.openNewTextDocument({ syntax: "html", column: 2 });
 nova.workspace.openNewTextDocument({ content: "<!doctype html>", syntax: "html", line: 1, column: 2 });
-
-


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * `TreeDataProvider.getParent`: https://docs.nova.app/api-reference/tree-data-provider/
  * `Workspace.openFile`: https://docs.nova.app/api-reference/workspace/#openfileuri-options
  * `Workspace.openNewTextDocument`: https://docs.nova.app/api-reference/workspace/#opennewtextdocumentoptions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.