### PR TITLE
Adds a script for closing old issues on the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ _infrastructure/tests/build
 !scripts/new-package.js
 !scripts/not-needed.js
 !scripts/lint.js
+!scripts/close-old-issues.js
 
 # npm
 node_modules

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/utils": "latest",
         "danger": "^10.1.1",
+        "@octokit/rest": "^16.0.0",
         "dtslint": "latest",
         "prettier": "^2.1.1",
         "remark-cli": "^9.0.0",

--- a/scripts/close-old-issues.js
+++ b/scripts/close-old-issues.js
@@ -1,0 +1,55 @@
+const { Octokit } = require('@octokit/rest');
+const { paginateRest } = require('@octokit/plugin-paginate-rest');
+
+const CustomOctokit = Octokit.plugin(paginateRest);
+const octokit = new CustomOctokit({ auth: process.env.GITHUB_API_TOKEN });
+
+const message = `
+Hi thread, we're moving DefinitelyTyped to use [GitHub Discussions](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/53377) for conversations the \`@types\` modules in DefinitelyTyped.
+
+To help with the transition, we're closing all issues which haven't had activity in the last 6 months, which includes this issue. `
+
+
+const go = async () => {
+    const sixMonthsAgo = addMonths(new Date(), -6);
+    const dateQuery = sixMonthsAgo.toISOString().split('T')[0];
+    
+    // For example:
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/search?q=updated%3A%3C%3D2021-02-01&state=open&type=issues
+
+    const parameters = {
+        per_page: 100,
+        q: `type:issue updated:<=${dateQuery} repo:DefinitelyTyped/DefinitelyTyped state:open`
+    };
+
+    for await (const response of octokit.paginate.iterator('GET /search/issues', parameters)) {
+        debugger
+        /** @type {Array<import("@octokit/types/src/generated/Endpoints").Endpoints["GET /issues"]["response"]["data"][number]>} */
+        const items = response.data
+        for (const issue of items) {
+            // Ignore issues with labels
+            if (issue.labels.length) continue;
+
+            await octokit.issues.update({ repo: "DefinitelyTyped", owner: "DefinitelyTyped", number: issue.number, state: "closed" })
+            await octokit.issues.createComment({ repo: "DefinitelyTyped", owner: "DefinitelyTyped", number: issue.number, body: message })
+        }
+    }
+};
+
+go();
+
+// https://stackoverflow.com/questions/1648392/get-a-date-object-six-months-prior-from-another-date-object
+function addMonths(date, months) {
+    var month = (date.getMonth() + months) % 12;
+    //create a new Date object that gets the last day of the desired month
+    var last = new Date(date.getFullYear(), month + 1, 0);
+
+    //compare dates and set appropriately
+    if (date.getDate() <= last.getDate()) {
+        date.setMonth(month);
+    } else {
+        date.setMonth(month, last.getDate());
+    }
+
+    return date;
+}

--- a/scripts/close-old-issues.js
+++ b/scripts/close-old-issues.js
@@ -7,7 +7,7 @@ const octokit = new CustomOctokit({ auth: process.env.GITHUB_API_TOKEN });
 const message = `
 Hi thread, we're moving DefinitelyTyped to use [GitHub Discussions](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/53377) for conversations the \`@types\` modules in DefinitelyTyped.
 
-To help with the transition, we're closing all issues which haven't had activity in the last 6 months, which includes this issue. `
+To help with the transition, we're closing all issues which haven't had activity in the last 6 months, which includes this issue. If you think closing this issue is a mistake, please pop into the [TypeScript Community Discord](https://discord.gg/typescript) and mention the issue in the \`definitely-typed\` channel.`
 
 
 const go = async () => {

--- a/scripts/close-old-issues.js
+++ b/scripts/close-old-issues.js
@@ -23,15 +23,16 @@ const go = async () => {
     };
 
     for await (const response of octokit.paginate.iterator('GET /search/issues', parameters)) {
-        debugger
+        console.log("\n-")
         /** @type {Array<import("@octokit/types/src/generated/Endpoints").Endpoints["GET /issues"]["response"]["data"][number]>} */
         const items = response.data
         for (const issue of items) {
             // Ignore issues with labels
             if (issue.labels.length) continue;
 
-            await octokit.issues.update({ repo: "DefinitelyTyped", owner: "DefinitelyTyped", number: issue.number, state: "closed" })
-            await octokit.issues.createComment({ repo: "DefinitelyTyped", owner: "DefinitelyTyped", number: issue.number, body: message })
+            process.stdout.write("#" + issue.number + " ")
+            await octokit.issues.update({ repo: "DefinitelyTyped", owner: "DefinitelyTyped", issue_number: issue.number, state: "closed" })
+            await octokit.issues.createComment({ repo: "DefinitelyTyped", owner: "DefinitelyTyped", issue_number: issue.number, body: message })
         }
     }
 };


### PR DESCRIPTION
Issues which are closed:

- Anything which hasn't had a comment in over 6 months 
- If the issue has _any_ labels then it is skipped

I validated in https://github.com/orta/FakeDTRepo/issues/2 that commenting updates the `updated_at` which is used in the search query. This doesn't add any new deps, it's already in the tree. I just make it explicit.


This is the query results: https://github.com/DefinitelyTyped/DefinitelyTyped/search?q=type%3Aissue+updated%3A%3C%3D2020-12-04+repo%3ADefinitelyTyped%2FDefinitelyTyped+state%3Aopen&type=issues