### PR TITLE
@ckeditor/ckeditor5-utils EventInfo requires Emitter

### DIFF
--- a/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
@@ -16,7 +16,7 @@ export default class CloudServices extends ContextPlugin implements Emitter, Obs
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -32,7 +32,7 @@ export default class CloudServices extends ContextPlugin implements Emitter, Obs
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/fileuploader.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/fileuploader.d.ts
@@ -15,7 +15,7 @@ export default class FileUploader implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -31,7 +31,7 @@ export default class FileUploader implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/command.d.ts
@@ -25,7 +25,7 @@ export default class Command implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -41,7 +41,7 @@ export default class Command implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
@@ -36,7 +36,7 @@ export default abstract class Editor implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: engine.DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -56,7 +56,7 @@ export default abstract class Editor implements Emitter, Observable {
         event?: string,
         callback?: (info: EventInfo, data: engine.DomEventData) => void,
     ): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 

--- a/types/ckeditor__ckeditor5-core/src/editor/editorui.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorui.d.ts
@@ -23,7 +23,7 @@ export default class EditorUI implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -39,7 +39,7 @@ export default class EditorUI implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
@@ -29,7 +29,7 @@ export default class PendingActions
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -45,7 +45,7 @@ export default class PendingActions
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugin.d.ts
@@ -21,24 +21,24 @@ export default class Plugin implements Emitter, Observable {
     decorate(methodName: string): void;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     destroy?(): void | Promise<any>;
-    fire<T>(eventOrInfo: string | EventInfo<Emitter>, ...args: T[]): T;
+    fire<T>(eventOrInfo: string | EventInfo, ...args: T[]): T;
     forceDisabled(id: string): void;
     init?(): Promise<void> | void;
     listenTo(
         emitter: Emitter,
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority?: number | PriorityString },
     ): void;
-    off(event: string, callback?: (info: EventInfo<Emitter>, data: DomEventData) => void): void;
+    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: number | PriorityString },
     ) => void;
     once(
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: number | PriorityString },
     ): void;
     private _disableStack;
@@ -48,7 +48,7 @@ export default class Plugin implements Emitter, Observable {
     stopListening(
         emitter?: Emitter,
         event?: string,
-        callback?: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback?: (info: EventInfo, data: DomEventData) => void,
     ): void;
     unbind(...unbindProperties: string[]): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
@@ -25,7 +25,7 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -41,7 +41,7 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/v11/index.d.ts
+++ b/types/ckeditor__ckeditor5-core/v11/index.d.ts
@@ -85,7 +85,7 @@ export namespace editor {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -142,7 +142,7 @@ export namespace editor {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -178,7 +178,7 @@ export class Command<T = undefined> implements Emitter, Observable {
 
     // Emitter
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     listenTo(
         emitter: Emitter,
         event: string,
@@ -253,7 +253,7 @@ export abstract class Plugin<T = void> implements Emitter, Observable {
 
     // Emitter
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     listenTo(
         emitter: Emitter,
         event: string,

--- a/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
@@ -52,7 +52,7 @@ export default class DataController implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -68,7 +68,7 @@ export default class DataController implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
@@ -26,7 +26,7 @@ export default class EditingController implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -42,7 +42,7 @@ export default class EditingController implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
@@ -36,7 +36,7 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -52,7 +52,7 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
@@ -56,7 +56,7 @@ export default class UpcastDispatcher implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -72,7 +72,7 @@ export default class UpcastDispatcher implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/document.d.ts
@@ -31,7 +31,7 @@ export default class Document implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -47,7 +47,7 @@ export default class Document implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
@@ -40,7 +40,7 @@ export default class DocumentSelection implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -56,7 +56,7 @@ export default class DocumentSelection implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
@@ -72,7 +72,7 @@ export default class Model implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -88,7 +88,7 @@ export default class Model implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
@@ -47,7 +47,7 @@ export default class Schema implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -63,7 +63,7 @@ export default class Schema implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
@@ -49,7 +49,7 @@ export default class Selection implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -65,7 +65,7 @@ export default class Selection implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
@@ -31,7 +31,7 @@ export default class Document implements BubblingEmitter, Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -47,7 +47,7 @@ export default class Document implements BubblingEmitter, Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/bubblingeventinfo.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/bubblingeventinfo.d.ts
@@ -8,5 +8,5 @@ export default class BubblingEventInfo extends EventInfo {
     readonly eventPhase: "none" | "capturing" | "atTarget" | "bubbling";
     readonly startRange: Range;
 
-    constructor(source: any, name: string, startRange: Range);
+    constructor(source: Document, name: string, startRange: Range);
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
@@ -55,7 +55,7 @@ export default class View implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -71,7 +71,7 @@ export default class View implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v11/index.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v11/index.d.ts
@@ -35,7 +35,7 @@ export namespace controller {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -69,7 +69,7 @@ export namespace controller {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -606,7 +606,7 @@ export namespace model {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -812,7 +812,7 @@ export namespace model {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -1076,7 +1076,7 @@ export namespace view {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,
@@ -1423,7 +1423,7 @@ export namespace view {
 
         // Emitter
         delegate(...events: string[]): EmitterMixinDelegateChain;
-        fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+        fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
         listenTo(
             emitter: Emitter,
             event: string,

--- a/types/ckeditor__ckeditor5-ui/src/model.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/model.d.ts
@@ -17,7 +17,7 @@ export default class Model implements Emitter, Observable {
 
     on(
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ): void;
     once(
@@ -33,7 +33,7 @@ export default class Model implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/notification/notification.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/notification/notification.d.ts
@@ -11,7 +11,7 @@ export default class Notification extends ContextPlugin implements Emitter {
 
     on(
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ): void;
     once(
@@ -27,7 +27,7 @@ export default class Notification extends ContextPlugin implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/template.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/template.d.ts
@@ -23,7 +23,7 @@ export default class Template implements Emitter {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -39,7 +39,7 @@ export default class Template implements Emitter {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/tooltip/tooltipview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/tooltip/tooltipview.d.ts
@@ -16,7 +16,7 @@ export default class TooltipView extends View implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -32,7 +32,7 @@ export default class TooltipView extends View implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/view.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/view.d.ts
@@ -36,7 +36,7 @@ export default class View implements Emitter, Observable {
 
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
@@ -52,7 +52,7 @@ export default class View implements Emitter, Observable {
         options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -416,7 +416,7 @@ emitter.delegate("foo").to(emitter, name => name + "-delegated");
 
 emitter.fire("foo");
 emitter.fire("foo", 1, "b", true);
-emitter.fire("getSelectedContent", (evt: EventInfo<any>) => {
+emitter.fire("getSelectedContent", (evt: EventInfo) => {
     evt.stop();
 });
 
@@ -457,8 +457,8 @@ bool = env.isMac;
 
 // utils/eventinfo ============================================================
 
-const event = new EventInfo({ a: 1 }, "test");
-num = event.source.a;
+const event = new EventInfo(EmitterMixin, "test");
+const emit: Emitter = event.source;
 str = event.name;
 
 event.path[0];

--- a/types/ckeditor__ckeditor5-utils/src/collection.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/collection.d.ts
@@ -228,7 +228,7 @@ export default class Collection<T> implements Iterable<T>, Emitter {
     [Symbol.iterator](): Iterator<T>;
 
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     listenTo(
         emitter: Emitter,
         event: string,
@@ -238,7 +238,7 @@ export default class Collection<T> implements Iterable<T>, Emitter {
     off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(

--- a/types/ckeditor__ckeditor5-utils/src/dom/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/dom/emittermixin.d.ts
@@ -5,7 +5,7 @@ import { PriorityString } from "../priorities";
 
 export interface Emitter extends BaseEmitter {
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     listenTo(
         emitter: Emitter,
         event: string,
@@ -15,7 +15,7 @@ export interface Emitter extends BaseEmitter {
     off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(

--- a/types/ckeditor__ckeditor5-utils/src/dom/resizeobserver.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/dom/resizeobserver.d.ts
@@ -35,7 +35,7 @@ export default class ResizeObserver implements Emitter {
 
     // Implements
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     listenTo(
         emitter: Emitter,
         event: string,
@@ -45,7 +45,7 @@ export default class ResizeObserver implements Emitter {
     off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(

--- a/types/ckeditor__ckeditor5-utils/src/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/emittermixin.d.ts
@@ -14,7 +14,7 @@ export interface Emitter {
      */
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     /**
@@ -85,7 +85,7 @@ export interface Emitter {
      * through modification of the {@link module:utils/eventinfo~EventInfo#return `evt.return`}'s property (the event info
      * is the first param of every callback).
      */
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     /**
      * Delegates selected events to another {@link module:utils/emittermixin~Emitter}. For instance:
      *

--- a/types/ckeditor__ckeditor5-utils/src/eventinfo.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/eventinfo.d.ts
@@ -1,8 +1,10 @@
+import { Emitter } from "./emittermixin";
+
 /**
  * The event object passed to event callbacks. It is used to provide information about the event as well as a tool to
  * manipulate it.
  */
-export default class EventInfo<S extends object = {}, N extends string = ""> {
+export default class EventInfo<S extends Emitter = Emitter, N extends string = ""> {
     constructor(source: S, name: N);
     /**
      * The object that fired the event.

--- a/types/ckeditor__ckeditor5-utils/src/focustracker.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/focustracker.d.ts
@@ -47,7 +47,7 @@ export default class FocusTracker implements Observable, Emitter, DomEmitter {
 
     // Observable (Emitter)
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     listenTo(
         emitter: Emitter,
         event: string,
@@ -57,7 +57,7 @@ export default class FocusTracker implements Observable, Emitter, DomEmitter {
     off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     on: (
         event: string,
-        callback: (info: EventInfo<Emitter>, data: DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(


### PR DESCRIPTION
Mark the `EventInfo` class as requiring an object that extends `Emitter`, instead of a generic object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/latest/api/module_utils_eventinfo-EventInfo.html#function-constructor
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.