### PR TITLE
[leaflet] Allow return type of DomUtil.create to be inferred

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -63,6 +63,13 @@ export namespace DomUtil {
      */
     function get(element: string | HTMLElement): HTMLElement | null;
     function getStyle(el: HTMLElement, styleAttrib: string): string | null;
+    /**
+     * Creates an HTML element with `tagName`, sets its class to `className`, and optionally appends it to `container` element.
+     * @param tagName The name of the tag to create (for example: `div` or `canvas`).
+     * @param className The class to set on the created element.
+     * @param container The container to append the created element to.
+     */
+    function create<T extends keyof HTMLElementTagNameMap>(tagName: T, className?: string, container?: HTMLElement): HTMLElementTagNameMap[T];
     function create(tagName: string, className?: string, container?: HTMLElement): HTMLElement;
     function remove(el: HTMLElement): void;
     function empty(el: HTMLElement): void;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -764,7 +764,7 @@ lg = new L.LayerGroup([new L.Layer(), new L.Layer()], {
 // adapted from GridLayer documentation
 const CanvasLayer = L.GridLayer.extend({
     createTile(coords: L.Coords, done: L.DoneCallback) {
-        const tile = (L.DomUtil.create('canvas', 'leaflet-tile') as HTMLCanvasElement);
+        const tile = L.DomUtil.create('canvas', 'leaflet-tile');
         const size = this.getTileSize();
         tile.width = size.x;
         tile.height = size.y;
@@ -775,7 +775,7 @@ const CanvasLayer = L.GridLayer.extend({
 // adapted from GridLayer documentation
 const AsyncCanvasLayer = L.GridLayer.extend({
     createTile(coords: L.Coords, done: L.DoneCallback) {
-        const tile = (L.DomUtil.create('canvas', 'leaflet-tile') as HTMLCanvasElement);
+        const tile = L.DomUtil.create('canvas', 'leaflet-tile');
         const size = this.getTileSize();
         tile.width = size.x;
         tile.height = size.y;

--- a/types/react-leaflet-markercluster/tsconfig.json
+++ b/types/react-leaflet-markercluster/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.7.1.html#domutil-create
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This adds an overload to `DomUtil.create` which allows the value of `tagName` to be restricted to elements in `HTMLElementTagNameMap` and infer the return type of the HTML element. It also adds more documentation to the function itself.