### PR TITLE
[request-ip] Request.connection is not required

### DIFF
--- a/types/request-ip/index.d.ts
+++ b/types/request-ip/index.d.ts
@@ -20,7 +20,7 @@ interface RequestHeaders extends http.IncomingHttpHeaders {
 
 interface Request {
     headers: RequestHeaders;
-    connection: {
+    connection?: {
         remoteAddress?: string;
         socket?: {
             remoteAddress?: string


### PR DESCRIPTION
As written in the package code : https://github.com/pbojinov/request-ip/blob/master/src/index.js#L107
the connection attribute in the Request parameter is not required.
This is problematic for @hapi/hapi for which the `connection` attribute does not exist.

-----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pbojinov/request-ip/blob/master/src/index.js#L107
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
