### PR TITLE
ffi-napi: Fix library function inference for JavaScript

### DIFF
--- a/types/ffi-napi/ffi-napi-tests.ts
+++ b/types/ffi-napi/ffi-napi-tests.ts
@@ -133,3 +133,13 @@ ffi.Library(null, { x: ["void", [], { abi: 0 }]}).x;
 ffi.Library(null, { x: ["void", [], { varargs: true }]}).x;
 // $ExpectType (args_0: (err: any, value: void) => void) => void
 ffi.Library(null, { x: ["void", [], { async: true }]}).x;
+
+{
+    // Ensure functions types are valid.
+    const PCALLBACK = ffi.Function("bool", ["int32"]);
+    const lib = ffi.Library(null, {
+        foo: ["void", [PCALLBACK]]
+    });
+    const callback = (x: number) => x > 0;
+    lib.foo(callback);
+}

--- a/types/ffi-napi/ffi-napi-tests.ts
+++ b/types/ffi-napi/ffi-napi-tests.ts
@@ -114,3 +114,22 @@ const TArray = ref_array(ref);
     });
     current.atoi('1234');
 }
+
+declare const any: any;
+
+// $ExpectType ForeignFunction<void, []> | VariadicForeignFunction<CoerceType<"void">, []> | ((args_0: (err: any, value: void) => void) => void)
+ffi.Library(null, { x: ["void", [], any]}).x;
+// $ExpectType ForeignFunction<void, []>
+ffi.Library(null, { x: ["void", [], undefined]}).x;
+// $ExpectType ForeignFunction<void, []>
+ffi.Library(null, { x: ["void", [], { }]}).x;
+// $ExpectType ForeignFunction<void, []>
+ffi.Library(null, { x: ["void", [], { varargs: false }]}).x;
+// $ExpectType ForeignFunction<void, []>
+ffi.Library(null, { x: ["void", [], { async: false }]}).x;
+// $ExpectType ForeignFunction<void, []>
+ffi.Library(null, { x: ["void", [], { abi: 0 }]}).x;
+// $ExpectType VariadicForeignFunction<CoerceType<"void">, []>
+ffi.Library(null, { x: ["void", [], { varargs: true }]}).x;
+// $ExpectType (args_0: (err: any, value: void) => void) => void
+ffi.Library(null, { x: ["void", [], { async: true }]}).x;

--- a/types/ffi-napi/index.d.ts
+++ b/types/ffi-napi/index.d.ts
@@ -128,7 +128,7 @@ export function errno(): number;
 export interface Function<
     TReturnType extends ref.Type = ref.Type,
     TArgTypes extends ref.Type[] = ref.Type[]
-> extends ref.Type<ForeignFunction<ref.UnderlyingType<TReturnType>, ref.UnderlyingTypes<TArgTypes>>> {
+> extends ref.Type<(...args: ref.UnderlyingTypes<TArgTypes>) => ref.UnderlyingType<TReturnType>> {
     /** The type of return value. */
     retType: TReturnType;
     /** The type of arguments. */

--- a/types/ffi-napi/index.d.ts
+++ b/types/ffi-napi/index.d.ts
@@ -32,7 +32,7 @@ export type LibraryObjectDefinitionBase = Record<string, [retType: ref.TypeLike,
 export type LibraryObjectDefinitionInferenceMarker = Record<string, [retType: "void", argTypes: ArgTypesInferenceMarker]>;
 
 /**
- * Converts a {@link LibraryObjectDefinitionBase} into a consistent subtype of {@link LibraryDefinitionBase}. If `"any"` is used, it is passed along
+ * Converts a {@link LibraryObjectDefinitionBase} into a consistent subtype of {@link LibraryDefinitionBase}. If `any` is used, it is passed along
  * to be interpreted to use a fallback definition for a union.
  */
 export type LibraryObjectDefinitionToLibraryDefinition<T extends LibraryObjectDefinitionBase> =
@@ -51,6 +51,7 @@ export type LibraryObject<T extends LibraryDefinitionBase> =
     [T] extends [never] | [0] ? any : // catches T extends never/any (since `0` doesn't overlap with our constraint)
     {
         [P in keyof T]:
+            T[P][2] extends undefined ? ForeignFunction<ref.UnderlyingType<T[P][0]>, ref.UnderlyingTypes<T[P][1]>> :
             T[P][2] extends { varargs: true } ? VariadicForeignFunction<T[P][0], T[P][1]> :
             T[P][2] extends { async: true } ? ForeignFunction<ref.UnderlyingType<T[P][0]>, ref.UnderlyingTypes<T[P][1]>>["async"] :
             ForeignFunction<ref.UnderlyingType<T[P][0]>, ref.UnderlyingTypes<T[P][1]>>;


### PR DESCRIPTION
This fixes an inference issue with `ffi.Library` when used from JavaScript. Without the explicit `undefined` branch, JavaScript consumers receive `VariadicForeignFunction` instead of `ForeignFunction`.
