### PR TITLE
react-simple-maps: update types for `onMove*` events of `ZoomableGroup`

### DIFF
--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -77,8 +77,9 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
      * @default false
      */
     disableZooming?: boolean | undefined;
-    onMoveStart?: ((event: any, position: Position) => void) | undefined;
-    onMoveEnd?: ((event: any, position: Position) => void) | undefined;
+    onMoveStart?: ((position: { coordinates: [number, number], zoom: number }, event: any) => void) | undefined;
+    onMove?: ((position: {x: number, y: number, k: number, dragging: WheelEvent }, event: any) => void) | undefined;
+    onMoveEnd?: ((position: { coordinates: [number, number], zoom: number }, event: any) => void) | undefined;
     onZoomStart?: ((event: any, position: Position) => void) | undefined;
     onZoomEnd?: ((event: any, position: Position) => void) | undefined;
     filterZoomEvent?: ((event: any) => boolean) | undefined;


### PR DESCRIPTION
- onMoveStart - https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L43
- onMove - https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L51
- onMoveEnd - https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L62