### PR TITLE
Update es-aggregate-error

### DIFF
--- a/types/es-aggregate-error/OTHER_FILES.txt
+++ b/types/es-aggregate-error/OTHER_FILES.txt
@@ -1,0 +1,2 @@
+auto.d.ts
+requirePromise.d.ts

--- a/types/es-aggregate-error/OTHER_FILES.txt
+++ b/types/es-aggregate-error/OTHER_FILES.txt
@@ -1,2 +1,1 @@
 auto.d.ts
-requirePromise.d.ts

--- a/types/es-aggregate-error/auto.d.ts
+++ b/types/es-aggregate-error/auto.d.ts
@@ -1,0 +1,5 @@
+// This file exists only to reflect the existence of the auto.js file in the source package, which has a side-effect
+// when imported.
+
+declare const exports: {};
+export = exports;

--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -1,4 +1,4 @@
-import AggregateError from "es-aggregate-error";
+import AggregateError = require("es-aggregate-error");
 
 const oneError = new RangeError("hi!");
 const otherError = new EvalError("oops");

--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -17,7 +17,7 @@ new AggregateError([oneError, otherError]); // $ExpectType AggregateError
 // $ExpectType AggregateError
 const error = new AggregateError([oneError, otherError], 'this is two kinds of errors');
 
-AggregateError.shim; // $ExpectType () => void
+AggregateError.shim; // $ExpectType (() => void) & (() => typeof AggregateError)
 AggregateError.shim(); // $ExpectType: void
 
 error.errors; // $ExpectType: Array<unknown>

--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -1,8 +1,4 @@
 import AggregateError = require('es-aggregate-error');
-import 'es-aggregate-error/auto';
-import 'es-aggregate-error/implementation';
-import 'es-aggregate-error/polyfill';
-import 'es-aggregate-error/shim';
 
 const oneError = new RangeError('hi!');
 const otherError = new EvalError('oops');

--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -1,17 +1,21 @@
-import AggregateError = require("es-aggregate-error");
+import AggregateError = require('es-aggregate-error');
+import 'es-aggregate-error/auto';
+import 'es-aggregate-error/implementation';
+import 'es-aggregate-error/polyfill';
+import 'es-aggregate-error/shim';
 
-const oneError = new RangeError("hi!");
-const otherError = new EvalError("oops");
+const oneError = new RangeError('hi!');
+const otherError = new EvalError('oops');
 
 new AggregateError(); // $ExpectError
-new AggregateError("this is not an error"); // $ExpectError
-AggregateError([oneError, otherError], "this is two kinds of errors"); // $ExpectError
+new AggregateError('this is not an error'); // $ExpectError
+AggregateError([oneError, otherError], 'this is two kinds of errors'); // $ExpectError
 
 new AggregateError([]); // $ExpectType AggregateError
 new AggregateError([oneError, otherError]); // $ExpectType AggregateError
 
 // $ExpectType AggregateError
-const error = new AggregateError([oneError, otherError], "this is two kinds of errors");
+const error = new AggregateError([oneError, otherError], 'this is two kinds of errors');
 
 AggregateError.shim; // $ExpectType () => void
 AggregateError.shim(); // $ExpectType: void
@@ -20,4 +24,4 @@ error.errors; // $ExpectType: Array<unknown>
 error.name; // $ExpectType: "AggregateError"
 error.message; // $ExpectType: string
 
-error.name = "something else"; // $ExpectError
+error.name = 'something else'; // $ExpectError

--- a/types/es-aggregate-error/implementation.d.ts
+++ b/types/es-aggregate-error/implementation.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="node" />
+
+declare class AggregateError extends Error implements NodeJS.ErrnoException {
+    readonly errors: ReadonlyArray<any>;
+    readonly name: 'AggregateError';
+    readonly message: string;
+
+    // any here, to match Node's own typings
+
+    constructor(errors: ReadonlyArray<any>, message?: string);
+
+    static shim(): void;
+}
+
+export = AggregateError;

--- a/types/es-aggregate-error/index.d.ts
+++ b/types/es-aggregate-error/index.d.ts
@@ -3,16 +3,21 @@
 // Definitions by: AverageHelper <https://github.com/AverageHelper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
+import implementation = require('./implementation');
+import getPolyfill = require('./polyfill');
+import shim = require('./shim');
 
-declare class AggregateError extends Error implements NodeJS.ErrnoException {
-    readonly errors: ReadonlyArray<unknown>;
-    readonly name: "AggregateError";
-    readonly message: string;
+type ExportedImplementationType = typeof implementation & {
+    getPolyfill: typeof getPolyfill;
+    implementation: typeof implementation;
+    shim: typeof shim;
+};
 
-    constructor(errors: ReadonlyArray<unknown>, message?: string);
+declare const exportedImplementation: ExportedImplementationType;
 
-    static shim(): void;
+export = exportedImplementation;
+
+// This seems to be the only way to export these types here without colliding with the "export =" syntax.
+declare namespace exportedImplementation {
+    type AggregateError = implementation;
 }
-
-export = AggregateError;

--- a/types/es-aggregate-error/polyfill.d.ts
+++ b/types/es-aggregate-error/polyfill.d.ts
@@ -1,0 +1,5 @@
+import implementation = require('./implementation');
+
+declare function getPolyfill(): typeof implementation;
+
+export = getPolyfill;

--- a/types/es-aggregate-error/shim.d.ts
+++ b/types/es-aggregate-error/shim.d.ts
@@ -1,0 +1,5 @@
+import implementation = require('./implementation');
+
+declare function shimAggregateError(): typeof implementation;
+
+export = shimAggregateError;

--- a/types/es-aggregate-error/tsconfig.json
+++ b/types/es-aggregate-error/tsconfig.json
@@ -7,7 +7,6 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
-        "esModuleInterop": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
* Removed `esModuleInterop` flag, as per [DefinitelyTyped/README](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#esmoduleinteropallowsyntheticdefaultimports).
* Added interfaces for additional importable files

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test es-aggregate-error`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [DefinitelyTyped/README](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#esmoduleinteropallowsyntheticdefaultimports)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
