### PR TITLE
[sharp] Add `density` property to `WriteableMetadata` interface

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -726,7 +726,7 @@ declare namespace sharp {
         /** Object keyed by IFD0, IFD1 etc. of key/value string pairs to write as EXIF data. (optional, default {}) */
         exif?: Record<string, any>;
         /** Number of pixels per inch (DPI) */
-        density?: number
+        density?: number;
     }
 
     interface Metadata {

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -725,6 +725,8 @@ declare namespace sharp {
         icc?: string;
         /** Object keyed by IFD0, IFD1 etc. of key/value string pairs to write as EXIF data. (optional, default {}) */
         exif?: Record<string, any>;
+        /** Number of pixels per inch (DPI) */
+        density?: number
     }
 
     interface Metadata {

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -31,6 +31,7 @@ sharp("input.png")
     .sharpen()
     .withMetadata()
     .withMetadata({
+        density: 96,
         orientation: 8,
         icc: "some/path",
         exif: { IFD0: { Copyright: "Wernham Hogg" } },


### PR DESCRIPTION
This pull request adds the `density` property to the `WriteableMetadata` introduced in `sharp@0.28.2` 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lovell/sharp/issues/967#issuecomment-821818957
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.