### PR TITLE
[chrome-remote-interface] Add event callbacks

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -21,6 +21,18 @@ import CDP = require('chrome-remote-interface');
         const loadEvent = await client['Page.loadEventFired'](); // instead of: await Page.loadEventFired();
         loadEvent.timestamp;
         await client['Page.interstitialHidden'](); // instead of: await Page.interstitialHidden();
+        // instead of: Network.requestWillBeSent((params, sessionId) => {});
+        const unsubscribe = client['Network.requestWillBeSent']((params, sessionId) => {
+            params.request.url;
+            unsubscribe();
+        });
+        const unsubscribe2 = client['Network.requestWillBeSent']((params) => {
+            params.request.url;
+            unsubscribe2();
+        });
+        const unsubscribe3 = client['Page.frameResized'](() => {
+            unsubscribe3();
+        });
         await Runtime.enable();
         const loc = await Runtime.evaluate({ expression: 'window.location.toString()' });
         const targets = await CDP.List(cdpPort);

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -205,7 +205,7 @@ declare namespace CDP {
     };
 
     type EventCallbacks<T extends ProtocolMappingApi.Events> = {
-        [Property in keyof T]: (callback: (params: T[Property] extends [any] ? T[Property][0] : undefined, sessionId?: string) => void) => () => void;
+        [Property in keyof T]: (callback: (params: T[Property] extends [any] ? T[Property][0] : undefined, sessionId?: string) => void) => () => CDP.Client;
     };
 }
 

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -197,11 +197,15 @@ declare namespace CDP {
         Tracing: ProtocolProxyApi.TracingApi;
         WebAudio: ProtocolProxyApi.WebAudioApi;
         WebAuthn: ProtocolProxyApi.WebAuthnApi;
-    } & EventPromises<ProtocolMappingApi.Events>;
+    } & EventPromises<ProtocolMappingApi.Events> & EventCallbacks<ProtocolMappingApi.Events>;
 
     // '<domain>.<event>' i.e. Page.loadEventFired
     type EventPromises<T extends ProtocolMappingApi.Events> = {
         [Property in keyof T]: () => T[Property] extends [any] ? Promise<T[Property][0]> : Promise<void>;
+    };
+
+    type EventCallbacks<T extends ProtocolMappingApi.Events> = {
+        [Property in keyof T]: (callback: (params: T[Property] extends [any] ? T[Property][0] : undefined, sessionId?: string) => void) => () => void;
     };
 }
 

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -205,7 +205,7 @@ declare namespace CDP {
     };
 
     type EventCallbacks<T extends ProtocolMappingApi.Events> = {
-        [Property in keyof T]: (callback: (params: T[Property] extends [any] ? T[Property][0] : undefined, sessionId?: string) => void) => () => CDP.Client;
+        [Property in keyof T]: (callback: (params: T[Property] extends [any] ? T[Property][0] : undefined, sessionId?: string) => void) => () => Client;
     };
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/chrome-remote-interface#clientdomaineventsessionid-callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
