### PR TITLE
Fix case of nouislider in notNeededPackages.json

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -2989,8 +2989,8 @@
             "libraryName": "notyf",
             "asOfVersion": "3.0.0"
         },
-        "noUiSlider": {
-            "libraryName": "noUiSlider",
+        "nouislider": {
+            "libraryName": "nouislider",
             "asOfVersion": "15.0.0"
         },
         "npm-email": {


### PR DESCRIPTION
On npm it's all lowercase, even though the package's print name is mixed case.
