### PR TITLE
[mathjs]: Fix simplify argument types

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -537,16 +537,12 @@ declare namespace math {
         /**
          * Simplify an expression tree.
          * @param expr The expression to be simplified
-         * @param rules (optional) A list of rules are applied to an expression, repeating
+         * @param [rules] (optional) A list of rules are applied to an expression, repeating
          * over the list until no further changes are made. It’s possible to
          * pass a custom set of rules to the function as second argument. A rule
          * can be specified as an object, string, or function.
-         * @param scope (optional) Scope to variables
-         * @param options (optional) Simplify options object with two knobs:
-         *   - `exactFractions`: a boolean which is `true` by default.
-         *   - `fractionsLimit`: when `exactFractions` is true, a fraction will be returned
-         * only when both numerator and denominator are smaller than `fractionsLimit`.
-         * Default value is 10000.
+         * @param [scope] (optional) Scope to variables
+         * @param {SimplifyOptions} [options] (optional) An object with simplify options
          * @returns Returns the simplified form of expr
          */
         simplify(
@@ -2959,7 +2955,13 @@ declare namespace math {
     }
 
     interface SimplifyOptions {
+        /** A boolean which is `true` by default. */
         exactFractions?: boolean;
+        /**
+         * When `exactFractions` is true, a fraction will be returned only
+         * when both numerator and denominator are smaller than `fractionsLimit`.
+         * Default value is 10000.
+         */
         fractionsLimit?: number;
     }
 

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -537,18 +537,25 @@ declare namespace math {
         /**
          * Simplify an expression tree.
          * @param expr The expression to be simplified
-         * @param rules A list of rules are applied to an expression, repeating
+         * @param rules (optional) A list of rules are applied to an expression, repeating
          * over the list until no further changes are made. It’s possible to
          * pass a custom set of rules to the function as second argument. A rule
          * can be specified as an object, string, or function.
-         * @param scope Scope to variables
+         * @param scope (optional) Scope to variables
+         * @param options (optional) Simplify options object with two knobs:
+         *   - `exactFractions`: a boolean which is `true` by default.
+         *   - `fractionsLimit`: when `exactFractions` is true, a fraction will be returned
+         * only when both numerator and denominator are smaller than `fractionsLimit`.
+         * Default value is 10000.
          * @returns Returns the simplified form of expr
          */
         simplify(
             expr: MathNode | string,
             rules?: Array<{ l: string; r: string } | string | ((node: MathNode) => MathNode)>,
             scope?: object,
+            options?: SimplifyOptions,
         ): MathNode;
+        simplify(expr: MathNode | string, scope?: object, options?: SimplifyOptions): MathNode;
 
         /**
          * Calculate the Sparse Matrix LU decomposition with full pivoting.
@@ -2949,6 +2956,11 @@ declare namespace math {
         prefixes?: string;
         offset?: number;
         aliases?: string[];
+    }
+
+    interface SimplifyOptions {
+        exactFractions?: boolean;
+        fractionsLimit?: number;
     }
 
     interface Index {} // tslint:disable-line no-empty-interface

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -542,7 +542,7 @@ declare namespace math {
          * pass a custom set of rules to the function as second argument. A rule
          * can be specified as an object, string, or function.
          * @param [scope] (optional) Scope to variables
-         * @param {SimplifyOptions} [options] (optional) An object with simplify options
+         * @param [options] (optional) An object with simplify options
          * @returns Returns the simplified form of expr
          */
         simplify(

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -93,6 +93,22 @@ Chaining examples
 }
 
 /*
+Simplify examples
+*/
+{
+    const math = create(all);
+
+    math.simplify("2 * 1 * x ^ (2 - 1)");
+    math.simplify("2 * 3 * x", { x: 4 });
+
+    const f = math.parse("2 * 1 * x ^ (2 - 1)");
+    math.simplify(f);
+
+    math.simplify("0.4 * x", {}, { exactFractions: true });
+    math.simplify("0.4 * x", {}, { exactFractions: false });
+}
+
+/*
 Complex numbers examples
 */
 {


### PR DESCRIPTION
Currently the type only supports (anche checks) when using `simplify` func with `expr` and `rules`.
Usage with also `expr` and `scope` is supported by `mathjs` and this PR fix that.

Bonus: added `SimplifyOptions`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [mathjs simplify](https://mathjs.org/docs/reference/functions/simplify.html#examples)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.