### PR TITLE
dom-mediacapture-record: inline RecordingState type alias

### DIFF
--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -38,7 +38,7 @@ recorder.stop();
 recorder.start(1000);
 recorder.pause();
 recorder.requestData();
-const state: RecordingState = recorder.state;
+const state: 'inactive' | 'recording' | 'paused' = recorder.state;
 const isRecording = state === 'recording';
 const isAudioVariableBitrate = recorder.audioBitrateMode === 'vbr';
 

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -55,7 +55,7 @@ interface MediaRecorderEventMap {
 interface MediaRecorder extends EventTarget {
     readonly stream: MediaStream;
     readonly mimeType: string;
-    readonly state: RecordingState;
+    readonly state: 'inactive' | 'recording' | 'paused';
     readonly videoBitsPerSecond: number;
     readonly audioBitsPerSecond: number;
     readonly audioBitrateMode: BitrateMode;


### PR DESCRIPTION
This allows the latest version of the package to work with pre-4.4 Typescripts.
