### PR TITLE
Authorization typings for autocomplete

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -170,6 +170,7 @@ declare namespace request {
         set(field: object): this;
         set(field: string, val: string): this;
         set(field: "Cookie", val: string[]): this;
+        set(field: 'Authorization', val: string): this;
         timeout(ms: number | { deadline?: number; response?: number }): this;
         trustLocalhost(enabled?: boolean): this;
         type(val: string): this;


### PR DESCRIPTION
There is a pain to always set authorization header e.g. using `chai-http` for testing JWT auth APIs manually without type completion hints :P `chai-http` uses up-to-date typings version for superagent according to current dependency definition in [package.json](https://github.com/chaijs/chai-http/blob/master/package.json)

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/chaijs/chai-http/blob/master/lib/request.js>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
