### PR TITLE
[braintree-web] typed `HostedFields.getState`

### DIFF
--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -124,11 +124,19 @@ export type HostedFieldsFieldDataFields = {
     [key in HostedFieldsHostedFieldsFieldName]: HostedFieldsHostedFieldsFieldData;
 };
 
-export interface HostedFieldsStateObject {
+export interface HostedFieldsState {
     cards: HostedFieldsHostedFieldsCard[];
-    emittedBy: HostedFieldsHostedFieldsFieldName;
     fields: HostedFieldsFieldDataFields;
 }
+
+export interface HostedFieldsEvent extends HostedFieldsState {
+    emittedBy: HostedFieldsHostedFieldsFieldName;
+}
+
+/**
+ * @deprecated Turned into an alias. Use `HostedFieldsEvent` instead
+ */
+export type HostedFieldsStateObject = HostedFieldsEvent;
 
 export type HostedFieldEventType = 'blur' | 'focus' | 'empty' | 'notEmpty'
     | 'cardTypeChange' | 'validityChange' | 'inputSubmitRequest';
@@ -233,8 +241,8 @@ export interface HostedFields {
      */
     VERSION: string;
 
-    on(event: HostedFieldEventType, handler: (event: HostedFieldsStateObject) => void): void;
-    off(event: HostedFieldEventType, handler: (event: HostedFieldsStateObject) => void): void;
+    on(event: HostedFieldEventType, handler: (event: HostedFieldsEvent) => void): void;
+    off(event: HostedFieldEventType, handler: (event: HostedFieldsEvent) => void): void;
 
     teardown(callback?: callback): void;
     teardown(): Promise<void>;
@@ -356,7 +364,7 @@ export interface HostedFields {
      *   return state.fields[key].isValid;
      * });
      */
-    getState(): any;
+    getState(): HostedFieldsState;
 
     /**
      * Programmatically focus a {@link module:braintree-web/hosted-fields-field field}.     *

--- a/types/braintree-web/test/node.ts
+++ b/types/braintree-web/test/node.ts
@@ -258,10 +258,7 @@ braintree.client.create(
                 hostedFieldsInstance.clear('expirationDate');
 
                 const state = braintree.hostedFields.getState();
-
-                const formValid = Object.keys(state.fields).every(key => {
-                    return state.fields[key].isValid;
-                });
+                Object.keys(state.fields).map(k => k as keyof typeof state.fields).every(k => state.fields[k].isValid);
 
                 hostedFieldsInstance.focus('cardholderName');
                 hostedFieldsInstance.focus('number', (focusErr: braintree.BraintreeError) => {

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -294,10 +294,7 @@ braintree.client.create(
                 hostedFieldsInstance.clear('expirationDate');
 
                 const state = braintree.hostedFields.getState();
-
-                const formValid = Object.keys(state.fields).every(key => {
-                    return state.fields[key].isValid;
-                });
+                Object.keys(state.fields).map(k => k as keyof typeof state.fields).every(k => state.fields[k].isValid);
 
                 hostedFieldsInstance.focus('cardholderName');
                 hostedFieldsInstance.focus('number', (focusErr: braintree.BraintreeError) => {


### PR DESCRIPTION
Changed `HostedFieldsStateObject` into the more aptly named `HostedFieldsEvent`. Left the former as an alias marked for deprecation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [braintree-web/hosted-fields.js/_state](https://github.com/braintree/braintree-web/blob/f8bc2aa78c3fe1fb7efeece24be0d88c46f50ed1/src/hosted-fields/external/hosted-fields.js#L437)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
