### PR TITLE
Making `setControllerName` second argument optional

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -60,7 +60,7 @@ export function setDispatcher(name: string, version?: string): void;
  * The `name` will be prefixed with 'Controller/' when sent.
  * The `action` defaults to the HTTP method used for the request.
  */
-export function setControllerName(name: string, action: string): void;
+export function setControllerName(name: string, action?: string): void;
 
 /**
  * Add a custom attribute to the current transaction.


### PR DESCRIPTION
Second argument `action` is optional as stated by the description above and the [newrelic docs](https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api/#controller).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.