### PR TITLE
[ramda] allPass and anyPass to support type guards

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -31,6 +31,7 @@
 //                 Mike Deverell <https://github.com/devrelm>
 //                 Jorge Santana <https://github.com/LORDBABUINO>
 //                 Mikael Couzic <https://github.com/couzic>
+//                 Dimitri Mitropoulos <https://github.com/dimitropoulos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
 
@@ -61,7 +62,10 @@ import {
     Reduced,
     SafePred,
     ValueOfRecord,
-    ValueOfUnion
+    ValueOfUnion,
+    GuardPredicates,
+    UnionToIntersection,
+    TupleUnion
 } from "./tools";
 
 export * from './tools';
@@ -104,7 +108,7 @@ export function all<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
 /**
  * Given a list of predicates, returns a new predicate that will be true exactly when all of them are.
  */
-export function allPass(preds: readonly Pred[]): Pred;
+export function allPass<T extends unknown[]>(preds: Readonly<GuardPredicates<T>>): (value: unknown) => value is UnionToIntersection<TupleUnion<T>>;
 
 /**
  * Returns a function that always returns the given value.
@@ -133,7 +137,7 @@ export function any<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
 /**
  * Given a list of predicates returns a new predicate that will be true exactly when any one of them is.
  */
-export function anyPass<T>(preds: Array<SafePred<T>>): SafePred<T>;
+export function anyPass<T extends unknown[]>(preds: GuardPredicates<T>): (value: unknown) => value is TupleUnion<T>;
 
 /**
  * ap applies a list of functions to a list of values.

--- a/types/ramda/test/allPass-tests.ts
+++ b/types/ramda/test/allPass-tests.ts
@@ -10,6 +10,23 @@ import * as R from 'ramda';
   }
 
   const f = R.allPass([gt10, even]);
-  f(11); // => false
-  f(12); // => true
+
+  // $ExpectType false
+  f(11);
+
+  // $ExpectType true
+  f(12);
+
+  interface Foo {
+    foo: number;
+  }
+  interface Bar {
+    bar: string;
+  }
+  const isFoo = (value: unknown): value is Foo => true;
+  const isBar = (value: unknown): value is Bar => true;
+  const x: unknown = null;
+  const f3 = R.allPass([isFoo, isBar])
+  // $ExpectType value is Foo & Bar
+  f3(x);
 };

--- a/types/ramda/test/anyPass-tests.ts
+++ b/types/ramda/test/anyPass-tests.ts
@@ -10,9 +10,28 @@ import * as R from 'ramda';
   }
 
   const f = R.anyPass([gt10, even]);
-  f(11); // => true
-  f(8); // => true
-  f(9); // => false
 
-  const f2 = R.anyPass<number>([gt10, even]);
+  // $ExpectType true
+  f(11);
+
+  // $ExpectType true
+  f(8);
+  
+  // $ExpectType false
+  f(9);
+
+  const f2 = R.anyPass([gt10, even]);
+
+  interface Foo {
+    foo: number;
+  }
+  interface Bar {
+    bar: string;
+  }
+  const isFoo = (value: unknown): value is Foo => true;
+  const isBar = (value: unknown): value is Bar => false;
+  const x: unknown = null;
+  const f3 = R.anyPass([isFoo, isBar])
+  // $ExpectType value is Foo | Bar
+  f3(x);
 };

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -457,4 +457,18 @@ export type ValueOfRecord<R> =
  */
 export type ValueOfUnion<T> = T extends infer U ? U[keyof U] : never;
 
+export type GuardType<T extends (value: unknown) => unknown> =
+  T extends (value: unknown) => value is infer Type ? Type : never;
+
+/** a tuple containing the values of an array of type guards */
+export type GuardPredicates<T extends unknown[]> = {
+    [K in keyof T]: (value: unknown) => value is T[K];
+} & unknown[];
+
+/** creates a union of a tuple's values */
+export type TupleUnion<T extends unknown[]> = T[keyof T & number];
+
+/** Taken from type-fest */
+export type UnionToIntersection<T> = (T extends unknown ? (distributedUnion: T) => void : never) extends ((mergedIntersection: infer U) => void) ? U : never;
+
 export {};


### PR DESCRIPTION
This is a work in Progress PR, but I'd like to get some feedback from the other maintainers.

The goal is fairly simple in practice: to enhance `allPass` and `anyPass` such that they will work as expected when passed an array of type guards.

There are a few things I'm stuck on:

1. is there a way for the generic argument to either function to just be `T` and not `T extends unknown[]`.  Doing `T extends uknown[]` breaks with the rest of the API but I can't get it to work otherwise.
1. While what I implemented _does_ work for guards, it breaks for regular predicate usage.  I'm not sure how we would create a typescript ternary to separate whether an array of guards was passed or not.
1. [Bonus] I'd love it to be possible to work with a mix of guards and other helpers, but I expect this may be impossible (e.g. `allPass([isFoo, fooIsEven])`).

-----

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
