### PR TITLE
Make webrtc work with TS 4.4 DOM

### DIFF
--- a/types/webrtc/MediaStream.d.ts
+++ b/types/webrtc/MediaStream.d.ts
@@ -156,9 +156,9 @@ interface MediaTrackSettings {
 }
 
 interface MediaStreamError {
-    //name: string;
-    //message: string;
-    //constraintName: string;
+    readonly name: string;
+    readonly message: string | null;
+    readonly constraintName: string | null;
 }
 
 interface NavigatorGetUserMedia {

--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -46,7 +46,6 @@ interface RTCIceTransport {
     readonly gatheringState: RTCIceGatheringState;
     getLocalCandidates(): RTCIceCandidate[];
     getRemoteCandidates(): RTCIceCandidate[];
-    getSelectedCandidatePair(): RTCIceCandidatePair | null;
     getLocalParameters(): RTCIceParameters | null;
     getRemoteParameters(): RTCIceParameters | null;
     onstatechange: IceTransportEventHandler;
@@ -243,7 +242,7 @@ interface RTCDataChannel extends EventTarget {
     onopen: DataChannelEventHandler<Event>;
     onmessage: DataChannelEventHandler<MessageEvent>;
     onbufferedamountlow: DataChannelEventHandler<Event>;
-    onerror: DataChannelEventHandler<RTCErrorEvent>;
+    // onerror: DataChannelEventHandler<RTCErrorEvent>;
     onclose: DataChannelEventHandler<Event>;
 }
 
@@ -335,7 +334,7 @@ interface RTCPeerConnection extends EventTarget {
         successCallback: () => void,
         failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
     getStats(selector: MediaStreamTrack | null,
-        successCallback: RTCStatsCallback,
+        successCallback: (report: RTCStatsReport) => void,
         failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
 }
 interface RTCPeerConnectionStatic {


### PR DESCRIPTION
TS 4.4 further changes webrtc types. This PR makes it match those
upcoming types, commenting out types that conflict between 4.4 and
earlier versions of TS.

Needed after microsoft/TypeScript#44684 is merged.