### PR TITLE
Fix missed mongoose dependents

### DIFF
--- a/types/mongoose-paginate/package.json
+++ b/types/mongoose-paginate/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/mongoose": "^5.10.5"
+    }
+}

--- a/types/mongoose-sequence/package.json
+++ b/types/mongoose-sequence/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/mongoose": "^5.10.5"
+    }
+}

--- a/types/passport-local-mongoose/package.json
+++ b/types/passport-local-mongoose/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/mongoose": "4.*"
+    }
+}


### PR DESCRIPTION
I think that @definitelytyped/dtslint-runner missed the dependency these three packages have on mongoose, and therefore didn't run them on #53417 
