### PR TITLE
[express-serve-static-core] fix stack depth error on long path parameters

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -80,6 +80,14 @@ app.get('/:foo/:bar(\\d:+)/:baz', req => {
     req.params.quxx; // $ExpectType string
 });
 
+// long path parameters - not supported - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53513#issuecomment-870550063
+app.get('/website-api/jobalarm/:jobalarmId/:subscriptionId/search', req => {
+    req.params.foo; // $ExpectType string
+    req.params.bar; // $ExpectType string
+    req.params.qux; // $ExpectType string
+    req.params.quxx; // $ExpectType string
+});
+
 // Query can be a custom type
 app.get<{}, any, any, { q: string }>('/:foo', req => {
     req.query.q; // $ExpectType string

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -80,12 +80,11 @@ app.get('/:foo/:bar(\\d:+)/:baz', req => {
     req.params.quxx; // $ExpectType string
 });
 
-// long path parameters - not supported - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53513#issuecomment-870550063
+// long path parameters - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53513#issuecomment-870550063
 app.get('/website-api/jobalarm/:jobalarmId/:subscriptionId/search', req => {
-    req.params.foo; // $ExpectType string
-    req.params.bar; // $ExpectType string
-    req.params.qux; // $ExpectType string
-    req.params.quxx; // $ExpectType string
+    req.params.jobalarmId; // $ExpectType string
+    req.params.subscriptionId; // $ExpectType string
+    req.params.foo; // $ExpectError
 });
 
 // Query can be a custom type

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -98,13 +98,11 @@ export type RequestHandlerParams<
     | ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>
     | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
 
-type GetRouteParameter<RouteAfterColon extends string, Depth extends never[] = []> = Depth['length'] extends 10
-    ? never
-    : RouteAfterColon extends `${infer Char}${infer Rest}`
-    ? Char extends '/' | '-' | '.'
-        ? ''
-        : `${Char}${GetRouteParameter<Rest, [...Depth, never]>}`
-    : RouteAfterColon;
+type RemoveTail<S extends string, Tail extends string> = S extends `${infer P}${Tail}` ? P : S;
+type GetRouteParameter<S extends string> = RemoveTail<
+    RemoveTail<RemoveTail<S, `/${string}`>, `-${string}`>,
+    `.${string}`
+>;
 
 // prettier-ignore
 export type RouteParameters<Route extends string> = string extends Route


### PR DESCRIPTION
Please fill in this template.

fix for this issue caused by my previous PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53513#issuecomment-870550063

i'm not really sure if this is the best way to detect the stack depth error. open to suggestions

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53513#issuecomment-870550063
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
