### PR TITLE
Types for W3C Clipboard API Working Draft May 2021.

### DIFF
--- a/types/w3c-clipboard/index.d.ts
+++ b/types/w3c-clipboard/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for non-npm package w3c-clipboard-api 1.0
+// Project: https://www.w3.org/TR/clipboard-apis/
+// Definitions by: William Furr <https://github.com/wffurr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type PresentationStyle = 'attachment' | 'inline' | 'unspecified';
+
+interface ClipboardItem {
+    readonly delayed: boolean;
+    readonly lastModified: number;
+    readonly presentationStyle: PresentationStyle;
+
+    readonly types: string[];
+
+    getType(mimeType: string): Promise<Blob>;
+}
+
+declare var ClipboardItem: {
+    prototype: ClipboardItem;
+    new (
+        items: { [key: string]: string | Blob | Promise<string | Blob> },
+        options?: {
+            presentationStyle?: 'unspecified' | 'inline' | 'attachment';
+        },
+    ): ClipboardItem;
+    createDelayed(
+        items: { [key: string]: () => string | Blob | Promise<string | Blob> },
+        options?: { presentationStyle?: 'unspecified' | 'inline' | 'attachment' },
+    ): ClipboardItem;
+};
+
+interface Clipboard {
+    read(): Promise<ClipboardItem[]>;
+    write(data: ClipboardItem[]): Promise<void>;
+}

--- a/types/w3c-clipboard/tsconfig.json
+++ b/types/w3c-clipboard/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "w3c-clipboard-tests.ts"
+    ]
+}

--- a/types/w3c-clipboard/tslint.json
+++ b/types/w3c-clipboard/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/w3c-clipboard/w3c-clipboard-tests.ts
+++ b/types/w3c-clipboard/w3c-clipboard-tests.ts
@@ -1,0 +1,23 @@
+async function readClipboardItems() {
+    const items = await navigator.clipboard.read();
+    for (const item of items) {
+        console.log(
+            `clipboard item:
+         delayed: ${item.delayed}
+         lastModified: ${item.lastModified}
+         presentationStyle: ${item.presentationStyle}
+         has types: ${item.types.join(',')}
+         data with size: ${(await item.getType(item.types[0])).size}
+      `);
+    }
+}
+
+async function writeClipboardItems() {
+    const stringItem = new ClipboardItem(
+        { 'text/plain': 'hello', 'text/html': '<p>hello' },
+        { presentationStyle: 'inline' },
+    );
+    const delayedStringItem = ClipboardItem.createDelayed({ 'text/plain': () => 'goodbye' });
+    const blobItem = new ClipboardItem({ 'application/json': new Blob(['blobbity']) });
+    await navigator.clipboard.write([stringItem, delayedStringItem, blobItem]);
+}


### PR DESCRIPTION
Based on https://www.w3.org/TR/2021/WD-clipboard-apis-20210525/.

ClipboardItem type and navigator.clipboard.read and write async functions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
