### PR TITLE
Check for parent === null in jquery.postmessage tests

### DIFF
--- a/types/jquery.postmessage/jquery.postmessage-tests.ts
+++ b/types/jquery.postmessage/jquery.postmessage-tests.ts
@@ -2,6 +2,7 @@
 /// <reference types="jquery" />
 
 function test_postMessage() {
+    if (!parent) return;
     // post plain message
     $.postMessage('test message', 'http://dummy.url/', parent);
 


### PR DESCRIPTION
Discovered while upgrading to TS 4.4's DOM.

microsoft/TypeScript#44684
