### PR TITLE
[stripe-v3] Add optional googlePay property to result of canMakePayment

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -907,7 +907,7 @@ declare namespace stripe {
         }
 
         interface StripePaymentRequest {
-            canMakePayment(): Promise<{ applePay?: boolean } | null>;
+            canMakePayment(): Promise<{ applePay?: boolean, googlePay?: boolean } | null>;
             show(): void;
             update(options: StripePaymentRequestUpdateOptions): void;
             on(event: 'token', handler: (response: StripeTokenPaymentResponse) => void): void;

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -216,6 +216,8 @@ describe("Stripe elements", () => {
         const prButton = elements.create('paymentRequestButton', { paymentRequest });
         paymentRequest.canMakePayment().then(result => {
             if (result) {
+                result.applePay; // $ExpectType boolean | undefined
+                result.googlePay; // $ExpectType boolean | undefined
                 prButton.mount('#payment-request-button');
             } else {
                 document.getElementById('payment-request-button')!.style.display = 'none';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/js/payment_request/can_make_payment>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.