### PR TITLE
Make voice-activity-detection work with TS 4.4 DOM

### DIFF
--- a/types/voice-activity-detection/voice-activity-detection-tests.ts
+++ b/types/voice-activity-detection/voice-activity-detection-tests.ts
@@ -10,8 +10,8 @@ requestMic();
 
 function requestMic() {
     try {
-        navigator.getUserMedia = navigator.getUserMedia;
-        navigator.getUserMedia({ audio: true }, startUserMedia, handleMicConnectError);
+        navigator.mediaDevices.getUserMedia = navigator.mediaDevices.getUserMedia;
+        navigator.mediaDevices.getUserMedia({ audio: true }).then(startUserMedia, handleMicConnectError);
     } catch (e) {
         handleUserMediaError();
     }


### PR DESCRIPTION
Its test refers to navigator.getUserMedia, which is replaced in TS 4.4's version of the DOM with navigator.mediaDevices.getUserMedia

microsoft/TypeScript#44684