### PR TITLE
[chec/commerce.js] Checkout Token "gateways" now returns an array of Gateway types

### DIFF
--- a/types/chec__commerce.js/types/checkout-token.d.ts
+++ b/types/chec__commerce.js/types/checkout-token.d.ts
@@ -1,6 +1,7 @@
 import { Merchant } from './merchant';
 import { Extrafield } from './extrafield';
 import { ShippingMethod } from './shipping-method';
+import { Gateway } from './gateway';
 import { Live } from './live';
 import { Price } from './price';
 import { SelectedVariant } from './selected-variant';
@@ -40,61 +41,7 @@ export interface CheckoutToken {
     line_items: CheckoutTokenLineItem[];
     merchant: Merchant;
     extra_fields: Extrafield[];
-    gateways: {
-        available: {
-            test_gateway: boolean;
-            stripe: boolean;
-            square: boolean;
-            paypal: boolean;
-            paymill: boolean;
-            razorpay: boolean;
-            manual: boolean;
-        };
-        available_count: number;
-        test_gateway?: {
-            type: string;
-            settings: any;
-        };
-        stripe?: {
-            type: string;
-            settings: {
-                publishable_key: string;
-            };
-            cards_accepted: string[];
-        };
-        square?: {
-            type: string;
-            settings: {
-                application_id: string;
-                square_merchant_id: string;
-            };
-            cards_accepted: string[];
-        };
-        paypal?: {
-            type: string;
-            settings: {
-                email: string;
-            };
-        };
-        paymill?: {
-            type: string;
-            settings: {
-                public_key: string;
-            };
-            cards_accepted: string[];
-        };
-        razorpay?: {
-            type: string;
-            settings: {
-                key_id: string;
-            };
-        };
-        manual?: Array<{
-            id: string;
-            name: string;
-            details: any;
-        }>;
-    };
+    gateways: Gateway[];
     shipping_methods: ShippingMethod[];
     live: Live;
 }

--- a/types/chec__commerce.js/types/gateway.d.ts
+++ b/types/chec__commerce.js/types/gateway.d.ts
@@ -1,0 +1,15 @@
+import { Price } from './price';
+
+export interface Gateway {
+    id: string;
+    code: string;
+    sandbox: {
+        supported: boolean;
+        enabled: boolean;
+    };
+    config: any;
+    transaction_volume: Price;
+    meta: any;
+    created: number;
+    updated: number;
+}


### PR DESCRIPTION
The 2021-06-23 Chec API release changes the `gateways` key in checkout tokens from what is removed in this PR to a list of Gateway types. See https://commercejs.com/docs/release-notes/#june-23-2021 for details, and https://commercejs.com/docs/api/#gateways for the type examples.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://commercejs.com/docs/release-notes/#june-23-2021
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.