### PR TITLE
update `breakpoints` type in Carousel component

### DIFF
--- a/types/brainhubeu__react-carousel/brainhubeu__react-carousel-tests.tsx
+++ b/types/brainhubeu__react-carousel/brainhubeu__react-carousel-tests.tsx
@@ -90,6 +90,28 @@ class MyCarousel extends React.Component<MyCarouselProps, MyCarouselState> {
                             resolve: fastSwipePlugin,
                         }
                     ]}
+                    breakpoints={{
+                        640: {
+                            plugins: [
+                                {
+                                    resolve: slidesToShowPlugin,
+                                    options: {
+                                        numberOfSlides: 1
+                                    }
+                                },
+                            ]
+                        },
+                        900: {
+                            plugins: [
+                                {
+                                    resolve: slidesToShowPlugin,
+                                    options: {
+                                        numberOfSlides: 2
+                                    }
+                                },
+                            ]
+                        }
+                    }}
                     animationSpeed={2000}
                     draggable
                     itemWidth={100}

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @brainhubeu/react-carousel 2.04
+// Type definitions for @brainhubeu/react-carousel 2.0
 // Project: https://github.com/brainhubeu/react-carousel
 // Definitions by: Jack Allen <https://github.com/jackall3n>
 //                 Jeff Wen <https://github.com/sinchang>

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jack Allen <https://github.com/jackall3n>
 //                 Jeff Wen <https://github.com/sinchang>
 //                 Robert Hebel <https://github.com/roberthebel>
+//                 Pinot Kim <https://github.com/kimpinot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -49,7 +50,7 @@ export interface CarouselProps {
     draggable?: boolean;
     animationSpeed?: number;
     className?: string;
-    breakpoints?: Pick<CarouselProps, Exclude<keyof CarouselProps, "breakpoints" | "plugins">>;
+    breakpoints?: Record<number, Pick<CarouselProps, Exclude<keyof CarouselProps, "breakpoints">>>;
     plugins?: Array<string|CarouselPluginTypes>;
 }
 

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @brainhubeu/react-carousel 2.0
+// Type definitions for @brainhubeu/react-carousel 2.0.4
 // Project: https://github.com/brainhubeu/react-carousel
 // Definitions by: Jack Allen <https://github.com/jackall3n>
 //                 Jeff Wen <https://github.com/sinchang>

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @brainhubeu/react-carousel 2.0
+// Type definitions for @brainhubeu/react-carousel 2.04
 // Project: https://github.com/brainhubeu/react-carousel
 // Definitions by: Jack Allen <https://github.com/jackall3n>
 //                 Jeff Wen <https://github.com/sinchang>

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @brainhubeu/react-carousel 2.0.4
+// Type definitions for @brainhubeu/react-carousel 2.0
 // Project: https://github.com/brainhubeu/react-carousel
 // Definitions by: Jack Allen <https://github.com/jackall3n>
 //                 Jeff Wen <https://github.com/sinchang>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://brainhubeu.github.io/react-carousel/docs/examples/responsive](https://brainhubeu.github.io/react-carousel/docs/examples/responsive)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

### problem
```typescript
 const option: CarouselProps = {
  offset: offset || 100,
  value: index,
  onChange(value: number) {
    setIndex(value);
  },
  plugins: [
    "centered",
    {
      resolve: slidesToShowPlugin,
      options: {
        numberOfSlides: 2,
      },
    },
    {
      resolve: slidesToScrollPlugin,
      options: {
        numberOfSlides: 1,
      },
    },
  ],
  breakpoints: {
    // TS2322: Type '{ 640: { plugins : {...} } }' is not assignable to type 'Pick<...>'
    640: {
      plugins: [
        {
          resolve: slidesToShowPlugin,
          options: {
            numberOfSlides: 4,
          },
        },
      ],
    },
  },
};

```
