### PR TITLE
[node] Add missing "crypto.generateKey" definition

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -376,6 +376,8 @@ declare module 'crypto' {
         type?: 'pkcs1' | 'spki';
     }
 
+    function generateKey(type: 'hmac' | 'aes', options: {length: number}, callback: (err: Error, key: KeyObject) => void): KeyObject;
+
     function createPrivateKey(key: PrivateKeyInput | string | Buffer): KeyObject;
     function createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject): KeyObject;
     function createSecretKey(key: NodeJS.ArrayBufferView): KeyObject;

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -376,7 +376,7 @@ declare module 'crypto' {
         type?: 'pkcs1' | 'spki';
     }
 
-    function generateKey(type: 'hmac' | 'aes', options: {length: number}, callback: (err: Error, key: KeyObject) => void): KeyObject;
+    function generateKey(type: 'hmac' | 'aes', options: {length: number}, callback: (err: Error | null, key: KeyObject) => void): KeyObject;
 
     function createPrivateKey(key: PrivateKeyInput | string | Buffer): KeyObject;
     function createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject): KeyObject;

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -396,6 +396,72 @@ import { promisify } from 'util';
 }
 
 {
+    crypto.generateKey(
+        'hmac',
+        {
+            length: 123,
+        },
+        (err: Error, key: crypto.KeyObject) => {},
+    );
+
+    crypto.generateKey(
+        'aes',
+        {
+            length: 128,
+        },
+        (err: Error, key: crypto.KeyObject) => {},
+    );
+
+    crypto.generateKey(
+        'aes',
+        {
+            length: 192,
+        },
+        (err: Error, key: crypto.KeyObject) => {},
+    );
+
+    crypto.generateKey(
+        'aes',
+        {
+            length: 256,
+        },
+        (err: Error, key: crypto.KeyObject) => {},
+    );
+}
+
+{
+    const generateKeyPromisified = promisify(crypto.generateKey);
+
+    const resHmac: Promise<crypto.KeyObject> = generateKeyPromisified(
+        'hmac',
+        {
+            length: 123,
+        },
+    );
+
+    const resAes128: Promise<crypto.KeyObject> = generateKeyPromisified(
+        'aes',
+        {
+            length: 128,
+        },
+    );
+
+    const resAes192: Promise<crypto.KeyObject> = generateKeyPromisified(
+        'aes',
+        {
+            length: 192,
+        },
+    );
+
+    const resAes256: Promise<crypto.KeyObject> = generateKeyPromisified(
+        'aes',
+        {
+            length: 256,
+        },
+    );
+}
+
+{
     const rsaRes: {
         publicKey: Buffer;
         privateKey: string;

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -401,7 +401,7 @@ import { promisify } from 'util';
         {
             length: 123,
         },
-        (err: Error, key: crypto.KeyObject) => {},
+        (err: Error | null, key: crypto.KeyObject) => {},
     );
 
     crypto.generateKey(
@@ -409,7 +409,7 @@ import { promisify } from 'util';
         {
             length: 128,
         },
-        (err: Error, key: crypto.KeyObject) => {},
+        (err: Error | null, key: crypto.KeyObject) => {},
     );
 
     crypto.generateKey(
@@ -417,7 +417,7 @@ import { promisify } from 'util';
         {
             length: 192,
         },
-        (err: Error, key: crypto.KeyObject) => {},
+        (err: Error | null, key: crypto.KeyObject) => {},
     );
 
     crypto.generateKey(
@@ -425,7 +425,7 @@ import { promisify } from 'util';
         {
             length: 256,
         },
-        (err: Error, key: crypto.KeyObject) => {},
+        (err: Error | null, key: crypto.KeyObject) => {},
     );
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v15.x/api/crypto.html#crypto_crypto_generatekey_type_options_callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
