### PR TITLE
inquirer-autocomplete-prompt: fix default lint

### DIFF
--- a/types/inquirer-autocomplete-prompt/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/index.d.ts
@@ -18,7 +18,7 @@ declare class AutocompletePrompt<T> extends Base {
     /**
      * The choices currently available on the prompt
      */
-    currentChoices: Choices<Answers>;
+    currentChoices: Choices;
 
     /**
      * Flag that is true on first render


### PR DESCRIPTION
The linter doesn't allow type arguments when the argument matches the type parameter's default. I think this rule was added in between CI running and the PR getting merged.
