### PR TITLE
added "required" field in ValidatorField

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1305,6 +1305,7 @@ declare global {
 
             interface ValidatorField {
                 type?: any;
+                required?: boolean;
                 constant?: boolean;
                 default?: any;
                 options?: any[] | Function;


### PR DESCRIPTION
added the "required" field in the ValidatorField type, as it exist in the doc (see https://docs.parseplatform.org/cloudcode/guide/#save-triggers), but not in the types definition

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.parseplatform.org/cloudcode/guide/#save-triggers>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
