### PR TITLE
Fix Type sshKeyPath

### DIFF
--- a/types/ftps/index.d.ts
+++ b/types/ftps/index.d.ts
@@ -22,7 +22,7 @@ declare namespace FTP {
         cwd?: string;
         additionalLftpCommands?: string;
         requireSSHKey?: boolean;
-        sshKeyPath?: boolean;
+        sshKeyPath?: string;
     }
 
     interface MirrorOptions {


### PR DESCRIPTION
change the type in value sshKeyPath, actuall is boolean, but this value must be string

Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

URL Documentation 
https://www.npmjs.com/package/ftps
