### PR TITLE
Make jquerymobile work with TS 4.4 DOM

### DIFF
--- a/types/jquerymobile/jquerymobile-tests.ts
+++ b/types/jquerymobile/jquerymobile-tests.ts
@@ -60,12 +60,7 @@ function test_pagesDialogs() {
     $.mobile.page.prototype.options.domCache = true;
 
     $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-        if (applicationCache &&
-             applicationCache.status != applicationCache.UNCACHED &&
-             applicationCache.status != applicationCache.OBSOLETE) {
-                 // the important bit
-            options.isLocal = true;
-        }
+        options.isLocal = true;
     });
 
     $(document).bind("pagebeforechange", function (e, data?) {


### PR DESCRIPTION
Its tests refer to applicationCache, which is removed in TS 4.4's version of the DOM.
I made the test less realistic by removing the feature-testing example code that referred to applicationCache, since it's not strictly related to jquerymobile anyway.

microsoft/TypeScript#44684
