### PR TITLE
Fix dom-mediacapture-record tests for TS 4.4

### DIFF
--- a/types/dom-mediacapture-transform/dom-mediacapture-transform-tests.ts
+++ b/types/dom-mediacapture-transform/dom-mediacapture-transform-tests.ts
@@ -1,4 +1,5 @@
 // Allow await in the code below.
+declare const imageBitmap: ImageBitmap;
 async function topLevel() {
     ////////////////////////////////////////////////////////////////////////////////
     // Based on the example from the spec: https://w3c.github.io/mediacapture-transform/#examples
@@ -92,8 +93,6 @@ async function topLevel() {
 
     // MediaStreamTrackGenerator-video.https.html
 
-    const offscreenCanvas = new OffscreenCanvas(1, 1);
-    const imageBitmap = offscreenCanvas.transferToImageBitmap();
     const videoFrame = new VideoFrame(imageBitmap, { timestamp: 1 });
 
     const videoCaptureStream = await navigator.mediaDevices.getUserMedia({ video: true });


### PR DESCRIPTION
OffscreenCanvas doesn't exist as a way to get ImageBitmaps anymore.
