### PR TITLE
[@types/mongodb] Fix Cursor<T> type (close() method)

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -3992,8 +3992,8 @@ export class Cursor<T = Default> extends Readable {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#close
      */
-    close(options?: { skipKillCursors: boolean }): Promise<void>;
-    close(options: { skipKillCursors: boolean }, callback?: MongoCallback<number>): void;
+    close(options?: { skipKillCursors: boolean }): Promise<CursorResult>;
+    close(options: { skipKillCursors: boolean }, callback: MongoCallback<CursorResult>): void;
     close(callback: MongoCallback<CursorResult>): void;
     /**
      * Set the collation options for the cursor.
@@ -4309,7 +4309,7 @@ export class AggregationCursor<T = Default> extends Cursor<T> {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/AggregationCursor.html#close
      */
-    close(): Promise<void>;
+    close(): Promise<AggregationCursorResult>;
     close(callback: MongoCallback<AggregationCursorResult>): void;
     /**
      * Iterates over all the documents for this cursor. As with `cursor.toArray()`,

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -3992,7 +3992,9 @@ export class Cursor<T = Default> extends Readable {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#close
      */
-    close(options?: { skipKillCursors: boolean }, callback?: MongoCallback<number>): void;
+    close(): Promise<void>;
+    close(options: { skipKillCursors: boolean }): Promise<void>;
+    close(options: { skipKillCursors: boolean }, callback?: MongoCallback<number>): void;
     close(callback: MongoCallback<CursorResult>): void;
     /**
      * Set the collation options for the cursor.

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -3992,7 +3992,7 @@ export class Cursor<T = Default> extends Readable {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#close
      */
-    close(options: { skipKillCursors: boolean }, callback?: MongoCallback<number>): void;
+    close(options?: { skipKillCursors: boolean }, callback?: MongoCallback<number>): void;
     close(callback: MongoCallback<CursorResult>): void;
     /**
      * Set the collation options for the cursor.

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -3992,8 +3992,7 @@ export class Cursor<T = Default> extends Readable {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#close
      */
-    close(): Promise<void>;
-    close(options: { skipKillCursors: boolean }): Promise<void>;
+    close(options?: { skipKillCursors: boolean }): Promise<void>;
     close(options: { skipKillCursors: boolean }, callback?: MongoCallback<number>): void;
     close(callback: MongoCallback<CursorResult>): void;
     /**

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -4309,7 +4309,7 @@ export class AggregationCursor<T = Default> extends Cursor<T> {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/AggregationCursor.html#close
      */
-    close(): Promise<AggregationCursorResult>;
+    close(): Promise<void>;
     close(callback: MongoCallback<AggregationCursorResult>): void;
     /**
      * Iterates over all the documents for this cursor. As with `cursor.toArray()`,


### PR DESCRIPTION
`options` parameter of the close() method is an 'optional parameter' but it was mis-typed.

- document url: https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#close
- occurred error:
![image](https://user-images.githubusercontent.com/18566690/118759753-921a1280-b8ac-11eb-975a-1848e5a66eaf.png)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#close
