### PR TITLE
Fix wrong JSDoc in @types/chai

### DIFF
--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -507,7 +507,7 @@ declare namespace Chai {
         notStrictEqual<T>(actual: T, expected: T, message?: string): void;
 
         /**
-         * Asserts that actual is deeply equal (==) to expected.
+         * Asserts that actual is deeply equal to expected.
          *
          * @type T   Type of the objects.
          * @param actual   Actual value.
@@ -517,7 +517,7 @@ declare namespace Chai {
         deepEqual<T>(actual: T, expected: T, message?: string): void;
 
         /**
-         * Asserts that actual is not deeply equal (==) to expected.
+         * Asserts that actual is not deeply equal to expected.
          *
          * @type T   Type of the objects.
          * @param actual   Actual value.
@@ -527,7 +527,7 @@ declare namespace Chai {
         notDeepEqual<T>(actual: T, expected: T, message?: string): void;
 
         /**
-         * Asserts that actual is deeply strict equal (===) to expected.
+         * Alias to deepEqual
          *
          * @type T   Type of the objects.
          * @param actual   Actual value.


### PR DESCRIPTION
deepStrictEqual() is actually just an alias to deepEqual(), which is already strict (see https://github.com/chaijs/chai/pull/653). notDeepEqual() is also strict.