### PR TITLE
Add explicit version dependency on @types/serve-static

### DIFF
--- a/types/express/package.json
+++ b/types/express/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "dependencies": {
-    "@types/express-serve-static-core": "^4.17.18"
+    "@types/express-serve-static-core": "^4.17.18",
+    "@types/serve-static": "^1.13.9"
   },
   "types": "index",
   "typesVersions": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/serve-static
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


This PR makes the version dependency of `@types/express` on `@types/serve-static` explicit, which fixes the compilation error I'm seeing:
```
Error: node_modules/@types/express/ts4.0/index.d.ts:43:29 - error TS2694: Namespace 'serveStatic' has no exported member 'RequestHandlerConstructor'.

43     var static: serveStatic.RequestHandlerConstructor<Response>;
                               ~~~~~~~~~~~~~~~~~~~~~~~~~
```
because `npm install` installs a requirement on `@types/serve-static` of version `*` that winds up being `1.13.6` which does not include commit 02b1ba5b78a3959945d7f9a7b9dd3529a7e3c0a7