### PR TITLE
lowdb: fixed copy and paste error in Memory adapter

### DIFF
--- a/types/lowdb/adapters/Memory.d.ts
+++ b/types/lowdb/adapters/Memory.d.ts
@@ -1,3 +1,3 @@
 import { AdapterSync } from "../index";
-declare const FileSync: AdapterSync;
-export = FileSync;
+declare const Memory: AdapterSync;
+export = Memory;


### PR DESCRIPTION
As you can see here (https://github.com/typicode/lowdb/blob/master/src/adapters/Memory.js), the name must be Memory.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/typicode/lowdb/blob/master/src/adapters/Memory.js

