### PR TITLE
[@types/react-d3-graph] Update type definitions to 2.6

### DIFF
--- a/types/react-d3-graph/index.d.ts
+++ b/types/react-d3-graph/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for react-d3-graph 2.3
+// Type definitions for react-d3-graph 2.6
 // Project: https://github.com/danielcaldas/react-d3-graph#readme
 // Definitions by: Harry Goode <https://github.com/hrngoode>
 //                 Adina Todoran <https://github.com/adina-todoran>
 //                 Robin Leclerc <https://github.com/BreadAndRoses95>
+//                 Nate Moore <https://github.com/TranquilMarmot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Component, MouseEvent } from 'react';
@@ -12,12 +13,19 @@ export type LinkLabelProperty<L extends GraphLink> = ((node: L) => string) | key
 
 export type NodeWithExtraParameters = GraphNode & { [key: string]: string };
 
+export type NodeSize =
+    | number
+    | {
+          width: number;
+          height: number;
+      };
+
 export interface NodeLevelNodeConfiguration {
     color: string;
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number | { width: number; height: number; };
+    size: NodeSize;
     strokeColor: string;
     strokeWidth: number;
     svg: string;
@@ -31,7 +39,7 @@ export interface GraphLevelNodeConfiguration<N extends GraphNode> {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number | { width: number; height: number; };
+    size: NodeSize;
     strokeColor: string;
     strokeWidth: number;
     svg: string;
@@ -94,6 +102,7 @@ export interface GraphConfiguration<N extends GraphNode, L extends GraphLink> {
     highlightOpacity: number;
     maxZoom: number;
     minZoom: number;
+    initialZoom: number;
     panAndZoom: boolean;
     staticGraph: boolean;
     staticGraphWithDragAndDrop: boolean;
@@ -152,6 +161,7 @@ export interface GraphEventCallbacks {
     onMouseOverLink: (source: string, target: string) => void;
     onMouseOutLink: (source: string, target: string) => void;
     onNodePositionChange: (nodeId: string, x: number, y: number) => void;
+    onZoomChange: (previousZoom: number, newZoom: number) => void;
 }
 
 export interface GraphProps<N extends GraphNode, L extends GraphLink> extends Partial<GraphEventCallbacks> {

--- a/types/react-d3-graph/react-d3-graph-tests.tsx
+++ b/types/react-d3-graph/react-d3-graph-tests.tsx
@@ -1,38 +1,90 @@
-import * as React from 'react';
 import { Graph, Link, Node } from 'react-d3-graph';
-
-const nodes = [
-    { id: 'node1', labelProperty: 'id' },
-    { id: 'node2', name: 'node2Name' },
-];
-
-type INode = typeof nodes[number];
-
-const links = [{ source: 'node1', target: 'node2' }];
-type ILink = typeof links[number];
+import * as React from 'react';
 
 export class Example extends React.Component {
-    ref: React.MutableRefObject<Graph<INode, ILink> | null> = React.createRef();
-
     render(): React.ReactElement {
         return (
             <div>
                 <Graph
-                    ref={this.ref}
-                    onClickGraph={() => {}}
                     id="test"
                     data={{
-                        nodes,
-                        links,
+                        nodes: [
+                            { id: 'node1', labelProperty: 'id' },
+                            { id: 'node2', name: 'node2Name', size: 100 },
+                            {
+                                id: 'node3',
+                                size: {
+                                    width: 100,
+                                    height: 200,
+                                },
+                            },
+                        ],
+                        links: [{ source: 'node1', target: 'node2' }],
+                        focusedNodeId: 'node1',
                     }}
                     config={{
                         node: {
+                            color: 'green',
+                            fontColor: 'blue',
+                            opacity: 0.5,
+                            renderLabel: true,
+                            size: 100,
+                            strokeColor: 'white',
+                            strokeWidth: 100,
+                            svg: '<line />',
+                            symbolType: 'circle',
+                            viewGenerator: node => <div>{node.name}</div>,
                             labelProperty: node => node.name || 'No name',
                         },
+                        link: {
+                            fontSize: 10,
+                            fontWeight: 'bold',
+                            highlightColor: '#fff',
+                            highlightFontWeight: '100',
+                            labelProperty: () => 'Label',
+                            renderLabel: true,
+                            semanticStrokeWidth: true,
+                            markerHeight: 100,
+                            type: 'circle',
+                            mouseCursor: 'pointer',
+                        },
+                        automaticRearrangeAfterDropNode: true,
+                        collapsible: true,
+                        directed: true,
+                        focusZoom: 5,
+                        focusAnimationDuration: 10,
+                        height: 10,
+                        nodeHighlightBehavior: true,
+                        linkHighlightBehavior: true,
+                        highlightDegree: 2,
+                        highlightOpacity: 0.5,
+                        maxZoom: 3.0,
+                        minZoom: 0.5,
+                        initialZoom: 2.0,
+                        panAndZoom: false,
+                        staticGraph: true,
+                        staticGraphWithDragAndDrop: true,
+                        width: 100,
                         d3: {
+                            alphaTarget: 1.0,
+                            gravity: 9.8,
+                            linkLength: 10,
+                            linkStrength: 10,
                             disableLinkForce: true,
                         },
                     }}
+                    onClickGraph={(event: MouseEvent) => {}}
+                    onClickNode={(nodeId: string) => {}}
+                    onDoubleClickNode={(nodeId: string) => {}}
+                    onRightClickNode={(event: MouseEvent, nodeId: string) => {}}
+                    onMouseOverNode={(nodeId: string) => {}}
+                    onMouseOutNode={(nodeId: string) => {}}
+                    onClickLink={(source: string, target: string) => {}}
+                    onRightClickLink={(event: MouseEvent, source: string, target: string) => {}}
+                    onMouseOverLink={(source: string, target: string) => {}}
+                    onMouseOutLink={(source: string, target: string) => {}}
+                    onNodePositionChange={(nodeId: string, x: number, y: number) => {}}
+                    onZoomChange={(previousZoom: number, newZoom: number) => {}}
                 />
                 <Link />
                 <Node />

--- a/types/react-d3-graph/react-d3-graph-tests.tsx
+++ b/types/react-d3-graph/react-d3-graph-tests.tsx
@@ -1,25 +1,35 @@
-import { Graph, Link, Node } from 'react-d3-graph';
 import * as React from 'react';
+import { Graph, Link, Node } from 'react-d3-graph';
+
+const nodes = [
+    { id: 'node1', labelProperty: 'id' },
+    { id: 'node2', name: 'node2Name' },
+    {
+        id: 'node3',
+        size: {
+            width: 100,
+            height: 200,
+        },
+    },
+];
+
+type INode = typeof nodes[number];
+
+const links = [{ source: 'node1', target: 'node2' }];
+type ILink = typeof links[number];
 
 export class Example extends React.Component {
+    ref: React.MutableRefObject<Graph<INode, ILink> | null> = React.createRef();
+
     render(): React.ReactElement {
         return (
             <div>
                 <Graph
+                    ref={this.ref}
                     id="test"
                     data={{
-                        nodes: [
-                            { id: 'node1', labelProperty: 'id' },
-                            { id: 'node2', name: 'node2Name', size: 100 },
-                            {
-                                id: 'node3',
-                                size: {
-                                    width: 100,
-                                    height: 200,
-                                },
-                            },
-                        ],
-                        links: [{ source: 'node1', target: 'node2' }],
+                        nodes,
+                        links,
                         focusedNodeId: 'node1',
                     }}
                     config={{


### PR DESCRIPTION
List of changes:
- Add definition for `initialZoom`
- Add definition for `onZoomChange` callback
- Add more tests for everything

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/danielcaldas/react-d3-graph/commit/5e5d76ecdc78efd7eb2268d2433685e6f7eccf91
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.