### PR TITLE
gdal: Added Geometry.fromGeoJson function and fixed the argument type of SpatialReference.fromEPSG

### DIFF
--- a/types/gdal/index.d.ts
+++ b/types/gdal/index.d.ts
@@ -421,6 +421,7 @@ export interface GDALDrivers {
 
 export abstract class Geometry {
     static create(type: number): Geometry;
+    static fromGeoJson(geojson: object, srs?: SpatialReference): Geometry;
     static fromWKB(wkb: number, srs?: SpatialReference): Geometry;
     static fromWKT(wkt: string, srs?: SpatialReference): Geometry;
     static getConstructor(type: number): Geometry;
@@ -671,7 +672,7 @@ export class SpatialReference {
     toXML(): string;
     validate(): string;
     static fromCRSURL(input: string): SpatialReference;
-    static fromEPSG(input: string): SpatialReference;
+    static fromEPSG(input: number): SpatialReference;
     static fromEPSGA(input: number): SpatialReference;
     static fromESRI(input: string[]): SpatialReference;
     static fromMICoordSys(input: string): SpatialReference;


### PR DESCRIPTION
Changed the argument type of SpatialReference.fromEPSG to integer
Added Geometry.fromGeoJson fuction

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: 

      https://naturalatlas.github.io/node-gdal/classes/gdal.Geometry.html#method-fromGeoJson 
      Here, the SpatialReference.fromEPSG checks for integer argument https://naturalatlas.github.io/node-gdal/files/src_gdal_spatial_reference.cpp.html#l779
      
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
