### PR TITLE
[quill] Fix import path from `parchment`

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -10,7 +10,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-import { Blot } from "parchment/src/blot/abstract/blot";
+import { Blot } from "parchment/dist/src/blot/abstract/blot";
 import Delta = require("quill-delta");
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR addresses [this discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52841#issuecomment-847661561). As agreed, I reverted the path change.

cc @43081j, @AmeerHamoodi
