### PR TITLE
[aws4] Fix incorrect type and add type expectations to test

### DIFF
--- a/types/aws4/aws4-tests.ts
+++ b/types/aws4/aws4-tests.ts
@@ -1,22 +1,36 @@
 import * as aws4 from "aws4";
 
 let requestSigner = new aws4.RequestSigner({}, {});
+// $ExpectType string[]
 requestSigner.matchHost("");
+// $ExpectType boolean
 requestSigner.isSingleRegion();
+// $ExpectType string
 requestSigner.createHost();
+// $ExpectType void
 requestSigner.prepareRequest();
 requestSigner.sign();
+// $ExpectType string
 requestSigner.getDateTime();
+// $ExpectType string
 requestSigner.getDate();
+// $ExpectType string
 requestSigner.authHeader();
+// $ExpectType string
 requestSigner.signature();
+// $ExpectType string
 requestSigner.stringToSign();
+// $ExpectType string
 requestSigner.canonicalString();
+// $ExpectType string
 requestSigner.canonicalHeaders();
+// $ExpectType string
 requestSigner.signedHeaders();
+// $ExpectType string
 requestSigner.credentialString();
 requestSigner.defaultCredentials();
 requestSigner.parsePath();
+// $ExpectType string
 requestSigner.formatPath();
 
 aws4.sign({}, {});

--- a/types/aws4/index.d.ts
+++ b/types/aws4/index.d.ts
@@ -11,7 +11,7 @@ export class RequestSigner {
     region: any;
     isCodeCommitGit: any;
 
-    matchHost(host?: string): string;
+    matchHost(host?: string): string[];
     isSingleRegion(): boolean;
     createHost(): string;
     prepareRequest(): void;


### PR DESCRIPTION
This PR updates the type signature of `matchHost` to accurately reflect the actual return type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mhart/aws4/blob/master/aws4.js#L77>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
