### PR TITLE
Fix declaration of PerformanceObserver in perf_hooks

### DIFF
--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -188,12 +188,13 @@ declare module 'perf_hooks' {
         disconnect(): void;
 
         /**
-         * Subscribes the PerformanceObserver instance to notifications of new PerformanceEntry instances identified by options.entryTypes.
+         * Subscribes the PerformanceObserver instance to notifications of new PerformanceEntry instances.
+         * The type of entries are identified via the use of one of options.entryTypes or options.type.
          * When options.buffered is false, the callback will be invoked once for every PerformanceEntry instance.
-         * Property buffered defaults to false.
+         * Property buffered defaults to false, and when used the user must use options.type instead of options.entryTypes.
          * @param options
          */
-        observe(options: { entryTypes: ReadonlyArray<EntryType>; buffered?: boolean }): void;
+        observe(options: { entryTypes?: ReadonlyArray<EntryType>; type?: EntryType; buffered?: boolean }): void;
     }
 
     namespace constants {

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -40,7 +40,7 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
 };
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({
-    entryTypes: ['function'] as ReadonlyArray<EntryType>,
+    type: 'function' as EntryType,
     buffered: true,
 });
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/perf_hooks.html#perf_hooks_performanceobserver_observe_options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
