### PR TITLE
[serverless] update `variablesResolutionMode` to a more generic type

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -9,7 +9,7 @@ declare namespace Aws {
         useDotenv?: boolean;
         frameworkVersion?: string;
         enableLocalInstallationFallback?: boolean;
-        variablesResolutionMode?: '20210219';
+        variablesResolutionMode?: string;
         unresolvedVariablesNotificationMode?: 'warn' | 'error';
         disabledDeprecations?: string[];
         configValidationMode?: 'warn' | 'error' | 'off';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.serverless.com/framework/docs/deprecations/#NEW_VARIABLES_RESOLVER
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR define the `variablesResolutionMode` as a string instead of a hard value. This is motivated by the fact that the value of this key can change. It was define as `'20210219'`, but in the documentation we can see that they are now using `20210326` as value.

I assume that the value of this variable changes when they introduce a new change. By defining as a string rather than a unique value we avoid having to update the type definition every time they will update the value.
