### PR TITLE
gestalt: Fix bug where BoxProps.ref is LegacyRef instead of Ref

### DIFF
--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import {
     ActivationCard,
     Avatar,
@@ -121,11 +120,11 @@ const CheckUseReducedMotion = () => {
 
 // Test Box accepts Ref.
 () => {
-    const ref = useRef<HTMLDivElement>(null);
-    return <Box ref={ref} />
-}
-// Test BoxProps.ref can be forwarded.
-(props: BoxProps) => <Box ref={props.ref} />;
+    const ref = React.useRef<HTMLDivElement>(null);
+    return <Box ref={ref} />;
+};
+// Test BoxProps can be forwarded to Box.
+(props: BoxProps) => <Box {...props} />;
 
 <Button ref={React.createRef<HTMLAnchorElement>()} text={'Click me'} />;
 <Button text="" />;

--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -1,9 +1,11 @@
+import { useRef } from "react";
 import {
     ActivationCard,
     Avatar,
     AvatarPair,
     Badge,
     Box,
+    BoxProps,
     Button,
     ButtonGroup,
     Callout,
@@ -116,6 +118,14 @@ const CheckUseReducedMotion = () => {
 <Box onDrag={(event) => { event.movementX; }} />;
 // $ExpectError
 <Box onDrag={((event) => { event.__nonExistentProperty__; })} />;
+
+// Test Box accepts Ref.
+() => {
+    const ref = useRef<HTMLDivElement>(null);
+    return <Box ref={ref} />
+}
+// Test BoxProps.ref can be forwarded.
+(props: BoxProps) => <Box ref={props.ref} />;
 
 <Button ref={React.createRef<HTMLAnchorElement>()} text={'Click me'} />;
 <Button text="" />;

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -102,7 +102,9 @@ export interface BadgeProps {
     position?: 'middle' | 'top';
 }
 
-export type BoxPassthroughProps = Omit<React.ComponentProps<'div'>, 'onClick' | 'className' | 'style'>;
+export type BoxPassthroughProps =
+    & Omit<React.ComponentProps<'div'>, 'onClick' | 'className' | 'style' | 'ref'>
+    & React.RefAttributes<HTMLDivElement>;
 
 /**
  * Box Props Interface


### PR DESCRIPTION
Ran into an issue when writing a wrapper on Box. Due to the change I made in  #53319, `BoxProps['ref']` is typed as `LegacyRef<HTMLDivElement>` but `ComponentProps<typeof Box>['ref']` is `Ref<HTMLDivElement>`.

This incompatibility of ref types means the following code will result in a type error:
```
const BoxWrapper = (props: BoxProps) => <Box {...props} />
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See `forwardRef` in the `Box` component: https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Box.js#L208
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

