### PR TITLE
Add types for command-shell-lib

### DIFF
--- a/types/command-shell-lib/command-shell-lib-tests.ts
+++ b/types/command-shell-lib/command-shell-lib-tests.ts
@@ -1,0 +1,70 @@
+import {
+    prompt,
+    showHelp,
+    executeCommander,
+    showConfig,
+    initialize,
+    destroy,
+    printName,
+    notImplemented,
+    handleError,
+    setWriter,
+    getWriter,
+} from 'command-shell-lib';
+
+// $ExpectType void
+prompt();
+
+// $ExpectType void
+showHelp({});
+// $ExpectError
+showHelp({ invalid: {} });
+// $ExpectError
+showHelp({ invalid: { description: 'This command is invalid, parameters missing', handler: () => {} } });
+// $ExpectError
+showHelp({ invalid: { parameters: ['missing', 'description'], handler: () => {} } });
+// $ExpectError
+showHelp({ invalid: { parameters: ['missing', 'handler'], description: '' } });
+// $ExpectType void
+showHelp({ valid: { parameters: ['valid'], description: 'This command is valid', handler: () => {} } });
+
+// $ExpectType void
+executeCommander(['some', 'command'], {});
+
+// $ExpectType () => void
+showConfig({}, '');
+// $ExpectError
+showConfig({}, null);
+
+// $ExpectType void
+initialize({}, 'This is a prompt string');
+// $ExpectError
+initialize({}, null);
+// $ExpectError
+initialize({ invalid: { parameters: ['missing', 'description'], handler: () => {} } }, 'invalid');
+
+// $ExpectType void
+destroy();
+
+// $ExpectType () => void
+printName('someName');
+// $ExpectError
+printName(0);
+
+// $ExpectType void
+notImplemented();
+
+// $ExpectType void
+handleError(new Error());
+// $ExpectError
+handleError('Only a message');
+
+// $ExpectType void
+setWriter({ log: (message?: any, ...optionalParams: any[]) => {} });
+// $ExpectError
+setWriter({ logs: (message?: any, ...optionalParams: any[]) => {} });
+// $ExpectType void
+setWriter({ log: (message?: any) => {} });
+
+// $ExpectType LogWriter
+getWriter();

--- a/types/command-shell-lib/index.d.ts
+++ b/types/command-shell-lib/index.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for command-shell-lib 1.0
+// Project: https://github.com/telefonicaid/command-shell-lib
+// Definitions by: Fabian Bäumer <https://github.com/TrueSkrillor>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace commandShellLib;
+
+/** A single command specifying parameters, description and the corresponding handler. */
+export interface Command {
+    /**
+     * A list of needed parameters for the command
+     * (if its invoked with a different number of parameters an error will be raised).
+     */
+    parameters: string[];
+    /** Contains the contents that will be shown in the command help. */
+    description: string;
+    /** The function that will be called when the command is executed. */
+    handler: (params: string[]) => void;
+}
+/** An object specifying multiple commands and the corresponding name as the attributes key. */
+export interface CommandsObject {
+    [name: string]: Command;
+}
+/** A simple object capable of writing to a log location (e. g. a Console object can be used). */
+export interface LogWriter {
+    log: (message?: any, ...optionalParams: any[]) => void;
+}
+
+/** Prints a prompt to the LogWriter if not performing a stress test. */
+export function prompt(): void;
+/** Shows the command help created from the commands object. */
+export function showHelp(commands: CommandsObject): void;
+/**
+ * Executes the given command (the list of words parsed from the command line input) in the context of the commands
+ * describe by the object Commands.
+ */
+export function executeCommander(command: string[], commands: CommandsObject): void;
+/** Creates a function that shows the selected branch (attribute) of the config, formatted with the correct indentation. */
+export function showConfig(config: { [name: string]: any }, branch: string): () => void;
+/**
+ * Initialize the command line client with the given commands and prompt. Each command has the following structure:
+ *
+ *     'create': {
+ *      parameters: ['objectUri'],
+ *      description: '\tCreate a new object. The object is specified using the /type/id OMA notation.',
+ *      handler: create
+ *  }
+ *
+ * where: the parameters attribute is a list of the needed parameters for the command (if its invoked with a different
+ * number of parameters an error will be raised); the description attribute contains the contents that will be shown
+ * in the command help; and the handler is the function that will be called when the command is executed.
+ */
+export function initialize(commands: CommandsObject, promptString: string): void;
+/** Destroys the underlying readline interface. */
+export function destroy(): void;
+/** Creates a function that prints the provided name. */
+export function printName(name: string): () => void;
+/** Prints a string to signal that a feature has not yet been implemented.  */
+export function notImplemented(): void;
+/** Handles a standard error by printing its name and message to the configured LogWriter. */
+export function handleError(error: Error): void;
+/** Sets the LogWriter object to be used for all logging. */
+export function setWriter(newWriter: LogWriter): void;
+/** Gets the currently used LogWriter object. */
+export function getWriter(): LogWriter;

--- a/types/command-shell-lib/index.d.ts
+++ b/types/command-shell-lib/index.d.ts
@@ -34,7 +34,7 @@ export function showHelp(commands: CommandsObject): void;
  * Executes the given command (the list of words parsed from the command line input) in the context of the commands
  * describe by the object Commands.
  */
-export function executeCommander(command: string[], commands: CommandsObject): void;
+export function executeCommander(command: ReadonlyArray<string>, commands: CommandsObject): void;
 /** Creates a function that shows the selected branch (attribute) of the config, formatted with the correct indentation. */
 export function showConfig(config: { [name: string]: any }, branch: string): () => void;
 /**

--- a/types/command-shell-lib/index.d.ts
+++ b/types/command-shell-lib/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Fabian Bäumer <https://github.com/TrueSkrillor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export as namespace commandShellLib;
-
 /** A single command specifying parameters, description and the corresponding handler. */
 export interface Command {
     /**

--- a/types/command-shell-lib/tsconfig.json
+++ b/types/command-shell-lib/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "command-shell-lib-tests.ts"
+    ]
+}

--- a/types/command-shell-lib/tslint.json
+++ b/types/command-shell-lib/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
