### PR TITLE
Make d3-shape tests pass in TS 4.4 and earlier

### DIFF
--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -173,10 +173,13 @@ canvasArc(arcDefaultDatum);
 // use with svg
 
 const pArc: Selection<SVGPathElement, ArcDatum, any, any> = select<SVGPathElement, ArcDatum>('.arc-paths'); // mock
+const svgArc2: d3Shape.Arc<SVGEllipseElement, ArcDatum> = d3Shape.arc<SVGEllipseElement, ArcDatum>();
 const wrongArc1: Selection<SVGCircleElement, ArcDatum, any, any> = select<SVGCircleElement, ArcDatum>('.arc-paths'); // mock
 const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.arc-paths'); // mock
 
 pArc.attr('d', svgArc);
+// $ExpectError
+wrongArc1.attr('d', svgArc2); // fails, incompatible datum types
 // $ExpectError
 wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
@@ -1189,6 +1192,9 @@ defaultLinkRadial(defaultLinkDatum);
 // vertical/horizontal
 
 pLink.attr('d', svgLink);
+declare const svgLink2: d3Shape.Link<SVGEllipseElement, HierarchyPointLink<TreeNodeDatum>, HierarchyPointNode<TreeNodeDatum>>;
+// $ExpectError
+wrongLink1.attr('d', svgLink2); // fails, incompatible datum types
 // $ExpectError
 wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
@@ -1199,7 +1205,10 @@ pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 
 // radial
 
+declare const svgLinkRadial2: d3Shape.LinkRadial<SVGEllipseElement, HierarchyPointLink<TreeNodeDatum>, HierarchyPointNode<TreeNodeDatum>>;
 pLink.attr('d', svgLinkRadial);
+// $ExpectError
+wrongLink1.attr('d', svgLinkRadial2); // fails, incompatible datum types
 // $ExpectError
 wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
@@ -1313,10 +1322,13 @@ const symbolDatum: SymbolDatum = {
 };
 
 const pSymbol: Selection<SVGPathElement, SymbolDatum, any, any> = select<SVGPathElement, SymbolDatum>('.symbol-path'); // mock
+declare const svgSymbol2: d3Shape.Symbol<SVGEllipseElement, SymbolDatum>;
 const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<SVGCircleElement, SymbolDatum>('.symbol-path'); // mock
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
+// $ExpectError
+wrongSymbol1.attr('d', svgSymbol2); // fails, incompatible datum types
 // $ExpectError
 wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 

--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -178,8 +178,6 @@ const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<
 
 pArc.attr('d', svgArc);
 // $ExpectError
-wrongArc1.attr('d', svgArc); // fails, incompatible this contexts
-// $ExpectError
 wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
 // $ExpectError
@@ -1192,8 +1190,6 @@ defaultLinkRadial(defaultLinkDatum);
 
 pLink.attr('d', svgLink);
 // $ExpectError
-wrongLink1.attr('d', svgLink); // fails, incompatible this contexts
-// $ExpectError
 wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
 pathStringMaybe = link(linkDatum);
@@ -1204,8 +1200,6 @@ pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 // radial
 
 pLink.attr('d', svgLinkRadial);
-// $ExpectError
-wrongLink1.attr('d', svgLinkRadial); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
@@ -1323,8 +1317,6 @@ const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
-// $ExpectError
-wrongSymbol1.attr('d', svgSymbol); // fails, incompatible this contexts
 // $ExpectError
 wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 

--- a/types/d3-shape/v1/d3-shape-tests.ts
+++ b/types/d3-shape/v1/d3-shape-tests.ts
@@ -178,8 +178,6 @@ const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<
 
 pArc.attr('d', svgArc);
 // $ExpectError
-wrongArc1.attr('d', svgArc); // fails, incompatible this contexts
-// $ExpectError
 wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
 // $ExpectError
@@ -1161,8 +1159,6 @@ defaultLinkRadial(defaultLinkDatum);
 
 pLink.attr('d', svgLink);
 // $ExpectError
-wrongLink1.attr('d', svgLink); // fails, incompatible this contexts
-// $ExpectError
 wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
 pathStringMaybe = link(linkDatum);
@@ -1173,8 +1169,6 @@ pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 // radial
 
 pLink.attr('d', svgLinkRadial);
-// $ExpectError
-wrongLink1.attr('d', svgLinkRadial); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
@@ -1272,8 +1266,6 @@ const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
-// $ExpectError
-wrongSymbol1.attr('d', svgSymbol); // fails, incompatible this contexts
 // $ExpectError
 wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 

--- a/types/d3-shape/v1/d3-shape-tests.ts
+++ b/types/d3-shape/v1/d3-shape-tests.ts
@@ -171,12 +171,14 @@ centroid = svgArc.centroid(arcDefaultDatum); // fails, wrong datum type
 canvasArc(arcDefaultDatum);
 
 // use with svg
-
+const svgArc2: d3Shape.Arc<SVGEllipseElement, ArcDatum> = d3Shape.arc<SVGEllipseElement, ArcDatum>();
 const pArc: Selection<SVGPathElement, ArcDatum, any, any> = select<SVGPathElement, ArcDatum>('.arc-paths'); // mock
 const wrongArc1: Selection<SVGCircleElement, ArcDatum, any, any> = select<SVGCircleElement, ArcDatum>('.arc-paths'); // mock
 const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.arc-paths'); // mock
 
 pArc.attr('d', svgArc);
+// $ExpectError
+wrongArc1.attr('d', svgArc2); // fails, incompatible this contexts
 // $ExpectError
 wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
@@ -1156,8 +1158,10 @@ defaultLinkRadial(defaultLinkDatum);
 // Render to svg ---------------------------------------------------------------------
 
 // vertical/horizontal
-
 pLink.attr('d', svgLink);
+declare const svgLink2: d3Shape.Link<SVGEllipseElement, HierarchyPointLink<TreeNodeDatum>, HierarchyPointNode<TreeNodeDatum>>;
+// $ExpectError
+wrongLink1.attr('d', svgLink2); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
@@ -1169,6 +1173,9 @@ pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 // radial
 
 pLink.attr('d', svgLinkRadial);
+declare const svgLinkRadial2: d3Shape.LinkRadial<SVGEllipseElement, HierarchyPointLink<TreeNodeDatum>, HierarchyPointNode<TreeNodeDatum>>;
+// $ExpectError
+wrongLink1.attr('d', svgLinkRadial2); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
@@ -1266,6 +1273,9 @@ const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
+declare const svgSymbol2: d3Shape.Symbol<SVGEllipseElement, SymbolDatum>;
+// $ExpectError
+wrongSymbol1.attr('d', svgSymbol2); // fails, incompatible this contexts
 // $ExpectError
 wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 

--- a/types/d3-shape/v2/d3-shape-tests.ts
+++ b/types/d3-shape/v2/d3-shape-tests.ts
@@ -173,10 +173,13 @@ canvasArc(arcDefaultDatum);
 // use with svg
 
 const pArc: Selection<SVGPathElement, ArcDatum, any, any> = select<SVGPathElement, ArcDatum>('.arc-paths'); // mock
+const svgArc2: d3Shape.Arc<SVGEllipseElement, ArcDatum> = d3Shape.arc<SVGEllipseElement, ArcDatum>();
 const wrongArc1: Selection<SVGCircleElement, ArcDatum, any, any> = select<SVGCircleElement, ArcDatum>('.arc-paths'); // mock
 const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.arc-paths'); // mock
 
 pArc.attr('d', svgArc);
+// $ExpectError
+wrongArc1.attr('d', svgArc2); // fails, incompatible this contexts
 // $ExpectError
 wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
@@ -1189,6 +1192,9 @@ defaultLinkRadial(defaultLinkDatum);
 // vertical/horizontal
 
 pLink.attr('d', svgLink);
+declare const svgLink2: d3Shape.Link<SVGEllipseElement, HierarchyPointLink<TreeNodeDatum>, HierarchyPointNode<TreeNodeDatum>>;
+// $ExpectError
+wrongLink1.attr('d', svgLink2); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
@@ -1200,6 +1206,9 @@ pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 // radial
 
 pLink.attr('d', svgLinkRadial);
+declare const svgLinkRadial2: d3Shape.LinkRadial<SVGEllipseElement, HierarchyPointLink<TreeNodeDatum>, HierarchyPointNode<TreeNodeDatum>>;
+// $ExpectError
+wrongLink1.attr('d', svgLinkRadial2); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
@@ -1317,6 +1326,9 @@ const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
+declare const svgSymbol2: d3Shape.Symbol<SVGEllipseElement, SymbolDatum>;
+// $ExpectError
+wrongSymbol1.attr('d', svgSymbol2); // fails, incompatible this contexts
 // $ExpectError
 wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 

--- a/types/d3-shape/v2/d3-shape-tests.ts
+++ b/types/d3-shape/v2/d3-shape-tests.ts
@@ -178,8 +178,6 @@ const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<
 
 pArc.attr('d', svgArc);
 // $ExpectError
-wrongArc1.attr('d', svgArc); // fails, incompatible this contexts
-// $ExpectError
 wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
 // $ExpectError
@@ -1192,8 +1190,6 @@ defaultLinkRadial(defaultLinkDatum);
 
 pLink.attr('d', svgLink);
 // $ExpectError
-wrongLink1.attr('d', svgLink); // fails, incompatible this contexts
-// $ExpectError
 wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
 pathStringMaybe = link(linkDatum);
@@ -1204,8 +1200,6 @@ pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 // radial
 
 pLink.attr('d', svgLinkRadial);
-// $ExpectError
-wrongLink1.attr('d', svgLinkRadial); // fails, incompatible this contexts
 // $ExpectError
 wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
@@ -1323,8 +1317,6 @@ const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
-// $ExpectError
-wrongSymbol1.attr('d', svgSymbol); // fails, incompatible this contexts
 // $ExpectError
 wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 


### PR DESCRIPTION
TS 4.4's DOM ends up making SVGCircleElement assignable to SVGPathElement because they have no unique properties -- they are structurally compatible. That means that $ExpectErrors in the test no longer fail.

Because the two types are still incompatible in TS 4.3, I couldn't find a better way to fix these tests for both 4.3 and 4.4 than to delete them. Since the intent appears to be to test `attr`, it might make sense to find related types that *are* incompatible.

Edit: I decided to introduce new variables with related, incompatible types instead.