### PR TITLE
fix(@babel/traverse): NodePath.parentPath may be null

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -20,7 +20,11 @@ const MyVisitor: Visitor = {
 const MyVisitor2: Visitor = {
     Identifier(path) {
         path.type; // $ExpectType "Identifier"
+        path.parentPath; // $ExpectType NodePath<Node>
         console.log('Visiting: ' + path.node.name);
+    },
+    Program(path) {
+        path.parentPath; // $ExpectType null
     },
 };
 
@@ -347,13 +351,11 @@ const visitorWithInvalidDenylist: Visitor = {
 };
 
 // Test that NodePath can be narrowed from union to single type
-const path: NodePath<
-  t.ExportDefaultDeclaration | t.ExportNamedDeclaration
-> = new NodePath<t.ExportNamedDeclaration>(
-  null as any,
-  {} as any,
+const path: NodePath<t.ExportDefaultDeclaration | t.ExportNamedDeclaration> = new NodePath<t.ExportNamedDeclaration>(
+    null as any,
+    {} as any,
 );
 
 if (path.isExportNamedDeclaration()) {
-  path.type; // $ExpectType "ExportNamedDeclaration"
+    path.type; // $ExpectType "ExportNamedDeclaration"
 }

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @babel/traverse 7.11
+// Type definitions for @babel/traverse 7.14
 // Project: https://github.com/babel/babel/tree/main/packages/babel-traverse, https://babeljs.io
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
@@ -7,6 +7,7 @@
 //                 Dean L. <https://github.com/dlgrit>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 //                 ExE Boss <https://github.com/ExE-Boss>
+//                 Daniel Tschinder <https://github.com/danez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as t from '@babel/types';
@@ -235,7 +236,7 @@ export class NodePath<T = Node> {
     state: any;
     opts: object;
     skipKeys: object;
-    parentPath: NodePath;
+    parentPath: T extends t.Program ? null : NodePath;
     context: TraversalContext;
     container: object | object[];
     listKey: string;

--- a/types/babel__traverse/ts4.1/babel__traverse-tests.ts
+++ b/types/babel__traverse/ts4.1/babel__traverse-tests.ts
@@ -20,7 +20,11 @@ const MyVisitor: Visitor = {
 const MyVisitor2: Visitor = {
     Identifier(path) {
         path.type; // $ExpectType "Identifier"
+        path.parentPath; // $ExpectType NodePath<Node>
         console.log('Visiting: ' + path.node.name);
+    },
+    Program(path) {
+        path.parentPath; // $ExpectType null
     },
 };
 

--- a/types/babel__traverse/ts4.1/index.d.ts
+++ b/types/babel__traverse/ts4.1/index.d.ts
@@ -224,7 +224,7 @@ export class NodePath<T = Node> {
     state: any;
     opts: object;
     skipKeys: object;
-    parentPath: NodePath;
+    parentPath: T extends t.Program ? null : NodePath;
     context: TraversalContext;
     container: object | object[];
     listKey: string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Here is the link to the source from babel: https://github.com/babel/babel/blob/672a58660f0b15691c44582f1f3fdcdac0fa0d2f/packages/babel-traverse/src/path/index.ts#L55

and here is a screenshot of ast-explorer (showing the value of `null`): 
![Screenshot 2021-05-31 at 20 02 56](https://user-images.githubusercontent.com/231804/120228377-3efc7400-c24b-11eb-8da0-e0af53c918b8.png)

I thought about just doing `NodePath | null` but I felt this is nicer and less breaking. If `@babel/traverse` is used as intended (NodePaths only created internally) only `Program` has `parentPath` set to null.
