### PR TITLE
Make w3c-css-typed-om-1 work with TS 4.4 DOM

### DIFF
--- a/types/w3c-css-typed-object-model-level-1/w3c-css-typed-object-model-level-1-tests.ts
+++ b/types/w3c-css-typed-object-model-level-1/w3c-css-typed-object-model-level-1-tests.ts
@@ -214,8 +214,8 @@
     }
 };
 
+declare const x: CSSRule;
 () => {
-    const x: CSSRule = window.getMatchedCSSRules(document.body)[0];
     if (!(x instanceof CSSStyleRule)) {
         return;
     }


### PR DESCRIPTION
TS 4.4 removes getMatchedCSSRules. This PR switches the test to just declaring a variable of type CSSRule.

microsoft/TypeScript#44684