### PR TITLE
Disable npm-naming rule for duo_web_sdk

### DIFF
--- a/types/duo_web_sdk/tslint.json
+++ b/types/duo_web_sdk/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
duo_web_sdk was the target of a namesquatting attack on npm, where
somebody published a malicious package hoping that somebody would depend
on it, not realising that duo_web_sdk isn't on npm.

Even though the malicious code has been taken down, duo_web_sdk remains
on npm, causing the npm-naming lint rule to fail for @types/duo_web_sdk.
This PR disables that rule. In the event that a real duo_web_sdk author
publishes a duo_web_sdk to npm, the exemption can be removed and
"non-npm package" can be removed from the header in index.d.ts.