### PR TITLE
[three] ShaderMaterial uniforms may not exist

### DIFF
--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -38,7 +38,7 @@ export class ShaderMaterial extends Material {
     /**
      * @default {}
      */
-    uniforms: { [uniform: string]: IUniform };
+    uniforms: { [uniform: string]: IUniform | undefined };
     vertexShader: string;
     fragmentShader: string;
 


### PR DESCRIPTION
Not every single property on `ShaderMaterial.uniforms` is defined, so the type should reflect that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
**This is a breaking change, and will break currently compiling code.**
However, that code can currently throw runtime errors, so I believe this change to be correct.

- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: RawShaderMaterial: https://github.com/mrdoob/three.js/blob/dev/src/materials/RawShaderMaterial.js
which inherits from ShaderMaterial, which may or may not have any arbitrary uniform defined:
https://github.com/mrdoob/three.js/blob/2383c1c0e48c3a966926f28a5acdb4b09f5dd35e/src/materials/ShaderMaterial.js#L34
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
