### PR TITLE
[node] Correct return type of "crypto.generateKey" from "KeyObject" to "void"

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -376,7 +376,7 @@ declare module 'crypto' {
         type?: 'pkcs1' | 'spki';
     }
 
-    function generateKey(type: 'hmac' | 'aes', options: {length: number}, callback: (err: Error | null, key: KeyObject) => void): KeyObject;
+    function generateKey(type: 'hmac' | 'aes', options: {length: number}, callback: (err: Error | null, key: KeyObject) => void): void;
 
     function createPrivateKey(key: PrivateKeyInput | string | Buffer): KeyObject;
     function createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject): KeyObject;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v15.x/api/crypto.html#crypto_crypto_generatekey_type_options_callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
