### PR TITLE
Type definitions improved for promise-state-machine-es6

### DIFF
--- a/types/promise-state-machine-es6/index.d.ts
+++ b/types/promise-state-machine-es6/index.d.ts
@@ -3,17 +3,45 @@
 // Definitions by: Dmitry Zakablukov <https://github.com/dmitry-zakablukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as events from 'events';
+
+interface DotNode<State, Transitions> {
+    from: State;
+    to: State;
+    transition: Transitions;
+}
+
+interface DotNodeStringified {
+    from: string;
+    to: string;
+    transition: string;
+}
+
+interface FsmBase<State, Transitions> {
+    state: State;
+
+    is(state: State | State[]): boolean;
+    is(...args: State[]): boolean;
+
+    can(state: Transitions | Transitions[]): boolean;
+    can(...args: Transitions[]): boolean;
+
+    toDOTsync(options?: { replacer: (data: DotNode<State, Transitions>) => DotNodeStringified}): string;
+}
+
 declare const PromiseStateMachine: {
-    new <State, Transitions>(payload: {
+    new <State, Transitions extends string>(payload: {
         initial: State;
-        events: {
-            [name in keyof Transitions]: { from: State | State[]; to: State };
-        };
-    }): {
-        state: State;
-    } & {
-        [name in keyof Transitions]: () => Promise<void>;
+        events: PromiseStateMachine.Events<State, Transitions>;
+    }): events.EventEmitter & FsmBase<State, Transitions> & {
+        [name in Transitions]: () => Promise<any>;
     };
 };
+
+declare namespace PromiseStateMachine {
+    type Events<State, Transitions extends string> = {
+        [name in Transitions]: { from: State | State[]; to: State };
+    };
+}
 
 export = PromiseStateMachine;

--- a/types/promise-state-machine-es6/index.d.ts
+++ b/types/promise-state-machine-es6/index.d.ts
@@ -20,10 +20,10 @@ interface DotNodeStringified {
 interface FsmBase<State, Transitions> {
     state: State;
 
-    is(state: State | State[]): boolean;
+    is(state: State): boolean;
     is(...args: State[]): boolean;
 
-    can(state: Transitions | Transitions[]): boolean;
+    can(state: Transitions): boolean;
     can(...args: Transitions[]): boolean;
 
     toDOTsync(options?: { replacer: (data: DotNode<State, Transitions>) => DotNodeStringified}): string;

--- a/types/promise-state-machine-es6/promise-state-machine-es6-tests.ts
+++ b/types/promise-state-machine-es6/promise-state-machine-es6-tests.ts
@@ -45,16 +45,10 @@ fsm.on('start', (from, to) => {
 fsm.is(State.stopped);
 
 // $ExpectType boolean
-fsm.is([State.stopped, State.running]);
-
-// $ExpectType boolean
 fsm.is(State.stopped, State.running);
 
 // $ExpectType boolean
 fsm.can(Transitions.start);
-
-// $ExpectType boolean
-fsm.can([Transitions.start, Transitions.stop]);
 
 // $ExpectType boolean
 fsm.can(Transitions.start, Transitions.stop);

--- a/types/promise-state-machine-es6/promise-state-machine-es6-tests.ts
+++ b/types/promise-state-machine-es6/promise-state-machine-es6-tests.ts
@@ -1,23 +1,72 @@
-import PromiseStateMachine = require("promise-state-machine-es6");
+import PromiseStateMachine = require('promise-state-machine-es6');
+import { Events } from 'promise-state-machine-es6';
 
 enum State {
     stopped,
     running
 }
 
-const fsm = new PromiseStateMachine({
+enum Transitions {
+    start = 'start',
+    stop = 'stop'
+}
+
+class MyFsm extends PromiseStateMachine<State, Transitions> {
+    constructor(props: {
+        initial: State,
+        events: Events<State, Transitions>
+    }) {
+        super(props);
+    }
+}
+
+const fsm = new MyFsm({
    initial: State.stopped,
    events: {
-       start: { from: State.stopped, to: State.running },
-       stop: { from: [State.running], to: State.stopped }
+       [Transitions.start]: { from: State.stopped, to: State.running },
+       [Transitions.stop]: { from: [State.running], to: State.stopped }
    }
 });
 
 // $ExpectType State
 fsm.state;
 
-// $ExpectType () => Promise<void>
+// $ExpectType () => Promise<any>
 fsm.stop;
 
-// $ExpectType Promise<void>
+// $ExpectType Promise<any>
 fsm.start();
+
+fsm.on('start', (from, to) => {
+    return Promise.resolve('Started');
+});
+
+// $ExpectType boolean
+fsm.is(State.stopped);
+
+// $ExpectType boolean
+fsm.is([State.stopped, State.running]);
+
+// $ExpectType boolean
+fsm.is(State.stopped, State.running);
+
+// $ExpectType boolean
+fsm.can(Transitions.start);
+
+// $ExpectType boolean
+fsm.can([Transitions.start, Transitions.stop]);
+
+// $ExpectType boolean
+fsm.can(Transitions.start, Transitions.stop);
+
+// $ExpectType string
+fsm.toDOTsync();
+
+// $ExpectType string
+fsm.toDOTsync({ replacer: (data) => {
+        return {
+            from: 'From: ' + String(data.from),
+            to: 'To: ' + String(data.to),
+            transition: 'Transition: ' + String(data.transition)
+        };
+    } });


### PR DESCRIPTION
Type definitions are updated to match the library code, see url below.
The changes are based on the suggestion of @peterblazejewicz in the previous pr, see #53557.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/promise-state-machine-es6>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
