### PR TITLE
matter-js update engine properties, add missing parameter to Bodies.fromVerticies

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -137,9 +137,10 @@ declare namespace Matter {
         * @param {bool} [flagInternal=false]
         * @param {number} [removeCollinear=0.01]
         * @param {number} [minimumArea=10]
+        * @param {number} [removeDuplicatePoints=0.01]
         * @return {body}
         */
-        static fromVertices(x: number, y: number, vertexSets: Array<Array<Vector>>, options?: IBodyDefinition, flagInternal?: boolean, removeCollinear?: number, minimumArea?: number): Body;
+        static fromVertices(x: number, y: number, vertexSets: Array<Array<Vector>>, options?: IBodyDefinition, flagInternal?: boolean, removeCollinear?: number, minimumArea?: number, removeDuplicatePoints?: number): Body;
     }
 
     export interface IBodyDefinition {
@@ -2078,12 +2079,13 @@ declare namespace Matter {
         static run(enige: Engine): void;
 
         /**
-         * An instance of a broadphase controller. The default value is a `Matter.Grid` instance created by `Engine.create`.
+         * Replaced by and now alias for `engine.grid`.
          *
-        * @property broadphase
-        * @type grid
-        * @default a Matter.Grid instance
-        */
+         * @deprecated use `engine.grid`
+         * @property broadphase
+         * @type grid
+         * @default a Matter.Grid instance
+         */
         broadphase: Grid;
         /**
          * An integer `Number` that specifies the number of constraint iterations to perform each update.
@@ -2110,6 +2112,24 @@ declare namespace Matter {
         * @default false
         */
         enableSleeping: boolean;
+
+        /**
+         * A `Matter.Grid` instance.
+         *
+         * @property grid
+         * @type grid
+         * @default a Matter.Grid instance
+         */
+        grid: Grid;
+
+
+        /**
+         * The gravity to apply on all bodies in `engine.world`.
+         *
+         * @property gravity
+         * @type object
+         */
+        gravity: Gravity;
 
         /**
          * Collision pair set for this `Engine`.
@@ -3223,6 +3243,9 @@ declare namespace Matter {
          */
         static create(options: IWorldDefinition): World;
 
+        /**
+         * @deprecated moved to engine.gravity
+         */
         gravity: Gravity;
         bounds: Bounds;
 


### PR DESCRIPTION
add missing parameter removeDuplicatePoints to Bodies.fromVerticies(https://brm.io/matter-js/docs/classes/Bodies.html#method_fromVertices)
add engine.grid property, mark engine.broadphase as deprecated(https://github.com/liabru/matter-js/blob/e909b0466cea2051267bab92a38ccaa9bf7f154e/src/core/Engine.js#L465)
add engine.gravity property, mark world.gravity as deprecated(https://brm.io/matter-js/docs/classes/World.html)
