### PR TITLE
[@types/js-yaml] Yaml can be loaded as Array

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -9,7 +9,7 @@
 
 export as namespace jsyaml;
 
-export function load(str: string, opts?: LoadOptions): object | string | number | null | undefined;
+export function load(str: string, opts?: LoadOptions): object | Array | string | number | null | undefined;
 
 export class Type {
     constructor(tag: string, opts?: TypeConstructorOptions);


### PR DESCRIPTION
Yaml file affords array, but the type of `load` function doesn't.

This PR adds `Array` as the response type of `load` function.