### PR TITLE
Drop those postfixes and set "variablesResolutionMode: 20210326"

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -9,7 +9,7 @@ declare namespace Aws {
         useDotenv?: boolean;
         frameworkVersion?: string;
         enableLocalInstallationFallback?: boolean;
-        variablesResolutionMode?: '20210219';
+        variablesResolutionMode?: '20210219' | '20210326';
         unresolvedVariablesNotificationMode?: 'warn' | 'error';
         disabledDeprecations?: string[];
         configValidationMode?: 'warn' | 'error' | 'off';


### PR DESCRIPTION
Deprecation warning: Syntax for referencing SSM parameters was upgraded with automatic type detection and there's no need to add "~true" or "~split" postfixes to variable references.
            Drop those postfixes and set "variablesResolutionMode: 20210326" in your service config to adapt to a new behavior.
            Starting with next major release, this will be communicated with a thrown error.

