### PR TITLE
styled-components: Allow a specific component type to be passed as generic to StyledComponentBase call

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -171,6 +171,9 @@ export interface StyledComponentBase<
     (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
         StyledComponentProps<C, T, O, A>
     >;
+    <SpecifiedC extends string | React.ComponentType<any> = C>(props: StyledComponentProps<SpecifiedC, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+        StyledComponentProps<SpecifiedC, T, O, A>
+    >;
     <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = C>(
         props: StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>,
     ): React.ReactElement<StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>>;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -224,6 +224,29 @@ const Article = styled.section`
 // A Link instance should be backed by an HTMLAnchorElement
 const ComposedLink = () => <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
+interface ComponentWithGenericsProps<T> { item: T;  render: (item: T) => any; }
+
+const ComponentWithGenerics = <T extends any>({
+    item,
+    render,
+}: { item: T,  render: (item: T) => any }): React.ReactElement => <div></div>;
+
+const StyledComponentWithGenerics = styled(ComponentWithGenerics)``;
+
+interface ItemType { title: string; }
+
+const shouldStillBeAbleToPassGenerics = () => {
+    return (
+        <StyledComponentWithGenerics<React.FC<ComponentWithGenericsProps<ItemType>>>
+            item={{ title: "" }}
+            render={item => {
+                // $ExpectType ItemType
+                item;
+            }}
+        />
+    );
+};
+
 /**
  * construction via string tag
  */


### PR DESCRIPTION
The latest change on version 5.1.9 -> 5.1.10 (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52242) breaks the existing solution for an issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39136. This PR attempts to solve it.

The solution presented on the issue relied on specifying a generic for the component instantiation, which made typescript use the second overload of `StyledComponentBase` which should be only used in the cases where `as` or `forwardedAs` is passed. In the latest PR we've adjusted the second overload so that it allowed for the props of `as` and `forwardedAs` to be linted properly. Now we introduce one more overload (there may be a better solution, ts experts send help) so that when specifying a generic it fallbacks to the correct overload.

```diff
export interface StyledComponentBase<
    C extends string | React.ComponentType<any>,
    T extends object,
    O extends object = {},
    A extends keyof any = never
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
    // add our own fake call signature to implement the polymorphic 'as' prop
    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
        StyledComponentProps<C, T, O, A>
    >;
+    <SpecifiedC extends string | React.ComponentType<any> = C>(props: StyledComponentProps<SpecifiedC, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+        StyledComponentProps<SpecifiedC, T, O, A>
+    >;
    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = C>(
        props: StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>,
    ): React.ReactElement<StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>>;

}
```

Added a test for this specific use-case so that it doesn't regress again :tada:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes issue <https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39136>
