### PR TITLE
Make webcomponents.js work with TS 4.4 DOM

### DIFF
--- a/types/polymer/index.d.ts
+++ b/types/polymer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Polymer/polymer
 // Definitions by: Louis Grignon <https://github.com/lgrignon>, Suguru Inatomi <https://github.com/laco0416>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 4.4
 
 import { CustomElementConstructor } from "webcomponents.js";
 

--- a/types/webcomponents.js/index.d.ts
+++ b/types/webcomponents.js/index.d.ts
@@ -65,6 +65,6 @@ declare global {
         HTMLImports: HTMLImportsPolyfill;
         WebComponents: Polyfill;
 
-        customElements: CustomElementRegistry;
+        readonly customElements: CustomElementRegistry;
     }
 }

--- a/types/webcomponents.js/index.d.ts
+++ b/types/webcomponents.js/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/webcomponents/webcomponentsjs, http://webcomponents.org
 // Definitions by: Adi Dahiya <https://github.com/adidahiya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 4.4
 
 export interface CustomElementInit {
     prototype: HTMLElement;


### PR DESCRIPTION
TS 4.4 improves its types for web components. This PR makes DT match those upcoming types.

Needed after microsoft/TypeScript#44684 is merged.