### PR TITLE
[materialize-css] Added missing exposed instance properties on the Timepicker

### DIFF
--- a/types/materialize-css/test/timepicker.test.ts
+++ b/types/materialize-css/test/timepicker.test.ts
@@ -1,13 +1,13 @@
 import * as materialize from "materialize-css";
 
-const elem = document.querySelector('.whatever')!;
+const elem = document.querySelector(".whatever")!;
 
 // $ExpectType Timepicker
 const _timePicker = new M.Timepicker(elem);
 // $ExpectType Timepicker
 const el = M.Timepicker.init(elem);
 // $ExpectType Timepicker[]
-const els = M.Timepicker.init(document.querySelectorAll('.whatever'));
+const els = M.Timepicker.init(document.querySelectorAll(".whatever"));
 
 // $ExpectType Timepicker
 new materialize.Timepicker(elem);
@@ -43,7 +43,7 @@ const timePicker = new materialize.Timepicker(elem, {
         hour;
         // $ExpectType number
         minute;
-    }
+    },
 });
 // $ExpectType void
 timePicker.open();
@@ -57,6 +57,12 @@ timePicker.options;
 timePicker.el;
 // $ExpectType boolean
 timePicker.isOpen;
+// $ExpectType string
+timePicker.amOrPm;
+// $ExpectType Views
+timePicker.currentView;
+// $ExpectType "vibrate" | "webkitVibrate" | null
+timePicker.vibrate;
 
 $(".whatever").timepicker();
 $(".whatever").timepicker({ defaultTime: "13:14" });

--- a/types/materialize-css/test/timepicker.test.ts
+++ b/types/materialize-css/test/timepicker.test.ts
@@ -57,7 +57,7 @@ timePicker.options;
 timePicker.el;
 // $ExpectType boolean
 timePicker.isOpen;
-// $ExpectType string
+// $ExpectType "AM" | "PM"
 timePicker.amOrPm;
 // $ExpectType Views
 timePicker.currentView;

--- a/types/materialize-css/timepicker.d.ts
+++ b/types/materialize-css/timepicker.d.ts
@@ -1,6 +1,8 @@
 /// <reference path="./common.d.ts" />
 
 declare namespace M {
+    type Views = "hours" | "minutes";
+
     class Timepicker extends Component<TimepickerOptions> {
         /**
          * Get Instance
@@ -18,6 +20,18 @@ declare namespace M {
         static init(els: MElements, options?: Partial<TimepickerOptions>): Timepicker[];
 
         /**
+         * If the time is AM or PM on twelve-hour clock
+         * @default 'PM'
+         */
+        amOrPm: string;
+
+        /**
+         * Current view on the timepicker
+         * @default 'hours'
+         */
+        currentView: Views;
+
+        /**
          * If the picker is open.
          */
         isOpen: boolean;
@@ -26,6 +40,11 @@ declare namespace M {
          * The selected time.
          */
         time: string;
+
+        /**
+         * Vibrate device when dragging clock hand.
+         */
+        vibrate: "vibrate" | "webkitVibrate" | null;
 
         /**
          * Open timepicker
@@ -41,7 +60,7 @@ declare namespace M {
          * Show hours or minutes view on timepicker
          * @param view The name of the view you want to switch to, 'hours' or 'minutes'.
          */
-        showView(view: "hours" | "minutes"): void;
+        showView(view: Views): void;
     }
 
     interface TimepickerOptions {

--- a/types/materialize-css/timepicker.d.ts
+++ b/types/materialize-css/timepicker.d.ts
@@ -23,7 +23,7 @@ declare namespace M {
          * If the time is AM or PM on twelve-hour clock
          * @default 'PM'
          */
-        amOrPm: string;
+        amOrPm: "AM" | "PM";
 
         /**
          * Current view on the timepicker


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/materializecss/materialize/blob/v1-dev/js/timepicker.js#L236>

This PR introduces 3 instance properties exposed on the Timepicker class. They have defaults and contain important information but probably were missed because they are set in the "private" method `_setupVariables` ([source](https://github.com/materializecss/materialize/blob/v1-dev/js/timepicker.js#L236)). The properties themselves are, however, public.