### PR TITLE
fix(tailwindcss): Remove readonly modifiers and some other refactors

### DIFF
--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -1183,9 +1183,9 @@ export interface TailwindConfig {
     readonly plugins: any[];
     readonly purge: any[];
     readonly presets: any[];
-    readonly darkMode: false;
+    darkMode: false | 'media' | 'class';
     readonly variantOrder: Variant[];
     readonly prefix: string;
-    readonly important: false;
+    important: boolean;
     readonly separator: string;
 }

--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -1185,7 +1185,7 @@ export interface TailwindConfig {
     readonly presets: any[];
     darkMode: false | 'media' | 'class';
     readonly variantOrder: Variant[];
-    readonly prefix: string;
+    prefix: string;
     important: boolean;
     readonly separator: string;
 }

--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -103,7 +103,7 @@ export interface TailwindColorConfig {
 }
 
 export interface TailwindConfig {
-    readonly theme: {
+    readonly theme: Partial<{
         readonly extend: Omit<TailwindConfig['theme'], 'extend'>
         readonly screens: {
             readonly sm: string;
@@ -937,8 +937,8 @@ export interface TailwindConfig {
             readonly '50': string;
             readonly auto: string;
         };
-    };
-    readonly variants: {
+    }>;
+    readonly variants: Partial<{
         readonly extend: Omit<TailwindConfig['variants'], 'extend'>
         readonly accessibility: Variant[];
         readonly alignContent: Variant[];
@@ -1058,7 +1058,7 @@ export interface TailwindConfig {
         readonly width: Variant[];
         readonly wordBreak: Variant[];
         readonly zIndex: Variant[];
-    };
+    }>;
     readonly corePlugins: [
         'preflight',
         'container',

--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -1180,9 +1180,9 @@ export interface TailwindConfig {
         'transitionDelay',
         'animation',
     ];
-    readonly plugins: [];
-    readonly purge: [];
-    readonly presets: [];
+    readonly plugins: any[];
+    readonly purge: any[];
+    readonly presets: any[];
     readonly darkMode: false;
     readonly variantOrder: Variant[];
     readonly prefix: string;

--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -103,7 +103,7 @@ export interface TailwindColorConfig {
 }
 
 export interface TailwindConfig {
-    readonly theme: Partial<{
+    theme: Partial<{
         readonly extend: Omit<TailwindConfig['theme'], 'extend'>
         readonly screens: {
             readonly sm: string;
@@ -938,7 +938,7 @@ export interface TailwindConfig {
             readonly auto: string;
         };
     }>;
-    readonly variants: Partial<{
+    variants: Partial<{
         readonly extend: Omit<TailwindConfig['variants'], 'extend'>
         readonly accessibility: Variant[];
         readonly alignContent: Variant[];
@@ -1059,7 +1059,7 @@ export interface TailwindConfig {
         readonly wordBreak: Variant[];
         readonly zIndex: Variant[];
     }>;
-    readonly corePlugins: [
+    corePlugins: [
         'preflight',
         'container',
         'space',
@@ -1180,12 +1180,12 @@ export interface TailwindConfig {
         'transitionDelay',
         'animation',
     ];
-    readonly plugins: any[];
-    readonly purge: any[];
-    readonly presets: any[];
+    plugins: any[];
+    purge: any[];
+    presets: any[];
     darkMode: false | 'media' | 'class';
-    readonly variantOrder: Variant[];
+    variantOrder: Variant[];
     prefix: string;
     important: boolean;
-    readonly separator: string;
+    separator: string;
 }

--- a/types/tailwindcss/tailwindcss-tests.ts
+++ b/types/tailwindcss/tailwindcss-tests.ts
@@ -6,7 +6,7 @@ import * as defaultTheme from 'tailwindcss/defaultTheme';
 
 import type { TailwindConfig } from 'tailwindcss/tailwind-config';
 
-import tailwindCss = require('tailwindcss');
+import tailwindCss from 'tailwindcss';
 
 // A typical TailwindCSS Config
 const configWithoutExtend: Omit<TailwindConfig, 'theme' | 'variants'> & {

--- a/types/tailwindcss/tailwindcss-tests.ts
+++ b/types/tailwindcss/tailwindcss-tests.ts
@@ -2521,7 +2521,7 @@ tailwindCss(tailwindConfig);
 
 tailwindConfig.theme.height;
 
-// @ts-expect-error
+// @ts-expect-error `colors` is possibly undefined
 tailwindConfig.theme.colors.gray[100];
 
 // $ExpectType string | undefined
@@ -2529,21 +2529,21 @@ tailwindConfig.theme.colors?.gray[100];
 
 // Examples from https://tailwindcss.com/docs/configuration#referencing-in-java-script
 
-// @ts-expect-error
+// @ts-expect-error `width` is possibly undefined
 tailwindConfig.theme.width[4];
 
 // $ExpectType string | undefined
 tailwindConfig.theme.width?.[4];
 // => '1rem'
 
-// @ts-expect-error
+// @ts-expect-error `screens` is possibly undefined
 tailwindConfig.theme.screens.md;
 
 // $ExpectType string | undefined
 tailwindConfig.theme.screens?.md;
 // => '768px'
 
-// @ts-expect-error
+// @ts-expect-error `boxShadow` is possibly undefined
 tailwindConfig.theme.boxShadow['2xl'];
 
 // $ExpectType string | undefined
@@ -2566,10 +2566,10 @@ colors.trueGray[500];
 colors.coolGray[500];
 colors.blueGray[500];
 
-// @ts-expect-error
+// @ts-expect-error `darkMode` isn't a property of `theme`
 defaultTheme.darkMode;
 
-// @ts-expect-error
+// @ts-expect-error `colors` is possibly undefined
 defaultTheme.colors.blue[800];
 
 // $ExpectType string | undefined
@@ -2589,10 +2589,10 @@ tailwindConfig.darkMode;
 
 tailwindConfig.darkMode = false;
 
-// @ts-expect-error
+// @ts-expect-error cannot assign `true`. `darkMode` isn't boolean
 tailwindConfig.darkMode = true;
 
-// @ts-expect-error
+// @ts-expect-error accepts only specific values
 tailwindConfig.darkMode = 'invalid-value';
 
 // $ExpectType Variant[]
@@ -2600,7 +2600,7 @@ tailwindConfig.variantOrder;
 
 tailwindConfig.variantOrder = ['active', 'checked'];
 
-// @ts-expect-error
+// @ts-expect-error value should be an array of Variant
 tailwindConfig.variantOrder = false;
 
 // $ExpectType string
@@ -2608,7 +2608,7 @@ tailwindConfig.prefix;
 
 tailwindConfig.prefix = 'tw-';
 
-// @ts-expect-error
+// @ts-expect-error value should be string
 tailwindConfig.prefix = 1000;
 
 // $ExpectType boolean
@@ -2616,7 +2616,7 @@ tailwindConfig.important;
 
 tailwindConfig.important = false;
 
-// @ts-expect-error
+// @ts-expect-error should be boolean
 tailwindConfig.important = 'false';
 
 // $ExpectType string
@@ -2624,5 +2624,5 @@ tailwindConfig.separator;
 
 tailwindConfig.separator = '_';
 
-// @ts-expect-error
+// @ts-expect-error should be string
 tailwindConfig.separator = 1234;

--- a/types/tailwindcss/tailwindcss-tests.ts
+++ b/types/tailwindcss/tailwindcss-tests.ts
@@ -2587,17 +2587,42 @@ tailwindConfig.presets;
 // $ExpectType false | "media" | "class"
 tailwindConfig.darkMode;
 
+tailwindConfig.darkMode = false;
+
 // @ts-expect-error
 tailwindConfig.darkMode = true;
 
 // @ts-expect-error
-tailwindConfig.darkMode = "test-value";
+tailwindConfig.darkMode = 'invalid-value';
 
-// $ExpectType boolean
-tailwindConfig.important;
+// $ExpectType Variant[]
+tailwindConfig.variantOrder;
+
+tailwindConfig.variantOrder = ['active', 'checked'];
+
+// @ts-expect-error
+tailwindConfig.variantOrder = false;
 
 // $ExpectType string
 tailwindConfig.prefix;
 
+tailwindConfig.prefix = 'tw-';
+
 // @ts-expect-error
 tailwindConfig.prefix = 1000;
+
+// $ExpectType boolean
+tailwindConfig.important;
+
+tailwindConfig.important = false;
+
+// @ts-expect-error
+tailwindConfig.important = 'false';
+
+// $ExpectType string
+tailwindConfig.separator;
+
+tailwindConfig.separator = '_';
+
+// @ts-expect-error
+tailwindConfig.separator = 1234;

--- a/types/tailwindcss/tailwindcss-tests.ts
+++ b/types/tailwindcss/tailwindcss-tests.ts
@@ -2520,17 +2520,34 @@ const tailwindConfig = resolveConfig(config);
 tailwindCss(tailwindConfig);
 
 tailwindConfig.theme.height;
+
+// @ts-expect-error
 tailwindConfig.theme.colors.gray[100];
+
+// $ExpectType string | undefined
+tailwindConfig.theme.colors?.gray[100];
 
 // Examples from https://tailwindcss.com/docs/configuration#referencing-in-java-script
 
+// @ts-expect-error
 tailwindConfig.theme.width[4];
+
+// $ExpectType string | undefined
+tailwindConfig.theme.width?.[4];
 // => '1rem'
 
+// @ts-expect-error
 tailwindConfig.theme.screens.md;
+
+// $ExpectType string | undefined
+tailwindConfig.theme.screens?.md;
 // => '768px'
 
+// @ts-expect-error
 tailwindConfig.theme.boxShadow['2xl'];
+
+// $ExpectType string | undefined
+tailwindConfig.theme.boxShadow?.['2xl'];
 // => '0 25px 50px -12px rgba(0, 0, 0, 0.25)'
 
 colors.red[500];
@@ -2551,4 +2568,30 @@ colors.blueGray[500];
 
 // @ts-expect-error
 defaultTheme.darkMode;
+
+// @ts-expect-error
 defaultTheme.colors.blue[800];
+
+// $ExpectType string | undefined
+defaultTheme.colors?.blue[800];
+
+// $ExpectType any[]
+tailwindConfig.plugins;
+
+// $ExpectType any[]
+tailwindConfig.purge;
+
+// $ExpectType any[]
+tailwindConfig.presets;
+
+// $ExpectType false | "media" | "class"
+tailwindConfig.darkMode;
+
+// @ts-expect-error
+tailwindConfig.darkMode = true;
+
+// @ts-expect-error
+tailwindConfig.darkMode = "test-value";
+
+// $ExpectType boolean
+tailwindConfig.important;

--- a/types/tailwindcss/tailwindcss-tests.ts
+++ b/types/tailwindcss/tailwindcss-tests.ts
@@ -2595,3 +2595,9 @@ tailwindConfig.darkMode = "test-value";
 
 // $ExpectType boolean
 tailwindConfig.important;
+
+// $ExpectType string
+tailwindConfig.prefix;
+
+// @ts-expect-error
+tailwindConfig.prefix = 1000;

--- a/types/tailwindcss/tsconfig.json
+++ b/types/tailwindcss/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
I've noticed that some properties have readonly modifier, and it isn't helpful when using the config interface in a Tailwind config file. 
I have removed them and add some tests as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://tailwindcss.com/docs/configuration>>