### PR TITLE
Upate sinon for @sinonjs/fake-timers

### DIFF
--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -163,8 +163,8 @@ function testClock() {
     clock.clearTimeout(timer);
     timer = clock.setInterval(fn, 0);
     clock.clearInterval(timer);
-    timer = clock.setImmediate(fn);
-    clock.clearImmediate(timer);
+    const immediate = clock.setImmediate(fn);
+    clock.clearImmediate(immediate);
 
     const animTimer = clock.requestAnimationFrame(fn);
     clock.cancelAnimationFrame(animTimer);


### PR DESCRIPTION
@sinonjs/fake-timers@7.1.0 has better types for setImmediate/clearImmediate -- previously they returned `any`, now they return an object type. Update the tests to show that the type is no longer compatible with the `number` that setTimeout returns.

@43081j you made the change to fake-timers' types, so you might be interested to know that they're now published and DT is updated to handle them.
