### PR TITLE
New @ckeditor/ckeditor5-autoformat v27

### DIFF
--- a/types/ckeditor__ckeditor5-autoformat/ckeditor__ckeditor5-autoformat-tests.ts
+++ b/types/ckeditor__ckeditor5-autoformat/ckeditor__ckeditor5-autoformat-tests.ts
@@ -1,0 +1,19 @@
+import { Autoformat } from "@ckeditor/ckeditor5-autoformat";
+import blockAutoformatEditing from "@ckeditor/ckeditor5-autoformat/src/blockautoformatediting";
+import inlineAutoformatEditing from "@ckeditor/ckeditor5-autoformat/src/inlineautoformatediting";
+import { Editor } from "@ckeditor/ckeditor5-core";
+
+class MyEditor extends Editor {}
+const autoformat = new Autoformat(new MyEditor());
+autoformat.afterInit();
+
+blockAutoformatEditing(new MyEditor(), autoformat, /foo/, "foo");
+blockAutoformatEditing(new MyEditor(), autoformat, /foo/, arg => {
+    arg?.index;
+    return;
+});
+
+inlineAutoformatEditing(new MyEditor(), autoformat, /foo/, writer => {
+    writer.createText("foo");
+    return false;
+});

--- a/types/ckeditor__ckeditor5-autoformat/index.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for @ckeditor/ckeditor5-autoformat 27.0
+// Project: https://ckeditor.com/docs/ckeditor5/latest/api/autoformat.html
+// Definitions by: Federico Panico <https://github.com/fedemp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.2
+export { default as Autoformat } from "./src/autoformat";

--- a/types/ckeditor__ckeditor5-autoformat/src/autoformat.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/src/autoformat.d.ts
@@ -1,0 +1,6 @@
+import { Plugin } from "@ckeditor/ckeditor5-core";
+
+export default class Autoformat extends Plugin {
+    static readonly pluginName: "Autoformat";
+    afterInit(): void;
+}

--- a/types/ckeditor__ckeditor5-autoformat/src/blockautoformatediting.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/src/blockautoformatediting.d.ts
@@ -1,0 +1,9 @@
+import { Editor } from "@ckeditor/ckeditor5-core";
+import Autoformat from "./autoformat";
+
+export default function blockAutoformatEditing(
+    editor: Editor,
+    plugin: Autoformat,
+    pattern: RegExp,
+    callbackOrCommand: string | ((arg: ReturnType<RegExp["exec"]>) => void),
+): void;

--- a/types/ckeditor__ckeditor5-autoformat/src/inlineautoformatediting.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/src/inlineautoformatediting.d.ts
@@ -1,0 +1,17 @@
+import { Editor } from "@ckeditor/ckeditor5-core";
+import { DowncastWriter } from "@ckeditor/ckeditor5-engine";
+import Autoformat from "./autoformat";
+
+export default function inlineAutoformatEditing(
+    editor: Editor,
+    plugin: Autoformat,
+    testRegexpOrCallback:
+        | RegExp
+        | ((
+              text: string,
+          ) => {
+              remove: number[][];
+              format: number[][];
+          }),
+    formatCallback: (writer: DowncastWriter, rangestoformat: unknown[]) => void | boolean,
+): void;

--- a/types/ckeditor__ckeditor5-autoformat/tsconfig.json
+++ b/types/ckeditor__ckeditor5-autoformat/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ckeditor/*": [
+                "ckeditor__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-autoformat-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-autoformat/tslint.json
+++ b/types/ckeditor__ckeditor5-autoformat/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.