### PR TITLE
Add support for type-level augmentation of types in `ref-napi`

### DIFF
--- a/types/ref-napi/ref-napi-tests.ts
+++ b/types/ref-napi/ref-napi-tests.ts
@@ -485,3 +485,13 @@ buffer.reinterpretUntilZeros(number, number);
 
 // $ExpectType Type<any> | undefined
 buffer.type;
+
+// Override types test:
+declare module "ref-napi" {
+    interface UnderlyingTypeOverrideRegistry {
+        "foo": number;
+    }
+}
+
+// $ExpectType Type<number>
+ref.coerceType("foo");


### PR DESCRIPTION
This adds support for module augmentation to override the behavior of `UnderlyingType<T>` when the resulting type is too specific for an individual use case. Default `Type` to TypeScript type relationships are stored in `UnderlyingTypeRegistry`, and user-specific overrides can be achieved by augmenting `UnderlyingTypeOverrideRegistry`. In addition, its now possible to augment the `types`, `alignof`, and `sizeof` types through module augmentation:

In addition, this adds a few tweaks for the `UnderlyingType` results for:
- `byte *` - from `Pointer<number>` to `Buffer | Pointer<number>`)
- `void *` - from `Pointer<void>` to `Pointer<unknown>`, since `void` can't be a value.


```ts
import * as ref from "ref-napi";
// use `bigint` instead of `string | number` for 64-bit integers...
declare module "ref-napi" {
  interface UnderlyingTypeOverrideRegistry {
    int64: bigint;
    uint64: bigint;
    ...
  }
  interface TypesOverrideRegistry {
    int64: Type<bigint>;
    uint64: Type<bigint>;
  }
}

ref.types.int64.get = (buf, offset) => buf[`readBigInt64${ref.endianness}`](offset || 0);
ref.types.int64.set = (buf, offset, val) => buf[`writeBigInt64${ref.endianness}`](val, offset || 0);
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

