### PR TITLE
Type declarations for cookieconsent

### DIFF
--- a/types/cookieconsent/cookieconsent-tests.ts
+++ b/types/cookieconsent/cookieconsent-tests.ts
@@ -1,0 +1,110 @@
+import { Consent, Country, Options, ServiceOptions, ServiceResponse, Service, ServiceDefinition } from 'cookieconsent';
+
+{
+    const country: Country = {
+        hasLaw: true,
+        revokable: true,
+        explicitAction: true,
+    };
+}
+
+{
+    const resp1: ServiceResponse = { code: 'foo' };
+    const resp2: ServiceResponse = new Error('foo');
+}
+
+{
+    const serviceOptions1: ServiceOptions = {
+        name: 'foo',
+    };
+
+    const serviceOptions2: ServiceOptions = {
+        name: 'foo',
+        interpolateUrl: {
+            key: 'value',
+        },
+    };
+
+    const serviceOptions3: ServiceOptions = {
+        name: 'foo',
+        interpolateUrl: {
+            key: 'value',
+        },
+        arg1: 'bar',
+        arg2: { buzz: 'bazz' },
+    };
+}
+
+{
+    const service1: Service = { name: 'foo' };
+    const service2: Service = 'foo';
+    const options: ServiceOptions = { name: 'foo' };
+    const service3: Service = () => options;
+}
+
+{
+    const ServiceDefinition1: ServiceDefinition = (options: ServiceOptions) => ({
+        url: 'foo',
+        callback(done, resp) {
+            return { code: 'us' };
+        },
+    });
+
+    const ServiceDefinition2: ServiceDefinition = (options: ServiceOptions) => ({
+        url: 'foo',
+        headers: ['Accept: application/json'],
+        callback(done, resp) {
+            return { code: 'us' };
+        },
+    });
+}
+
+{
+    const options1: Options = {};
+
+    const options2: Options = {
+        content: {},
+        elements: {},
+        palette: {},
+        law: {},
+        location: {},
+    };
+
+    const options3: Options = {
+        palette: {
+            popup: {
+                background: 'red',
+                text: 'white',
+                link: 'blue',
+            },
+            button: {
+                background: 'red',
+                border: 'white',
+                text: 'blue',
+            },
+            highlight: {
+                background: 'red',
+                border: 'white',
+                text: 'blue',
+            },
+        },
+    };
+}
+
+declare var mockConsent: Consent;
+
+{
+    mockConsent.initialise({});
+    mockConsent.initialise({}, () => {});
+    mockConsent.initialise(
+        {},
+        () => {},
+        () => {},
+    );
+
+    mockConsent.getCountryCode(
+        {},
+        () => {},
+        () => {},
+    );
+}

--- a/types/cookieconsent/index.d.ts
+++ b/types/cookieconsent/index.d.ts
@@ -1,0 +1,159 @@
+// Type definitions for cookieconsent 3.1
+// Project: https://www.npmjs.com/package/cookieconsent
+// Definitions by: Kelly Littlepage <https://github.com/klittlepage>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as CSS from 'csstype';
+
+export type Status = 'deny' | 'allow' | 'dismiss';
+
+export interface Country {
+    hasLaw: boolean;
+    revokable: boolean;
+    explicitAction: boolean;
+}
+
+export type ServiceResponse =
+    | {
+          code: string;
+      }
+    | Error;
+
+export interface ServiceOptions {
+    name: string;
+    interpolateUrl?: {
+        [key: string]: string;
+    };
+    [key: string]: unknown;
+}
+
+export type Service = ServiceOptions | string | (() => ServiceOptions);
+
+export type ServiceDefinition = (options: ServiceOptions) => {
+    url: string;
+    headers?: string[];
+    isScript?: boolean;
+    callback: (done: (resp: ServiceResponse) => void, response: string) => ServiceResponse;
+};
+
+export interface ComplianceTypes {
+    info: string;
+    'opt-in': string;
+    'opt-out': string;
+}
+
+export type LayoutTypes = { basic?: string } & { [key: string]: string };
+
+export interface Options {
+    enabled?: boolean;
+    container?: HTMLElement;
+    cookie?: {
+        name?: string;
+        path?: string;
+        domain?: string;
+        expiryDays?: number;
+        secure?: boolean;
+    };
+    onPopupOpen?: () => void;
+    onPopupClose?: () => void;
+    onInitialise?: (status: Status) => void;
+    onStatusChange?: (status: Status, chosenBefore: boolean) => void;
+    onRevokeChoice?: () => void;
+    onNoCookieLaw?: (countryCode: string, country: Country) => void;
+    content?: {
+        header?: string;
+        message?: string;
+        dismiss?: string;
+        allow?: string;
+        deny?: string;
+        link?: string;
+        href?: string;
+        close?: string;
+        target?: string;
+        policy?: string;
+    };
+    elements?: {
+        header?: string;
+        message?: string;
+        messagelink?: string;
+        dismiss?: string;
+        allow?: string;
+        deny?: string;
+        link?: string;
+        close?: string;
+    };
+    window?: string;
+    revokeBtn?: string;
+    compliance?: ComplianceTypes;
+    type?: keyof ComplianceTypes;
+    layouts?: LayoutTypes;
+    layout?: LayoutTypes;
+    position?: 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+    theme?: 'block' | 'edgeless' | 'classic';
+    static?: boolean;
+    palette?: {
+        popup?: {
+            background?: CSS.Properties['background'];
+            text?: CSS.Properties['color'];
+            link?: CSS.Properties['color'];
+        };
+
+        button?: {
+            background?: CSS.Properties['background'];
+            border?: CSS.Properties['color'];
+            text?: CSS.Properties['color'];
+        };
+
+        highlight?: {
+            background?: CSS.Properties['background'];
+            border?: CSS.Properties['color'];
+            text?: CSS.Properties['color'];
+        };
+    };
+    revokable?: boolean;
+    animateRevokable?: boolean;
+    showLink?: boolean;
+    dismissOnScroll?: boolean;
+    dismissOnTimeout?: boolean;
+    dismissOnWindowClick?: boolean;
+    ignoreClicksFrom?: string[];
+    autoOpen?: boolean;
+    autoAttach?: boolean;
+    whitelistPage?: string[];
+    blacklistPage?: string[];
+    overrideHTML?: string;
+    law?: {
+        countryCode?: string;
+        regionalLaw?: boolean;
+    };
+    location?: {
+        timeout?: number;
+        services?: Service[];
+        serviceDefinitions?: { [key: string]: ServiceDefinition };
+    };
+}
+
+export interface Popup {
+    autoOpen(options: Options): void;
+    clearStatus(): void;
+    close(showRevoke: boolean): void;
+    destroy(): void;
+    fadeIn(): void;
+    fadeOut(): void;
+    getStatus(): Status;
+    hasAnswered(options: Options): void;
+    hasConsented(): void;
+    initialise(options: Options): void;
+    isOpen(): boolean;
+    open(): void;
+    revokeChoice(preventOpen: boolean): void;
+    setStatus(status: Status): void;
+    toggleRevokeButton(show: boolean): void;
+}
+
+export interface Consent {
+    initialise(options: Options, success?: (cb: Popup) => void, error?: (cb: Popup) => void): void;
+    getCountryCode(options: Options, success: (resp: { code?: string }) => void, error: (err: Error) => void): void;
+    hasTransition: boolean;
+    hasInitialised: boolean;
+}

--- a/types/cookieconsent/package.json
+++ b/types/cookieconsent/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "csstype": "^3.0.2"
+    }
+}

--- a/types/cookieconsent/tsconfig.json
+++ b/types/cookieconsent/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cookieconsent-tests.ts"
+    ]
+}

--- a/types/cookieconsent/tslint.json
+++ b/types/cookieconsent/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Added type declarations for Osano's `cookieconsent` script:
https://www.osano.com/cookieconsent/documentation/javascript-api/

NB: the cookieconsent script as it stands is not a proper module; it works
by binding a `cookieconsent` object directly to the window object in-browser.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.