### PR TITLE
dynamodb 1.3: Add Generics to Query/Scanning Promises and Callback results

### DIFF
--- a/types/dynamodb/Callback.d.ts
+++ b/types/dynamodb/Callback.d.ts
@@ -1,1 +1,1 @@
-export type Callback = (err: any, result: any) => void;
+export type Callback<T> = (err: any, result: T) => void;

--- a/types/dynamodb/ExecuteFilter.d.ts
+++ b/types/dynamodb/ExecuteFilter.d.ts
@@ -2,11 +2,11 @@ import { Readable } from 'stream';
 
 import { Callback } from './Callback';
 
-export interface PromisedReadable extends Readable {
-    promise(): Promise<any>;
+export interface PromisedReadable<T> extends Readable {
+    promise(): Promise<T>;
 }
 
-export interface ExecuteFilter {
-    (callback: Callback): void;
-    (): PromisedReadable;
+export interface ExecuteFilter<T> {
+    (callback: Callback<T>): void;
+    (): PromisedReadable<T>;
 }

--- a/types/dynamodb/ExecuteFilter.d.ts
+++ b/types/dynamodb/ExecuteFilter.d.ts
@@ -3,7 +3,8 @@ import { Readable } from 'stream';
 import { Callback } from './Callback';
 
 export interface PromisedReadable<T> extends Readable {
-    promise(): Promise<T>;
+    // DevNote: Promise function in dynamodb wraps results in an array
+    promise(): Promise<Array<T>>;
 }
 
 export interface ExecuteFilter<T> {

--- a/types/dynamodb/ExecuteFilter.d.ts
+++ b/types/dynamodb/ExecuteFilter.d.ts
@@ -4,7 +4,7 @@ import { Callback } from './Callback';
 
 export interface PromisedReadable<T> extends Readable {
     // DevNote: Promise function in dynamodb wraps results in an array
-    promise(): Promise<Array<T>>;
+    promise(): Promise<T[]>;
 }
 
 export interface ExecuteFilter<T> {

--- a/types/dynamodb/Model.d.ts
+++ b/types/dynamodb/Model.d.ts
@@ -1,85 +1,82 @@
-import { AnySchema } from 'joi';
 import * as bunyan from 'bunyan';
-import { GetItemInput, DynamoDB } from './DynamoDB';
+import { DynamoDB } from './DynamoDB';
 
 import { Callback } from './Callback';
 import { Query } from './Query';
 import { Scan, ParallelScan } from './Scan';
 import { EventEmitter } from 'events';
 
-export class Item extends EventEmitter {
-    constructor(attrs: object, table: any);
+export class Item<T> extends EventEmitter {
+    constructor(attrs: T, table: any);
     get(name: string): any;
     set(params: any): this;
-    save(callback: Callback): void;
-    save(): Promise<any>;
-    update(options: any, callback: Callback): void;
-    update(options: any): Promise<any>;
-    destroy(options: any, callback: Callback): void;
-    destroy(options: any): Promise<any>;
-    toJSON(): object;
+    save(callback: Callback<T>): void;
+    save(): Promise<T>;
+    update(options: any, callback: Callback<Item<T>>): void;
+    update(options: any): Promise<Item<T>>;
+    destroy(options: any, callback: Callback<Item<T>>): void;
+    destroy(options: any): Promise<Item<T>>;
+    toJSON(): T;
 }
 
-export class Model extends Item {
-    constructor(attrs: any);
+export class Model<T> extends Item<T> implements Model<T> {
+    constructor(attrs: T);
+}
+
+export interface Model<T> {
+    new (attrs: T): Model<T>;
+    attrs: Model<T>;
+    table: any;
+    get(hashKey: string, rangeKey: string, options: object, callback: Callback<Model<T>>): void;
+    get(data: object | string, options: object | string, callback: Callback<Model<T>>): void;
+    get(data: object | string, callback: Callback<Model<T>>): void;
+    get(hashKey: string, rangeKey: string, options: object): Promise<Model<T>>;
+    get(hashKey: string, options?: object | string): Promise<Model<T>>;
+    update(item: any, options: Model.OperationOptions, callback: Callback<Model<T>>): void;
+    update(item: any, callback: Callback<Model<T>>): void;
+    update(item: any, options?: Model.OperationOptions): Promise<Model<T>>;
+    create(doc: any, params: Model.OperationOptions, callback: Callback<Model<T>>): void;
+    create(doc: any, callback: Callback<Model<T>>): void;
+    create(doc: any, params?: Model.OperationOptions): Promise<Model<T>>;
+    destroy(hashKey: string, rangeKey: string, options: Model.OperationOptions, callback: Callback<Model<T>>): void;
+    destroy(hashKey: string, rangeKey: string, callback: Callback<Model<T>>): void;
+    destroy(data: { [key: string]: any } | string, options: Model.OperationOptions, callback: Callback<Model<T>>): void;
+    destroy(data: { [key: string]: any } | string, callback: Callback<Model<T>>): void;
+    destroy(hashKey: string, rangeKey: string, options: Model.OperationOptions): Promise<Model<T>>;
+    destroy(hashKey: string, options?: Model.OperationOptions | string): Promise<Model<T>>;
+    getItems(keys: ReadonlyArray<any>, options: any, callback: Callback<Array<Model<T>>>): void;
+    getItems(keys: ReadonlyArray<any>, callback: Callback<Array<Model<T>>>): void;
+    getItems(keys: ReadonlyArray<any>, options?: any): Promise<Array<Model<T>>>;
+    query(hashKey: string): Query<T>;
+    scan(): Scan<T>;
+    parallelScan(totalSegments: number): ParallelScan<T>;
+    batchGetItems(hashKey: string, rangeKey: string, options: any, callback?: Callback<any>): Promise<any> | void;
+    createTable(hashKey: string, rangeKey: string, options: any, callback?: Callback<any>): Promise<any> | void;
+    updateTable(hashKey: string, rangeKey: string, options: any, callback?: Callback<any>): Promise<any> | void;
+    describeTable(hashKey: string, rangeKey: string, options: any, callback?: Callback<any>): Promise<any> | void;
+    deleteTable(callback: Callback<any>): void;
+    deleteTable(): Promise<any>;
+    tableName(hashKey: string, rangeKey: string, options: any, callback: Callback<any>): void;
+    tableName(hashKey: string, rangeKey: string, options: any): Promise<any>;
+    itemFactory: Model<T>;
+    log: bunyan;
+    after: any;
+    before: any;
+    config(config: { dynamodb?: DynamoDB; tableName?: string }): any;
+}
+
+export interface Page<T> {
+    Items: Array<Model<T>>;
+    Count: number;
+    ScannedCount?: number;
+    LastEvaluatedKey?: any;
+    ConsumedCapacity?: {
+        CapacityUnits: number;
+        TableName: string;
+    };
 }
 
 export namespace Model {
-    const get: GetOperation;
-    const create: CreateOperation;
-    const update: UpdateOperation;
-    const destroy: DestroyOperation;
-    function query(hashKey: string): Query;
-    function scan(): Scan;
-    function parallelScan(totalSegments: number): ParallelScan;
-    const getItems: GetItemsOperation;
-    function batchGetItems(
-        hashKey: string,
-        rangeKey: string,
-        options: any,
-        callback?: Callback,
-    ): Promise<any> | void;
-    function createTable(
-        hashKey: string,
-        rangeKey: string,
-        options: any,
-        callback?: Callback,
-    ): Promise<any> | void;
-    function updateTable(
-        hashKey: string,
-        rangeKey: string,
-        options: any,
-        callback?: Callback,
-    ): Promise<any> | void;
-    function describeTable(
-        hashKey: string,
-        rangeKey: string,
-        options: any,
-        callback?: Callback,
-    ): Promise<any> | void;
-    function deleteTable(callback: Callback): void;
-    function deleteTable(): Promise<any>;
-    function tableName(
-        hashKey: string,
-        rangeKey: string,
-        options: any,
-        callback: Callback,
-    ): void;
-    function tableName(
-        hashKey: string,
-        rangeKey: string,
-        options: any,
-    ): Promise<any>;
-    const itemFactory: typeof Model;
-    const log: bunyan;
-    const after: any;
-    const before: any;
-    function config(config: { dynamodb?: DynamoDB; tableName?: string }): any;
-
-    interface OperationResult {
-        get(name: string): any;
-    }
-
     interface OperationOptions {
         UpdateExpression?: any;
         ConditionExpression?: any;
@@ -88,60 +85,5 @@ export namespace Model {
         expected?: any;
         overwrite?: boolean;
         ReturnValues?: string | boolean;
-    }
-
-    interface UpdateOperation {
-        (item: any, options: OperationOptions, callback: Callback): void;
-        (item: any, callback: Callback): void;
-        (item: any, options?: OperationOptions): Promise<any>;
-    }
-
-    interface GetOperation {
-        (
-            hashKey: string,
-            rangeKey: string,
-            options: object,
-            callback: Callback,
-        ): void;
-        (
-            data: object | string,
-            options: object | string,
-            callback: Callback,
-        ): void;
-        (data: object | string, callback: Callback): void;
-        (hashKey: string, rangeKey: string, options: object): Promise<any>;
-        (hashKey: string, options?: object | string): Promise<any>;
-    }
-
-    interface CreateOperation {
-        (doc: any, params: OperationOptions, callback: Callback): void;
-        (doc: any, callback: Callback): void;
-        (doc: any, params?: OperationOptions): Promise<any>;
-    }
-
-    interface DestroyOperation {
-        (
-            hashKey: string,
-            rangeKey: string,
-            options: OperationOptions,
-            callback: Callback,
-        ): void;
-        (hashKey: string, rangeKey: string, callback: Callback): void;
-        (
-            data: { [key: string]: any } | string,
-            options: OperationOptions,
-            callback: Callback,
-        ): void;
-        (data: { [key: string]: any } | string, callback: Callback): void;
-        (hashKey: string, rangeKey: string, options: OperationOptions): Promise<
-            any
-        >;
-        (hashKey: string, options?: OperationOptions | string): Promise<any>;
-    }
-
-    interface GetItemsOperation {
-        (keys: ReadonlyArray<any>, options: any, callback: Callback): void;
-        (keys: ReadonlyArray<any>, callback: Callback): void;
-        (keys: ReadonlyArray<any>, options?: any): Promise<any>;
     }
 }

--- a/types/dynamodb/Model.d.ts
+++ b/types/dynamodb/Model.d.ts
@@ -24,6 +24,7 @@ export class Model<T> extends Item<T> implements Model<T> {
 }
 
 export interface Model<T> {
+    // tslint:disable-next-line:no-misused-new
     new (attrs: T): Model<T>;
     attrs: T;
     table: any;

--- a/types/dynamodb/Model.d.ts
+++ b/types/dynamodb/Model.d.ts
@@ -25,7 +25,7 @@ export class Model<T> extends Item<T> implements Model<T> {
 
 export interface Model<T> {
     new (attrs: T): Model<T>;
-    attrs: Model<T>;
+    attrs: T;
     table: any;
     get(hashKey: string, rangeKey: string, options: object, callback: Callback<Model<T>>): void;
     get(data: object | string, options: object | string, callback: Callback<Model<T>>): void;
@@ -35,15 +35,18 @@ export interface Model<T> {
     update(item: any, options: Model.OperationOptions, callback: Callback<Model<T>>): void;
     update(item: any, callback: Callback<Model<T>>): void;
     update(item: any, options?: Model.OperationOptions): Promise<Model<T>>;
-    create(doc: any, params: Model.OperationOptions, callback: Callback<Model<T>>): void;
-    create(doc: any, callback: Callback<Model<T>>): void;
-    create(doc: any, params?: Model.OperationOptions): Promise<Model<T>>;
-    destroy(hashKey: string, rangeKey: string, options: Model.OperationOptions, callback: Callback<Model<T>>): void;
-    destroy(hashKey: string, rangeKey: string, callback: Callback<Model<T>>): void;
-    destroy(data: { [key: string]: any } | string, options: Model.OperationOptions, callback: Callback<Model<T>>): void;
-    destroy(data: { [key: string]: any } | string, callback: Callback<Model<T>>): void;
-    destroy(hashKey: string, rangeKey: string, options: Model.OperationOptions): Promise<Model<T>>;
-    destroy(hashKey: string, options?: Model.OperationOptions | string): Promise<Model<T>>;
+    create(doc: T, params: Model.OperationOptions, callback: Callback<Model<T>>): void;
+    create(doc: T, callback: Callback<Model<T>>): void;
+    create(doc: T, params?: Model.OperationOptions): Promise<Model<T>>;
+    create(doc: ReadonlyArray<T>, params: Model.OperationOptions, callback: Callback<Array<Model<T>>>): void;
+    create(doc: ReadonlyArray<T>, callback: Callback<Array<Model<T>>>): void;
+    create(doc: ReadonlyArray<T>, params?: Model.OperationOptions): Promise<Array<Model<T>>>;
+    destroy(hashKey: string, rangeKey: string, options: Model.OperationOptions, callback: Callback<any>): void;
+    destroy(hashKey: string, rangeKey: string, callback: Callback<any>): void;
+    destroy(data: { [key: string]: any } | string, options: Model.OperationOptions, callback: Callback<any>): void;
+    destroy(data: { [key: string]: any } | string, callback: Callback<any>): void;
+    destroy(hashKey: string, rangeKey: string, options: Model.OperationOptions): Promise<any>;
+    destroy(hashKey: string, options?: Model.OperationOptions | string): Promise<any>;
     getItems(keys: ReadonlyArray<any>, options: any, callback: Callback<Array<Model<T>>>): void;
     getItems(keys: ReadonlyArray<any>, callback: Callback<Array<Model<T>>>): void;
     getItems(keys: ReadonlyArray<any>, options?: any): Promise<Array<Model<T>>>;

--- a/types/dynamodb/Query.d.ts
+++ b/types/dynamodb/Query.d.ts
@@ -1,42 +1,43 @@
 import { ExecuteFilter } from './ExecuteFilter';
+import { Page } from './Model';
 
-export interface Query {
+export interface Query<T> {
     (hashKey: string, table: any, serializer: any): void;
-    limit(num: number): Query;
-    filterExpression(expression: any): Query;
-    expressionAttributeValues(data: any): Query;
-    expressionAttributeNames(data: any): Query;
-    projectionExpression(data: any): Query;
-    usingIndex(name: string): Query;
-    consistentRead(read: boolean): Query;
+    limit(num: number): Query<T>;
+    filterExpression(expression: any): Query<T>;
+    expressionAttributeValues(data: any): Query<T>;
+    expressionAttributeNames(data: any): Query<T>;
+    projectionExpression(data: any): Query<T>;
+    usingIndex(name: string): Query<T>;
+    consistentRead(read: boolean): Query<T>;
     addKeyCondition(condition: {
         attributeNames: any;
         attributeValues: any;
-    }): Query;
+    }): Query<T>;
     addFilterCondition(condition: {
         attributeNames: any;
         attributeValues: any;
-    }): Query;
-    startKey(hashKey: string, rangeKey: string): Query;
-    attributes(attrs: ReadonlyArray<string> | string): Query;
-    ascending(): Query;
-    descending(): Query;
-    select(value: string): Query;
-    returnConsumedCapacity(value?: string): Query;
-    loadAll(): Query;
-    where(keyName: string): Query;
-    contains(name: string): Query;
-    notContains(name: string): Query;
-    filter(keyName: string): Query;
-    exec: ExecuteFilter;
+    }): Query<T>;
+    startKey(hashKey: string, rangeKey: string): Query<T>;
+    attributes(attrs: ReadonlyArray<string> | string): Query<T>;
+    ascending(): Query<T>;
+    descending(): Query<T>;
+    select(value: string): Query<T>;
+    returnConsumedCapacity(value?: string): Query<T>;
+    loadAll(): Query<T>;
+    where(keyName: string): Query<T>;
+    contains(name: string): Query<T>;
+    notContains(name: string): Query<T>;
+    filter(keyName: string): Query<T>;
+    exec: ExecuteFilter<Array<Page<T>>>;
     buildKey(): string;
     buildRequest(): any;
-    equals: (...args: any[]) => Query;
-    eq: (...args: any[]) => Query;
-    lte: (...args: any[]) => Query;
-    lt: (...args: any[]) => Query;
-    gte: (...args: any[]) => Query;
-    gt: (...args: any[]) => Query;
-    beginsWith: (...args: any[]) => Query;
-    between: (...args: any[]) => Query;
+    equals: (...args: any[]) => Query<T>;
+    eq: (...args: any[]) => Query<T>;
+    lte: (...args: any[]) => Query<T>;
+    lt: (...args: any[]) => Query<T>;
+    gte: (...args: any[]) => Query<T>;
+    gt: (...args: any[]) => Query<T>;
+    beginsWith: (...args: any[]) => Query<T>;
+    between: (...args: any[]) => Query<T>;
 }

--- a/types/dynamodb/Query.d.ts
+++ b/types/dynamodb/Query.d.ts
@@ -29,7 +29,7 @@ export interface Query<T> {
     contains(name: string): Query<T>;
     notContains(name: string): Query<T>;
     filter(keyName: string): Query<T>;
-    exec: ExecuteFilter<Array<Page<T>>>;
+    exec: ExecuteFilter<Page<T>>;
     buildKey(): string;
     buildRequest(): any;
     equals: (...args: any[]) => Query<T>;

--- a/types/dynamodb/Scan.d.ts
+++ b/types/dynamodb/Scan.d.ts
@@ -1,38 +1,39 @@
 import { ExecuteFilter } from './ExecuteFilter';
+import { Page } from './Model';
 
-export interface Scan {
-    limit(num: number): Scan;
+export interface Scan<T> {
+    limit(num: number): Scan<T>;
     addFilterCondition(condition: {
         attributeNames: any;
         attributeValues: any;
-    }): Scan;
-    startKey(hashKey: string, rangeKey?: string): Scan;
-    attributes(attrs: ReadonlyArray<string> | string): Scan;
-    select(value: string): Scan;
-    returnConsumedCapacity(value?: string): Scan;
-    segments(segment: any, totalSegments: any): Scan;
-    where(keyName: string): Scan;
-    filterExpression(expression: any): Scan;
-    expressionAttributeValues(data: any): Scan;
-    expressionAttributeNames(data: any): Scan;
-    projectionExpression(data: any): Scan;
-    loadAll(): Scan;
-    notNull(): Scan;
-    null(): Scan;
-    contains(name: string): Scan;
-    beginsWith(name: string): Scan;
-    between(start: string, end: string): Scan;
-    notContains(name: string): Scan;
-    equals: (...args: any[]) => Scan;
-    in: (...args: any[]) => Scan;
-    ne: (...args: any[]) => Scan;
-    eq: (...args: any[]) => Scan;
-    lte: (...args: any[]) => Scan;
-    lt: (...args: any[]) => Scan;
-    gte: (...args: any[]) => Scan;
-    gt: (...args: any[]) => Scan;
-    exec: ExecuteFilter;
+    }): Scan<T>;
+    startKey(hashKey: string, rangeKey?: string): Scan<T>;
+    attributes(attrs: ReadonlyArray<string> | string): Scan<T>;
+    select(value: string): Scan<T>;
+    returnConsumedCapacity(value?: string): Scan<T>;
+    segments(segment: any, totalSegments: any): Scan<T>;
+    where(keyName: string): Scan<T>;
+    filterExpression(expression: any): Scan<T>;
+    expressionAttributeValues(data: any): Scan<T>;
+    expressionAttributeNames(data: any): Scan<T>;
+    projectionExpression(data: any): Scan<T>;
+    loadAll(): Scan<T>;
+    notNull(): Scan<T>;
+    null(): Scan<T>;
+    contains(name: string): Scan<T>;
+    beginsWith(name: string): Scan<T>;
+    between(start: string, end: string): Scan<T>;
+    notContains(name: string): Scan<T>;
+    equals: (...args: any[]) => Scan<T>;
+    in: (...args: any[]) => Scan<T>;
+    ne: (...args: any[]) => Scan<T>;
+    eq: (...args: any[]) => Scan<T>;
+    lte: (...args: any[]) => Scan<T>;
+    lt: (...args: any[]) => Scan<T>;
+    gte: (...args: any[]) => Scan<T>;
+    gt: (...args: any[]) => Scan<T>;
+    exec: ExecuteFilter<Array<Page<T>>>;
     buildRequest(): any;
 }
 
-export type ParallelScan = Scan;
+export type ParallelScan<T> = Scan<T>;

--- a/types/dynamodb/Scan.d.ts
+++ b/types/dynamodb/Scan.d.ts
@@ -32,7 +32,7 @@ export interface Scan<T> {
     lt: (...args: any[]) => Scan<T>;
     gte: (...args: any[]) => Scan<T>;
     gt: (...args: any[]) => Scan<T>;
-    exec: ExecuteFilter<Array<Page<T>>>;
+    exec: ExecuteFilter<Page<T>>;
     buildRequest(): any;
 }
 

--- a/types/dynamodb/dynamodb-tests.ts
+++ b/types/dynamodb/dynamodb-tests.ts
@@ -522,7 +522,7 @@ GameScore.query('Galaxy Invaders')
     .gt(1000)
     .descending()
     .exec((err, data) => {
-        console.log(data.Items);
+        console.log(data[0].Items);
     });
 
 BlogPost = dynamo.define('Account', {

--- a/types/dynamodb/dynamodb-tests.ts
+++ b/types/dynamodb/dynamodb-tests.ts
@@ -27,6 +27,30 @@ let Account = dynamo.define('Account', {
     },
 });
 
+let AccountTyped = dynamo.define<{
+    email: string;
+    name: string;
+    age?: number;
+    roles?: string[];
+    settings?: { nickname: string; acceptedTerms: boolean };
+}>('Account', {
+    hashKey: 'email',
+
+    // add the timestamp attributes (updatedAt, createdAt)
+    timestamps: true,
+
+    schema: {
+        email: Joi.string().email(),
+        name: Joi.string(),
+        age: Joi.number(),
+        roles: dynamo.types.stringSet(),
+        settings: {
+            nickname: Joi.string(),
+            acceptedTerms: Joi.boolean().default(false),
+        },
+    },
+});
+
 let BlogPost = dynamo.define('BlogPost', {
     hashKey: 'email',
     rangeKey: 'title',
@@ -138,10 +162,20 @@ Account.create(
     },
 );
 
+AccountTyped.create({ email: 'foo@example.com', name: 'Foo Bar', age: 21 }, (err, acc) => {
+    console.log('created account in DynamoDB', acc.get('email'), acc.attrs.email);
+});
+
 const acc = new Account({ email: 'test@example.com', name: 'Test Example' });
 
 acc.save(err => {
     console.log('created account in DynamoDB', acc.get('email'));
+});
+
+const accTyped = new AccountTyped({ email: 'test@example.com', name: 'Test Example' });
+
+accTyped.save(err => {
+    console.log('created account in DynamoDB', accTyped.get('email'), accTyped.attrs.email);
 });
 
 BlogPost.create(
@@ -163,6 +197,12 @@ Account.create([item1, item2, item3], (err, accounts) => {
     console.log('created 3 accounts in DynamoDB', accounts);
 });
 
+AccountTyped.create([item1, item2, item3], (err, accounts) => {
+    accounts.map(acc => {
+        console.log('created account', acc.get('email'), acc.attrs.email);
+    });
+});
+
 let params: dynamo.Model.OperationOptions = {};
 params.ConditionExpression = '#i <> :x';
 params.ExpressionAttributeNames = { '#i': 'id' };
@@ -182,6 +222,10 @@ Account.create(
 
 Account.update({ email: 'foo@example.com', name: 'Bar Tester' }, (err, acc) => {
     console.log('update account', acc.get('name'));
+});
+
+AccountTyped.update({ email: 'foo@example.com', name: 'Bar Tester' }, (err, acc) => {
+    console.log('update account', acc.get('name'), acc.attrs.name);
 });
 
 Account.update(
@@ -316,6 +360,10 @@ Account.get('test@example.com', (err, acc) => {
     console.log('got account', acc.get('email'));
 });
 
+AccountTyped.get('test@example.com', (err, acc) => {
+    console.log('got account', acc.get('email'), acc.attrs.email);
+});
+
 Account.get('test@example.com', { ConsistentRead: true }, (err, acc) => {
     console.log('got account', acc.get('email'));
 });
@@ -353,6 +401,17 @@ Account.get(
 );
 
 const callback = () => {};
+
+// Typed Account query
+AccountTyped.query('foo1@example.com').exec((err, data) => {
+    data.Items.map(i => console.log('fetched account', i.get('email'), i.attrs.email));
+});
+
+// Typed Account query with promise (incl. nested array)
+AccountTyped.query('foo1@example.com')
+    .exec()
+    .promise()
+    .then(data => data[0].Items.map(i => console.log('fetched account', i.get('email'), i.attrs.email)));
 
 // query for blog posts by werner@example.com
 BlogPost.query('werner@example.com').exec(callback);
@@ -522,7 +581,7 @@ GameScore.query('Galaxy Invaders')
     .gt(1000)
     .descending()
     .exec((err, data) => {
-        console.log(data[0].Items);
+        console.log(data.Items);
     });
 
 BlogPost = dynamo.define('Account', {
@@ -570,6 +629,22 @@ Account.scan().exec(callback);
 Account.scan()
     .loadAll()
     .exec(callback);
+
+AccountTyped.scan()
+    .loadAll()
+    .exec((err, data) => {
+        data.Items.map(i => {
+            console.log('scanned account: ', i.get('email'), i.attrs.email);
+        });
+    });
+
+// Promised scan with nested array
+AccountTyped.scan()
+    .loadAll()
+    .exec()
+    .promise()
+    .then()
+    .then(data => data[0].Items.map(i => console.log('fetched account 1234', i.get('email'), i.attrs.email)));
 
 // Load 20 accounts
 Account.scan()
@@ -716,6 +791,10 @@ Account.getItems(
         console.log(`loaded ${accounts.length} accounts`); // prints loaded 3 accounts
     },
 );
+
+AccountTyped.getItems(['foo@example.com', 'bar@example.com', 'test@example.com'], (err, accounts) => {
+    console.log(`loaded ${accounts.length} accounts`); // prints loaded 3 accounts
+});
 
 // For models with range keys you must pass in objects of hash and range key attributes
 const postKey1 = { email: 'test@example.com', title: 'Hello World!' };

--- a/types/dynamodb/dynamodb-tests.ts
+++ b/types/dynamodb/dynamodb-tests.ts
@@ -27,7 +27,7 @@ let Account = dynamo.define('Account', {
     },
 });
 
-let AccountTyped = dynamo.define<{
+const AccountTyped = dynamo.define<{
     email: string;
     name: string;
     age?: number;

--- a/types/dynamodb/index.d.ts
+++ b/types/dynamodb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for dynamodb 1.2
+// Type definitions for dynamodb 1.3
 // Project: https://github.com/baseprime/dynamodb#readme
 // Definitions by: katsanva <https://github.com/katsanva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -19,8 +19,8 @@ interface CreateTablesOptions {
 
 interface CreateTables {
     (options?: CreateTablesOptions): Promise<any>;
-    (options: CreateTablesOptions, callback: Callback): void;
-    (callback: Callback): void;
+    (options: CreateTablesOptions, callback: Callback<any>): void;
+    (callback: Callback<any>): void;
 }
 
 interface IndexDefinition {
@@ -31,7 +31,7 @@ interface IndexDefinition {
     projection?: Projection;
 }
 
-export interface DefineConfig {
+export interface DefineConfig<T> {
     hashKey: string;
     rangeKey?: string;
     timestamps?: boolean;
@@ -49,8 +49,10 @@ export function dynamoDriver(driver?: DynamoDB): DynamoDB;
 export function documentClient(docClient?: DocumentClient): DocumentClient;
 export function reset(): void;
 export function Set(data: ReadonlyArray<any>, type: string): DynamoDbSet;
-export function define(name: string, config: DefineConfig): typeof Model;
-export function model(name: string, model?: Model): typeof Model;
+export function define(name: string, config: DefineConfig<any>): Model<any>;
+export function define<T>(name: string, config: DefineConfig<T>): Model<T>;
+export function model(name: string, model?: Model<any>): Model<any>;
+export function model<T>(name: string, model?: Model<T>): Model<T>;
 export const createTables: CreateTables;
 export const types: {
     stringSet: () => AnySchema;

--- a/types/dynamodb/tslint.json
+++ b/types/dynamodb/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-misused-new": false
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/dynamodb/tslint.json
+++ b/types/dynamodb/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-misused-new": false
+    }
+}


### PR DESCRIPTION
Updating the dynamodb types to reflect the various callback/promise types to be more strongly typed.

More advanced functions with various return options such as `destroy` were left to return any.

Also, when retrieving a query/scan promise, it nests the results in (what appears to be) a single element array, so the types now account for this anomaly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test dynamodb`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
