### PR TITLE
[color-thief-node] Fixed the return types 

### DIFF
--- a/types/color-thief-node/color-thief-node-tests.ts
+++ b/types/color-thief-node/color-thief-node-tests.ts
@@ -4,9 +4,11 @@ const imageUrl =
     "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Firefox_Logo%2C_2017.svg/1024px-Firefox_Logo%2C_2017.svg.png";
 
 getColorFromURL(imageUrl).then(color => {
-    color.r; // $ExpectType number
-    color.g; // $ExpectType number
-    color.b; // $ExpectType number
+    // $ExpectType Palette
+    color;
 });
 
-getPaletteFromURL(imageUrl); // $ExpectType Promise<Color>
+getPaletteFromURL(imageUrl).then(color => {
+    // $ExpectType Palette
+    color[0];
+});

--- a/types/color-thief-node/index.d.ts
+++ b/types/color-thief-node/index.d.ts
@@ -2,27 +2,24 @@
 // Project: https://github.com/zicodeng/color-thief-node#readme
 // Definitions by: Almeida <https://github.com/almeidx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.0
 
-export interface Color {
-    r: number;
-    g: number;
-    b: number;
-}
+export type Palette = [red: number, green: number, blue: number];
 
 /**
  * Use the median cut algorithm provided by quantize.js to cluster similar
  * colors and return the base color from the largest cluster.
  */
-export function getColor(sourceImage: HTMLImageElement, quality?: number): Promise<Color>;
+export function getColor(sourceImage: HTMLImageElement, quality?: number): Promise<Palette>;
 
 /**
  * Use the median cut algorithm provided by quantize.js
  * to cluster similar colors.
  */
-export function getPaletteFromURL(URL: string, colorCount?: number, quality?: number): Promise<Color>;
+export function getPaletteFromURL(URL: string, colorCount?: number, quality?: number): Promise<Palette[]>;
 
 /**
  * Use the median cut algorithm provided by quantize.js
  * to cluster similar colors.
  */
-export function getColorFromURL(imageURL: string, quality?: number): Promise<Color>;
+export function getColorFromURL(imageURL: string, quality?: number): Promise<Palette>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [`getPallete()`](https://github.com/zicodeng/color-thief-node/blob/c323d7325d68667c6c1b8d18c97909795a9ec71b/src/color-thief.js#L83) (the private function every other public function is based of)
    - Returns an array of arrays instead of an array of objects (like the jsdoc suggests)
  - [`getPaletteFromURL()`](https://github.com/zicodeng/color-thief-node/blob/c323d7325d68667c6c1b8d18c97909795a9ec71b/src/color-thief.js#L133) - Returns an array of palettes.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

***

I used a labeled tuple in the Palette type since that's what made the most sense to me, but that means the minimum typescript version is 4.0. Not sure how you guys feel about this.