### PR TITLE
Ensures java-applet compiles with TS 4.4

### DIFF
--- a/types/java-applet/index.d.ts
+++ b/types/java-applet/index.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// HTMLAppletElement was removed in TS 4.4's DOM APIs
+interface HTMLAppletElement extends HTMLElement {}
+
 /**
  * @summary Java applet Status. More details: {@link http://docs.oracle.com/javase/8/docs/technotes/guides/deploy/applet_dev_guide.html#JSDPG719|Applet Status And Event Handlers}
  */

--- a/types/java-applet/tslint.json
+++ b/types/java-applet/tslint.json
@@ -9,6 +9,7 @@
         "npm-naming": false,
         "prefer-const": false,
         "trim-file": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-empty-interface": false
     }
 }


### PR DESCRIPTION
Re: https://github.com/microsoft/TypeScript/pull/44684

Adds a blank interface so that the types can extend it, which would still work with older DOM APIs with `HTMLAppletElement` included.