### PR TITLE
Allow custom CSS properties (aka CSS variables) for styled-system

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -10,7 +10,7 @@
 //                 mrkosima <https://github.com/mrkosima>
 //                 rafaelalmeidatk <https://github.com/rafaelalmeidatk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// Minimum TypeScript Version: 4.1
 
 import { ResponsiveStyleValue, SystemStyleObject } from '@styled-system/css';
 import * as React from 'react';

--- a/types/rebass__forms/index.d.ts
+++ b/types/rebass__forms/index.d.ts
@@ -4,7 +4,7 @@
 //                 trumanshuck <https://github.com/trumanshuck>
 //                 Eddie Cooro <https://github.com/Eddie-CooRo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// Minimum TypeScript Version: 4.1
 
 import * as React from 'react';
 import * as Rebass from 'rebass';

--- a/types/rebass__grid/index.d.ts
+++ b/types/rebass__grid/index.d.ts
@@ -7,7 +7,7 @@
 //                 Erin Noe-Payne <https://github.com/autoric>
 //                 akameco <https://github.com/akameco>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Minimum TypeScript Version: 4.1
 
 import * as React from "react";
 import * as StyledSystem from "styled-system";

--- a/types/rebass__layout/index.d.ts
+++ b/types/rebass__layout/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/rebassjs/rebass#readme
 // Definitions by: Rafael Almeida <https://github.com/rafaelalmeidatk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.1
 
 import * as React from 'react';
 import * as Rebass from 'rebass';

--- a/types/reflexbox/index.d.ts
+++ b/types/reflexbox/index.d.ts
@@ -8,7 +8,7 @@
 //                 Erin Noe-Payne <https://github.com/autoric>
 //                 akameco <https://github.com/akameco>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// Minimum TypeScript Version: 4.1
 
 import * as React from 'react';
 import * as StyledSystem from 'styled-system';

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -153,15 +153,16 @@ export interface styleFn {
 }
 
 export type CSSVariable = `--${string}`;
+export type CSSProperty = keyof CSS.Properties | CSSVariable;
 
 export interface ConfigStyle {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
-    property?: keyof CSS.Properties | CSSVariable;
+    property?: CSSProperty;
     /**
      * An array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
      * assigned (overrides `property` when present).
      */
-    properties?: Array<keyof CSS.Properties | CSSVariable>;
+    properties?: CSSProperty[];
     /** A string referencing a key in the `theme` object. */
     scale?: string;
     /** A fallback scale object for when there isn't one defined in the `theme` object. */

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -21,7 +21,7 @@
 //                 Dhruv Jain <https://github.com/maddhruv>
 //                 Jeffrey Cherewaty <https://github.com/cherewaty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Minimum TypeScript Version: 4.1
 
 import * as CSS from 'csstype';
 
@@ -152,14 +152,16 @@ export interface styleFn {
     cache?: object;
 }
 
+export type CSSVariable = `--${string}`;
+
 export interface ConfigStyle {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
-    property?: keyof CSS.Properties;
+    property?: keyof CSS.Properties | CSSVariable;
     /**
      * An array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
      * assigned (overrides `property` when present).
      */
-    properties?: Array<keyof CSS.Properties>;
+    properties?: Array<keyof CSS.Properties | CSSVariable>;
     /** A string referencing a key in the `theme` object. */
     scale?: string;
     /** A fallback scale object for when there isn't one defined in the `theme` object. */

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -511,6 +511,14 @@ const customFontStyles = system({
         defaultScale: [200, 400, 600],
         transform: (n, scale) => get(scale, n),
     },
+    variable: {
+        property: '--some-var',
+        scale: 'fontWeights'
+    },
+    manyVariables: {
+        properties: ['--some-other-var'],
+        scale: 'fontWeights'
+    },
     letterSpacing: true,
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

We use this for a private repo, so I cannot share docs. But we want to create CSS variables because we need to set some css properties with values coming from two scales, `space` and `borderWidths`. So something like:
```js
css({
  py: 'calc(var(--space-value) - var(--border-width-value))',
})
```
So we created those variables like:
```js
const inputVariables = system({
  paddingVariable: {
    property: '--space-variable',
    scale: 'space'
  },
  borderVariable: {
    property: '--border-width-variable',
    scale: 'borderWidths'
  }
})
// ...
styled('input')(
  inputVariables({
    theme,
    paddingVariable: 'inc30',
    borderVariable: 'inc70',
  }),
  css({
    py: 'calc(var(--space-value) - var(--border-width-value))'
  })
```
I left all the types out for simplicity. But this works, it's only that the styled-system types complain because `--space-variable` for example, is not a valid CSS.Properties type. The csstypes library will never support it, and leaves it up to authors to implement it themselves according to their needs: https://github.com/frenic/csstype/issues/63

So that's why I have this PR here. There is nothing about the library that prevents this from working, and in fact `system` is for defining your own properties, and CSS variables are valid properties, so the typescript types should support it.