### PR TITLE
[@types/styled-components] Allow type hinting for props

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -255,9 +255,7 @@ export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = 
     : C;
 export type StyledComponentPropsWithRef<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-> = C extends React.ComponentType<infer I>
-    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<React.ComponentType<I>>>
-    : React.ComponentPropsWithRef<C>;
+> = React.ComponentPropsWithRef<C>;
 export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
     any,
     any,

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -255,8 +255,8 @@ export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = 
     : C;
 export type StyledComponentPropsWithRef<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-> = C extends AnyStyledComponent
-    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
+> = C extends React.ComponentType<infer I>
+    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<React.ComponentType<I>>>
     : React.ComponentPropsWithRef<C>;
 export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
     any,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #53033
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As C always extends to `AnyStyledComponent` the props type always seems to resolve to `any`. Adding a more specific condition avoids this issue.
EDIT: At east I don't have any type hints for the props in the test/index.tsx, without this change. Maybe you can also give me some more insights on this.