### PR TITLE
Ensures playerframework compiles with TS 4.4 -

### DIFF
--- a/types/playerframework/index.d.ts
+++ b/types/playerframework/index.d.ts
@@ -1777,7 +1777,7 @@ declare namespace PlayerFramework {
         * Sets the MSMediaKeys to be used for decrypting media data.
         * @param mediaKeys The media keys to use for decrypting media data.
         **/
-        msSetMediaKeys(mediaKeys: MSMediaKeys): void;
+        msSetMediaKeys(mediaKeys: any): void;
         /**
         * Sets the media protection manager for a given media pipeline.
         * @param mediaProtectionManager


### PR DESCRIPTION
Re: https://github.com/microsoft/TypeScript/pull/44684

I switched it from a type which doesn't exist anymore to an `any` -  I was tempted to remove all the `ms*` methods but realized that this is really for a library which no one is probably using anymore - https://archive.codeplex.com/?p=playerframework, so weakening is probably a bit better than complete removal