### PR TITLE
[react-native]: Update AbortSignal

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -373,7 +373,7 @@ interface AbortEvent extends Event {
     type: 'abort';
 }
 
-declare class AbortSignal {
+declare class AbortSignal implements EventTarget {
     /**
      * AbortSignal cannot be constructed directly.
      */
@@ -384,6 +384,16 @@ declare class AbortSignal {
     readonly aborted: boolean;
 
     onabort: (event: AbortEvent) => void;
+
+    addEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
+        capture?: boolean,
+        once?: boolean,
+        passive?: boolean
+    }) => void;
+
+    removeEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
+        capture?: boolean
+    }) => void;
 }
 
 declare class AbortController {

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -7,6 +7,7 @@ const myInit: RequestInit = {
     method: 'GET',
     headers: myHeaders,
     mode: 'cors',
+    signal: new AbortSignal(),
 };
 
 const myRequest = new Request('flowers.jpg');


### PR DESCRIPTION
`AbortSignal` is an `EventTarget` that supports `addEventListener` and `removeEventListener`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysticatea/abort-controller
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

React Native uses `abort-controller` package under the hood. Its type definitions are here: https://github.com/mysticatea/abort-controller/blob/master/dist/abort-controller.d.ts