### PR TITLE
[jasmine] Add aliases for renamed interfaces

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -992,6 +992,15 @@ declare namespace jasmine {
         deprecationWarnings: ExpectationResult[];
     }
 
+    /** @deprecated use JasmineStartedInfo instead */
+    type SuiteInfo = JasmineStartedInfo;
+
+    /** @deprecated use SuiteResult or SpecResult instead */
+    type CustomReporterResult = SuiteResult & SpecResult;
+
+    /** @deprecated use JasmineDoneInfo instead */
+    type RunDetails = JasmineDoneInfo;
+
     interface CustomReporter {
         jasmineStarted?(suiteInfo: JasmineStartedInfo, done?: () => void): void | Promise<void>;
         suiteStarted?(result: SuiteResult, done?: () => void): void | Promise<void>;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -2061,6 +2061,47 @@ const myAsyncReporter: jasmine.CustomReporter = {
 
 jasmine.getEnv().addReporter(myAsyncReporter);
 
+const legacyReporter: jasmine.CustomReporter = {
+    jasmineStarted(suiteInfo: jasmine.SuiteInfo) {
+        console.log(`Running suite with ${suiteInfo.totalSpecsDefined}`);
+    },
+
+    suiteStarted(result: jasmine.CustomReporterResult) {
+        console.log(`Suite started: ${result.description} whose full description is: ${result.fullName}`);
+    },
+
+    specStarted(result: jasmine.CustomReporterResult) {
+        console.log(`Spec started: ${result.description} whose full description is: ${result.fullName}`);
+    },
+
+    specDone(result: jasmine.CustomReporterResult) {
+        console.log(`Spec: ${result.description} was ${result.status}`);
+
+        for (const failedExpectation of result.failedExpectations) {
+            console.log(`Failure: ${failedExpectation.message}`);
+            console.log(failedExpectation.stack);
+        }
+
+        console.log(result.passedExpectations.length);
+    },
+
+    suiteDone(result: jasmine.CustomReporterResult) {
+        console.log(`Suite: ${result.description} was ${result.status}`);
+        for (const failedExpectation of result.failedExpectations) {
+            console.log(`Suite ${failedExpectation.message}`);
+            console.log(failedExpectation.stack);
+        }
+    },
+
+    jasmineDone(result: jasmine.RunDetails) {
+        console.log(`Finished suite: ${result.overallStatus}`);
+        for (const failedExpectation of result.failedExpectations) {
+            console.log(`Global ${failedExpectation.message}`);
+            console.log(failedExpectation.stack);
+        }
+    },
+};
+
 describe("Randomize Tests", () => {
     it("should allow randomization of the order of tests", () => {
         expect(() => {


### PR DESCRIPTION
This adds almost (besides nullability of some fields, which I believe shouldn't be a problem in practice) backward compatible aliases for the interfaces, which were renamed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52004. As it [turned out](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52004#issuecomment-842171031) the change was disruptive for people using custom reporters and adding backward-compatible aliases should make upgrading easier.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52004#issuecomment-842171031
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.