### PR TITLE
Update mssql typings for v7 releases

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for mssql 7.1.0
 // Project: https://www.npmjs.com/package/mssql
 // Definitions by: COLSA Corporation <http://www.colsa.com/>
-//                 Matt Richardson <https://github.com/mrrichar>
 //                 Jørgen Elgaard Larsen <https://github.com/elhaard>
 //                 Peter Keuter <https://github.com/pkeuter>
 //                 David Gasperoni <https://github.com/mcdado>

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -11,7 +11,7 @@
 //                 Rifa Achrinza <https://github.com/achrinza>
 //                 Daniel Hensby <https://github.com/dhensby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 3.6
 
 /// <reference types="node" />
 

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for mssql 7.1.0
 // Project: https://www.npmjs.com/package/mssql
 // Definitions by: COLSA Corporation <http://www.colsa.com/>
-//                 Vitor Buzinaro <https://github.com/buzinas>
 //                 Matt Richardson <https://github.com/mrrichar>
 //                 Jørgen Elgaard Larsen <https://github.com/elhaard>
 //                 Peter Keuter <https://github.com/pkeuter>

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mssql 6.0.0
+// Type definitions for mssql 7.1.0
 // Project: https://www.npmjs.com/package/mssql
 // Definitions by: COLSA Corporation <http://www.colsa.com/>
 //                 Vitor Buzinaro <https://github.com/buzinas>
@@ -9,6 +9,7 @@
 //                 Jeff Wooden <https://github.com/woodenconsulting>
 //                 Cahil Foley <https://github.com/cahilfoley>
 //                 Rifa Achrinza <https://github.com/achrinza>
+//                 Daniel Hensby <https://github.com/dhensby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: COLSA Corporation <http://www.colsa.com/>
 //                 Jørgen Elgaard Larsen <https://github.com/elhaard>
 //                 Peter Keuter <https://github.com/pkeuter>
-//                 David Gasperoni <https://github.com/mcdado>
 //                 Jeff Wooden <https://github.com/woodenconsulting>
 //                 Cahil Foley <https://github.com/cahilfoley>
 //                 Rifa Achrinza <https://github.com/achrinza>

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -218,9 +218,14 @@ export declare class MSSQLError extends Error {
 }
 
 export declare class ConnectionPool extends events.EventEmitter {
-    public connected: boolean;
-    public connecting: boolean;
-    public driver: string;
+    public readonly connected: boolean;
+    public readonly connecting: boolean;
+    public readonly healthy: boolean;
+    public readonly driver: string;
+    public readonly size: number;
+    public readonly available: number;
+    public readonly pending: number;
+    public readonly borrowed: number;
     public constructor(config: config, callback?: (err?: any) => void);
     public constructor(connectionString: string, callback?: (err?: any) => void);
     public query(command: string): Promise<IResult<any>>;

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -18,6 +18,7 @@
 
 import events = require('events');
 import tds = require('tedious');
+import msnodesql = require('msnodesqlv8');
 import { Pool } from 'tarn';
 import { CallbackOrPromise, PoolOptions } from 'tarn/dist/Pool';
 export interface ISqlType {
@@ -72,7 +73,7 @@ export declare var Geography: ISqlTypeFactoryWithNoParams;
 export declare var Geometry: ISqlTypeFactoryWithNoParams;
 export declare var Variant: ISqlTypeFactoryWithNoParams;
 
-export type Connection = tds.Connection;
+export type Connection = tds.Connection | msnodesql.Connection;
 
 export declare var TYPES: {
     VarChar: ISqlTypeFactoryWithLength;

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -202,6 +202,7 @@ export interface config {
     parseJSON?: boolean;
     options?: IOptions;
     pool?: IPool;
+    arrayRowMode?: boolean;
     /**
      * Invoked before opening the connection. The parameter conn is the configured
      * tedious Connection. It can be used for attaching event handlers.

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -1,5 +1,6 @@
 import * as sql from 'mssql';
 import * as msnodesqlv8 from 'mssql/msnodesqlv8';
+import tds = require('tedious');
 
 interface Entity {
     value: number;
@@ -14,13 +15,11 @@ var config: sql.config = {
     options: {
         encrypt: true
     },
-    pool: {
-        autostart: true
-    },
-    beforeConnect: conn => {
-        conn.on('debug', message => console.info(message));
-        conn.on('error', err => console.error(err));
-        conn.removeAllListeners();
+    pool: {},
+    beforeConnect: (conn) => {
+        (conn as tds.Connection).on('debug', message => console.info(message));
+        (conn as tds.Connection).on('error', err => console.error(err));
+        (conn as tds.Connection).removeAllListeners();
     }
 }
 

--- a/types/mssql/package.json
+++ b/types/mssql/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "tarn": "^3.0.1"
+    }
+}

--- a/types/mssql/package.json
+++ b/types/mssql/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
+        "msnodesqlv8": "^2.2.0",
         "tarn": "^3.0.1"
     }
 }

--- a/types/mssql/tsconfig.json
+++ b/types/mssql/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "ES5",
         "module": "commonjs",
         "lib": [
             "es6"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/node-mssql/blob/master/CHANGELOG.txt#L1-L26
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Help needed [solved]:

The underlying connection pool in mssql is powered by [Tarn](https://www.npmjs.com/package/tarn). I've attempted to pull this in, but the tests do not like the getter syntax used on `Resource.ts`:

```
Error: Errors in typescript@3.5 for external dependencies:
node_modules/tarn/dist/Resource.d.ts(7,9): error TS1086: An accessor cannot be declared in an ambient context.
```

It looks like this will never pass in typescript@3.5, and really I'm not too interested in the dependencies of mssql passing linting. I've attempted to add `skipLibCheck` to the compiler options, but the tests don't like that either.

Fixed by updating the `// TypeScript Version:` header in the type definitions