### PR TITLE
Fix @ckeditor/ckeditor5-classic-editor: Allow Element

### DIFF
--- a/types/ckeditor__ckeditor5-editor-classic/ckeditor__ckeditor5-editor-classic-tests.ts
+++ b/types/ckeditor__ckeditor5-editor-classic/ckeditor__ckeditor5-editor-classic-tests.ts
@@ -7,6 +7,8 @@ import View from "@ckeditor/ckeditor5-engine/src/view/view";
 import { EditorUIView, ToolbarView } from "@ckeditor/ckeditor5-ui";
 import { Locale } from "@ckeditor/ckeditor5-utils";
 
+let locale = new Locale();
+
 ClassicEditor.create("", { placeholder: "foo" }).then(editor => {
     editor.commands.get("");
     ClassicEditor.defaultConfig?.plugins?.map(strOrPlugin => {
@@ -18,7 +20,7 @@ ClassicEditor.create("", { placeholder: "foo" }).then(editor => {
     const classicEditorUI = new ClassicEditorUI(editor, new EditorUIView());
     classicEditorUI.init(document.createElement("div"));
     classicEditorUI.init();
-    new ClassicEditorUIView(new Locale(), new View(new StylesProcessor()), {
+    new ClassicEditorUIView(locale, new View(new StylesProcessor()), {
         shouldToolbarGroupWhenFull: true,
     });
 });
@@ -41,16 +43,19 @@ class MyPlugin extends Plugin {}
     editor.setData();
     const processor: HtmlDataProcessor = editor.data.processor;
     editor.updateSourceElement();
-    const elem: HTMLElement = editor.sourceElement!;
+    htmlElement = editor.sourceElement!;
     const ui: ClassicEditorUI = editor.ui;
     const uiView: ClassicEditorUIView = editor.ui.view;
+
+    const num: number = uiView.stickyPanel.viewportTopOffset;
+    let bool: boolean = ui.focusTracker.isFocused;
 
     editor = await ClassicEditor.create(htmlElement, {
         toolbar: {
             items: [],
             removeItems: [],
-            viewportTopOffset: 0,
-            shouldNotGroupWhenFull: true,
+            viewportTopOffset: num,
+            shouldNotGroupWhenFull: bool,
         },
     });
 
@@ -59,15 +64,15 @@ class MyPlugin extends Plugin {}
     ui.init();
     ui.init(null);
     ui.init(htmlElement);
-    let bool: boolean = ui.focusTracker.isFocused;
 
     bool = uiView.isRendered;
     bool = uiView.stickyPanel.isSticky;
-    const num: number = uiView.stickyPanel.viewportTopOffset;
 
     htmlElement = ui.getEditableElement()!;
 
     uiView.render();
     const toolbarView: ToolbarView = uiView.toolbar;
-    const locale: Locale = uiView.toolbar.locale!;
+    locale = uiView.toolbar.locale!;
 })();
+
+ClassicEditor.create(document.querySelector('#editor')!);

--- a/types/ckeditor__ckeditor5-editor-classic/src/classiceditor.d.ts
+++ b/types/ckeditor__ckeditor5-editor-classic/src/classiceditor.d.ts
@@ -7,7 +7,7 @@ import ClassicEditorUI from "./classiceditorui";
 
 export default class ClassicEditor extends Editor implements DataApi, EditorWithUI, ElementApi {
     ui: ClassicEditorUI;
-    static create(sourceElementOrData: HTMLElement | string, config?: EditorConfig): Promise<ClassicEditor>;
+    static create(sourceElementOrData: Element | string, config?: EditorConfig): Promise<ClassicEditor>;
 
     setData(data: string): void;
     getData(options?: { rootName?: string; trim?: "empty" | "none" }): string;


### PR DESCRIPTION
Current definitions for the `create` element does not allow the return type of `document.querySelector('#editor')`,
which is used in the docs.

Replace `HTMLElement` with `Element`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/latest/framework/guides/tutorials/implementing-a-block-widget.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.