### PR TITLE
Typo fix for eventLoopUtilization in worker_threads::Worker::performance

### DIFF
--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -108,5 +108,5 @@ import { EventLoopUtilization } from 'perf_hooks';
 
 {
     const worker = new workerThreads.Worker(__filename);
-    const utilization: EventLoopUtilization = worker.performance.eventLoopUtilitzation();
+    const utilization: EventLoopUtilization = worker.performance.eventLoopUtilization();
 }

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -19,7 +19,7 @@ declare module 'worker_threads' {
     }
 
     interface WorkerPerformance {
-        eventLoopUtilitzation: EventLoopUtilityFunction;
+        eventLoopUtilization: EventLoopUtilityFunction;
     }
 
     type TransferListItem = ArrayBuffer | MessagePort | FileHandle;


### PR DESCRIPTION
worker_threads: type fix for Worker::performance::eventLoopUtilization

Looks like the typo had also been copypasted / autocompleted into the test, rendering the test somewhat useless for catching the issue.

Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓][ Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [✓] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/worker_threads.html#worker_threads_worker_performance>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
