### PR TITLE
fix(pg-large-object): remove 3rd party library import

### DIFF
--- a/types/pg-large-object/index.d.ts
+++ b/types/pg-large-object/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/Joris-van-der-Wel/node-pg-large-object#readme
 // Definitions by: Mateusz Krupa <https://github.com/mateuszkrupa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/pg-large-object/pg-large-object-tests.ts
+++ b/types/pg-large-object/pg-large-object-tests.ts
@@ -5,10 +5,9 @@ import {
   ReadStream,
   WriteStream
 } from "pg-large-object";
-import { Buffer } from "buffer";
 import pg = require("pg");
 
-const buffer = new Buffer("");
+const buffer = Buffer.from("");
 const bufferSize = 16384;
 const length = 16384;
 const oid = 1;


### PR DESCRIPTION
AFAIK: the intent was to use Buffer (from Node), not custom Buffer (for
browser). PG is for Node, not for browser and 3rd party Buffer is not
whitelisted, so it impacted (best guess) recent failing CI tests.

Thanks!

see: #52775
/cc @SimonSchick

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).