### PR TITLE
[@types/koa__router] add optional generic types to method function definitions

### DIFF
--- a/types/koa__router/index.d.ts
+++ b/types/koa__router/index.d.ts
@@ -180,266 +180,145 @@ declare class Router<StateT = any, CustomT = {}> {
     /**
      * HTTP get method
      */
-    get(
+    get<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    get(
+    get<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    get<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    get<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP post method
      */
-    post(
+    post<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    post(
+    post<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    post<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    post<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP put method
      */
-    put(
+    put<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    put(
+    put<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    put<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    put<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP link method
      */
-    link(
+    link<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    link(
+    link<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    link<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    link<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP unlink method
      */
-    unlink(
+    unlink<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    unlink(
+    unlink<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    unlink<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    unlink<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP delete method
      */
-    delete(
+    delete<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    delete(
+    delete<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    delete<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    delete<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * Alias for `router.delete()` because delete is a reserved word
      */
-    del(
+    del<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    del(
+    del<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    del<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    del<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP head method
      */
-    head(
+    head<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    head(
+    head<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    head<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    head<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP options method
      */
-    options(
+    options<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    options(
+    options<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    options<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    options<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP patch method
      */
-    patch(
+    patch<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    patch(
+    patch<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    patch<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    patch<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * Register route with all methods.
      */
-    all(
+    all<T = {}, U = {}>(
         name: string,
         path: string | RegExp,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    all(
+    all<T = {}, U = {}>(
         path: string | RegExp | Array<string | RegExp>,
-        ...middleware: Array<Router.Middleware<StateT, CustomT>>
+        ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
     ): Router<StateT, CustomT>;
-    all<T, U>(
-        name: string,
-        path: string | RegExp,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
-    all<T, U>(
-        path: string | RegExp | Array<string | RegExp>,
-        middleware: Koa.Middleware<T, U>,
-        routeHandler: Router.Middleware<StateT & T, CustomT & U>
-    ): Router<StateT & T, CustomT & U>;
 
     /**
      * Set the path prefix for a Router instance that was already initialized.

--- a/types/koa__router/koa__router-tests.ts
+++ b/types/koa__router/koa__router-tests.ts
@@ -192,3 +192,26 @@ router5.register('/foo', ['GET'], middleware1, {
     name: 'foo',
 });
 router5.register('/bar', ['GET', 'DELETE'], [middleware1, middleware2]);
+
+const router6 = new Router<{}>();
+router6.post<MyState, MyContext>('/foo', async (ctx) => {
+    ctx.state.foo = 'bar';
+    ctx.bar = 'foo';
+});
+router6.put<MyState>('/bar', async (ctx) => {
+    ctx.state.foo = 'bar';
+    // $ExpectError
+    ctx.bar = 'foo';
+});
+router6.del('/baz', async (ctx) => {
+    // $ExpectError
+    ctx.state.foo = 'bar';
+    // $ExpectError
+    ctx.bar = 'foo';
+});
+router6.put<number>('/blah', async (ctx) => {
+    ctx.state = 123;
+});
+router6.put<string>('/blerg', async (ctx) => {
+    ctx.state = 'abc';
+});

--- a/types/koa__router/tslint.json
+++ b/types/koa__router/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Description

The existing definitions allowed for typing the `METHOD` functions - `get/put/post/del/etc.` - to specify a `state` and `ctx` for that specific route method.

```ts
put<T, U>(
    path: string | RegExp | Array<string | RegExp>,
    middleware: Koa.Middleware<T, U>,
    routeHandler: Router.Middleware<StateT & T, CustomT & U>
): Router<StateT & T, CustomT & U>;
```

However, the signatures for those functions don't match the implementation in [`@koajs/router`](https://github.com/koajs/router/blob/master/lib/router.js#L191), where all the function parameters passed to the `METHOD` function are treated the same. So, there shouldn't be any distinction between `middleware` and `routeHandler` in the library, and therefor shouldn't be in the definitions.

```ts
put<T = {}, U = {}>(
    path: string | RegExp | Array<string | RegExp>,
    ...middleware: Array<Router.Middleware<StateT & T, CustomT & U>>
): Router<StateT, CustomT>;
```

This change makes all `METHOD` functions optionally typed, with the `state` and `ctx` types safely defaulting to `{}` since they're intersected with the middleware types. This means we're no longer allowing an explicit `middleware: Koa.Middleware<T, U>` argument, but this shouldn't be a problem since `Router.Middleware<StateT & T, CustomT & U>` extends it.

All existing tests pass, and I've added some additional tests to demonstrate and validate the new definitions' functionality. These changes shouldn't affect existing users of the definitions.

### `tslint` Change

I added `"no-unnecessary-generics": false` since that rule is raising a false alarm on the new function definitions. This is commonplace throughout many types in DT.