### PR TITLE
Extended Typings for Custom Components in MUI-Datatables (3.7.*)

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -846,7 +846,18 @@ export type MUIDataTableColumnDef = string | MUIDataTableColumn;
 type RenderCustomComponent<P> = (props: P) => React.ReactNode;
 
 export interface MUIDataTableCheckboxProps {
-  'data-description': 'row-select' | 'row-select-header' | 'table-filter' | 'table-view-col';
+    checked: boolean;
+    classes: {
+        checked: string;
+        disabled: string;
+        root: string;
+    };
+    color: 'primary' | 'secondary';
+    'data-description': 'row-select' | 'row-select-header' | 'table-filter' | 'table-view-col';
+    'data-index': number | null;
+    disabled: boolean;
+    indeterminante: boolean;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
 }
 
 export interface MUIDataTableProps {
@@ -863,13 +874,13 @@ export interface MUIDataTableProps {
     TableToolbar: RenderCustomComponent<MUIDataTableToolbar> | React.ReactNode;
     TableToolbarSelect: RenderCustomComponent<MUIDataTableToolbarSelect> | React.ReactNode;
     Tooltip: React.ReactNode;
-    icons: {
+    icons: Partial<{
       SearchIcon: React.ReactNode;
       DownloadIcon: React.ReactNode;
       PrintIcon: React.ReactNode;
       ViewColumnIcon: React.ReactNode;
       FilterIcon: React.ReactNode;
-    }
+    }>
   }>;
   data: Array<object | number[] | string[]>;
   options?: MUIDataTableOptions;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -7,7 +7,6 @@
 //                 Byron "Byrekt" Mitchell <https://github.com/byrekt>
 //                 Bohdan Yavorskyi <https://github.com/BohdanYavorskyi>
 //                 Patrick Erichsen <https://github.com/Patrick-Erichsen>
-//                 Jan Eckert <https://github.com/meinlebenswerk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
 

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -7,6 +7,7 @@
 //                 Byron "Byrekt" Mitchell <https://github.com/byrekt>
 //                 Bohdan Yavorskyi <https://github.com/BohdanYavorskyi>
 //                 Patrick Erichsen <https://github.com/Patrick-Erichsen>
+//                 Jan Eckert <https://github.com/meinlebenswerk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
 
@@ -845,23 +846,36 @@ export type MUIDataTableColumnDef = string | MUIDataTableColumn;
 
 type RenderCustomComponent<P> = (props: P) => React.ReactNode;
 
+export interface MUIDataTableCheckboxProps {
+  'data-description': 'row-select' | 'row-select-header' | 'table-filter' | 'table-view-col';
+}
+
 export interface MUIDataTableProps {
-    columns: MUIDataTableColumnDef[];
-    components?: Partial<{
-        ExpandButton: RenderCustomComponent<MUIDataTableExpandButton> | React.ReactNode;
-        TableBody: RenderCustomComponent<MUIDataTableBody> | React.ReactNode;
-        TableFooter: RenderCustomComponent<MUIDataTableFooter> | React.ReactNode;
-        TableHead: RenderCustomComponent<MUIDataTableHead> | React.ReactNode;
-        TableResize: RenderCustomComponent<MUIDataTableResize> | React.ReactNode;
-        TableToolbar: RenderCustomComponent<MUIDataTableToolbar> | React.ReactNode;
-        TableToolbarSelect: RenderCustomComponent<MUIDataTableToolbarSelect> | React.ReactNode;
-        TableFilterList: RenderCustomComponent<MUIDataTableFilterList> | React.ReactNode;
-        Tooltip: React.ReactNode;
-    }>;
-    data: Array<object | number[] | string[]>;
-    options?: MUIDataTableOptions;
-    title: string | React.ReactNode;
-    innerRef?: React.RefObject<React.Component<MUIDataTableProps, MUIDataTableState> | null | undefined>;
+  columns: MUIDataTableColumnDef[];
+  components?: Partial<{
+    Checkbox: RenderCustomComponent<MUIDataTableCheckboxProps> | React.ReactNode;
+    ExpandButton: RenderCustomComponent<MUIDataTableExpandButton> | React.ReactNode;
+    TableBody: RenderCustomComponent<MUIDataTableBody> | React.ReactNode;
+    TableViewCol: RenderCustomComponent<MUIDataTableViewCol> | React.ReactNode;
+    TableFilterList: RenderCustomComponent<MUIDataTableFilterList> | React.ReactNode;
+    TableFooter: RenderCustomComponent<MUIDataTableFooter> | React.ReactNode;
+    TableHead: RenderCustomComponent<MUIDataTableHead> | React.ReactNode;
+    TableResize: RenderCustomComponent<MUIDataTableResize> | React.ReactNode;
+    TableToolbar: RenderCustomComponent<MUIDataTableToolbar> | React.ReactNode;
+    TableToolbarSelect: RenderCustomComponent<MUIDataTableToolbarSelect> | React.ReactNode;
+    Tooltip: React.ReactNode;
+    icons: {
+      SearchIcon: React.ReactNode;
+      DownloadIcon: React.ReactNode;
+      PrintIcon: React.ReactNode;
+      ViewColumnIcon: React.ReactNode;
+      FilterIcon: React.ReactNode;
+    }
+  }>;
+  data: Array<object | number[] | string[]>;
+  options?: MUIDataTableOptions;
+  title: string | React.ReactNode;
+  innerRef?: React.RefObject<React.Component<MUIDataTableProps, MUIDataTableState> | null | undefined>;
 }
 
 export interface MUIDataTableExpandButton {

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,6 +1,6 @@
-import MUIDataTable, { ExpandButton, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState } from 'mui-datatables';
+import MUIDataTable, { ExpandButton, MUIDataTableCheckboxProps, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState } from 'mui-datatables';
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core';
+import { createMuiTheme, Checkbox, Radio } from '@material-ui/core';
 
 interface Props extends Omit<MUIDataTableProps, 'columns'> {
     columns?: MUIDataTableColumn[];
@@ -215,9 +215,25 @@ const todoOptions: MUIDataTableOptions = {
 
 <MuiCustomTable title="Todo Table" data={Todos} options={todoOptions} />;
 
+const CustomCheckbox = (props: MUIDataTableCheckboxProps) => {
+    const newProps = {...props};
+    newProps.color = props['data-description'] === 'row-select' ? 'secondary' : 'primary';
+    if (props['data-description'] === 'row-select') {
+      return (<Radio {...newProps} />);
+    } else {
+      return (<Checkbox {...newProps} />);
+    }
+};
+
 const customComponents: MUIDataTableProps['components'] = {
     ExpandButton: ({ dataIndex }) => (dataIndex === 1 ? <>expand button</> : null),
     TableFooter: props => <>table footer</>,
+    Checkbox: CustomCheckbox,
+    icons: {
+        DownloadIcon: <>DownloadIcon</>,
+        FilterIcon: <>FilterIcon</>,
+        SearchIcon: <>SearchIcon</>
+    }
 };
 
 <MuiCustomTable title="Todo Table" data={Todos} options={todoOptions} components={customComponents} />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Custom Components in MUI-Datatables](https://github.com/gregnb/mui-datatables#custom-componentss)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 


The current definitions match version 3.7, but lack some of the custom components supported by the datatable.
This includes the slots for Checkbox, TableViewCol and Icons, which are added by this change.