### PR TITLE
[detox] update type for negating not call

### DIFF
--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -380,7 +380,7 @@ declare global {
              * Negate the expectation.
              * @example await expect(element(by.id('UniqueId205'))).not.toBeVisible();
              */
-            not: Expect<Promise<void>>;
+            not: Expect<R>;
             /**
              * Expect the view to not be visible.
              * @deprecated Use `.not.toBeVisible()` instead.

--- a/types/detox/test/detox-global-tests.ts
+++ b/types/detox/test/detox-global-tests.ts
@@ -81,6 +81,10 @@ describe('Test', () => {
         await waitFor(element(by.id('UniqueId204')))
             .toBeVisible()
             .withTimeout(2000);
+        await waitFor(element(by.id('element')))
+            .not
+            .toBeVisible()
+            .withTimeout(2000);
         await expect(element(by.id('element'))).not.toBeVisible();
         await expect(element(by.id('element'))).not.toExist();
     });

--- a/types/detox/test/detox-module-tests.ts
+++ b/types/detox/test/detox-module-tests.ts
@@ -83,6 +83,10 @@ describe('Test', () => {
         await waitFor(element(by.id('UniqueId204')))
             .toBeVisible()
             .withTimeout(2000);
+        await waitFor(element(by.id('element')))
+            .not
+            .toBeVisible()
+            .withTimeout(2000);
         await expect(element(by.id('element'))).not.toBeVisible();
         await expect(element(by.id('element'))).not.toExist();
     });


### PR DESCRIPTION
This enables calling the functionality of `Detox.WaitFor`. Previously we were not able to call `withTimeout`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/Detox/blob/master/detox/test/e2e/05.waitfor.test.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
