### PR TITLE
gatsby-plugin-breakpoints: Update BreakpointProvider type

### DIFF
--- a/types/gatsby-plugin-breakpoints/gatsby-plugin-breakpoints-tests.tsx
+++ b/types/gatsby-plugin-breakpoints/gatsby-plugin-breakpoints-tests.tsx
@@ -50,5 +50,5 @@ function useContext() {
 }
 // BreakpointProvider
 const ProviderComponent: React.FC = ({ children }) => {
-    return <BreakpointProvider value={defaultQueries}>{children}</BreakpointProvider>;
+    return <BreakpointProvider queries={defaultQueries}>{children}</BreakpointProvider>;
 };

--- a/types/gatsby-plugin-breakpoints/index.d.ts
+++ b/types/gatsby-plugin-breakpoints/index.d.ts
@@ -13,6 +13,12 @@ export type QueriesObject = Record<string, string>;
 export interface BreakpointProps {
     breakpoints: BreakpointsObject;
 }
+
+export interface BreakpointProviderProps {
+    children: React.ReactNode;
+    queries: QueriesObject;
+}
+
 export interface BreakpointOptions {
     queries?: QueriesObject;
 }
@@ -27,4 +33,4 @@ export function withBreakpoints<P extends BreakpointProps>(Component: React.Comp
 
 export const BreakpointContext: React.Context<QueriesObject>;
 
-export const BreakpointProvider: React.Provider<QueriesObject>;
+export const BreakpointProvider: React.ProviderExoticComponent<BreakpointProviderProps>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
`BreakpointProvider` is a wrapper around `React.Provider` that takes in a queries object and return a provider
Declaration
https://github.com/JimmyBeldone/gatsby-plugin-breakpoints/blob/a0db5b06a1927c0aa7244c1274fa62123b00302d/src/BreakpointProvider.js#L8
Example use
https://github.com/JimmyBeldone/gatsby-plugin-breakpoints/blob/a0db5b06a1927c0aa7244c1274fa62123b00302d/src/gatsby-ssr.js#L7-L15
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A