### PR TITLE
react-gravatar: added default 'mp' to match docs

### DIFF
--- a/types/react-gravatar/index.d.ts
+++ b/types/react-gravatar/index.d.ts
@@ -22,7 +22,7 @@ declare class Gravatar extends React.Component<Gravatar.Props> {
 }
 
 declare namespace Gravatar {
-    type DefaultImage = "404" | "mm" | "identicon" | "monsterid" | "wavatar" | "retro" | "blank";
+    type DefaultImage = "404" | "mm" | "mp" | "identicon" | "monsterid" | "wavatar" | "retro" | "blank";
     type Rating = "g" | "pg" | "r" | "x";
 
     interface Props extends Partial<JSX.IntrinsicElements['img']> {


### PR DESCRIPTION
The react-gravatar docs list 'mp' (short for mystery person) as an option for a default avatar. Added this option as well to be in line with the docs.

docs reference: https://en.gravatar.com/site/implement/images/

