### PR TITLE
[har-format] Adding render blocking and LCP info

### DIFF
--- a/types/har-format/index.d.ts
+++ b/types/har-format/index.d.ts
@@ -500,7 +500,7 @@ export interface Entry {
     /** _non-standard_  */
     _renderBlocking?: string | null;
     /** _non-standard_  */
-    _isLCP?: boolean | null;
+    _isLCP?: boolean | null;
 }
 /**
  * This object contains detailed info about performed request.

--- a/types/har-format/index.d.ts
+++ b/types/har-format/index.d.ts
@@ -497,6 +497,10 @@ export interface Entry {
     _was_pushed?: number | string | null;
     /** _non-standard_  */
     _initialPriority?: string | null;
+    /** _non-standard_  */
+    _renderBlocking?: string | null;
+    /** _non-standard_  */
+    _isLCP?: boolean | null;
 }
 /**
  * This object contains detailed info about performed request.


### PR DESCRIPTION
In Browsertime and coming Chrome 92 we will have support for knowing if a request is render blocking or not. We also will be able to know if an image is the largest Contentful paint (or not). HARs generated from Browsertime/Chrome/Edge will include these new fields.

See https://github.com/micmro/PerfCascade/pull/278

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/micmro/PerfCascade/pull/278
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
