### PR TITLE
[@chec/commerce.js] Add Phone to Customer Type + Order Type

### DIFF
--- a/types/chec__commerce.js/features/customer.d.ts
+++ b/types/chec__commerce.js/features/customer.d.ts
@@ -1,12 +1,21 @@
 import Commerce = require('@chec/commerce.js');
+import { Customer as CustomerType } from '../types/customer';
+import { Order as OrderType } from '../types/order';
+import { PaginationMeta } from '../types/pagination';
 import { RequestMethod } from './cart';
 
 export interface CustomerUpdate {
     email?: string;
+    phone?: string;
     firstname?: string;
     lastname?: string;
     external_id?: string;
     meta?: object;
+}
+
+export interface CustomerOrdersCollection {
+    data: OrderType[];
+    meta: PaginationMeta;
 }
 
 export class Customer {
@@ -14,10 +23,10 @@ export class Customer {
 
     login(email: string, base_url: string): Promise<{ success: boolean }>;
     getToken(token: string, save?: boolean): Promise<{ customer_id: string, jwt: string }>;
-    update(data: CustomerUpdate, customerId?: string, token?: string): Promise<any>;
-    getOrders(customerId?: string, token?: string, params?: object): Promise<any>;
-    getOrder(orderId: string, customerId?: string, token?: string): Promise<any>;
-    about(): Promise<any>;
+    update(data: CustomerUpdate, customerId?: string, token?: string): Promise<CustomerType>;
+    getOrders(customerId?: string, token?: string, params?: object): Promise<CustomerOrdersCollection>;
+    getOrder(orderId: string, customerId?: string, token?: string): Promise<OrderType>;
+    about(): Promise<CustomerType>;
     id(): string|null;
     token(): string|null;
     isLoggedIn(): boolean;

--- a/types/chec__commerce.js/test/customer.ts
+++ b/types/chec__commerce.js/test/customer.ts
@@ -1,4 +1,5 @@
 import Commerce = require('@chec/commerce.js');
+import Customer = require('@chec/commerce.js/types/customer');
 
 const commerce = new Commerce('{your_public_key}');
 
@@ -14,16 +15,16 @@ commerce.customer.login(email, base_url);
 // $ExpectType Promise<{ customer_id: string; jwt: string; }>
 commerce.customer.getToken(token, true);
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<Customer>
 commerce.customer.update({}, customerId, token);
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<CustomerOrdersCollection>
 commerce.customer.getOrders(customerId, token, {});
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<Order>
 commerce.customer.getOrder(orderId, customerId, token);
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<Customer>
 commerce.customer.about();
 
 // $ExpectType string | null
@@ -37,3 +38,16 @@ commerce.customer.isLoggedIn();
 
 // $ExpectType void
 commerce.customer.logout();
+
+// From https://api.chec.io/v1/customer/<customer>
+const customer: Customer.Customer = {
+    id: "cstmr_cO3J2apam2oDdz",
+    external_id: null,
+    firstname: "John",
+    lastname: "Doe",
+    email: "john.doe@example.com",
+    phone: null,
+    meta: [],
+    created: 1621784891,
+    updated: 1621784891
+};

--- a/types/chec__commerce.js/test/order.ts
+++ b/types/chec__commerce.js/test/order.ts
@@ -1,0 +1,281 @@
+import Order = require('@chec/commerce.js/types/order');
+
+// From: https://api.chec.io/v1/customers/<customer>/orders/<order>>
+const order: Order.Order = {
+  version: "v1.5",
+  sandbox: false,
+  id: "ord_",
+  checkout_token_id: "chkt_",
+  cart_id: "cart_",
+  customer_reference: "ANY-1234",
+  created: 1622591923,
+  status_payment: "paid",
+  status_fulfillment: "not_fulfilled",
+  currency: {
+    code: "CAD",
+    symbol: "$"
+  },
+  order_value: {
+    raw: 0,
+    formatted: "0.00",
+    formatted_with_symbol: "$0.00",
+    formatted_with_code: "0.00 CAD"
+  },
+  conditionals: {
+    collected_fullname: true,
+    collected_shipping_address: true,
+    collected_billing_address: true,
+    collected_extra_fields: true,
+    collected_tax: false,
+    collected_eu_vat_moss_evidence: false,
+    has_physical_fulfillment: true,
+    has_digital_fulfillment: false,
+    has_extend_fulfillment: false,
+    has_webhook_fulfillment: false,
+    has_extend_apps: false,
+    has_pay_what_you_want: false,
+    has_discounts: true,
+    has_subscription_items: false,
+    is_free: true,
+    is_fulfilled: false
+  },
+  fraud: [],
+  meta: [],
+  redirect: false,
+  collected: {
+    fullname: true,
+    shipping_address: true,
+    billing_address: true,
+    extra_fields: true,
+    tax: false,
+    eu_vat_moss_evidence: false
+  },
+  has: {
+    physical_fulfillment: true,
+    digital_fulfillment: false,
+    extend_fulfillment: false,
+    webhook_fulfillment: false,
+    extend_apps: false,
+    pay_what_you_want: false,
+    discounts: true,
+    subscription_items: false
+  },
+  is: {
+    free: true,
+    fulfilled: false
+  },
+  order: {
+    subtotal: {
+      raw: 32,
+      formatted: "32.00",
+      formatted_with_symbol: "$32.00",
+      formatted_with_code: "32.00 CAD"
+    },
+    total: {
+      raw: 0,
+      formatted: "0.00",
+      formatted_with_symbol: "$0.00",
+      formatted_with_code: "0.00 CAD"
+    },
+    total_with_tax: {
+      raw: 0,
+      formatted: "0.00",
+      formatted_with_symbol: "$0.00",
+      formatted_with_code: "0.00 CAD"
+    },
+    total_paid: {
+      raw: 0,
+      formatted: "0.00",
+      formatted_with_symbol: "$0.00",
+      formatted_with_code: "0.00 CAD"
+    },
+    pay_what_you_want: {
+      enabled: false,
+      minimum: null,
+      customer_set_price: null
+    },
+    shipping: {
+      id: "ship_",
+      description: "Local Pickup",
+      provider: "chec",
+      price: {
+        raw: 0,
+        formatted: "0.00",
+        formatted_with_symbol: "$0.00",
+        formatted_with_code: "0.00 CAD"
+      }
+    },
+    line_items: [
+      {
+        id: "item_",
+        product_id: "prod_",
+        product_name: "Something",
+        product_sku: null,
+        quantity: 1,
+        price: {
+          raw: 32,
+          formatted: "32.00",
+          formatted_with_symbol: "$32.00",
+          formatted_with_code: "32.00 CAD"
+        },
+        line_total: {
+          raw: 32,
+          formatted: "32.00",
+          formatted_with_symbol: "$32.00",
+          formatted_with_code: "32.00 CAD"
+        },
+        line_total_with_tax: {
+          raw: 32,
+          formatted: "32.00",
+          formatted_with_symbol: "$32.00",
+          formatted_with_code: "32.00 CAD"
+        },
+        variant: [],
+        selected_options: [],
+        tax: {
+          is_taxable: true,
+          amount: {
+            raw: 0,
+            formatted: "0.00",
+            formatted_with_symbol: "$0.00",
+            formatted_with_code: "0.00 CAD"
+          },
+          taxable_amount: {
+            raw: 32,
+            formatted: "32.00",
+            formatted_with_symbol: "$32.00",
+            formatted_with_code: "32.00 CAD"
+          },
+          rate: 0.13,
+          rate_percentage: "13%",
+          breakdown: [
+            {
+              amount: {
+                raw: 0,
+                formatted: "0.00",
+                formatted_with_symbol: "$0.00",
+                formatted_with_code: "0.00 CAD"
+              },
+              rate: 0.13,
+              rate_percentage: "13%",
+              type: "regional_tax"
+            }
+          ]
+        }
+      }
+    ],
+    discount: {
+      type: "percentage",
+      code: "ANYTHINGYOUWANT",
+      value: 100,
+      amount_saved: {
+        raw: 32,
+        formatted: "32.00",
+        formatted_with_symbol: "$32.00",
+        formatted_with_code: "32.00 CAD"
+      }
+    },
+    giftcard: []
+  },
+  shipping: {
+    name: "John Doe",
+    street: '123 Fake St',
+    street_2: null,
+    town_city: "Toronto",
+    postal_zip_code: "M4C0A0",
+    county_state: "ON",
+    country: "CA",
+    meta: null
+  },
+  billing: {
+    name: "John Doe",
+    street: '123 Fake St',
+    street_2: null,
+    town_city: "Toronto",
+    postal_zip_code: "M4C0A0",
+    county_state: "ON",
+    country: "CA",
+    meta: null
+  },
+  transactions: [],
+  fulfillment: {
+    physical: {
+      items: [
+        {
+          id: "ful_",
+          shipping_method_id: "ship_",
+          line_item_id: "item_",
+          product_id: "prod_",
+          shipping_description: "Local Pickup",
+          provider: "chec",
+          provider_type: "native_shipping",
+          product_name: "Something",
+          status: "not_fulfilled",
+          quantity: {
+            total: 1,
+            fulfilled: 0,
+            remaining: 1
+          },
+          quantity_fulfilled: 0,
+          quantity_remaining: 1,
+          last_updated: 1622591924,
+          linked_shipments: [],
+          selected_options: []
+        }
+      ],
+      shipments: []
+    },
+    digital: {
+      downloads: []
+    }
+  },
+  customer: {
+    id: "cstmr_",
+    external_id: null,
+    firstname: "John",
+    lastname: "Doe",
+    email: "john.doe@example.com",
+    phone: null,
+    meta: [],
+    created: 1621784891,
+    updated: 1621784891
+  },
+  extra_fields: [
+    {
+      id: "extr_",
+      name: "Note",
+      type: "text",
+      required: false,
+      value: "TEST ORDER."
+    }
+  ],
+  client_details: [],
+  tax: {
+    amount: {
+      raw: 0,
+      formatted: "0.00",
+      formatted_with_symbol: "$0.00",
+      formatted_with_code: "0.00 CAD"
+    },
+    included_in_price: false,
+    provider: "chec",
+    provider_type: "native",
+    breakdown: [
+      {
+        amount: {
+          raw: 0,
+          formatted: "0.00",
+          formatted_with_symbol: "$0.00",
+          formatted_with_code: "0.00 CAD"
+        },
+        type: "regional_tax"
+      }
+    ],
+    zone: {
+      country: "CA",
+      region: "ON",
+      postal_zip_code: "M4C 0A0",
+      ip_address: null
+    }
+  }
+};

--- a/types/chec__commerce.js/tsconfig.json
+++ b/types/chec__commerce.js/tsconfig.json
@@ -27,6 +27,7 @@
         "test/customer.ts",
         "test/index.ts",
         "test/merchants.ts",
+        "test/order.ts",
         "test/products.ts",
         "test/services.ts"
     ]

--- a/types/chec__commerce.js/types/address.d.ts
+++ b/types/chec__commerce.js/types/address.d.ts
@@ -1,9 +1,10 @@
 export interface Address {
   name: string;
   street: string;
-  street_2: string;
+  street_2: string | null;
   town_city: string;
   county_state: string;
   postal_zip_code: string;
   country: string;
+  meta?: any;
 }

--- a/types/chec__commerce.js/types/checkout-capture-response.d.ts
+++ b/types/chec__commerce.js/types/checkout-capture-response.d.ts
@@ -1,4 +1,6 @@
 import { Price } from './price';
+import { OrderConditionals } from './order-conditionals';
+import { OrderCollected } from './order-collected';
 import { Currency } from './currency';
 
 export type PaymentStatus = 'paid' | 'not_paid' | 'partially_paid' | 'refunded' | 'authorized';
@@ -29,28 +31,8 @@ export interface CheckoutCaptureResponse {
     required: boolean;
     value: string;
   }>;
-  conditionals: {
-    collected_fullname: boolean;
-    collected_shipping_address: boolean;
-    collected_billing_address: boolean;
-    collected_extra_fields: boolean;
-    collected_tax: boolean;
-    collected_eu_vat_moss_evidence: boolean;
-    has_physical_fulfillment: boolean;
-    has_digital_fulfillment: boolean;
-    has_pay_what_you_want: boolean;
-    has_discounts: boolean;
-    is_free: boolean;
-    is_fulfilled: boolean;
-  };
-  collected: {
-    fullname: boolean;
-    shipping_address: boolean;
-    billing_address: boolean;
-    extra_fields: boolean;
-    tax: boolean;
-    eu_vat_moss_evidence: boolean;
-  };
+  conditionals: OrderConditionals;
+  collected: OrderCollected;
   has: {
     physical_fulfillment: boolean;
     digital_fulfillment: boolean;
@@ -61,9 +43,6 @@ export interface CheckoutCaptureResponse {
     free: boolean;
     fulfilled: boolean;
   };
-  fraud: {
-    provider: string;
-    response: any;
-  };
+  fraud: any;
   meta: any;
 }

--- a/types/chec__commerce.js/types/checkout-capture.d.ts
+++ b/types/chec__commerce.js/types/checkout-capture.d.ts
@@ -1,12 +1,17 @@
 import { Extrafield } from './extrafield';
 import { Address } from './address';
-import { Customer } from './customer';
 
 export interface CheckoutCapture {
   line_items: any;
   discount_code?: string;
   extra_fields?: Extrafield[];
-  customer: Partial<Omit<Customer, 'external_id'>>;
+  customer: {
+    firstname?: string;
+    lastname?: string;
+    email: string;
+    phone?: string;
+    meta?: any;
+  };
   shipping?: Partial<Address>;
   fulfillment?: {
     shipping_method: string;

--- a/types/chec__commerce.js/types/customer.d.ts
+++ b/types/chec__commerce.js/types/customer.d.ts
@@ -1,8 +1,11 @@
 export interface Customer {
   id: string;
-  external_id: string;
+  external_id: string | null;
   firstname: string;
   lastname: string;
   email: string;
+  phone: string | null;
   meta: any;
+  created: number;
+  updated: number;
 }

--- a/types/chec__commerce.js/types/order-collected.d.ts
+++ b/types/chec__commerce.js/types/order-collected.d.ts
@@ -1,0 +1,8 @@
+export interface OrderCollected {
+    fullname: boolean;
+    shipping_address: boolean;
+    billing_address: boolean;
+    extra_fields: boolean;
+    tax: boolean;
+    eu_vat_moss_evidence: boolean;
+}

--- a/types/chec__commerce.js/types/order-conditionals.d.ts
+++ b/types/chec__commerce.js/types/order-conditionals.d.ts
@@ -1,0 +1,18 @@
+export interface OrderConditionals {
+    collected_fullname: boolean;
+    collected_shipping_address: boolean;
+    collected_billing_address: boolean;
+    collected_extra_fields: boolean;
+    collected_tax: boolean;
+    collected_eu_vat_moss_evidence: boolean;
+    has_physical_fulfillment: boolean;
+    has_digital_fulfillment: boolean;
+    has_extend_fulfillment: boolean;
+    has_extend_apps: boolean;
+    has_webhook_fulfillment: boolean;
+    has_pay_what_you_want: boolean;
+    has_discounts: boolean;
+    has_subscription_items: boolean;
+    is_free: boolean;
+    is_fulfilled: boolean;
+}

--- a/types/chec__commerce.js/types/order-line-item.d.ts
+++ b/types/chec__commerce.js/types/order-line-item.d.ts
@@ -1,0 +1,15 @@
+import { Price } from './price';
+
+export interface OrderLineItem {
+  id: string;
+  product_id: string;
+  product_name: string;
+  product_sku: string | null;
+  quantity: number;
+  price: Price;
+  line_total: Price;
+  line_total_with_tax: Price;
+  variant: any;
+  selected_options: any;
+  tax: any;
+}

--- a/types/chec__commerce.js/types/order-tax-line.d.ts
+++ b/types/chec__commerce.js/types/order-tax-line.d.ts
@@ -2,7 +2,7 @@ import { Price } from './price';
 
 export interface OrderTaxLine {
   amount: Price;
-  rate: number;
-  rate_percentage: string;
+  rate?: number;
+  rate_percentage?: string;
   type: string;
 }

--- a/types/chec__commerce.js/types/order-tax.d.ts
+++ b/types/chec__commerce.js/types/order-tax.d.ts
@@ -4,11 +4,13 @@ import { OrderTaxLine } from './order-tax-line';
 export interface OrderTax {
   amount: Price;
   included_in_price: boolean;
+  provider: string;
+  provider_type?: string;
   breakdown: OrderTaxLine[];
   zone: {
     country: string;
     region: string;
     postal_zip_code: string;
-    ip_address: string;
+    ip_address: string | null;
   };
 }

--- a/types/chec__commerce.js/types/order.d.ts
+++ b/types/chec__commerce.js/types/order.d.ts
@@ -1,0 +1,72 @@
+import { Address } from './address';
+import { FulfillmentStatus, PaymentStatus } from './checkout-capture-response';
+import { Currency } from './currency';
+import { Customer } from './customer';
+import { OrderConditionals } from './order-conditionals';
+import { OrderCollected } from './order-collected';
+import { OrderLineItem } from './order-line-item';
+import { OrderTax } from './order-tax';
+import { Price } from './price';
+import { Discount } from './discount';
+
+export interface Order {
+  version: string;
+  sandbox: boolean;
+  id: string;
+  checkout_token_id: string;
+  cart_id: string;
+  customer_reference: string;
+  created: number;
+  status_payment: PaymentStatus;
+  status_fulfillment: FulfillmentStatus;
+  currency: Currency;
+  order_value: Price;
+  conditionals: OrderConditionals;
+  fraud: any;
+  meta: any;
+  redirect: boolean;
+  collected: OrderCollected;
+  has: {
+    digital_fulfillment: boolean;
+    discounts: boolean;
+    extend_apps: boolean;
+    extend_fulfillment: boolean;
+    pay_what_you_want: boolean;
+    physical_fulfillment: boolean;
+    subscription_items: boolean;
+    webhook_fulfillment: boolean;
+  };
+  is: {
+    free: boolean;
+    fulfilled: boolean;
+  };
+  order: {
+    subtotal: Price;
+    total: Price;
+    total_with_tax: Price;
+    total_paid: Price;
+    pay_what_you_want: {
+      enabled: boolean;
+      minimum: Price | null;
+      customer_set_price: Price | null;
+    };
+    shipping: any;
+    line_items: OrderLineItem[];
+    discount: Omit<Discount, 'valid'> | [];
+    giftcard: any;
+  };
+  shipping: Address;
+  billing: Address;
+  transactions: any[];
+  fulfillment: any;
+  customer: Customer;
+  extra_fields: Array<{
+    id: string;
+    name: string;
+    type: string;
+    required: boolean;
+    value: string;
+  }>;
+  client_details: any;
+  tax: OrderTax;
+}


### PR DESCRIPTION
Adds recently added customer phone field.

1) Does checkout capture have customer.phone too? I've added it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://commercejs.com/docs/api/?shell#get-customer
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
