### PR TITLE
Fix input property on styles object for @types/react-select

### DIFF
--- a/types/react-select/src/styles.d.ts
+++ b/types/react-select/src/styles.d.ts
@@ -32,7 +32,7 @@ export interface Styles<
     groupHeading?(base: CSSObject, props: GroupHeadingProps<OptionType, IsMulti, GroupType>): CSSObject;
     indicatorsContainer?(base: CSSObject, props: IndicatorContainerProps<OptionType, IsMulti, GroupType>): CSSObject;
     indicatorSeparator?(base: CSSObject, props: IndicatorProps<OptionType, IsMulti, GroupType>): CSSObject;
-    input?: (base: CSSObject, props: InputProps) => CSSObject;
+    input?(base: CSSObject, props: InputProps): CSSObject;
     loadingIndicator?(base: CSSObject, props: LoadingIndicatorProps<OptionType, IsMulti, GroupType>): CSSObject;
     loadingMessage?(base: CSSObject, props: NoticeProps<OptionType, IsMulti, GroupType>): CSSObject;
     menu?(base: CSSObject, props: MenuProps<OptionType, IsMulti, GroupType>): CSSObject;

--- a/types/react-select/test/InputStyles.tsx
+++ b/types/react-select/test/InputStyles.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Select, { OptionTypeBase, StylesConfig } from 'react-select';
+
+const inputStyles: StylesConfig<OptionTypeBase, boolean> = {
+    input: (base , { isDisabled }) => ({
+        ...base,
+        backgroundClip: 'padding-box',
+        borderColor:  isDisabled ? 'rgba(0,0,0,0.1)' : 'red',
+        opacity: 0
+    }),
+};
+
+export const Content = () => <Select styles={inputStyles} />;

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -31,6 +31,7 @@
         "test/Placeholder.tsx",
         "test/SetValue.tsx",
         "test/Tests.tsx",
+        "test/InputStyles.tsx",
         "test/examples/AccessingInternals.tsx",
         "test/examples/AnimatedMulti.tsx",
         "test/examples/AsyncCallbacks.tsx",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- current definition gives an error when trying to set custom input styles as per docs:

```
const customStyles = {
  input: (provided: CSSObject ) => ({
    ...provided,
   opacity: 0
  }),
}

  const App = () => (
    <Select
      styles={customStyles}
      width='200px'
      menuColor='red'
    />
  );
```
The error looks as follows:

```
Types of property 'input' are incompatible.  
'(provided: CSSObject) => { opacity: number; alignContent?: string | string[] | undefined; alignItems?: string | string[] |
undefined; alignSelf?: string | string[] | undefined; alignTracks?: string | string[] | undefined; ... 881 more ...; ":visited"?:
CSSObject | undefined; }' is not assignable to type '(base: CSSObject, props: InputProps) => CSSObject'. Types of
parameters 'provided' and 'base' are incompatible.
```

However, with this PR edit it works as expected


