### PR TITLE
Make jsdom work with TS 4.4 DOM

### DIFF
--- a/types/jsdom/base.d.ts
+++ b/types/jsdom/base.d.ts
@@ -306,7 +306,6 @@ declare module "jsdom" {
         HTMLDataElement: typeof HTMLDataElement;
         HTMLDataListElement: typeof HTMLDataListElement;
         HTMLDetailsElement: typeof HTMLDetailsElement;
-        HTMLDialogElement: typeof HTMLDialogElement;
         HTMLDirectoryElement: typeof HTMLDirectoryElement;
         HTMLFieldSetElement: typeof HTMLFieldSetElement;
         HTMLFontElement: typeof HTMLFontElement;

--- a/types/jsdom/base.d.ts
+++ b/types/jsdom/base.d.ts
@@ -306,6 +306,10 @@ declare module "jsdom" {
         HTMLDataElement: typeof HTMLDataElement;
         HTMLDataListElement: typeof HTMLDataListElement;
         HTMLDetailsElement: typeof HTMLDetailsElement;
+        HTMLDialogElement: {
+            new(): HTMLDialogElement;
+            readonly prototype: HTMLDialogElement;
+        };
         HTMLDirectoryElement: typeof HTMLDirectoryElement;
         HTMLFieldSetElement: typeof HTMLFieldSetElement;
         HTMLFontElement: typeof HTMLFontElement;


### PR DESCRIPTION
It refers to HTMLDialogElement, which is removed in TS 4.4's version of the DOM.

microsoft/TypeScript#44684