### PR TITLE
fix: adds missing params object for getTextContent type for pdfjs-dist

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -394,6 +394,12 @@ interface PDFViewerParams {
     viewer?: HTMLElement;
 }
 
+interface GetTextContentParams {
+    normalizeWhitespace?: boolean;
+    disableCombineTextItems?: boolean;
+    includeMarkedContent?: boolean;
+}
+
 /**
  * RenderTask is basically a promise but adds a cancel function to termiate it.
  **/
@@ -451,7 +457,7 @@ interface PDFPageProxy {
     /**
      * A promise that is resolved with the string that is the text content frm the page.
      **/
-    getTextContent(): Promise<TextContent>;
+    getTextContent(params?: GetTextContentParams): Promise<TextContent>;
 
     /**
      * marked as future feature


### PR DESCRIPTION
The `getTextContent` function can accept an optional params object setting the `GetTextContext` event options.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mozilla/pdf.js/blob/ed0990ab6f4ad660052a204254bcef2871f17eb6/src/display/api.js#L1488>><<https://github.com/mozilla/pdf.js/blob/ed0990ab6f4ad660052a204254bcef2871f17eb6/src/display/api.js#L1460>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
