### PR TITLE
Make firefox work with TS 4.4 DOM

### DIFF
--- a/types/firefox/index.d.ts
+++ b/types/firefox/index.d.ts
@@ -22,7 +22,7 @@ interface DOMRequest<T> {
     onerror: Function;
     readyState:string; // "done" or "pending"
     result:T;
-    error:DOMError;
+    error:Error;
 }
 
 interface App {


### PR DESCRIPTION
It refers to DOMError, which is no longer declared in TS 4.4's version of the DOM.

https://github.com/microsoft/TypeScript/pull/44684