### PR TITLE
update(firstline): typed input encoding options

### DIFF
--- a/types/firstline/firstline-tests.ts
+++ b/types/firstline/firstline-tests.ts
@@ -1,15 +1,10 @@
 import firstline = require('firstline');
 
-// Imagine the file content is:
-// abc
-// def
-// ghi
-//
-
 // $ExpectType: Promise<string>
 firstline('./my-file.txt');
-// -> Returns a promise that will be fulfilled with 'abc'.
-
 // $ExpectType: Promise<string>
 firstline('./my-file.txt', { lineEnding: '\r' });
-// -> Same as above, but using '\r' as line ending.
+// $ExpectType: Promise<string>
+firstline('./my-file.txt', { lineEnding: '\r', encoding: 'ascii' });
+// $ExpectError
+firstline('./my-file.txt', { lineEnding: '\r', encoding: 'utf88' });

--- a/types/firstline/index.d.ts
+++ b/types/firstline/index.d.ts
@@ -2,7 +2,16 @@
 // Project: https://github.com/pensierinmusica/firstline
 // Definitions by: Emily Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+/// <reference types="node" />
 export = firstline;
 
-declare function firstline(filePath: string, opts?: { lineEnding?: string, encoding?: string }): Promise<string>;
+declare function firstline(filePath: string, opts?: firstline.Options): Promise<string>;
+
+declare namespace firstline {
+    interface Options {
+        /** @default 'utf8' */
+        encoding?: BufferEncoding;
+        /** @default '\n' */
+        lineEnding?: string;
+    }
+}


### PR DESCRIPTION
- as per implementation, these are only allowed types from Node:
https://github.com/pensierinmusica/firstline#usage
- move options into interface for consumption

The expected minor drawback, is CI dependency on DT types to Node.
The types are supposed to be already used with Node types anyway (the
only spported client).

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).