### PR TITLE
fix(safer-buffer): resolve 'buffer' with paths

### DIFF
--- a/types/safer-buffer/tsconfig.json
+++ b/types/safer-buffer/tsconfig.json
@@ -12,6 +12,11 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "buffer": [
+                "node/buffer"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
This removes error:

```text
C:\develop\DefinitelyTyped [fix/safer-buffer]> npm test safer-buffer

> definitely-typed@0.0.3 test C:\develop\DefinitelyTyped
> dtslint types "safer-buffer"

Error: C:/develop/DefinitelyTyped/node_modules/buffer/index.d.ts:1:1
ERROR: 1:1  no-outside-dependencies  File
C:/develop/DefinitelyTyped/node_modules/buffer/index.d.ts comes from a
`node_modules` but is not declared in this type's `package.json`.  See:
https://github.com/Microsoft/dtslint/blob/master/docs/no-outside-dependencies.md
```

Thanks!

@sandersn let me know if that is a proper way to address the problems in #52775 (failing CI tests)