### PR TITLE
[cloudinary-uploadwidget] Add typings for cloudinary-uploadwidget non-module script (v2)

### DIFF
--- a/types/cloudinary-uploadwidget-browser/cloudinary-uploadwidget-browser-tests.ts
+++ b/types/cloudinary-uploadwidget-browser/cloudinary-uploadwidget-browser-tests.ts
@@ -1,0 +1,213 @@
+import 'cloudinary-uploadwidget-browser';
+
+// $ExpectType void
+cloudinary.setCloudName('my-cloud-name');
+cloudinary.setCloudName(); // $ExpectError
+
+// $ExpectType CloudinaryUploadWidget
+const widget = cloudinary.createUploadWidget(
+    { cloudName: 'my-cloud-name', uploadPreset: 'preset-1' },
+    (error, result) => {},
+);
+
+widget.open(); // $ExpectType void
+widget.open('url'); // $ExpectType void
+widget.hide(); // $ExpectType void
+widget.show(); // $ExpectType void
+widget.close(); // $ExpectType void
+widget.close({ quiet: true }); // $ExpectType void
+widget.minimize();
+widget.destroy(); // $ExpectType void
+widget.destroy({ removeThumbnails: true }); // $ExpectType void
+widget.isShowing(); // $ExpectType boolean
+widget.isMinimized(); // $ExpectType boolean
+widget.isDestroyed(); // $ExpectType boolean
+
+// $ExpectType CloudinaryUploadWidget
+cloudinary.openUploadWidget(
+    {
+        cloudName: 'my-cloud-name',
+        uploadPreset: 'preset1',
+    },
+    (error, result) => {},
+);
+
+// $ExpectType CloudinaryUploadWidget
+cloudinary.applyUploadWidget(
+    document.getElementById('opener')!,
+    { cloudName: 'my-cloud-name', uploadPreset: 'preset1' },
+    (error, result) => {},
+);
+
+cloudinary.createUploadWidget({ cloudName: 'my-cloud-name', uploadSignature: 'c347053314777423cd4f' });
+cloudinary.createUploadWidget({
+    cloudName: 'my-cloud-name',
+    uploadSignature: (next, options) => Promise.resolve('c347053314777423cd4f').then(next),
+    uploadSignatureTimestamp: 1315060076,
+});
+
+// $ExpectType void
+widget.update({
+    cloudName: 'demo',
+    uploadPreset: 'preset1',
+    sources: ['local', 'url'],
+    encryption: { key: 'ff234fe526725753fa45b53325', iv: 'cd8a46d72e26a365dca78ef' },
+    defaultSource: 'local',
+    multiple: false,
+    maxFiles: 3,
+
+    cropping: true,
+    showSkipCropButton: false,
+    croppingAspectRatio: null,
+    croppingDefaultSelectionRatio: 0.5,
+    croppingShowDimensions: true,
+    croppingCoordinatesMode: 'face',
+    croppingShowBackButton: false,
+
+    dropboxAppKey: 'dropbox',
+    facebookAppId: 'facebook',
+    googleApiKey: 'google',
+    searchBySites: ['all'],
+    searchByRights: true,
+    instagramClientId: 'instagram',
+    googleDriveClientId: 'google_drive',
+
+    publicId: 'profile_11002',
+    folder: 'user_photos',
+    tags: ['users', 'content'],
+    resourceType: 'image',
+    context: { alt: 'my_alt', caption: 'my_caption' },
+
+    clientAllowedFormats: ['webp', 'gif', 'videos'],
+    maxFileSize: 5500000,
+    maxImageFileSize: 1500000,
+    maxVideoFileSize: 15000000,
+    maxRawFileSize: 2000000,
+    maxImageWidth: 2000,
+    maxImageHeight: 2000,
+    validateMaxWidthHeight: false,
+    minImageWidth: 200,
+    minImageHeight: 200,
+    croppingValidateDimensions: true,
+    maxChunkSize: 5000000,
+
+    form: '#my_form',
+    thumbnails: '.content .uploaded',
+    thumbnailTransformation: 'w_200,h_200,c_fill',
+
+    buttonClass: 'btn btn-default',
+    buttonCaption: 'Upload',
+    theme: 'minimal',
+    styles: {
+        palette: {
+            window: '#FFF',
+            windowBorder: '#90A0B3',
+            tabIcon: '#0E2F5A',
+            menuIcons: '#5A616A',
+            textDark: '#000000',
+            textLight: '#FFFFFF',
+            link: '#0078FF',
+            action: '#FF620C',
+            inactiveTabIcon: '#0E2F5A',
+            error: '#F44235',
+            inProgress: '#0078FF',
+            complete: '#20B832',
+            sourceBg: '#E4EBF1',
+        },
+        fonts: {
+            "'Cute Font', cursive": 'https://fonts.googleapis.com/css?family=Cute+Font',
+        },
+    },
+    text: {
+        en: {
+            queue: {
+                title: 'Files to upload',
+                title_uploading_with_counter: 'Uploading {{num}} files',
+            },
+            crop: {
+                title: 'Crop your image',
+            },
+        },
+    },
+
+    showPoweredBy: false,
+    autoMinimize: false,
+    getUploadPresets(cb) {
+        cb(['signed', 'video', 'eager']);
+    },
+    prepareUploadParams() {},
+    language: 'en',
+    showAdvancedOptions: true,
+    showCompletedButton: true,
+    showUploadMoreButton: true,
+    singleUploadAutoClose: true,
+    queueViewPosition: 'right:35px',
+    showInsecurePreview: false,
+});
+
+cloudinary.createUploadWidget({
+    cloudName: 'my-cloud-name',
+    form: '#my_form',
+    fieldName: 'file',
+    thumbnails: '.thumbnails',
+    thumbnailTransformation: [{ width: 200, height: 200, crop: 'fill' }, { effect: 'sepia' }],
+});
+
+cloudinary.createUploadWidget({
+    cloudName: 'demo',
+    getTags(cb, prefix) {
+        cb(prefix === 'night' ? ['evening', 'dark'] : ['morning', 'sunny']);
+    },
+    preBatch() {},
+    inlineContainer: '#my-widget-container',
+});
+
+cloudinary.createUploadWidget({
+    cloudName: 'demo',
+    inlineContainer: document.getElementById('my-widget-container'),
+});
+
+cloudinary.openUploadWidget(
+    {
+        uploadPreset: 'preset1',
+        cloudName: 'demo',
+        preBatch: (cb, data) => {
+            if (data.files[0].name === 'TopSecret') {
+                cb({ cancel: true });
+            } else {
+                cb();
+            }
+        },
+        prepareUploadParams: (cb, parameters) => {
+            const params = ([] as object[]).concat(parameters);
+            Promise.all(
+                params.map(req =>
+                    fetch('https://mysite.example.com/prepare', req)
+                        .then(res => res.json())
+                        .then(response => ({
+                            signature: response.signature,
+                            apiKey: response.api_key,
+                            ...response.upload_params,
+                        })),
+                ),
+            ).then(results => cb(results.length === 1 ? results[0] : results));
+        },
+    },
+    (error, result) => {},
+);
+
+cloudinary.openUploadWidget(
+    {
+        cloudName: 'demo',
+        uploadPreset: 'preset1',
+        showCompletedButton: true,
+    },
+    (error, result) => {
+        if (!error && result.event === 'show-completed') {
+            result.info.items.forEach(item => {
+                console.log(`show completed for item with id:
+        ${item.uploadInfo.public_id}`); // uploadInfo is the data returned in the upload response
+            });
+        }
+    },
+);

--- a/types/cloudinary-uploadwidget-browser/index.d.ts
+++ b/types/cloudinary-uploadwidget-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cloudinary upload widget 2.3
+// Type definitions for non-npm package cloudinary-uploadwidget-browser 2.3
 // Project: https://cloudinary.com/documentation/upload_widget_reference
 // Definitions by: Jeremy Liberman <https://github.com/mrleebo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/cloudinary-uploadwidget-browser/index.d.ts
+++ b/types/cloudinary-uploadwidget-browser/index.d.ts
@@ -1,0 +1,259 @@
+// Type definitions for cloudinary upload widget 2.3
+// Project: https://cloudinary.com/documentation/upload_widget_reference
+// Definitions by: Jeremy Liberman <https://github.com/mrleebo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var cloudinary: CloudinaryBase;
+
+interface CloudinaryBase {
+    setCloudName(name: string): void;
+
+    createUploadWidget(
+        options: CloudinaryUploadWidgetOptions,
+        resultCallback?: (error: string | null, result: CloudinaryEvent) => void,
+    ): CloudinaryUploadWidget;
+
+    openUploadWidget(
+        options: CloudinaryUploadWidgetOptions,
+        resultCallback?: (error: string | null, result: CloudinaryEvent) => void,
+    ): CloudinaryUploadWidget;
+
+    applyUploadWidget(
+        element: HTMLElement,
+        options: CloudinaryUploadWidgetOptions,
+        resultCallback?: (error: string | null, result: CloudinaryEvent) => void,
+    ): CloudinaryUploadWidget;
+}
+
+interface CloudinaryUploadWidget {
+    open(files?: string): void;
+    close(options?: { quiet: boolean }): void;
+    update(options: Partial<Omit<CloudinaryUploadWidgetOptions, NotSupportedForUpdates>>): void;
+    hide(): void;
+    show(): void;
+    minimize(): void;
+    destroy(options?: { removeThumbnails: boolean }): void;
+    isShowing(): boolean;
+    isMinimized(): boolean;
+    isDestroyed(): boolean;
+}
+
+type NotSupportedForUpdates = 'secure' | 'uploadSignature' | 'getTags' | 'preBatch' | 'inlineContainer' | 'fieldName';
+
+type CloudinaryUploadWidgetOptions = RequiredParameters &
+    WidgetParameters &
+    CroppingParameters &
+    SourcesParameters &
+    UploadParameters &
+    ClientParameters &
+    PageParameters &
+    CustomizationParameters &
+    AdvancedParameters;
+
+interface RequiredParameters {
+    cloudName: string;
+    uploadPreset?: string;
+}
+
+interface WidgetParameters {
+    sources?: Source[];
+    secure?: boolean;
+    encryption?: { key: string; iv: string };
+    defaultSource?: Source;
+    multiple?: boolean;
+    maxFiles?: number;
+}
+
+interface CroppingParameters {
+    cropping?: boolean;
+    showSkipCropButton?: boolean;
+    croppingAspectRatio?: number | null;
+    croppingDefaultSelectionRatio?: number;
+    croppingShowDimensions?: boolean;
+    croppingCoordinatesMode?: 'custom' | 'face';
+    croppingShowBackButton?: boolean;
+}
+
+interface SourcesParameters {
+    dropboxAppKey?: string;
+    facebookAppId?: string;
+    googleApiKey?: string;
+    searchBySites?: string[];
+    searchByRights?: boolean;
+    instagramClientId?: string;
+    googleDriveClientId?: string;
+}
+
+interface UploadParameters {
+    publicId?: string | null;
+    folder?: string | null;
+    tags?: string[] | null;
+    resourceType?: 'auto' | 'image' | 'video' | 'raw';
+    context?: Record<string, any>;
+    uploadSignature?: string | ((callback: (result: string) => void, params: CloudinaryUploadWidgetOptions) => void);
+    uploadSignatureTimestamp?: number;
+}
+
+interface ClientParameters {
+    clientAllowedFormats?: string[] | null;
+    maxFileSize?: number;
+    maxImageFileSize?: number;
+    maxVideoFileSize?: number;
+    maxRawFileSize?: number;
+    maxImageWidth?: number | null;
+    maxImageHeight?: number | null;
+    validateMaxWidthHeight?: boolean;
+    minImageWidth?: number | null;
+    minImageHeight?: number | null;
+    croppingValidateDimensions?: boolean;
+    maxChunkSize?: number;
+}
+
+interface PageParameters {
+    form?: string;
+    fieldName?: string;
+    thumbnails?: string | null;
+    thumbnailTransformation?: string | ThumbnailTransformation[];
+}
+
+interface CustomizationParameters {
+    buttonClass?: string;
+    buttonCaption?: string;
+    theme?: 'default' | 'white' | 'minimal' | 'purple';
+    styles?: CustomizedStyles;
+    text?: CustomizedText;
+}
+
+interface AdvancedParameters {
+    showPoweredBy?: boolean;
+    autoMinimize?: boolean;
+    getTags?: (cb: (tags: ReadonlyArray<string>) => void, prefix: string) => void;
+    getUploadPresets?: (cb: (presets: ReadonlyArray<string>) => void) => void;
+    preBatch?: (cb: (options?: { cancel: boolean }) => void, data: { [key: string]: any }) => void;
+    prepareUploadParams?: (cb: (results: any) => void, params: any) => void;
+    language?: string;
+    showAdvancedOptions?: boolean;
+    showCompletedButton?: boolean;
+    showUploadMoreButton?: boolean;
+    singleUploadAutoClose?: boolean;
+    queueViewPosition?: string;
+    showInsecurePreview?: boolean;
+    inlineContainer?: string | HTMLElement | null;
+}
+
+type ThumbnailTransformation = { [key: string]: any } & {
+    width?: number;
+    height?: number;
+    crop?: string;
+    effect?: string;
+};
+
+interface CustomizedStyles {
+    [key: string]: any;
+}
+
+interface CustomizedText {
+    [key: string]: any;
+}
+
+type Source =
+    | 'local'
+    | 'url'
+    | 'camera'
+    | 'dropbox'
+    | 'image_search'
+    | 'facebook'
+    | 'instagram'
+    | 'shutterstock'
+    | 'google_drive';
+
+type CloudinaryEvent =
+    | AbortEvent
+    | BatchCancelledEvent
+    | CloseEvent
+    | DisplayChangedEvent
+    | PublicIdEvent
+    | QueuesEndEvent
+    | QueuesStartEvent
+    | RetryEvent
+    | ShowCompletedEvent
+    | SourceChangedEvent
+    | SuccessEvent
+    | TagsEvent
+    | UploadAddedEvent;
+
+interface AbortEvent {
+    event: 'abort';
+    info: {
+        ids: string[];
+        all: boolean;
+    };
+}
+
+interface BatchCancelledEvent {
+    event: 'batch-cancelled';
+    info: { reason: 'MAX_EXCEEDED' | 'INVALID_PUBLIC_ID' };
+}
+
+interface CloseEvent {
+    event: 'close';
+}
+
+interface DisplayChangedEvent {
+    event: 'display-changed';
+    info: 'shown' | 'hidden' | 'minimized' | 'expanded';
+}
+
+interface PublicIdEvent {
+    event: 'publicid';
+    info: { id: string | null };
+}
+
+interface QueuesEndEvent {
+    event: 'queues-end';
+    info: any;
+}
+
+interface QueuesStartEvent {
+    event: 'queues-start';
+}
+
+interface RetryEvent {
+    event: 'retry';
+    info: {
+        ids: string[];
+        all: boolean;
+    };
+}
+
+interface ShowCompletedEvent {
+    event: 'show-completed';
+    info: {
+        items: any[];
+    };
+}
+
+interface SourceChangedEvent {
+    event: 'source-changed';
+    info: { source: string };
+}
+
+interface SuccessEvent {
+    event: 'success';
+    info: any;
+}
+
+interface TagsEvent {
+    event: 'tags';
+    info: {
+        tags: string[];
+    };
+}
+
+interface UploadAddedEvent {
+    event: 'upload-added';
+    info: {
+        file: any;
+        publicId: string | null;
+    };
+}

--- a/types/cloudinary-uploadwidget-browser/tsconfig.json
+++ b/types/cloudinary-uploadwidget-browser/tsconfig.json
@@ -5,7 +5,10 @@
             "es6",
             "dom"
         ],
-        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/cloudinary-uploadwidget-browser/tsconfig.json
+++ b/types/cloudinary-uploadwidget-browser/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cloudinary-uploadwidget-browser-tests.ts"
+    ]
+}

--- a/types/cloudinary-uploadwidget-browser/tslint.json
+++ b/types/cloudinary-uploadwidget-browser/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/cloudinary-uploadwidget-browser/tslint.json
+++ b/types/cloudinary-uploadwidget-browser/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
  - https://cloudinary.com/documentation/upload_widget
  - Cloudinary has type definitions for their NodeJS and React APIs, but
    not for their upload widget. This commit provides them.
  - Covers the majority of the APIs, excluding the localization and styling parts
  - Tests are mostly code samples copy+pasted from the widget docs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
