### PR TITLE
gestalt: Allow Box to support div props interface

### DIFF
--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -107,6 +107,15 @@ const CheckUseReducedMotion = () => {
 />;
 <Badge text="Nicolas" />;
 <Box ref={React.createRef<HTMLDivElement>()} />;
+
+<Box aria-colspan={1} />;
+// $ExpectError
+<Box aria-colspan="foo" />;
+
+<Box onDrag={(event) => { event.movementX; }} />;
+// $ExpectError
+<Box onDrag={((event) => { event.__nonExistentProperty__; })} />;
+
 <Button ref={React.createRef<HTMLAnchorElement>()} text={'Click me'} />;
 <Button text="" />;
 <ButtonGroup>

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -102,11 +102,13 @@ export interface BadgeProps {
     position?: 'middle' | 'top';
 }
 
+export type BoxPassthroughProps = Omit<React.ComponentProps<'div'>, 'onClick' | 'className' | 'style'>;
+
 /**
  * Box Props Interface
  * https://gestalt.netlify.app/Box
  */
-export interface BoxProps {
+export interface BoxProps extends BoxPassthroughProps {
     alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
     alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
     alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch';


### PR DESCRIPTION
Props not handled by Box are actually passed through to the underlying div component. Currently, using div props results in type errors. This fixes the Box interface so that div props can be passed through via Box (except for `onClick`, `className` and `style`).

Note that with this change, all of the underlying div props will be shown in editor auto-complete, so this may affect your workflow since it may be difficult to tell which are div props vs. Box props. But regardless, I think this change is still valuable since you do not need to wrap a Box with another div or type cast Box just so you can use div props. 

![Screen Shot 2021-05-22 at 2 52 35 PM](https://user-images.githubusercontent.com/590451/119241709-5af66c00-bb0d-11eb-9748-e9a8b781c106.png)

Full list of props that will be exposed to the Box component can be seen in MDN's [Global attributes doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes). 

---------------
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Box.js#L185-L189

