### PR TITLE
Finish putting riderize__passport-strava-oauth2 back

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -4286,10 +4286,6 @@
             "libraryName": "rgb2hex",
             "asOfVersion": "0.2.1"
         },
-        "riderize__passport-strava-oauth2": {
-            "libraryName": "@riderize/passport-strava-oauth2",
-            "asOfVersion": "1.1.1"
-        },
         "riot": {
             "libraryName": "riot",
             "asOfVersion": "4.1.0"

--- a/types/riderize__passport-strava-oauth2/index.d.ts
+++ b/types/riderize__passport-strava-oauth2/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/Riderize/passport-strava-oauth2
 // Definitions by: edilson <https://github.com/edilson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
 
 // tslint:disable-next-line:no-single-declare-module
 declare module '@riderize/passport-strava-oauth2' {


### PR DESCRIPTION
Tests didn't catch the fact that notNeededPackages.json needs to be updated, probably because this has never happened before.

To make sure that the publisher tries to publish a new version, I touched index.d.ts -- I removed a now-unused line, since DT only supports TS3.6 and above anyway.