### PR TITLE
update(get-image-colors): v4 updates

### DIFF
--- a/types/get-image-colors/get-image-colors-tests.ts
+++ b/types/get-image-colors/get-image-colors-tests.ts
@@ -1,28 +1,24 @@
-import path = require('path');
-import fs = require('fs');
 import getColors = require('get-image-colors');
 import { Options } from 'get-image-colors';
 
-const buffer = fs.readFileSync(path.join(__dirname, 'double-rainbow.gif'));
+declare const buffer: Buffer;
 const options: Options = {
     count: 10,
     type: 'image/png',
 };
 
-getColors('./path').then(colors => {
-    colors; // $ExpectType Color[]
-});
-getColors('./path', (err, colors) => {
-    if (err) throw err;
-    colors; // $ExpectType Color[]
-});
+(async () => {
+    // $ExpectType Color[]
+    await getColors('./double-rainbow.png');
 
-getColors(buffer, 'image/gif').then(colors => {
-    colors; // $ExpectType Color[]
-    colors.map(color => color.hex());
-    colors[0].alpha(0.5).css();
-});
+    getColors('./double-rainbow.png', (err, colors) => {
+        if (err) throw err;
+        colors; // $ExpectType Color[]
+    });
 
-getColors(path.join(__dirname, 'double-rainbow.png'), options).then(colors => {
-    colors; // $ExpectType Color[]
-});
+    // $ExpectType Color[]
+    await getColors(buffer, 'image/gif');
+
+    // $ExpectType Color[]
+    await getColors('./double-rainbow.png', options);
+})();

--- a/types/get-image-colors/index.d.ts
+++ b/types/get-image-colors/index.d.ts
@@ -1,21 +1,26 @@
-// Type definitions for get-image-colors 2.0
+// Type definitions for get-image-colors 4.0
 // Project: https://github.com/colorjs/get-image-colors#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 /// <reference types="node" />
-import chroma = require('chroma-js');
+
+import { Color } from 'chroma-js';
 
 /**
  * Extract colors from images. Supports GIF, JPG, PNG, and even SVG!
  */
-declare function colorPalette(input: Buffer, options: colorPalette.Options, callback: chroma.Color[]): void;
+declare function colorPalette(input: Buffer, options: colorPalette.Options, callback: Color[]): void;
 declare function colorPalette(input: Buffer, type: string, callback: colorPalette.Callback): void;
-declare function colorPalette(input: Buffer, type: string): Promise<chroma.Color[]>;
-declare function colorPalette(input: string, options?: colorPalette.Options): Promise<chroma.Color[]>;
+declare function colorPalette(input: Buffer, type: string): Promise<Color[]>;
+declare function colorPalette(input: string, options?: colorPalette.Options): Promise<Color[]>;
 declare function colorPalette(input: string, callback: colorPalette.Callback): void;
 
 declare namespace colorPalette {
     interface Options {
+        /**
+         * @default undefined
+         */
         type?: string;
         /**
          * @default 5
@@ -26,7 +31,7 @@ declare namespace colorPalette {
     /**
      * If you don't like promises, you can use node-style callbacks too
      */
-    type Callback = (error: Error | null, colors: chroma.Color[]) => void;
+    type Callback = (error: Error | null, colors: Color[]) => void;
 }
 
 export = colorPalette;


### PR DESCRIPTION
Backward compatible changes, minor refinements to package:
- update missing default option value doc
- import just required type dependency
- tests amended to use also async/await
- version bump

https://github.com/colorjs/get-image-colors/blob/master/index.js#L44

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).