### PR TITLE
Stricter types and type inference for `ffi-napi`, `ref-napi`, and related packages.

### DIFF
--- a/types/ffi-napi/index.d.ts
+++ b/types/ffi-napi/index.d.ts
@@ -9,6 +9,53 @@ import ref = require('ref-napi');
 import ref_struct = require('ref-struct-di');
 import StructType = ref_struct.StructType;
 
+/**
+ * This is a marker type that causes TypeScript to use string literal inference when inferring a generic from an array of {@link ref.TypeLike}.
+ */
+export type ArgTypesInferenceMarker = ["void"];
+
+export interface LibraryFunctionOptions {
+    abi?: number;
+    async?: boolean;
+    varargs?: boolean;
+}
+
+/**
+ * Base constraint for an object-based library type definition.
+ */
+export type LibraryObjectDefinitionBase = Record<string, [retType: ref.TypeLike, argTypes: ref.TypeLike[], opts?: LibraryFunctionOptions]>;
+
+/**
+ * This is a marker type that causes TypeScript to use string literal inference when inferring a generic from {@link LibraryObjectDefinitionBase}.
+ * If it is not used, `new Library(..., { x: ["int", ["int"]] })` will be inferred as `new Library<{ x: [string, string[]] }>(...)` instead of `new UnionType<{ x: ["int", ["int"]] }>(...)`.
+ */
+export type LibraryObjectDefinitionInferenceMarker = Record<string, [retType: "void", argTypes: ArgTypesInferenceMarker]>;
+
+/**
+ * Converts a {@link LibraryObjectDefinitionBase} into a consistent subtype of {@link LibraryDefinitionBase}. If `"any"` is used, it is passed along
+ * to be interpreted to use a fallback definition for a union.
+ */
+export type LibraryObjectDefinitionToLibraryDefinition<T extends LibraryObjectDefinitionBase> =
+    [T] extends [never] | [0] ? any : // catches T extends never/any (since `0` doesn't overlap with our constraint)
+    { [P in keyof T]: [retType: ref.CoerceType<T[P][0]>, argTypes: ref.CoerceTypes<T[P][1]>, opts: T[P][2]] };
+
+/**
+ * Base constraint for a consistent library type definition.
+ */
+export type LibraryDefinitionBase = Record<string, [retType: ref.Type, argTypes: ref.Type[], opts: LibraryFunctionOptions | undefined]>;
+
+/**
+ * Represents a {@link Library} instance created from a {@link LibraryDefinitionBase}.
+ */
+export type LibraryObject<T extends LibraryDefinitionBase> =
+    [T] extends [never] | [0] ? any : // catches T extends never/any (since `0` doesn't overlap with our constraint)
+    {
+        [P in keyof T]:
+            T[P][2] extends { varargs: true } ? VariadicForeignFunction<T[P][0], T[P][1]> :
+            T[P][2] extends { async: true } ? ForeignFunction<ref.UnderlyingType<T[P][0]>, ref.UnderlyingTypes<T[P][1]>>["async"] :
+            ForeignFunction<ref.UnderlyingType<T[P][0]>, ref.UnderlyingTypes<T[P][1]>>;
+    };
+
 /** Provides a friendly API on-top of `DynamicLibrary` and `ForeignFunction`. */
 export interface Library {
     /** The extension to use on libraries. */
@@ -19,44 +66,116 @@ export interface Library {
      * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
      * @param lib hash that will be extended
      */
-    new (libFile: string | null, funcs?: Record<string, [string | ref.Type, Array<string | ref.Type>, { abi?: number, async?: boolean, varargs?: boolean }?]>, lib?: object): any;
+    new <TDefinition extends LibraryObjectDefinitionBase | LibraryObjectDefinitionInferenceMarker, T>(
+        libFile: string | null,
+        funcs: TDefinition,
+        lib: T
+    ): T & LibraryObject<LibraryObjectDefinitionToLibraryDefinition<TDefinition>>;
 
     /**
      * @param libFile name of library
      * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
      * @param lib hash that will be extended
      */
-    (libFile: string | null, funcs?: Record<string, [string | ref.Type, Array<string | ref.Type>, { abi?: number, async?: boolean, varargs?: boolean }?]>, lib?: object): any;
+    new <TDefinition extends LibraryObjectDefinitionBase | LibraryObjectDefinitionInferenceMarker>(
+        libFile: string | null,
+        funcs: TDefinition,
+        lib?: object
+    ): LibraryObject<LibraryObjectDefinitionToLibraryDefinition<TDefinition>>;
+
+    /**
+     * @param libFile name of library
+     * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
+     * @param lib hash that will be extended
+     */
+    new (libFile: string | null, funcs?: Record<string, [retType: ref.TypeLike, argTypes: ref.TypeLike[], opts?: LibraryFunctionOptions]>, lib?: object): any;
+
+    /**
+     * @param libFile name of library
+     * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
+     * @param lib hash that will be extended
+     */
+    <TDefinition extends LibraryObjectDefinitionBase | LibraryObjectDefinitionInferenceMarker, T>(
+        libFile: string | null,
+        funcs: TDefinition,
+        lib: T
+    ): T & LibraryObject<LibraryObjectDefinitionToLibraryDefinition<TDefinition>>;
+
+    /**
+     * @param libFile name of library
+     * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
+     * @param lib hash that will be extended
+     */
+    <TDefinition extends LibraryObjectDefinitionBase | LibraryObjectDefinitionInferenceMarker>(
+        libFile: string | null,
+        funcs: TDefinition,
+        lib?: object
+    ): LibraryObject<LibraryObjectDefinitionToLibraryDefinition<TDefinition>>;
+
+    /**
+     * @param libFile name of library
+     * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
+     * @param lib hash that will be extended
+     */
+     (libFile: string | null, funcs?: Record<string, [retType: ref.TypeLike, argTypes: ref.TypeLike[], opts?: LibraryFunctionOptions]>, lib?: object): any;
 }
 export const Library: Library;
 
 /** Get value of errno. */
 export function errno(): number;
 
-export interface Function extends ref.Type {
+export interface Function<
+    TReturnType extends ref.Type = ref.Type,
+    TArgTypes extends ref.Type[] = ref.Type[]
+> extends ref.Type<ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>> {
     /** The type of return value. */
-    retType: ref.Type;
+    retType: TReturnType;
     /** The type of arguments. */
-    argTypes: ref.Type[];
+    argTypes: TArgTypes;
     /** Is set for node-ffi functions. */
     ffi_type: Buffer;
     abi: number;
 
     /** Get a `Callback` pointer of this function type. */
-    toPointer(fn: (...args: any[]) => any): Buffer;
+    toPointer(fn: (...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
     /** Get a `ForeignFunction` of this function type. */
-    toFunction(buf: Buffer): ForeignFunction;
+    toFunction(buf: Buffer): ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>;
 }
 
 /** Creates and returns a type for a C function pointer. */
 export const Function: {
-    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): Function;
-    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): Function;
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    new <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[] | ArgTypesInferenceMarker>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+        ): Function<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+    new <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): Function<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+
+    new (retType: ref.TypeLike, argTypes: ref.TypeLike[], abi?: number): Function;
+
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[] | ArgTypesInferenceMarker>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): Function<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+    <TReturnType extends ref.TypeLike, TArgTypes extends ref.Type[] | ArgTypesInferenceMarker>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): Function<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+
+    (retType: ref.TypeLike, argTypes: ref.TypeLike[], abi?: number): Function;
 };
 
-export interface ForeignFunction {
-    (...args: any[]): any;
-    async(...args: any[]): void;
+export interface ForeignFunction<TReturn = any, TArgs extends any[] = any[]> {
+    (...args: TArgs): TReturn;
+    async(...args: [...TArgs, (err: any, value: TReturn) => void]): void;
 }
 
 /**
@@ -66,23 +185,58 @@ export interface ForeignFunction {
  * execution.
  */
 export const ForeignFunction: {
-    new (ptr: Buffer, retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): ForeignFunction;
-    (ptr: Buffer, retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): ForeignFunction;
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    new <TReturnType extends ref.NamedType, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>;
+    new <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>;
+
+    new (ptr: Buffer, retType: ref.TypeLike, argTypes: ref.TypeLike[], abi?: number): ForeignFunction;
+
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    <TReturnType extends ref.NamedType, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>;
+    <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi?: number
+    ): ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>;
+
+    (ptr: Buffer, retType: ref.TypeLike, argTypes: ref.TypeLike[], abi?: number): ForeignFunction;
 };
 
-export interface VariadicForeignFunction {
+export interface VariadicForeignFunction<TReturnType extends ref.Type = ref.Type, TArgTypes extends ref.Type[] = ref.Type[]> {
     /**
      * What gets returned is another function that needs to be invoked with the rest
      * of the variadic types that are being invoked from the function.
      */
-    (...args: Array<string | ref.Type>): ForeignFunction;
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    <A extends ref.NamedTypeLike[]>(...args: A): ForeignFunction<ref.UnderlyingType<TReturnType>, [...ref.UnderlyingTypes<TArgTypes>, ...ref.UnderlyingTypes<A>]>;
+    /**
+     * What gets returned is another function that needs to be invoked with the rest
+     * of the variadic types that are being invoked from the function.
+     */
+    <A extends ref.TypeLike[]>(...args: A): ForeignFunction<ref.UnderlyingType<TReturnType>, [...ref.UnderlyingTypes<TArgTypes>, ...ref.UnderlyingTypes<A>]>;
 
     /**
      * Return type as a property of the function generator to
      * allow for monkey patching the return value in the very rare case where the
      * return type is variadic as well
      */
-    returnType: ref.Type;
+    returnType: TReturnType;
 }
 
 /**
@@ -93,8 +247,37 @@ export interface VariadicForeignFunction {
  * contain the same ffi_type argument signature.
  */
 export const VariadicForeignFunction: {
-    new (ptr: Buffer, ret: string | ref.Type, fixedArgs: Array<string | ref.Type>, abi?: number): VariadicForeignFunction;
-    (ptr: Buffer, ret: string | ref.Type, fixedArgs: Array<string | ref.Type>, abi?: number): VariadicForeignFunction;
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    new <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        ret: TReturnType,
+        fixedArgs: TArgTypes,
+        abi?: number
+    ): VariadicForeignFunction<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+    new <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        ret: TReturnType,
+        fixedArgs: TArgTypes,
+        abi?: number
+    ): VariadicForeignFunction<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+
+    new (ptr: Buffer, ret: ref.TypeLike, fixedArgs: ref.TypeLike[], abi?: number): VariadicForeignFunction;
+
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        ret: TReturnType,
+        fixedArgs: TArgTypes,
+        abi?: number
+    ): VariadicForeignFunction<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+    <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[] | ArgTypesInferenceMarker>(
+        ptr: Buffer,
+        ret: TReturnType,
+        fixedArgs: TArgTypes,
+        abi?: number
+    ): VariadicForeignFunction<ref.CoerceType<TReturnType>, ref.CoerceTypes<TArgTypes>>;
+
+    (ptr: Buffer, ret: ref.TypeLike, fixedArgs: ref.TypeLike[], abi?: number): VariadicForeignFunction;
 };
 
 export interface DynamicLibrary {
@@ -135,21 +318,74 @@ export const DynamicLibrary: {
  * accept C callback functions.
  */
 export interface Callback {
-    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi: number, fn: (...args: any[]) => any): Buffer;
-    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, fn: (...args: any[]) => any): Buffer;
-    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi: number, fn: (...args: any[]) => any): Buffer;
-    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, fn: (...args: any[]) => any): Buffer;
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    new <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi: number,
+        fn: (...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+    new <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi: number,
+        fn: (...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    new <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        fn: (...ags: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+    new <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        fn: (...ags: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+
+    new (retType: ref.TypeLike, argTypes: ref.TypeLike[], abi: number, fn: (...args: any[]) => any): Buffer;
+    new (retType: ref.TypeLike, argTypes: ref.TypeLike[], fn: (...args: any[]) => any): Buffer;
+
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi: number,
+        fn: (...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+    <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        abi: number,
+        fn: (...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+
+    // NOTE: This overload is a subtype of the next overload, but provides better completions.
+    <TReturnType extends ref.NamedTypeLike, TArgTypes extends ref.NamedTypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        fn: (...ags: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+    <TReturnType extends ref.TypeLike, TArgTypes extends ref.TypeLike[]>(
+        retType: TReturnType,
+        argTypes: TArgTypes,
+        fn: (...ags: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>
+    ): ref.Pointer<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>>;
+
+    (retType: ref.TypeLike, argTypes: ref.TypeLike[], abi: number, fn: (...args: any[]) => any): Buffer;
+    (retType: ref.TypeLike, argTypes: ref.TypeLike[], fn: (...args: any[]) => any): Buffer;
 }
 export const Callback: Callback;
 
 export const ffiType: {
     /** Get a `ffi_type *` Buffer appropriate for the given type. */
-    (type: string | ref.Type): Buffer
+    (type: ref.TypeLike): Buffer
     FFI_TYPE: StructType;
 };
 
-export function CIF(retType: string | ref.Type, types: Array<string | ref.Type>, abi?: number): Buffer;
-export function CIF_var(retType: string | ref.Type, types: Array<string | ref.Type>, numFixedArgs: number, abi?: number): Buffer;
+export function CIF(retType: ref.TypeLike, types: ref.TypeLike[], abi?: number): Buffer;
+export function CIF_var(retType: ref.TypeLike, types: ref.TypeLike[], numFixedArgs: number, abi?: number): Buffer;
 export const HAS_OBJC: boolean;
 export const FFI_TYPES: Record<string, Buffer>;
 export const FFI_OK: number;

--- a/types/ffi-napi/package.json
+++ b/types/ffi-napi/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=4.1": {
+            "*": [
+                "ts4.1/*"
+            ]
+        }
+    }
+}

--- a/types/ffi-napi/ts4.1/ffi-napi-tests.ts
+++ b/types/ffi-napi/ts4.1/ffi-napi-tests.ts
@@ -1,0 +1,116 @@
+import ffi = require('ffi-napi');
+import ref = require('ref-napi');
+import ref_struct = require('ref-struct-di');
+import ref_union = require('ref-union-di');
+import ref_array = require('ref-array-di');
+const Struct = ref_struct(ref);
+const Union = ref_union(ref);
+const TArray = ref_array(ref);
+
+{
+    const sqlite3 = ref.types.void;
+    const sqlite3Ptr = ref.refType(sqlite3);
+    const sqlite3PtrPtr = ref.refType(sqlite3Ptr);
+    const stringPtr = ref.refType(ref.types.CString);
+
+    const libsqlite3 = ffi.Library('libsqlite3', {
+      sqlite3_open: [ 'int', [ 'string', sqlite3PtrPtr ] ],
+      sqlite3_close: [ 'int', [ sqlite3PtrPtr ] ],
+      sqlite3_exec: [ 'int', [ sqlite3PtrPtr, 'string', 'pointer', 'pointer', stringPtr ] ],
+      sqlite3_changes: [ 'int', [ sqlite3PtrPtr ]]
+    });
+
+    const dbPtrPtr = ref.alloc(sqlite3PtrPtr);
+    libsqlite3.sqlite3_open("test.sqlite3", dbPtrPtr);
+}
+{
+    const func = ffi.ForeignFunction(new Buffer(10), 'int', [ 'int' ]);
+    func(-5);
+    func.async(-5, (err: any, res: any) => {});
+}
+{
+    const funcPtr = ffi.Callback('int', [ 'int' ], Math.abs);
+    const func    = ffi.ForeignFunction(funcPtr, 'int', [ 'int' ]);
+}
+{
+    const printfPointer = ffi.DynamicLibrary().get('printf');
+    const printfGen = ffi.VariadicForeignFunction(printfPointer, 'void', [ 'string' ]);
+    printfGen()('Hello World!\n');
+    printfGen('int')('This is an int: %d\n', 10);
+    printfGen('string')('This is a string: %s\n', 'hello');
+}
+{
+    ref.address(Buffer.alloc(1));
+    const intBuf = ref.alloc(ref.types.int);
+    const intWith4 = ref.alloc(ref.types.int, 4);
+    const buf0 = ref.allocCString('hello world');
+    const type = ref.coerceType('int **');
+    const val = ref.deref(intBuf);
+}
+{
+    ref.isNull(Buffer.alloc(1));
+}
+{
+    const str = ref.readCString(Buffer.from('hello\0world\0'), 0);
+    const buf = ref.alloc('int64');
+    ref.writeInt64BE(buf, 0, '9223372036854775807');
+    const val = ref.readInt64BE(buf, 0);
+}
+{
+    const voidPtrType = ref.refType(ref.types.void);
+    const buf = ref.alloc('int64');
+    ref.writeInt64LE(buf, 0, '9223372036854775807');
+}
+{
+    const S1 = Struct({ a: ref.types.int });
+    const S2 = new Struct({ a: 'int' });
+}
+{
+    const P = new Struct();
+    P.defineProperty('a', ref.types.int);
+    P.defineProperty('d', 'long');
+}
+{
+    const SimpleStruct = Struct({
+        first : ref.types.byte,
+        last  : ref.types.byte
+    });
+
+    const ss = new SimpleStruct({ first: 50, last: 100 });
+    ss.first += 200;
+}
+{
+    const ST = Struct();
+    const test: ref.Type = ST.fields['t'].type;
+}
+{
+    const CharArray = TArray('char');
+    const b = Buffer.from('hello', 'ascii');
+    const a = new CharArray(b);
+}
+{
+    const Int32Array = TArray(ref.types.int32);
+    const input = [1, 4, 91, 123123, 5123512, 0, -1];
+    const a = new Int32Array(input);
+}
+{
+    const int = ref.types.int;
+    const IntArray = TArray(int);
+
+    const buf = new Buffer(int.size * 3);
+    int.set(buf, int.size * 0, 5);
+    int.set(buf, int.size * 1, 8);
+    int.set(buf, int.size * 2, 0);
+
+    const array = IntArray.untilZeros(buf);
+}
+{
+    const refCharArr = TArray('char')([1, 3, 5], 2).ref();
+}
+{
+    // You can also access just functions in the current process by passing a null
+    const current = ffi.Library(null, {
+      atoi: [ 'int', [ 'string' ] ]
+    });
+    current.atoi('1234');
+}

--- a/types/ffi-napi/ts4.1/index.d.ts
+++ b/types/ffi-napi/ts4.1/index.d.ts
@@ -1,0 +1,170 @@
+/// <reference types="node" />
+
+import ref = require('ref-napi');
+import ref_struct = require('ref-struct-di');
+import StructType = ref_struct.StructType;
+
+/** Provides a friendly API on-top of `DynamicLibrary` and `ForeignFunction`. */
+export interface Library {
+    /** The extension to use on libraries. */
+    EXT: string;
+
+    /**
+     * @param libFile name of library
+     * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
+     * @param lib hash that will be extended
+     */
+    new (libFile: string | null, funcs?: Record<string, [string | ref.Type, Array<string | ref.Type>, { abi?: number, async?: boolean, varargs?: boolean }?]>, lib?: object): any;
+
+    /**
+     * @param libFile name of library
+     * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
+     * @param lib hash that will be extended
+     */
+    (libFile: string | null, funcs?: Record<string, [string | ref.Type, Array<string | ref.Type>, { abi?: number, async?: boolean, varargs?: boolean }?]>, lib?: object): any;
+}
+export const Library: Library;
+
+/** Get value of errno. */
+export function errno(): number;
+
+export interface Function extends ref.Type {
+    /** The type of return value. */
+    retType: ref.Type;
+    /** The type of arguments. */
+    argTypes: ref.Type[];
+    /** Is set for node-ffi functions. */
+    ffi_type: Buffer;
+    abi: number;
+
+    /** Get a `Callback` pointer of this function type. */
+    toPointer(fn: (...args: any[]) => any): Buffer;
+    /** Get a `ForeignFunction` of this function type. */
+    toFunction(buf: Buffer): ForeignFunction;
+}
+
+/** Creates and returns a type for a C function pointer. */
+export const Function: {
+    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): Function;
+    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): Function;
+};
+
+export interface ForeignFunction {
+    (...args: any[]): any;
+    async(...args: any[]): void;
+}
+
+/**
+ * Represents a foreign function in another library. Manages all of the aspects
+ * of function execution, including marshalling the data parameters for the
+ * function into native types and also unmarshalling the return from function
+ * execution.
+ */
+export const ForeignFunction: {
+    new (ptr: Buffer, retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): ForeignFunction;
+    (ptr: Buffer, retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi?: number): ForeignFunction;
+};
+
+export interface VariadicForeignFunction {
+    /**
+     * What gets returned is another function that needs to be invoked with the rest
+     * of the variadic types that are being invoked from the function.
+     */
+    (...args: Array<string | ref.Type>): ForeignFunction;
+
+    /**
+     * Return type as a property of the function generator to
+     * allow for monkey patching the return value in the very rare case where the
+     * return type is variadic as well
+     */
+    returnType: ref.Type;
+}
+
+/**
+ * For when you want to call to a C function with variable amount of arguments.
+ * i.e. `printf`.
+ *
+ * This function takes care of caching and reusing `ForeignFunction` instances that
+ * contain the same ffi_type argument signature.
+ */
+export const VariadicForeignFunction: {
+    new (ptr: Buffer, ret: string | ref.Type, fixedArgs: Array<string | ref.Type>, abi?: number): VariadicForeignFunction;
+    (ptr: Buffer, ret: string | ref.Type, fixedArgs: Array<string | ref.Type>, abi?: number): VariadicForeignFunction;
+};
+
+export interface DynamicLibrary {
+    /** Close library, returns the result of the `dlclose` system function. */
+    close(): number;
+    /** Get a symbol from this library. */
+    get(symbol: string): Buffer;
+    /** Get the result of the `dlerror` system function. */
+    error(): string;
+}
+
+/**
+ * This class loads and fetches function pointers for dynamic libraries
+ * (.so, .dylib, etc). After the libray's function pointer is acquired, then you
+ * call `get(symbol)` to retreive a pointer to an exported symbol. You need to
+ * call `get___` on the pointer to dereference it into its actual value, or
+ * turn the pointer into a callable function with `ForeignFunction`.
+ */
+export const DynamicLibrary: {
+    FLAGS: {
+        RTLD_LAZY: number;
+        RTLD_NOW: number;
+        RTLD_LOCAL: number;
+        RTLD_GLOBAL: number;
+        RTLD_NOLOAD: number;
+        RTLD_NODELETE: number;
+        RTLD_NEXT: Buffer;
+        RTLD_DEFAUL: Buffer;
+    }
+
+    new (path?: string, mode?: number): DynamicLibrary;
+    (path?: string, mode?: number): DynamicLibrary;
+};
+
+/**
+ * Turns a JavaScript function into a C function pointer.
+ * The function pointer may be used in other C functions that
+ * accept C callback functions.
+ */
+export interface Callback {
+    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi: number, fn: (...args: any[]) => any): Buffer;
+    new (retType: string | ref.Type, argTypes: Array<string | ref.Type>, fn: (...args: any[]) => any): Buffer;
+    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, abi: number, fn: (...args: any[]) => any): Buffer;
+    (retType: string | ref.Type, argTypes: Array<string | ref.Type>, fn: (...args: any[]) => any): Buffer;
+}
+export const Callback: Callback;
+
+export const ffiType: {
+    /** Get a `ffi_type *` Buffer appropriate for the given type. */
+    (type: string | ref.Type): Buffer
+    FFI_TYPE: StructType;
+};
+
+export function CIF(retType: string | ref.Type, types: Array<string | ref.Type>, abi?: number): Buffer;
+export function CIF_var(retType: string | ref.Type, types: Array<string | ref.Type>, numFixedArgs: number, abi?: number): Buffer;
+export const HAS_OBJC: boolean;
+export const FFI_TYPES: Record<string, Buffer>;
+export const FFI_OK: number;
+export const FFI_BAD_TYPEDEF: number;
+export const FFI_BAD_ABI: number;
+export const FFI_DEFAULT_ABI: number;
+export const FFI_FIRST_ABI: number;
+export const FFI_LAST_ABI: number;
+export const FFI_SYSV: number;
+export const FFI_UNIX64: number;
+export const RTLD_LAZY: number;
+export const RTLD_NOW: number;
+export const RTLD_LOCAL: number;
+export const RTLD_GLOBAL: number;
+export const RTLD_NOLOAD: number;
+export const RTLD_NODELETE: number;
+export const RTLD_NEXT: Buffer;
+export const RTLD_DEFAULT: Buffer;
+export const LIB_EXT: string;
+export const FFI_TYPE: StructType;
+
+/** Default types. */
+export import types = ref.types;

--- a/types/ffi-napi/ts4.1/tsconfig.json
+++ b/types/ffi-napi/ts4.1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ffi-napi-tests.ts"
+    ]
+}

--- a/types/ffi-napi/ts4.1/tslint.json
+++ b/types/ffi-napi/ts4.1/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": false,
+        "no-consecutive-blank-lines": false
+    }
+}

--- a/types/ref-array-di/index.d.ts
+++ b/types/ref-array-di/index.d.ts
@@ -11,45 +11,102 @@ import ref = require('ref-napi');
  * TypedArray API.
  */
 declare var ArrayType: {
-    new <T>(type: string | ref.Type, length: number): array.FixedLengthArrayType<T>;
-    new <T>(type: string | ref.Type, length?: number): array.ArrayType<T>;
-    <T>(type: string | ref.Type, length: number): array.FixedLengthArrayType<T>;
-    <T>(type: string | ref.Type, length?: number): array.ArrayType<T>;
+    // NOTE: The `ref.NamedType` overload is a subset of the `ref.TypeLike` overload, but provides better completions.
+    new <TType extends ref.NamedType, TLength extends number = number>(type: TType, length: TLength): array.FixedLengthArrayType<ref.UnderlyingType<TType>, TLength>;
+    new <TType extends ref.TypeLike, TLength extends number = number>(type: TType, length: TLength): array.FixedLengthArrayType<ref.UnderlyingType<TType>, TLength>;
+    new <T, TLength extends number = number>(type: ref.TypeLike, length: TLength): array.FixedLengthArrayType<T, TLength>;
+    // NOTE: The `ref.NamedType` overload is a subset of the `ref.TypeLike` overload, but provides better completions.
+    new <TType extends ref.NamedType>(type: TType, length?: number): array.ArrayType<ref.UnderlyingType<TType>>;
+    new <TType extends ref.TypeLike>(type: TType, length?: number): array.ArrayType<ref.UnderlyingType<TType>>;
+    new <T>(type: ref.TypeLike, length?: number): array.ArrayType<T>;
+
+    // NOTE: The `ref.NamedType` overload is a subset of the `ref.TypeLike` overload, but provides better completions.
+    <TType extends ref.NamedType, TLength extends number = number>(type: TType, length: TLength): array.FixedLengthArrayType<ref.UnderlyingType<TType>, TLength>;
+    <TType extends ref.TypeLike, TLength extends number = number>(type: TType, length: TLength): array.FixedLengthArrayType<ref.UnderlyingType<TType>, TLength>;
+    <T, TLength extends number = number>(type: ref.TypeLike, length: TLength): array.FixedLengthArrayType<T, TLength>;
+    // NOTE: The `ref.NamedType` overload is a subset of the `ref.TypeLike` overload, but provides better completions.
+    <TType extends ref.NamedType>(type: TType, length?: number): array.ArrayType<ref.UnderlyingType<TType>>;
+    <TType extends ref.TypeLike>(type: TType, length?: number): array.ArrayType<ref.UnderlyingType<TType>>;
+    <T>(type: ref.TypeLike, length?: number): array.ArrayType<T>;
 };
 
 type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "readPointer" | "writePointer" | "reinterpret" | "reinterpretUntilZeros" | "ref" | "types" | "NULL">;
 
 declare function array(ref: RefModuleLike): typeof ArrayType;
 declare namespace array {
-    interface TypedArray<T> {
+    interface TypedArray<T, TLength extends number = number> {
         [i: number]: T;
-        length: number;
+        length: TLength;
         toArray(): T[];
         toJSON(): T[];
         inspect(): string;
         buffer: Buffer;
         ref(): Buffer;
     }
-    interface ArrayType<T> extends ref.Type {
+
+    interface ArrayType<T> extends ref.Type<TypedArray<T>> {
         BYTES_PER_ELEMENT: number;
         fixedLength?: number;
+
         /** The reference to the base type. */
-        type: ref.Type;
+        type: ref.Type<T>;
+
         /**
          * Accepts a Buffer instance that should be an already-populated with data
          * for the ArrayType. The "length" of the Array is determined by searching
          * through the buffer's contents until an aligned NULL pointer is encountered.
          */
         untilZeros(buffer: Buffer): TypedArray<T>;
+
+        new <TLength extends number>(length: TLength): TypedArray<T, TLength>;
         new (length?: number): TypedArray<T>;
-        new (data: number[], length?: number): TypedArray<T>;
+        new <TLength extends number>(data: readonly number[], length: TLength): TypedArray<T, TLength>;
+        new <TData extends readonly number[] | []>(data: TData): TypedArray<T, TData["length"]>;
+        new (data: readonly number[], length?: number): TypedArray<T>;
+        new <TLength extends number>(data: Buffer, length: TLength): TypedArray<T, TLength>;
         new (data: Buffer, length?: number): TypedArray<T>;
+
+        <TLength extends number>(length: TLength): TypedArray<T, TLength>;
         (length?: number): TypedArray<T>;
-        (data: number[], length?: number): TypedArray<T>;
+        <TLength extends number>(data: readonly number[], length: TLength): TypedArray<T, TLength>;
+        <TData extends readonly number[] | []>(data: TData): TypedArray<T, TData["length"]>;
+        (data: readonly number[], length?: number): TypedArray<T>;
+        <TLength extends number>(data: Buffer, length: TLength): TypedArray<T, TLength>;
         (data: Buffer, length?: number): TypedArray<T>;
     }
-    interface FixedLengthArrayType<T> extends ArrayType<T> {
-        fixedLength: number;
+
+    interface FixedLengthArrayType<T, TLength extends number = number> extends ArrayType<T>, ref.Type<TypedArray<T, TLength>> {
+        fixedLength: TLength;
+
+        /**
+         * Accepts a Buffer instance that should be an already-populated with data
+         * for the ArrayType. The "length" of the Array is determined by searching
+         * through the buffer's contents until an aligned NULL pointer is encountered.
+         */
+        untilZeros(buffer: Buffer): TypedArray<T, TLength>;
+
+        new (): TypedArray<T, TLength>;
+        new <TLength extends number>(length: TLength): TypedArray<T, TLength>;
+        new (length?: number): TypedArray<T>;
+        new (data: readonly number[]): TypedArray<T, TLength>;
+        new <TLength extends number>(data: readonly number[], length: TLength): TypedArray<T, TLength>;
+        new (data: readonly number[], length?: number): TypedArray<T>;
+        new (data: Buffer): TypedArray<T, TLength>;
+        new <TLength extends number>(data: Buffer, length: TLength): TypedArray<T, TLength>;
+        new (data: Buffer, length?: number): TypedArray<T>;
+
+        (): TypedArray<T, TLength>;
+        <TLength extends number>(length: TLength): TypedArray<T, TLength>;
+        (length?: number): TypedArray<T>;
+        (data: readonly number[]): TypedArray<T, TLength>;
+        <TLength extends number>(data: readonly number[], length: TLength): TypedArray<T, TLength>;
+        (data: readonly number[], length?: number): TypedArray<T>;
+        (data: Buffer): TypedArray<T, TLength>;
+        <TLength extends number>(data: Buffer, length: TLength): TypedArray<T, TLength>;
+        (data: Buffer, length?: number): TypedArray<T>;
+
+        get(buffer: Buffer, offset: number): TypedArray<T, TLength>;
+        set(buffer: Buffer, offset: number, value: TypedArray<T, TLength>): void;
     }
 }
 

--- a/types/ref-array-di/package.json
+++ b/types/ref-array-di/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=4.1": {
+            "*": [
+                "ts4.1/*"
+            ]
+        }
+    }
+}

--- a/types/ref-array-di/ts4.1/index.d.ts
+++ b/types/ref-array-di/ts4.1/index.d.ts
@@ -1,0 +1,51 @@
+import ref = require('ref-napi');
+
+/**
+ * The array type meta-constructor.
+ * The returned constructor's API is highly influenced by the WebGL
+ * TypedArray API.
+ */
+declare var ArrayType: {
+    new <T>(type: string | ref.Type, length: number): array.FixedLengthArrayType<T>;
+    new <T>(type: string | ref.Type, length?: number): array.ArrayType<T>;
+    <T>(type: string | ref.Type, length: number): array.FixedLengthArrayType<T>;
+    <T>(type: string | ref.Type, length?: number): array.ArrayType<T>;
+};
+
+type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "readPointer" | "writePointer" | "reinterpret" | "reinterpretUntilZeros" | "ref" | "types" | "NULL">;
+
+declare function array(ref: RefModuleLike): typeof ArrayType;
+declare namespace array {
+    interface TypedArray<T> {
+        [i: number]: T;
+        length: number;
+        toArray(): T[];
+        toJSON(): T[];
+        inspect(): string;
+        buffer: Buffer;
+        ref(): Buffer;
+    }
+    interface ArrayType<T> extends ref.Type {
+        BYTES_PER_ELEMENT: number;
+        fixedLength?: number;
+        /** The reference to the base type. */
+        type: ref.Type;
+        /**
+         * Accepts a Buffer instance that should be an already-populated with data
+         * for the ArrayType. The "length" of the Array is determined by searching
+         * through the buffer's contents until an aligned NULL pointer is encountered.
+         */
+        untilZeros(buffer: Buffer): TypedArray<T>;
+        new (length?: number): TypedArray<T>;
+        new (data: number[], length?: number): TypedArray<T>;
+        new (data: Buffer, length?: number): TypedArray<T>;
+        (length?: number): TypedArray<T>;
+        (data: number[], length?: number): TypedArray<T>;
+        (data: Buffer, length?: number): TypedArray<T>;
+    }
+    interface FixedLengthArrayType<T> extends ArrayType<T> {
+        fixedLength: number;
+    }
+}
+
+export = array;

--- a/types/ref-array-di/ts4.1/ref-array-di-tests.ts
+++ b/types/ref-array-di/ts4.1/ref-array-di-tests.ts
@@ -2,7 +2,7 @@ import ref = require("ref-napi");
 import ref_array = require("ref-array-di");
 const ArrayType = ref_array(ref);
 
-declare const typeLike: string | ref.Type<unknown>;
+declare const typeLike: string | ref.Type;
 declare const buffer: Buffer;
 declare const number: number;
 declare const numberArray: number[];
@@ -11,19 +11,15 @@ declare const numberArray: number[];
 ArrayType(typeLike);
 // $ExpectType ArrayType<unknown>
 ArrayType(typeLike, undefined);
-// $ExpectType FixedLengthArrayType<unknown, number>
+// $ExpectType FixedLengthArrayType<unknown>
 ArrayType(typeLike, number);
-// $ExpectType FixedLengthArrayType<unknown, 1>
-ArrayType(typeLike, 1);
 
 // $ExpectType ArrayType<unknown>
 new ArrayType(typeLike);
 // $ExpectType ArrayType<unknown>
 new ArrayType(typeLike, undefined);
-// $ExpectType FixedLengthArrayType<unknown, number>
+// $ExpectType FixedLengthArrayType<unknown>
 new ArrayType(typeLike, number);
-// $ExpectType FixedLengthArrayType<unknown, 1>
-new ArrayType(typeLike, 1);
 
 // define the "int[]" type
 declare const IntArray: ref_array.ArrayType<number>;
@@ -34,61 +30,49 @@ IntArray.BYTES_PER_ELEMENT;
 // $ExpectType number | undefined
 IntArray.fixedLength;
 
-// $ExpectType Type<number>
+// $ExpectType Type
 IntArray.type;
 
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray.untilZeros(buffer);
 
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray();
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(undefined);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(number);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(numberArray);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(numberArray, undefined);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(numberArray, number);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(buffer);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(buffer, undefined);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 IntArray(buffer, number);
-// $ExpectType TypedArray<number, 1>
-IntArray([1]);
 
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray();
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(undefined);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(number);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(numberArray);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(numberArray, undefined);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(numberArray, number);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(buffer);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(buffer, undefined);
-// $ExpectType TypedArray<number, number>
+// $ExpectType TypedArray<number>
 new IntArray(buffer, number);
-// $ExpectType TypedArray<number, 1>
-new IntArray([1]);
-
-declare const IntArray1: ref_array.FixedLengthArrayType<number, 1>;
-
-// $ExpectType 1
-IntArray1.fixedLength;
-
-// $ExpectType TypedArray<number, 1>
-IntArray1();
 
 declare const ar: ref_array.TypedArray<number>;
 
@@ -112,8 +96,3 @@ ar.buffer;
 
 // $ExpectType Buffer
 ar.ref();
-
-declare const ar1: ref_array.TypedArray<number, 1>;
-
-// $ExpectType 1
-ar1.length;

--- a/types/ref-array-di/ts4.1/tsconfig.json
+++ b/types/ref-array-di/ts4.1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ref-array-di-tests.ts"
+    ]
+}

--- a/types/ref-array-di/ts4.1/tslint.json
+++ b/types/ref-array-di/ts4.1/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false,
+        "unified-signatures": false
+    }
+}

--- a/types/ref-napi/index.d.ts
+++ b/types/ref-napi/index.d.ts
@@ -5,15 +5,97 @@
 
 /// <reference types="node" />
 
-export interface Type {
+/**
+ * A set of commonly understood string names for types to help with completions.
+ */
+export type NamedType = "string" | "pointer" | keyof typeof types | `${keyof typeof types}${"*" | " *" | "**" | " **"}`;
+
+/**
+ * Base constraint for a type understood by the package.
+ */
+export type TypeLike = Type | string;
+
+/**
+ * Base constraint for a type understood by the package. This is similar to {@link TypeLike} but is more restrictive. Its
+ * primary use is in overloads that take {@link TypeLike} in order to improve completions.
+ */
+export type NamedTypeLike = Type | NamedType;
+
+/**
+ * Gets the underlying type for a {@link Type} or {@link BaseNamedType}.
+ */
+export type UnderlyingType<T extends TypeLike> =
+    T extends Type<infer U> ? U :
+    T extends "void" ? void : // tslint:disable-line void-return
+    T extends "bool" ? boolean :
+    T extends "int8" | "uint8" | "int16" | "uint16" | "int32" | "uint32" | "float" | "double" | "byte" | "char" | "uchar" | "short" | "ushort" | "int" | "uint" ? number :
+    T extends "int64" | "uint64" | "long" | "longlong" | "ulong" | "ulonglong" | "size_t" ? string | number :
+    T extends "Object" ? unknown :
+    T extends "CString" | "string" ? string | null :
+    T extends "pointer" ? Pointer<any> :
+    T extends `${infer U}${"" | " "}*` ? U extends "char" ? string : Pointer<UnderlyingType<U>> :
+    unknown;
+
+/**
+ * Helper type to get a tuple of the underlying types of a tuple of {@link TypeLike} types.
+ */
+export type UnderlyingTypes<T extends readonly TypeLike[]> = Extract<{
+    [P in keyof T]: P extends `${number}` ? UnderlyingType<Extract<T[P], TypeLike>> : T[P];
+}, any[]>;
+
+/**
+ * Coerces a {@link TypeLike} to a {@link Type}.
+ */
+export type CoerceType<T extends TypeLike> = Type<UnderlyingType<T>>;
+
+/**
+ * Helper type to coerce a tuple of {@link TypeLike} types to a tuple of {@link Type} types.
+ */
+export type CoerceTypes<T extends readonly TypeLike[]> = Extract<{
+    [P in keyof T]: P extends `${number}` ? CoerceType<Extract<T[P], TypeLike>> : T[P];
+}, any[]>;
+
+/**
+ * Dereferences a type
+ */
+export type DerefType<T extends TypeLike> =
+    UnderlyingType<T> extends Pointer<infer U> ? Type<U> :
+    never;
+
+/**
+ * Helper type to deref a tuple of {@link TypeLike} types to a tuple of {@link Type} types.
+ */
+export type DerefTypes<T extends readonly TypeLike[]> = Extract<{
+    [P in keyof T]: P extends `${number}` ? DerefType<Extract<T[P], TypeLike>> : T[P];
+}, any[]>;
+
+/**
+ * A typed pointer.
+ */
+export interface Pointer<T> extends Buffer {
+    ref(): Pointer<Pointer<T>>;
+    deref(): T;
+    type: Type<T>;
+}
+
+/**
+ * A buffer representing a value.
+ */
+export interface Value<T> extends Buffer {
+    ref(): Pointer<T>;
+    deref(): never;
+    type: Type<T>;
+}
+
+export interface Type<T = any> {
     /** The size in bytes required to hold this datatype. */
     size: number;
     /** The current level of indirection of the buffer. */
     indirection: number;
     /** To invoke when `ref.get` is invoked on a buffer of this type. */
-    get(buffer: Buffer, offset: number): any;
+    get(buffer: Buffer, offset: number): T;
     /** To invoke when `ref.set` is invoked on a buffer of this type. */
-    set(buffer: Buffer, offset: number, value: any): void;
+    set(buffer: Buffer, offset: number, value: T): void;
     /** The name to use during debugging for this datatype. */
     name?: string;
     /** The alignment of this datatype when placed inside a struct. */
@@ -21,25 +103,39 @@ export interface Type {
 }
 
 /** A Buffer that references the C NULL pointer. */
-export declare var NULL: Buffer;
+export declare var NULL: Value<null>;
+
 /** A pointer-sized buffer pointing to NULL. */
-export declare var NULL_POINTER: Buffer;
+export declare var NULL_POINTER: Pointer<Value<null>>;
+
 /** Get the memory address of buffer. */
 export declare function address(buffer: Buffer): number;
+
 /** Get the memory address of buffer. */
 export declare function hexAddress(buffer: Buffer): string;
+
 /** Allocate the memory with the given value written to it. */
-export declare function alloc(type: string | Type, value?: any): Buffer;
+export declare function alloc<TType extends NamedType>(type: TType, value?: UnderlyingType<TType>):
+    [UnderlyingType<TType>] extends [never] | [0] ? Value<any> :
+    UnderlyingType<TType> extends Buffer ? UnderlyingType<TType> :
+    Value<UnderlyingType<TType>>;
+/** Allocate the memory with the given value written to it. */
+export declare function alloc<TType extends TypeLike>(type: TType, value?: UnderlyingType<TType>):
+    [UnderlyingType<TType>] extends [never] | [0] ? Value<any> :
+    UnderlyingType<TType> extends Buffer ? UnderlyingType<TType> :
+    Value<UnderlyingType<TType>>;
 
 /**
  * Allocate the memory with the given string written to it with the given
  * encoding (defaults to utf8). The buffer is 1 byte longer than the
  * string itself, and is NULL terminated.
  */
-export declare function allocCString(string: string, encoding?: string): Buffer;
+export declare function allocCString(string: string, encoding?: BufferEncoding): Value<string>;
+export declare function allocCString(string: string | null, encoding?: BufferEncoding): Value<string | null>;
 
 /** Coerce a type. String are looked up from the ref.types object. */
-export declare function coerceType(type: string | Type): Type;
+export declare function coerceType<T extends NamedType>(type: T): Type<UnderlyingType<T>>;
+export declare function coerceType<T extends TypeLike>(type: T): Type<UnderlyingType<T>>;
 
 /**
  * Get value after dereferencing buffer.
@@ -47,18 +143,30 @@ export declare function coerceType(type: string | Type): Type;
  * if it's greater than 1 then it merely returns another Buffer, but with
  * one level less indirection.
  */
+export declare function deref<T>(buffer: Pointer<T>): T;
 export declare function deref(buffer: Buffer): any;
 
 /** Create clone of the type, with decremented indirection level by 1. */
-export declare function derefType(type: string | Type): Type;
+export declare function derefType<T extends NamedType>(type: T): DerefType<T>;
+export declare function derefType<T extends TypeLike>(type: T): DerefType<T>;
+export declare function derefType(type: TypeLike): Type;
+
 /** Represents the native endianness of the processor ("LE" or "BE"). */
 export declare var endianness: "LE" | "BE";
+
 /** Check the indirection level and return a dereferenced when necessary. */
-export declare function get(buffer: Buffer, offset?: number, type?: string | Type): any;
+export declare function get<T>(buffer: Pointer<T> | Value<T>, offset?: 0): T;
+export declare function get<T extends NamedType>(buffer: Buffer, offset: number | undefined, type: T): UnderlyingType<T>;
+export declare function get<T extends TypeLike>(buffer: Buffer, offset: number | undefined, type: T): UnderlyingType<T>;
+export declare function get(buffer: Buffer, offset?: number, type?: TypeLike): any;
+
 /** Get type of the buffer. Create a default type when none exists. */
+export declare function getType<T>(buffer: Pointer<T>): Type<T>;
 export declare function getType(buffer: Buffer): Type;
+
 /** Check the NULL. */
 export declare function isNull(buffer: Buffer): boolean;
+
 /** Read C string until the first NULL. */
 export declare function readCString(buffer: Buffer, offset?: number): string;
 
@@ -77,10 +185,12 @@ export declare function readInt64BE(buffer: Buffer, offset?: number): number | s
 export declare function readInt64LE(buffer: Buffer, offset?: number): number | string;
 
 /** Read a JS Object that has previously been written. */
+export declare function readObject<T>(buffer: Pointer<T>, offset?: 0): T;
 export declare function readObject(buffer: Buffer, offset?: number): Object;
+
 /** Read data from the pointer. */
-export declare function readPointer(buffer: Buffer, offset?: number,
-    length?: number): Buffer;
+export declare function readPointer(buffer: Buffer, offset?: number, length?: number): Buffer;
+
 /**
  * Read a big-endian unsigned 64-bit int.
  * If there is losing precision, then return a string, otherwise a number.
@@ -96,31 +206,40 @@ export declare function readUInt64BE(buffer: Buffer, offset?: number): string | 
 export declare function readUInt64LE(buffer: Buffer, offset?: number): string | number;
 
 /** Create pointer to buffer. */
+export declare function ref<T>(buffer: Pointer<T>): Pointer<Pointer<T>>;
+export declare function ref<T>(buffer: Value<T>): Pointer<T>;
 export declare function ref(buffer: Buffer): Buffer;
+
 /** Create clone of the type, with incremented indirection level by 1. */
-export declare function refType(type: string | Type): Type;
+export declare function refType<T extends NamedTypeLike>(type: T): Type<Pointer<UnderlyingType<T>>>;
+export declare function refType<T extends TypeLike>(type: T): Type<Pointer<UnderlyingType<T>>>;
+export declare function refType(type: TypeLike): Type;
 
 /**
  * Create buffer with the specified size, with the same address as source.
  * This function "attaches" source to the returned buffer to prevent it from
  * being garbage collected.
  */
-export declare function reinterpret(buffer: Buffer, size: number,
-    offset?: number): Buffer;
+export declare function reinterpret(buffer: Buffer, size: number, offset?: number): Buffer;
+
 /**
  * Scan past the boundary of the buffer's length until it finds size number
  * of aligned NULL bytes.
  */
-export declare function reinterpretUntilZeros(buffer: Buffer, size: number,
-    offset?: number): Buffer;
+export declare function reinterpretUntilZeros(buffer: Buffer, size: number, offset?: number): Buffer;
 
 /** Write pointer if the indirection is 1, otherwise write value. */
-export declare function set(buffer: Buffer, offset: number, value: any, type?: string | Type): void;
+export declare function set<T>(buffer: Pointer<T> | Value<T>, offset: 0, value: T): void;
+export declare function set<T extends NamedType>(buffer: Buffer, offset: number, value: UnderlyingType<T>, type: T): void;
+export declare function set<T extends TypeLike>(buffer: Buffer, offset: number, value: UnderlyingType<T>, type: T): void;
+export declare function set(buffer: Buffer, offset: number, value: any, type?: TypeLike): void;
+
 /** Write the string as a NULL terminated. Default encoding is utf8. */
-export declare function writeCString(buffer: Buffer, offset: number,
-    string: string, encoding?: string): void;
+export declare function writeCString(buffer: Buffer, offset: number, string: string, encoding?: BufferEncoding): void;
+
 /** Write a big-endian signed 64-bit int. */
 export declare function writeInt64BE(buffer: Buffer, offset: number, input: string | number): void;
+
 /** Write a little-endian signed 64-bit int. */
 export declare function writeInt64LE(buffer: Buffer, offset: number, input: string | number): void;
 
@@ -128,17 +247,18 @@ export declare function writeInt64LE(buffer: Buffer, offset: number, input: stri
  * Write the JS Object. This function "attaches" object to buffer to prevent
  * it from being garbage collected.
  */
+export declare function writeObject<T>(buffer: Value<T>, offset: 0, object: T): void;
 export declare function writeObject(buffer: Buffer, offset: number, object: Object): void;
 
 /**
  * Write the memory address of pointer to buffer at the specified offset. This
  * function "attaches" object to buffer to prevent it from being garbage collected.
  */
-export declare function writePointer(buffer: Buffer, offset: number,
-    pointer: Buffer): void;
+export declare function writePointer(buffer: Buffer, offset: number, pointer: Buffer): void;
 
 /** Write a big-endian unsigned 64-bit int. */
 export declare function writeUInt64BE(buffer: Buffer, offset: number, input: string | number): void;
+
 /** Write a little-endian unsigned 64-bit int. */
 export declare function writeUInt64LE(buffer: Buffer, offset: number, input: string | number): void;
 
@@ -149,51 +269,102 @@ export declare function writeUInt64LE(buffer: Buffer, offset: number, input: str
 export declare function _attach(buffer: Buffer, object: Object): void;
 
 /** Same as ref.reinterpret, except that this version does not attach buffer. */
-export declare function _reinterpret(buffer: Buffer, size: number,
-    offset?: number): Buffer;
+export declare function _reinterpret(buffer: Buffer, size: number, offset?: number): Buffer;
+
 /** Same as ref.reinterpretUntilZeros, except that this version does not attach buffer. */
-export declare function _reinterpretUntilZeros(buffer: Buffer, size: number,
-    offset?: number): Buffer;
+export declare function _reinterpretUntilZeros(buffer: Buffer, size: number, offset?: number): Buffer;
+
 /** Same as ref.writePointer, except that this version does not attach pointer. */
-export declare function _writePointer(buffer: Buffer, offset: number,
-    pointer: Buffer): void;
+export declare function _writePointer(buffer: Buffer, offset: number, pointer: Buffer): void;
+
 /** Same as ref.writeObject, except that this version does not attach object. */
+export declare function _writeObject<T>(buffer: Value<T>, offset: 0, object: T): void;
 export declare function _writeObject(buffer: Buffer, offset: number, object: Object): void;
 
 /** Default types. */
 export declare var types: {
-    void: Type; int64: Type; ushort: Type;
-    int: Type; uint64: Type; float: Type;
-    uint: Type; long: Type; double: Type;
-    int8: Type; ulong: Type; Object: Type;
-    uint8: Type; longlong: Type; CString: Type;
-    int16: Type; ulonglong: Type; bool: Type;
-    uint16: Type; char: Type; byte: Type;
-    int32: Type; uchar: Type; size_t: Type;
-    uint32: Type; short: Type;
+    void: Type<void>;
+    int64: Type<string | number>;
+    ushort: Type<number>;
+    int: Type<number>;
+    uint64: Type<string | number>;
+    float: Type<number>;
+    uint: Type<number>;
+    long: Type<string | number>;
+    double: Type<number>;
+    int8: Type<number>;
+    ulong: Type<string | number>;
+    Object: Type<unknown>;
+    uint8: Type<number>;
+    longlong: Type<string | number>;
+    CString: Type<string | null>;
+    int16: Type<number>;
+    ulonglong: Type<string | number>;
+    bool: Type<boolean>;
+    uint16: Type<number>;
+    char: Type<number>;
+    byte: Type<number>;
+    int32: Type<number>;
+    uchar: Type<number>;
+    size_t: Type<string | number>;
+    uint32: Type<number>;
+    short: Type<number>;
 };
 
 export declare var alignof: {
-    pointer: number; int64: number; ushort: number;
-    int: number; uint64: number; float: number;
-    uint: number; long: number; double: number;
-    int8: number; ulong: number; Object: number;
-    uint8: number; longlong: number;
-    int16: number; ulonglong: number; bool: number;
-    uint16: number; char: number; byte: number;
-    int32: number; uchar: number; size_t: number;
-    uint32: number; short: number;
+    pointer: number;
+    int64: number;
+    ushort: number;
+    int: number;
+    uint64: number;
+    float: number;
+    uint: number;
+    long: number;
+    double: number;
+    int8: number;
+    ulong: number;
+    Object: number;
+    uint8: number;
+    longlong: number;
+    int16: number;
+    ulonglong: number;
+    bool: number;
+    uint16: number;
+    char: number;
+    byte: number;
+    int32: number;
+    uchar: number;
+    size_t: number;
+    uint32: number;
+    short: number;
 };
+
 export declare var sizeof: {
-    pointer: number; int64: number; ushort: number;
-    int: number; uint64: number; float: number;
-    uint: number; long: number; double: number;
-    int8: number; ulong: number; Object: number;
-    uint8: number; longlong: number;
-    int16: number; ulonglong: number; bool: number;
-    uint16: number; char: number; byte: number;
-    int32: number; uchar: number; size_t: number;
-    uint32: number; short: number;
+    pointer: number;
+    int64: number;
+    ushort: number;
+    int: number;
+    uint64: number;
+    float: number;
+    uint: number;
+    long: number;
+    double: number;
+    int8: number;
+    ulong: number;
+    Object: number;
+    uint8: number;
+    longlong: number;
+    int16: number;
+    ulonglong: number;
+    bool: number;
+    uint16: number;
+    char: number;
+    byte: number;
+    int32: number;
+    uchar: number;
+    size_t: number;
+    uint32: number;
+    short: number;
 };
 
 declare global {

--- a/types/ref-napi/package.json
+++ b/types/ref-napi/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=4.1": {
+            "*": [
+                "ts4.1/*"
+            ]
+        }
+    }
+}

--- a/types/ref-napi/ts4.1/index.d.ts
+++ b/types/ref-napi/ts4.1/index.d.ts
@@ -1,0 +1,219 @@
+/// <reference types="node" />
+
+export interface Type {
+    /** The size in bytes required to hold this datatype. */
+    size: number;
+    /** The current level of indirection of the buffer. */
+    indirection: number;
+    /** To invoke when `ref.get` is invoked on a buffer of this type. */
+    get(buffer: Buffer, offset: number): any;
+    /** To invoke when `ref.set` is invoked on a buffer of this type. */
+    set(buffer: Buffer, offset: number, value: any): void;
+    /** The name to use during debugging for this datatype. */
+    name?: string;
+    /** The alignment of this datatype when placed inside a struct. */
+    alignment?: number;
+}
+
+/** A Buffer that references the C NULL pointer. */
+export declare var NULL: Buffer;
+/** A pointer-sized buffer pointing to NULL. */
+export declare var NULL_POINTER: Buffer;
+/** Get the memory address of buffer. */
+export declare function address(buffer: Buffer): number;
+/** Get the memory address of buffer. */
+export declare function hexAddress(buffer: Buffer): string;
+/** Allocate the memory with the given value written to it. */
+export declare function alloc(type: string | Type, value?: any): Buffer;
+
+/**
+ * Allocate the memory with the given string written to it with the given
+ * encoding (defaults to utf8). The buffer is 1 byte longer than the
+ * string itself, and is NULL terminated.
+ */
+export declare function allocCString(string: string, encoding?: string): Buffer;
+
+/** Coerce a type. String are looked up from the ref.types object. */
+export declare function coerceType(type: string | Type): Type;
+
+/**
+ * Get value after dereferencing buffer.
+ * That is, first it checks the indirection count of buffer's type, and
+ * if it's greater than 1 then it merely returns another Buffer, but with
+ * one level less indirection.
+ */
+export declare function deref(buffer: Buffer): any;
+
+/** Create clone of the type, with decremented indirection level by 1. */
+export declare function derefType(type: string | Type): Type;
+/** Represents the native endianness of the processor ("LE" or "BE"). */
+export declare var endianness: "LE" | "BE";
+/** Check the indirection level and return a dereferenced when necessary. */
+export declare function get(buffer: Buffer, offset?: number, type?: string | Type): any;
+/** Get type of the buffer. Create a default type when none exists. */
+export declare function getType(buffer: Buffer): Type;
+/** Check the NULL. */
+export declare function isNull(buffer: Buffer): boolean;
+/** Read C string until the first NULL. */
+export declare function readCString(buffer: Buffer, offset?: number): string;
+
+/**
+ * Read a big-endian signed 64-bit int.
+ * If there is losing precision, then return a string, otherwise a number.
+ * @return {number|string}
+ */
+export declare function readInt64BE(buffer: Buffer, offset?: number): number | string;
+
+/**
+ * Read a little-endian signed 64-bit int.
+ * If there is losing precision, then return a string, otherwise a number.
+ * @return {number|string}
+ */
+export declare function readInt64LE(buffer: Buffer, offset?: number): number | string;
+
+/** Read a JS Object that has previously been written. */
+export declare function readObject(buffer: Buffer, offset?: number): Object;
+/** Read data from the pointer. */
+export declare function readPointer(buffer: Buffer, offset?: number,
+    length?: number): Buffer;
+/**
+ * Read a big-endian unsigned 64-bit int.
+ * If there is losing precision, then return a string, otherwise a number.
+ * @return {number|string}
+ */
+export declare function readUInt64BE(buffer: Buffer, offset?: number): string | number;
+
+/**
+ * Read a little-endian unsigned 64-bit int.
+ * If there is losing precision, then return a string, otherwise a number.
+ * @return {number|string}
+ */
+export declare function readUInt64LE(buffer: Buffer, offset?: number): string | number;
+
+/** Create pointer to buffer. */
+export declare function ref(buffer: Buffer): Buffer;
+/** Create clone of the type, with incremented indirection level by 1. */
+export declare function refType(type: string | Type): Type;
+
+/**
+ * Create buffer with the specified size, with the same address as source.
+ * This function "attaches" source to the returned buffer to prevent it from
+ * being garbage collected.
+ */
+export declare function reinterpret(buffer: Buffer, size: number,
+    offset?: number): Buffer;
+/**
+ * Scan past the boundary of the buffer's length until it finds size number
+ * of aligned NULL bytes.
+ */
+export declare function reinterpretUntilZeros(buffer: Buffer, size: number,
+    offset?: number): Buffer;
+
+/** Write pointer if the indirection is 1, otherwise write value. */
+export declare function set(buffer: Buffer, offset: number, value: any, type?: string | Type): void;
+/** Write the string as a NULL terminated. Default encoding is utf8. */
+export declare function writeCString(buffer: Buffer, offset: number,
+    string: string, encoding?: string): void;
+/** Write a big-endian signed 64-bit int. */
+export declare function writeInt64BE(buffer: Buffer, offset: number, input: string | number): void;
+/** Write a little-endian signed 64-bit int. */
+export declare function writeInt64LE(buffer: Buffer, offset: number, input: string | number): void;
+
+/**
+ * Write the JS Object. This function "attaches" object to buffer to prevent
+ * it from being garbage collected.
+ */
+export declare function writeObject(buffer: Buffer, offset: number, object: Object): void;
+
+/**
+ * Write the memory address of pointer to buffer at the specified offset. This
+ * function "attaches" object to buffer to prevent it from being garbage collected.
+ */
+export declare function writePointer(buffer: Buffer, offset: number,
+    pointer: Buffer): void;
+
+/** Write a big-endian unsigned 64-bit int. */
+export declare function writeUInt64BE(buffer: Buffer, offset: number, input: string | number): void;
+/** Write a little-endian unsigned 64-bit int. */
+export declare function writeUInt64LE(buffer: Buffer, offset: number, input: string | number): void;
+
+/**
+ * Attach object to buffer such.
+ * It prevents object from being garbage collected until buffer does.
+ */
+export declare function _attach(buffer: Buffer, object: Object): void;
+
+/** Same as ref.reinterpret, except that this version does not attach buffer. */
+export declare function _reinterpret(buffer: Buffer, size: number,
+    offset?: number): Buffer;
+/** Same as ref.reinterpretUntilZeros, except that this version does not attach buffer. */
+export declare function _reinterpretUntilZeros(buffer: Buffer, size: number,
+    offset?: number): Buffer;
+/** Same as ref.writePointer, except that this version does not attach pointer. */
+export declare function _writePointer(buffer: Buffer, offset: number,
+    pointer: Buffer): void;
+/** Same as ref.writeObject, except that this version does not attach object. */
+export declare function _writeObject(buffer: Buffer, offset: number, object: Object): void;
+
+/** Default types. */
+export declare var types: {
+    void: Type; int64: Type; ushort: Type;
+    int: Type; uint64: Type; float: Type;
+    uint: Type; long: Type; double: Type;
+    int8: Type; ulong: Type; Object: Type;
+    uint8: Type; longlong: Type; CString: Type;
+    int16: Type; ulonglong: Type; bool: Type;
+    uint16: Type; char: Type; byte: Type;
+    int32: Type; uchar: Type; size_t: Type;
+    uint32: Type; short: Type;
+};
+
+export declare var alignof: {
+    pointer: number; int64: number; ushort: number;
+    int: number; uint64: number; float: number;
+    uint: number; long: number; double: number;
+    int8: number; ulong: number; Object: number;
+    uint8: number; longlong: number;
+    int16: number; ulonglong: number; bool: number;
+    uint16: number; char: number; byte: number;
+    int32: number; uchar: number; size_t: number;
+    uint32: number; short: number;
+};
+export declare var sizeof: {
+    pointer: number; int64: number; ushort: number;
+    int: number; uint64: number; float: number;
+    uint: number; long: number; double: number;
+    int8: number; ulong: number; Object: number;
+    uint8: number; longlong: number;
+    int16: number; ulonglong: number; bool: number;
+    uint16: number; char: number; byte: number;
+    int32: number; uchar: number; size_t: number;
+    uint32: number; short: number;
+};
+
+declare global {
+  interface Buffer {
+    address(): number;
+    hexAddress(): string;
+    isNull(): boolean;
+    ref(): Buffer;
+    deref(): any;
+    readObject(offset?: number): Object;
+    writeObject(offset: number, object: Object): void;
+    readPointer(offset?: number, length?: number): Buffer;
+    writePointer(offset: number, pointer: Buffer): void;
+    readCString(offset?: number): string;
+    writeCString(offset: number, string: string, encoding?: string): void;
+    readInt64BE(offset?: number): string | number;
+    writeInt64BE(offset: number, input: string | number): void;
+    readUInt64BE(offset?: number): string | number;
+    writeUInt64BE(offset: number, input: string | number): void;
+    readInt64LE(offset?: number): string | number;
+    writeInt64LE(offset: number, input: string | number): void;
+    readUInt64LE(offset?: number): string | number;
+    writeUInt64LE(offset: number, input: string | number): void;
+    reinterpret(size: number, offset?: number): Buffer;
+    reinterpretUntilZeros(size: number, offset?: number): Buffer;
+    type?: Type;
+  }
+}

--- a/types/ref-napi/ts4.1/ref-napi-tests.ts
+++ b/types/ref-napi/ts4.1/ref-napi-tests.ts
@@ -1,16 +1,8 @@
 import ref = require("ref-napi");
 
-interface Foo {
-    x: number;
-}
-
-declare const typeLike: ref.NamedType | ref.Type;
-declare const numberPointer: ref.Pointer<number>;
-declare const numberPointerType: ref.Type<ref.Pointer<number>>;
-declare const fooPointer: ref.Pointer<Foo>;
+declare const typeLike: string | ref.Type;
 declare const buffer: Buffer;
 declare const string: string;
-declare const encoding: BufferEncoding;
 declare const number: number;
 declare const any: any;
 declare const int64Like: string | number;
@@ -22,43 +14,24 @@ ref.address(buffer);
 // $ExpectType string
 ref.hexAddress(buffer);
 
-// $ExpectType Value<any>
+// $ExpectType Buffer
 ref.alloc(typeLike, 0);
-// $ExpectType Value<number>
-ref.alloc("int");
-// $ExpectType Value<number>
-ref.alloc("int", 4);
 
-// $ExpectType Value<string>
+// $ExpectType Buffer
 ref.allocCString(string);
-// $ExpectType Value<string>
+// $ExpectType Buffer
 ref.allocCString(string, undefined);
-// $ExpectType Value<string>
-ref.allocCString(string, encoding);
+// $ExpectType Buffer
+ref.allocCString(string, string);
 
-// $ExpectType Value<string | null>
-ref.allocCString(null);
-// $ExpectType Value<string | null>
-ref.allocCString(null, undefined);
-// $ExpectType Value<string | null>
-ref.allocCString(null, encoding);
-
-// $ExpectType Type<any>
+// $ExpectType Type
 ref.coerceType(typeLike);
-// $ExpectType Type<number>
-ref.coerceType(ref.types.int);
-// $ExpectType Type<number>
-ref.coerceType("int");
 
 // $ExpectType any
 ref.deref(buffer);
-// $ExpectType number
-ref.deref(numberPointer);
 
-// $ExpectType Type<unknown>
+// $ExpectType Type
 ref.derefType(typeLike);
-// $ExpectType Type<number>
-ref.derefType(numberPointerType);
 
 // $ExpectType "LE" | "BE"
 ref.endianness;
@@ -75,21 +48,9 @@ ref.get(buffer, number);
 ref.get(buffer, number, undefined);
 // $ExpectType any
 ref.get(buffer, number, typeLike);
-// $ExpectType number
-ref.get(numberPointer);
-// $ExpectType number
-ref.get(numberPointer, undefined);
-// $ExpectType number
-ref.get(numberPointer, 0);
-// $ExpectType any
-ref.get(numberPointer, number);
-// $ExpectType number
-ref.get(buffer, number, ref.types.int);
 
-// $ExpectType Type<any>
+// $ExpectType Type
 ref.getType(buffer);
-// $ExpectType Type<number>
-ref.getType(numberPointer);
 
 // $ExpectType boolean
 ref.isNull(buffer);
@@ -121,24 +82,12 @@ ref.readObject(buffer);
 ref.readObject(buffer, undefined);
 // $ExpectType Object
 ref.readObject(buffer, number);
-// $ExpectType Foo
-ref.readObject(fooPointer);
-// $ExpectType Foo
-ref.readObject(fooPointer, undefined);
-// $ExpectType Foo
-ref.readObject(fooPointer, 0);
-// $ExpectType Object
-ref.readObject(fooPointer, number);
 
 // $ExpectType Buffer
 ref.ref(buffer);
-// $ExpectType Pointer<Pointer<number>>
-ref.ref(numberPointer);
 
-// $ExpectType Type<Pointer<any>>
+// $ExpectType Type
 ref.refType(typeLike);
-// $ExpectType Type<Pointer<number>>
-ref.refType(ref.types.int);
 
 // $ExpectType Buffer
 ref.reinterpret(buffer, number);
@@ -166,7 +115,7 @@ ref.writeCString(buffer, number, string);
 // $ExpectType void
 ref.writeCString(buffer, number, string, undefined);
 // $ExpectType void
-ref.writeCString(buffer, number, string, encoding);
+ref.writeCString(buffer, number, string, string);
 
 // $ExpectType void
 ref.writeInt64BE(buffer, number, int64Like);
@@ -209,62 +158,62 @@ ref._writePointer(buffer, number, buffer);
 // $ExpectType void
 ref._writeObject(buffer, number, jsObject);
 
-// $ExpectType Type<void>
+// $ExpectType Type
 ref.types.void;
-// @ts-expect-error
+// $ExpectError
 ref.types.pointer; // `pointer` doesn't exist on `types`, though it exists on `sizeof`/`alignof`
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.int64;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.ushort;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.int;
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.uint64;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.float;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.uint;
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.long;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.double;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.int8;
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.ulong;
-// $ExpectType Type<unknown>
+// $ExpectType Type
 ref.types.Object;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.uint8;
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.longlong;
-// $ExpectType Type<string | null>
+// $ExpectType Type
 ref.types.CString;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.int16;
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.ulonglong;
-// $ExpectType Type<boolean>
+// $ExpectType Type
 ref.types.bool;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.uint16;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.char;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.byte;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.int32;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.uchar;
-// $ExpectType Type<string | number>
+// $ExpectType Type
 ref.types.size_t;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.uint32;
-// $ExpectType Type<number>
+// $ExpectType Type
 ref.types.short;
 
-// @ts-expect-error
+// $ExpectError
 ref.alignof.void; // `void` doesn't have an alignment
 // $ExpectType number
 ref.alignof.pointer;
@@ -294,7 +243,7 @@ ref.alignof.Object;
 ref.alignof.uint8;
 // $ExpectType number
 ref.alignof.longlong;
-// @ts-expect-error
+// $ExpectError
 ref.alignof.CString; // `CString` doesn't have an alignment
 // $ExpectType number
 ref.alignof.int16;
@@ -319,7 +268,7 @@ ref.alignof.uint32;
 // $ExpectType number
 ref.alignof.short;
 
-// @ts-expect-error
+// $ExpectError
 ref.sizeof.void; // `void` doesn't have an size
 // $ExpectType number
 ref.sizeof.pointer;
@@ -349,7 +298,7 @@ ref.sizeof.Object;
 ref.sizeof.uint8;
 // $ExpectType number
 ref.sizeof.longlong;
-// @ts-expect-error
+// $ExpectError
 ref.sizeof.CString; // `CString` doesn't have an size
 // $ExpectType number
 ref.sizeof.int16;
@@ -483,5 +432,5 @@ buffer.reinterpretUntilZeros(number, undefined);
 // $ExpectType Buffer
 buffer.reinterpretUntilZeros(number, number);
 
-// $ExpectType Type<any> | undefined
+// $ExpectType Type | undefined
 buffer.type;

--- a/types/ref-napi/ts4.1/tsconfig.json
+++ b/types/ref-napi/ts4.1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ref-napi-tests.ts"
+    ]
+}

--- a/types/ref-napi/ts4.1/tslint.json
+++ b/types/ref-napi/ts4.1/tslint.json
@@ -1,0 +1,10 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": false,
+        "jsdoc-format": false,
+        "no-redundant-jsdoc-2": false,
+        "strict-export-declare-modifiers": false,
+        "unified-signatures": false
+    }
+}

--- a/types/ref-struct-di/package.json
+++ b/types/ref-struct-di/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=4.1": {
+            "*": [
+                "ts4.1/*"
+            ]
+        }
+    }
+}

--- a/types/ref-struct-di/ref-struct-di-tests.ts
+++ b/types/ref-struct-di/ref-struct-di-tests.ts
@@ -12,51 +12,76 @@ const packedStruct = StructType({
   v: ref.types.long,
 }, {packed: true});
 
-declare const typeLike: string | ref.Type;
+declare const typeLike: ref.TypeLike;
 declare const buffer: Buffer;
 declare const number: number;
 declare const string: string;
 declare const boolean: boolean;
 
-// $ExpectType StructType
+// $ExpectType StructType<any>
 StructType();
-// $ExpectType StructType
+// $ExpectType StructType<any>
 StructType(undefined);
-// $ExpectType StructType
+// $ExpectType StructType<any>
 StructType(undefined, undefined);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 StructType({ x: typeLike });
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 StructType({ x: typeLike }, undefined);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 StructType({ x: typeLike }, { packed: boolean });
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<number>; }>
+StructType({ x: ref.types.int }, { packed: boolean });
+// $ExpectType StructType<{ x: Type<number>; }>
+StructType({ x: "int" }, { packed: boolean });
+// $ExpectType StructType<{ x: Type<any>; }>
 StructType([["x", typeLike]]);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 StructType([["x", typeLike]], undefined);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 StructType([["x", typeLike]], { packed: boolean });
+// $ExpectType StructType<{ x: Type<number>; }>
+StructType([["x", ref.types.int]], { packed: boolean });
+// $ExpectType StructType<{ x: Type<number>; }>
+StructType([["x", "int"]], { packed: boolean });
 
-// $ExpectType StructType
+// $ExpectType StructType<any>
 new StructType();
-// $ExpectType StructType
+// $ExpectType StructType<any>
 new StructType(undefined);
-// $ExpectType StructType
+// $ExpectType StructType<any>
 new StructType(undefined, undefined);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 new StructType({ x: typeLike });
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 new StructType({ x: typeLike }, undefined);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 new StructType({ x: typeLike }, { packed: boolean });
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<number>; }>
+new StructType({ x: ref.types.int }, { packed: boolean });
+// $ExpectType StructType<{ x: Type<number>; }>
+new StructType({ x: "int" }, { packed: boolean });
+// $ExpectType StructType<{ x: Type<any>; }>
 new StructType([["x", typeLike]]);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 new StructType([["x", typeLike]], undefined);
-// $ExpectType StructType
+// $ExpectType StructType<{ x: Type<any>; }>
 new StructType([["x", typeLike]], { packed: boolean });
+// $ExpectType StructType<{ x: Type<number>; }>
+new StructType([["x", ref.types.int]], { packed: boolean });
+// $ExpectType StructType<{ x: Type<number>; }>
+new StructType([["x", "int"]], { packed: boolean });
 
 declare const struct: ref_struct.StructType;
+
+// $ExpectType Record<string, Field<any>>
+struct.fields;
+
+// $ExpectType void
+struct.defineProperty(string, typeLike);
+
+// $ExpectType string
+struct.toString();
 
 // $ExpectType Record<string, any>
 struct();
@@ -84,11 +109,33 @@ new struct(buffer, undefined);
 // $ExpectType Record<string, any>
 new struct(buffer, { x: number });
 
-// $ExpectType Record<string, Field>
-struct.fields;
+declare const Point: ref_struct.StructType<{ x: ref.Type<number>, y: ref.Type<number> }>;
 
-// $ExpectType void
-struct.defineProperty(string, typeLike);
+// $ExpectType { x: Field<number>; y: Field<number>; }
+Point.fields;
 
-// $ExpectType string
-struct.toString();
+// $ExpectType { x: number; y: number; }
+Point();
+// $ExpectType { x: number; y: number; }
+Point(undefined);
+// $ExpectType { x: number; y: number; }
+Point({ x: number });
+// $ExpectType { x: number; y: number; }
+Point(buffer);
+// $ExpectType { x: number; y: number; }
+Point(buffer, undefined);
+// $ExpectType { x: number; y: number; }
+Point(buffer, { x: number });
+
+// $ExpectType { x: number; y: number; }
+new Point();
+// $ExpectType { x: number; y: number; }
+new Point(undefined);
+// $ExpectType { x: number; y: number; }
+new Point({ x: number });
+// $ExpectType { x: number; y: number; }
+new Point(buffer);
+// $ExpectType { x: number; y: number; }
+new Point(buffer, undefined);
+// $ExpectType { x: number; y: number; }
+new Point(buffer, { x: number });

--- a/types/ref-struct-di/ts4.1/index.d.ts
+++ b/types/ref-struct-di/ts4.1/index.d.ts
@@ -1,0 +1,55 @@
+import ref = require('ref-napi');
+
+declare var StructType: {
+    new (fields?: Record<string, string | ref.Type>, opt?: { packed?: boolean }): struct.StructType;
+    new (fields?: Array<[string, string | ref.Type]>, opt?: { packed?: boolean }): struct.StructType;
+    (fields?: Record<string, string | ref.Type>, opt?: { packed?: boolean }): struct.StructType;
+    (fields?: Array<[string, string | ref.Type]>, opt?: { packed?: boolean }): struct.StructType;
+};
+
+type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "NULL">;
+
+declare function struct(ref: RefModuleLike): typeof StructType;
+declare namespace struct {
+    interface Field {
+        type: ref.Type;
+        offset: number;
+    }
+    /**
+     * This is the `constructor` of the Struct type that gets returned.
+     *
+     * Invoke it with `new` to create a new Buffer instance backing the struct.
+     * Pass it an existing Buffer instance to use that as the backing buffer.
+     * Pass in an Object containing the struct fields to auto-populate the
+     * struct with the data.
+     *
+     * @constructor
+     */
+    interface StructType extends ref.Type {
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        new (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        new (data?: Record<string, any>): Record<string, any>;
+
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        (data?: Record<string, any>): Record<string, any>;
+
+        fields: Record<string, Field>;
+
+        /**
+         * Adds a new field to the struct instance with the given name and type.
+         * Note that this function will throw an Error if any instances of the struct
+         * type have already been created, therefore this function must be called at the
+         * beginning, before any instances are created.
+         */
+        defineProperty(name: string, type: string | ref.Type): void;
+
+        /**
+         * Custom for struct type instances.
+         * @override
+         */
+        toString(): string;
+    }
+}
+
+export = struct;

--- a/types/ref-struct-di/ts4.1/ref-struct-di-tests.ts
+++ b/types/ref-struct-di/ts4.1/ref-struct-di-tests.ts
@@ -1,0 +1,94 @@
+import ref = require("ref-napi");
+import ref_struct = require("ref-struct-di");
+const StructType = ref_struct(ref);
+
+const normalStruct = StructType({
+  t: ref.types.uint8,
+  v: ref.types.long,
+});
+
+const packedStruct = StructType({
+  t: ref.types.uint8,
+  v: ref.types.long,
+}, {packed: true});
+
+declare const typeLike: string | ref.Type;
+declare const buffer: Buffer;
+declare const number: number;
+declare const string: string;
+declare const boolean: boolean;
+
+// $ExpectType StructType
+StructType();
+// $ExpectType StructType
+StructType(undefined);
+// $ExpectType StructType
+StructType(undefined, undefined);
+// $ExpectType StructType
+StructType({ x: typeLike });
+// $ExpectType StructType
+StructType({ x: typeLike }, undefined);
+// $ExpectType StructType
+StructType({ x: typeLike }, { packed: boolean });
+// $ExpectType StructType
+StructType([["x", typeLike]]);
+// $ExpectType StructType
+StructType([["x", typeLike]], undefined);
+// $ExpectType StructType
+StructType([["x", typeLike]], { packed: boolean });
+
+// $ExpectType StructType
+new StructType();
+// $ExpectType StructType
+new StructType(undefined);
+// $ExpectType StructType
+new StructType(undefined, undefined);
+// $ExpectType StructType
+new StructType({ x: typeLike });
+// $ExpectType StructType
+new StructType({ x: typeLike }, undefined);
+// $ExpectType StructType
+new StructType({ x: typeLike }, { packed: boolean });
+// $ExpectType StructType
+new StructType([["x", typeLike]]);
+// $ExpectType StructType
+new StructType([["x", typeLike]], undefined);
+// $ExpectType StructType
+new StructType([["x", typeLike]], { packed: boolean });
+
+declare const struct: ref_struct.StructType;
+
+// $ExpectType Record<string, any>
+struct();
+// $ExpectType Record<string, any>
+struct(undefined);
+// $ExpectType Record<string, any>
+struct({ x: number });
+// $ExpectType Record<string, any>
+struct(buffer);
+// $ExpectType Record<string, any>
+struct(buffer, undefined);
+// $ExpectType Record<string, any>
+struct(buffer, { x: number });
+
+// $ExpectType Record<string, any>
+new struct();
+// $ExpectType Record<string, any>
+new struct(undefined);
+// $ExpectType Record<string, any>
+new struct({ x: number });
+// $ExpectType Record<string, any>
+new struct(buffer);
+// $ExpectType Record<string, any>
+new struct(buffer, undefined);
+// $ExpectType Record<string, any>
+new struct(buffer, { x: number });
+
+// $ExpectType Record<string, Field>
+struct.fields;
+
+// $ExpectType void
+struct.defineProperty(string, typeLike);
+
+// $ExpectType string
+struct.toString();

--- a/types/ref-struct-di/ts4.1/tsconfig.json
+++ b/types/ref-struct-di/ts4.1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ref-struct-di-tests.ts"
+    ]
+}

--- a/types/ref-struct-di/ts4.1/tslint.json
+++ b/types/ref-struct-di/ts4.1/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc-2": false,
+        "semicolon": false,
+        "unified-signatures": false
+    }
+}

--- a/types/ref-union-di/package.json
+++ b/types/ref-union-di/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=4.1": {
+            "*": [
+                "ts4.1/*"
+            ]
+        }
+    }
+}

--- a/types/ref-union-di/ref-union-di-tests.ts
+++ b/types/ref-union-di/ref-union-di-tests.ts
@@ -7,25 +7,25 @@ declare const buffer: Buffer;
 declare const number: number;
 declare const string: string;
 
-// $ExpectType UnionType
-UnionType();
-// $ExpectType UnionType
-UnionType({
-    ival: typeLike,
-    fval: typeLike,
-});
+type T = ref_union.UnionFields<any>;
 
-// $ExpectType UnionType
+// $ExpectType UnionType<any>
+UnionType();
+// $ExpectType UnionType<{ ival: Type<any>; fval: Type<any>; }>
+UnionType({ ival: typeLike, fval: typeLike });
+// $ExpectType UnionType<{ ival: Type<number>; fval: Type<number>; }>
+UnionType({ ival: "int", fval: "float" });
+
+// $ExpectType UnionType<any>
 new UnionType();
-// $ExpectType UnionType
-new UnionType({
-    ival: typeLike,
-    fval: typeLike,
-});
+// $ExpectType UnionType<{ ival: Type<any>; fval: Type<any>; }>
+new UnionType({ ival: typeLike, fval: typeLike });
+// $ExpectType UnionType<{ ival: Type<number>; fval: Type<number>; }>
+new UnionType({ ival: "int", fval: "float" });
 
 declare const union: ref_union.UnionType;
 
-// $ExpectType Record<string, Field>
+// $ExpectType Record<string, Field<any>>
 union.fields;
 
 // $ExpectType void
@@ -59,3 +59,26 @@ new union(buffer);
 new union(buffer, undefined);
 // $ExpectType Record<string, any>
 new union(buffer, { ival: number });
+
+declare const int32tofloat32: ref_union.UnionType<{ ival: ref.Type<number>, fval: ref.Type<number> }>;
+
+// $ExpectType { ival: Field<number>; fval: Field<number>; }
+int32tofloat32.fields;
+
+// $ExpectType { ival: number; fval: number; }
+int32tofloat32();
+// $ExpectType { ival: number; fval: number; }
+int32tofloat32({ ival: 1 });
+// $ExpectType { ival: number; fval: number; }
+int32tofloat32({ fval: 1.1 });
+// @ts-expect-error
+int32tofloat32({ ival: 1, fval: 1.1 });
+
+// $ExpectType { ival: number; fval: number; }
+new int32tofloat32();
+// $ExpectType { ival: number; fval: number; }
+new int32tofloat32({ ival: 1 });
+// $ExpectType { ival: number; fval: number; }
+new int32tofloat32({ fval: 1.1 });
+// @ts-expect-error
+new int32tofloat32({ ival: 1, fval: 1.1 });

--- a/types/ref-union-di/ts4.1/index.d.ts
+++ b/types/ref-union-di/ts4.1/index.d.ts
@@ -1,0 +1,53 @@
+import ref = require('ref-napi');
+
+declare var UnionType: {
+    new (fields?: Record<string, string | ref.Type>): union.UnionType;
+    (fields?: Record<string, string | ref.Type>): union.UnionType;
+};
+
+type RefModuleLike = Pick<typeof ref, "coerceType" | "get" | "set" | "alignof" | "sizeof" | "NULL">;
+
+declare function union(ref: RefModuleLike): typeof UnionType;
+declare namespace union {
+    interface Field {
+        type: ref.Type;
+    }
+
+    /**
+     * This is the `constructor` of the Struct type that gets returned.
+     *
+     * Invoke it with `new` to create a new Buffer instance backing the union.
+     * Pass it an existing Buffer instance to use that as the backing buffer.
+     * Pass in an Object containing the union fields to auto-populate the
+     * union with the data.
+     *
+     * @constructor
+     */
+    interface UnionType extends ref.Type {
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        new (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        new (data?: Record<string, any>): Record<string, any>;
+
+        /** Pass it an existing Buffer instance to use that as the backing buffer. */
+        (arg: Buffer, data?: Record<string, any>): Record<string, any>;
+        (data?: Record<string, any>): Record<string, any>;
+
+        fields: Record<string, Field>;
+
+        /**
+         * Adds a new field to the union instance with the given name and type.
+         * Note that this function will throw an Error if any instances of the union
+         * type have already been created, therefore this function must be called at the
+         * beginning, before any instances are created.
+         */
+        defineProperty(name: string, type: string | ref.Type): void;
+
+        /**
+         * Custom for union type instances.
+         * @override
+         */
+        toString(): string;
+    }
+}
+
+export = union;

--- a/types/ref-union-di/ts4.1/ref-union-di-tests.ts
+++ b/types/ref-union-di/ts4.1/ref-union-di-tests.ts
@@ -1,0 +1,61 @@
+import ref = require("ref-napi");
+import ref_union = require("ref-union-di");
+const UnionType = ref_union(ref);
+
+declare const typeLike: string | ref.Type;
+declare const buffer: Buffer;
+declare const number: number;
+declare const string: string;
+
+// $ExpectType UnionType
+UnionType();
+// $ExpectType UnionType
+UnionType({
+    ival: typeLike,
+    fval: typeLike,
+});
+
+// $ExpectType UnionType
+new UnionType();
+// $ExpectType UnionType
+new UnionType({
+    ival: typeLike,
+    fval: typeLike,
+});
+
+declare const union: ref_union.UnionType;
+
+// $ExpectType Record<string, Field>
+union.fields;
+
+// $ExpectType void
+union.defineProperty(string, typeLike);
+
+// $ExpectType string
+union.toString();
+
+// $ExpectType Record<string, any>
+union();
+// $ExpectType Record<string, any>
+union(undefined);
+// $ExpectType Record<string, any>
+union({ ival: number });
+// $ExpectType Record<string, any>
+union(buffer);
+// $ExpectType Record<string, any>
+union(buffer, undefined);
+// $ExpectType Record<string, any>
+union(buffer, { ival: number });
+
+// $ExpectType Record<string, any>
+new union();
+// $ExpectType Record<string, any>
+new union(undefined);
+// $ExpectType Record<string, any>
+new union({ ival: number });
+// $ExpectType Record<string, any>
+new union(buffer);
+// $ExpectType Record<string, any>
+new union(buffer, undefined);
+// $ExpectType Record<string, any>
+new union(buffer, { ival: number });

--- a/types/ref-union-di/ts4.1/tsconfig.json
+++ b/types/ref-union-di/ts4.1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ref-union-di-tests.ts"
+    ]
+}

--- a/types/ref-union-di/ts4.1/tslint.json
+++ b/types/ref-union-di/ts4.1/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc-2": false,
+        "semicolon": false,
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
This further improves upon #53425 to provide improved type inference and stricter types for `ffi-napi`, `ref-napi`, `ref-struct-di`, `ref-array-di`, and `ref-union-di`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
