### PR TITLE
update(video.js): correct `this` scope in inline `ready` callbacks

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -33,11 +33,18 @@
  *
  * @return A player instance
  */
-declare function videojs(id: string | Element, options?: videojs.PlayerOptions, ready?: () => void): videojs.Player;
+declare function videojs(
+    id: string | Element,
+    options?: videojs.PlayerOptions,
+    ready?: videojs.ReadyCallback,
+): videojs.Player;
 export default videojs;
 export as namespace videojs;
 
 declare namespace videojs {
+    interface ReadyCallback {
+        (this: Player): void;
+    }
     /**
      * Adding languages so that they're available to all players.
      * Example: `addLanguage('es', { 'Hello': 'Hola' });`
@@ -1689,7 +1696,7 @@ declare namespace videojs {
          *
          * @return Returns itself; method can be chained.
          */
-        ready(callback: (this: Player) => void): this;
+        ready(callback: ReadyCallback): this;
 
         /**
          * Remove an attribute from the `Component`s element.

--- a/types/video.js/test/videojs-alt-distributions-tests.ts
+++ b/types/video.js/test/videojs-alt-distributions-tests.ts
@@ -5,7 +5,16 @@ test(videojsnovtt);
 test(videojscore);
 
 function test(videojs: typeof videojsnovtt | typeof videojscore) {
-    videojs('example_video_1').ready(function() {
+    // support for inline player ready callback with proper `this`
+    videojs('example_video_1', {}, function onPlayerReady() {
+        this; // $ExpectType VideoJsPlayer
+        const playPromise = this.play();
+        this.pause();
+        const isPaused: boolean = this.paused();
+        const isPlaying: boolean = !this.paused();
+    });
+
+    videojs('example_video_1').ready(function playerReady() {
         // EXAMPLE: Start playing the video.
         const playPromise = this.play();
 

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -82,7 +82,7 @@ playerOptions.controlBar! = {
     timeDivider: false,
 };
 
-videojs('example_video_1', playerOptions).ready(function() {
+videojs('example_video_1', playerOptions).ready(function playerReady() {
     // EXAMPLE: Start playing the video.
     const playPromise = this.play();
 


### PR DESCRIPTION
This corrects acess to proper scope when using inline callbacks, instead
`ready` hook.
To keep dry, `ReadyCallback` is added to `Player` namespace itself.

https://docs.videojs.com/tutorial-setup.html#player-readiness

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).