### PR TITLE
Make guacamole-client work with TS 4.4 DOM

### DIFF
--- a/types/guacamole-client/lib/BlobWriter.d.ts
+++ b/types/guacamole-client/lib/BlobWriter.d.ts
@@ -37,7 +37,7 @@ export class BlobWriter {
      * @param offset The offset of the failed read attempt within the blob, in bytes.
      * @param error The error that occurred.
      */
-    onerror: null | ((blob: Blob, offset: number, error: DOMError) => void);
+    onerror: null | ((blob: Blob, offset: number, error: Error) => void);
 
     /**
      * Fired for each successfully-read chunk of data as a blob is being sent via sendBlob().


### PR DESCRIPTION
It refers to DOMError, which is no longer declared in TS 4.4's version of the DOM.

microsoft/TypeScript#44684