### PR TITLE
gulp-connect - Add missing optional callback parameter

### DIFF
--- a/types/gulp-connect/gulp-connect-tests.ts
+++ b/types/gulp-connect/gulp-connect-tests.ts
@@ -119,3 +119,12 @@ gulp.task('connect', () => {
         middleware: (connect, opt) => middleware
     });
 });
+
+// Pass a callback function for when server starts listening
+gulp.task('callback-connect', () => {
+  function cb() {
+    console.log('server has started listening');
+  }
+
+  connect.server({}, cb);
+});

--- a/types/gulp-connect/index.d.ts
+++ b/types/gulp-connect/index.d.ts
@@ -68,7 +68,7 @@ export interface ConnectAppOptions {
 }
 
 /** Create a gulp-connect server with the given options */
-export function server(options?: ConnectAppOptions): ConnectAppOptions;
+export function server(options?: ConnectAppOptions, startedCallback?: () => unknown): ConnectAppOptions;
 
 /** Reload all gulp-connect servers that have livereload enabled */
 export function reload(): any;


### PR DESCRIPTION
There is an optional callback parameter in the constructor that is not typed. Although it is not documented, the source code shows that it works as one would expect. https://github.com/avevlad/gulp-connect/blob/d306eb32c362189e24d2927da712abd589796e42/src/index.coffee#L17

I have been using the callback for a while so I know it works fine but now updating to typescript, typescript throws an error as the parameter is missing from the type definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/avevlad/gulp-connect/blob/d306eb32c362189e24d2927da712abd589796e42/src/index.coffee#L17
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

