### PR TITLE
Inline idle request callback

### DIFF
--- a/types/requestidlecallback/index.d.ts
+++ b/types/requestidlecallback/index.d.ts
@@ -5,7 +5,6 @@
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 //                 Teramoto Daiki <https://github.com/teramotodaiki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.4
 
 /// <reference lib="dom" />
 

--- a/types/requestidlecallback/index.d.ts
+++ b/types/requestidlecallback/index.d.ts
@@ -21,12 +21,12 @@ interface IdleRequestOptions {
 type IdleCallbackHandle = number;
 
 interface Window {
-    requestIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;
+    requestIdleCallback(callback: (deadline: IdleDeadline) => void, options?: IdleRequestOptions): IdleCallbackHandle;
     cancelIdleCallback(handle: number): void;
 }
 
-declare function requestIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): number;
+declare function requestIdleCallback(callback: (deadline: IdleDeadline) => void, options?: IdleRequestOptions): number;
 declare function cancelIdleCallback(handle: number): void;
 
-declare function request(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;
+declare function request(callback: (deadline: IdleDeadline) => void, options?: IdleRequestOptions): IdleCallbackHandle;
 declare function cancel(handle: IdleCallbackHandle): void;


### PR DESCRIPTION
The type alias IdleRequestCallback can't be defined twice in 4.4, but inlining its definition allows older Typescripts to keep using requestidlecallback.