### PR TITLE
tailwindcss: Add postcss

### DIFF
--- a/types/tailwindcss/index.d.ts
+++ b/types/tailwindcss/index.d.ts
@@ -13,4 +13,8 @@ declare function tailwindcss(
     plugins: string[];
 };
 
+declare namespace tailwindcss {
+    let postcss: true
+}
+
 export = tailwindcss;

--- a/types/tailwindcss/index.d.ts
+++ b/types/tailwindcss/index.d.ts
@@ -14,7 +14,7 @@ declare function tailwindcss(
 };
 
 declare namespace tailwindcss {
-    let postcss: true
+    let postcss: true;
 }
 
 export = tailwindcss;


### PR DESCRIPTION
PostCSS requires `PluginCreator` to have postcss variable. https://github.com/postcss/postcss/blob/main/lib/postcss.d.ts#L197

Defined it similar to `autoprefixer`: https://github.com/postcss/autoprefixer/blob/main/lib/autoprefixer.d.ts#L84

Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tailwindlabs/tailwindcss/blob/master/src/index.js#L99