### PR TITLE
Add types for create-test-server

### DIFF
--- a/types/create-test-server/create-test-server-tests.ts
+++ b/types/create-test-server/create-test-server-tests.ts
@@ -1,0 +1,34 @@
+import createTestServer = require('create-test-server');
+
+const server = createTestServer().then((server) => {
+    // $ExpectType string
+    server.url;
+    // $ExpectType string
+    server.sslUrl;
+    // $ExpectType string
+    server.caCert;
+    // $ExpectType number
+    server.port;
+    // $ExpectType number
+    server.sslPort;
+
+    // This is just an Express route
+    // You could use any Express middleware too
+    server.get('/foo', (req, res) => {
+      res.send('bar');
+    });
+
+    // You can return a body directly too
+    server.get('/foo', () => 'bar');
+    server.get('/foo', 'bar');
+
+    return server;
+});
+
+server.then((s) => {
+    s.listen().then(() => {
+        s.close();
+    });
+})
+
+createTestServer({certificate: 'example.com', bodyParser: false})

--- a/types/create-test-server/create-test-server-tests.ts
+++ b/types/create-test-server/create-test-server-tests.ts
@@ -1,15 +1,15 @@
 import createTestServer = require('create-test-server');
 
 const server = createTestServer().then((server) => {
-    // $ExpectType string
+    // $ExpectType string | undefined
     server.url;
-    // $ExpectType string
+    // $ExpectType string | undefined
     server.sslUrl;
     // $ExpectType string
     server.caCert;
-    // $ExpectType number
+    // $ExpectType number | undefined
     server.port;
-    // $ExpectType number
+    // $ExpectType number | undefined
     server.sslPort;
 
     // This is just an Express route
@@ -29,6 +29,6 @@ server.then((s) => {
     s.listen().then(() => {
         s.close();
     });
-})
+});
 
-createTestServer({certificate: 'example.com', bodyParser: false})
+createTestServer({certificate: 'example.com', bodyParser: false});

--- a/types/create-test-server/index.d.ts
+++ b/types/create-test-server/index.d.ts
@@ -28,8 +28,8 @@ declare namespace createTestServer {
         certificate?: string | CreateCertOptions;
         /**
          * Body parser options object to be passed to `body-parser` methods.
-
-           If set to `false` then all body parsing middleware will be disabled.
+         *
+         * If set to `false` then all body parsing middleware will be disabled.
          */
         bodyParser?: false | OptionsJson & OptionsText & OptionsUrlencoded;
     }
@@ -84,14 +84,15 @@ declare namespace createTestServer {
          *
          * Once the servers are listening, `server.url` and `server.sslUrl` will be updated.
          *
-         * Please note, this function doesn't take a port argument, it uses a new randomised port each time. Also, you don't need to manually call this after creating a server, it will start listening automatically.
+         * Please note, this function doesn't take a port argument, it uses a new randomised port each time.
+         * Also, you don't need to manually call this after creating a server, it will start listening automatically.
          */
-        listen: () => Promise<void>
+        listen: () => Promise<void>;
         /**
          * Returns a Promise that resolves when both the HTTP and HTTPS servers have stopped listening.
          *
          * Once the servers have stopped listening, `server.url` and `server.sslUrl` will be set to undefined.
          */
-        close: () => Promise<void>
+        close: () => Promise<void>;
     }
 }

--- a/types/create-test-server/index.d.ts
+++ b/types/create-test-server/index.d.ts
@@ -1,0 +1,97 @@
+// Type definitions for create-test-server 3.0
+// Project: https://github.com/lukechilds/create-test-server
+// Definitions by: Chris Midgley <https://github.com/midgleyc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.5
+/// <reference types="node" />
+
+import { Options as CreateCertOptions } from 'create-cert';
+import { OptionsJson, OptionsText, OptionsUrlencoded } from 'body-parser';
+import { Express } from 'express';
+import * as http from 'http';
+import * as https from 'https';
+
+type Server = createTestServer.TestServer & Omit<Express, 'listen'> & {get: (url: string, response: string) => void};
+
+/**
+ * Returns a Promise which resolves to an (already listening) server.
+ */
+declare function createTestServer(options?: createTestServer.Options): Promise<Server>;
+
+export = createTestServer;
+
+declare namespace createTestServer {
+    interface Options {
+        /**
+         * SSL certificate options to be passed to {@link create-cert#createCert | createCert()}.
+         */
+        certificate?: string | CreateCertOptions;
+        /**
+         * Body parser options object to be passed to `body-parser` methods.
+
+           If set to `false` then all body parsing middleware will be disabled.
+         */
+        bodyParser?: false | OptionsJson & OptionsText & OptionsUrlencoded;
+    }
+
+    interface TestServer {
+        /**
+         * The url you can reach the HTTP server on.
+         *
+         * e.g: `'http://localhost:5486'`
+         *
+         * `undefined` while the server is not listening.
+         */
+        url?: string;
+        /**
+         * The port number you can reach the HTTP server on.
+         *
+         * e.g: `5486`
+         *
+         * `undefined` while the server is not listening.
+         */
+        port?: number;
+        /**
+         * The url you can reach the HTTPS server on.
+         *
+         * e.g: `'https://localhost:5487'`
+         *
+         * `undefined` while the server is not listening.
+         */
+        sslUrl?: string;
+        /**
+         * The port number you can reach the HTTPS server on.
+         *
+         * e.g: `5487`
+         *
+         * `undefined` while the server is not listening.
+         */
+        sslPort?: number;
+        /**
+         * The CA certificate to validate the server certificate against.
+         */
+        caCert: string;
+        /**
+         * The underlying HTTP server instance.
+         */
+        http: http.Server;
+        /**
+         * The underlying HTTPS server instance.
+         */
+        https: https.Server;
+        /**
+         * Returns a Promise that resolves when both the HTTP and HTTPS servers are listening.
+         *
+         * Once the servers are listening, `server.url` and `server.sslUrl` will be updated.
+         *
+         * Please note, this function doesn't take a port argument, it uses a new randomised port each time. Also, you don't need to manually call this after creating a server, it will start listening automatically.
+         */
+        listen: () => Promise<void>
+        /**
+         * Returns a Promise that resolves when both the HTTP and HTTPS servers have stopped listening.
+         *
+         * Once the servers have stopped listening, `server.url` and `server.sslUrl` will be set to undefined.
+         */
+        close: () => Promise<void>
+    }
+}

--- a/types/create-test-server/tsconfig.json
+++ b/types/create-test-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "create-test-server-tests.ts"
+    ]
+}

--- a/types/create-test-server/tslint.json
+++ b/types/create-test-server/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add types for create-test-server. This one does two annoying things: it exposes a server that extends from Express, but redefines the "listen" method with a different contract, and overloads "get" to accept a different input (or the express input).

Added a minimum TS version of 3.5 due to Omit. Given the minimum global tested version is 3.6 I'm not sure whether this was necessary, but it might be nice to consumers.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.