### PR TITLE
Make tinymce work with TS 4.4 DOM

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -744,7 +744,7 @@ export interface Theme {
 }
 
 export interface UndoManager {
-    add(level?: {}, event?: DocumentEvent): {};
+    add(level?: {}, event?: Event): {};
 
     beforeChange(): void;
 


### PR DESCRIPTION
UndoManager refers to DocumentEvent, which is removed in TS 4.4's version of the DOM. I replaced it with Event, since I don't think it was meant to be DocumentEvent in the first place, based on DocumentEvent's definition as an event factory.

microsoft/TypeScript#44684