### PR TITLE
[react-native] Change ColorValue type so that it can be assignable from objects

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6037,9 +6037,7 @@ interface PlatformWebStatic extends PlatformStatic {
     OS: 'web';
 }
 
-declare const OpaqueColorValue: unique symbol;
-type OpaqueColorValue = typeof OpaqueColorValue;
-
+type OpaqueColorValue = symbol & { __TYPE__: 'Color' };
 export type ColorValue = string | OpaqueColorValue;
 
 export type ProcessedColorValue = number | OpaqueColorValue;

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1521,7 +1521,7 @@ StyleSheet.create({
 });
 
 function someColorString(): ColorValue {
-    return "#000000";
+    return '#000000';
 }
 
 function somePlatformColor(): ColorValue {
@@ -1531,7 +1531,7 @@ function somePlatformColor(): ColorValue {
 const colors = {
     color: someColorString(),
     backgroundColor: somePlatformColor(),
-}
+};
 
 StyleSheet.create({
     labelCell: {
@@ -1756,10 +1756,8 @@ const I18nManagerTest = () => {
 };
 
 // LayoutAnimations
-LayoutAnimation.configureNext(LayoutAnimation.create(
-    123,
-    LayoutAnimation.Types.easeIn,
-    LayoutAnimation.Properties.opacity,
-));
+LayoutAnimation.configureNext(
+    LayoutAnimation.create(123, LayoutAnimation.Types.easeIn, LayoutAnimation.Properties.opacity),
+);
 
 LayoutAnimation.configureNext(LayoutAnimation.create(123, 'easeIn', 'opacity'));

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1520,6 +1520,34 @@ StyleSheet.create({
     },
 });
 
+function someColorString(): ColorValue {
+    return "#000000";
+}
+
+function somePlatformColor(): ColorValue {
+    return PlatformColor('test');
+}
+
+const colors = {
+    color: someColorString(),
+    backgroundColor: somePlatformColor(),
+}
+
+StyleSheet.create({
+    labelCell: {
+        color: colors.color,
+        backgroundColor: colors.backgroundColor,
+    },
+});
+
+const OpaqueTest3 = () => (
+    <View
+        style={{
+            backgroundColor: colors.backgroundColor,
+        }}
+    />
+);
+
 // ProgressBarAndroid
 const ProgressBarAndroidTest = () => {
     <ProgressBarAndroid animating color="white" styleAttr="Horizontal" progress={0.42} />;


### PR DESCRIPTION
Fixes #46864

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46864
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR fixes an issue where you cannot assign ColorValues from an object to another object. If you have an object that has many ColorValues as property values, the current typing makes it very difficult to work with them unless you add casts to deal with the type mismatch. See https://github.com/microsoft/fluentui-react-native/pull/694 as an example. The new typing is based off a suggestion taken from the issue linked above.