### PR TITLE
update(use-color-scheme): derive tuple types and preferences

### DIFF
--- a/types/use-color-scheme/index.d.ts
+++ b/types/use-color-scheme/index.d.ts
@@ -3,19 +3,20 @@
 // Definitions by: Marton Lederer <https://github.com/martonlederer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type Preference = "dark" | "light" | "no-preference";
+type Preference = typeof PREFERENCES[keyof typeof PREFERENCES];
 
 export const PREFERENCES: {
-  DARK: "dark",
-  LIGHT: "light",
-  NONE: "no-preference"
+    DARK: 'dark';
+    LIGHT: 'light';
+    NONE: 'no-preference';
 };
 
-export const values: [string, string, string];
+export const values: Array<typeof PREFERENCES[keyof typeof PREFERENCES]>;
 
 export function makeQuery(pref: Preference): string;
 export function matchPreference(pref: Preference): MediaQueryList;
 export function getPreference(preferences: Preference[]): Preference;
 export function attachListener(pref: Preference, setScheme: (pref: Preference) => void): () => void;
 export function useColorScheme(): { scheme: Preference };
+
 export {};

--- a/types/use-color-scheme/use-color-scheme-tests.ts
+++ b/types/use-color-scheme/use-color-scheme-tests.ts
@@ -5,3 +5,4 @@ _useColorScheme.getPreference(["dark", "light"]);
 _useColorScheme.makeQuery("light");
 _useColorScheme.matchPreference("no-preference");
 _useColorScheme.useColorScheme();
+_useColorScheme.values[0]; // $ExpectType "dark" | "light" | "no-preference"


### PR DESCRIPTION
Use constant values to derive types for preferences and for value.
Minor change to reuse code and type check values.

https://github.com/mujo-code/use-color-scheme/blob/master/src/index.js#L9

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes