### PR TITLE
[node] v14: Add 'etag' in http.IncomingHttpHeaders

### DIFF
--- a/types/node/v14/http.d.ts
+++ b/types/node/v14/http.d.ts
@@ -32,6 +32,7 @@ declare module 'http' {
         'content-type'?: string;
         'cookie'?: string;
         'date'?: string;
+        'etag'?: string;
         'expect'?: string;
         'expires'?: string;
         'forwarded'?: string;


### PR DESCRIPTION
I had previously added the `ETag` header in all `http.d.ts` (c.f. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51633), but it was not included in the `v14` directory when it was created: #52357, so it's missing in Node 14 types.
This PR adds it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag

