### PR TITLE
[kendo-ui] Wrong return type in "expand" method "SchedulerDataSource" class

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -793,7 +793,7 @@ declare namespace kendo.data {
         insert(index: number, model: kendo.data.SchedulerEvent): kendo.data.SchedulerEvent;
         insert(index: number, model: Object): kendo.data.SchedulerEvent;
         remove(model: kendo.data.SchedulerEvent): void;
-        expand(start: Date, end: Date): kendo.data.SchedulerEvent;
+        expand(start: Date, end: Date): kendo.data.SchedulerEvent[];
     }
 
     class GanttDataSource extends DataSource {

--- a/types/kendo-ui/kendo-ui-tests.ts
+++ b/types/kendo-ui/kendo-ui-tests.ts
@@ -32,3 +32,19 @@ $(() => {
     var $switch = <kendo.ui.Switch>$(switchElement).data("kendoSwitch");
     $switch.readonly(true);
 })
+
+// SchedulerDataSource
+$(() => {
+    const dataSource = new kendo.data.SchedulerDataSource({
+        data: [
+            new kendo.data.SchedulerEvent({
+                id: 1,
+                title: "Event",
+                start: new Date("2021/4/4 12:00"),
+                end: new Date("2021/4/4 14:00")
+            })
+        ]
+    });
+    const occurrences = dataSource.expand(new Date("2021/4/1"), new Date("2021/5/1"));
+    const firstOccurence = occurrences[0];
+})


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.telerik.com/kendo-ui/api/javascript/data/schedulerdatasource/methods/expand>>

