### PR TITLE
fix(console-log-level): make `options` optional

### DIFF
--- a/types/console-log-level/console-log-level-tests.ts
+++ b/types/console-log-level/console-log-level-tests.ts
@@ -1,5 +1,7 @@
 import consoleLogLevel = require("console-log-level");
 
+const logger0 = consoleLogLevel();
+
 const logger1 = consoleLogLevel({
     level: "trace",
     stderr: undefined,

--- a/types/console-log-level/index.d.ts
+++ b/types/console-log-level/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/watson/console-log-level
 // Definitions by: Ali Ijaz Sheikh <https://github.com/ofrobots>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 type PrefixFunction = (level: string) => string;
 
@@ -18,6 +17,6 @@ interface Options {
     stderr?: boolean;
 }
 
-declare function consoleLogLevel(opts: Options): consoleLogLevel.Logger;
+declare function consoleLogLevel(opts?: Options): consoleLogLevel.Logger;
 
 export = consoleLogLevel;


### PR DESCRIPTION
Default creation function accepts no options, using all defaults:

https://github.com/watson/console-log-level/blob/master/index.js#L9

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).