### PR TITLE
[trusted-types] Move core type definitions into 'trusted-types/lib'

### DIFF
--- a/types/trusted-types/README.md
+++ b/types/trusted-types/README.md
@@ -1,0 +1,44 @@
+# @types/trusted-types
+Type definitions for the [Trusted Types web
+specification](https://w3c.github.io/webappsec-trusted-types/dist/spec/) as
+well as the associated [polyfill](https://www.npmjs.com/package/trusted-types).
+
+## Usage
+Install the @types/trusted-types package and follow the [official
+instructions](https://github.com/DefinitelyTyped/DefinitelyTyped#what-are-declaration-files-and-how-do-i-get-them).
+This will make the type definitions available globally within your package, and
+you will be able to use them directly:
+```typescript
+if (window.trustedTypes && trustedTypes.createPolicy) {
+  const policy = trustedTypes.createPolicy('my-policy', {
+    createHTML: val => val.replace(/\</g, '&lt;')
+  });
+
+  const safe: TrustedHTML = policy.createHTML('<h1>Hello</h1>');
+}
+```
+
+### Library usage
+The @types/trusted-types entrypoint adds the Trusted Types type definitions to
+the global scope. This may be unattractive to library authors that want to use
+the type definitions, as this would pollute the global scope for all their
+downstream users. A second entrypoint was introduced for this use case,
+@types/trusted-types/lib, which exports the types without attaching them to the
+global scope. Libraries using that entrypoint will need to explicitly import the
+types that they need to use, as well as cast the window object to gain access to
+the `trustedTypes` property:
+```
+import {TrustedHTML, TrustedTypePolicy, TrustedTypesWindow} from '@types/trusted-types/lib';
+
+const ttWindow = window as unknown as TrustedTypesWindow;
+if (ttWindow.trustedTypes) {
+  // ...
+}
+```
+
+## lib.dom.d.ts migration
+As a native web API, the Trusted Types type definitions will eventually make
+their way into lib.dom.d.ts. To aid with the migration, and to prevent two
+incompatible versions of the types from coexisting, this package will be
+updated to re-export the Trusted Types type definitions from lib.dom.d.ts as
+soon as they become available.

--- a/types/trusted-types/index.d.ts
+++ b/types/trusted-types/index.d.ts
@@ -7,72 +7,35 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-type FnNames = keyof TrustedTypePolicyOptions;
-type Args<Options extends TrustedTypePolicyOptions, K extends FnNames> =
-    Parameters<NonNullable<Options[K]>>;
+import * as lib from './lib';
 
+// Re-export the type definitions globally.
 declare global {
-    class TrustedHTML {
-        private constructor(); // To prevent instantiting with 'new'.
-        private brand: true; // To prevent structural typing.
-    }
+    const TrustedHTML: typeof lib.TrustedHTML;
+    type TrustedHTML = lib.TrustedHTML;
+    const TrustedScript: typeof lib.TrustedScript;
+    type TrustedScript = lib.TrustedScript;
+    const TrustedScriptURL: typeof lib.TrustedScriptURL;
+    type TrustedScriptURL = lib.TrustedScriptURL;
 
-    class TrustedScript {
-        private constructor(); // To prevent instantiting with 'new'.
-        private brand: true; // To prevent structural typing.
-    }
+    const TrustedTypePolicy: typeof lib.TrustedTypePolicy;
+    type TrustedTypePolicy = lib.TrustedTypePolicy;
 
-    class TrustedScriptURL {
-        private constructor(); // To prevent instantiting with 'new'.
-        private brand: true; // To prevent structural typing.
-    }
+    const TrustedTypePolicyFactory: typeof lib.TrustedTypePolicyFactory;
+    type TrustedTypePolicyFactory = lib.TrustedTypePolicyFactory;
 
-    abstract class TrustedTypePolicyFactory {
-        createPolicy<Options extends TrustedTypePolicyOptions>(
-            policyName: string,
-            policyOptions?: Options,
-        ): Pick<TrustedTypePolicy<Options>, 'name'|Extract<keyof Options, FnNames>>;
-        isHTML(value: unknown): value is TrustedHTML;
-        isScript(value: unknown): value is TrustedScript;
-        isScriptURL(value: unknown): value is TrustedScriptURL;
-        readonly emptyHTML: TrustedHTML;
-        readonly emptyScript: TrustedScript;
-        getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
-        getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
-        readonly defaultPolicy: TrustedTypePolicy | null;
-    }
+    type TrustedTypePolicyOptions = lib.TrustedTypePolicyOptions;
 
-    abstract class TrustedTypePolicy<Options extends TrustedTypePolicyOptions = TrustedTypePolicyOptions> {
-        readonly name: string;
-        createHTML(...args: Args<Options, 'createHTML'>): TrustedHTML;
-        createScript(...args: Args<Options, 'createScript'>): TrustedScript;
-        createScriptURL(...args: Args<Options, 'createScriptURL'>): TrustedScriptURL;
-    }
-
-    interface TrustedTypePolicyOptions {
-        createHTML?: (input: string, ...arguments: any[]) => string;
-        createScript?: (input: string, ...arguments: any[]) => string;
-        createScriptURL?: (input: string, ...arguments: any[]) => string;
-    }
-
-    interface Window {
-        // `trustedTypes` is left intentionally optional to make sure that
-        // people handle the case when their code is running in a browser not
-        // supporting trustedTypes.
-        trustedTypes?: TrustedTypePolicyFactory;
-        TrustedHTML: typeof TrustedHTML;
-        TrustedScript: typeof TrustedScript;
-        TrustedScriptURL: typeof TrustedScriptURL;
-        TrustedTypePolicyFactory: typeof TrustedTypePolicyFactory;
-        TrustedTypePolicy: typeof TrustedTypePolicy;
-    }
+    // Attach the relevant Trusted Types properties to the Window object.
+    // tslint:disable-next-line no-empty-interface
+    interface Window extends lib.TrustedTypesWindow {}
 }
 
 // These are the available exports when using the polyfill as npm package (e.g. in nodejs)
-interface InternalTrustedTypePolicyFactory extends TrustedTypePolicyFactory {
-  TrustedHTML: typeof TrustedHTML;
-  TrustedScript: typeof TrustedScript;
-  TrustedScriptURL: typeof TrustedScriptURL;
+interface InternalTrustedTypePolicyFactory extends lib.TrustedTypePolicyFactory {
+    TrustedHTML: typeof lib.TrustedHTML;
+    TrustedScript: typeof lib.TrustedScript;
+    TrustedScriptURL: typeof lib.TrustedScriptURL;
 }
 
 declare const trustedTypes: InternalTrustedTypePolicyFactory;
@@ -85,14 +48,14 @@ declare class TrustedTypesEnforcer {
 
 // tslint:disable-next-line no-unnecessary-class
 declare class TrustedTypeConfig {
-  constructor(
-    isLoggingEnabled: boolean,
-    isEnforcementEnabled: boolean,
-    allowedPolicyNames: string[],
-    allowDuplicates: boolean,
-    cspString?: string | null,
-    windowObject?: Window
-  )
+    constructor(
+        isLoggingEnabled: boolean,
+        isEnforcementEnabled: boolean,
+        allowedPolicyNames: string[],
+        allowDuplicates: boolean,
+        cspString?: string | null,
+        windowObject?: Window,
+    );
 }
 
 export { trustedTypes, TrustedTypesEnforcer, TrustedTypeConfig, TrustedTypePolicy, TrustedTypePolicyFactory };

--- a/types/trusted-types/lib/index.d.ts
+++ b/types/trusted-types/lib/index.d.ts
@@ -1,0 +1,64 @@
+// The main type definitions. Packages that do not want to pollute the global
+// scope with Trusted Types (e.g. libraries whose users may not be using Trusted
+// Types) can import the types directly from 'trusted-types/lib'.
+
+export type FnNames = keyof TrustedTypePolicyOptions;
+export type Args<Options extends TrustedTypePolicyOptions, K extends FnNames> = Parameters<NonNullable<Options[K]>>;
+
+export class TrustedHTML {
+    private constructor(); // To prevent instantiting with 'new'.
+    private brand: true; // To prevent structural typing.
+}
+
+export class TrustedScript {
+    private constructor(); // To prevent instantiting with 'new'.
+    private brand: true; // To prevent structural typing.
+}
+
+export class TrustedScriptURL {
+    private constructor(); // To prevent instantiting with 'new'.
+    private brand: true; // To prevent structural typing.
+}
+
+export abstract class TrustedTypePolicyFactory {
+    createPolicy<Options extends TrustedTypePolicyOptions>(
+        policyName: string,
+        policyOptions?: Options,
+    ): Pick<TrustedTypePolicy<Options>, 'name' | Extract<keyof Options, FnNames>>;
+    isHTML(value: unknown): value is TrustedHTML;
+    isScript(value: unknown): value is TrustedScript;
+    isScriptURL(value: unknown): value is TrustedScriptURL;
+    readonly emptyHTML: TrustedHTML;
+    readonly emptyScript: TrustedScript;
+    getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
+    getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
+    readonly defaultPolicy: TrustedTypePolicy | null;
+}
+
+export abstract class TrustedTypePolicy<Options extends TrustedTypePolicyOptions = TrustedTypePolicyOptions> {
+    readonly name: string;
+    createHTML(...args: Args<Options, 'createHTML'>): TrustedHTML;
+    createScript(...args: Args<Options, 'createScript'>): TrustedScript;
+    createScriptURL(...args: Args<Options, 'createScriptURL'>): TrustedScriptURL;
+}
+
+export interface TrustedTypePolicyOptions {
+    createHTML?: (input: string, ...arguments: any[]) => string;
+    createScript?: (input: string, ...arguments: any[]) => string;
+    createScriptURL?: (input: string, ...arguments: any[]) => string;
+}
+
+// The Window object is augmented with the following properties in browsers that
+// support Trusted Types. Users of the 'trusted-types/lib' entrypoint can cast
+// window as TrustedTypesWindow to access these properties.
+export interface TrustedTypesWindow {
+    // `trustedTypes` is left intentionally optional to make sure that
+    // people handle the case when their code is running in a browser not
+    // supporting trustedTypes.
+    trustedTypes?: TrustedTypePolicyFactory;
+    TrustedHTML: typeof TrustedHTML;
+    TrustedScript: typeof TrustedScript;
+    TrustedScriptURL: typeof TrustedScriptURL;
+    TrustedTypePolicyFactory: typeof TrustedTypePolicyFactory;
+    TrustedTypePolicy: typeof TrustedTypePolicy;
+}

--- a/types/trusted-types/test/lib.ts
+++ b/types/trusted-types/test/lib.ts
@@ -1,0 +1,23 @@
+import * as lib from 'trusted-types/lib';
+
+// $ExpectType TrustedTypesWindow
+const ttWindow = window as lib.TrustedTypesWindow;
+
+let trustedHTML: TrustedHTML = null as any;
+let libTrustedHTML: lib.TrustedHTML = null as any;
+const trustedScript: TrustedScript = null as any;
+const libTrustedScript: lib.TrustedScript = null as any;
+
+// Ensure the globally available types are the same as the library-exported ones
+trustedHTML = libTrustedHTML;
+libTrustedHTML = trustedHTML;
+
+// Ensure that different types are not compatible
+// $ExpectError
+trustedHTML = trustedScript;
+// $ExpectError
+trustedHTML = libTrustedScript;
+// $ExpectError
+libTrustedHTML = trustedScript;
+// $ExpectError
+libTrustedHTML = libTrustedScript;

--- a/types/trusted-types/test/module.ts
+++ b/types/trusted-types/test/module.ts
@@ -1,4 +1,4 @@
-import { trustedTypes as importedTrustedTypes, TrustedTypesEnforcer, TrustedTypeConfig } from 'trusted-types';
+import { TrustedTypeConfig, trustedTypes as importedTrustedTypes, TrustedTypesEnforcer } from 'trusted-types';
 
 // $ExpectType InternalTrustedTypePolicyFactory
 importedTrustedTypes;

--- a/types/trusted-types/tsconfig.json
+++ b/types/trusted-types/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "test/browser.ts",
+        "test/lib.ts",
         "test/module.ts"
     ]
 }


### PR DESCRIPTION
The 'trusted-types' entrypoint attaches the Trusted Types type
definitions to the global scope. As a native DOM API, Trusted Types
should indeed be available globally, but this makes it unattractive for
library authors to adopt the type definitions, as this pollutes the
global scope for all its users. Even worse, when Trusted Types become
part of lib.dom.d.ts the duplicate type definitions will cause a
compilation error that is very tricky to address, both at the
application and library level.

To circumvent this, introduce a new 'trusted-types/lib' entrypoint
intended specifically for libraries that want to adopt the types. The
core type definitions are moved into this entrypoint but then
re-exported into the global scope in the 'trusted-types' endpoint, which
application authors can continue to use. The main caveat is that
libraries will need to explicitly import all the types that they use,
and cast the window object as TrustedTypesWindow to access its Trusted
Types properties.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).