### PR TITLE
[ffi-napi] Augments 'ref.Type' with 'ffi_type' when 'ffi-napi' is loaded

### DIFF
--- a/types/ffi-napi/ffi-napi-tests.ts
+++ b/types/ffi-napi/ffi-napi-tests.ts
@@ -143,3 +143,9 @@ ffi.Library(null, { x: ["void", [], { async: true }]}).x;
     const callback = (x: number) => x > 0;
     lib.foo(callback);
 }
+
+// $ExpectType PFFI_TYPE | undefined
+ref.types.uint32.ffi_type;
+
+// $ExpectType PFFI_TYPE
+ffi.FFI_TYPES.void;


### PR DESCRIPTION
Please fill in this template.

`ffi-napi` extends the built-in types in `ref` with an `ffi_type` field that it uses for marshalling. If you define a custom `ref.Type` implementation, it may be necessary to set the correct `ffi_type` from the `FFI_TYPES` object for your type to work with `ffi-napi`.

This cleans up some of the typing to give a more specific type for `FFI_TYPE` and adds a module augmentation for `"ref"` to augment the `Type` interface and add `ffi_type` whenever `ffi-napi` is referenced in a TypeScript program.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/node-ffi-napi/node-ffi-napi/blob/00df1232a25b1b0f026b5d1b4c9efc67497e4b48/lib/type.js#L17
  - https://github.com/node-ffi-napi/node-ffi-napi/blob/00df1232a25b1b0f026b5d1b4c9efc67497e4b48/lib/ffi.js#L40
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
