### PR TITLE
update webpack-merge-and-include-globally to 2.3.4

### DIFF
--- a/types/webpack-merge-and-include-globally/index.d.ts
+++ b/types/webpack-merge-and-include-globally/index.d.ts
@@ -34,11 +34,13 @@ declare namespace MergeIntoFile {
     interface Options {
         /**
          * array of entry points (strings) for which this plugin should run only
-         * {@link https://github.com/markshapiro/webpack-merge-and-include-globally#hash}
+         * {@link https://github.com/markshapiro/webpack-merge-and-include-globally#chunks}
+         * @default undefined
          */
         chunks?: string[];
         /**
          * encoding of node.js reading
+         * {@link https://github.com/markshapiro/webpack-merge-and-include-globally#encoding}
          * @default 'utf-8'
          */
         encoding?: string;
@@ -56,6 +58,12 @@ declare namespace MergeIntoFile {
         transform?: {
             [key: string]: (code: string) => string;
         };
+        /**
+         * string used between files when joining them together
+         * {@link https://github.com/markshapiro/webpack-merge-and-include-globally#separator}
+         * @default '\n'
+         */
+        separator?: string;
     }
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/markshapiro/webpack-merge-and-include-globally#separator>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I was unable to run `npm run test webpack-merge-and-include-globally` successfully. See the following output:
```sh
$ npm run test webpack-merge-and-include-globally

> definitely-typed@0.0.3 test <repo-path>/DefinitelyTyped
> dtslint types "webpack-merge-and-include-globally"

Error: Errors in typescript@4.4 for external dependencies:
../clean-css/index.d.ts(11,50): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../uglify-js/index.d.ts(9,30): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack-sources/lib/CachedSource.d.ts(1,30): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack-sources/lib/ConcatSource.d.ts(2,28): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack-sources/lib/index.d.ts(1,30): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack-sources/lib/OriginalSource.d.ts(2,28): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack-sources/lib/Source.d.ts(2,30): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack-sources/lib/SourceMapSource.d.ts(1,50): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
../webpack/v4/index.d.ts(46,30): error TS7016: Could not find a declaration file for module 'source-map'. '<repo-path>/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`

    at <repo-path>/DefinitelyTyped/node_modules/dtslint/bin/index.js:207:19
    at Generator.next (<anonymous>)
    at fulfilled (<repo-path>/DefinitelyTyped/node_modules/dtslint/bin/index.js:6:58)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! definitely-typed@0.0.3 test: `dtslint types "webpack-merge-and-include-globally"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the definitely-typed@0.0.3 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     <home-dir>/.npm/_logs/2021-06-02T13_23_49_512Z-debug.log
```
Trying the suggestion in the error log did not help.
