### PR TITLE
[sinon] allow partial arguments for calledWith

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1117,20 +1117,20 @@ declare namespace Sinon {
          */
         calledWith<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchArguments<TArgs>
+            ...args: Partial<MatchArguments<TArgs>>
         ): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
          * @param args
          */
-        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;
+        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: Partial<MatchArguments<TArgs>>): void;
         /**
          * Passes if spy was never called with the provided arguments.
          * @param spy
          * @param args
          */
-        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;
+        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: Partial<MatchArguments<TArgs>>): void;
         /**
          * Passes if spy was called with the provided arguments and no others.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -302,6 +302,7 @@ function testAssert() {
     sinon.assert.callOrder(spy, spyTwo);
     sinon.assert.calledOn(spy, obj);
     sinon.assert.calledOn(spy.firstCall, obj);
+    sinon.assert.calledWith(spy, "a", "b", "c");
     sinon.assert.alwaysCalledOn(spy, obj);
     sinon.assert.alwaysCalledWith(spy, "a", "b", "c");
     sinon.assert.neverCalledWith(spy, "a", "b", "c");
@@ -342,11 +343,16 @@ function testAssert() {
     sinon.assert.callOrder(typedSpy, spyTwo);
     sinon.assert.calledOn(typedSpy, obj);
     sinon.assert.calledOn(typedSpy.firstCall, obj);
+    sinon.assert.calledWith(typedSpy, "a", true);
+    sinon.assert.calledWith(typedSpy, "a");
+    sinon.assert.calledWith(typedSpy, "a", "b"); // $ExpectError
     sinon.assert.alwaysCalledOn(typedSpy, obj);
     sinon.assert.alwaysCalledWith(typedSpy, "a", "b", "c"); // $ExpectError
     sinon.assert.alwaysCalledWith(typedSpy, "a", true);
+    sinon.assert.alwaysCalledWith(typedSpy, "a");
     sinon.assert.neverCalledWith(typedSpy, "a", false);
     sinon.assert.neverCalledWith(typedSpy, "a", "b"); // $ExpectError
+    sinon.assert.neverCalledWith(typedSpy, "a");
     sinon.assert.calledWithExactly(typedSpy, "a", true);
     sinon.assert.calledWithExactly(typedSpy, "a", "b"); // $ExpectError
     sinon.assert.alwaysCalledWithExactly(typedSpy, "a", true);


### PR DESCRIPTION
Allow partial arguments for `calledWith`, `alwaysCalledWith` and `neverCalledWith` as this is a valid usecase.

Only the `xxxExactly` asserts verify all arguments.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v11.1.1/assertions/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


