### PR TITLE
[open-graph-scraper] Add customMetaTags field to Options and Update type test

### DIFF
--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for open-graph-scraper 4.7
+// Type definitions for open-graph-scraper 4.8
 // Project: https://github.com/jshemas/openGraphScraper#readme
 // Definitions by: Florian Imdahl <https://github.com/ffflorian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -228,6 +228,12 @@ declare namespace run {
         require_valid_protocol?: boolean;
     }
 
+    interface CustomMetaTag {
+        multiple?: boolean;
+        property: string;
+        fieldName: string;
+    }
+
     interface Options {
         /** By default, OGS will only send back the first image/video it finds (default: `false`). */
         allMedia?: boolean;
@@ -262,6 +268,8 @@ declare namespace run {
         url: string;
         /** Sets the options used by `validator.js` for testing the URL. */
         urlValidatorSettings?: URLValidatorSettings;
+        /** Add custom meta tags if there are no what you want in open graph properties type */
+        customMetaTags?: CustomMetaTag[];
     }
 }
 

--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -268,7 +268,7 @@ declare namespace run {
         url: string;
         /** Sets the options used by `validator.js` for testing the URL. */
         urlValidatorSettings?: URLValidatorSettings;
-        /** Add custom meta tags if there are no what you want in open graph properties type */
+        /** Here you can define custom meta tags you want to scrape. */
         customMetaTags?: CustomMetaTag[];
     }
 }

--- a/types/open-graph-scraper/open-graph-scraper-tests.ts
+++ b/types/open-graph-scraper/open-graph-scraper-tests.ts
@@ -7,24 +7,24 @@ const options: openGraphScraper.Options = {
 };
 
 openGraphScraper(options, (error, results, response) => {
-    error; // $expectType boolean
-    results; // $expectType SuccessResult | ErrorResult
-    response; // $expectType PassThrough
+    error; // $ExpectType boolean
+    results; // $ExpectType SuccessResult | ErrorResult
+    response; // $ExpectType PassThrough
 });
 
 openGraphScraper(options).then(data => {
     if (!data.error) {
         const { error, result, response } = data;
-        error; // $expectType false
-        result; // $expectType SuccessResult
-        response; // $expectType PassThrough
-        result.ogUrl; // $expectType string | undefined
-        result.modifiedTime; // $expectType string | undefined
-        result.customValue; // $expectType string | undefined
+        error; // $ExpectType false
+        result; // $ExpectType OpenGraphProperties & { ogImage?: OpenGraphImage | OpenGraphImage[] | undefined; success: true; }
+        response; // $ExpectType PassThrough
+        result.ogUrl; // $ExpectType string | undefined
+        result.modifiedTime; // $ExpectType string | undefined
+        result.customValue; // $ExpectType string | undefined
     } else {
         const { error, result } = data;
-        error; // $expectType true
-        result; // $expectType ErrorResult
-        result.errorDetails; // $expectType Error
+        error; // $ExpectType true
+        result; // $ExpectType { error: string; errorDetails: Error; success: false; }
+        result.errorDetails; // $ExpectType Error
     }
 });


### PR DESCRIPTION
- Add `customMetaTags` field to `Options` type and also add `CustomMetaTag` interface
- Update Test
  - fix miss spell: `$expectType` -> `$ExpectType` (it's case sensitive 😂)
  - update type of result field in `SuccessResult` type (the type has changed in #50978) 
  - update type of result field in `ErrorResult` type

thank you :)

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- I referred these urls
  - [customMetaTags in document](https://github.com/jshemas/openGraphScraper#custom-meta-tag-example)
  - [customMetaTags in source code](https://github.com/jshemas/openGraphScraper/blob/857245d8753380ce9adf0c1956edff06b45b523a/lib/extract.js#L13)
