### PR TITLE
update(serve-index): update to 1.9

### DIFF
--- a/types/serve-index/index.d.ts
+++ b/types/serve-index/index.d.ts
@@ -1,44 +1,41 @@
-// Type definitions for serve-index v1.7.2
+// Type definitions for serve-index 1.9
 // Project: https://github.com/expressjs/serve-index
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
+import { Handler } from 'express';
+import { Stats } from 'fs';
 
-
-
-import * as express from 'express';
-import * as fs from 'fs';
+/** Serves pages that contain directory listings for a given path. */
+declare function serveIndex(path: string, options?: serveIndex.Options): Handler;
 
 declare namespace serveIndex {
     interface File {
         name: string;
-        stat: fs.Stats;
+        stat: Stats;
     }
 
     interface Locals {
         directory: string;
         displayIcons: boolean;
-        fileList: Array<File>;
+        fileList: File[];
         name: string;
-        stat: fs.Stats;
+        stat: Stats;
         path: string;
         style: string;
         viewName: string;
     }
 
-    type templateCallback = (error: Error, htmlString?: string) => void;
+    type TemplateCallback = (error: Error | null, htmlString?: string) => void;
 
     interface Options {
-        filter?: (filename: string, index: number, files: Array<File>, dir: string) => boolean;
+        filter?: (filename: string, index: number, files: File[], dir: string) => boolean;
         hidden?: boolean;
         icons?: boolean;
         stylesheet?: string;
-        template?: string | ((locals: Locals, callback: templateCallback) => void);
+        template?: string | ((locals: Locals, callback: TemplateCallback) => void);
         view?: string;
     }
 }
-
-declare function serveIndex(path: string, options?: serveIndex.Options): express.Handler;
 
 export = serveIndex;

--- a/types/serve-index/serve-index-tests.ts
+++ b/types/serve-index/serve-index-tests.ts
@@ -1,69 +1,56 @@
 import express = require('express');
 import serveIndex = require('serve-index');
-import * as fs from 'fs';
 
 const app = express();
 
-// Serve URLs like /ftp/thing as public/ftp/thing
-app.use('/ftp', serveIndex('public/ftp', {'icons': true}));
+const filter = (name: string): boolean => {
+    if (name.indexOf('foo') === -1) return true;
+    return false;
+};
+
+app.use('/ftp', serveIndex('public/ftp', { icons: true }));
 app.listen(8080);
 
+const fixtures = '/fixtures';
 
-// Taken from https://github.com/expressjs/serve-index/blob/v1.7.2/test/test.js
+serveIndex('test/fixtures', { hidden: false });
+serveIndex('test/fixtures', { hidden: true });
+serveIndex(fixtures, { filter });
+serveIndex(fixtures, { filter, hidden: false });
+serveIndex(fixtures, { icons: true });
+serveIndex(fixtures, { template: __dirname + '/shared/template.html' });
+serveIndex(fixtures, {
+    template: (locals, callback) => {
+        callback(null, 'This is a template.');
+    },
+});
 
-import * as path from 'path';
-var fixtures = path.join(__dirname, '/fixtures');
-const createServer = serveIndex;
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(new Error('boom!')),
+});
 
-var server = createServer('test/fixtures', {'hidden': false});
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(null, JSON.stringify(locals.directory)),
+});
 
-var server = createServer('test/fixtures', {'hidden': true});
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(null, JSON.stringify(locals.displayIcons)),
+});
 
-var server = createServer(fixtures, {'filter': filter});
-function filter(name: string): boolean {
-  if (name.indexOf('foo') === -1) return true
-  return false
-}
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(null, JSON.stringify(locals.fileList.map(file => file))),
+});
 
-var server = createServer(fixtures, {'filter': filter, 'hidden': false});
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(null, JSON.stringify(locals.path)),
+});
 
-var server = createServer(fixtures, {'icons': true});
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(null, JSON.stringify(locals.style)),
+});
 
-var server = createServer(fixtures, {'template': __dirname + '/shared/template.html'});
+serveIndex(fixtures, {
+    template: (locals, callback) => callback(null, JSON.stringify(locals.viewName)),
+});
 
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, 'This is a template.');
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(new Error('boom!'));
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, JSON.stringify(locals.directory));
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, JSON.stringify(locals.displayIcons));
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, JSON.stringify(locals.fileList.map(function (file) {
-    //file.stat = file.stat instanceof fs.Stats;
-    return file;
-  })));
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, JSON.stringify(locals.path));
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, JSON.stringify(locals.style));
-}});
-
-var server = createServer(fixtures, {'template': function (locals, callback) {
-  callback(null, JSON.stringify(locals.viewName));
-}});
-
-var server = createServer(fixtures, {'stylesheet': __dirname + '/shared/styles.css'});
+serveIndex(fixtures, { stylesheet: __dirname + '/shared/styles.css' });

--- a/types/serve-index/tsconfig.json
+++ b/types/serve-index/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/serve-index/tslint.json
+++ b/types/serve-index/tslint.json
@@ -1,17 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "array-type": false,
-        "comment-format": false,
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-duplicate-variable": false,
-        "no-var-keyword": false,
-        "object-literal-key-quotes": false,
-        "object-literal-shorthand": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "semicolon": false,
-        "space-before-function-paren": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
This is no api changing update to keep in sync with native JS module:
- simplify types and drop all DT exclusions
- reformat

https://github.com/expressjs/serve-index/compare/v1.3.1...v1.9.1

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.