### PR TITLE
update(canvas-confetti): fix Promise return and global script

### DIFF
--- a/types/canvas-confetti/canvas-confetti-tests.ts
+++ b/types/canvas-confetti/canvas-confetti-tests.ts
@@ -57,5 +57,12 @@ confetti.reset();
 myConfetti.reset();
 
 myConfetti({
-    particleCount: 150
+    particleCount: 150,
+});
+
+confetti()!.then(() => {
+    // ready
+});
+confetti()!.then(param => {
+    param; // $ExpectType undefined
 });

--- a/types/canvas-confetti/index.d.ts
+++ b/types/canvas-confetti/index.d.ts
@@ -17,7 +17,7 @@
  * `confetti` will resolve once all animations are done.
  *
  */
-declare function confetti(options?: confetti.Options): Promise<null> | null;
+declare function confetti(options?: confetti.Options): Promise<undefined> | null;
 
 declare namespace confetti {
     /**
@@ -149,4 +149,5 @@ declare namespace confetti {
     ): CreateTypes;
 }
 
+export as namespace confetti;
 export = confetti;


### PR DESCRIPTION
- promise resolves with `undefined`:
https://github.com/catdad/canvas-confetti/blob/master/src/confetti.js#L103
- package can be used directly in global
  script:
https://github.com/catdad/canvas-confetti#install

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).