### PR TITLE
Add promise.any

### DIFF
--- a/types/promise.any/OTHER_FILES.txt
+++ b/types/promise.any/OTHER_FILES.txt
@@ -1,0 +1,2 @@
+auto.d.ts
+requirePromise.d.ts

--- a/types/promise.any/auto.d.ts
+++ b/types/promise.any/auto.d.ts
@@ -1,0 +1,5 @@
+// This file exists only to reflect the existence of the auto.js file in the source package, which has a side-effect
+// when imported.
+
+declare const exports: {};
+export = exports;

--- a/types/promise.any/implementation.d.ts
+++ b/types/promise.any/implementation.d.ts
@@ -1,0 +1,5 @@
+declare function any<T>(
+    iterable: ReadonlyArray<T | PromiseLike<T>> | Readonly<Iterable<T | PromiseLike<T>>>,
+): Promise<T>;
+
+export = any;

--- a/types/promise.any/index.d.ts
+++ b/types/promise.any/index.d.ts
@@ -2,10 +2,11 @@
 // Project: https://github.com/es-shims/Promise.any#readme
 // Definitions by: AverageHelper <https://github.com/AverageHelper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
 
-import implementation = require("./implementation");
-import getPolyfill = require("./polyfill");
-import shim = require("./shim");
+import implementation = require('./implementation');
+import getPolyfill = require('./polyfill');
+import shim = require('./shim');
 
 type ExportedImplementationType = typeof implementation & {
     getPolyfill: typeof getPolyfill;

--- a/types/promise.any/index.d.ts
+++ b/types/promise.any/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for promise.any 2.0
+// Project: https://github.com/es-shims/Promise.any#readme
+// Definitions by: AverageHelper <https://github.com/AverageHelper>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import implementation = require("./implementation");
+import getPolyfill = require("./polyfill");
+import shim = require("./shim");
+
+type ExportedImplementationType = typeof implementation & {
+    getPolyfill: typeof getPolyfill;
+    implementation: typeof implementation;
+    shim: typeof shim;
+};
+
+declare const exportedImplementation: ExportedImplementationType;
+
+export = exportedImplementation;

--- a/types/promise.any/polyfill.d.ts
+++ b/types/promise.any/polyfill.d.ts
@@ -1,0 +1,5 @@
+import implementation = require('./implementation');
+
+declare function getPolyfill(): typeof implementation;
+
+export = getPolyfill;

--- a/types/promise.any/promise.any-tests.ts
+++ b/types/promise.any/promise.any-tests.ts
@@ -1,5 +1,5 @@
-import assert = require("assert");
-import any = require("promise.any");
+import assert = require('assert');
+import any = require('promise.any');
 
 const resolved = Promise.resolve(42);
 const rejected = Promise.reject(-1);
@@ -9,22 +9,22 @@ any(); // $ExpectError
 
 any([]); // $ExpectType Promise<never>
 
-any([resolved, rejected, alsoRejected]).then(function (result) {
+any([resolved, rejected, alsoRejected]).then(result => {
     assert.strictEqual(result, 42);
 });
 
-any([rejected, alsoRejected]).catch(function (error) {
+any([rejected, alsoRejected]).catch(error => {
     assert.ok(error instanceof AggregateError);
     assert.strictEqual(error.errors, [-1, Infinity]);
 });
 
 any.shim();
 
-Promise.any([resolved, rejected, alsoRejected]).then(function (result) {
+Promise.any([resolved, rejected, alsoRejected]).then(result => {
     assert.strictEqual(result, 42);
 });
 
-Promise.any([rejected, alsoRejected]).catch(function (error) {
+Promise.any([rejected, alsoRejected]).catch(error => {
     assert.ok(error instanceof AggregateError);
     assert.strictEqual(error.errors, [-1, Infinity]);
 });

--- a/types/promise.any/promise.any-tests.ts
+++ b/types/promise.any/promise.any-tests.ts
@@ -1,0 +1,30 @@
+import assert = require("assert");
+import any = require("promise.any");
+
+const resolved = Promise.resolve(42);
+const rejected = Promise.reject(-1);
+const alsoRejected = Promise.reject(Infinity);
+
+any(); // $ExpectError
+
+any([]); // $ExpectType Promise<never>
+
+any([resolved, rejected, alsoRejected]).then(function (result) {
+    assert.strictEqual(result, 42);
+});
+
+any([rejected, alsoRejected]).catch(function (error) {
+    assert.ok(error instanceof AggregateError);
+    assert.strictEqual(error.errors, [-1, Infinity]);
+});
+
+any.shim();
+
+Promise.any([resolved, rejected, alsoRejected]).then(function (result) {
+    assert.strictEqual(result, 42);
+});
+
+Promise.any([rejected, alsoRejected]).catch(function (error) {
+    assert.ok(error instanceof AggregateError);
+    assert.strictEqual(error.errors, [-1, Infinity]);
+});

--- a/types/promise.any/requirePromise.d.ts
+++ b/types/promise.any/requirePromise.d.ts
@@ -1,0 +1,3 @@
+declare function requirePromise(): void;
+
+export = requirePromise;

--- a/types/promise.any/shim.d.ts
+++ b/types/promise.any/shim.d.ts
@@ -1,0 +1,5 @@
+import implementation = require("./implementation");
+
+declare function shimAny(): typeof implementation;
+
+export = shimAny;

--- a/types/promise.any/tsconfig.json
+++ b/types/promise.any/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "ESNext"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "promise.any-tests.ts"
+    ]
+}

--- a/types/promise.any/tslint.json
+++ b/types/promise.any/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

This works at runtime only if users import using `import ... = require(...)`. There's a [known bug](https://github.com/es-shims/Promise.allSettled/issues/5#issuecomment-810804609) with a dependency of `promise.any` that should be fixed in the next TypeScript version.

I don't know how that bug affects this PR. The typings are accurate to the best of my knowledge, and they _work_ at runtime... users just can't use TypeScript's `esModuleInterop` with it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test promise.any`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
