### PR TITLE
Upgrade wordpress/* type dependencies

### DIFF
--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/block-editor 2.2
+// Type definitions for @wordpress/block-editor 6.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>

--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0",
-        "react-autosize-textarea": "^7.0.0"
+        "@wordpress/element": "^3.0.0",
+        "react-autosize-textarea": "^7.1.0"
     }
 }

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -272,8 +272,7 @@ export namespace AttributeSource {
         | {
               type: 'string';
               default?: string;
-          }
-    );
+          });
 
     interface Children {
         source: 'children';
@@ -331,8 +330,7 @@ export namespace AttributeSource {
         | {
               type: 'string';
               default?: string;
-          }
-    );
+          });
 }
 
 export type BlockAttribute<T> =

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/blocks 6.4
+// Type definitions for @wordpress/blocks 9.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>
@@ -272,7 +272,8 @@ export namespace AttributeSource {
         | {
               type: 'string';
               default?: string;
-          });
+          }
+    );
 
     interface Children {
         source: 'children';
@@ -330,7 +331,8 @@ export namespace AttributeSource {
         | {
               type: 'string';
               default?: string;
-          });
+          }
+    );
 }
 
 export type BlockAttribute<T> =

--- a/types/wordpress__blocks/package.json
+++ b/types/wordpress__blocks/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0"
+        "@wordpress/element": "^3.0.0"
     }
 }

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/components 9.8
+// Type definitions for @wordpress/components 14.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>

--- a/types/wordpress__components/package.json
+++ b/types/wordpress__components/package.json
@@ -1,8 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0",
-        "downshift": "^4.0.5",
-        "re-resizable": "^4.7.1"
+        "@wordpress/element": "^3.0.0",
+        "downshift": "^6.0.15",
+        "re-resizable": "^6.4.0"
     }
 }

--- a/types/wordpress__compose/index.d.ts
+++ b/types/wordpress__compose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/compose 3.4
+// Type definitions for @wordpress/compose 4.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/compose/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__compose/package.json
+++ b/types/wordpress__compose/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0"
+        "@wordpress/element": "^3.0.0"
     }
 }

--- a/types/wordpress__edit-post/index.d.ts
+++ b/types/wordpress__edit-post/index.d.ts
@@ -163,7 +163,7 @@ export function initializeEditor(
     postId: string | number,
     settings?: Partial<EditorSettings>,
     // FIXME: it is unclear what this is
-    initialEdits?: object,
+    initialEdits?: object
 ): void;
 
 /**
@@ -184,10 +184,12 @@ export function reinitializeEditor(
     target: Element,
     settings?: Partial<EditorSettings>,
     // FIXME: it is unclear what this is
-    initialEdits?: object,
+    initialEdits?: object
 ): void;
 
-export { default as PluginBlockSettingsMenuItem } from './components/block-settings-menu/plugin-block-settings-menu-item';
+export {
+    default as PluginBlockSettingsMenuItem,
+} from './components/block-settings-menu/plugin-block-settings-menu-item';
 export { default as PluginDocumentSettingPanel } from './components/sidebar/plugin-document-setting-panel';
 export { default as PluginMoreMenuItem } from './components/header/plugin-more-menu-item';
 export { default as PluginPostPublishPanel } from './components/sidebar/plugin-post-publish-panel';

--- a/types/wordpress__edit-post/index.d.ts
+++ b/types/wordpress__edit-post/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/edit-post 3.5
+// Type definitions for @wordpress/edit-post 4.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/edit-post/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -163,7 +163,7 @@ export function initializeEditor(
     postId: string | number,
     settings?: Partial<EditorSettings>,
     // FIXME: it is unclear what this is
-    initialEdits?: object
+    initialEdits?: object,
 ): void;
 
 /**
@@ -184,12 +184,10 @@ export function reinitializeEditor(
     target: Element,
     settings?: Partial<EditorSettings>,
     // FIXME: it is unclear what this is
-    initialEdits?: object
+    initialEdits?: object,
 ): void;
 
-export {
-    default as PluginBlockSettingsMenuItem,
-} from './components/block-settings-menu/plugin-block-settings-menu-item';
+export { default as PluginBlockSettingsMenuItem } from './components/block-settings-menu/plugin-block-settings-menu-item';
 export { default as PluginDocumentSettingPanel } from './components/sidebar/plugin-document-setting-panel';
 export { default as PluginMoreMenuItem } from './components/header/plugin-more-menu-item';
 export { default as PluginPostPublishPanel } from './components/sidebar/plugin-post-publish-panel';

--- a/types/wordpress__edit-post/package.json
+++ b/types/wordpress__edit-post/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0"
+        "@wordpress/element": "^3.0.0"
     }
 }

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/editor 9.4
+// Type definitions for @wordpress/editor 10.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__editor/package.json
+++ b/types/wordpress__editor/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0"
+        "@wordpress/element": "^3.0.0"
     }
 }

--- a/types/wordpress__media-utils/index.d.ts
+++ b/types/wordpress__media-utils/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/media-utils 0.2
+// Type definitions for @wordpress/media-utils 2.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/media-utils/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__media-utils/package.json
+++ b/types/wordpress__media-utils/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0"
+        "@wordpress/element": "^3.0.0"
     }
 }

--- a/types/wordpress__plugins/index.d.ts
+++ b/types/wordpress__plugins/index.d.ts
@@ -69,5 +69,5 @@ export function unregisterPlugin(name: string): Plugin | undefined;
  * A Higher Order Component used to inject Plugin context to the wrapped component.
  */
 export function withPluginContext<CP = {}, OP = {}>(
-    mapContextToProps: (context: PluginContext, props: OP) => CP,
+    mapContextToProps: (context: PluginContext, props: OP) => CP
 ): (Component: ComponentType<CP & OP>) => ComponentType<OP>;

--- a/types/wordpress__plugins/index.d.ts
+++ b/types/wordpress__plugins/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/plugins 2.3
+// Type definitions for @wordpress/plugins 3.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/plugins/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -69,5 +69,5 @@ export function unregisterPlugin(name: string): Plugin | undefined;
  * A Higher Order Component used to inject Plugin context to the wrapped component.
  */
 export function withPluginContext<CP = {}, OP = {}>(
-    mapContextToProps: (context: PluginContext, props: OP) => CP
+    mapContextToProps: (context: PluginContext, props: OP) => CP,
 ): (Component: ComponentType<CP & OP>) => ComponentType<OP>;

--- a/types/wordpress__plugins/package.json
+++ b/types/wordpress__plugins/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^2.14.0"
+        "@wordpress/element": "^3.0.0"
     }
 }


### PR DESCRIPTION
Upgrade dependencies for @wordpress/* types.

When using several @wordpress/* type packages, they'll pull in stale (non-type) dependencies _duplicating_ dependencies of the actual @wordpress/* package.

- @wordpress/element
- downshift
- react-autosize-textarea
- re-resizable

This updates all affected packages to the major version aligning with current dependencies:

- https://unpkg.com/browse/@wordpress/block-editor@6.0.0/package.json
- https://unpkg.com/browse/@wordpress/blocks@9.0.0/package.json
- https://unpkg.com/browse/@wordpress/components@14.0.0/package.json
- https://unpkg.com/browse/@wordpress/compose@4.0.0/package.json
- https://unpkg.com/browse/@wordpress/edit-post@4.0.0/package.json
- https://unpkg.com/browse/@wordpress/editor@10.0.0/package.json
- https://unpkg.com/browse/@wordpress/media-utils@2.0.0/package.json
- https://unpkg.com/browse/@wordpress/plugins@3.0/package.json

No other changes have been made.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
