### PR TITLE
Removed unnecessary children prop in react-scroll-sync props interfaces

### DIFF
--- a/types/react-scroll-sync/index.d.ts
+++ b/types/react-scroll-sync/index.d.ts
@@ -7,7 +7,6 @@ import * as React from 'react';
 
 export interface ScrollSyncProps {
     onSync?(el: Element): void;
-    children: React.ReactNode;
     proportional?: boolean;
     vertical?: boolean;
     horizontal?: boolean;
@@ -15,7 +14,6 @@ export interface ScrollSyncProps {
 }
 
 export interface ScrollSyncPaneProps {
-    children: React.ReactNode;
     attachTo?: HTMLElement;
     group?: string;
     enabled?: boolean;


### PR DESCRIPTION
This PR removes the `children` prop defined in the `ScrollSyncProps` and `ScrollSyncPaneProps` interfaces, as discussed in #54170.

Fixes #54171

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components