### PR TITLE
Make aframe work with TS 4.4 DOM

### DIFF
--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -331,7 +331,6 @@ export interface Utils {
     };
     device: {
         isWebXRAvailable: boolean;
-        getVRDisplay(): VRDisplay[];
         checkHeadsetConnected(): boolean;
         checkHasPositionalTracking(): boolean;
         isMobile(): boolean;


### PR DESCRIPTION
Typescript 4.4's version of the DOM no longer includes VRDisplay, meaning that `getVRDisplay` needs to be removed or its return type polyfilled. In this PR I remove `getVRDisplay`.
