### PR TITLE
Fix amap-js-api-transfer test for TS 4.4

### DIFF
--- a/types/amap-js-api-transfer/amap-js-api-transfer-tests.ts
+++ b/types/amap-js-api-transfer/amap-js-api-transfer-tests.ts
@@ -43,7 +43,7 @@ transfer.search(lnglat, lnglat, (status, result) => {
             end.location;
             // $ExpectType string
             end.name;
-            // $ExpectType "start" | "end"
+            // $ExpectType "end" | "start" || "start" | "end"
             end.type;
         }
         // $ExpectType string


### PR DESCRIPTION
TS 4.4 changes the order that it displays the union `"start" | "end"`.
