### PR TITLE
Update types for `ffi-napi`, `ref-napi`, `ref-struct-di`, `ref-array-di`, and `ref-union-di`

### DIFF
--- a/types/ffi-napi/ffi-napi-tests.ts
+++ b/types/ffi-napi/ffi-napi-tests.ts
@@ -1,8 +1,11 @@
 import ffi = require('ffi-napi');
 import ref = require('ref-napi');
-import Struct = require('ref-struct-di');
-import Union = require('ref-union-di');
-import TArray = require('ref-array-di');
+import ref_struct = require('ref-struct-di');
+import ref_union = require('ref-union-di');
+import ref_array = require('ref-array-di');
+const Struct = ref_struct(ref);
+const Union = ref_union(ref);
+const TArray = ref_array(ref);
 
 {
     const sqlite3 = ref.types.void;
@@ -37,7 +40,7 @@ import TArray = require('ref-array-di');
     printfGen('string')('This is a string: %s\n', 'hello');
 }
 {
-    ref.address(new Buffer(1));
+    ref.address(Buffer.alloc(1));
     const intBuf = ref.alloc(ref.types.int);
     const intWith4 = ref.alloc(ref.types.int, 4);
     const buf0 = ref.allocCString('hello world');
@@ -45,10 +48,10 @@ import TArray = require('ref-array-di');
     const val = ref.deref(intBuf);
 }
 {
-    ref.isNull(new Buffer(1));
+    ref.isNull(Buffer.alloc(1));
 }
 {
-    const str = ref.readCString(new Buffer('hello\0world\0'), 0);
+    const str = ref.readCString(Buffer.from('hello\0world\0'), 0);
     const buf = ref.alloc('int64');
     ref.writeInt64BE(buf, 0, '9223372036854775807');
     const val = ref.readInt64BE(buf, 0);
@@ -82,7 +85,7 @@ import TArray = require('ref-array-di');
 }
 {
     const CharArray = TArray('char');
-    const b = new Buffer('hello', 'ascii');
+    const b = Buffer.from('hello', 'ascii');
     const a = new CharArray(b);
 }
 {

--- a/types/ffi-napi/index.d.ts
+++ b/types/ffi-napi/index.d.ts
@@ -1,14 +1,13 @@
-// Type definitions for node-ffi-napi 2.4
+// Type definitions for ffi-napi 4.0
 // Project: http://github.com/node-ffi-napi/node-ffi-napi
 // Definitions by: Keerthi Niranjan <https://github.com/keerthi16>, Kiran Niranjan <https://github.com/KiranNiranjan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 /// <reference types="node" />
 
-
 import ref = require('ref-napi');
-import StructType = require('ref-struct-di');
+import ref_struct = require('ref-struct-di');
+import StructType = ref_struct.StructType;
 
 /** Provides a friendly API on-top of `DynamicLibrary` and `ForeignFunction`. */
 export interface Library {
@@ -20,14 +19,14 @@ export interface Library {
      * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
      * @param lib hash that will be extended
      */
-    new (libFile: string | null, funcs?: {[key: string]: any[]}, lib?: object): any;
+    new (libFile: string | null, funcs?: Record<string, [string | ref.Type, Array<string | ref.Type>, { abi?: number, async?: boolean, varargs?: boolean }?]>, lib?: object): any;
 
     /**
      * @param libFile name of library
      * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
      * @param lib hash that will be extended
      */
-    (libFile: string | null, funcs?: {[key: string]: any[]}, lib?: object): any;
+    (libFile: string | null, funcs?: Record<string, [string | ref.Type, Array<string | ref.Type>, { abi?: number, async?: boolean, varargs?: boolean }?]>, lib?: object): any;
 }
 export const Library: Library;
 
@@ -51,8 +50,8 @@ export interface Function extends ref.Type {
 
 /** Creates and returns a type for a C function pointer. */
 export const Function: {
-    new (retType: ref.Type | string, argTypes: any[], abi?: number): Function;
-    (retType: ref.Type | string, argTypes: any[], abi?: number): Function;
+    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): Function;
+    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): Function;
 };
 
 export interface ForeignFunction {
@@ -67,8 +66,8 @@ export interface ForeignFunction {
  * execution.
  */
 export const ForeignFunction: {
-    new (ptr: Buffer, retType: ref.Type | string, argTypes: any[], abi?: number): ForeignFunction;
-    (ptr: Buffer, retType: ref.Type | string, argTypes: any[], abi?: number): ForeignFunction;
+    new (ptr: Buffer, retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): ForeignFunction;
+    (ptr: Buffer, retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): ForeignFunction;
 };
 
 export interface VariadicForeignFunction {
@@ -76,14 +75,14 @@ export interface VariadicForeignFunction {
      * What gets returned is another function that needs to be invoked with the rest
      * of the variadic types that are being invoked from the function.
      */
-    (...args: any[]): ForeignFunction;
+    (...args: Array<string | ref.Type>): ForeignFunction;
 
     /**
      * Return type as a property of the function generator to
      * allow for monkey patching the return value in the very rare case where the
      * return type is variadic as well
      */
-    returnType: any;
+    returnType: ref.Type;
 }
 
 /**
@@ -94,8 +93,8 @@ export interface VariadicForeignFunction {
  * contain the same ffi_type argument signature.
  */
 export const VariadicForeignFunction: {
-    new (ptr: Buffer, ret: ref.Type | string, fixedArgs: any[], abi?: number): VariadicForeignFunction;
-    (ptr: Buffer, ret: ref.Type | string, fixedArgs: any[], abi?: number): VariadicForeignFunction;
+    new (ptr: Buffer, ret: string | ref.Type, fixedArgs: Array<string | ref.Type>, abi?: number): VariadicForeignFunction;
+    (ptr: Buffer, ret: string | ref.Type, fixedArgs: Array<string | ref.Type>, abi?: number): VariadicForeignFunction;
 };
 
 export interface DynamicLibrary {
@@ -136,23 +135,23 @@ export const DynamicLibrary: {
  * accept C callback functions.
  */
 export interface Callback {
-    new (retType: any, argTypes: any[], abi: number, fn: any): Buffer;
-    new (retType: any, argTypes: any[], fn: any): Buffer;
-    (retType: any, argTypes: any[], abi: number, fn: any): Buffer;
-    (retType: any, argTypes: any[], fn: any): Buffer;
+    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi: number, fn: (...args: any[]) => any): Buffer;
+    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, fn: (...args: any[]) => any): Buffer;
+    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi: number, fn: (...args: any[]) => any): Buffer;
+    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, fn: (...args: any[]) => any): Buffer;
 }
 export const Callback: Callback;
 
 export const ffiType: {
     /** Get a `ffi_type *` Buffer appropriate for the given type. */
-    (type: ref.Type | string): Buffer
+    (type: string | ref.Type): Buffer
     FFI_TYPE: StructType;
 };
 
-export function CIF(retType: any, types: any[], abi?: any): Buffer;
-export function CIF_var(retType: any, types: any[], numFixedArgs: number, abi?: any): Buffer;
+export function CIF(retType: string | ref.Type, types: Array<string | ref.Type>, abi?: number): Buffer;
+export function CIF_var(retType: string | ref.Type, types: Array<string | ref.Type>, numFixedArgs: number, abi?: number): Buffer;
 export const HAS_OBJC: boolean;
-export const FFI_TYPES: {[key: string]: Buffer};
+export const FFI_TYPES: Record<string, Buffer>;
 export const FFI_OK: number;
 export const FFI_BAD_TYPEDEF: number;
 export const FFI_BAD_ABI: number;
@@ -173,14 +172,4 @@ export const LIB_EXT: string;
 export const FFI_TYPE: StructType;
 
 /** Default types. */
-export const types: {
-    void: ref.Type;                 int64: ref.Type;                 ushort: ref.Type;
-    int: ref.Type;                  uint64: ref.Type;                float: ref.Type;
-    uint: ref.Type;                 long: ref.Type;                  double: ref.Type;
-    int8: ref.Type;                 ulong: ref.Type;                 Object: ref.Type;
-    uint8: ref.Type;                longlong: ref.Type;              CString: ref.Type;
-    int16: ref.Type;                ulonglong: ref.Type;             bool: ref.Type;
-    uint16: ref.Type;               char: ref.Type;                  byte: ref.Type;
-    int32: ref.Type;                uchar: ref.Type;                 size_t: ref.Type;
-    uint32: ref.Type;               short: ref.Type;
-};
+export import types = ref.types;

--- a/types/ref-array-di/index.d.ts
+++ b/types/ref-array-di/index.d.ts
@@ -5,58 +5,52 @@
 
 import ref = require('ref-napi');
 
-interface ArrayType<T> extends ref.Type {
-    BYTES_PER_ELEMENT: number;
-    fixedLength: number;
-    /** The reference to the base type. */
-    type: ref.Type;
-
-    /**
-     * Accepts a Buffer instance that should be an already-populated with data
-     * for the ArrayType. The "length" of the Array is determined by searching
-     * through the buffer's contents until an aligned NULL pointer is encountered.
-     */
-    untilZeros(buffer: Buffer): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-
-    new (length?: number): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-    new (data: number[], length?: number): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-    new (data: Buffer, length?: number): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-    (length?: number): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-    (data: number[], length?: number): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-    (data: Buffer, length?: number): {
-        [i: number]: T; length: number; toArray(): T[];
-        toJSON(): T[]; inspect(): string; buffer: Buffer; ref(): Buffer;
-    };
-}
-
 /**
  * The array type meta-constructor.
  * The returned constructor's API is highly influenced by the WebGL
  * TypedArray API.
  */
 declare var ArrayType: {
-    new <T>(type: ref.Type, length?: number): ArrayType<T>;
-    new <T>(type: string, length?: number): ArrayType<T>;
-    <T>(type: ref.Type, length?: number): ArrayType<T>;
-    <T>(type: string, length?: number): ArrayType<T>;
+    new <T>(type: string | ref.Type, length: number): array.FixedLengthArrayType<T>;
+    new <T>(type: string | ref.Type, length?: number): array.ArrayType<T>;
+    <T>(type: string | ref.Type, length: number): array.FixedLengthArrayType<T>;
+    <T>(type: string | ref.Type, length?: number): array.ArrayType<T>;
 };
 
-export = ArrayType;
+type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "readPointer" | "writePointer" | "reinterpret" | "reinterpretUntilZeros" | "ref" | "types" | "NULL">;
+
+declare function array(ref: RefModuleLike): typeof ArrayType;
+declare namespace array {
+    interface TypedArray<T> {
+        [i: number]: T;
+        length: number;
+        toArray(): T[];
+        toJSON(): T[];
+        inspect(): string;
+        buffer: Buffer;
+        ref(): Buffer;
+    }
+    interface ArrayType<T> extends ref.Type {
+        BYTES_PER_ELEMENT: number;
+        fixedLength?: number;
+        /** The reference to the base type. */
+        type: ref.Type;
+        /**
+         * Accepts a Buffer instance that should be an already-populated with data
+         * for the ArrayType. The "length" of the Array is determined by searching
+         * through the buffer's contents until an aligned NULL pointer is encountered.
+         */
+        untilZeros(buffer: Buffer): TypedArray<T>;
+        new (length?: number): TypedArray<T>;
+        new (data: number[], length?: number): TypedArray<T>;
+        new (data: Buffer, length?: number): TypedArray<T>;
+        (length?: number): TypedArray<T>;
+        (data: number[], length?: number): TypedArray<T>;
+        (data: Buffer, length?: number): TypedArray<T>;
+    }
+    interface FixedLengthArrayType<T> extends ArrayType<T> {
+        fixedLength: number;
+    }
+}
+
+export = array;

--- a/types/ref-array-di/ref-array-di-tests.ts
+++ b/types/ref-array-di/ref-array-di-tests.ts
@@ -1,0 +1,98 @@
+import ref = require("ref-napi");
+import ref_array = require("ref-array-di");
+const ArrayType = ref_array(ref);
+
+declare const typeLike: string | ref.Type;
+declare const buffer: Buffer;
+declare const number: number;
+declare const numberArray: number[];
+
+// $ExpectType ArrayType<unknown>
+ArrayType(typeLike);
+// $ExpectType ArrayType<unknown>
+ArrayType(typeLike, undefined);
+// $ExpectType FixedLengthArrayType<unknown>
+ArrayType(typeLike, number);
+
+// $ExpectType ArrayType<unknown>
+new ArrayType(typeLike);
+// $ExpectType ArrayType<unknown>
+new ArrayType(typeLike, undefined);
+// $ExpectType FixedLengthArrayType<unknown>
+new ArrayType(typeLike, number);
+
+// define the "int[]" type
+declare const IntArray: ref_array.ArrayType<number>;
+
+// $ExpectType number
+IntArray.BYTES_PER_ELEMENT;
+
+// $ExpectType number | undefined
+IntArray.fixedLength;
+
+// $ExpectType Type
+IntArray.type;
+
+// $ExpectType TypedArray<number>
+IntArray.untilZeros(buffer);
+
+// $ExpectType TypedArray<number>
+IntArray();
+// $ExpectType TypedArray<number>
+IntArray(undefined);
+// $ExpectType TypedArray<number>
+IntArray(number);
+// $ExpectType TypedArray<number>
+IntArray(numberArray);
+// $ExpectType TypedArray<number>
+IntArray(numberArray, undefined);
+// $ExpectType TypedArray<number>
+IntArray(numberArray, number);
+// $ExpectType TypedArray<number>
+IntArray(buffer);
+// $ExpectType TypedArray<number>
+IntArray(buffer, undefined);
+// $ExpectType TypedArray<number>
+IntArray(buffer, number);
+
+// $ExpectType TypedArray<number>
+new IntArray();
+// $ExpectType TypedArray<number>
+new IntArray(undefined);
+// $ExpectType TypedArray<number>
+new IntArray(number);
+// $ExpectType TypedArray<number>
+new IntArray(numberArray);
+// $ExpectType TypedArray<number>
+new IntArray(numberArray, undefined);
+// $ExpectType TypedArray<number>
+new IntArray(numberArray, number);
+// $ExpectType TypedArray<number>
+new IntArray(buffer);
+// $ExpectType TypedArray<number>
+new IntArray(buffer, undefined);
+// $ExpectType TypedArray<number>
+new IntArray(buffer, number);
+
+declare const ar: ref_array.TypedArray<number>;
+
+// $ExpectType number
+ar[0];
+
+// $ExpectType number
+ar.length;
+
+// $ExpectType number[]
+ar.toArray();
+
+// $ExpectType number[]
+ar.toJSON();
+
+// $ExpectType string
+ar.inspect();
+
+// $ExpectType Buffer
+ar.buffer;
+
+// $ExpectType Buffer
+ar.ref();

--- a/types/ref-array-di/tsconfig.json
+++ b/types/ref-array-di/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "ref-array-di-tests.ts"
     ]
 }

--- a/types/ref-napi/index.d.ts
+++ b/types/ref-napi/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ref-napi 1.4
+// Type definitions for ref-napi 3.0
 // Project: https://github.com/node-ffi-napi/ref-napi
 // Definitions by: Keerthi Niranjan <https://github.com/keerthi16>, Kiran Niranjan <https://github.com/KiranNiranjan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -26,10 +26,10 @@ export declare var NULL: Buffer;
 export declare var NULL_POINTER: Buffer;
 /** Get the memory address of buffer. */
 export declare function address(buffer: Buffer): number;
+/** Get the memory address of buffer. */
+export declare function hexAddress(buffer: Buffer): string;
 /** Allocate the memory with the given value written to it. */
-export declare function alloc(type: Type, value?: any): Buffer;
-/** Allocate the memory with the given value written to it. */
-export declare function alloc(type: string, value?: any): Buffer;
+export declare function alloc(type: string | Type, value?: any): Buffer;
 
 /**
  * Allocate the memory with the given string written to it with the given
@@ -38,10 +38,8 @@ export declare function alloc(type: string, value?: any): Buffer;
  */
 export declare function allocCString(string: string, encoding?: string): Buffer;
 
-/** Coerce a type.*/
-export declare function coerceType(type: Type): Type;
 /** Coerce a type. String are looked up from the ref.types object. */
-export declare function coerceType(type: string): Type;
+export declare function coerceType(type: string | Type): Type;
 
 /**
  * Get value after dereferencing buffer.
@@ -52,15 +50,11 @@ export declare function coerceType(type: string): Type;
 export declare function deref(buffer: Buffer): any;
 
 /** Create clone of the type, with decremented indirection level by 1. */
-export declare function derefType(type: Type): Type;
-/** Create clone of the type, with decremented indirection level by 1. */
-export declare function derefType(type: string): Type;
+export declare function derefType(type: string | Type): Type;
 /** Represents the native endianness of the processor ("LE" or "BE"). */
-export declare var endianness: string;
+export declare var endianness: "LE" | "BE";
 /** Check the indirection level and return a dereferenced when necessary. */
-export declare function get(buffer: Buffer, offset?: number, type?: Type): any;
-/** Check the indirection level and return a dereferenced when necessary. */
-export declare function get(buffer: Buffer, offset?: number, type?: string): any;
+export declare function get(buffer: Buffer, offset?: number, type?: string | Type): any;
 /** Get type of the buffer. Create a default type when none exists. */
 export declare function getType(buffer: Buffer): Type;
 /** Check the NULL. */
@@ -73,14 +67,14 @@ export declare function readCString(buffer: Buffer, offset?: number): string;
  * If there is losing precision, then return a string, otherwise a number.
  * @return {number|string}
  */
-export declare function readInt64BE(buffer: Buffer, offset?: number): any;
+export declare function readInt64BE(buffer: Buffer, offset?: number): number | string;
 
 /**
  * Read a little-endian signed 64-bit int.
  * If there is losing precision, then return a string, otherwise a number.
  * @return {number|string}
  */
-export declare function readInt64LE(buffer: Buffer, offset?: number): any;
+export declare function readInt64LE(buffer: Buffer, offset?: number): number | string;
 
 /** Read a JS Object that has previously been written. */
 export declare function readObject(buffer: Buffer, offset?: number): Object;
@@ -92,21 +86,19 @@ export declare function readPointer(buffer: Buffer, offset?: number,
  * If there is losing precision, then return a string, otherwise a number.
  * @return {number|string}
  */
-export declare function readUInt64BE(buffer: Buffer, offset?: number): any;
+export declare function readUInt64BE(buffer: Buffer, offset?: number): string | number;
 
 /**
  * Read a little-endian unsigned 64-bit int.
  * If there is losing precision, then return a string, otherwise a number.
  * @return {number|string}
  */
-export declare function readUInt64LE(buffer: Buffer, offset?: number): any;
+export declare function readUInt64LE(buffer: Buffer, offset?: number): string | number;
 
 /** Create pointer to buffer. */
 export declare function ref(buffer: Buffer): Buffer;
 /** Create clone of the type, with incremented indirection level by 1. */
-export declare function refType(type: Type): Type;
-/** Create clone of the type, with incremented indirection level by 1. */
-export declare function refType(type: string): Type;
+export declare function refType(type: string | Type): Type;
 
 /**
  * Create buffer with the specified size, with the same address as source.
@@ -123,20 +115,14 @@ export declare function reinterpretUntilZeros(buffer: Buffer, size: number,
     offset?: number): Buffer;
 
 /** Write pointer if the indirection is 1, otherwise write value. */
-export declare function set(buffer: Buffer, offset: number, value: any, type?: Type): void;
-/** Write pointer if the indirection is 1, otherwise write value. */
-export declare function set(buffer: Buffer, offset: number, value: any, type?: string): void;
+export declare function set(buffer: Buffer, offset: number, value: any, type?: string | Type): void;
 /** Write the string as a NULL terminated. Default encoding is utf8. */
 export declare function writeCString(buffer: Buffer, offset: number,
     string: string, encoding?: string): void;
 /** Write a big-endian signed 64-bit int. */
-export declare function writeInt64BE(buffer: Buffer, offset: number, input: number): void;
-/** Write a big-endian signed 64-bit int. */
-export declare function writeInt64BE(buffer: Buffer, offset: number, input: string): void;
+export declare function writeInt64BE(buffer: Buffer, offset: number, input: string | number): void;
 /** Write a little-endian signed 64-bit int. */
-export declare function writeInt64LE(buffer: Buffer, offset: number, input: number): void;
-/** Write a little-endian signed 64-bit int. */
-export declare function writeInt64LE(buffer: Buffer, offset: number, input: string): void;
+export declare function writeInt64LE(buffer: Buffer, offset: number, input: string | number): void;
 
 /**
  * Write the JS Object. This function "attaches" object to buffer to prevent
@@ -151,10 +137,10 @@ export declare function writeObject(buffer: Buffer, offset: number, object: Obje
 export declare function writePointer(buffer: Buffer, offset: number,
     pointer: Buffer): void;
 
+/** Write a big-endian unsigned 64-bit int. */
+export declare function writeUInt64BE(buffer: Buffer, offset: number, input: string | number): void;
 /** Write a little-endian unsigned 64-bit int. */
-export declare function writeUInt64BE(buffer: Buffer, offset: number, input: number): void;
-/** Write a little-endian unsigned 64-bit int. */
-export declare function writeUInt64BE(buffer: Buffer, offset: number, input: string): void;
+export declare function writeUInt64LE(buffer: Buffer, offset: number, input: string | number): void;
 
 /**
  * Attach object to buffer such.
@@ -187,26 +173,52 @@ export declare var types: {
     uint32: Type; short: Type;
 };
 
+export declare var alignof: {
+    pointer: number; int64: number; ushort: number;
+    int: number; uint64: number; float: number;
+    uint: number; long: number; double: number;
+    int8: number; ulong: number; Object: number;
+    uint8: number; longlong: number;
+    int16: number; ulonglong: number; bool: number;
+    uint16: number; char: number; byte: number;
+    int32: number; uchar: number; size_t: number;
+    uint32: number; short: number;
+};
+export declare var sizeof: {
+    pointer: number; int64: number; ushort: number;
+    int: number; uint64: number; float: number;
+    uint: number; long: number; double: number;
+    int8: number; ulong: number; Object: number;
+    uint8: number; longlong: number;
+    int16: number; ulonglong: number; bool: number;
+    uint16: number; char: number; byte: number;
+    int32: number; uchar: number; size_t: number;
+    uint32: number; short: number;
+};
+
 declare global {
   interface Buffer {
-    address: typeof address;
-    isNull: typeof isNull;
-    ref: typeof ref;
-    deref: typeof deref;
-    readObject: typeof readObject;
-    writeObject: typeof writeObject;
-    readPointer: typeof readPointer;
-    writePointer: typeof writePointer;
-    readCString: typeof readCString;
-    writeCString: typeof writeCString;
-    readInt64BE: typeof readInt64BE;
-    writeInt64BE: typeof writeInt64BE;
-    readUInt64BE: typeof readUInt64BE;
-    writeUInt64BE: typeof writeUInt64BE;
-    readInt64LE: typeof readInt64LE;
-    writeInt64LE: typeof writeInt64LE;
-    reinterpret: typeof reinterpret;
-    reinterpretUntilZeros: typeof reinterpretUntilZeros;
+    address(): number;
+    hexAddress(): string;
+    isNull(): boolean;
+    ref(): Buffer;
+    deref(): any;
+    readObject(offset?: number): Object;
+    writeObject(offset: number, object: Object): void;
+    readPointer(offset?: number, length?: number): Buffer;
+    writePointer(offset: number, pointer: Buffer): void;
+    readCString(offset?: number): string;
+    writeCString(offset: number, string: string, encoding?: string): void;
+    readInt64BE(offset?: number): string | number;
+    writeInt64BE(offset: number, input: string | number): void;
+    readUInt64BE(offset?: number): string | number;
+    writeUInt64BE(offset: number, input: string | number): void;
+    readInt64LE(offset?: number): string | number;
+    writeInt64LE(offset: number, input: string | number): void;
+    readUInt64LE(offset?: number): string | number;
+    writeUInt64LE(offset: number, input: string | number): void;
+    reinterpret(size: number, offset?: number): Buffer;
+    reinterpretUntilZeros(size: number, offset?: number): Buffer;
     type?: Type;
   }
 }

--- a/types/ref-napi/ref-napi-tests.ts
+++ b/types/ref-napi/ref-napi-tests.ts
@@ -1,0 +1,436 @@
+import ref = require("ref-napi");
+
+declare const typeLike: string | ref.Type;
+declare const buffer: Buffer;
+declare const string: string;
+declare const number: number;
+declare const any: any;
+declare const int64Like: string | number;
+declare const jsObject: Object;
+
+// $ExpectType number
+ref.address(buffer);
+
+// $ExpectType string
+ref.hexAddress(buffer);
+
+// $ExpectType Buffer
+ref.alloc(typeLike, 0);
+
+// $ExpectType Buffer
+ref.allocCString(string);
+// $ExpectType Buffer
+ref.allocCString(string, undefined);
+// $ExpectType Buffer
+ref.allocCString(string, string);
+
+// $ExpectType Type
+ref.coerceType(typeLike);
+
+// $ExpectType any
+ref.deref(buffer);
+
+// $ExpectType Type
+ref.derefType(typeLike);
+
+// $ExpectType "LE" | "BE"
+ref.endianness;
+
+// $ExpectType any
+ref.get(buffer);
+// $ExpectType any
+ref.get(buffer, undefined);
+// $ExpectType any
+ref.get(buffer, undefined, undefined);
+// $ExpectType any
+ref.get(buffer, number);
+// $ExpectType any
+ref.get(buffer, number, undefined);
+// $ExpectType any
+ref.get(buffer, number, typeLike);
+
+// $ExpectType Type
+ref.getType(buffer);
+
+// $ExpectType boolean
+ref.isNull(buffer);
+
+// $ExpectType string
+ref.readCString(buffer);
+// $ExpectType string
+ref.readCString(buffer, undefined);
+// $ExpectType string
+ref.readCString(buffer, number);
+
+// $ExpectType string | number
+ref.readInt64BE(buffer);
+// $ExpectType string | number
+ref.readInt64BE(buffer, undefined);
+// $ExpectType string | number
+ref.readInt64BE(buffer, number);
+
+// $ExpectType string | number
+ref.readInt64LE(buffer);
+// $ExpectType string | number
+ref.readInt64LE(buffer, undefined);
+// $ExpectType string | number
+ref.readInt64LE(buffer, number);
+
+// $ExpectType Object
+ref.readObject(buffer);
+// $ExpectType Object
+ref.readObject(buffer, undefined);
+// $ExpectType Object
+ref.readObject(buffer, number);
+
+// $ExpectType Buffer
+ref.ref(buffer);
+
+// $ExpectType Type
+ref.refType(typeLike);
+
+// $ExpectType Buffer
+ref.reinterpret(buffer, number);
+// $ExpectType Buffer
+ref.reinterpret(buffer, number, undefined);
+// $ExpectType Buffer
+ref.reinterpret(buffer, number, number);
+
+// $ExpectType Buffer
+ref.reinterpretUntilZeros(buffer, number);
+// $ExpectType Buffer
+ref.reinterpretUntilZeros(buffer, number, undefined);
+// $ExpectType Buffer
+ref.reinterpretUntilZeros(buffer, number, number);
+
+// $ExpectType void
+ref.set(buffer, number, any);
+// $ExpectType void
+ref.set(buffer, number, any, undefined);
+// $ExpectType void
+ref.set(buffer, number, any, typeLike);
+
+// $ExpectType void
+ref.writeCString(buffer, number, string);
+// $ExpectType void
+ref.writeCString(buffer, number, string, undefined);
+// $ExpectType void
+ref.writeCString(buffer, number, string, string);
+
+// $ExpectType void
+ref.writeInt64BE(buffer, number, int64Like);
+
+// $ExpectType void
+ref.writeInt64LE(buffer, number, int64Like);
+
+// $ExpectType void
+ref.writeObject(buffer, number, jsObject);
+
+// $ExpectType void
+ref.writePointer(buffer, number, buffer);
+
+// $ExpectType void
+ref.writeUInt64BE(buffer, number, int64Like);
+
+// $ExpectType void
+ref.writeUInt64LE(buffer, number, int64Like);
+
+// $ExpectType void
+ref._attach(buffer, jsObject);
+
+// $ExpectType Buffer
+ref._reinterpret(buffer, number);
+// $ExpectType Buffer
+ref._reinterpret(buffer, number, undefined);
+// $ExpectType Buffer
+ref._reinterpret(buffer, number, number);
+
+// $ExpectType Buffer
+ref._reinterpretUntilZeros(buffer, number);
+// $ExpectType Buffer
+ref._reinterpretUntilZeros(buffer, number, undefined);
+// $ExpectType Buffer
+ref._reinterpretUntilZeros(buffer, number, number);
+
+// $ExpectType void
+ref._writePointer(buffer, number, buffer);
+
+// $ExpectType void
+ref._writeObject(buffer, number, jsObject);
+
+// $ExpectType Type
+ref.types.void;
+// $ExpectError
+ref.types.pointer; // `pointer` doesn't exist on `types`, though it exists on `sizeof`/`alignof`
+// $ExpectType Type
+ref.types.int64;
+// $ExpectType Type
+ref.types.ushort;
+// $ExpectType Type
+ref.types.int;
+// $ExpectType Type
+ref.types.uint64;
+// $ExpectType Type
+ref.types.float;
+// $ExpectType Type
+ref.types.uint;
+// $ExpectType Type
+ref.types.long;
+// $ExpectType Type
+ref.types.double;
+// $ExpectType Type
+ref.types.int8;
+// $ExpectType Type
+ref.types.ulong;
+// $ExpectType Type
+ref.types.Object;
+// $ExpectType Type
+ref.types.uint8;
+// $ExpectType Type
+ref.types.longlong;
+// $ExpectType Type
+ref.types.CString;
+// $ExpectType Type
+ref.types.int16;
+// $ExpectType Type
+ref.types.ulonglong;
+// $ExpectType Type
+ref.types.bool;
+// $ExpectType Type
+ref.types.uint16;
+// $ExpectType Type
+ref.types.char;
+// $ExpectType Type
+ref.types.byte;
+// $ExpectType Type
+ref.types.int32;
+// $ExpectType Type
+ref.types.uchar;
+// $ExpectType Type
+ref.types.size_t;
+// $ExpectType Type
+ref.types.uint32;
+// $ExpectType Type
+ref.types.short;
+
+// $ExpectError
+ref.alignof.void; // `void` doesn't have an alignment
+// $ExpectType number
+ref.alignof.pointer;
+// $ExpectType number
+ref.alignof.int64;
+// $ExpectType number
+ref.alignof.ushort;
+// $ExpectType number
+ref.alignof.int;
+// $ExpectType number
+ref.alignof.uint64;
+// $ExpectType number
+ref.alignof.float;
+// $ExpectType number
+ref.alignof.uint;
+// $ExpectType number
+ref.alignof.long;
+// $ExpectType number
+ref.alignof.double;
+// $ExpectType number
+ref.alignof.int8;
+// $ExpectType number
+ref.alignof.ulong;
+// $ExpectType number
+ref.alignof.Object;
+// $ExpectType number
+ref.alignof.uint8;
+// $ExpectType number
+ref.alignof.longlong;
+// $ExpectError
+ref.alignof.CString; // `CString` doesn't have an alignment
+// $ExpectType number
+ref.alignof.int16;
+// $ExpectType number
+ref.alignof.ulonglong;
+// $ExpectType number
+ref.alignof.bool;
+// $ExpectType number
+ref.alignof.uint16;
+// $ExpectType number
+ref.alignof.char;
+// $ExpectType number
+ref.alignof.byte;
+// $ExpectType number
+ref.alignof.int32;
+// $ExpectType number
+ref.alignof.uchar;
+// $ExpectType number
+ref.alignof.size_t;
+// $ExpectType number
+ref.alignof.uint32;
+// $ExpectType number
+ref.alignof.short;
+
+// $ExpectError
+ref.sizeof.void; // `void` doesn't have an size
+// $ExpectType number
+ref.sizeof.pointer;
+// $ExpectType number
+ref.sizeof.int64;
+// $ExpectType number
+ref.sizeof.ushort;
+// $ExpectType number
+ref.sizeof.int;
+// $ExpectType number
+ref.sizeof.uint64;
+// $ExpectType number
+ref.sizeof.float;
+// $ExpectType number
+ref.sizeof.uint;
+// $ExpectType number
+ref.sizeof.long;
+// $ExpectType number
+ref.sizeof.double;
+// $ExpectType number
+ref.sizeof.int8;
+// $ExpectType number
+ref.sizeof.ulong;
+// $ExpectType number
+ref.sizeof.Object;
+// $ExpectType number
+ref.sizeof.uint8;
+// $ExpectType number
+ref.sizeof.longlong;
+// $ExpectError
+ref.sizeof.CString; // `CString` doesn't have an size
+// $ExpectType number
+ref.sizeof.int16;
+// $ExpectType number
+ref.sizeof.ulonglong;
+// $ExpectType number
+ref.sizeof.bool;
+// $ExpectType number
+ref.sizeof.uint16;
+// $ExpectType number
+ref.sizeof.char;
+// $ExpectType number
+ref.sizeof.byte;
+// $ExpectType number
+ref.sizeof.int32;
+// $ExpectType number
+ref.sizeof.uchar;
+// $ExpectType number
+ref.sizeof.size_t;
+// $ExpectType number
+ref.sizeof.uint32;
+// $ExpectType number
+ref.sizeof.short;
+
+// $ExpectType number
+buffer.address();
+
+// $ExpectType string
+buffer.hexAddress();
+
+// $ExpectType boolean
+buffer.isNull();
+
+// $ExpectType Buffer
+buffer.ref();
+
+// $ExpectType any
+buffer.deref();
+
+// $ExpectType Object
+buffer.readObject();
+// $ExpectType Object
+buffer.readObject(undefined);
+// $ExpectType Object
+buffer.readObject(number);
+
+// $ExpectType void
+buffer.writeObject(number, jsObject);
+
+// $ExpectType Buffer
+buffer.readPointer();
+// $ExpectType Buffer
+buffer.readPointer(undefined);
+// $ExpectType Buffer
+buffer.readPointer(undefined, undefined);
+// $ExpectType Buffer
+buffer.readPointer(number);
+// $ExpectType Buffer
+buffer.readPointer(number, undefined);
+// $ExpectType Buffer
+buffer.readPointer(number, number);
+
+// $ExpectType void
+buffer.writePointer(number, buffer);
+
+// $ExpectType string
+buffer.readCString();
+// $ExpectType string
+buffer.readCString(undefined);
+// $ExpectType string
+buffer.readCString(number);
+
+// $ExpectType void
+buffer.writeCString(number, string);
+// $ExpectType void
+buffer.writeCString(number, string, undefined);
+// $ExpectType void
+buffer.writeCString(number, string, string);
+
+// $ExpectType string | number
+buffer.readInt64BE();
+// $ExpectType string | number
+buffer.readInt64BE(undefined);
+// $ExpectType string | number
+buffer.readInt64BE(number);
+
+// $ExpectType void
+buffer.writeInt64BE(number, int64Like);
+
+// $ExpectType string | number
+buffer.readUInt64BE();
+// $ExpectType string | number
+buffer.readUInt64BE(undefined);
+// $ExpectType string | number
+buffer.readUInt64BE(number);
+
+// $ExpectType void
+buffer.writeUInt64BE(number, int64Like);
+
+// $ExpectType string | number
+buffer.readInt64LE();
+// $ExpectType string | number
+buffer.readInt64LE(undefined);
+// $ExpectType string | number
+buffer.readInt64LE(number);
+
+// $ExpectType void
+buffer.writeInt64LE(number, int64Like);
+
+// $ExpectType string | number
+buffer.readUInt64LE();
+// $ExpectType string | number
+buffer.readUInt64LE(undefined);
+// $ExpectType string | number
+buffer.readUInt64LE(number);
+
+// $ExpectType void
+buffer.writeUInt64LE(number, int64Like);
+
+// $ExpectType Buffer
+buffer.reinterpret(number);
+// $ExpectType Buffer
+buffer.reinterpret(number, undefined);
+// $ExpectType Buffer
+buffer.reinterpret(number, number);
+
+// $ExpectType Buffer
+buffer.reinterpretUntilZeros(number);
+// $ExpectType Buffer
+buffer.reinterpretUntilZeros(number, undefined);
+// $ExpectType Buffer
+buffer.reinterpretUntilZeros(number, number);
+
+// $ExpectType Type | undefined
+buffer.type;

--- a/types/ref-napi/tsconfig.json
+++ b/types/ref-napi/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "ref-napi-tests.ts"
     ]
 }

--- a/types/ref-struct-di/index.d.ts
+++ b/types/ref-struct-di/index.d.ts
@@ -2,59 +2,59 @@
 // Project: https://github.com/node-ffi-napi/ref-struct-di
 // Definitions by: Keerthi Niranjan <https://github.com/keerthi16>, Kiran Niranjan <https://github.com/KiranNiranjan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 import ref = require('ref-napi');
 
-/**
- * This is the `constructor` of the Struct type that gets returned.
- *
- * Invoke it with `new` to create a new Buffer instance backing the struct.
- * Pass it an existing Buffer instance to use that as the backing buffer.
- * Pass in an Object containing the struct fields to auto-populate the
- * struct with the data.
- *
- * @constructor
- */
-interface StructType extends ref.Type {
-    /** Pass it an existing Buffer instance to use that as the backing buffer. */
-    new (arg: Buffer, data?: {}): any;
-    new (data?: {}): any;
-    /** Pass it an existing Buffer instance to use that as the backing buffer. */
-    (arg: Buffer, data?: {}): any;
-    (data?: {}): any;
-
-    fields: { [key: string]: { type: ref.Type } };
-
-    /**
-     * Adds a new field to the struct instance with the given name and type.
-     * Note that this function will throw an Error if any instances of the struct
-     * type have already been created, therefore this function must be called at the
-     * beginning, before any instances are created.
-     */
-    defineProperty(name: string, type: ref.Type): void;
-
-    /**
-     * Adds a new field to the struct instance with the given name and type.
-     * Note that this function will throw an Error if any instances of the struct
-     * type have already been created, therefore this function must be called at the
-     * beginning, before any instances are created.
-     */
-    defineProperty(name: string, type: string): void;
-
-    /**
-     * Custom for struct type instances.
-     * @override
-     */
-    toString(): string;
-}
-
-/** The struct type meta-constructor. */
 declare var StructType: {
-    new (fields?: object, opt?: object): StructType;
-    new (fields?: any[]): StructType;
-    (fields?: object, opt?: object): StructType;
-    (fields?: any[]): StructType;
+    new (fields?: Record<string, string | ref.Type>, opt?: { packed?: boolean }): struct.StructType;
+    new (fields?: Array<[string, string | ref.Type]>, opt?: { packed?: boolean }): struct.StructType;
+    (fields?: Record<string, string | ref.Type>, opt?: { packed?: boolean }): struct.StructType;
+    (fields?: Array<[string, string | ref.Type]>, opt?: { packed?: boolean }): struct.StructType;
+};
+
+type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "NULL">;
+
+declare function struct(ref: RefModuleLike): typeof StructType;
+declare namespace struct {
+    interface Field {
+        type: ref.Type;
+        offset: number;
+    }
+    /**
+     * This is the `constructor` of the Struct type that gets returned.
+     *
+     * Invoke it with `new` to create a new Buffer instance backing the struct.
+     * Pass it an existing Buffer instance to use that as the backing buffer.
+     * Pass in an Object containing the struct fields to auto-populate the
+     * struct with the data.
+     *
+     * @constructor
+     */
+    interface StructType extends ref.Type {
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        new (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        new (data?: Record<string, any>): Record<string, any>;
+
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        (data?: Record<string, any>): Record<string, any>;
+
+        fields: Record<string, Field>;
+
+        /**
+         * Adds a new field to the struct instance with the given name and type.
+         * Note that this function will throw an Error if any instances of the struct
+         * type have already been created, therefore this function must be called at the
+         * beginning, before any instances are created.
+         */
+        defineProperty(name: string, type: string | ref.Type): void;
+
+        /**
+         * Custom for struct type instances.
+         * @override
+         */
+        toString(): string;
+    }
 }
 
-export = StructType;
+export = struct;

--- a/types/ref-struct-di/ref-struct-di-tests.ts
+++ b/types/ref-struct-di/ref-struct-di-tests.ts
@@ -1,5 +1,6 @@
 import ref = require("ref-napi");
-import StructType = require("ref-struct-di");
+import ref_struct = require("ref-struct-di");
+const StructType = ref_struct(ref);
 
 const normalStruct = StructType({
   t: ref.types.uint8,
@@ -10,3 +11,84 @@ const packedStruct = StructType({
   t: ref.types.uint8,
   v: ref.types.long,
 }, {packed: true});
+
+declare const typeLike: string | ref.Type;
+declare const buffer: Buffer;
+declare const number: number;
+declare const string: string;
+declare const boolean: boolean;
+
+// $ExpectType StructType
+StructType();
+// $ExpectType StructType
+StructType(undefined);
+// $ExpectType StructType
+StructType(undefined, undefined);
+// $ExpectType StructType
+StructType({ x: typeLike });
+// $ExpectType StructType
+StructType({ x: typeLike }, undefined);
+// $ExpectType StructType
+StructType({ x: typeLike }, { packed: boolean });
+// $ExpectType StructType
+StructType([["x", typeLike]]);
+// $ExpectType StructType
+StructType([["x", typeLike]], undefined);
+// $ExpectType StructType
+StructType([["x", typeLike]], { packed: boolean });
+
+// $ExpectType StructType
+new StructType();
+// $ExpectType StructType
+new StructType(undefined);
+// $ExpectType StructType
+new StructType(undefined, undefined);
+// $ExpectType StructType
+new StructType({ x: typeLike });
+// $ExpectType StructType
+new StructType({ x: typeLike }, undefined);
+// $ExpectType StructType
+new StructType({ x: typeLike }, { packed: boolean });
+// $ExpectType StructType
+new StructType([["x", typeLike]]);
+// $ExpectType StructType
+new StructType([["x", typeLike]], undefined);
+// $ExpectType StructType
+new StructType([["x", typeLike]], { packed: boolean });
+
+declare const struct: ref_struct.StructType;
+
+// $ExpectType Record<string, any>
+struct();
+// $ExpectType Record<string, any>
+struct(undefined);
+// $ExpectType Record<string, any>
+struct({ x: number });
+// $ExpectType Record<string, any>
+struct(buffer);
+// $ExpectType Record<string, any>
+struct(buffer, undefined);
+// $ExpectType Record<string, any>
+struct(buffer, { x: number });
+
+// $ExpectType Record<string, any>
+new struct();
+// $ExpectType Record<string, any>
+new struct(undefined);
+// $ExpectType Record<string, any>
+new struct({ x: number });
+// $ExpectType Record<string, any>
+new struct(buffer);
+// $ExpectType Record<string, any>
+new struct(buffer, undefined);
+// $ExpectType Record<string, any>
+new struct(buffer, { x: number });
+
+// $ExpectType Record<string, Field>
+struct.fields;
+
+// $ExpectType void
+struct.defineProperty(string, typeLike);
+
+// $ExpectType string
+struct.toString();

--- a/types/ref-union-di/index.d.ts
+++ b/types/ref-union-di/index.d.ts
@@ -5,55 +5,54 @@
 
 import ref = require('ref-napi');
 
-/**
- * This is the `constructor` of the Struct type that gets returned.
- *
- * Invoke it with `new` to create a new Buffer instance backing the union.
- * Pass it an existing Buffer instance to use that as the backing buffer.
- * Pass in an Object containing the union fields to auto-populate the
- * union with the data.
- *
- * @constructor
- */
-interface UnionType extends ref.Type {
-    /** Pass it an existing Buffer instance to use that as the backing buffer. */
-    new (arg: Buffer, data?: {}): any;
-    new (data?: {}): any;
-    /** Pass it an existing Buffer instance to use that as the backing buffer. */
-    (arg: Buffer, data?: {}): any;
-    (data?: {}): any;
-
-    fields: { [key: string]: { type: ref.Type } };
-
-    /**
-     * Adds a new field to the union instance with the given name and type.
-     * Note that this function will throw an Error if any instances of the union
-     * type have already been created, therefore this function must be called at the
-     * beginning, before any instances are created.
-     */
-    defineProperty(name: string, type: ref.Type): void;
-
-    /**
-     * Adds a new field to the union instance with the given name and type.
-     * Note that this function will throw an Error if any instances of the union
-     * type have already been created, therefore this function must be called at the
-     * beginning, before any instances are created.
-     */
-    defineProperty(name: string, type: string): void;
-
-    /**
-     * Custom for union type instances.
-     * @override
-     */
-    toString(): string;
-}
-
-/** The union type meta-constructor. */
 declare var UnionType: {
-    new (fields?: {}): UnionType;
-    new (fields?: any[]): UnionType;
-    (fields?: {}): UnionType;
-    (fields?: any[]): UnionType;
+    new (fields?: Record<string, string | ref.Type>): union.UnionType;
+    (fields?: Record<string, string | ref.Type>): union.UnionType;
+};
+
+type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "NULL">;
+
+declare function union(ref: RefModuleLike): typeof UnionType;
+declare namespace union {
+    interface Field {
+        type: ref.Type;
+    }
+
+    /**
+     * This is the `constructor` of the Struct type that gets returned.
+     *
+     * Invoke it with `new` to create a new Buffer instance backing the union.
+     * Pass it an existing Buffer instance to use that as the backing buffer.
+     * Pass in an Object containing the union fields to auto-populate the
+     * union with the data.
+     *
+     * @constructor
+     */
+    interface UnionType extends ref.Type {
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        new (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        new (data?: Record<string, any>): Record<string, any>;
+
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        (data?: Record<string, any>): Record<string, any>;
+
+        fields: Record<string, Field>;
+
+        /**
+         * Adds a new field to the union instance with the given name and type.
+         * Note that this function will throw an Error if any instances of the union
+         * type have already been created, therefore this function must be called at the
+         * beginning, before any instances are created.
+         */
+        defineProperty(name: string, type: string | ref.Type): void;
+
+        /**
+         * Custom for union type instances.
+         * @override
+         */
+        toString(): string;
+    }
 }
 
-export = UnionType;
+export = union;

--- a/types/ref-union-di/ref-union-di-tests.ts
+++ b/types/ref-union-di/ref-union-di-tests.ts
@@ -1,0 +1,61 @@
+import ref = require("ref-napi");
+import ref_union = require("ref-union-di");
+const UnionType = ref_union(ref);
+
+declare const typeLike: string | ref.Type;
+declare const buffer: Buffer;
+declare const number: number;
+declare const string: string;
+
+// $ExpectType UnionType
+UnionType();
+// $ExpectType UnionType
+UnionType({
+    ival: typeLike,
+    fval: typeLike,
+});
+
+// $ExpectType UnionType
+new UnionType();
+// $ExpectType UnionType
+new UnionType({
+    ival: typeLike,
+    fval: typeLike,
+});
+
+declare const union: ref_union.UnionType;
+
+// $ExpectType Record<string, Field>
+union.fields;
+
+// $ExpectType void
+union.defineProperty(string, typeLike);
+
+// $ExpectType string
+union.toString();
+
+// $ExpectType Record<string, any>
+union();
+// $ExpectType Record<string, any>
+union(undefined);
+// $ExpectType Record<string, any>
+union({ ival: number });
+// $ExpectType Record<string, any>
+union(buffer);
+// $ExpectType Record<string, any>
+union(buffer, undefined);
+// $ExpectType Record<string, any>
+union(buffer, { ival: number });
+
+// $ExpectType Record<string, any>
+new union();
+// $ExpectType Record<string, any>
+new union(undefined);
+// $ExpectType Record<string, any>
+new union({ ival: number });
+// $ExpectType Record<string, any>
+new union(buffer);
+// $ExpectType Record<string, any>
+new union(buffer, undefined);
+// $ExpectType Record<string, any>
+new union(buffer, { ival: number });

--- a/types/ref-union-di/tsconfig.json
+++ b/types/ref-union-di/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "ref-union-di-tests.ts"
     ]
 }


### PR DESCRIPTION
Ran into the following issues while trying to use `dbghelp32` from within NodeJS using `ffi-napi`:
- The `ref-struct-di`, `ref-array-di`, and `ref-union-di` modules do not export `StructType`, `ArrayType`, and `UnionType` directly. Instead, they export a _function_ that takes in a `ref`/`ref-napi` compatible module. As is the type definitions are unusable.
- The `ref-napi` package exports `alignof` and `sizeof` properties that are essential for use.
- The `Buffer` augmentations in `ref-napi` do not correctly uncurry the leading `buffer` argument.
- In all 5 packages, I merged overloads that took either `string` or `ref.Type` to take a union of `string | ref.Type`.

It would be nice to add stronger typings for these libraries, but I'd prefer to defer that to a later PR.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/node-ffi-napi/ref-napi/blob/e36f35eaa653bb599be158a83f3ca519b46718e9/src/binding.cc#L685-L686
  - https://github.com/node-ffi-napi/ref-struct-di/blob/master/lib/struct.js#L57
  - https://github.com/node-ffi-napi/ref-array-di/blob/master/lib/array.js#L17
  - https://github.com/node-ffi-napi/ref-union-di/blob/latest/lib/union.js#L14
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
