### PR TITLE
[react-tracking] Update types for 8.1

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -97,8 +97,6 @@ export const ReactTrackingContext: TrackingContext;
  *
  * @param trackingData represents the data to be tracked (or a function returning that data)
  * @param options Additional options
- *
- * @returns object with
  */
 export function useTracking<P = {}>(trackingData?: Partial<P>, options?: Partial<Options<P>>): TrackingHook<P>;
 

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-tracking 7.0
+// Type definitions for react-tracking 8.1
 // Project: https://github.com/NYTimes/react-tracking
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Christopher Pappas <https://github.com/damassi>
@@ -6,9 +6,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from 'react';
+import * as React from "react";
 
 export interface TrackingProp<P = {}> {
+    /**
+     * This function tracks an event, along with related data.
+     */
     trackEvent(data: Partial<P>): void;
 
     /**
@@ -17,7 +20,14 @@ export interface TrackingProp<P = {}> {
     getTrackingData(): {};
 }
 
-type Falsy = false | null | undefined | '';
+export interface TrackingHook<P = {}> extends TrackingProp<P> {
+    /**
+     * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
+     */
+    Track: TrackingComponent<P>;
+}
+
+type Falsy = false | null | undefined | "";
 
 export interface Options<T> {
     /**
@@ -52,6 +62,16 @@ export interface Options<T> {
     process?(ownTrackingData: T): T | Falsy;
 }
 
+export interface DecoratorOptions<T> {
+    /**
+     * When set to `true`, adding a ref to the wrapped component will actually return the instance of the underlying
+     * component.
+     *
+     * Default is `false`.
+     */
+    forwardRef?: boolean;
+}
+
 export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any], [value, err]: [any, any]) => T | Falsy);
 
 // Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
@@ -60,7 +80,7 @@ type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFuncti
 type MethodDecorator = <T>(
     target: object,
     propertyKey: string | symbol,
-    descriptor: TypedPropertyDescriptor<T>
+    descriptor: TypedPropertyDescriptor<T>,
 ) => TypedPropertyDescriptor<T>;
 export type Decorator = ClassDecorator & MethodDecorator;
 
@@ -74,8 +94,13 @@ export const ReactTrackingContext: TrackingContext;
 
 /**
  * A React hook used to tap into the tracking context.
+ *
+ * @param trackingData represents the data to be tracked (or a function returning that data)
+ * @param options Additional options
+ *
+ * @returns object with
  */
-export function useTracking<P = {}>(): TrackingProp<P>;
+export function useTracking<P = {}>(trackingData?: Partial<P>, options?: Partial<Options<P>>): TrackingHook<P>;
 
 /**
  * This is the type of the `track` function. It’s declared as an interface so that consumers can extend the typing and
@@ -84,8 +109,16 @@ export function useTracking<P = {}>(): TrackingProp<P>;
  * For examples of such extensions see: https://github.com/artsy/reaction/blob/master/src/utils/track.ts
  */
 export interface Track<T = any, P = any, S = any> {
-    <K extends keyof T>(trackingInfo?: TrackingInfo<Pick<T, K>, P, S>, options?: Options<Partial<T>>): Decorator;
+    <K extends keyof T>(
+        trackingInfo?: TrackingInfo<Pick<T, K>, P, S>,
+        options?: Options<Partial<T>> & DecoratorOptions<Partial<T>>,
+    ): Decorator;
 }
+
+/**
+ * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
+ */
+export type TrackingComponent<P = {}> = React.FC;
 
 export const track: Track;
 export default track;

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -62,7 +62,7 @@ export interface Options<T> {
     process?(ownTrackingData: T): T | Falsy;
 }
 
-export interface DecoratorOptions<T> {
+export interface DecoratorOptions<T> extends Options<T> {
     /**
      * When set to `true`, adding a ref to the wrapped component will actually return the instance of the underlying
      * component.
@@ -109,7 +109,7 @@ export function useTracking<P = {}>(trackingData?: Partial<P>, options?: Partial
 export interface Track<T = any, P = any, S = any> {
     <K extends keyof T>(
         trackingInfo?: TrackingInfo<Pick<T, K>, P, S>,
-        options?: Options<Partial<T>> & DecoratorOptions<Partial<T>>,
+        options?: DecoratorOptions<Partial<T>>,
     ): Decorator;
 }
 

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 import {
     Track,
     track as _track,
@@ -8,10 +8,9 @@ import {
     TrackingContext,
     ReactTrackingContext,
     useTracking,
-} from 'react-tracking';
-import { string } from 'prop-types';
+} from "react-tracking";
 
-function customEventReporter(data: { page?: string }) { }
+function customEventReporter(data: { page?: string }) {}
 
 interface Props {
     someProp: string;
@@ -30,18 +29,18 @@ interface TrackingData {
 const track: Track<TrackingData, Props, State> = _track;
 
 @track(
-    { page: 'ClassPage' },
+    { page: "ClassPage" },
     {
         dispatch: customEventReporter,
-        dispatchOnMount: contextData => ({ event: 'pageDataReady' }),
-        process: ownTrackingData => (ownTrackingData.page ? { event: 'pageview' } : null),
-    }
+        dispatchOnMount: contextData => ({ event: "pageDataReady" }),
+        process: ownTrackingData => (ownTrackingData.page ? { event: "pageview" } : null),
+    },
 )
 class ClassPage extends React.Component<Props, State> {
-    @track({ event: 'Clicked' })
+    @track({ event: "Clicked" })
     @track((_props, _state, [e]: [React.MouseEvent]) => {
         if (e.ctrlKey) {
-            return { event: 'Click + ctrl key' };
+            return { event: "Click + ctrl key" };
         }
     })
     handleClick() {
@@ -64,21 +63,21 @@ class ClassPage extends React.Component<Props, State> {
 
     @track((_props, _state, _args, [resp, err]) => {
         if (err || !resp) {
-            return { event: 'Async Error' };
+            return { event: "Async Error" };
         }
-        return { event: 'Async Response' };
+        return { event: "Async Response" };
     })
     async handleAsync() {
         // ... other stuff
-        return 'response';
+        return "response";
     }
 }
 
-const FunctionPage: React.SFC<Props> = props => {
+const FunctionPage: React.FC<Props> = props => {
     return (
         <div
             onClick={() => {
-                props.tracking && props.tracking.trackEvent({ action: 'click' });
+                props.tracking && props.tracking.trackEvent({ action: "click" });
             }}
         />
     );
@@ -86,11 +85,11 @@ const FunctionPage: React.SFC<Props> = props => {
 
 const WrappedFunctionPage = track(
     {
-        page: 'FunctionPage',
+        page: "FunctionPage",
     },
     {
         dispatchOnMount: true,
-    }
+    },
 )(FunctionPage);
 
 class Test extends React.Component<any, null> {
@@ -107,7 +106,7 @@ class Test extends React.Component<any, null> {
 const TestContext = () => {
     const trackingContext = {
         tracking: {
-            data: { foo: 'bar' },
+            data: { foo: "bar" },
             dispatch: (data: {}) => data,
             process: (x: string) => x,
         },
@@ -121,24 +120,50 @@ const TestContext = () => {
 
 interface Trackables {
     page: string;
+    action: string;
     app: string;
 }
 
-const App = track()((props: { foo: string }) => {
-    const tracking = useTracking<Trackables>();
+const TestHook = track()((props: { foo: string }) => {
+    const { Track, trackEvent } = useTracking<Trackables>({ page: "Page" }, { dispatchOnMount: false });
 
     React.useEffect(() =>
-        tracking.trackEvent({
-            page: 'Home - useEffect callback'
-        })
+        trackEvent({
+            action: "useEffect callback",
+        }),
     );
     return (
-        <div
-            onClick={() => {
-                tracking.trackEvent({
-                    page: 'Home',
-                });
-            }}
-        />
+        <Track>
+            <div
+                onClick={() => {
+                    trackEvent({
+                        action: "Click",
+                    });
+                }}
+            />
+        </Track>
+    );
+});
+
+const TestEmptyHook = track()((props: { foo: string }) => {
+    const { Track, trackEvent } = useTracking<Trackables>();
+
+    React.useEffect(() =>
+        trackEvent({
+            page: "Home",
+            action: "useEffect callback",
+        }),
+    );
+    return (
+        <Track>
+            <div
+                onClick={() => {
+                    trackEvent({
+                        page: "Home",
+                        action: "Click",
+                    });
+                }}
+            />
+        </Track>
     );
 });

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -46,7 +46,7 @@ class ClassPage extends React.Component<any> {
     }
 }
 
-const FunctionPage: React.SFC<any> = props => {
+const FunctionPage: React.FC<any> = props => {
     return (
         <div
             onClick={() => {

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
-import { Track, track, TrackingProp, useTracking } from 'react-tracking';
+import * as React from "react";
+import { Track, track, TrackingProp, useTracking } from "react-tracking";
 
-function customEventReporter(data: { page?: string }) { }
+function customEventReporter(data: { page?: string }) {}
 
 @track(
-    { page: 'ClassPage' },
+    { page: "ClassPage" },
     {
         dispatch: customEventReporter,
-        dispatchOnMount: contextData => ({ event: 'pageDataReady' }),
-        process: ownTrackingData => (ownTrackingData.page ? { event: 'pageview' } : null),
-    }
+        dispatchOnMount: contextData => ({ event: "pageDataReady" }),
+        process: ownTrackingData => (ownTrackingData.page ? { event: "pageview" } : null),
+    },
 )
 class ClassPage extends React.Component<any> {
-    @track({ event: 'Clicked' })
+    @track({ event: "Clicked" })
     @track((_props, _state, [e]) => {
         if (e.ctrlKey) {
-            return { event: 'Click + ctrl key' };
+            return { event: "Click + ctrl key" };
         }
     })
     handleClick() {
@@ -33,7 +33,7 @@ class ClassPage extends React.Component<any> {
         return <button onClick={this.handleClick}>Click Me!</button>;
     }
 
-    @track({ event: 'Async' })
+    @track({ event: "Async" })
     @track((_props, _state, _args, [resp, err]) => {
         if (resp) {
             return { result: resp, error: null };
@@ -42,7 +42,7 @@ class ClassPage extends React.Component<any> {
     })
     async handleAsync() {
         // ... other stuff
-        return 'response';
+        return "response";
     }
 }
 
@@ -50,7 +50,7 @@ const FunctionPage: React.SFC<any> = props => {
     return (
         <div
             onClick={() => {
-                props.tracking && props.tracking.trackEvent({ action: 'click' });
+                props.tracking && props.tracking.trackEvent({ action: "click" });
             }}
         />
     );
@@ -58,11 +58,11 @@ const FunctionPage: React.SFC<any> = props => {
 
 const WrappedFunctionPage = track(
     {
-        page: 'FunctionPage',
+        page: "FunctionPage",
     },
     {
         dispatchOnMount: true,
-    }
+    },
 )(FunctionPage);
 
 class Test extends React.Component<any, null> {
@@ -76,22 +76,52 @@ class Test extends React.Component<any, null> {
     }
 }
 
-const App = track()(({ foo }: { foo: string }) => {
-    const tracking = useTracking();
+const TestHook = track()((props: { foo: string }) => {
+    const { Track, trackEvent } = useTracking(
+        {
+            page: "Page",
+            action: "Load",
+        },
+        { dispatchOnMount: true },
+    );
 
     React.useEffect(() =>
-        tracking.trackEvent({
-            page: 'Home - useEffect callback'
-        })
+        trackEvent({
+            action: "useEffect callback",
+        }),
     );
     return (
-        <div
-            onClick={() => {
-                tracking.trackEvent({
-                    page: 'Home',
-                    foo,
-                });
-            }}
-        />
+        <Track>
+            <div
+                onClick={() => {
+                    trackEvent({
+                        action: "Click",
+                    });
+                }}
+            />
+        </Track>
+    );
+});
+
+const TestEmptyHook = track()((props: { foo: string }) => {
+    const { Track, trackEvent } = useTracking();
+
+    React.useEffect(() =>
+        trackEvent({
+            page: "Home",
+            action: "useEffect callback",
+        }),
+    );
+    return (
+        <Track>
+            <div
+                onClick={() => {
+                    trackEvent({
+                        page: "Home",
+                        action: "Click",
+                    });
+                }}
+            />
+        </Track>
     );
 });

--- a/types/react-tracking/tslint.json
+++ b/types/react-tracking/tslint.json
@@ -2,7 +2,6 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "ban-types": false,
-        "no-unnecessary-generics": false,
-        "no-outside-dependencies": false
+        "no-unnecessary-generics": false
     }
 }

--- a/types/react-tracking/tslint.json
+++ b/types/react-tracking/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "ban-types": false,
-        "no-unnecessary-generics": false
+        "no-unnecessary-generics": false,
+        "no-outside-dependencies": false
     }
 }


### PR DESCRIPTION
Hi, 
I have made updates to support the latest version of [@nytimes/react-tracking](https://github.com/nytimes/react-tracking).

Fixes #52105

The following is a breakdown of the major changes:

- add `TrackingHook` interface
- add `TrackingComponent` type
- add parameters to `useTracking`
- add `DecoratorOptions` to `Track`

Here are additional changes made:

- ~~`tslint.json` was updated because of an error when testing. I can revert this change if it is unnecessary and is only a problem on my machine. This was the error:~~
    ```
    yarn test react-tracking
    yarn run v1.22.10
    $ dtslint types react-tracking
    Error: <path>/DefinitelyTyped/node_modules/csstype/index.d.ts:1:1
    ERROR: 1:1  no-outside-dependencies  File <path>/Dev/DefinitelyTyped/node_modules/csstype/index.d.ts comes from a `node_modules` but is not declared in this type's `package.json`.  See: 
    https://github.com/Microsoft/dtslint/blob/master/docs/no-outside-dependencies.md

        at <path>/DefinitelyTyped/node_modules/dtslint/bin/index.js:207:19
        at Generator.next (<anonymous>)
        at fulfilled (<path>/DefinitelyTyped/node_modules/dtslint/bin/index.js:6:58) error Command failed with exit code 1.
    ```
- `prettier` formatted some of the lines, mostly replacing single with double quotes

PR checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nytimes/react-tracking/releases/tag/v8.1.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.