### PR TITLE
Make recordrtc work with TS 4.4 DOM

### DIFF
--- a/types/recordrtc/recordrtc-tests.ts
+++ b/types/recordrtc/recordrtc-tests.ts
@@ -2,9 +2,7 @@ import RecordRTC, { Options } from 'recordrtc';
 
 const opts: Options = {};
 
-navigator.getUserMedia(
-    { audio: true, video: true },
-    stream => {
+navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then(stream => {
         const instance = new RecordRTC(stream, {
             type: 'video',
             disableLogs: true,


### PR DESCRIPTION
Its test refers to navigator.getUserMedia, which is replaced in TS 4.4's version of the DOM with navigator.mediaDevices.getUserMedia

microsoft/TypeScript#44684
