### PR TITLE
[cloudflare] Fix priority property of DnsRecord type

### DIFF
--- a/types/cloudflare/cloudflare-tests.ts
+++ b/types/cloudflare/cloudflare-tests.ts
@@ -10,3 +10,27 @@ cf.ips.browse();
 cf.user.edit('asd');
 
 const types: Cloudflare.RecordTypes = 'AAAA';
+
+cf.dnsRecords.add("123", {
+    type: "CNAME",
+    name: "irrelevant",
+    content: "irrelevant",
+    ttl: 1,
+});
+
+cf.dnsRecords.add("123", {
+    type: "MX",
+    name: "irrelevant",
+    content: "irrelevant",
+    ttl: 1,
+    priority: 12
+});
+
+cf.dnsRecords.add("123", {
+    type: "CNAME",
+    name: "irrelevant",
+    content: "irrelevant",
+    ttl: 1,
+    // $ExpectError
+    priority: 12
+});

--- a/types/cloudflare/index.d.ts
+++ b/types/cloudflare/index.d.ts
@@ -34,17 +34,30 @@ declare namespace Cloudflare {
         token?: string;
     }
 
+    interface DnsRecordWithoutPriority {
+        type: Exclude<RecordTypes, 'MX' | 'SRV' | 'URI'>;
+        name: string;
+        content: string;
+        ttl: number;
+        proxied?: boolean;
+    }
+
+    interface DnsRecordWithPriority {
+        type: Extract<RecordTypes, 'MX' | 'SRV' | 'URI'>;
+        name: string;
+        content: string;
+        ttl: number;
+        proxied?: boolean;
+        priority: number;
+    }
+
+    type DnsRecord = DnsRecordWithPriority | DnsRecordWithoutPriority;
+
     interface DNSRecords {
         edit(
             zone_id: string,
             id: string,
-            record: {
-                type: RecordTypes;
-                name: string;
-                content: string;
-                ttl: number;
-                proxied?: boolean;
-            },
+            record: DnsRecord,
         ): ResponseObjectPromise;
         browse(zone_id: string): ResponseObjectPromise;
         export(zone_id: string): ResponseObjectPromise;
@@ -52,14 +65,7 @@ declare namespace Cloudflare {
         read(zone_id: string, id: string): ResponseObjectPromise;
         add(
             zone_id: string,
-            record: {
-                type: RecordTypes;
-                name: string;
-                content: string;
-                ttl: number;
-                priority: number;
-                proxied?: boolean;
-            },
+            record: DnsRecord,
         ): ResponseObjectPromise;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Adjusts the `priority` property to the API definition: "Required for MX, SRV and URI records; unused by other record types."

