### PR TITLE
[@types/styled-components] Fix type linting for `as` property

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -78,15 +78,13 @@ export type StyledComponentProps<
     O extends object,
     // The props that are made optional by .attrs
     A extends keyof any,
-    // The Component passed with "as" prop
-    AsC extends string | React.ComponentType<any> = C,
     // The Component passed with "forwardedAs" prop
     FAsC extends string | React.ComponentType<any> = C
 > =
     // Distribute O if O is a union type
     O extends object
         ? WithOptionalTheme<
-              MakeAttrsOptional<C, O, A> & MakeAttrsOptional<AsC, O, A> & MakeAttrsOptional<FAsC, O, A>,
+              MakeAttrsOptional<C, O, A> & MakeAttrsOptional<FAsC, O, A>,
               T
           > &
               WithChildrenIfReactComponentClass<C>
@@ -109,7 +107,7 @@ type StyledComponentPropsWithAs<
     A extends keyof any,
     AsC extends string | React.ComponentType<any> = C,
     FAsC extends string | React.ComponentType<any> = C
-> = StyledComponentProps<C, T, O, A, AsC, FAsC> & { as?: AsC | undefined; forwardedAs?: FAsC | undefined };
+> = StyledComponentProps<C, T, O, A, FAsC> & { as?: AsC | undefined; forwardedAs?: FAsC | undefined };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> = InterpolationValue | InterpolationFunction<P> | FlattenInterpolation<P>;
@@ -171,9 +169,9 @@ export interface StyledComponentBase<
     (props: StyledComponentProps<C, T, O, A> & { as?: never | undefined; forwardedAs?: never | undefined }): React.ReactElement<
         StyledComponentProps<C, T, O, A>
     >;
-    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = C>(
-        props: StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>,
-    ): React.ReactElement<StyledComponentPropsWithAs<C, T, O, A, AsC, FAsC>>;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
+        props: StyledComponentPropsWithAs<AsC, T, O, A, AsC, FAsC>,
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, AsC, FAsC>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC,

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -676,7 +676,7 @@ const HasAttributesOfAsOrForwardedAsComponent = (
         <WrappedExternalAsComponent as="a" type="primitive" href="/" />
         <WrappedExternalAsComponent forwardedAs="a" type="complex" href="/" />
         <WrappedExternalAsComponent as={OtherExternalComponent} requiredProp="test" />
-        {<WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" /> // $ExpectError
+        <WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" /> { // $ExpectError
         }
         <WrappedExternalAsComponent forwardedAs={OtherExternalComponent} type="complex" requiredProp="test" />
     </>
@@ -706,6 +706,37 @@ class Test2Container extends React.Component<Test2ContainerProps> {
 const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
 const containerTestFailed = <StyledTestContainer as={Test2Container} type="foo" size="big" />; // $ExpectError
 const containerTestTwo = <StyledTestContainer forwardedAs={Test2Container} type="foo" size="big" />;
+
+interface GenericComponentProps<T> {
+    someProp: T;
+}
+const GenericComponent = <T, >(props: GenericComponentProps<T>): React.ReactElement<GenericComponentProps<T>> | null => null;
+const StyledGenericComponent = styled(GenericComponent)``;
+const TestStyledGenericComponent = (
+    <>
+        <StyledGenericComponent /> { // $ExpectError
+        }
+        <StyledGenericComponent someProp="someString" />
+        <StyledGenericComponent someProp={42} />
+        <StyledGenericComponent<React.FC<GenericComponentProps<string>>> someProp="someString" />
+        <StyledGenericComponent<React.FC<GenericComponentProps<string>>> someProp={42} /> { // $ExpectError
+        }
+        <StyledGenericComponent as="h1" />
+        <StyledGenericComponent as="h1" someProp="someString" /> { // $ExpectError
+        }
+
+        <WithComponentH1 as={GenericComponent} /> { // $ExpectError
+        }
+        <WithComponentH1 as={GenericComponent} someProp="someString" />
+        <WithComponentH1 as={GenericComponent} someProp={42} />
+        <WithComponentH1<React.FC<GenericComponentProps<string>>> as={GenericComponent} /> { // $ExpectError
+        }
+        <WithComponentH1<React.FC<GenericComponentProps<string>>> as={GenericComponent} someProp="someString" />
+        <WithComponentH1<React.FC<GenericComponentProps<number>>> as={GenericComponent} someProp={42} />
+        <WithComponentH1<React.FC<GenericComponentProps<string>>> as={GenericComponent} someProp={42} /> { // $ExpectError
+        }
+    </>
+);
 
 // 4.0 refs
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -627,6 +627,9 @@ const asTest = (
     <>
         <WithComponentH1 as="h2" />
         <WithComponentH1 as={WithComponentH2} />
+        <WithComponentH1 as="a" href="" />
+        <WithComponentH1 as="div" href="" /> { // $ExpectError
+        }
     </>
 );
 
@@ -636,6 +639,9 @@ const forwardedAsTest = (
     <>
         <ForwardedAsComponent forwardedAs="h2" />
         <ForwardedAsComponent forwardedAs={WithComponentH2} />
+        <ForwardedAsComponent forwardedAs="a" href="" />
+        <ForwardedAsComponent forwardedAs="div" href="" /> { // $ExpectError
+        }
     </>
 );
 
@@ -669,7 +675,9 @@ const HasAttributesOfAsOrForwardedAsComponent = (
     <>
         <WrappedExternalAsComponent as="a" type="primitive" href="/" />
         <WrappedExternalAsComponent forwardedAs="a" type="complex" href="/" />
-        <WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" />
+        <WrappedExternalAsComponent as={OtherExternalComponent} requiredProp="test" />
+        {<WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" /> // $ExpectError
+        }
         <WrappedExternalAsComponent forwardedAs={OtherExternalComponent} type="complex" requiredProp="test" />
     </>
 );
@@ -695,7 +703,8 @@ class Test2Container extends React.Component<Test2ContainerProps> {
     }
 }
 
-const containerTest = <StyledTestContainer as={Test2Container} type="foo" size="big"/>;
+const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
+const containerTestFailed = <StyledTestContainer as={Test2Container} type="foo" size="big" />; // $ExpectError
 const containerTestTwo = <StyledTestContainer forwardedAs={Test2Container} type="foo" size="big" />;
 
 // 4.0 refs

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -674,7 +674,7 @@ const HasAttributesOfAsOrForwardedAsComponent = (
         <WrappedExternalAsComponent as="a" type="primitive" href="/" />
         <WrappedExternalAsComponent forwardedAs="a" type="complex" href="/" />
         <WrappedExternalAsComponent as={OtherExternalComponent} requiredProp="test" />
-        {<WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" /> // $ExpectError
+        <WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" /> { // $ExpectError
         }
         <WrappedExternalAsComponent forwardedAs={OtherExternalComponent} type="complex" requiredProp="test" />
     </>
@@ -704,6 +704,37 @@ class Test2Container extends React.Component<Test2ContainerProps> {
 const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
 const containerTestFailed = <StyledTestContainer as={Test2Container} type="foo" size="big" />; // $ExpectError
 const containerTestTwo = <StyledTestContainer forwardedAs={Test2Container} type="foo" size="big" />;
+
+interface GenericComponentProps<T> {
+    someProp: T;
+}
+const GenericComponent = <T, >(props: GenericComponentProps<T>): React.ReactElement<GenericComponentProps<T>> | null => null;
+const StyledGenericComponent = styled(GenericComponent)``;
+const TestStyledGenericComponent = (
+    <>
+        <StyledGenericComponent /> { // $ExpectError
+        }
+        <StyledGenericComponent someProp="someString" />
+        <StyledGenericComponent someProp={42} />
+        <StyledGenericComponent<React.FC<GenericComponentProps<string>>> someProp="someString" />
+        <StyledGenericComponent<React.FC<GenericComponentProps<string>>> someProp={42} /> { // $ExpectError
+        }
+        <StyledGenericComponent as="h1" />
+        <StyledGenericComponent as="h1" someProp="someString" /> { // $ExpectError
+        }
+
+        <WithComponentH1 as={GenericComponent} /> { // $ExpectError
+        }
+        <WithComponentH1 as={GenericComponent} someProp="someString" />
+        <WithComponentH1 as={GenericComponent} someProp={42} />
+        <WithComponentH1<React.FC<GenericComponentProps<string>>> as={GenericComponent} /> { // $ExpectError
+        }
+        <WithComponentH1<React.FC<GenericComponentProps<string>>> as={GenericComponent} someProp="someString" />
+        <WithComponentH1<React.FC<GenericComponentProps<number>>> as={GenericComponent} someProp={42} />
+        <WithComponentH1<React.FC<GenericComponentProps<string>>> as={GenericComponent} someProp={42} /> { // $ExpectError
+        }
+    </>
+);
 
 // 4.0 refs
 

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -625,6 +625,9 @@ const asTest = (
     <>
         <WithComponentH1 as="h2" />
         <WithComponentH1 as={WithComponentH2} />
+        <WithComponentH1 as="a" href="" />
+        <WithComponentH1 as="div" href="" /> { // $ExpectError
+        }
     </>
 );
 
@@ -634,6 +637,9 @@ const forwardedAsTest = (
     <>
         <ForwardedAsComponent forwardedAs="h2" />
         <ForwardedAsComponent forwardedAs={WithComponentH2} />
+        <ForwardedAsComponent forwardedAs="a" href="" />
+        <ForwardedAsComponent forwardedAs="div" href="" /> { // $ExpectError
+        }
     </>
 );
 
@@ -641,9 +647,10 @@ interface ExternalAsComponentProps {
     as?: string | React.ComponentType<any>;
     type: 'primitive' | 'complex';
 }
-
 const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
 const WrappedExternalAsComponent = styled(ExternalAsComponent)``;
+const testRequiredProp = <WrappedExternalAsComponent />; // $ExpectError
+const testRequiredPropWhenForwardedAs = <WrappedExternalAsComponent forwardedAs="h2" />; // $ExpectError
 const ForwardedAsWithWrappedExternalTest = (
     <>
         <WrappedExternalAsComponent forwardedAs="h2" type="primitive" />
@@ -654,6 +661,22 @@ const ForwardedAsWithNestedAsExternalTest = (
     <>
         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs="h2" type="primitive" />
         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs={WithComponentH2} type="complex" />
+    </>
+);
+
+interface OtherExternalComponentProps {
+    requiredProp: 'test';
+}
+
+const OtherExternalComponent: React.FC<OtherExternalComponentProps> = () => null;
+const HasAttributesOfAsOrForwardedAsComponent = (
+    <>
+        <WrappedExternalAsComponent as="a" type="primitive" href="/" />
+        <WrappedExternalAsComponent forwardedAs="a" type="complex" href="/" />
+        <WrappedExternalAsComponent as={OtherExternalComponent} requiredProp="test" />
+        {<WrappedExternalAsComponent as={OtherExternalComponent} type="primitive" requiredProp="test" /> // $ExpectError
+        }
+        <WrappedExternalAsComponent forwardedAs={OtherExternalComponent} type="complex" requiredProp="test" />
     </>
 );
 
@@ -679,6 +702,8 @@ class Test2Container extends React.Component<Test2ContainerProps> {
 }
 
 const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
+const containerTestFailed = <StyledTestContainer as={Test2Container} type="foo" size="big" />; // $ExpectError
+const containerTestTwo = <StyledTestContainer forwardedAs={Test2Container} type="foo" size="big" />;
 
 // 4.0 refs
 


### PR DESCRIPTION
The latest change on version 5.1.9 -> 5.1.10 (#52242) breaks the existing solution for an issue #39136. Additionally, the introduced change weakened the type checking since it changed the allowed props for the resulting styled components to be the union of the original and the `as` component.

This PR attempts to fix both issues and:

* Adapt tests for `as`
* Add tests for generic types as used in #39136
* Re-introduced tests from PR  #41347
* Update/sync ts3.6 definitions and tests for `as`/`forwardedAs`
* Keeps types & tests for `forwardedAs` untouched

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #39136, #52242, #53716, 
