### PR TITLE
react-native-vector-icons allow multiple style props for fontawesome5

### DIFF
--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
-import { Component } from 'react';
-import { Icon, IconProps, ImageSource } from './Icon';
+import { Component } from "react";
+import { Icon, IconProps, ImageSource } from "./Icon";
 
 export const FA5Style: {
     regular: 0;
@@ -14,22 +14,25 @@ export type ValueOf<T> = T[keyof T];
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, 'regular'>;
+export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
 
 export type FontAwesome5IconProps = { [K in FontAwesome5IconVariants]?: boolean } & IconProps;
 
-export default class FontAwesome5Icon extends Component<FontAwesome5IconProps, any> {
+export default class FontAwesome5Icon extends Component<
+    FontAwesome5IconProps, 
+    any
+> {
     static getImageSource(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>,
+        fa5Style?: ValueOf<typeof FA5Style>
     ): Promise<ImageSource>;
     static getImageSourceSync(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>,
+        fa5Style?: ValueOf<typeof FA5Style>
     ): ImageSource;
     static loadFont(file?: string): Promise<void>;
     static hasIcon(name: string): boolean;

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
-import { Component } from 'react';
-import { Icon, IconProps, ImageSource } from './Icon';
+import { Component } from "react";
+import { Icon, IconProps, ImageSource } from "./Icon";
 
 export const FA5Style: {
     regular: 0;
@@ -14,22 +14,25 @@ export type ValueOf<T> = T[keyof T];
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, 'regular'>;
+export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
 
 export type FontAwesome5IconProps = { [K in FontAwesome5IconVariants]?: boolean } & IconProps;
 
-export default class FontAwesome5Icon extends Component<FontAwesome5IconProps, any> {
+export default class FontAwesome5Icon extends Component<
+    FontAwesome5IconProps,
+    any
+> {
     static getImageSource(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>,
+        fa5Style?: ValueOf<typeof FA5Style>
     ): Promise<ImageSource>;
     static getImageSourceSync(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>,
+        fa5Style?: ValueOf<typeof FA5Style>
     ): ImageSource;
     static loadFont(file?: string): Promise<void>;
     static hasIcon(name: string): boolean;

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
-import { Component } from "react";
-import { Icon, IconProps, ImageSource } from "./Icon";
+import { Component } from 'react';
+import { Icon, IconProps, ImageSource } from './Icon';
 
 export const FA5Style: {
     regular: 0;
@@ -14,35 +14,22 @@ export type ValueOf<T> = T[keyof T];
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
+export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, 'regular'>;
 
-// modified from https://stackoverflow.com/a/49725198/1105281
-export type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
-    {
-        [K in Keys]-?: Partial<Pick<T, K>> &
-            Partial<Record<Exclude<Keys, K>, undefined>>
-    }[Keys];
+export type FontAwesome5IconProps = { [K in FontAwesome5IconVariants]?: boolean } & IconProps;
 
-export type FontAwesome5IconProps = AllowOnlyOne<
-    { [K in FontAwesome5IconVariants]?: boolean } & IconProps,
-    FontAwesome5IconVariants
->;
-
-export default class FontAwesome5Icon extends Component<
-    FontAwesome5IconProps,
-    any
-> {
+export default class FontAwesome5Icon extends Component<FontAwesome5IconProps, any> {
     static getImageSource(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>
+        fa5Style?: ValueOf<typeof FA5Style>,
     ): Promise<ImageSource>;
     static getImageSourceSync(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>
+        fa5Style?: ValueOf<typeof FA5Style>,
     ): ImageSource;
     static loadFont(file?: string): Promise<void>;
     static hasIcon(name: string): boolean;

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
-import { Component } from "react";
-import { Icon, IconProps, ImageSource } from "./Icon";
+import { Component } from 'react';
+import { Icon, IconProps, ImageSource } from './Icon';
 
 export const FA5Style: {
     regular: 0;
@@ -14,25 +14,22 @@ export type ValueOf<T> = T[keyof T];
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
+export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, 'regular'>;
 
 export type FontAwesome5IconProps = { [K in FontAwesome5IconVariants]?: boolean } & IconProps;
 
-export default class FontAwesome5Icon extends Component<
-    FontAwesome5IconProps, 
-    any
-> {
+export default class FontAwesome5Icon extends Component<FontAwesome5IconProps, any> {
     static getImageSource(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>
+        fa5Style?: ValueOf<typeof FA5Style>,
     ): Promise<ImageSource>;
     static getImageSourceSync(
         name: string,
         size?: number,
         color?: string,
-        fa5Style?: ValueOf<typeof FA5Style>
+        fa5Style?: ValueOf<typeof FA5Style>,
     ): ImageSource;
     static loadFont(file?: string): Promise<void>;
     static hasIcon(name: string): boolean;

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -20,7 +20,11 @@ import { TextProps } from 'react-native';
  * to the font file in you asset folder.
  *
  */
-export function createIconSet(glyphMap: {}, fontFamily: string, fontFile?: string): typeof Icon;
+export function createIconSet(
+  glyphMap: {}, 
+  fontFamily: string, 
+  fontFile?: string
+): typeof Icon;
 
 /**
  * Convenience method to create a custom font based on a fontello config file.

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -21,8 +21,8 @@ import { TextProps } from 'react-native';
  *
  */
 export function createIconSet(
-  glyphMap: {}, 
-  fontFamily: string, 
+  glyphMap: {},
+  fontFamily: string,
   fontFile?: string
 ): typeof Icon;
 

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -4,6 +4,7 @@
 //                 Tim Wang <https://github.com/timwangdev>
 //                 Robert Ying <https://github.com/robertying>
 //                 Jesse Katsumata <https://github.com/Naturalclar>
+//                 Cambo <https://github.com/indentedspace>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -19,11 +20,7 @@ import { TextProps } from 'react-native';
  * to the font file in you asset folder.
  *
  */
-export function createIconSet(
-  glyphMap: {},
-  fontFamily: string,
-  fontFile?: string
-): typeof Icon;
+export function createIconSet(glyphMap: {}, fontFamily: string, fontFile?: string): typeof Icon;
 
 /**
  * Convenience method to create a custom font based on a fontello config file.

--- a/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
+++ b/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
@@ -35,7 +35,7 @@ class Example extends React.Component {
         <MaterialIcon size={30} color="red" name="exit" />
         <FontAwesome5Icon size={10} name="handshake" />
         <FontAwesome5Icon size={10} name="handshake" solid />
-        <FontAwesome5ProIcon size={10} name="parachute-box" light />
+        <FontAwesome5ProIcon size={10} name="parachute-box" light={true} solid={false} />
         <Fontisto size={10} name="fontisto" />
 
         {/* Icon button  */}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-multi-style-icon-set.js#L39)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Justification for change:
Currently the type definition for FontAwesome 5 icons only allows for defining at max one style prop ("solid", "light", "brands"), but the code allows for defining multiple/all of them, it simply applies the first one that has a value of true. This change allows for turning on/off style props as desired using variables.