### PR TITLE
Ensures webxr compiles with TS 4.4 

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -67,7 +67,9 @@ export type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame)
 export type XRPlaneSet = Set<XRPlane>;
 export type XRAnchorSet = Set<XRAnchor>;
 
-export type XREventHandler = EventHandlerNonNull;
+export interface XREventHandler {
+    (event: Event): any;
+}
 
 // tslint:disable-next-line no-empty-interface
 export interface XRLayer extends EventTarget {}


### PR DESCRIPTION
This type was removed in 4.4 - it was just an empty function-like interface, so I've replaced it with that.

Re: https://github.com/microsoft/TypeScript/pull/44684

