### PR TITLE
[@types/google-map-react] Added url to BootstrapURLKeys

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 const center = { lat: 0, lng: 0 };
 
 const key: BootstrapURLKeys = { key: 'my-google-maps-key', libraries: "places" };
+const keyWithURL: BootstrapURLKeys = { key: 'my-google-maps-key', libraries: "places", url: "http://maps.google.cn" };
 const client: BootstrapURLKeys = { client: 'my-client-identifier', v: '3.28' , language: 'en', libraries: "places", region: "PR" };
 const options: MapOptions = {
     zoomControl: false,

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -13,6 +13,7 @@ declare namespace googleMapReact {
         language?: string;
         region?: string;
         libraries?: string[] | string;
+        url?: string;
     };
 
     interface MapTypeStyle {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/googlemaps/js-api-loader/blob/master/src/index.ts#L158) and [here](https://github.com/google-map-react/google-map-react/blob/a783cd62767f824a6eb072e523c8d06ea660c7ee/src/loaders/google_map_loader.js#L65)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR adds the ability to pass `url` to `google-map-react` `BootstrapURLKeys` which lets us use a custom domain to load the Google Maps API script. This is useful for countries like China which uses a custom URL to load google maps which is `http://maps.google.cn` instead of `https://maps.googleapis.com`. Since `google-map-react` simply delegates the props to `@googlemaps/js-api-loader` we can pass in a custom map URL.
