### PR TITLE
[selenium-webdriver] Allow Condition.fn to return Promise<T | null> and null

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -308,6 +308,8 @@ export namespace error {
   function encodeError(err: any): {error: string, message: string};
 }
 
+type ConditionFn<T> = (webdriver: WebDriver) => T | null | Promise<T | null>;
+
 /**
  * Defines a condition for use with WebDriver's WebDriver#wait wait command.
  */
@@ -319,13 +321,13 @@ export class Condition<T> {
    *     evaluate on each iteration of the wait loop.
    * @constructor
    */
-  constructor(message: string, fn: (webdriver: WebDriver) => T);
+  constructor(message: string, fn: ConditionFn<T>);
 
   /** @return {string} A description of this condition. */
   description(): string;
 
   /** @type {function(!WebDriver): OUT} */
-  fn(webdriver: WebDriver): T;
+  fn(webdriver: WebDriver): ConditionFn<T>;
 }
 
 /**

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -524,6 +524,11 @@ function TestWebElementPromise() {
     elementPromise.then((element: webdriver.WebElement) => 'foo', (error: any) => 'bar').then((result: string) => {});
 }
 
+function testCondition() {
+    const conditionString = new webdriver.Condition<string>('message', () => Math.random() > 0.5 ? 'foo' : null);
+    const conditionStringPromise = new webdriver.Condition<string>('message', async () => Math.random() > 0.5 ? 'foo' : null);
+}
+
 declare let stringPromise: Promise<string>;
 
 function TestUntilModule() {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  The JSDoc on Condition doesn't mention this, but the condition fn must allow returning falsey values (driver.wait's documentation mentions this), otherwise it's not a condition. `until` from lib uses `null`, which seems more sensible then encoding every falsey value explicitly (https://github.com/SeleniumHQ/selenium/blob/selenium-4.0.0-beta-3/javascript/node/selenium-webdriver/lib/until.js#L312)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
