### PR TITLE
`debug`:  adds "selectColor" method to debug.Debug (default) interface

### DIFF
--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -33,3 +33,8 @@ extendedWithCustomDelimiter("Testing this is an IDebugger, too.");
 debug2.log = console.log.bind(console);
 const anotherLogger = debug2("DefinitelyTyped:error");
 anotherLogger("This should be printed to stdout");
+
+// $ExpectType string | number
+debug1.selectColor("DefinitelyTyped:log");
+// $ExpectType string | number
+debug2.selectColor("DefinitelyTyped:log");

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -6,6 +6,7 @@
 //                 Brasten Sager <https://github.com/brasten>
 //                 Nicolas Penin <https://github.com/npenin>
 //                 Kristian Brünn <https://github.com/kristianmitk>
+//                 Caleb Gregory <https://github.com/calebgregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var debug: debug.Debug & { debug: debug.Debug; default: debug.Debug };
@@ -21,6 +22,7 @@ declare namespace debug {
         enable: (namespaces: string) => void;
         enabled: (namespaces: string) => boolean;
         log: (...args: any[]) => any;
+        selectColor: (namespace: string) => string | number;
 
         names: RegExp[];
         skips: RegExp[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`selectColor` definition](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/common.js#L35-L51), which pulls a value off of `createDebug.colors`, which varies according to declaration in [`node.js` (number)](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/node.js#L27) and [`browser.js` (string)](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/browser.js#L27).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.