### PR TITLE
vscode-notebook-renderer: Allow returning undefined or promise from activate

### DIFF
--- a/types/vscode-notebook-renderer/index.d.ts
+++ b/types/vscode-notebook-renderer/index.d.ts
@@ -139,4 +139,11 @@ export interface RendererApi {
  *
  * @template TState Type of the renderer specific state persisted in the webview.
  */
-export type ActivationFunction<TState = any> = (context: RendererContext<TState>) => RendererApi;
+export interface ActivationFunction<TState = any> {
+    /**
+     * @param context Collection of APIs provided to your renderer.
+     *
+     * @return The renderer for your API or undefined if your renderer extends another and will not be called directly.
+     */
+    (context: RendererContext<TState>): Promise<RendererApi | undefined> | RendererApi | undefined;
+}


### PR DESCRIPTION
We support returning `undefined` from the activation function for renderers that extend other renderers

We also support returning a promise to the renderer api if the renderer needs to perform some work async

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
