### PR TITLE
add(svg-maps/common): shared types for @svg-maps

### DIFF
--- a/types/svg-maps__brazil/index.d.ts
+++ b/types/svg-maps__brazil/index.d.ts
@@ -3,18 +3,9 @@
 // Definitions by: Joao Sutel <https://github.com/joaosutel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace brazil {
-    interface Location {
-        path: string;
-        id: string;
-        name?: string;
-    }
-    interface Map {
-        viewBox: string;
-        locations: Location[];
-        label?: string;
-    }
-}
+import { Location, Map } from '@svg-maps/common';
 
-declare const brazil: brazil.Map;
-export = brazil;
+declare const brazil: Map;
+
+export default brazil;
+export { Location, Map };

--- a/types/svg-maps__brazil/svg-maps__brazil-tests.ts
+++ b/types/svg-maps__brazil/svg-maps__brazil-tests.ts
@@ -1,19 +1,23 @@
-import * as brazil from 'svg-maps__brazil';
+import * as brazil from '@svg-maps/brazil';
 
 const SVGMapContainer: brazil.Map = {
-  viewBox: 'viewBox',
-  locations: [{
-    path: 'path',
-    id: 'id',
-    name: 'name'
-  }],
-  label: 'label'
+    viewBox: 'viewBox',
+    locations: [
+        {
+            path: 'path',
+            id: 'id',
+            name: 'name',
+        },
+    ],
+    label: 'label',
 };
 
 const SVGMapContainerNoOptional: brazil.Map = {
-  viewBox: 'vieweBox',
-  locations: [{
-  path: 'path',
-  id: 'id',
-  }],
+    viewBox: 'viewBox',
+    locations: [
+        {
+            path: 'path',
+            id: 'id',
+        },
+    ],
 };

--- a/types/svg-maps__brazil/tsconfig.json
+++ b/types/svg-maps__brazil/tsconfig.json
@@ -12,6 +12,9 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "@svg-maps/*": ["svg-maps__*"]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/svg-maps__common/index.d.ts
+++ b/types/svg-maps__common/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for @svg-maps
+// Project: https://github.com/VictorCazanave/svg-maps
+// Definitions by: Nick Glazer <https://github.com/nickglazer>
+//                 Piotr Blażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// This extracts the common definitions from SVGMaps to allow reusing common interfaces in SVG maps packages.
+
+export interface Location {
+    path: string;
+    id: string;
+    name?: string;
+}
+
+export interface Map {
+    viewBox: string;
+    locations: Location[];
+    label?: string;
+}

--- a/types/svg-maps__common/svg-maps__common-tests.ts
+++ b/types/svg-maps__common/svg-maps__common-tests.ts
@@ -1,0 +1,36 @@
+import { Location, Map } from '@svg-maps/common';
+
+const SVGLocation: Location = {
+    path: 'path',
+    id: 'id',
+    name: 'name',
+};
+const SVGMapContainer: Map = {
+    viewBox: 'viewBox',
+    locations: [
+        {
+            path: 'path',
+            id: 'id',
+            name: 'name',
+        },
+    ],
+    label: 'label',
+};
+
+const SVGMapContainerNoOptional: Map = {
+    viewBox: 'vieweBox',
+    locations: [
+        {
+            path: 'path',
+            id: 'id',
+        },
+    ],
+};
+
+declare const Atlantis: Map;
+
+Atlantis.label; // $ExpectType string | undefined
+Atlantis.locations[0].id; // $ExpectType string
+Atlantis.locations[0].path; // $ExpectType string
+Atlantis.locations[0].name; // $ExpectType string | undefined
+Atlantis.viewBox; // $ExpectType string

--- a/types/svg-maps__common/tsconfig.json
+++ b/types/svg-maps__common/tsconfig.json
@@ -8,12 +8,12 @@
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
+        "types": [],
         "paths": {
             "@svg-maps/*": ["svg-maps__*"]
         },
-        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts", "svg-maps__usa-tests.ts"]
+    "files": ["index.d.ts", "svg-maps__common-tests.ts"]
 }

--- a/types/svg-maps__common/tslint.json
+++ b/types/svg-maps__common/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false,
+        "npm-naming": false
+    }
+}

--- a/types/svg-maps__usa/index.d.ts
+++ b/types/svg-maps__usa/index.d.ts
@@ -3,20 +3,9 @@
 // Definitions by: Nick Glazer <https://github.com/nickglazer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// tslint:disable-next-line no-single-declare-module
-declare module '@svg-maps/usa' {
-    export interface Location {
-        path: string;
-        id: string;
-        name?: string;
-    }
+import { Location, Map } from '@svg-maps/common';
 
-    export interface Map {
-        viewBox: string;
-        locations: Location[];
-        label?: string;
-    }
+declare const USA: Map;
 
-    const USA: Map;
-    export default USA;
-}
+export default USA;
+export { Location, Map };

--- a/types/svg-maps__usa/svg-maps__usa-tests.ts
+++ b/types/svg-maps__usa/svg-maps__usa-tests.ts
@@ -3,19 +3,23 @@ import USA, { Map } from '@svg-maps/usa';
 const map: Map = USA;
 
 const SVGMapContainer: Map = {
-  viewBox: 'viewBox',
-  locations: [{
-    path: 'path',
-    id: 'id',
-    name: 'name'
-  }],
-  label: 'label'
+    viewBox: 'viewBox',
+    locations: [
+        {
+            path: 'path',
+            id: 'id',
+            name: 'name',
+        },
+    ],
+    label: 'label',
 };
 
 const SVGMapContainerNoOptional: Map = {
-  viewBox: 'vieweBox',
-  locations: [{
-  path: 'path',
-  id: 'id',
-  }],
+    viewBox: 'viewBox',
+    locations: [
+        {
+            path: 'path',
+            id: 'id',
+        },
+    ],
 };


### PR DESCRIPTION
This extracts common interfaces used accross @svg-maps packages into
definition only repo file, that could be shared accross all packages
implementing @svg-maps/* on DT

/cc @nickglazer for your review

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).