### PR TITLE
fix(node): remove abort method on AbortSignal

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -332,11 +332,6 @@ interface AbortSignal {
      * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
      */
     readonly aborted: boolean;
-
-    /**
-     * Invoking this method will set this object's AbortSignal's aborted flag and signal to any observers that the associated activity is to be aborted.
-     */
-    abort(): void;
 }
 
 declare var AbortController: {
@@ -347,6 +342,7 @@ declare var AbortController: {
 declare var AbortSignal: {
     prototype: AbortSignal;
     new(): AbortSignal;
+    // TODO: Add abort() static
 };
 //#endregion borrowed
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/globals.html#globals_class_abortsignal
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Caveat: This method is meant to be static but I cannot reasonable declare it due to lib dom using a type rather than an interface which makes decl merging seemingly impossible.