### PR TITLE
Make dom-mediacapture-record work on TS 4.4's DOM

### DIFF
--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -24,8 +24,8 @@ const onDataAvailable = (event: BlobEvent) => {
     const blobType = event.data.type;
 };
 
-const onError = (event: MediaRecorderErrorEvent) => {
-    const errorMessage = event.error.message;
+const onError = (event: Event) => {
+    const errorMessage = (event as MediaRecorderErrorEvent).error.message;
 };
 
 const onEvent = (event: Event) => {};
@@ -62,7 +62,7 @@ recorder.onstart = null;
 recorder.onstop = null;
 
 recorder.addEventListener('dataavailable', (e: BlobEvent) => {});
-recorder.addEventListener('error', (e: MediaRecorderErrorEvent) => {});
+recorder.addEventListener('error', (e: Event) => {});
 recorder.addEventListener('pause', onEvent);
 recorder.addEventListener('resume', onEvent);
 recorder.addEventListener('dataavailable', onEvent);

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -3,26 +3,35 @@
 // Definitions by: Elias Meire <https://github.com/elsmr>
 //                 AppLover69 <https://github.com/AppLover69>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.4
 
 interface MediaRecorderErrorEventInit extends EventInit {
     error: DOMException;
 }
 
-declare class MediaRecorderErrorEvent extends Event {
-    constructor(type: string, eventInitDict: MediaRecorderErrorEventInit);
+interface MediaRecorderErrorEvent extends Event {
     readonly error: DOMException;
 }
+
+declare var MediaRecorderErrorEvent: {
+    prototype: MediaRecorderErrorEvent;
+    new(type: string, eventInitDict: MediaRecorderErrorEventInit): MediaRecorderErrorEvent;
+};
 
 interface BlobEventInit extends EventInit {
     data: Blob;
     timecode?: number;
 }
 
-declare class BlobEvent extends Event {
-    constructor(type: string, eventInitDict: BlobEventInit);
+interface BlobEvent extends Event {
     readonly data: Blob;
-    readonly timecode: number;
+    readonly timecode: DOMHighResTimeStamp;
 }
+
+declare var BlobEvent: {
+    prototype: BlobEvent;
+    new(type: string, eventInitDict: BlobEventInit): BlobEvent;
+};
 
 type BitrateMode = 'vbr' | 'cbr';
 
@@ -34,18 +43,16 @@ interface MediaRecorderOptions {
     audioBitrateMode?: BitrateMode;
 }
 
-type RecordingState = 'inactive' | 'recording' | 'paused';
-
 interface MediaRecorderEventMap {
     "dataavailable": BlobEvent;
-    "error": MediaRecorderErrorEvent;
+    "error": Event;
     "pause": Event;
     "resume": Event;
     "start": Event;
     "stop": Event;
 }
 
-declare class MediaRecorder extends EventTarget {
+interface MediaRecorder extends EventTarget {
     readonly stream: MediaStream;
     readonly mimeType: string;
     readonly state: RecordingState;
@@ -53,14 +60,12 @@ declare class MediaRecorder extends EventTarget {
     readonly audioBitsPerSecond: number;
     readonly audioBitrateMode: BitrateMode;
 
-    ondataavailable: ((event: BlobEvent) => void) | null;
-    onerror: ((event: MediaRecorderErrorEvent) => void) | null;
-    onpause: EventListener | null;
-    onresume: EventListener | null;
-    onstart: EventListener | null;
-    onstop: EventListener | null;
-
-    constructor(stream: MediaStream, options?: MediaRecorderOptions);
+    ondataavailable: ((this: MediaRecorder, event: BlobEvent) => any) | null;
+    onerror: ((this: MediaRecorder, event: Event) => any) | null;
+    onpause: ((this: MediaRecorder, event: Event) => any) | null;
+    onresume: ((this: MediaRecorder, event: Event) => any) | null;
+    onstart: ((this: MediaRecorder, event: Event) => any) | null;
+    onstop: ((this: MediaRecorder, event: Event) => any) | null;
 
     addEventListener<K extends keyof MediaRecorderEventMap>(type: K, listener: (this: MediaRecorder, ev: MediaRecorderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -72,9 +77,13 @@ declare class MediaRecorder extends EventTarget {
     resume(): void;
     pause(): void;
     requestData(): void;
-
-    static isTypeSupported(type: string): boolean;
 }
+
+declare var MediaRecorder: {
+    prototype: MediaRecorder;
+    new(stream: MediaStream, options?: MediaRecorderOptions): MediaRecorder;
+    isTypeSupported(type: string): boolean;
+};
 
 interface Window {
     MediaRecorder: typeof MediaRecorder;


### PR DESCRIPTION
TS 4.4 changes mediacapture-record types. This PR makes it match those
upcoming types.

Needed after microsoft/TypeScript#44684 is merged.