### PR TITLE
[preact-custom-element] Make `tagName` parameter optional

### DIFF
--- a/types/preact-custom-element/index.d.ts
+++ b/types/preact-custom-element/index.d.ts
@@ -7,7 +7,7 @@
 import { ComponentClass, FunctionComponent, FunctionalComponent } from 'preact';
 declare function register(
     componentDefinition: FunctionComponent<any> | ComponentClass<any> | FunctionalComponent<any>,
-    tagName: string,
+    tagName?: string,
     observedAttributes?: string[],
     options?: { shadow: boolean },
 ): void;

--- a/types/preact-custom-element/preact-custom-element-tests.tsx
+++ b/types/preact-custom-element/preact-custom-element-tests.tsx
@@ -6,3 +6,12 @@ const Foo: FunctionalComponent<any> = props => {
 };
 
 register(Foo, 'my-foo');
+
+class Bar extends Component {
+    static tagName = 'my-bar';
+    static observedAttributes = [];
+    render() {
+        return <div>bar</div>;
+    }
+}
+register(Bar);


### PR DESCRIPTION
`register()` can be called with just a single parameter, so the `tagName` parameter should be optional:
https://github.com/preactjs/preact-custom-element#prop-names-and-automatic-prop-names

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/preactjs/preact-custom-element#prop-names-and-automatic-prop-names
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *(Version unchanged)*