### PR TITLE
Add documented but not typed functions and options for Leaflet, v1.7.1

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -30,6 +30,12 @@ export class Transformation {
     untransform(point: Point, scale?: number): Point;
 }
 
+/** Instantiates a Transformation object with the given coefficients. */
+export function transformation(a: number, b: number, c: number, d: number): Transformation;
+
+/** Expects an coefficients array of the form `[a: Number, b: Number, c: Number, d: Number]`. */
+export function transformation(coefficients: [number, number, number, number]): Transformation;
+
 /**
  * @see https://github.com/Leaflet/Leaflet/blob/bc918d4bdc2ba189807bc207c77080fb41ecc196/src/geometry/LineUtil.js#L118
  */
@@ -757,6 +763,16 @@ export interface GridLayerOptions {
     bounds?: LatLngBoundsExpression;
     minZoom?: number;
     maxZoom?: number;
+    /**
+     * Maximum zoom number the tile source has available. If it is specified, the tiles on all zoom levels higher than
+     * `maxNativeZoom` will be loaded from `maxNativeZoom` level and auto-scaled.
+     */
+    maxNativeZoom?: number;
+    /**
+     * Minimum zoom number the tile source has available. If it is specified, the tiles on all zoom levels lower than
+     * `minNativeZoom` will be loaded from `minNativeZoom` level and auto-scaled.
+     */
+    minNativeZoom?: number;
     noWrap?: boolean;
     pane?: string;
     className?: string;
@@ -811,7 +827,7 @@ export interface TileLayerOptions extends GridLayerOptions {
     detectRetina?: boolean;
     crossOrigin?: CrossOrigin;
     // [name: string]: any;
-    // You are able add additional properties, but it makes this interface unchackable.
+    // You are able add additional properties, but it makes this interface uncheckable.
     // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15313
     // Example:
     // tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png?{foo}&{bar}&{abc}', {foo: 'bar', bar: (data: any) => 'foo', abc: () => ''});
@@ -934,8 +950,13 @@ export interface VideoOverlayOptions extends ImageOverlayOptions {
     autoplay?: boolean;
     /** Whether the video will loop back to the beginning when played. */
     loop?: boolean;
-    /** Whether the video will save aspect ratio after the projection. */
+    /**
+     * Whether the video will save aspect ratio after the projection. Relevant for supported browsers. See
+     * [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
+     */
     keepAspectRatio?: boolean;
+    /** Whether the video starts on mute when loaded. */
+    muted?: boolean;
 }
 
 export class VideoOverlay extends Layer { /** VideoOverlay doesn't extend ImageOverlay because VideoOverlay.getElement returns HTMLImageElement */
@@ -1182,7 +1203,7 @@ export class FeatureGroup<P = any> extends LayerGroup<P> {
 /**
  * Create a feature group, optionally given an initial set of layers.
  */
-export function featureGroup(layers?: Layer[]): FeatureGroup;
+export function featureGroup(layers?: Layer[], options?: LayerOptions): FeatureGroup;
 
 export type StyleFunction<P = any> = (feature?: geojson.Feature<geojson.GeometryObject, P>) => PathOptions;
 
@@ -1246,6 +1267,9 @@ export interface GeoJSONOptions<P = any> extends InteractiveLayerOptions {
      * The default is the coordsToLatLng static method.
      */
     coordsToLatLng?(coords: [number, number] | [number, number, number]): LatLng; // check if LatLng has an altitude property
+
+    /** Whether default Markers for "Point" type Features inherit from group options. */
+    markersInheritOptions?: boolean;
 }
 
 /**
@@ -1297,13 +1321,13 @@ export class GeoJSON<P = any> extends FeatureGroup<P> {
     /**
      * Adds a GeoJSON object to the layer.
      */
-    addData(data: geojson.GeoJsonObject): Layer;
+    addData(data: geojson.GeoJsonObject): this;
 
     /**
      * Resets the given vector layer's style to the original GeoJSON style,
      * useful for resetting style after hover events.
      */
-    resetStyle(layer?: Layer): Layer;
+    resetStyle(layer?: Layer): this;
 
     /**
      * Same as FeatureGroup's setStyle method, but style-functions are also
@@ -1433,6 +1457,17 @@ export namespace Control {
         collapsed?: boolean;
         autoZIndex?: boolean;
         hideSingleBase?: boolean;
+        /**
+         * Whether to sort the layers. When `false`, layers will keep the order in which they were added to the control.
+         */
+        sortLayers?: boolean;
+        /**
+         * A [compare function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
+         * that will be used for sorting the layers, when `sortLayers` is `true`. The function receives both the
+         * [`L.Layer`](https://leafletjs.com/reference.html#layer) instances and their names, as in
+         * `sortFunction(layerA, layerB, nameA, nameB)`. By default, it sorts layers alphabetically by their name.
+         */
+        sortFunction?: (layerA: Layer, layerB: Layer, nameA: string, nameB: string) => number;
     }
 
     interface LayersObject {

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -45,7 +45,10 @@ let distance: number;
 distance = point.distanceTo(point);
 distance = point.distanceTo(pointTuple);
 
-const transformation = new L.Transformation(1, 2, 3, 4);
+let transformation: L.Transformation;
+transformation = new L.Transformation(1, 2, 3, 4);
+transformation = L.transformation(1, 2, 3, 4);
+transformation = L.transformation([1, 2, 3, 4]);
 point = transformation.transform(point);
 point = transformation.transform(point, 2);
 point = transformation.untransform(point);
@@ -362,7 +365,8 @@ videoOverlayOptions = {
     interactive: true,
     opacity: 100,
     autoplay: true,
-    loop: false
+    loop: false,
+    muted: true
 };
 
 const videoOverlayBounds = latLngBounds;
@@ -528,7 +532,7 @@ let nestedTwoCoords = [[12, 13], [13, 14], [14, 15]];
 const nestedLatLngs: L.LatLng[] = L.GeoJSON.coordsToLatLngs(nestedTwoCoords, 1);
 nestedTwoCoords = L.GeoJSON.latLngsToCoords(nestedLatLngs, 1);
 
-const geojsonOptions: L.GeoJSONOptions = { interactive: true, bubblingMouseEvents: false };
+const geojsonOptions: L.GeoJSONOptions = { interactive: true, bubblingMouseEvents: false, markersInheritOptions: true };
 const geojson = new L.GeoJSON(null, geojsonOptions);
 
 geojson.toGeoJSON();


### PR DESCRIPTION
Adds functions and options present in the [Leaflet documentation](https://leafletjs.com/reference-1.7.1.html) but not in the typings. Also fixes a few minor discrepancies between the docs and typings.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.7.1.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.