### PR TITLE
Make css-font-loading-module match TS 4.4's DOM

### DIFF
--- a/types/css-font-loading-module/css-font-loading-module-tests.ts
+++ b/types/css-font-loading-module/css-font-loading-module-tests.ts
@@ -23,7 +23,7 @@ contexts.forEach(context => {
         evt.fontfaces;
     });
     context.fonts.onloadingdone = (evt) => {
-        evt.fontfaces;
+        (evt as FontFaceSetLoadEvent).fontfaces;
     };
     context.fonts.dispatchEvent(e);
 });

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -7,15 +7,6 @@ export type FontFaceLoadStatus = 'unloaded' | 'loading' | 'loaded' | 'error';
 export type FontFaceSetLoadStatus = 'loading' | 'loaded';
 export type BinaryData = ArrayBuffer | ArrayBufferView;
 
-export interface FontFaceDescriptors {
-    style?: string;
-    weight?: string;
-    stretch?: string;
-    unicodeRange?: string;
-    variant?: string;
-    featureSettings?: string;
-}
-
 export interface FontFaceSetLoadEventInit extends EventInit {
     fontfaces?: FontFace[];
 }
@@ -28,9 +19,9 @@ export interface FontFaceSetEventMap {
 
 export interface FontFaceSet extends Set<FontFace>, EventTarget {
     // events for when loading state changes
-    onloading: ((this: FontFaceSet, event: FontFaceSetLoadEvent) => any) | null;
-    onloadingdone: ((this: FontFaceSet, event: FontFaceSetLoadEvent) => any) | null;
-    onloadingerror: ((this: FontFaceSet, event: FontFaceSetLoadEvent) => any) | null;
+    onloading: ((this: FontFaceSet, event: Event) => any ) | null;
+    onloadingdone: ((this: FontFaceSet, event: Event) => any) | null;
+    onloadingerror: ((this: FontFaceSet, event: Event) => any) | null;
 
     // EventTarget
     addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetEventMap[K], options?: boolean | AddEventListenerOptions): void;
@@ -45,6 +36,8 @@ export interface FontFaceSet extends Set<FontFace>, EventTarget {
     // (does not initiate load if not available)
     check(font: string, text?: string): boolean;
 
+    forEach(callbackfn: (value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: any): void;
+
     // async notification that font loading and layout operations are done
     readonly ready: Promise<FontFaceSet>;
 
@@ -53,8 +46,17 @@ export interface FontFaceSet extends Set<FontFace>, EventTarget {
 }
 
 declare global {
-    class FontFace {
-        constructor(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors);
+    interface FontFaceDescriptors {
+        display?: string;
+        featureSettings?: string;
+        stretch?: string;
+        style?: string;
+        unicodeRange?: string;
+        variant?: string;
+        weight?: string;
+    }
+
+    interface FontFace {
         load(): Promise<FontFace>;
 
         family: string;
@@ -70,10 +72,19 @@ declare global {
         readonly loaded: Promise<FontFace>;
     }
 
-    class FontFaceSetLoadEvent extends Event {
-        constructor(type: string, eventInitDict?: FontFaceSetLoadEventInit);
-        readonly fontfaces: FontFace[];
+    var FontFace: {
+        prototype: FontFace;
+        new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
+    };
+
+    interface FontFaceSetLoadEvent extends Event {
+        readonly fontfaces: ReadonlyArray<FontFace>;
     }
+
+    var FontFaceSetLoadEvent: {
+        prototype: FontFaceSetLoadEvent;
+        new(type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
+    };
 
     interface Document {
         fonts: FontFaceSet;

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -19,7 +19,7 @@ export interface FontFaceSetEventMap {
 
 export interface FontFaceSet extends Set<FontFace>, EventTarget {
     // events for when loading state changes
-    onloading: ((this: FontFaceSet, event: Event) => any ) | null;
+    onloading: ((this: FontFaceSet, event: Event) => any) | null;
     onloadingdone: ((this: FontFaceSet, event: Event) => any) | null;
     onloadingerror: ((this: FontFaceSet, event: Event) => any) | null;
 

--- a/types/css-font-loading-module/tsconfig.json
+++ b/types/css-font-loading-module/tsconfig.json
@@ -3,7 +3,8 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "dom.iterable"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
TS 4.4 adds CSS Font Loading to the DOM. This PR makes it match those upcoming types.

Needed after https://github.com/microsoft/TypeScript/pull/44684 is merged.
