### PR TITLE
Dinerojs. Introduce array containing all corrency codes

### DIFF
--- a/types/dinero.js/index.d.ts
+++ b/types/dinero.js/index.d.ts
@@ -92,184 +92,187 @@ declare namespace DineroFactory {
      * Taken from https://www.iso.org/iso-4217-currency-codes.html
      * sorted and parsed
      */
-    type Currency =
-        | 'AED'
-        | 'AFN'
-        | 'ALL'
-        | 'AMD'
-        | 'ANG'
-        | 'AOA'
-        | 'ARS'
-        | 'AUD'
-        | 'AWG'
-        | 'AZN'
-        | 'BAM'
-        | 'BBD'
-        | 'BDT'
-        | 'BGN'
-        | 'BHD'
-        | 'BIF'
-        | 'BMD'
-        | 'BND'
-        | 'BOB'
-        | 'BOV'
-        | 'BRL'
-        | 'BSD'
-        | 'BTN'
-        | 'BWP'
-        | 'BYN'
-        | 'BZD'
-        | 'CAD'
-        | 'CDF'
-        | 'CHE'
-        | 'CHF'
-        | 'CHW'
-        | 'CLF'
-        | 'CLP'
-        | 'CNY'
-        | 'COP'
-        | 'COU'
-        | 'CRC'
-        | 'CUC'
-        | 'CUP'
-        | 'CVE'
-        | 'CZK'
-        | 'DJF'
-        | 'DKK'
-        | 'DOP'
-        | 'DZD'
-        | 'EGP'
-        | 'ERN'
-        | 'ETB'
-        | 'EUR'
-        | 'FJD'
-        | 'FKP'
-        | 'GBP'
-        | 'GEL'
-        | 'GHS'
-        | 'GIP'
-        | 'GMD'
-        | 'GNF'
-        | 'GTQ'
-        | 'GYD'
-        | 'HKD'
-        | 'HNL'
-        | 'HRK'
-        | 'HTG'
-        | 'HUF'
-        | 'IDR'
-        | 'ILS'
-        | 'INR'
-        | 'IQD'
-        | 'IRR'
-        | 'ISK'
-        | 'JMD'
-        | 'JOD'
-        | 'JPY'
-        | 'KES'
-        | 'KGS'
-        | 'KHR'
-        | 'KMF'
-        | 'KPW'
-        | 'KRW'
-        | 'KWD'
-        | 'KYD'
-        | 'KZT'
-        | 'LAK'
-        | 'LBP'
-        | 'LKR'
-        | 'LRD'
-        | 'LSL'
-        | 'LYD'
-        | 'MAD'
-        | 'MDL'
-        | 'MGA'
-        | 'MKD'
-        | 'MMK'
-        | 'MNT'
-        | 'MOP'
-        | 'MRU'
-        | 'MUR'
-        | 'MVR'
-        | 'MWK'
-        | 'MXN'
-        | 'MXV'
-        | 'MYR'
-        | 'MZN'
-        | 'NAD'
-        | 'NGN'
-        | 'NIO'
-        | 'NOK'
-        | 'NPR'
-        | 'NZD'
-        | 'OMR'
-        | 'PAB'
-        | 'PEN'
-        | 'PGK'
-        | 'PHP'
-        | 'PKR'
-        | 'PLN'
-        | 'PYG'
-        | 'QAR'
-        | 'RON'
-        | 'RSD'
-        | 'RUB'
-        | 'RWF'
-        | 'SAR'
-        | 'SBD'
-        | 'SCR'
-        | 'SDG'
-        | 'SEK'
-        | 'SGD'
-        | 'SHP'
-        | 'SLL'
-        | 'SOS'
-        | 'SRD'
-        | 'SSP'
-        | 'STN'
-        | 'SVC'
-        | 'SYP'
-        | 'SZL'
-        | 'THB'
-        | 'TJS'
-        | 'TMT'
-        | 'TND'
-        | 'TOP'
-        | 'TRY'
-        | 'TTD'
-        | 'TWD'
-        | 'TZS'
-        | 'UAH'
-        | 'UGX'
-        | 'USD'
-        | 'USN'
-        | 'UYI'
-        | 'UYU'
-        | 'UYW'
-        | 'UZS'
-        | 'VES'
-        | 'VND'
-        | 'VUV'
-        | 'WST'
-        | 'XAF'
-        | 'XAG'
-        | 'XAU'
-        | 'XBA'
-        | 'XBB'
-        | 'XBC'
-        | 'XBD'
-        | 'XCD'
-        | 'XDR'
-        | 'XOF'
-        | 'XPD'
-        | 'XPF'
-        | 'XPT'
-        | 'XSU'
-        | 'XTS'
-        | 'XUA'
-        | 'XXX'
-        | 'YER'
-        | 'ZAR'
-        | 'ZMW'
-        | 'ZWL';
+    const Currencies = [
+        'AED',
+        'AFN',
+        'ALL',
+        'AMD',
+        'ANG',
+        'AOA',
+        'ARS',
+        'AUD',
+        'AWG',
+        'AZN',
+        'BAM',
+        'BBD',
+        'BDT',
+        'BGN',
+        'BHD',
+        'BIF',
+        'BMD',
+        'BND',
+        'BOB',
+        'BOV',
+        'BRL',
+        'BSD',
+        'BTN',
+        'BWP',
+        'BYN',
+        'BZD',
+        'CAD',
+        'CDF',
+        'CHE',
+        'CHF',
+        'CHW',
+        'CLF',
+        'CLP',
+        'CNY',
+        'COP',
+        'COU',
+        'CRC',
+        'CUC',
+        'CUP',
+        'CVE',
+        'CZK',
+        'DJF',
+        'DKK',
+        'DOP',
+        'DZD',
+        'EGP',
+        'ERN',
+        'ETB',
+        'EUR',
+        'FJD',
+        'FKP',
+        'GBP',
+        'GEL',
+        'GHS',
+        'GIP',
+        'GMD',
+        'GNF',
+        'GTQ',
+        'GYD',
+        'HKD',
+        'HNL',
+        'HRK',
+        'HTG',
+        'HUF',
+        'IDR',
+        'ILS',
+        'INR',
+        'IQD',
+        'IRR',
+        'ISK',
+        'JMD',
+        'JOD',
+        'JPY',
+        'KES',
+        'KGS',
+        'KHR',
+        'KMF',
+        'KPW',
+        'KRW',
+        'KWD',
+        'KYD',
+        'KZT',
+        'LAK',
+        'LBP',
+        'LKR',
+        'LRD',
+        'LSL',
+        'LYD',
+        'MAD',
+        'MDL',
+        'MGA',
+        'MKD',
+        'MMK',
+        'MNT',
+        'MOP',
+        'MRU',
+        'MUR',
+        'MVR',
+        'MWK',
+        'MXN',
+        'MXV',
+        'MYR',
+        'MZN',
+        'NAD',
+        'NGN',
+        'NIO',
+        'NOK',
+        'NPR',
+        'NZD',
+        'OMR',
+        'PAB',
+        'PEN',
+        'PGK',
+        'PHP',
+        'PKR',
+        'PLN',
+        'PYG',
+        'QAR',
+        'RON',
+        'RSD',
+        'RUB',
+        'RWF',
+        'SAR',
+        'SBD',
+        'SCR',
+        'SDG',
+        'SEK',
+        'SGD',
+        'SHP',
+        'SLL',
+        'SOS',
+        'SRD',
+        'SSP',
+        'STN',
+        'SVC',
+        'SYP',
+        'SZL',
+        'THB',
+        'TJS',
+        'TMT',
+        'TND',
+        'TOP',
+        'TRY',
+        'TTD',
+        'TWD',
+        'TZS',
+        'UAH',
+        'UGX',
+        'USD',
+        'USN',
+        'UYI',
+        'UYU',
+        'UYW',
+        'UZS',
+        'VES',
+        'VND',
+        'VUV',
+        'WST',
+        'XAF',
+        'XAG',
+        'XAU',
+        'XBA',
+        'XBB',
+        'XBC',
+        'XBD',
+        'XCD',
+        'XDR',
+        'XOF',
+        'XPD',
+        'XPF',
+        'XPT',
+        'XSU',
+        'XTS',
+        'XUA',
+        'XXX',
+        'YER',
+        'ZAR',
+        'ZMW',
+        'ZWL',
+    ] as const;
+
+    type Currency = typeof Currencies[number]
 }

--- a/types/dinero.js/index.d.ts
+++ b/types/dinero.js/index.d.ts
@@ -274,5 +274,5 @@ declare namespace DineroFactory {
         'ZWL',
     ] as const;
 
-    type Currency = typeof Currencies[number]
+    type Currency = typeof Currencies[number];
 }


### PR DESCRIPTION
Introduce array containing all corrency codes and creating a type from it. This will help all Swagger users to have proper Currency type.

Currently it is not possible tell Swagger to use Currency type, because type can not be used as value inside `@ApiProperty` decorator. With having all currencies as an array, we could use it like this `@ApiProperty({enum: Currencies})` so the value of currency property will match with Currency type

This will not bring any breaking changes into existing solution.

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes

There is no source for describing context of the change, but a typescript error when Currency is being used as value in `@ApiProperty` decorator:

'Currency' only refers to a type, but is being used as a value here.ts(2693)