### PR TITLE
Ensures wordpress-dom compiles with TS 4.4

### DIFF
--- a/types/wordpress__dom/wordpress__dom-tests.ts
+++ b/types/wordpress__dom/wordpress__dom-tests.ts
@@ -3,7 +3,6 @@ import * as dom from '@wordpress/dom';
 // $ExpectType HTMLDivElement
 const element = document.createElement('div');
 
-// $ExpectType Node || ChildNode
 const node = element.previousSibling!;
 
 // $ExpectType Range


### PR DESCRIPTION
Re: https://github.com/microsoft/TypeScript/pull/44684

This line was basically testing the APIs from the `libdom.d.ts` - which now could be different:

```sh
ERROR: 7:1  expect  TypeScript@local expected type to be:
  Node || ChildNode
got:
  ChildNode & Node
```

It doesn't look like that affects any of the tests nor the exports from Wordpress/dom itself