### PR TITLE
Fix withHandler types for Kefir

### DIFF
--- a/types/kefir/index.d.ts
+++ b/types/kefir/index.d.ts
@@ -98,7 +98,7 @@ export class Observable<T, S> {
     bufferWithCount(count: number, options?: { flushOnEnd: boolean }): Observable<T[], S>;
     bufferWithTimeOrCount(interval: number, count: number, options?: { flushOnEnd: boolean }): Observable<T[], S>;
     transduce<U>(transducer: any): Observable<U, S>;
-    withHandler<U, V>(handler: (emitter: Emitter<U, S>, event: Event<T, S>) => void): Observable<U, S>;
+    withHandler<U, V>(handler: (emitter: Emitter<U, V>, event: Event<T, S>) => void): Observable<U, V>;
     // Combine streams
     combine<U, V, W>(otherObs: Observable<U, V>, combinator?: (value: T, ...values: U[]) => W): Observable<W, S | V>;
     zip<U, V, W>(otherObs: Observable<U, V>, combinator?: (value: T, ...values: U[]) => W): Observable<W, S | V>;

--- a/types/kefir/kefir-tests.ts
+++ b/types/kefir/kefir-tests.ts
@@ -147,6 +147,21 @@ import { Observable, Pool, Stream, Property, Event, Emitter } from 'kefir';
 
     const thru = (a: Observable<string, never>) => 1;
     let observable33: number = Kefir.constant('hello').thru(thru);
+    let observable34: Observable<string, Error> = Kefir.stream<number, string>((emitter: Emitter<number, string>) => {
+        emitter.emit(1);
+        emitter.error("some error");
+        emitter.end();
+    }).withHandler<string, Error>((emitter: Emitter<string, Error>, event: Event<number, string>) => {
+        if (event.type === "value") {
+            emitter.emit(`${event.value}`);
+        }
+        if (event.type === "error") {
+            emitter.error(new Error(event.value));
+        }
+        if (event.type === "end") {
+            emitter.end();
+        }
+    });
 }
 
 // Combine observables


### PR DESCRIPTION
The `V` type in `withHandler` was not used. The `U`, and `V` types on `withHandler` should represent the types in the `Observable` returned from `withHandler`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code that provides context for the suggested changes: [Documentation](https://kefirjs.github.io/kefir/#with-handler). The [source for with handler](https://github.com/kefirjs/kefir/blob/1ceca1fd655cd3cd382b15d99e93e1e2a3961e2f/src/one-source/with-handler.js#L15-L17) shows that `_handleAny` is being overloaded with a handler that is passed in. That handler can emit any type it wants.  [The definition of the base `_handleAny`](https://github.com/kefirjs/kefir/blob/1ceca1fd655cd3cd382b15d99e93e1e2a3961e2f/src/patterns/one-source.js#L31-L40) for context
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

