### PR TITLE
fix(webpack): fix invalid `anymatch` module resolution

### DIFF
--- a/types/webpack/v4/package.json
+++ b/types/webpack/v4/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
+        "anymatch": "^3.0.0",
         "source-map": "^0.6.0"
     }
 }


### PR DESCRIPTION
Fix issue with TSC resolving dependencies to `anymatch` module to
external paths from e.g. `node_modules` within other package, instead of
resolving into `anymatch` dependency of this package (v4 of Webpack)

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.

This will require change in allowed packages

/cc @sandersn 