### PR TITLE
update analytics-node Identity type

### DIFF
--- a/types/analytics-node/analytics-node-tests.ts
+++ b/types/analytics-node/analytics-node-tests.ts
@@ -66,7 +66,6 @@ function testTrack(): void {
     }
   });
 
-  // $ExpectError
   analytics.track({
     event: 'Purchased an Item',
     properties: {

--- a/types/analytics-node/index.d.ts
+++ b/types/analytics-node/index.d.ts
@@ -8,10 +8,10 @@
 export = AnalyticsNode.Analytics;
 
 declare namespace AnalyticsNode {
-  type Identity = { 
-    userId?: string | number | undefined;
-    anonymousId?: string | number | undefined
-  };
+  interface Identity {
+    userId?: string | number;
+    anonymousId?: string | number;
+  }
 
   type Message = Identity & {
     type: string;

--- a/types/analytics-node/index.d.ts
+++ b/types/analytics-node/index.d.ts
@@ -8,9 +8,10 @@
 export = AnalyticsNode.Analytics;
 
 declare namespace AnalyticsNode {
-  type Identity =
-    | { userId: string | number }
-    | { userId?: string | number; anonymousId: string | number };
+  type Identity = { 
+    userId?: string | number | undefined;
+    anonymousId?: string | number | undefined
+  };
 
   type Message = Identity & {
     type: string;


### PR DESCRIPTION
Update analytics-node based on segmentio/typewriter and segmentio/analytics-node@4.0.1.
userId and anonymousId are both optional in the typewriter definition: https://github.com/segmentio/typewriter/blob/f09e96eb9b32f866abb5197da67641cdb98951ff/src/generators/javascript/templates/segment.hbs#L27-L30
No new tests required, only one test need to pass instead of failing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/segmentio/typewriter/blob/f09e96eb9b32f866abb5197da67641cdb98951ff/src/generators/javascript/templates/segment.hbs#L27-L30
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
