### PR TITLE
Make spectrogram with TS 4.4 DOM

### DIFF
--- a/types/spectrogram/spectrogram-tests.ts
+++ b/types/spectrogram/spectrogram-tests.ts
@@ -50,11 +50,7 @@ const spectro2 = new Spectrogram(canvas2, {
 });
 
 const audioContext2 = new AudioContext();
-navigator.getUserMedia(
-    {
-        video: false,
-        audio: true
-    },
+navigator.mediaDevices.getUserMedia({ video: false, audio: true }).then(
     (stream) => {
         const input = audioContext2.createMediaStreamSource(stream);
         const analyser = audioContext2.createAnalyser();


### PR DESCRIPTION
TS 4.4 removes navigator.getUserMedia. This PR switches to navigator.mediaDevices.getUserMedia instead.

microsoft/TypeScript#44684