### PR TITLE
[mongodb] allow passing of undefined to $unset

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2698,7 +2698,7 @@ export type UpdateQuery<TSchema> = {
     $rename?: { [key: string]: string };
     $set?: MatchKeysAndValues<TSchema>;
     $setOnInsert?: MatchKeysAndValues<TSchema>;
-    $unset?: OnlyFieldsOfType<TSchema, any, "" | 1 | true>;
+    $unset?: OnlyFieldsOfType<TSchema, any, "" | 1 | true | undefined>;
 
     $addToSet?: SetFields<TSchema>;
     $pop?: OnlyFieldsOfType<TSchema, ReadonlyArray<any>, 1 | -1>;

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -148,6 +148,18 @@ async function run() {
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$[bla]': 1 } });
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$[]': 1 } });
 
+    const shouldUnset = true as boolean;
+    buildUpdateQuery({ $unset: { numberField: shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { decimal128Field: shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { doubleField: shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { int32Field: shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { longField: shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { dateField: shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { 'dot.notation': shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { 'subInterfaceArray.$': shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { 'subInterfaceArray.$[bla]': shouldUnset ? true : undefined } });
+    buildUpdateQuery({ $unset: { 'subInterfaceArray.$[]': shouldUnset ? true : undefined } });
+
     buildUpdateQuery({ $rename: { numberField2: 'stringField' } });
 
     buildUpdateQuery({ $addToSet: { fruitTags: 'stringField' } });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes: (see below)
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

A common pattern in APIs when patching is to let consumers send in `null` to remove a value, and omit the value to keep it as is. Provided that you use the `ignoreUndefined` option, this can be easily implemented like so:

```typescript
const $set = {
  _updated_at: requestTime,
  'lightMode.accentColor': patch.lightMode?.accentColor ?? undefined,
  'lightMode.primaryColor': patch.lightMode?.primaryColor ?? undefined,
  'lightMode.retroProductButtonsColorByCategory': patch.lightMode?.retroProductButtonsColorByCategory ?? undefined,
  'lightMode.secondaryColor': patch.lightMode?.secondaryColor ?? undefined
}

const $unset = {
  'lightMode.accentColor': patch.lightMode?.accentColor === null ? true : undefined,
  'lightMode.primaryColor': patch.lightMode?.primaryColor === null ? true : undefined,
  'lightMode.retroProductButtonsColorByCategory': patch.lightMode?.retroProductButtonsColorByCategory === null ? true : undefined,
  'lightMode.secondaryColor': patch.lightMode?.secondaryColor === null ? true : undefined
} as const

return await collections.restaurantTheme.findOneAndUpdate(
  { restaurantId },
  {
    $set,
    $setOnInsert: { _created_at: requestTime },
    $unset
  },
  { returnOriginal: false, upsert: true }
)
```

Only this currently isn't allowed since `undefined` is not an accepted field value for the `$unset` operator.

This patch fixes that by allowing `undefined` to appear in the `$unset` value part.