### PR TITLE
[pdfjs-dist]: well formatted comment

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-/// <reference lib="dom"/>
+// <reference lib="dom"/>
 
 declare const version: string;
 


### PR DESCRIPTION
change comment from: /// <reference lib="dom"/> to // <reference lib="dom"/>

solves: ERROR in node_modules/@types/pdfjs-dist/index.d.ts(9,1): error TS1084: Invalid reference directive syntax.
