### PR TITLE
[es-aggregate-error] Fix types when using exported namespace as a class prototype

### DIFF
--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -11,13 +11,24 @@ new AggregateError([]); // $ExpectType AggregateError
 new AggregateError([oneError, otherError]); // $ExpectType AggregateError
 
 // $ExpectType AggregateError
-const error = new AggregateError([oneError, otherError], 'this is two kinds of errors');
+const implicitError = new AggregateError([oneError, otherError], 'this is two kinds of errors');
 
-AggregateError.shim; // $ExpectType (() => void) & (() => typeof AggregateError)
-AggregateError.shim(); // $ExpectType: void
+// $ExpectType AggregateError
+const explicitError: AggregateError = new AggregateError([oneError, otherError], 'this is two kinds of errors');
 
-error.errors; // $ExpectType: Array<unknown>
-error.name; // $ExpectType: "AggregateError"
-error.message; // $ExpectType: string
+AggregateError.prototype; // $ExpectType AggregateError
+AggregateError.shim; // $ExpectType () => typeof AggregateError
+AggregateError.shim(); // $ExpectType: AggregateError
 
-error.name = 'something else'; // $ExpectError
+implicitError.errors; // $ExpectType: Array<unknown>
+implicitError.message; // $ExpectType: string
+implicitError.name; // $ExpectType: "AggregateError"
+
+implicitError.name = 'something else'; // $ExpectError
+
+const err = new Error('test');
+if (err instanceof AggregateError) {
+    const aggregateErr: AggregateError = err; // $ExpectType: AggregateError
+    const notAggregateErr: typeof AggregateError = err; // $ExpectError
+    aggregateErr.name; // $ExpectType: "AggregateError"
+}

--- a/types/es-aggregate-error/implementation.d.ts
+++ b/types/es-aggregate-error/implementation.d.ts
@@ -5,11 +5,8 @@ declare class AggregateError extends Error implements NodeJS.ErrnoException {
     readonly name: 'AggregateError';
     readonly message: string;
 
-    // any here, to match Node's own typings
-
+    // Using `any` here, to match Node's own typings:
     constructor(errors: ReadonlyArray<any>, message?: string);
-
-    static shim(): void;
 }
 
 export = AggregateError;

--- a/types/es-aggregate-error/index.d.ts
+++ b/types/es-aggregate-error/index.d.ts
@@ -7,17 +7,10 @@ import implementation = require('./implementation');
 import getPolyfill = require('./polyfill');
 import shim = require('./shim');
 
-type ExportedImplementationType = typeof implementation & {
-    getPolyfill: typeof getPolyfill;
-    implementation: typeof implementation;
-    shim: typeof shim;
-};
-
-declare const exportedImplementation: ExportedImplementationType;
-
-export = exportedImplementation;
-
-// This seems to be the only way to export these types here without colliding with the "export =" syntax.
-declare namespace exportedImplementation {
-    type AggregateError = implementation;
+declare class AggregateError extends implementation {
+    static getPolyfill: typeof getPolyfill;
+    static implementation: typeof implementation;
+    static shim: typeof shim;
 }
+
+export = AggregateError;


### PR DESCRIPTION
The typings before did not support using the exported class directly, instead _forcing_ users to import the shimmed class from one of the other exported headers (i.e. `es-aggregate-error/implementation`) which causes very strange behavior on Node 16 when used in combination with other shim libraries like promise.any.

For example, `instanceof` would not work correctly in the following case at compile time, but worked fine at runtime:
```TS
import AggregateError = require('es-aggregate-error');
const err = new Error('test');

if (err instanceof AggregateError) {
  const error: AggregateError = err;
  //           ^^^^^^^^^^^^^^
  //           Error: Using a namespace in a type position. This is correct at runtime,
  //           and according to docs, so the typings are incorrect.
}
```

This branch reorganizes index.d.ts to more closely match [the expected export](https://github.com/es-shims/AggregateError/blob/main/index.js), fixing the above issue and a few others.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test es-aggregate-error`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/es-shims/AggregateError/blob/main/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
