### PR TITLE
Add missing "measure" property to ConditionalFormat interface (Flexmonster 2.9.0)

### DIFF
--- a/types/flexmonster/index.d.ts
+++ b/types/flexmonster/index.d.ts
@@ -484,6 +484,7 @@ declare namespace Flexmonster {
         row?: number;
         column?: number;
         measureName?: string;
+        measure?: string;
         hierarchy?: string;
         member?: string;
         isTotal?: number;


### PR DESCRIPTION
Added "measure" property to ConditionalFormat interface because "measureName" is not recognized in the most recent version of Flexmonster.

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.