### PR TITLE
ref-struct-di, ref-union-di: Adds a base type for struct and union types

### DIFF
--- a/types/ref-struct-di/index.d.ts
+++ b/types/ref-struct-di/index.d.ts
@@ -108,11 +108,39 @@ declare namespace struct {
         { [P in keyof T]: Field<ref.UnderlyingType<T[P]>>; };
 
     /**
+     * The base type of any {@link StructObjectProperties}
+     */
+    interface StructObjectBase {
+        /**
+         * Flattens the Struct instance into a regular JavaScript Object. This function
+         * "gets" all the defined properties.
+         */
+        toObject(): any;
+        /**
+         * Basic `JSON.stringify(struct)` support.
+         */
+        toJSON(): any;
+        /**
+         * `.inspect()` override. For the REPL.
+         */
+        inspect(): string;
+        /**
+         * Returns a {@link Buffer} pointing to this struct data structure.
+         */
+        ref(): ref.Pointer<this>;
+    }
+
+    /**
      * Converts a {@link StructTypeDefinitionBase} into a an object type representing the runtime shape of a {@link StructType}.
      */
-    type StructObject<T extends StructTypeDefinitionBase> =
+    type StructObjectProperties<T extends StructTypeDefinitionBase> =
         [T] extends [never] | [0] ? Record<string, any> : // catches T extends never/any (since `0` doesn't overlap with our constraint)
         { [P in keyof T]: ref.UnderlyingType<T[P]>; };
+
+    /**
+     * Represents the instance type of a struct type.
+     */
+    type StructObject<T> = StructObjectBase & T;
 
     /**
      * Defines a field in a {@link StructType}.
@@ -132,14 +160,14 @@ declare namespace struct {
      *
      * @constructor
      */
-    interface StructType<TDefinition extends StructTypeDefinitionBase = any> extends ref.Type<StructObject<TDefinition>> {
+    interface StructType<TDefinition extends StructTypeDefinitionBase = any> extends ref.Type<StructObject<StructObjectProperties<TDefinition>>> {
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        new (arg: Buffer, data?: Partial<StructObject<TDefinition>>): StructObject<TDefinition>;
-        new (data?: Partial<StructObject<TDefinition>>): StructObject<TDefinition>;
+        new (arg: Buffer, data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
+        new (data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
 
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        (arg: Buffer, data?: Partial<StructObject<TDefinition>>): StructObject<TDefinition>;
-        (data?: Partial<StructObject<TDefinition>>): StructObject<TDefinition>;
+        (arg: Buffer, data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
+        (data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
 
         fields: StructFields<TDefinition>;
 

--- a/types/ref-struct-di/ref-struct-di-tests.ts
+++ b/types/ref-struct-di/ref-struct-di-tests.ts
@@ -83,30 +83,30 @@ struct.defineProperty(string, typeLike);
 // $ExpectType string
 struct.toString();
 
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 struct();
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 struct(undefined);
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 struct({ x: number });
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 struct(buffer);
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 struct(buffer, undefined);
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 struct(buffer, { x: number });
 
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 new struct();
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 new struct(undefined);
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 new struct({ x: number });
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 new struct(buffer);
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 new struct(buffer, undefined);
-// $ExpectType Record<string, any>
+// $ExpectType StructObject<Record<string, any>>
 new struct(buffer, { x: number });
 
 declare const Point: ref_struct.StructType<{ x: ref.Type<number>, y: ref.Type<number> }>;
@@ -114,28 +114,48 @@ declare const Point: ref_struct.StructType<{ x: ref.Type<number>, y: ref.Type<nu
 // $ExpectType { x: Field<number>; y: Field<number>; }
 Point.fields;
 
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 Point();
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 Point(undefined);
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 Point({ x: number });
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 Point(buffer);
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 Point(buffer, undefined);
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 Point(buffer, { x: number });
 
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 new Point();
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 new Point(undefined);
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 new Point({ x: number });
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 new Point(buffer);
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 new Point(buffer, undefined);
-// $ExpectType { x: number; y: number; }
+// $ExpectType StructObject<{ x: number; y: number; }>
 new Point(buffer, { x: number });
+
+declare const point: ReturnType<typeof Point>;
+
+// $ExpectType number
+point.x;
+
+// $ExpectType number
+point.y;
+
+// $ExpectType any
+point.toObject();
+
+// $ExpectType any
+point.toJSON();
+
+// $ExpectType string
+point.inspect();
+
+// $ExpectType Pointer<StructObject<{ x: number; y: number; }>>
+point.ref();

--- a/types/ref-union-di/index.d.ts
+++ b/types/ref-union-di/index.d.ts
@@ -53,11 +53,26 @@ declare namespace union {
         { [P in keyof T]: Field<ref.UnderlyingType<T[P]>>; };
 
     /**
+     * The base type of any {@link UnionObjectProperties}
+     */
+    interface UnionObjectBase {
+        /**
+         * Returns a {@link Buffer} pointing to this struct data structure.
+         */
+        ref(): ref.Pointer<this>;
+    }
+
+    /**
      * Converts a {@link UnionTypeDefinitionBase} into a an object type representing the runtime shape of a {@link UnionType}.
      */
-    type UnionObject<T extends UnionTypeDefinitionBase> =
+    type UnionObjectProperties<T extends UnionTypeDefinitionBase> =
         [T] extends [never] | [0] ? Record<string, any> : // catches T extends never/any (since `0` doesn't overlap with our constraint)
         { [P in keyof T]: ref.UnderlyingType<T[P]>; };
+
+    /**
+     * Represents the instance type of a union type.
+     */
+    type UnionObject<T> = UnionObjectBase & T;
 
     /**
      * Converts a {@link UnionTypeDefinitionBase} into a union of possible inputs, allowing only a single key/value of the union.
@@ -74,7 +89,7 @@ declare namespace union {
             //          x: { x: number, y?: never };
             //          y: { y: number, x?: never };
             //      }
-            [P in keyof UnionObject<T>]: Pick<UnionObject<T>, P> & Partial<Record<Exclude<keyof UnionObject<T>, P>, never>>;
+            [P in keyof UnionObjectProperties<T>]: Pick<UnionObjectProperties<T>, P> & Partial<Record<Exclude<keyof UnionObjectProperties<T>, P>, never>>;
 
             // Performing an indexed access on the result using the expected keys gives us a union of non-overlapping values.
             //
@@ -85,7 +100,7 @@ declare namespace union {
             //      }
             // Becomes:
             //      { x: number, y?: never } | { y: number, x?: never };
-        }[keyof UnionObject<T>];
+        }[keyof UnionObjectProperties<T>];
 
     /**
      * Defines a field in a {@link UnionType}.
@@ -104,14 +119,14 @@ declare namespace union {
      *
      * @constructor
      */
-    interface UnionType<TDefinition extends UnionTypeDefinitionBase = any> extends ref.Type<UnionObject<TDefinition>> {
+    interface UnionType<TDefinition extends UnionTypeDefinitionBase = any> extends ref.Type<UnionObject<UnionObjectProperties<TDefinition>>> {
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        new (arg: Buffer, data?: UnionInput<TDefinition>): UnionObject<TDefinition>;
-        new (data?: UnionInput<TDefinition>): UnionObject<TDefinition>;
+        new (arg: Buffer, data?: UnionInput<TDefinition>): UnionObject<UnionObjectProperties<TDefinition>>;
+        new (data?: UnionInput<TDefinition>): UnionObject<UnionObjectProperties<TDefinition>>;
 
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        (arg: Buffer, data?: UnionInput<TDefinition>): UnionObject<TDefinition>;
-        (data?: UnionInput<TDefinition>): UnionObject<TDefinition>;
+        (arg: Buffer, data?: UnionInput<TDefinition>): UnionObject<UnionObjectProperties<TDefinition>>;
+        (data?: UnionInput<TDefinition>): UnionObject<UnionObjectProperties<TDefinition>>;
 
         fields: UnionFields<TDefinition>;
 

--- a/types/ref-union-di/ref-union-di-tests.ts
+++ b/types/ref-union-di/ref-union-di-tests.ts
@@ -34,30 +34,30 @@ union.defineProperty(string, typeLike);
 // $ExpectType string
 union.toString();
 
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 union();
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 union(undefined);
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 union({ ival: number });
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 union(buffer);
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 union(buffer, undefined);
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 union(buffer, { ival: number });
 
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 new union();
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 new union(undefined);
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 new union({ ival: number });
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 new union(buffer);
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 new union(buffer, undefined);
-// $ExpectType Record<string, any>
+// $ExpectType UnionObject<Record<string, any>>
 new union(buffer, { ival: number });
 
 declare const int32tofloat32: ref_union.UnionType<{ ival: ref.Type<number>, fval: ref.Type<number> }>;
@@ -65,20 +65,31 @@ declare const int32tofloat32: ref_union.UnionType<{ ival: ref.Type<number>, fval
 // $ExpectType { ival: Field<number>; fval: Field<number>; }
 int32tofloat32.fields;
 
-// $ExpectType { ival: number; fval: number; }
+// $ExpectType UnionObject<{ ival: number; fval: number; }>
 int32tofloat32();
-// $ExpectType { ival: number; fval: number; }
+// $ExpectType UnionObject<{ ival: number; fval: number; }>
 int32tofloat32({ ival: 1 });
-// $ExpectType { ival: number; fval: number; }
+// $ExpectType UnionObject<{ ival: number; fval: number; }>
 int32tofloat32({ fval: 1.1 });
 // @ts-expect-error
 int32tofloat32({ ival: 1, fval: 1.1 });
 
-// $ExpectType { ival: number; fval: number; }
+// $ExpectType UnionObject<{ ival: number; fval: number; }>
 new int32tofloat32();
-// $ExpectType { ival: number; fval: number; }
+// $ExpectType UnionObject<{ ival: number; fval: number; }>
 new int32tofloat32({ ival: 1 });
-// $ExpectType { ival: number; fval: number; }
+// $ExpectType UnionObject<{ ival: number; fval: number; }>
 new int32tofloat32({ fval: 1.1 });
 // @ts-expect-error
 new int32tofloat32({ ival: 1, fval: 1.1 });
+
+declare const i2f: ReturnType<typeof int32tofloat32>;
+
+// $ExpectType number
+i2f.ival;
+
+// $ExpectType number
+i2f.fval;
+
+// $ExpectType Pointer<UnionObject<{ ival: number; fval: number; }>>
+i2f.ref();


### PR DESCRIPTION
This adds missing base type members for `ref-struct-di` and `ref-union-di`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/node-ffi-napi/ref-struct-di/blob/master/lib/struct.js#L322
  - https://github.com/node-ffi-napi/ref-union-di/blob/858792be59a2c75f4a8d8958b1c59c3bb7483671/lib/union.js#L214
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~