### PR TITLE
[@types/indy-sdk] fix: do not depend on node type

### DIFF
--- a/types/indy-sdk/index.d.ts
+++ b/types/indy-sdk/index.d.ts
@@ -5,7 +5,7 @@
 //                 Karim Stekelenburg <https://github.com/karimStekelenburg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
+import { Buffer } from 'buffer';
 
 export function createWallet(config: WalletConfig, credentials: WalletCredentials): Promise<void>;
 export function openWallet(config: WalletConfig, credentials: OpenWalletCredentials): Promise<WalletHandle>;

--- a/types/indy-sdk/indy-sdk-tests.ts
+++ b/types/indy-sdk/indy-sdk-tests.ts
@@ -1,4 +1,5 @@
 import indy from "indy-sdk";
+import { Buffer } from 'buffer';
 
 indy.openBlobStorageWriter("default", {
     base_dir: "dir",

--- a/types/indy-sdk/package.json
+++ b/types/indy-sdk/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "buffer": "^6.0.0"
+    }
+}

--- a/types/indy-sdk/tsconfig.json
+++ b/types/indy-sdk/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "ESNext.BigInt"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/indy-sdk/tslint.json
+++ b/types/indy-sdk/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-outside-dependencies": false
+    }
+}


### PR DESCRIPTION
The package can be used outside of node environments, thus removing the dependency on `@types/node`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [-] Provide a URL to documentation or source code which provides context for the suggested changes: none, shouldn't have depended on NodeJS types
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.