### PR TITLE
Add errorHandler argument to `*hot.accept` in webpack-env

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -126,14 +126,16 @@ declare namespace __WebpackModuleApi {
          * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
          * @param dependencies
          * @param callback
+         * @param errorHandler
          */
-        accept(dependencies: string[], callback?: (updatedDependencies: ModuleId[]) => void): void;
+        accept(dependencies: string[], callback?: (updatedDependencies: ModuleId[]) => void, errorHandler?: (err: Error) => void): void;
         /**
          * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
          * @param dependency
          * @param callback
+         * @param errorHandler
          */
-        accept(dependency: string, callback?: () => void): void;
+        accept(dependency: string, callback?: () => void, errorHandler?: (err: Error) => void): void;
         /**
          * Accept code updates for this module without notification of parents.
          * This should only be used if the module doesn’t export anything.

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -28,6 +28,17 @@ if(module.hot) {
     module.hot.accept("./handler.js", function() {
         //...
     });
+
+    // accept update of dependency with an error handler
+    module.hot.accept(
+        "./handler.js",
+        function() {
+            //...
+        },
+        function(err: Error) {
+            // ...
+        }
+    );
 }
 
 module.exports = null;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/api/hot-module-replacement/#errorhandler-for-accept
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I'm not sure if version number here reflects webpack version or it's module API version somewhere.