### PR TITLE
node: Fix link tags using parens

### DIFF
--- a/types/node/console.d.ts
+++ b/types/node/console.d.ts
@@ -25,16 +25,16 @@ declare module 'console' {
              */
             countReset(label?: string): void;
             /**
-             * The `console.debug()` function is an alias for {@link console.log()}.
+             * The `console.debug()` function is an alias for {@link console.log}.
              */
             debug(message?: any, ...optionalParams: any[]): void;
             /**
-             * Uses {@link util.inspect()} on `obj` and prints the resulting string to `stdout`.
+             * Uses {@link util.inspect} on `obj` and prints the resulting string to `stdout`.
              * This function bypasses any custom `inspect()` function defined on `obj`.
              */
             dir(obj: any, options?: InspectOptions): void;
             /**
-             * This method calls {@link console.log()} passing it the arguments received. Please note that this method does not produce any XML formatting
+             * This method calls {@link console.log} passing it the arguments received. Please note that this method does not produce any XML formatting
              */
             dirxml(...data: any[]): void;
             /**
@@ -47,7 +47,7 @@ declare module 'console' {
              */
             group(...label: any[]): void;
             /**
-             * The `console.groupCollapsed()` function is an alias for {@link console.group()}.
+             * The `console.groupCollapsed()` function is an alias for {@link console.group}.
              */
             groupCollapsed(...label: any[]): void;
             /**
@@ -55,7 +55,7 @@ declare module 'console' {
              */
             groupEnd(): void;
             /**
-             * The {@link console.info()} function is an alias for {@link console.log()}.
+             * The {@link console.info} function is an alias for {@link console.log}.
              */
             info(message?: any, ...optionalParams: any[]): void;
             /**
@@ -72,19 +72,19 @@ declare module 'console' {
              */
             time(label?: string): void;
             /**
-             * Stops a timer that was previously started by calling {@link console.time()} and prints the result to `stdout`.
+             * Stops a timer that was previously started by calling {@link console.time} and prints the result to `stdout`.
              */
             timeEnd(label?: string): void;
             /**
-             * For a timer that was previously started by calling {@link console.time()}, prints the elapsed time and other `data` arguments to `stdout`.
+             * For a timer that was previously started by calling {@link console.time}, prints the elapsed time and other `data` arguments to `stdout`.
              */
             timeLog(label?: string, ...data: any[]): void;
             /**
-             * Prints to `stderr` the string 'Trace :', followed by the {@link util.format()} formatted message and stack trace to the current position in the code.
+             * Prints to `stderr` the string 'Trace :', followed by the {@link util.format} formatted message and stack trace to the current position in the code.
              */
             trace(message?: any, ...optionalParams: any[]): void;
             /**
-             * The {@link console.warn()} function is an alias for {@link console.error()}.
+             * The {@link console.warn} function is an alias for {@link console.error}.
              */
             warn(message?: any, ...optionalParams: any[]): void;
 

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -21,16 +21,16 @@ interface Console {
      */
     countReset(label?: string): void;
     /**
-     * The `console.debug()` function is an alias for {@link console.log()}.
+     * The `console.debug()` function is an alias for {@link console.log}.
      */
     debug(message?: any, ...optionalParams: any[]): void;
     /**
-     * Uses {@link util.inspect()} on `obj` and prints the resulting string to `stdout`.
+     * Uses {@link util.inspect} on `obj` and prints the resulting string to `stdout`.
      * This function bypasses any custom `inspect()` function defined on `obj`.
      */
     dir(obj: any, options?: NodeJS.InspectOptions): void;
     /**
-     * This method calls {@link console.log()} passing it the arguments received. Please note that this method does not produce any XML formatting
+     * This method calls {@link console.log} passing it the arguments received. Please note that this method does not produce any XML formatting
      */
     dirxml(...data: any[]): void;
     /**
@@ -43,7 +43,7 @@ interface Console {
      */
     group(...label: any[]): void;
     /**
-     * The `console.groupCollapsed()` function is an alias for {@link console.group()}.
+     * The `console.groupCollapsed()` function is an alias for {@link console.group}.
      */
     groupCollapsed(...label: any[]): void;
     /**
@@ -51,7 +51,7 @@ interface Console {
      */
     groupEnd(): void;
     /**
-     * The {@link console.info()} function is an alias for {@link console.log()}.
+     * The {@link console.info} function is an alias for {@link console.log}.
      */
     info(message?: any, ...optionalParams: any[]): void;
     /**
@@ -68,19 +68,19 @@ interface Console {
      */
     time(label?: string): void;
     /**
-     * Stops a timer that was previously started by calling {@link console.time()} and prints the result to `stdout`.
+     * Stops a timer that was previously started by calling {@link console.time} and prints the result to `stdout`.
      */
     timeEnd(label?: string): void;
     /**
-     * For a timer that was previously started by calling {@link console.time()}, prints the elapsed time and other `data` arguments to `stdout`.
+     * For a timer that was previously started by calling {@link console.time}, prints the elapsed time and other `data` arguments to `stdout`.
      */
     timeLog(label?: string, ...data: any[]): void;
     /**
-     * Prints to `stderr` the string 'Trace :', followed by the {@link util.format()} formatted message and stack trace to the current position in the code.
+     * Prints to `stderr` the string 'Trace :', followed by the {@link util.format} formatted message and stack trace to the current position in the code.
      */
     trace(message?: any, ...optionalParams: any[]): void;
     /**
-     * The {@link console.warn()} function is an alias for {@link console.error()}.
+     * The {@link console.warn} function is an alias for {@link console.error}.
      */
     warn(message?: any, ...optionalParams: any[]): void;
 

--- a/types/node/v14/console.d.ts
+++ b/types/node/v14/console.d.ts
@@ -25,16 +25,16 @@ declare module 'console' {
              */
             countReset(label?: string): void;
             /**
-             * The `console.debug()` function is an alias for {@link console.log()}.
+             * The `console.debug()` function is an alias for {@link console.log}.
              */
             debug(message?: any, ...optionalParams: any[]): void;
             /**
-             * Uses {@link util.inspect()} on `obj` and prints the resulting string to `stdout`.
+             * Uses {@link util.inspect} on `obj` and prints the resulting string to `stdout`.
              * This function bypasses any custom `inspect()` function defined on `obj`.
              */
             dir(obj: any, options?: InspectOptions): void;
             /**
-             * This method calls {@link console.log()} passing it the arguments received. Please note that this method does not produce any XML formatting
+             * This method calls {@link console.log} passing it the arguments received. Please note that this method does not produce any XML formatting
              */
             dirxml(...data: any[]): void;
             /**
@@ -47,7 +47,7 @@ declare module 'console' {
              */
             group(...label: any[]): void;
             /**
-             * The `console.groupCollapsed()` function is an alias for {@link console.group()}.
+             * The `console.groupCollapsed()` function is an alias for {@link console.group}.
              */
             groupCollapsed(...label: any[]): void;
             /**
@@ -55,7 +55,7 @@ declare module 'console' {
              */
             groupEnd(): void;
             /**
-             * The {@link console.info()} function is an alias for {@link console.log()}.
+             * The {@link console.info} function is an alias for {@link console.log}.
              */
             info(message?: any, ...optionalParams: any[]): void;
             /**
@@ -72,19 +72,19 @@ declare module 'console' {
              */
             time(label?: string): void;
             /**
-             * Stops a timer that was previously started by calling {@link console.time()} and prints the result to `stdout`.
+             * Stops a timer that was previously started by calling {@link console.time} and prints the result to `stdout`.
              */
             timeEnd(label?: string): void;
             /**
-             * For a timer that was previously started by calling {@link console.time()}, prints the elapsed time and other `data` arguments to `stdout`.
+             * For a timer that was previously started by calling {@link console.time}, prints the elapsed time and other `data` arguments to `stdout`.
              */
             timeLog(label?: string, ...data: any[]): void;
             /**
-             * Prints to `stderr` the string 'Trace :', followed by the {@link util.format()} formatted message and stack trace to the current position in the code.
+             * Prints to `stderr` the string 'Trace :', followed by the {@link util.format} formatted message and stack trace to the current position in the code.
              */
             trace(message?: any, ...optionalParams: any[]): void;
             /**
-             * The {@link console.warn()} function is an alias for {@link console.error()}.
+             * The {@link console.warn} function is an alias for {@link console.error}.
              */
             warn(message?: any, ...optionalParams: any[]): void;
 


### PR DESCRIPTION
`@link` should reference the symbol name without the `()`

Fixes https://github.com/microsoft/vscode/issues/124937

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
NA