### PR TITLE
Add `Partial<S>` to setState

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -480,7 +480,7 @@ declare namespace React {
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
         // Also, the ` | S` allows intellisense to not be dumbisense
         setState<K extends keyof S>(
-            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | Partial<S> | S | null)) | (Pick<S, K> | Partial<S> | S | null),
             callback?: () => void
         ): void;
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -141,22 +141,31 @@ const ContextUsingUnstableObservedBits = React.createContext(undefined, (previou
 </div>;
 
 // Below tests that setState() works properly for both regular and callback modes
-class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
+type StateOfSetStateTest = { foo: boolean, bar: boolean }
+class SetStateTest extends React.Component<{}, StateOfSetStateTest> {
     handleSomething = () => {
-      this.setState({ foo: '' }); // $ExpectError
-      this.setState({ foo: true });
-      this.setState({ foo: true, bar: true });
-      this.setState({});
-      this.setState(null);
-      this.setState({ foo: true, foo2: true }); // $ExpectError
-      this.setState(() => ({ foo: '' })); // $ExpectError
-      this.setState(() => ({ foo: true }));
-      this.setState(() => ({ foo: true, bar: true }));
-      this.setState(() => ({ foo: true, foo2: true })); // $ExpectError
-      this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
-      this.setState(() => ({ })); // ok!
-      this.setState({ foo: true, bar: undefined}); // $ExpectError
-      this.setState(prevState => (prevState.bar ? { bar: false } : null));
+        function complicatedReturn (original: StateOfSetStateTest) {
+            if (Math.random() > 0.5) {
+                return original;
+            }
+            return { foo: true };
+        }
+
+        this.setState({ foo: '' }); // $ExpectError
+        this.setState({ foo: true });
+        this.setState({ foo: true, bar: true });
+        this.setState({});
+        this.setState(null);
+        this.setState({ foo: true, foo2: true }); // $ExpectError
+        this.setState(() => ({ foo: '' })); // $ExpectError
+        this.setState(() => ({ foo: true }));
+        this.setState(() => ({ foo: true, bar: true }));
+        this.setState(() => ({ foo: true, foo2: true })); // $ExpectError
+        this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
+        this.setState(() => ({ })); // ok!
+        this.setState({ foo: true, bar: undefined }); // $ExpectError
+        this.setState(prevState => complicatedReturn(prevState));
+        this.setState(prevState => (prevState.bar ? { bar: false } : null));
     }
 }
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -141,7 +141,7 @@ const ContextUsingUnstableObservedBits = React.createContext(undefined, (previou
 </div>;
 
 // Below tests that setState() works properly for both regular and callback modes
-type StateOfSetStateTest = { foo: boolean, bar: boolean }
+type StateOfSetStateTest = { foo: boolean, bar: boolean };
 class SetStateTest extends React.Component<{}, StateOfSetStateTest> {
     handleSomething = () => {
         function complicatedReturn (original: StateOfSetStateTest) {


### PR DESCRIPTION
`Partial<S>` makes all properties of S optional: `type Partial<T> = { [P in keyof T]?: T[P] | undefined; }`
`Pick<S, K>`, described as "from T, pick a set of properties in the union K" : `type Pick<T, K extends keyof T> = { [P in K]: T[P]; }`

But wait, `setState` allows passing in an object that only has some properties, right?

__Draft status:__ Oh, there's a whole process. Right now this pr is just a single commit.
______
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
    ```ts
    // This is the code I actually used at icecream17/Solver, in order to override it.
    type SetStateResult<S, K extends keyof S> = Pick<S, K> | Partial<S> | S | null
 
    declare module 'React' {
       interface Component<P, S> {
          setState<K extends keyof S>(
             state: SetStateResult<S, K> | ((prevState: Readonly<S>, props: Readonly<P>) => SetStateResult<S, K>),
             callback?: () => void
          ): void;
       }
    }
    ```
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reactjs.org/docs/react-component.html#setstate>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

__________
`index.ts` has a comment about TS >= 2.7 on line 86, and the ts version in `index.d.ts` is 2.8, so maybe update that. (But that's out of scope of this pr)