### PR TITLE
[inquirer] Fix broken inquirer-types

### DIFF
--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -317,11 +317,8 @@ declare namespace inquirer {
 
     /**
      * Provides options for a choice.
-     *
-     * @template T
-     * The type of the answers.
      */
-    interface ChoiceOptions<T extends Answers = Answers> extends ChoiceBase {
+    interface ChoiceOptions extends ChoiceBase {
         /**
          * @inheritdoc
          */
@@ -354,7 +351,7 @@ declare namespace inquirer {
      * @template T
      * The type of the answers.
      */
-    interface ListChoiceOptions<T extends Answers = Answers> extends ChoiceOptions<T> {
+    interface ListChoiceOptions<T extends Answers = Answers> extends ChoiceOptions {
         /**
          * A value indicating whether the choice is disabled.
          */
@@ -376,11 +373,8 @@ declare namespace inquirer {
 
     /**
      * Provides options for a choice of the `ExpandPrompt`.
-     *
-     * @template T
-     * The type of the answers.
      */
-    interface ExpandChoiceOptions<T extends Answers = Answers> extends ChoiceOptions<T> {
+    interface ExpandChoiceOptions extends ChoiceOptions {
         /**
          * The key to press for selecting the choice.
          */
@@ -410,7 +404,7 @@ declare namespace inquirer {
      */
     interface BaseChoiceMap<T extends Answers = Answers> {
         Choice: Choice<T>;
-        ChoiceOptions: ChoiceOptions<T>;
+        ChoiceOptions: ChoiceOptions;
         SeparatorOptions: SeparatorOptions;
         Separator: Separator;
     }
@@ -442,7 +436,7 @@ declare namespace inquirer {
      * The type of the answers.
      */
     interface ExpandChoiceMap<T extends Answers = Answers> extends BaseChoiceMap<T> {
-        ExpandChoiceOptions: ExpandChoiceOptions<T>;
+        ExpandChoiceOptions: ExpandChoiceOptions;
     }
 
     /**

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -483,7 +483,7 @@ declare namespace inquirer {
      * @template T
      * The type of the answers.
      */
-    type ChoiceCollection<T extends Answers = Answers> = Array<DistinctChoice<AllChoiceMap>>;
+    type ChoiceCollection<T extends Answers = Answers> = Array<DistinctChoice<AllChoiceMap<T>>>;
 
     /**
      * Provides options for a question for the `InputPrompt`.

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -473,7 +473,7 @@ declare namespace inquirer {
      * @template TChoiceMap
      * The choice-types to provide.
      */
-    type DistinctChoice<TChoiceMap> =
+    type DistinctChoice<TAnswers extends Answers = Answers, TChoiceMap = AllChoiceMap<TAnswers>> =
         string |
         TChoiceMap[keyof TChoiceMap];
 

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -229,11 +229,23 @@ declare namespace inquirer {
 
     /**
      * Represents a dynamic property for a question.
+     *
+     * @template T
+     * The type of the property.
+     *
+     * @template TAnswers
+     * The type of the answers.
      */
     type DynamicQuestionProperty<T, TAnswers extends Answers = Answers> = T | ((answers: TAnswers) => T);
 
     /**
      * Represents a dynamic property for a question which can be fetched asynchronously.
+     *
+     * @template T
+     * The type of the property.
+     *
+     * @template TAnswers
+     * The type of the answers.
      */
     type AsyncDynamicQuestionProperty<T, TAnswers extends Answers = Answers> = DynamicQuestionProperty<T | Promise<T>, TAnswers>;
 
@@ -455,6 +467,9 @@ declare namespace inquirer {
     /**
      * Provides valid choices for the question of the `TChoiceMap`.
      *
+     * @template TAnswers
+     * The type of the answers.
+     *
      * @template TChoiceMap
      * The choice-types to provide.
      */
@@ -464,6 +479,9 @@ declare namespace inquirer {
 
     /**
      * Represents a set of choices.
+     *
+     * @template T
+     * The type of the answers.
      */
     type ChoiceCollection<T extends Answers = Answers> = Array<DistinctChoice<AllChoiceMap>>;
 

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -396,7 +396,7 @@ declare namespace inquirer {
     /**
      * Represents a separator.
      */
-    interface SeparatorOptions {
+    interface SeparatorOptions extends ChoiceBase {
         /**
          * Gets the type of the choice.
          */

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -1,3 +1,4 @@
+import { Separator } from "inquirer";
 import inquirer = require("inquirer");
 import InputPrompt = require("inquirer/lib/prompts/input");
 {
@@ -46,6 +47,21 @@ import InputPrompt = require("inquirer/lib/prompts/input");
         }
     ]);
 }
+{
+    let choice: inquirer.DistinctChoice;
+
+    choice = {
+        type: "separator",
+        line: "This is a test"
+    };
+
+    if (
+        choice.type === "separator" &&
+        !(choice instanceof Separator)) {
+        // $ExpectType SeparatorOptions
+        choice;
+    }
+}
 
 interface ChalkQuestionOptions<T extends inquirer.Answers = inquirer.Answers> extends inquirer.InputQuestionOptions<T> {
     previewColors: boolean;
@@ -57,6 +73,8 @@ interface ChalkQuestion<T extends inquirer.Answers = inquirer.Answers> extends C
 
 class ChalkPrompt extends InputPrompt {
     /* stuff */
+
+    protected onKeypress() { }
 }
 
 inquirer.registerPrompt("chalk", ChalkPrompt);

--- a/types/inquirer/lib/objects/choice.d.ts
+++ b/types/inquirer/lib/objects/choice.d.ts
@@ -9,7 +9,7 @@ import inquirer = require('../..');
 declare class Choice<T extends inquirer.Answers = inquirer.Answers> implements
     inquirer.ListChoiceOptions<T>,
     inquirer.CheckboxChoiceOptions<T>,
-    inquirer.ExpandChoiceOptions<T> {
+    inquirer.ExpandChoiceOptions {
     /**
      * @inheritdoc
      */

--- a/types/inquirer/lib/objects/choice.d.ts
+++ b/types/inquirer/lib/objects/choice.d.ts
@@ -1,4 +1,4 @@
-import inquirer = require('../..');
+import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from "../..";
 
 /**
  * Represents a choice for several question-types.
@@ -6,10 +6,10 @@ import inquirer = require('../..');
  * @template T
  * The type of the answers.
  */
-declare class Choice<T extends inquirer.Answers = inquirer.Answers> implements
-    inquirer.ListChoiceOptions<T>,
-    inquirer.CheckboxChoiceOptions<T>,
-    inquirer.ExpandChoiceOptions {
+declare class Choice<T extends Answers = Answers> implements
+    ListChoiceOptions<T>,
+    CheckboxChoiceOptions<T>,
+    ExpandChoiceOptions {
     /**
      * @inheritdoc
      */

--- a/types/inquirer/lib/objects/choices.d.ts
+++ b/types/inquirer/lib/objects/choices.d.ts
@@ -1,4 +1,4 @@
-import inquirer = require("../..");
+import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from "../..";
 import Choice = require("./choice");
 import Separator = require("./separator");
 
@@ -8,7 +8,7 @@ import Separator = require("./separator");
  * @template T
  * The type of the answers.
  */
-type DistinctChoice<T> = inquirer.AllChoiceMap<T>[keyof inquirer.AllChoiceMap<T>];
+type DistinctChoice<T> = AllChoiceMap<T>[keyof AllChoiceMap<T>];
 
 /**
  * Represents a valid real choice for the `Choices` class.
@@ -24,7 +24,7 @@ type RealChoice<T> = Exclude<DistinctChoice<T>, { type: Separator["type"] }>;
  * @template T
  * The type of the answers.
  */
-type ChoiceProperty<T> = inquirer.KeyUnion<inquirer.UnionToIntersection<RealChoice<T>>>;
+type ChoiceProperty<T> = KeyUnion<UnionToIntersection<RealChoice<T>>>;
 
 /**
  * A collection of multiple `Choice`-objects.
@@ -32,7 +32,7 @@ type ChoiceProperty<T> = inquirer.KeyUnion<inquirer.UnionToIntersection<RealChoi
  * @template T
  * The type of the answers.
  */
-declare class Choices<T extends inquirer.Answers = inquirer.Answers> {
+declare class Choices<T extends Answers = Answers> {
     /**
      * The number of selectable choices.
      */

--- a/types/inquirer/lib/objects/separator.d.ts
+++ b/types/inquirer/lib/objects/separator.d.ts
@@ -1,9 +1,9 @@
-import inquirer = require("../..");
+import { SeparatorOptions } from "../..";
 
 /**
  * Represents a choice-item separator.
  */
-declare class Separator implements inquirer.SeparatorOptions {
+declare class Separator implements SeparatorOptions {
     /**
      * @inheritdoc
      */

--- a/types/inquirer/lib/objects/separator.d.ts
+++ b/types/inquirer/lib/objects/separator.d.ts
@@ -3,7 +3,7 @@ import inquirer = require("../..");
 /**
  * Represents a choice-item separator.
  */
-declare class Separator implements inquirer.ChoiceBase, inquirer.SeparatorOptions {
+declare class Separator implements inquirer.SeparatorOptions {
     /**
      * @inheritdoc
      */

--- a/types/inquirer/lib/prompts/confirm.d.ts
+++ b/types/inquirer/lib/prompts/confirm.d.ts
@@ -1,11 +1,11 @@
 import Prompt = require("./base");
-import inquirer = require("../..");
+import { Answers, ConfirmQuestionOptions } from "../..";
 import { Interface as ReadlineInterface } from "readline";
 
 /**
  * The question-options for the `ConfirmPrompt<T>`.
  */
-type Question = inquirer.ConfirmQuestionOptions<inquirer.Answers>;
+type Question = ConfirmQuestionOptions<Answers>;
 
 /**
  * Represents a prompt which provides a message to confirm.
@@ -26,7 +26,7 @@ declare class ConfirmPrompt<TQuestion extends Question = Question> extends Promp
      * @param answers
      * The answer-object.
      */
-    constructor(questions: TQuestion, readLine: ReadlineInterface, answers: inquirer.Answers);
+    constructor(questions: TQuestion, readLine: ReadlineInterface, answers: Answers);
 
     /**
      * Renders the prompt.

--- a/types/inquirer/lib/prompts/confirm.d.ts
+++ b/types/inquirer/lib/prompts/confirm.d.ts
@@ -5,7 +5,7 @@ import { Interface as ReadlineInterface } from "readline";
 /**
  * The question-options for the `ConfirmPrompt<T>`.
  */
-type Question = ConfirmQuestionOptions<Answers>;
+type Question = ConfirmQuestionOptions;
 
 /**
  * Represents a prompt which provides a message to confirm.

--- a/types/inquirer/lib/prompts/input.d.ts
+++ b/types/inquirer/lib/prompts/input.d.ts
@@ -76,7 +76,7 @@ declare class InputPrompt<TQuestion extends Question = Question> extends Prompt<
     /**
      * Handles the `keypress`-event of the prompt.
      */
-    protected onKeyPress(): void;
+    protected onKeypress(): void;
 }
 
 export = InputPrompt;

--- a/types/inquirer/lib/prompts/list.d.ts
+++ b/types/inquirer/lib/prompts/list.d.ts
@@ -6,7 +6,7 @@ import { Interface as ReadlineInterface } from "readline";
 /**
  * The question-options for the `ListPrompt<T>`.
  */
-type Question = ListQuestionOptions<Answers>;
+type Question = ListQuestionOptions;
 
 /**
  * Represents a prompt which provides a list to choose an answer from.

--- a/types/inquirer/lib/prompts/list.d.ts
+++ b/types/inquirer/lib/prompts/list.d.ts
@@ -1,12 +1,12 @@
 import Prompt = require("./base");
-import inquirer = require("../..");
+import { Answers, ListQuestionOptions } from "../..";
 import Paginator = require("../utils/paginator");
 import { Interface as ReadlineInterface } from "readline";
 
 /**
  * The question-options for the `ListPrompt<T>`.
  */
-type Question = inquirer.ListQuestionOptions<inquirer.Answers>;
+type Question = ListQuestionOptions<Answers>;
 
 /**
  * Represents a prompt which provides a list to choose an answer from.
@@ -47,7 +47,7 @@ declare class ListPrompt<TQuestion extends Question = Question> extends Prompt<T
      * @param answers
      * The answer-object.
      */
-    constructor(question: TQuestion, readLine: ReadlineInterface, answers: inquirer.Answers);
+    constructor(question: TQuestion, readLine: ReadlineInterface, answers: Answers);
 
     /**
      * Renders the prompt.

--- a/types/inquirer/lib/prompts/number.d.ts
+++ b/types/inquirer/lib/prompts/number.d.ts
@@ -5,7 +5,7 @@ import { Interface as ReadlineInterface } from "readline";
 /**
  * The question for the `NumberPrompt<T>`.
  */
-type Question = NumberQuestionOptions<Answers>;
+type Question = NumberQuestionOptions;
 
 /**
  * Provides a prompt which allows the user to type a number as answer.

--- a/types/inquirer/lib/prompts/number.d.ts
+++ b/types/inquirer/lib/prompts/number.d.ts
@@ -1,11 +1,11 @@
 import InputPrompt = require("./input");
-import inquirer = require("../..");
+import { Answers, NumberQuestionOptions } from "../..";
 import { Interface as ReadlineInterface } from "readline";
 
 /**
  * The question for the `NumberPrompt<T>`.
  */
-type Question = inquirer.NumberQuestionOptions<inquirer.Answers>;
+type Question = NumberQuestionOptions<Answers>;
 
 /**
  * Provides a prompt which allows the user to type a number as answer.
@@ -26,7 +26,7 @@ declare class NumberPrompt<TQuestion extends Question = Question> extends InputP
      * @param answers
      * The answer-object.
      */
-    constructor(question: TQuestion, readLine: ReadlineInterface, answers: inquirer.Answers);
+    constructor(question: TQuestion, readLine: ReadlineInterface, answers: Answers);
 }
 
 export = NumberPrompt;

--- a/types/inquirer/lib/prompts/password.d.ts
+++ b/types/inquirer/lib/prompts/password.d.ts
@@ -60,7 +60,7 @@ declare class PasswordPrompt<TQuestion extends Question = Question> extends Prom
     /**
      * Handles the `keypress`-event of the prompt.
      */
-    protected onKeyPress(): void;
+    protected onKeypress(): void;
 
     /**
      * Handles the `success`-event of the prompt.

--- a/types/inquirer/lib/utils/utils.d.ts
+++ b/types/inquirer/lib/utils/utils.d.ts
@@ -7,11 +7,6 @@ import { Observable } from "rxjs";
 type QuestionProperty = inquirer.KeyUnion<inquirer.UnionToIntersection<inquirer.DistinctQuestion>>;
 
 /**
- * Unpacks a question-property.
- */
-type UnpackQuestionProperty<T> = T extends inquirer.AsyncDynamicQuestionProperty<inquirer.Answers, infer U> ? (U extends Promise<infer U2> ? U2 : U) : T;
-
-/**
  * Fetches a property of the specified `question`.
  *
  * @param question

--- a/types/inquirer/lib/utils/utils.d.ts
+++ b/types/inquirer/lib/utils/utils.d.ts
@@ -1,10 +1,10 @@
-import inquirer = require("../..");
+import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from "../..";
 import { Observable } from "rxjs";
 
 /**
  * Represents a property-name of any question-type.
  */
-type QuestionProperty = inquirer.KeyUnion<inquirer.UnionToIntersection<inquirer.DistinctQuestion>>;
+type QuestionProperty = KeyUnion<UnionToIntersection<DistinctQuestion>>;
 
 /**
  * Fetches a property of the specified `question`.
@@ -22,8 +22,8 @@ type QuestionProperty = inquirer.KeyUnion<inquirer.UnionToIntersection<inquirer.
  * The processed question.
  */
 export function fetchAsyncQuestionPropertyQuestionProperty(
-    question: inquirer.DistinctQuestion,
+    question: DistinctQuestion,
     prop: QuestionProperty,
-    answers: inquirer.Answers): Observable<inquirer.DistinctQuestion>;
+    answers: Answers): Observable<DistinctQuestion>;
 
 export { };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/SBoudrias/Inquirer.js/blob/v6.0.0/lib/prompts/password.js#L104-L106>
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

In the last `inquirer`-definitions I mistyped `InputPrompt.onKeyPress`, which is incorrect, instead of `InputPrompt.onKeypress`.

Also, I removed type-parameters where unnecessary and changed the types to make it easier to represent a single choice-option.