### PR TITLE
Add 'clean' script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "not-needed": "node scripts/not-needed.js",
         "update-codeowners": "node scripts/update-codeowners.js",
         "test-all": "node node_modules/@definitelytyped/dtslint-runner/dist/index.js --path .",
+        "clean": "node scripts/remove-empty.js",
         "test": "dtslint types",
         "lint": "dtslint types",
         "prettier": "prettier"

--- a/scripts/remove-empty.js
+++ b/scripts/remove-empty.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+const path = require('path')
+for (const d of fs.readdirSync("../types")) {
+  const dir = path.join("../types", d)
+  const files = fs.readdirSync(dir)
+  if (files.length === 0 || files.length === 1) {
+    console.log("Deleting unused directory", dir)
+    fs.rmdirSync(dir, { recursive: true })
+  }
+}


### PR DESCRIPTION
It removes empty folders from now-removed packages so that test-all will run without complaining. Also removes folders that are empty except for `node_modules`.
