### PR TITLE
chore(react): Remove TODOs related to type parameters defaulting to unknown

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1018,7 +1018,6 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T>(initialValue: T): MutableRefObject<T>;
     // convenience overload for refs given as a ref prop as they typically start with a null value
     /**
@@ -1034,7 +1033,6 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T>(initialValue: T|null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
@@ -1048,7 +1046,6 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T = undefined>(): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1019,7 +1019,6 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T>(initialValue: T): MutableRefObject<T>;
     // convenience overload for refs given as a ref prop as they typically start with a null value
     /**
@@ -1035,7 +1034,6 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T>(initialValue: T|null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
@@ -1049,7 +1047,6 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T = undefined>(): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.


### PR DESCRIPTION
Unclear why we'd need the generics to explicitly extend `unknown`. My best guess is that this relates to  generics being implicitly constrained to `{}` when they don't have an explicit constraint in TypeScript  3.4 and earlier.

[3.5 and above constrain generics to `unknown` if they don't have an explicit constraint](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#generic-type-parameters-are-implicitly-constrained-to-unknown) and since [TypeScript 3.4 and lower are no longer supported](https://github.com/DefinitelyTyped/DefinitelyTyped#older-versions-of-typescript-34-and-earlier), we don't have to change anything.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- ~[ ]~ Provide a URL to documentation or source code which provides context for the suggested changes: 
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


