### PR TITLE
Fix $ExpectType in postcss-safe-parser tests

### DIFF
--- a/types/postcss-safe-parser/postcss-safe-parser-tests.ts
+++ b/types/postcss-safe-parser/postcss-safe-parser-tests.ts
@@ -10,4 +10,4 @@ postcss()
         result.css; // $ExpectType string
     });
 
-safe; // $ExpectType Parser
+safe; // $ExpectType Parser<Root> || PostCssSafeParser


### PR DESCRIPTION
TS 4.4 is better at respecting aliases than previous versions. Also add a missed type argument to the expected type for previous versions.