### PR TITLE
fix(prettier): all `default` value should be optional

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -360,9 +360,14 @@ export interface SupportOptionRange {
 
 export type SupportOptionType = 'int' | 'boolean' | 'choice' | 'path';
 
+export type CoreCategoryType = 'Config' | 'Editor' | 'Format' | 'Other' | 'Output' | 'Global' | 'Special'
+
 export interface BaseSupportOption<Type extends SupportOptionType> {
     readonly name?: string;
     since: string;
+    /**
+     * Usually you can use {@link CoreCategoryType}
+     */
     category: string;
     /**
      * The type of the option.
@@ -387,30 +392,30 @@ export interface BaseSupportOption<Type extends SupportOptionType> {
 }
 
 export interface IntSupportOption extends BaseSupportOption<'int'> {
-    default: number;
+    default?: number;
     array?: false;
     range?: SupportOptionRange;
 }
 
 export interface IntArraySupportOption extends BaseSupportOption<'int'> {
-    default: Array<{ value: number[] }>;
+    default?: Array<{ value: number[] }>;
     array: true;
 }
 
 export interface BooleanSupportOption extends BaseSupportOption<'boolean'> {
-    default: boolean;
+    default?: boolean;
     array?: false;
     description: string;
     oppositeDescription?: string;
 }
 
 export interface BooleanArraySupportOption extends BaseSupportOption<'boolean'> {
-    default: Array<{ value: boolean[] }>;
+    default?: Array<{ value: boolean[] }>;
     array: true;
 }
 
 export interface ChoiceSupportOption<Value = any> extends BaseSupportOption<'choice'> {
-    default: Value | Array<{ since: string; value: Value }>;
+    default?: Value | Array<{ since: string; value: Value }>;
     description: string;
     choices: Array<{
         since?: string;
@@ -420,12 +425,12 @@ export interface ChoiceSupportOption<Value = any> extends BaseSupportOption<'cho
 }
 
 export interface PathSupportOption extends BaseSupportOption<'path'> {
-    default: string;
+    default?: string;
     array?: false;
 }
 
 export interface PathArraySupportOption extends BaseSupportOption<'path'> {
-    default: Array<{ value: string[] }>;
+    default?: Array<{ value: string[] }>;
     array: true;
 }
 

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -7,6 +7,7 @@
 //                 Christopher Quadflieg <https://github.com/Shinigami92>
 //                 Kevin Deisz <https://github.com/kddeisz>
 //                 Georgii Dolzhykov <https://github.com/thorn0>
+//                 JounQin <https://github.com/JounQin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
@@ -360,7 +361,7 @@ export interface SupportOptionRange {
 
 export type SupportOptionType = 'int' | 'boolean' | 'choice' | 'path';
 
-export type CoreCategoryType = 'Config' | 'Editor' | 'Format' | 'Other' | 'Output' | 'Global' | 'Special'
+export type CoreCategoryType = 'Config' | 'Editor' | 'Format' | 'Other' | 'Output' | 'Global' | 'Special';
 
 export interface BaseSupportOption<Type extends SupportOptionType> {
     readonly name?: string;

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -222,6 +222,11 @@ const plugin: prettier.Plugin<PluginAST> = {
             array: true,
             default: [{ value: ['./pathA.js', './pathB.js'] }],
         },
+        testNoDefaultOption: {
+            since: '1.0.0',
+            type: 'path',
+            category: 'Test',
+        }
     },
 };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/prettier/prettier/blob/main/src/cli/usage.js#L29
https://github.com/prettier/prettier/blob/main/src/cli/create-minimist-options.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
