### PR TITLE
mongodb: Add returnDocument and deprecate returnOriginal

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -3399,6 +3399,8 @@ export interface FindOneAndReplaceOption<T> extends CommonOptions {
     sort?: SortOptionObject<T>;
     maxTimeMS?: number;
     upsert?: boolean;
+    returnDocument?: 'after' | 'before';
+    /** @deprecated Use returnDocument */
     returnOriginal?: boolean;
     collation?: CollationDocument;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/node-mongodb-native/pull/2808
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR adds a definition for the new `returnDocument` option used in `findOneAndReplace()` and `findOneAndUpdate()`. It also marks `returnOriginal` with a deprecated comment. CC https://github.com/mongodb/node-mongodb-native/pull/2808