### PR TITLE
[react-router]: Fix param types of generatePath for zero or more and …

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -145,6 +145,10 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
 
 export type ExtractRouteOptionalParam<T extends string, U = string | number | boolean> = T extends `${infer Param}?`
     ? { [k in Param]?: U }
+    : T extends `${infer Param}*`
+    ? { [k in Param]?: U }
+    : T extends `${infer Param}+`
+    ? { [k in Param]: U }
     : { [k in T]: U };
 
 export type ExtractRouteParams<T extends string, U = string | number | boolean> = string extends T

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -6,6 +6,7 @@ declare const unknownPath: string;
 generatePath('/posts/:postId', {}); // $ExpectError
 generatePath('/posts/:postId/comments/:commentId', { postId: '1' }); // $ExpectError
 generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
+generatePath('/posts/:postId/:commentId+', { postId: '1' }); // $ExpectError
 generatePath(unknownPath, { nullParam: null }); // $ExpectError
 
 // correct
@@ -14,8 +15,11 @@ generatePath('/posts/:postId', { postId: 1 });
 generatePath('/posts/:postId', { postId: true });
 generatePath('/posts/:postId(\d+)', { postId: 1 });
 generatePath('/posts/:postId');
+generatePath('/posts/:postId+', { postId: '1' });
 generatePath('/posts/:postId?', {});
 generatePath('/posts/:postId?', { postId: '1' });
+generatePath('/posts/:postId*', {});
+generatePath('/posts/:postId*', { postId: '1' });
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1' });
 generatePath('/posts/:postId(\d+)/comments/:commentId(\d+)', { postId: 1, commentId: 1 });
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1', commentId: '1' });


### PR DESCRIPTION
…one or more modifiers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#zero-or-more
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

path-to-regexp, which is used by react-router under the hood, allows for for `+` as `one or more` and `*` as `zero or more` modifiers for path parameters: https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#zero-or-more
This is not reflected in the param types of `generatePath` however.