### PR TITLE
[chrome-remote-interface] declare type for `CDP.Close()` options

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -3,7 +3,11 @@ import CDP = require('chrome-remote-interface');
 (async () => {
     let client: CDP.Client | undefined;
     try {
-        const cdpPort = { port: 9223 };
+        // $ExpectError
+        const cdpOpt_err1: CDP.BaseOptions = { host: '127.0.0.1', por: 9223 };
+        // $ExpectError
+        const cdpOpt_err2: CDP.CloseOptions = { host: '127.0.0.1', port: 9223 };
+        const cdpPort: CDP.BaseOptions = { host: '127.0.0.1', port: 9223 };
         client = await CDP(cdpPort);
         const { Page, Runtime } = client;
         await Page.enable();
@@ -25,7 +29,7 @@ import CDP = require('chrome-remote-interface');
 })();
 
 (() => {
-    const cdpPort = { port: 9223 };
+    const cdpPort: CDP.BaseOptions = { port: 9223 };
     CDP(cdpPort, client => {
         CDP.List(cdpPort, (err, targets) => {
             if (!err) {

--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -3,9 +3,9 @@ import CDP = require('chrome-remote-interface');
 (async () => {
     let client: CDP.Client | undefined;
     try {
-        // $ExpectError
+        // @ts-expect-error
         const cdpOpt_err1: CDP.BaseOptions = { host: '127.0.0.1', por: 9223 };
-        // $ExpectError
+        // @ts-expect-error
         const cdpOpt_err2: CDP.CloseOptions = { host: '127.0.0.1', port: 9223 };
         const cdpPort: CDP.BaseOptions = { host: '127.0.0.1', port: 9223 };
         client = await CDP(cdpPort);

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -12,6 +12,10 @@ declare namespace CDP {
         port?: number;
     }
 
+    type CloseOptions = BaseOptions & {
+        id: string;
+    };
+
     interface ListJson {
         description: string;
         devtoolsFrontendUrl: string;
@@ -34,8 +38,8 @@ declare const CDP: {
     (callback: (client: CDP.Client) => void): void;
     (options?: CDP.BaseOptions): Promise<CDP.Client>;
 
-    Close(options: CDP.BaseOptions & { id: string }, callback: (err: Error | null) => void): void;
-    Close(options: CDP.BaseOptions & { id: string }): Promise<void>;
+    Close(options: CDP.CloseOptions, callback: (err: Error | null) => void): void;
+    Close(options: CDP.CloseOptions): Promise<void>;
 
     List(options: CDP.BaseOptions, callback: (err: Error | null, targets: CDP.ListJson[]) => void): void;
     List(callback: (err: Error | null, targets: CDP.ListJson[]) => void): void;

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cyrus-and/chrome-remote-interface
 // Definitions by: Khairul Azhar Kasmiran <https://github.com/kazarmy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.8
+// Minimum TypeScript Version: 3.9
 
 import type ProtocolProxyApi from 'devtools-protocol/types/protocol-proxy-api';
 

--- a/types/chrome-remote-interface/package.json
+++ b/types/chrome-remote-interface/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "devtools-protocol": "0.0.894172"
+        "devtools-protocol": "0.0.894467"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The type can be used as a variable type for better and earlier type-checking.