### PR TITLE
Add mjClass prop to ClassNameProps in mjml-react package

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -48,6 +48,7 @@ export interface BorderProps {
 
 export interface ClassNameProps {
     cssClass?: string;
+    mjClass?: string;
 }
 
 export interface HrefProps {
@@ -62,30 +63,30 @@ export interface MjmlProps {
     owa?: string;
 }
 
-export class Mjml extends React.Component<MjmlProps> { }
+export class Mjml extends React.Component<MjmlProps> {}
 
 // mj-head
-export class MjmlHead extends React.Component { }
+export class MjmlHead extends React.Component {}
 
 // mj-attributes
-export class MjmlAttributes extends React.Component { }
-export class MjmlAll extends React.Component<{ [key: string]: any; children?: React.ReactNode }> { }
-export class MjmlClass extends React.Component<{ [key: string]: any; children?: React.ReactNode; name: string }> { }
+export class MjmlAttributes extends React.Component {}
+export class MjmlAll extends React.Component<{ [key: string]: any; children?: React.ReactNode }> {}
+export class MjmlClass extends React.Component<{ [key: string]: any; children?: React.ReactNode; name: string }> {}
 
 // mj-breakpoint
 export interface MjmlBreakpointProps {
     width?: string | number;
 }
 
-export class MjmlBreakpoint extends React.Component<MjmlBreakpointProps> { }
+export class MjmlBreakpoint extends React.Component<MjmlBreakpointProps> {}
 
 // mj-body
 export interface MjmlBodyProps {
-    width ?: number;
+    width?: number;
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlBody extends React.Component<MjmlBodyProps & ClassNameProps> { }
+export class MjmlBody extends React.Component<MjmlBodyProps & ClassNameProps> {}
 
 // mj-font
 export interface MjmlFontProps {
@@ -93,19 +94,19 @@ export interface MjmlFontProps {
     name?: string;
 }
 
-export class MjmlFont extends React.Component<MjmlFontProps> { }
+export class MjmlFont extends React.Component<MjmlFontProps> {}
 
 // mj-preview
-export class MjmlPreview extends React.Component<{ children: string }> { }
+export class MjmlPreview extends React.Component<{ children: string }> {}
 
 // mj-style
-export class MjmlStyle extends React.Component<{ children: string, inline?: boolean }> { }
+export class MjmlStyle extends React.Component<{ children: string; inline?: boolean }> {}
 
 // mj-title
-export class MjmlTitle extends React.Component<{ children: string }> { }
+export class MjmlTitle extends React.Component<{ children: string }> {}
 
 // mj-accordion
-export class MjmlAccordion extends React.Component<MjmlAccordionElementProps> { }
+export class MjmlAccordion extends React.Component<MjmlAccordionElementProps> {}
 
 export interface MjmlAccordionElementProps {
     fontFamily?: string;
@@ -120,7 +121,7 @@ export interface MjmlAccordionElementProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlAccordionElement extends React.Component<MjmlAccordionElementProps & ClassNameProps> { }
+export class MjmlAccordionElement extends React.Component<MjmlAccordionElementProps & ClassNameProps> {}
 
 export interface MjmlAccordionTextProps {
     color?: React.CSSProperties['color'];
@@ -129,7 +130,7 @@ export interface MjmlAccordionTextProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlAccordionText extends React.Component<MjmlAccordionTextProps & PaddingProps & ClassNameProps> { }
+export class MjmlAccordionText extends React.Component<MjmlAccordionTextProps & PaddingProps & ClassNameProps> {}
 
 export interface MjmlAccordionTitleProps {
     color?: React.CSSProperties['color'];
@@ -138,7 +139,7 @@ export interface MjmlAccordionTitleProps {
     fontSize?: string | number;
 }
 
-export class MjmlAccordionTitle extends React.Component<MjmlAccordionTitleProps & PaddingProps & ClassNameProps> { }
+export class MjmlAccordionTitle extends React.Component<MjmlAccordionTitleProps & PaddingProps & ClassNameProps> {}
 
 // mj-button
 export interface MjmlButtonProps {
@@ -160,7 +161,9 @@ export interface MjmlButtonProps {
     height?: string | number;
 }
 
-export class MjmlButton extends React.Component<MjmlButtonProps & PaddingProps & ClassNameProps & HrefProps & BorderProps> { }
+export class MjmlButton extends React.Component<
+    MjmlButtonProps & PaddingProps & ClassNameProps & HrefProps & BorderProps
+> {}
 
 // mj-carousel
 export interface MjmlCarouselProps {
@@ -187,7 +190,7 @@ export interface MjmlCarouselImageProps {
     title?: string;
 }
 
-export class MjmlCarouselImage extends React.Component<MjmlCarouselImageProps & ClassNameProps & HrefProps> { }
+export class MjmlCarouselImage extends React.Component<MjmlCarouselImageProps & ClassNameProps & HrefProps> {}
 
 // mj-carousel
 export interface MjmlColumnProps {
@@ -196,7 +199,7 @@ export interface MjmlColumnProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlColumn extends React.Component<MjmlColumnProps & PaddingProps & ClassNameProps & BorderProps> { }
+export class MjmlColumn extends React.Component<MjmlColumnProps & PaddingProps & ClassNameProps & BorderProps> {}
 
 // mj-divider
 export interface MjmlDividerProps {
@@ -207,7 +210,7 @@ export interface MjmlDividerProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlDivider extends React.Component<MjmlDividerProps & ClassNameProps & PaddingProps> { }
+export class MjmlDivider extends React.Component<MjmlDividerProps & ClassNameProps & PaddingProps> {}
 
 // mj-group
 export interface MjmlGroupProps {
@@ -216,7 +219,7 @@ export interface MjmlGroupProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlGroup extends React.Component<MjmlGroupProps & ClassNameProps> { }
+export class MjmlGroup extends React.Component<MjmlGroupProps & ClassNameProps> {}
 
 // mj-hero
 export interface MjmlHeroProps {
@@ -231,7 +234,7 @@ export interface MjmlHeroProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlHero extends React.Component<MjmlHeroProps & ClassNameProps & PaddingProps> { }
+export class MjmlHero extends React.Component<MjmlHeroProps & ClassNameProps & PaddingProps> {}
 
 // mj-image
 export interface MjmlImageProps {
@@ -248,7 +251,7 @@ export interface MjmlImageProps {
     fluidOnMobile?: string;
 }
 
-export class MjmlImage extends React.Component<MjmlImageProps & PaddingProps & ClassNameProps & HrefProps> { }
+export class MjmlImage extends React.Component<MjmlImageProps & PaddingProps & ClassNameProps & HrefProps> {}
 
 // mj-navbar
 export interface MjmlNavbarProps {
@@ -270,7 +273,7 @@ export interface MjmlNavbarProps {
     icoLineHeight?: string;
 }
 
-export class MjmlNavbar extends React.Component<MjmlNavbarProps> { }
+export class MjmlNavbar extends React.Component<MjmlNavbarProps> {}
 
 export interface MjmlNavbarLinkProps {
     color?: React.CSSProperties['color'];
@@ -283,10 +286,10 @@ export interface MjmlNavbarLinkProps {
     textTransform?: string;
 }
 
-export class MjmlNavbarLink extends React.Component<MjmlNavbarLinkProps & HrefProps & PaddingProps> { }
+export class MjmlNavbarLink extends React.Component<MjmlNavbarLinkProps & HrefProps & PaddingProps> {}
 
 // mj-raw
-export class MjmlRaw extends React.Component { }
+export class MjmlRaw extends React.Component {}
 
 // mj-section
 export interface MjmlSectionProps {
@@ -300,7 +303,7 @@ export interface MjmlSectionProps {
     direction?: 'ltr' | 'rtl';
 }
 
-export class MjmlSection extends React.Component<MjmlSectionProps & BorderProps & PaddingProps & ClassNameProps> { }
+export class MjmlSection extends React.Component<MjmlSectionProps & BorderProps & PaddingProps & ClassNameProps> {}
 
 // mj-social
 export interface MjmlSocialProps {
@@ -318,7 +321,7 @@ export interface MjmlSocialProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlSocial extends React.Component<MjmlSocialProps & PaddingProps> { }
+export class MjmlSocial extends React.Component<MjmlSocialProps & PaddingProps> {}
 
 export interface MjmlSocialElementProps {
     borderRadius?: string | number;
@@ -332,15 +335,36 @@ export interface MjmlSocialElementProps {
     textDecoration?: string;
     align?: string;
     color?: React.CSSProperties['color'];
-    name?: 'facebook' | 'facebook-noshare' | 'twitter' | 'twitter-noshare' | 'google' | 'google-noshare' | 'pinterest' | 'pinterest-noshare' |
-        'linkedin' | 'linkedin-noshare' | 'tumblr' | 'tumblr-noshare' | 'xing' | 'xing-noshare' |
-        'github' | 'instagram' | 'web' | 'snapchat' | 'youtube' | 'vimeo' | 'medium' | 'soundcloud' | 'dribbble';
+    name?:
+        | 'facebook'
+        | 'facebook-noshare'
+        | 'twitter'
+        | 'twitter-noshare'
+        | 'google'
+        | 'google-noshare'
+        | 'pinterest'
+        | 'pinterest-noshare'
+        | 'linkedin'
+        | 'linkedin-noshare'
+        | 'tumblr'
+        | 'tumblr-noshare'
+        | 'xing'
+        | 'xing-noshare'
+        | 'github'
+        | 'instagram'
+        | 'web'
+        | 'snapchat'
+        | 'youtube'
+        | 'vimeo'
+        | 'medium'
+        | 'soundcloud'
+        | 'dribbble';
     src?: string;
     alt?: string;
     iconPadding?: string;
 }
 
-export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & HrefProps & PaddingProps> { }
+export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & HrefProps & PaddingProps> {}
 
 // mj-spacer
 export interface MjmlSpacerProps {
@@ -350,7 +374,7 @@ export interface MjmlSpacerProps {
     verticalAlign?: React.CSSProperties['verticalAlign'];
 }
 
-export class MjmlSpacer extends React.Component<MjmlSpacerProps & BorderProps & PaddingProps & ClassNameProps> { }
+export class MjmlSpacer extends React.Component<MjmlSpacerProps & BorderProps & PaddingProps & ClassNameProps> {}
 
 // mj-table
 export interface MjmlTableProps {
@@ -367,7 +391,7 @@ export interface MjmlTableProps {
     align?: 'left' | 'right' | 'center';
 }
 
-export class MjmlTable extends React.Component<MjmlTableProps & PaddingProps> { }
+export class MjmlTable extends React.Component<MjmlTableProps & PaddingProps> {}
 
 // mj-text
 export interface MjmlTextProps {
@@ -385,7 +409,7 @@ export interface MjmlTextProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlText extends React.Component<MjmlTextProps & PaddingProps & ClassNameProps> { }
+export class MjmlText extends React.Component<MjmlTextProps & PaddingProps & ClassNameProps> {}
 
 // mj-wrapper
 export interface MjmlWrapperProps {
@@ -398,4 +422,4 @@ export interface MjmlWrapperProps {
     textAlign?: React.CSSProperties['textAlign'];
 }
 
-export class MjmlWrapper extends React.Component<MjmlWrapperProps & BorderProps & PaddingProps & ClassNameProps> { }
+export class MjmlWrapper extends React.Component<MjmlWrapperProps & BorderProps & PaddingProps & ClassNameProps> {}

--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -63,30 +63,30 @@ export interface MjmlProps {
     owa?: string;
 }
 
-export class Mjml extends React.Component<MjmlProps> {}
+export class Mjml extends React.Component<MjmlProps> { }
 
 // mj-head
-export class MjmlHead extends React.Component {}
+export class MjmlHead extends React.Component { }
 
 // mj-attributes
-export class MjmlAttributes extends React.Component {}
-export class MjmlAll extends React.Component<{ [key: string]: any; children?: React.ReactNode }> {}
-export class MjmlClass extends React.Component<{ [key: string]: any; children?: React.ReactNode; name: string }> {}
+export class MjmlAttributes extends React.Component { }
+export class MjmlAll extends React.Component<{ [key: string]: any; children?: React.ReactNode }> { }
+export class MjmlClass extends React.Component<{ [key: string]: any; children?: React.ReactNode; name: string }> { }
 
 // mj-breakpoint
 export interface MjmlBreakpointProps {
     width?: string | number;
 }
 
-export class MjmlBreakpoint extends React.Component<MjmlBreakpointProps> {}
+export class MjmlBreakpoint extends React.Component<MjmlBreakpointProps> { }
 
 // mj-body
 export interface MjmlBodyProps {
-    width?: number;
+    width ?: number;
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlBody extends React.Component<MjmlBodyProps & ClassNameProps> {}
+export class MjmlBody extends React.Component<MjmlBodyProps & ClassNameProps> { }
 
 // mj-font
 export interface MjmlFontProps {
@@ -94,19 +94,19 @@ export interface MjmlFontProps {
     name?: string;
 }
 
-export class MjmlFont extends React.Component<MjmlFontProps> {}
+export class MjmlFont extends React.Component<MjmlFontProps> { }
 
 // mj-preview
-export class MjmlPreview extends React.Component<{ children: string }> {}
+export class MjmlPreview extends React.Component<{ children: string }> { }
 
 // mj-style
-export class MjmlStyle extends React.Component<{ children: string; inline?: boolean }> {}
+export class MjmlStyle extends React.Component<{ children: string, inline?: boolean }> { }
 
 // mj-title
-export class MjmlTitle extends React.Component<{ children: string }> {}
+export class MjmlTitle extends React.Component<{ children: string }> { }
 
 // mj-accordion
-export class MjmlAccordion extends React.Component<MjmlAccordionElementProps> {}
+export class MjmlAccordion extends React.Component<MjmlAccordionElementProps> { }
 
 export interface MjmlAccordionElementProps {
     fontFamily?: string;
@@ -121,7 +121,7 @@ export interface MjmlAccordionElementProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlAccordionElement extends React.Component<MjmlAccordionElementProps & ClassNameProps> {}
+export class MjmlAccordionElement extends React.Component<MjmlAccordionElementProps & ClassNameProps> { }
 
 export interface MjmlAccordionTextProps {
     color?: React.CSSProperties['color'];
@@ -130,7 +130,7 @@ export interface MjmlAccordionTextProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlAccordionText extends React.Component<MjmlAccordionTextProps & PaddingProps & ClassNameProps> {}
+export class MjmlAccordionText extends React.Component<MjmlAccordionTextProps & PaddingProps & ClassNameProps> { }
 
 export interface MjmlAccordionTitleProps {
     color?: React.CSSProperties['color'];
@@ -139,7 +139,7 @@ export interface MjmlAccordionTitleProps {
     fontSize?: string | number;
 }
 
-export class MjmlAccordionTitle extends React.Component<MjmlAccordionTitleProps & PaddingProps & ClassNameProps> {}
+export class MjmlAccordionTitle extends React.Component<MjmlAccordionTitleProps & PaddingProps & ClassNameProps> { }
 
 // mj-button
 export interface MjmlButtonProps {
@@ -161,9 +161,7 @@ export interface MjmlButtonProps {
     height?: string | number;
 }
 
-export class MjmlButton extends React.Component<
-    MjmlButtonProps & PaddingProps & ClassNameProps & HrefProps & BorderProps
-> {}
+export class MjmlButton extends React.Component<MjmlButtonProps & PaddingProps & ClassNameProps & HrefProps & BorderProps> { }
 
 // mj-carousel
 export interface MjmlCarouselProps {
@@ -190,7 +188,7 @@ export interface MjmlCarouselImageProps {
     title?: string;
 }
 
-export class MjmlCarouselImage extends React.Component<MjmlCarouselImageProps & ClassNameProps & HrefProps> {}
+export class MjmlCarouselImage extends React.Component<MjmlCarouselImageProps & ClassNameProps & HrefProps> { }
 
 // mj-carousel
 export interface MjmlColumnProps {
@@ -199,7 +197,7 @@ export interface MjmlColumnProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlColumn extends React.Component<MjmlColumnProps & PaddingProps & ClassNameProps & BorderProps> {}
+export class MjmlColumn extends React.Component<MjmlColumnProps & PaddingProps & ClassNameProps & BorderProps> { }
 
 // mj-divider
 export interface MjmlDividerProps {
@@ -210,7 +208,7 @@ export interface MjmlDividerProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlDivider extends React.Component<MjmlDividerProps & ClassNameProps & PaddingProps> {}
+export class MjmlDivider extends React.Component<MjmlDividerProps & ClassNameProps & PaddingProps> { }
 
 // mj-group
 export interface MjmlGroupProps {
@@ -219,7 +217,7 @@ export interface MjmlGroupProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlGroup extends React.Component<MjmlGroupProps & ClassNameProps> {}
+export class MjmlGroup extends React.Component<MjmlGroupProps & ClassNameProps> { }
 
 // mj-hero
 export interface MjmlHeroProps {
@@ -234,7 +232,7 @@ export interface MjmlHeroProps {
     backgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlHero extends React.Component<MjmlHeroProps & ClassNameProps & PaddingProps> {}
+export class MjmlHero extends React.Component<MjmlHeroProps & ClassNameProps & PaddingProps> { }
 
 // mj-image
 export interface MjmlImageProps {
@@ -251,7 +249,7 @@ export interface MjmlImageProps {
     fluidOnMobile?: string;
 }
 
-export class MjmlImage extends React.Component<MjmlImageProps & PaddingProps & ClassNameProps & HrefProps> {}
+export class MjmlImage extends React.Component<MjmlImageProps & PaddingProps & ClassNameProps & HrefProps> { }
 
 // mj-navbar
 export interface MjmlNavbarProps {
@@ -273,7 +271,7 @@ export interface MjmlNavbarProps {
     icoLineHeight?: string;
 }
 
-export class MjmlNavbar extends React.Component<MjmlNavbarProps> {}
+export class MjmlNavbar extends React.Component<MjmlNavbarProps> { }
 
 export interface MjmlNavbarLinkProps {
     color?: React.CSSProperties['color'];
@@ -286,10 +284,10 @@ export interface MjmlNavbarLinkProps {
     textTransform?: string;
 }
 
-export class MjmlNavbarLink extends React.Component<MjmlNavbarLinkProps & HrefProps & PaddingProps> {}
+export class MjmlNavbarLink extends React.Component<MjmlNavbarLinkProps & HrefProps & PaddingProps> { }
 
 // mj-raw
-export class MjmlRaw extends React.Component {}
+export class MjmlRaw extends React.Component { }
 
 // mj-section
 export interface MjmlSectionProps {
@@ -303,7 +301,7 @@ export interface MjmlSectionProps {
     direction?: 'ltr' | 'rtl';
 }
 
-export class MjmlSection extends React.Component<MjmlSectionProps & BorderProps & PaddingProps & ClassNameProps> {}
+export class MjmlSection extends React.Component<MjmlSectionProps & BorderProps & PaddingProps & ClassNameProps> { }
 
 // mj-social
 export interface MjmlSocialProps {
@@ -321,7 +319,7 @@ export interface MjmlSocialProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlSocial extends React.Component<MjmlSocialProps & PaddingProps> {}
+export class MjmlSocial extends React.Component<MjmlSocialProps & PaddingProps> { }
 
 export interface MjmlSocialElementProps {
     borderRadius?: string | number;
@@ -335,36 +333,15 @@ export interface MjmlSocialElementProps {
     textDecoration?: string;
     align?: string;
     color?: React.CSSProperties['color'];
-    name?:
-        | 'facebook'
-        | 'facebook-noshare'
-        | 'twitter'
-        | 'twitter-noshare'
-        | 'google'
-        | 'google-noshare'
-        | 'pinterest'
-        | 'pinterest-noshare'
-        | 'linkedin'
-        | 'linkedin-noshare'
-        | 'tumblr'
-        | 'tumblr-noshare'
-        | 'xing'
-        | 'xing-noshare'
-        | 'github'
-        | 'instagram'
-        | 'web'
-        | 'snapchat'
-        | 'youtube'
-        | 'vimeo'
-        | 'medium'
-        | 'soundcloud'
-        | 'dribbble';
+    name?: 'facebook' | 'facebook-noshare' | 'twitter' | 'twitter-noshare' | 'google' | 'google-noshare' | 'pinterest' | 'pinterest-noshare' |
+        'linkedin' | 'linkedin-noshare' | 'tumblr' | 'tumblr-noshare' | 'xing' | 'xing-noshare' |
+        'github' | 'instagram' | 'web' | 'snapchat' | 'youtube' | 'vimeo' | 'medium' | 'soundcloud' | 'dribbble';
     src?: string;
     alt?: string;
     iconPadding?: string;
 }
 
-export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & HrefProps & PaddingProps> {}
+export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & HrefProps & PaddingProps> { }
 
 // mj-spacer
 export interface MjmlSpacerProps {
@@ -374,7 +351,7 @@ export interface MjmlSpacerProps {
     verticalAlign?: React.CSSProperties['verticalAlign'];
 }
 
-export class MjmlSpacer extends React.Component<MjmlSpacerProps & BorderProps & PaddingProps & ClassNameProps> {}
+export class MjmlSpacer extends React.Component<MjmlSpacerProps & BorderProps & PaddingProps & ClassNameProps> { }
 
 // mj-table
 export interface MjmlTableProps {
@@ -391,7 +368,7 @@ export interface MjmlTableProps {
     align?: 'left' | 'right' | 'center';
 }
 
-export class MjmlTable extends React.Component<MjmlTableProps & PaddingProps> {}
+export class MjmlTable extends React.Component<MjmlTableProps & PaddingProps> { }
 
 // mj-text
 export interface MjmlTextProps {
@@ -409,7 +386,7 @@ export interface MjmlTextProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlText extends React.Component<MjmlTextProps & PaddingProps & ClassNameProps> {}
+export class MjmlText extends React.Component<MjmlTextProps & PaddingProps & ClassNameProps> { }
 
 // mj-wrapper
 export interface MjmlWrapperProps {
@@ -422,4 +399,4 @@ export interface MjmlWrapperProps {
     textAlign?: React.CSSProperties['textAlign'];
 }
 
-export class MjmlWrapper extends React.Component<MjmlWrapperProps & BorderProps & PaddingProps & ClassNameProps> {}
+export class MjmlWrapper extends React.Component<MjmlWrapperProps & BorderProps & PaddingProps & ClassNameProps> { }

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -121,7 +121,7 @@ function renderOutTestEmail() {
 {
     const minProps: React.ReactNode = <MjmlBody />;
     const maxProps: React.ReactNode = (
-        <MjmlBody cssClass="" width={1} backgroundColor="">
+        <MjmlBody cssClass="" mjClass="" width={1} backgroundColor="">
             child
         </MjmlBody>
     );


### PR DESCRIPTION
Add "mjClass" to ClassNameProps for mjml-react.
In raw MJML, `mj-class` can be used on any `mj-` element to apply an `mj-class`. While this is supported in mjml-react, but the typedef does not reflect this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - The change in question will be used in an internal repo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - This does not coincide with a recent change to [mjml-react](https://github.com/wix-incubator/mjml-react)
