### PR TITLE
add cssClass prop to MjmlSocial component in mjml-react

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -318,7 +318,7 @@ export interface MjmlSocialProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'];
 }
 
-export class MjmlSocial extends React.Component<MjmlSocialProps & PaddingProps> { }
+export class MjmlSocial extends React.Component<MjmlSocialProps & PaddingProps & ClassNameProps> { }
 
 export interface MjmlSocialElementProps {
     borderRadius?: string | number;

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -272,6 +272,6 @@ function renderOutTestEmail() {
     // MjmlSocial
     {
         const minProps: React.ReactNode = <MjmlSocial />;
-        const maxProps: React.ReactNode = <MjmlSocial>child</MjmlSocial>;
+        const maxProps: React.ReactNode = <MjmlSocial cssClass="">child</MjmlSocial>;
     }
 }


### PR DESCRIPTION
Add `ClassNameProps` to `MjmlSocial` for mjml-react.
In raw MJML, both `css-class` and `mj-class` can be applied to `mj-social`. This is supported in mjml-react, however the typedef does not reflect this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - The change in question will be used in an internal repo (in here: https://github.com/hooroo)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - This does not coincide with a recent change to [mjml-react](https://github.com/wix-incubator/mjml-react)