### PR TITLE
[ndarray] Infer types from input `data` array

### DIFF
--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -6,60 +6,67 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-declare function ndarray<T = number>(
-    data: ndarray.Data<T>,
+declare function ndarray<D extends ndarray.Data = ndarray.Data<number>>(
+    data: D,
     shape?: number[],
     stride?: number[],
     offset?: number,
-): ndarray.NdArray<T>;
+): ndarray.NdArray<D>;
 
 declare namespace ndarray {
-    interface NdArray<T = number> {
-        data: Data<T>;
+    interface NdArray<D extends Data = Data<number>> {
+        data: D;
         shape: number[];
         stride: number[];
         offset: number;
-        dtype: DataType;
+        dtype: DataType<D>;
         size: number;
         order: number[];
         dimension: number;
-        get(...args: number[]): T;
-        set(...args: number[]): T;
-        index(...args: number[]): T;
-        lo(...args: number[]): NdArray<T>;
-        hi(...args: number[]): NdArray<T>;
-        step(...args: number[]): NdArray<T>;
-        transpose(...args: number[]): NdArray<T>;
-        pick(...args: Array<number | null>): NdArray<T>;
-        reshape(...shapes: number[]): NdArray<T>;
-        T: NdArray<T>;
+        get(...args: number[]): Value<D>;
+        set(...args: number[]): Value<D>;
+        index(...args: number[]): Value<D>;
+        lo(...args: number[]): NdArray<D>;
+        hi(...args: number[]): NdArray<D>;
+        step(...args: number[]): NdArray<D>;
+        transpose(...args: number[]): NdArray<D>;
+        pick(...args: Array<number | null>): NdArray<D>;
+        T: NdArray<D>;
     }
 
-    type Data<T> =
-        | T[]
+    type Data<T = any> = T[] | TypedArray;
+    type TypedArray =
         | Int8Array
         | Int16Array
         | Int32Array
         | Uint8Array
+        | Uint8ClampedArray
         | Uint16Array
         | Uint32Array
         | Float32Array
-        | Float64Array
-        | Uint8ClampedArray;
+        | Float64Array;
 
-    type DataType =
-        | "int8"
-        | "int16"
-        | "int32"
-        | "uint8"
-        | "uint16"
-        | "uint32"
-        | "float32"
-        | "float64"
-        | "array"
-        | "uint8_clamped"
-        | "buffer"
-        | "generic";
+    type Value<D extends Data> = D extends Array<infer T> ? T : number;
+
+    type DataType<D extends Data = Data> = D extends Int8Array
+        ? 'int8'
+        : D extends Int16Array
+        ? 'int16'
+        : D extends Int32Array
+        ? 'int32'
+        : D extends Uint8Array
+        ? 'uint8'
+        : D extends Uint8ClampedArray
+        ? 'uint8_clamped'
+        : D extends Uint16Array
+        ? 'uint16'
+        : D extends Uint32Array
+        ? 'uint32'
+        : D extends Float32Array
+        ? 'float32'
+        : D extends Float64Array
+        ? 'float64'
+        : 'array';
 }
 
 export = ndarray;

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -1,26 +1,58 @@
-import ndarray = require("ndarray");
+import ndarray = require('ndarray');
 
-const data = new Int32Array(2 * 2 * 2 + 10);
-const a = ndarray(data, [2, 2, 2], [1, 2, 4], 5);
+const data1 = new Int32Array(2 * 2 * 2 + 10);
+const typedArr = ndarray(data1, [2, 2, 2], [1, 2, 4], 5);
+console.log(typedArr.data === data1);
+console.log(typedArr.data.buffer.byteLength);
+console.log(typedArr.shape[0] === 2);
+console.log(typedArr.shape[1] === 2);
+console.log(typedArr.shape[2] === 2);
+console.log(typedArr.stride[0] === 1);
+console.log(typedArr.stride[1] === 2);
+console.log(typedArr.stride[2] === 4);
+console.log(typedArr.offset === 5);
+console.log(typedArr.dtype === 'int32');
+console.log(typedArr.size === 8);
+console.log(typedArr.order[0] === 0);
+console.log(typedArr.order[1] === 1);
+console.log(typedArr.order[2] === 2);
+console.log(typedArr.dimension === 3);
+console.log(typedArr.set(0, 0, 0, 1) >= 1);
+console.log(typedArr.get(0, 0, 0) >= 1);
+console.log(typedArr.index(1, 1, 1) >= 12);
 
-console.log(a.data === data);
-console.log(a.shape[0] === 2);
-console.log(a.shape[1] === 2);
-console.log(a.shape[2] === 2);
-console.log(a.stride[0] === 1);
-console.log(a.stride[1] === 2);
-console.log(a.stride[2] === 4);
-console.log(a.offset === 5);
-console.log(a.dtype === "int32");
-console.log(a.size === 8);
-console.log(a.order[0] === 0);
-console.log(a.order[1] === 1);
-console.log(a.order[2] === 2);
-console.log(a.dimension === 3);
-console.log(a.set(0, 0, 0, 1) === 1);
-console.log(a.get(0, 0, 0) === 1);
-console.log(a.index(1, 1, 1) === 12);
+const typedView = typedArr.lo(0, 0, 0).hi(1, 1, 1).step(0, 1).transpose(0, 1).pick(null, null, 1);
+console.log(typedView.data === data1);
+console.log(typedView.data.buffer.byteLength);
 
-const b = a.lo(0, 0, 0).hi(1, 1, 1);
+const data2 = [0, 1, 2, 3];
+const numArr = ndarray(data2);
+console.log(numArr.data.concat([]).length);
+console.log(numArr.shape[0] === 4);
+console.log(numArr.data === data2);
+console.log(numArr.get(0) >= 0);
+console.log(numArr.lo(0).data === data2);
 
-a.pick(null, null, 1);
+const data3 = [true, false];
+const boolArr = ndarray(data3);
+console.log(boolArr.data[0] ? 1 : 0);
+
+function generic1<D extends ndarray.TypedArray>(data: D): ndarray.NdArray<D> {
+    return ndarray(data);
+}
+
+const gen1 = generic1(Float32Array.from([0, 1]));
+console.log(gen1.get(0) === 0);
+console.log(gen1.data.buffer.byteLength);
+
+function generic2<T>(...values: T[]): ndarray.NdArray<T[]> {
+    return ndarray(values);
+}
+
+const gen2 = generic2<string | boolean>('test', 'blah', true);
+const firstVal = gen2.get(0);
+console.log(typeof firstVal === 'string' ? firstVal.length : firstVal.valueOf());
+
+function getFirstValue(arr: ndarray.NdArray): number {
+    return arr.get(0);
+}

--- a/types/numjs/index.d.ts
+++ b/types/numjs/index.d.ts
@@ -9,7 +9,7 @@ import { Data, DataType, NdArray as BaseNdArray } from "ndarray";
 
 export type NdType<T> = DataType | Data<T>;
 
-export interface NdArray<T = number> extends BaseNdArray<T> {
+export interface NdArray<T = number> extends BaseNdArray<Data<T>> {
     ndim: number;
     T: NdArray<T>;
     slice(...args: Array<number | number[]>): NdArray<T>;

--- a/types/numjs/index.d.ts
+++ b/types/numjs/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace nj;
-import { Data, DataType, NdArray as BaseNdArray } from "ndarray";
+import { Data, DataType, NdArray as BaseNdArray } from 'ndarray';
 
 export type NdType<T> = DataType | Data<T>;
 
@@ -152,6 +152,13 @@ export interface NdArray<T = number> extends BaseNdArray<Data<T>> {
     convolve(filter: NjArray<T>): NdArray<T>;
 
     fftconvolve(filter: NjArray<T>): NdArray<T>;
+
+    /**
+     * Gives a new shape to an array without changing its data.
+     *
+     * @param shape The new shape should be compatible with the original shape. If an integer, then the result will be a 1-D array of that length
+     */
+    reshape<T = number>(...shape: number[]): NdArray<T>;
 }
 
 export type NdArrayData<T> = Data<T>;

--- a/types/numjs/numjs-tests.ts
+++ b/types/numjs/numjs-tests.ts
@@ -3,6 +3,9 @@ import nj = require("numjs");
 const a = nj.abs(2);
 
 const arr = nj.arange(6);
+arr.reshape(1, 2, 3);
+// array([[[ 0, 1, 2],
+//         [ 3, 4, 5]]])
 arr.T;
 // array([[[ 0],
 //         [ 3]],

--- a/types/numjs/numjs-tests.ts
+++ b/types/numjs/numjs-tests.ts
@@ -3,9 +3,6 @@ import nj = require("numjs");
 const a = nj.abs(2);
 
 const arr = nj.arange(6);
-arr.reshape(1, 2, 3);
-// array([[[ 0, 1, 2],
-//         [ 3, 4, 5]]])
 arr.T;
 // array([[[ 0],
 //         [ 3]],


### PR DESCRIPTION
⚠️ **Breaking change!** ⚠️ 

The generic type of the `ndarray` function now refers to the type of the input array instead of the type of the values contained in the input array: `ndarray<D>(data: D)`. This is a breaking change for cases where the generic is specified explicitly. If the generic is not specified, it is inferred from the input array.

This change brings some major benefits, notably:

1. The input array exposed through `arr.data` no longer "loses" its type.
2. `arr.dtype` can now be inferred to the correct string.
3. In most cases, the generic no longer has to be specified when calling `ndarray()`, even when dealing with input values of another type than `number` -- everything gets inferred properly from the type of the input array.
4. It's no longer possible to specify a generic that is incompatible with the input array.

```tsx
// BEFORE
const arr = ndarray([0, 1]);
const data: number[] = arr.data as number[]; // `arr.data` has type `number[] | Int8Array | ...
const dtype = arr.dtype; // 'int8' | 'int16' | ...

// AFTER
const arr = ndarray([0, 1]); // no breaking change here, everything just works
const data: number[] = arr.data; // no cast required
const dtype = arr.dtype; // 'array'
```

```tsx
// BEFORE
const arr = ndarray(Float32Array.from([0, 1]));
const data: ArrayBuffer = (arr.data as Float32Array).buffer;
const dtype = arr.dtype; // 'int8' | 'int16' | ...

// AFTER
const arr = ndarray(Float32Array.from([0, 1])); // no breaking change here, everything just works
const data: ArrayBuffer = arr.data.buffer; // no cast required
const dtype = arr.dtype; // 'float32'
```

```tsx
// BEFORE
const arr = ndarray<string>(['foo', 'bar']);
const data: string[] = arr.data as string[];

// AFTER
const arr = ndarray(['foo', 'bar']); // BREAKING CHANGE: generic must be removed or replaced with `string[]`
const data: string[] = arr.data; // no cast required
```

```tsx
// BEFORE
function doSomething(arr: NdArray<string>) { ... }

// AFTER
function doSomething(arr: NdArray<string[]>) { ... } // BREAKING CHANGE: generic must be replaced with `string[]`
```

```tsx
// BEFORE
const arr = ndarray<string>(Float32Array.from([0,1])); // no error, even though a `Float32Array` cannot possibly contain strings

// AFTER
const arr = ndarray<string[]>(Float32Array.from([0,1])); // error
//                            ^ Argument of type 'Float32Array' is not assignable to parameter of type 'string[]'
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/scijs/ndarray/blob/master/ndarray.js
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~