### PR TITLE
Ensure Ember types are compatible with `strictFunctionTypes`

### DIFF
--- a/types/ember/test/create.ts
+++ b/types/ember/test/create.ts
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { assertType } from './lib/assert';
+import { UnwrapComputedPropertyGetter } from "@ember/object/-private/types";
 
 /**
  * Zero-argument case
@@ -10,7 +11,7 @@ assertType<object>(o);
 // object returned by create type-checks as an instance of Ember.Object
 assertType<boolean>(o.isDestroyed); // from instance
 assertType<boolean>(o.isDestroying); // from instance
-assertType<(key: string) => any>(o.get); // from prototype
+assertType<<K extends keyof Ember.Object>(key: K) => UnwrapComputedPropertyGetter<Ember.Object[K]>>(o.get); // from prototype
 
 /**
  * One-argument case

--- a/types/ember/test/helper.ts
+++ b/types/ember/test/helper.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const FormatCurrencyHelper = Ember.Helper.helper((params, hash: { currency: string }) => {
+const FormatCurrencyHelper = Ember.Helper.helper((params: [number], hash: { currency: string }) => {
     const cents = params[0];
     const currency = hash.currency;
     return `${currency}${cents * 0.01}`;

--- a/types/ember/test/observable.ts
+++ b/types/ember/test/observable.ts
@@ -23,7 +23,7 @@ class MyComponent extends Ember.Component {
         Ember.removeObserver(this, 'foo', lambda);
     }
 
-    fooDidChange(sender: MyComponent, key: 'foo') {
+    fooDidChange(sender: MyComponent, key: string) {
         // your code
     }
 }

--- a/types/ember/test/private/observable-tests.ts
+++ b/types/ember/test/private/observable-tests.ts
@@ -10,7 +10,7 @@ import {
 import Observable from '@ember/object/observable';
 
 class OtherThing {
-    observerOfDemo(target: DemoObservable, key: 'foo') {}
+    observerOfDemo(target: DemoObservable, key: string) {}
 }
 
 class DemoObservable implements Observable {
@@ -54,8 +54,8 @@ class DemoObservable implements Observable {
         Ember.removeObserver(this, 'foo', lambda);
     }
 
-    fooDidChange(obj: this, propName: 'foo') {}
-    protected fooDidChangeProtected(obj: this, propName: 'foo') {}
+    fooDidChange(obj: this, propName: string) {}
+    protected fooDidChangeProtected(obj: this, propName: string) {}
     get<K extends keyof this>(key: K): UnwrapComputedPropertyGetter<this[K]> {
         throw new Error('Method not implemented.');
     }

--- a/types/ember/tsconfig.json
+++ b/types/ember/tsconfig.json
@@ -9,7 +9,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -10,7 +10,7 @@ export default class Helper extends EmberObject {
      * The `helper` method create pure-function helpers without instances. For
      * example:
      */
-    static helper(helper: (params: any[], hash?: object) => any): Helper;
+    static helper(helper: (params: any, hash: any) => any): Helper;
     /**
      * Override this function when writing a class-based helper.
      */
@@ -35,4 +35,4 @@ export default class Helper extends EmberObject {
  * });
  * ```
  */
-export function helper(helperFn: (params: any[], hash?: any) => any): any;
+export function helper(helperFn: (params: any, hash: any) => any): any;


### PR DESCRIPTION
We've had `strictFunctionTypes` disabled for `@types/ember` for a long time, and accordingly have advised Ember projects to disable that flag for themselves. Reviewing the reasons we needed that, they all stemmed from either errors in the types themselves or erroneous assertions in the tests.

This fixes those issues and sets `strictFunctionTypes: true` so we don't regress in the future.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
