### PR TITLE
New @ckeditor/ckeditor5-remove-format v28

### DIFF
--- a/types/ckeditor__ckeditor5-remove-format/ckeditor__ckeditor5-remove-format-tests.ts
+++ b/types/ckeditor__ckeditor5-remove-format/ckeditor__ckeditor5-remove-format-tests.ts
@@ -1,0 +1,12 @@
+import { Editor } from '@ckeditor/ckeditor5-core';
+import { RemoveFormat, RemoveFormatUI, RemoveFormatEditing } from '@ckeditor/ckeditor5-remove-format';
+import RemoveFormatCommand from '@ckeditor/ckeditor5-remove-format/src/removeformatcommand';
+
+class MyEditor extends Editor {}
+const editor = new MyEditor();
+
+RemoveFormat.requires.forEach(Plugin => new Plugin(editor).init());
+[RemoveFormatUI, RemoveFormatEditing].forEach(Plugin => new Plugin(editor).init());
+
+new RemoveFormatCommand(editor).refresh();
+new RemoveFormatCommand(editor).execute();

--- a/types/ckeditor__ckeditor5-remove-format/index.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for @ckeditor/ckeditor5-remove-format 28.0
+// Project: https://ckeditor.com/docs/ckeditor5/latest/api/remove-format.html
+// Definitions by: Federico Panico <https://github.com/fedemp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.2
+export { default as RemoveFormat } from './src/removeformat';
+export { default as RemoveFormatEditing } from './src/removeformatediting';
+export { default as RemoveFormatUI } from './src/removeformatui';

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformat.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformat.d.ts
@@ -1,0 +1,8 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import RemoveFormatEditing from './removeformatediting';
+import RemoveFormatUI from './removeformatui';
+
+export default class RemoveFormat extends Plugin {
+    static readonly requires: [typeof RemoveFormatEditing, typeof RemoveFormatUI];
+    static readonly pluginName: 'RemoveFormat';
+}

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformatcommand.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformatcommand.d.ts
@@ -1,0 +1,6 @@
+import { Command } from '@ckeditor/ckeditor5-core';
+
+export default class RemoveFormatCommand extends Command {
+    refresh(): void;
+    execute(): void;
+}

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformatediting.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformatediting.d.ts
@@ -1,0 +1,6 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+
+export default class RemoveFormatEditing extends Plugin {
+    static readonly pluginName: 'RemoveFormatEditing';
+    init(): void;
+}

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformatui.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformatui.d.ts
@@ -1,0 +1,6 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+
+export default class RemoveFormatUI extends Plugin {
+    static readonly pluginName: 'RemoveFormatUI';
+    init(): void;
+}

--- a/types/ckeditor__ckeditor5-remove-format/tsconfig.json
+++ b/types/ckeditor__ckeditor5-remove-format/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ckeditor/*": [
+                "ckeditor__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-remove-format-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-remove-format/tslint.json
+++ b/types/ckeditor__ckeditor5-remove-format/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.