### PR TITLE
Fix import-statement which breaks `@types/vinyl-file` when using `esModuleInterop`

### DIFF
--- a/types/vinyl-file/index.d.ts
+++ b/types/vinyl-file/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 3.8
 
 /// <reference types="node" />
-import * as File from 'vinyl';
+import File = require('vinyl');
 
 export interface VinylFileOptions {
     /** Specifies the working directory the folder is relative to */

--- a/types/vinyl-file/tsconfig.json
+++ b/types/vinyl-file/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "module": "commonjs",
         "lib": [
             "es6"

--- a/types/vinyl-file/vinyl-file-tests.ts
+++ b/types/vinyl-file/vinyl-file-tests.ts
@@ -1,4 +1,6 @@
 import vinylFile = require("vinyl-file");
+import * as StarFile from "vinyl";
+import File = require("vinyl");
 import path = require("path");
 const sample = path.join(__dirname, "./tsconfig.json");
 vinylFile
@@ -10,6 +12,24 @@ vinylFile
         console.log(file.cwd);
     });
 
+const file: vinylFile.VinylFile = {} as any;
+// $ExpectType VinylFile
+file.clone();
+
+// This test proofs, that when having `esModuleInterop` enabled,
+// importing `vinyl` using a `import * as File from "vinyl"` causes an error.
+// $ExpectError
+interface TestStarFile extends StarFile {
+    clone(opts?: { contents?: boolean, deep?: boolean } | boolean): this;
+}
+
+interface TestFile extends File {
+    clone(opts?: { contents?: boolean, deep?: boolean } | boolean): this;
+}
+
+const testFile: TestFile = {} as any;
+// $ExpectType TestFile
+testFile.clone();
 const sanpleInfo = vinylFile.readSync(sample);
 console.log(sanpleInfo.cwd);
 console.log(sanpleInfo.isBuffer());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/SBoudrias/mem-fs/pull/22#issuecomment-848169890>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
