### PR TITLE
Fix assert definition in check-types

### DIFF
--- a/types/check-types/check-types-tests.ts
+++ b/types/check-types/check-types-tests.ts
@@ -1,11 +1,11 @@
-import * as check from "check-types";
+import * as check from 'check-types';
 
 const a: boolean = check.number(2);
 
 const b: any = 2;
 
 if (check.string(b)) {
-  const c = b.slice(0, 1);
+    const c = b.slice(0, 1);
 }
 
 check.map({ val: 1, val2: 2 }, { val: check.number, val2: check.string });
@@ -18,40 +18,36 @@ check.maybe.even(2);
 
 check.assert.like({ foo: 'bar' }, { baz: 'qux' });
 
-check.assert(false, "msg", Error);
+check.assert(false, 'msg', Error);
 
 check.assert.not.like({ foo: 'bar' }, { baz: 'qux' });
 
+check.assert.not.like({ foo: 'bar' }, { baz: 'qux' }, 'with a message');
+
 check.assert.maybe.like(undefined, { foo: 'bar' });
 
-check.assert(function a(): any { return {}; }, 'Something went wrong', Error);
+check.assert.maybe.like(undefined, { foo: 'bar' }, 'with a message');
 
-check.apply([ 'foo', 'bar', '' ], check.nonEmptyString);
+check.assert.nonEmptyArray([1, 2], 'With a message');
 
-check.any(
-  check.apply(
-      [ 1, 2, 3, '' ],
-      check.string
-  )
+check.assert.not.inRange(1, 2, 3);
+
+check.assert.not.inRange(1, 2, 3, 'With a message');
+
+check.assert(
+    function a(): any {
+        return {};
+    },
+    'Something went wrong',
+    Error,
 );
 
-check.any(
-  check.map(
-    { foo: 0, bar: '' },
-    { foo: check.number, bar: check.string }
-  )
-);
+check.apply(['foo', 'bar', ''], check.nonEmptyString);
 
-check.all(
-  check.map(
-      { foo: 0, bar: '' },
-      { foo: check.number, bar: check.string }
-  )
-);
+check.any(check.apply([1, 2, 3, ''], check.string));
 
-check.all(
-  check.apply(
-    [ 1, 2, 3, '' ],
-    check.string
-  )
-);
+check.any(check.map({ foo: 0, bar: '' }, { foo: check.number, bar: check.string }));
+
+check.all(check.map({ foo: 0, bar: '' }, { foo: check.number, bar: check.string }));
+
+check.all(check.apply([1, 2, 3, ''], check.string));

--- a/types/check-types/check-types-tests.ts
+++ b/types/check-types/check-types-tests.ts
@@ -34,6 +34,16 @@ check.assert.not.inRange(1, 2, 3);
 
 check.assert.not.inRange(1, 2, 3, 'With a message');
 
+check.assert.array.of.string(['']);
+
+check.assert.array.of.string([''], 'With a message');
+
+check.assert.not.array.of.string(['']);
+
+check.assert.not.array.of.string([''], 'With a message');
+
+check.array.of.string(['']);
+
 check.assert(
     function a(): any {
         return {};

--- a/types/check-types/index.d.ts
+++ b/types/check-types/index.d.ts
@@ -8,7 +8,7 @@ type NegationFunction = (val: any) => boolean;
 
 type MaybeFunction = <T>(val: T) => boolean | T;
 
-type Predicates = Pick<
+type CheckTypePredicates = Pick<
     CheckType,
     | 'equal'
     | 'undefined'
@@ -54,25 +54,25 @@ type Predicates = Pick<
 interface ArrayFunction {
     (a: any): a is any[];
 
-    of: Predicates;
+    of: CheckTypePredicates;
 }
 
 interface ArrayLikeFunction {
     (a: any): a is ArrayLike<any>;
 
-    of: Predicates;
+    of: CheckTypePredicates;
 }
 
 interface IterableFunction {
     (a: any): a is Iterable<any>;
 
-    of: Predicates;
+    of: CheckTypePredicates;
 }
 
 interface ObjectFunction {
     (a: any): a is object;
 
-    of: Predicates;
+    of: CheckTypePredicates;
 }
 
 type AssertExtended<T extends any[], R> = (...args: [...T, string?]) => R;
@@ -82,7 +82,7 @@ type ExtendWithAssert<T> = {
         ? AssertExtended<U, R> & ExtendWithAssert<T[K]>
         : ExtendWithAssert<T[K]>;
 };
-interface AssertFunction extends ExtendWithAssert<CheckType> {
+interface AssertFunction {
     <T>(possibleFalsy: T, message?: string, errorType?: { new (...args: any[]): any }): T;
 }
 
@@ -167,9 +167,9 @@ interface CheckType {
     function(a: any): a is (...args: any[]) => any;
 
     /* Modifiers (some of them in their respected sections) */
-    not: Predicates & NegationFunction;
-    maybe: Predicates & MaybeFunction;
-    assert: AssertFunction;
+    not: CheckTypePredicates & NegationFunction;
+    maybe: CheckTypePredicates & MaybeFunction;
+    assert: ExtendWithAssert<CheckTypePredicates> & ExtendWithAssert<Pick<CheckType, 'not' | 'maybe'>> & AssertFunction;
 
     /* Batch operations */
 

--- a/types/check-types/index.d.ts
+++ b/types/check-types/index.d.ts
@@ -2,159 +2,166 @@
 // Project: https://gitlab.com/philbooth/check-types.js
 // Definitions by: idchlife <https://github.com/idchlife>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/
-// TypeScript Version: 2.2
+// Minimum TypeScript Version: 4.0
 
 type NegationFunction = (val: any) => boolean;
 
 type MaybeFunction = <T>(val: T) => boolean | T;
 
 interface ArrayFunction {
-  (a: any): a is any[];
+    (a: any): a is any[];
 
-  // TODO: Maybe there is a way to create type guards for array type checks
-  // Since syntax is like check.array.of.number(2) - it's not yet clear to me how this even works, so...
-  // I might use of: CheckType, but it will just return type guards for primitives and object type
-  // and will make variable simply non array type in conditionals.
-  of: {
-    [method: string]: boolean;
-  };
+    // TODO: Maybe there is a way to create type guards for array type checks
+    // Since syntax is like check.array.of.number(2) - it's not yet clear to me how this even works, so...
+    // I might use of: CheckType, but it will just return type guards for primitives and object type
+    // and will make variable simply non array type in conditionals.
+    of: {
+        [method: string]: boolean;
+    };
 }
 
 interface ArrayLikeFunction {
-  (a: any): a is ArrayLike<any>;
+    (a: any): a is ArrayLike<any>;
 
-  // See in array explanation of this type
-  of: {
-    [method: string]: boolean;
-  };
+    // See in array explanation of this type
+    of: {
+        [method: string]: boolean;
+    };
 }
 
 interface IterableFunction {
-  (a: any): a is Iterable<any>;
+    (a: any): a is Iterable<any>;
 
-  // See in array explanation of this type
-  of: {
-    [method: string]: boolean;
-  };
+    // See in array explanation of this type
+    of: {
+        [method: string]: boolean;
+    };
 }
 
 interface ObjectFunction {
-  (a: any): a is object;
+    (a: any): a is object;
 
-  // See in array explanation of this type
-  of: {
-    [method: string]: boolean;
-  };
+    // See in array explanation of this type
+    of: {
+        [method: string]: boolean;
+    };
 }
 
-interface AssertFunction extends CheckType {
-  <T>(possibleFalsy: T, message?: string, errorType?: { new(...args: any[]): any }): T;
+type AssertExtended<T extends any[], R> = (...args: [...T, string?]) => R;
+
+type ExtendWithAssert<T> = {
+    [K in keyof T]: T[K] extends (...a: infer U) => infer R
+        ? AssertExtended<U, R> & ExtendWithAssert<T[K]>
+        : ExtendWithAssert<T[K]>;
+};
+interface AssertFunction extends ExtendWithAssert<CheckType> {
+    <T>(possibleFalsy: T, message?: string, errorType?: { new (...args: any[]): any }): T;
 }
 
 interface CheckType {
-  /* General predicates */
+    /* General predicates */
 
-  equal(a: any, b: any): boolean;
-  null(a: any): a is null;
-  undefined(a: any): a is undefined;
-  assigned(a: any): boolean;
-  primitive(a: any): a is number | string | boolean | null | undefined | symbol;
-  hasLength(a: any, length: number): boolean;
+    equal(a: any, b: any): boolean;
+    null(a: any): a is null;
+    undefined(a: any): a is undefined;
+    assigned(a: any): boolean;
+    primitive(a: any): a is number | string | boolean | null | undefined | symbol;
+    hasLength(a: any, length: number): boolean;
 
-  /* String predicates */
+    /* String predicates */
 
-  string(a: any): a is string;
-  emptyString(a: string): boolean;
-  nonEmptyString(a: string): boolean;
-  contains(a: string, substring: string): boolean;
-  match(a: string, b: RegExp): boolean;
+    string(a: any): a is string;
+    emptyString(a: string): boolean;
+    nonEmptyString(a: string): boolean;
+    contains(a: string, substring: string): boolean;
+    match(a: string, b: RegExp): boolean;
 
-  /* Number predicates */
+    /* Number predicates */
 
-  number(a: any): a is number;
-  integer(a: any): a is number;
-  zero(a: any): boolean;
-  infinity(a: any): boolean;
-  greater(num: number, greaterThan: number): boolean;
-  greaterOrEqual(num: number, greaterOrEqual: number): boolean;
-  less(num: number, lessThan: number): boolean;
-  lessOrEqual(num: number, lessOrEqual: number): boolean;
-  /**
-   * Excluding a and b. Any order of a, b
-   */
-  between(num: number, a: number, b: number): boolean;
-  /**
-   * Including a, b. Any order of a, b
-   */
-  inRange(num: number, a: number, b: number): boolean;
-  positive(num: number): boolean;
-  negative(num: number): boolean;
-  odd(num: number): boolean;
-  even(num: number): boolean;
+    number(a: any): a is number;
+    integer(a: any): a is number;
+    zero(a: any): boolean;
+    infinity(a: any): boolean;
+    greater(num: number, greaterThan: number): boolean;
+    greaterOrEqual(num: number, greaterOrEqual: number): boolean;
+    less(num: number, lessThan: number): boolean;
+    lessOrEqual(num: number, lessOrEqual: number): boolean;
+    /**
+     * Excluding a and b. Any order of a, b
+     */
+    between(num: number, a: number, b: number): boolean;
+    /**
+     * Including a, b. Any order of a, b
+     */
+    inRange(num: number, a: number, b: number): boolean;
+    positive(num: number): boolean;
+    negative(num: number): boolean;
+    odd(num: number): boolean;
+    even(num: number): boolean;
 
-  /* Boolean predicates */
+    /* Boolean predicates */
 
-  boolean(a: any): a is boolean;
+    boolean(a: any): a is boolean;
 
-  /* Object predicates */
+    /* Object predicates */
 
-  object: ObjectFunction;
-  emptyObject(a: object): boolean;
-  nonEmptyObject(a: object): boolean;
-  /**
-   * Checking via instanceof
-   */
-  instanceStrict<T extends object>(a: any, prototype: T): a is T;
-  /**
-   * Checking via instanceof, fallback constructor.name and .toString()
-   */
-  instance<T extends object>(a: any, prototype: T): a is T;
-  /**
-   * Duck type checking. Structural in other words. Checking if a has all properties of duck
-   */
-  like<T extends object>(a: any, duck: T): a is T;
+    object: ObjectFunction;
+    emptyObject(a: object): boolean;
+    nonEmptyObject(a: object): boolean;
+    /**
+     * Checking via instanceof
+     */
+    instanceStrict<T extends object>(a: any, prototype: T): a is T;
+    /**
+     * Checking via instanceof, fallback constructor.name and .toString()
+     */
+    instance<T extends object>(a: any, prototype: T): a is T;
+    /**
+     * Duck type checking. Structural in other words. Checking if a has all properties of duck
+     */
+    like<T extends object>(a: any, duck: T): a is T;
 
-  /* Array predicates */
+    /* Array predicates */
 
-  array: ArrayFunction;
-  emptyArray(a: any[]): boolean;
-  nonEmptyArray(a: any[]): boolean;
-  arrayLike: ArrayLikeFunction;
-  iterable: IterableFunction;
-  includes(a: any[], value: any): boolean;
+    array: ArrayFunction;
+    emptyArray(a: any[]): boolean;
+    nonEmptyArray(a: any[]): boolean;
+    arrayLike: ArrayLikeFunction;
+    iterable: IterableFunction;
+    includes(a: any[], value: any): boolean;
 
-  /* Date predicates */
+    /* Date predicates */
 
-  date(a: any): a is Date;
+    date(a: any): a is Date;
 
-  /* Function predicates */
+    /* Function predicates */
 
-  function(a: any): a is (...args: any[]) => any;
+    function(a: any): a is (...args: any[]) => any;
 
-  /* Modifiers (some of them in their respected sections) */
-  not: CheckType & NegationFunction;
-  maybe: CheckType & MaybeFunction;
-  assert: AssertFunction;
+    /* Modifiers (some of them in their respected sections) */
+    not: CheckType & NegationFunction;
+    maybe: CheckType & MaybeFunction;
+    assert: AssertFunction;
 
-  /* Batch operations */
+    /* Batch operations */
 
-  /**
-   * Applying predicate to every element of array and returning resulting array
-   *
-   * Example: apply([2, 3, "four"], check.number) => [true, true, false]
-   */
-  apply<T>(arr: any[], predicate: (...args: any[]) => T): T[];
+    /**
+     * Applying predicate to every element of array and returning resulting array
+     *
+     * Example: apply([2, 3, "four"], check.number) => [true, true, false]
+     */
+    apply<T>(arr: any[], predicate: (...args: any[]) => T): T[];
 
-  // Also some difficulties with returning object with only defined in predicates object propertis.
-  // Will gladly accept help or ideas. Now using any for returned object
-  map<T extends { [k: string]: any }>(
-    arr: T,
-    predicates: Partial<{ [k in keyof T]: (...args: any[]) => boolean }>
-  ): Partial<{ [k in keyof T]: any }>;
+    // Also some difficulties with returning object with only defined in predicates object propertis.
+    // Will gladly accept help or ideas. Now using any for returned object
+    map<T extends { [k: string]: any }>(
+        arr: T,
+        predicates: Partial<{ [k in keyof T]: (...args: any[]) => boolean }>,
+    ): Partial<{ [k in keyof T]: any }>;
 
-  all(arr: boolean[] | { [k: string]: boolean }): boolean;
+    all(arr: boolean[] | { [k: string]: boolean }): boolean;
 
-  any(arr: boolean[] | { [k: string]: boolean }): boolean;
+    any(arr: boolean[] | { [k: string]: boolean }): boolean;
 }
 
 declare const check: CheckType;

--- a/types/check-types/index.d.ts
+++ b/types/check-types/index.d.ts
@@ -8,43 +8,71 @@ type NegationFunction = (val: any) => boolean;
 
 type MaybeFunction = <T>(val: T) => boolean | T;
 
+type Predicates = Pick<
+    CheckType,
+    | 'equal'
+    | 'undefined'
+    | 'null'
+    | 'assigned'
+    | 'primitive'
+    | 'zero'
+    | 'infinity'
+    | 'number'
+    | 'integer'
+    | 'even'
+    | 'odd'
+    | 'greater'
+    | 'less'
+    | 'between'
+    | 'greaterOrEqual'
+    | 'lessOrEqual'
+    | 'inRange'
+    | 'positive'
+    | 'negative'
+    | 'string'
+    | 'emptyString'
+    | 'nonEmptyString'
+    | 'contains'
+    | 'match'
+    | 'boolean'
+    | 'object'
+    | 'emptyObject'
+    | 'nonEmptyObject'
+    | 'instanceStrict'
+    | 'instance'
+    | 'like'
+    | 'array'
+    | 'emptyArray'
+    | 'nonEmptyArray'
+    | 'arrayLike'
+    | 'iterable'
+    | 'date'
+    | 'function'
+    | 'hasLength'
+>;
+
 interface ArrayFunction {
     (a: any): a is any[];
 
-    // TODO: Maybe there is a way to create type guards for array type checks
-    // Since syntax is like check.array.of.number(2) - it's not yet clear to me how this even works, so...
-    // I might use of: CheckType, but it will just return type guards for primitives and object type
-    // and will make variable simply non array type in conditionals.
-    of: {
-        [method: string]: boolean;
-    };
+    of: Predicates;
 }
 
 interface ArrayLikeFunction {
     (a: any): a is ArrayLike<any>;
 
-    // See in array explanation of this type
-    of: {
-        [method: string]: boolean;
-    };
+    of: Predicates;
 }
 
 interface IterableFunction {
     (a: any): a is Iterable<any>;
 
-    // See in array explanation of this type
-    of: {
-        [method: string]: boolean;
-    };
+    of: Predicates;
 }
 
 interface ObjectFunction {
     (a: any): a is object;
 
-    // See in array explanation of this type
-    of: {
-        [method: string]: boolean;
-    };
+    of: Predicates;
 }
 
 type AssertExtended<T extends any[], R> = (...args: [...T, string?]) => R;
@@ -139,8 +167,8 @@ interface CheckType {
     function(a: any): a is (...args: any[]) => any;
 
     /* Modifiers (some of them in their respected sections) */
-    not: CheckType & NegationFunction;
-    maybe: CheckType & MaybeFunction;
+    not: Predicates & NegationFunction;
+    maybe: Predicates & MaybeFunction;
     assert: AssertFunction;
 
     /* Batch operations */


### PR DESCRIPTION
This is a reopen of #51375, because the automated review process failed when a reviewer commented with a question and then abandoned the PR.

Original text follows:
----
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://gitlab.com/philbooth/check-types.js/-/blob/3114d7f1325698e555275e186d8c126733ca5f3a/src/check-types.js

^ This link the source for `check-types` at version 7.3.0. I noticed that the definitions weren't quite in line with the implementations, so I made this PR. It does three things:

1) Introduces the types for the augmented functions under `assert.xxx`, eg, `assert.number(0, "Some error message")`, which are copies of the standard functions but with the error message parameter added.

2) Introduces typing for the `of` functions, eg `array.of.string([""])`. The type guards under `of` are still not entirely correct for arrays and objects- but they will now compile for most (all?) uses, whereas before they didn't compile.

3) Reduces the properties included in `not` and `maybe` to match the implementation

I've also introduced several new tests. Apologies for the large diff - I think the prettier settings have changed since the types were originally contributed.

Many thanks for providing the definitions in the first place! I couldn't have done this work without the initial definitions.

I had to bump the typescript requirement to 4.0, in order to use tuples to define rest parameters at the start of the function arguments. If you feel strongly that this should be avoided, the only way I can see is to explicitly define the entire `assert` type. Of course, there might be a way that I haven't thought of. 