### PR TITLE
fix(multer): make `file`/`files` nullable

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -49,12 +49,12 @@ declare global {
 
         interface Request {
             /** `Multer.File` object populated by `single()` middleware. */
-            file: Multer.File;
+            file?: Multer.File;
             /**
              * Array or dictionary of `Multer.File` object populated by `array()`,
              * `fields()`, and `any()` middleware.
              */
-            files: {
+            files?: {
                 [fieldname: string]: Multer.File[];
             } | Multer.File[];
         }

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -18,9 +18,11 @@ assert.strictEqual(upload.constructor.name, 'Multer');
 const app = express();
 
 app.post('/profile', upload.single('avatar'), (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    req.file; // $ExpectTYpe File | undefined
 });
 
 app.post('/photos/upload', upload.array('photos', 12), (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    req.files; // $ExpectType { [fieldname: string]: File[]; } | File[] | undefined
 });
 
 const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }]);


### PR DESCRIPTION
The `files` array and `file` object are created conditionally on the
request. The types should reflect this:

https://github.com/richardgirges/express-fileupload/blob/master/example/server.js#L19

Please review this PR for possibe breaking change, depending on how the
code is being consumed.

Thanks!

/cc @kndt

Fixes #53374

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).