### PR TITLE
Add types for create-cert

### DIFF
--- a/types/create-cert/create-cert-tests.ts
+++ b/types/create-cert/create-cert-tests.ts
@@ -7,7 +7,7 @@ createCert('commonName').then((keys) => {
     const cert = keys.cert;
     // $ExpectType string
     const caCert = keys.caCert;
-})
+});
 
 createCert();
 

--- a/types/create-cert/create-cert-tests.ts
+++ b/types/create-cert/create-cert-tests.ts
@@ -9,6 +9,8 @@ createCert('commonName').then((keys) => {
     const caCert = keys.caCert;
 })
 
+createCert();
+
 createCert({});
 
 createCert({days: 128, commonName: 'hello', emailAddress: 'me@example.com'});

--- a/types/create-cert/create-cert-tests.ts
+++ b/types/create-cert/create-cert-tests.ts
@@ -1,0 +1,14 @@
+import createCert = require("create-cert");
+
+createCert('commonName').then((keys) => {
+    // $ExpectType string
+    const key = keys.key;
+    // $ExpectType string
+    const cert = keys.cert;
+    // $ExpectType string
+    const caCert = keys.caCert;
+})
+
+createCert({});
+
+createCert({days: 128, commonName: 'hello', emailAddress: 'me@example.com'});

--- a/types/create-cert/index.d.ts
+++ b/types/create-cert/index.d.ts
@@ -3,23 +3,21 @@
 // Definitions by: Chris Midgley <https://github.com/midgleyc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'create-cert' {
-    import { CertificateCreationOptions } from 'pem';
+import { CertificateCreationOptions } from 'pem';
 
-    function createCert(opts?: Partial<createCert.Options & CertificateCreationOptions> | string): Promise<createCert.CertificateData>;
+declare function createCert(opts?: Partial<createCert.Options & CertificateCreationOptions> | string): Promise<createCert.CertificateData>;
 
-    export = createCert;
+export = createCert;
 
-    namespace createCert {
-        export interface Options {
-            days: number;
-            commonName: string;
-        }
+declare namespace createCert {
+    interface Options {
+        days: number;
+        commonName: string;
+    }
 
-        export interface CertificateData {
-            key: string;
-            cert: string;
-            caCert: string;
-        }
+    interface CertificateData {
+        key: string;
+        cert: string;
+        caCert: string;
     }
 }

--- a/types/create-cert/index.d.ts
+++ b/types/create-cert/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for create-cert 1.0
+// Project: https://github.com/lukechilds/create-cert
+// Definitions by: Chris Midgley <https://github.com/midgleyc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { CertificateCreationOptions } from 'pem';
+
+declare interface Options {
+    days: number;
+    commonName: string;
+}
+
+declare interface CertificateData {
+    key: string;
+    cert: string;
+    caCert: string;
+}
+
+declare function createCert(opts: Partial<Options & CertificateCreationOptions> | string): Promise<CertificateData>;
+
+export = createCert;

--- a/types/create-cert/index.d.ts
+++ b/types/create-cert/index.d.ts
@@ -3,19 +3,23 @@
 // Definitions by: Chris Midgley <https://github.com/midgleyc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { CertificateCreationOptions } from 'pem';
+declare module 'create-cert' {
+    import { CertificateCreationOptions } from 'pem';
 
-declare interface Options {
-    days: number;
-    commonName: string;
+    function createCert(opts?: Partial<createCert.Options & CertificateCreationOptions> | string): Promise<createCert.CertificateData>;
+
+    export = createCert;
+
+    namespace createCert {
+        export interface Options {
+            days: number;
+            commonName: string;
+        }
+
+        export interface CertificateData {
+            key: string;
+            cert: string;
+            caCert: string;
+        }
+    }
 }
-
-declare interface CertificateData {
-    key: string;
-    cert: string;
-    caCert: string;
-}
-
-declare function createCert(opts?: Partial<Options & CertificateCreationOptions> | string): Promise<CertificateData>;
-
-export = createCert;

--- a/types/create-cert/index.d.ts
+++ b/types/create-cert/index.d.ts
@@ -16,6 +16,6 @@ declare interface CertificateData {
     caCert: string;
 }
 
-declare function createCert(opts: Partial<Options & CertificateCreationOptions> | string): Promise<CertificateData>;
+declare function createCert(opts?: Partial<Options & CertificateCreationOptions> | string): Promise<CertificateData>;
 
 export = createCert;

--- a/types/create-cert/index.d.ts
+++ b/types/create-cert/index.d.ts
@@ -6,14 +6,14 @@
 
 import { CertificateCreationOptions } from 'pem';
 
-declare function createCert(opts?: Partial<createCert.Options & CertificateCreationOptions> | string): Promise<createCert.CertificateData>;
+declare function createCert(opts?: createCert.Options | string): Promise<createCert.CertificateData>;
 
 export = createCert;
 
 declare namespace createCert {
-    interface Options {
-        days: number;
-        commonName: string;
+    interface Options extends CertificateCreationOptions {
+        days?: number;
+        commonName?: string;
     }
 
     interface CertificateData {

--- a/types/create-cert/index.d.ts
+++ b/types/create-cert/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/lukechilds/create-cert
 // Definitions by: Chris Midgley <https://github.com/midgleyc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
 
 import { CertificateCreationOptions } from 'pem';
 

--- a/types/create-cert/tsconfig.json
+++ b/types/create-cert/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "create-cert-tests.ts"
+    ]
+}

--- a/types/create-cert/tslint.json
+++ b/types/create-cert/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add types for `create-cert`. Limited to TypeScript 3.4 and above, due to an error when running dtslint:

```
Error: Errors in typescript@3.3 for external dependencies:
 ../node/globals.global.d.ts(1,44): error TS2304: Cannot find name 'globalThis'.
```

I found this odd because the docs say that only 3.6+ are tested in the first place.

Uses the types for `pem`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Adding a new package
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.