### PR TITLE
Add types for vscode webviews

### DIFF
--- a/types/vscode-webview/index.d.ts
+++ b/types/vscode-webview/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for non-npm package vscode-webview 1.57
+// Project: https://code.visualstudio.com/api/extension-guides/webview
+// Definitions by: Matt Bierner <https://github.com/mjbvz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+/**
+ * API exposed to webviews.
+ *
+ * @template StateType Type of the persisted state stored for the webview.
+ */
+export interface WebviewApi<StateType> {
+    /**
+     * Post a message to the owner of the webview.
+     *
+     * @param message Data to post. Must be JSON serializable.
+     */
+    postMessage(message: any): void;
+
+    /**
+     * Get the persistent state stored for this webview.
+     *
+     * @return The current state or `undefined` if it has not been set.
+     */
+    getState(): StateType | undefined;
+
+    /**
+     * Set the persistent state stored for this webview.
+     *
+     * @param newState New persisted state. This must be a JSON serializable object. Can be retrieved
+     * using {@link getState}.
+     *
+     * @return The new state.
+     */
+    setState(newState: StateType): StateType;
+    setState(newState: undefined): undefined;
+}
+
+declare global {
+    /**
+     * Acquire an instance of the webview API.
+     *
+     * This may only be called once in a webview's context. Attempting call `acquireVsCodeApi` after it has already
+     * been called will throw an exception.
+     *
+     * @template StateType Type of the persisted state stored for the webview
+     */
+    // tslint:disable-next-line:no-unnecessary-generics
+    function acquireVsCodeApi<StateType = unknown>(): WebviewApi<StateType>;
+}

--- a/types/vscode-webview/index.d.ts
+++ b/types/vscode-webview/index.d.ts
@@ -15,7 +15,7 @@ export interface WebviewApi<StateType> {
      *
      * @param message Data to post. Must be JSON serializable.
      */
-    postMessage(message: any): void;
+    postMessage(message: unknown): void;
 
     /**
      * Get the persistent state stored for this webview.
@@ -32,8 +32,7 @@ export interface WebviewApi<StateType> {
      *
      * @return The new state.
      */
-    setState(newState: StateType): StateType;
-    setState(newState: undefined): undefined;
+    setState<T extends StateType | undefined>(newState: T): T;
 }
 
 declare global {

--- a/types/vscode-webview/index.d.ts
+++ b/types/vscode-webview/index.d.ts
@@ -20,7 +20,7 @@ export interface WebviewApi<StateType> {
     /**
      * Get the persistent state stored for this webview.
      *
-     * @return The current state or `undefined` if it has not been set.
+     * @return The current state or `undefined` if no state has been set.
      */
     getState(): StateType | undefined;
 
@@ -40,10 +40,10 @@ declare global {
     /**
      * Acquire an instance of the webview API.
      *
-     * This may only be called once in a webview's context. Attempting call `acquireVsCodeApi` after it has already
+     * This may only be called once in a webview's context. Attempting to call `acquireVsCodeApi` after it has already
      * been called will throw an exception.
      *
-     * @template StateType Type of the persisted state stored for the webview
+     * @template StateType Type of the persisted state stored for the webview.
      */
     // tslint:disable-next-line:no-unnecessary-generics
     function acquireVsCodeApi<StateType = unknown>(): WebviewApi<StateType>;

--- a/types/vscode-webview/tsconfig.json
+++ b/types/vscode-webview/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vscode-webview-tests.ts"
+    ]
+}

--- a/types/vscode-webview/tslint.json
+++ b/types/vscode-webview/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/vscode-webview/vscode-webview-tests.ts
+++ b/types/vscode-webview/vscode-webview-tests.ts
@@ -1,0 +1,6 @@
+import { WebviewApi } from "vscode-webview";
+
+const vscode = acquireVsCodeApi<string>();
+
+// $ExpectType string | undefined
+vscode.getState();


### PR DESCRIPTION
This add typings for VS Code's webviews. This is a non-npm based package


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
