### PR TITLE
html-to-text: upgrade to v8

### DIFF
--- a/types/html-to-text/html-to-text-tests.ts
+++ b/types/html-to-text/html-to-text-tests.ts
@@ -1,4 +1,4 @@
-import { FormatCallback, htmlToText, HtmlToTextOptions,
+import { compile, FormatCallback, htmlToText, HtmlToTextOptions,
     TagDefinition } from 'html-to-text';
 import * as formatters from 'html-to-text/lib/formatter';
 
@@ -167,3 +167,45 @@ const fmtOptionsTable: HtmlToTextOptions = {
 };
 console.log('Test current table builder interfaces');
 console.log(htmlToText(blockTextTestElements, fmtOptionsTable));
+
+const selOptions: HtmlToTextOptions = {
+    formatters: {
+        h1Formatter: (elem, walk, builder, options) => {
+            builder.addInline("preheading: ", { noWordTransform: false });
+            walk(elem.children, builder);
+        }
+    },
+    selectors: [
+        {
+            selector: "h1",
+            format: 'h1Formatter',
+        },
+        {
+            selector: "hr",
+            options: {length: 5},
+        },
+    ]
+};
+
+console.log('Test with selectors');
+console.log(htmlToText(allElements, selOptions));
+
+console.log('Test with compiler function');
+const converter = compile(selOptions);
+console.log(converter(allElements));
+
+console.log('Test with any tag');
+console.log(htmlToText("<h1>Starting foo test</h1><foo>bar</foo>", {
+    formatters: {
+        fooFormatter: (elem, walk, builder, options) => {
+            builder.addInline("fooFormatter: ", { noWordTransform: false });
+            walk(elem.children, builder);
+        }
+    },
+    selectors: [
+        {
+            selector: "foo",
+            format: 'fooFormatter',
+        },
+    ]
+}));

--- a/types/html-to-text/html-to-text-tests.ts
+++ b/types/html-to-text/html-to-text-tests.ts
@@ -116,4 +116,54 @@ const fmtOptions: HtmlToTextOptions = {
         unorderedList: elementFormatter,
     },
 };
+console.log('Emit all elements with "--" wrapping');
 console.log(htmlToText(allElements, fmtOptions));
+
+const blockTextTestElements = '<a>a</a>\
+<blockquote>b</blockquote>\
+<p>1234567890123456789012345678901234567890</p>\
+<table></table>';
+
+const fmtOptionsDepr: HtmlToTextOptions = {
+    formatters: {
+        table: (elem, walk, builder, options) => {
+            builder.openBlock(options.leadingLineBreaks || 2);
+            builder.openTable();
+            builder.openTableRow();
+            builder.openTableCell(22);
+            builder.addInline("Cell 1 data", false);
+            builder.closeTableCell(2);
+            builder.openTableCell(6);
+            builder.addInline("Cell 2 data", false);
+            builder.closeTableCell(1);
+            builder.closeTableRow();
+            builder.closeTable(4);
+            // walk(elem.children, builder);
+            builder.closeBlock(options.trailingLineBreaks || 2);
+        },
+    },
+};
+console.log('Test deprecated table builder interfaces');
+console.log(htmlToText(blockTextTestElements, fmtOptionsDepr));
+
+const fmtOptionsTable: HtmlToTextOptions = {
+    formatters: {
+        table: (elem, walk, builder, options) => {
+            builder.openBlock({ leadingLineBreaks: options.leadingLineBreaks || 2 });
+            builder.openTable();
+            builder.openTableRow();
+            builder.openTableCell({ maxColumnWidth: 22});
+            builder.addInline("Cell 1 data", { noWordTransform: false });
+            builder.closeTableCell({ colspan: 2 });
+            builder.openTableCell({ maxColumnWidth: 6 });
+            builder.addInline("Cell 2 data", { noWordTransform: false });
+            builder.closeTableCell();
+            builder.closeTableRow();
+            builder.closeTable({ colSpacing: 4 });
+            // walk(elem.children, builder);
+            builder.closeBlock({ trailingLineBreaks: options.trailingLineBreaks || 2 });
+        },
+    },
+};
+console.log('Test current table builder interfaces');
+console.log(htmlToText(blockTextTestElements, fmtOptionsTable));

--- a/types/html-to-text/lib/block-text-builder.d.ts
+++ b/types/html-to-text/lib/block-text-builder.d.ts
@@ -1,4 +1,21 @@
 /**
+ * types of options for BlockTextBuilder methods.  These replace previously positional options.
+ */
+
+export interface AddInlineOptions { noWordTransform?: boolean; }
+export interface OpenBlockOptions { leadingLineBreaks?: number;
+    reservedLineLength?: number;
+    isPre?: boolean; }
+export type BlockTransformer = (str: string) => string;
+export interface CloseBlockOptions { trailingLineBreaks?: number; blockTransform?: BlockTransformer; }
+export interface OpenTableCellOptions { maxColumnWidth?: number; }
+export interface CloseTableCellOptions { colspan?: number; rowspan?: number; }
+export interface CloseTableOptions { colSpacing?: number;
+    rowSpacing?: number;
+    leadingLineBreaks?: number;
+    trailingLineBreaks?: number; }
+
+/**
  * Helps to build text from inline and block elements.
  */
 export interface BlockTextBuilder {
@@ -25,9 +42,18 @@ export interface BlockTextBuilder {
     /**
      * Add a node inline into the currently built block.
      */
+    addInline(str: string, addInlineOptions?: AddInlineOptions): void;
+    /**
+     *  @deprecated See the documentation.
+     */
+    // tslint:disable-next-line:unified-signatures
     addInline(str: string, noWordTransform?: boolean): void;
     /**
      * Start building a new block.
+     */
+    openBlock(openBlockOptions?: OpenBlockOptions): void;
+    /**
+     *  @deprecated See the documentation.
      */
     openBlock(leadingLineBreaks?: number, reservedLineLength?: number, isPre?: boolean): void;
     /**
@@ -38,7 +64,11 @@ export interface BlockTextBuilder {
      * in order to keep line lengths correct.
      * Used for whole block markup.
      */
-    closeBlock(trailingLineBreaks?: number, blockTransform?: (str: string) => string): void;
+    closeBlock(closeBlockOptions?: CloseBlockOptions): void;
+    /**
+     *  @deprecated See the documentation.
+     */
+    closeBlock(trailingLineBreaks?: number, blockTransform?: BlockTransformer): void;
     /**
      * Start building a table.
      */
@@ -50,9 +80,18 @@ export interface BlockTextBuilder {
     /**
      * Start building a table cell.
      */
+    openTableCell(openTableCellOptions?: OpenTableCellOptions): void;
+    /**
+     *  @deprecated See the documentation.
+     */
+    // tslint:disable-next-line:unified-signatures
     openTableCell(maxColumnWidth?: number): void;
     /**
      * Finalize currently built table cell and add it to parent table row's cells.
+     */
+    closeTableCell(closeTableCellOptions?: CloseTableCellOptions): void;
+    /**
+     *  @deprecated See the documentation.
      */
     closeTableCell(colspan?: number, rowspan?: number): void;
     /**
@@ -61,6 +100,10 @@ export interface BlockTextBuilder {
     closeTableRow(): void;
     /**
      * Finalize currently built table and add the rendered text to the parent block.
+     */
+    closeTable(closeTableOptions?: CloseTableOptions): void;
+    /**
+     *  @deprecated See the documentation.
      */
     closeTable(colSpacing?: number, rowSpacing?: number, leadingLineBreaks?: number, trailingLineBreaks?: number): void;
     /**


### PR DESCRIPTION
1. Add compile function
2. Add new `baseElements` to options
3. Add new `selectors` to options
4. Flag newly deprecated options
5. Add tests for compiler, `selectors` and custom elements

For v7:
A number of block-text-builder methods have added support for an
options object in preference for options being separate parameters.

This will correct html-to-text issue [223](https://github.com/html-to-text/node-html-to-text/issues/223).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/html-to-text/node-html-to-text/blob/master/CHANGELOG.md>>
- [x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
