### PR TITLE
[Redis] move add_command to correct location

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -1380,9 +1380,6 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
     send_command(command: string, cb?: Callback<any>): boolean;
     send_command(command: string, args?: any[], cb?: Callback<any>): boolean;
 
-    addCommand(command: string): void;
-    add_command(command: string): void;
-
     /**
      * Mark the start of a transaction block.
      */
@@ -1409,6 +1406,9 @@ export function createClient(port: number, host?: string, options?: ClientOpts):
 export function createClient(unix_socket: string, options?: ClientOpts): RedisClient;
 export function createClient(redis_url: string, options?: ClientOpts): RedisClient;
 export function createClient(options?: ClientOpts): RedisClient;
+
+export function addCommand(command: string): void;
+export function add_command(command: string): void;
 
 export function print(err: Error | null, reply: any): void;
 

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -19,6 +19,10 @@ const messageHandler: (channel: string, message: any) => void = () => {};
 const debug_mode: boolean = redis.debug_mode;
 redis.print(err, value);
 
+// Add command
+redis.add_command('my command');
+redis.addCommand('my other command');
+
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 const options: redis.ClientOpts = {
@@ -158,10 +162,6 @@ client.cork();
 client.set('abc', 'fff', strCallback);
 client.get('abc', resCallback);
 client.uncork();
-
-// Add command
-client.add_command('my command');
-client.addCommand('my other command');
 
 // redis.print as callback
 client.set(str, str, redis.print);


### PR DESCRIPTION
The original PR incorrectly added the method to the client. Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21890

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node-redis/commit/0437aa49851365bdf82711b7ff6ac7dc369ec7bb
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.