### PR TITLE
matter-js fix Composite.add and World.add argument types

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1275,7 +1275,7 @@ declare namespace Matter {
          * @param {} object
          * @return {composite} The original composite with the objects added
          */
-        static add(composite: Composite, object: Body | Composite | Constraint): Composite;
+        static add(composite: Composite, object: Body | Composite | Constraint | MouseConstraint | Array<Body | Composite | Constraint | MouseConstraint>): Composite;
 
         /**
          * Returns all bodies in the given composite, including all bodies in its children, recursively.
@@ -3196,7 +3196,7 @@ declare namespace Matter {
          * @param body
          * @returns world
          */
-        static add(world: World, body: Body | Array<Body> | Composite | Array<Composite> | Constraint | Array<Constraint> | MouseConstraint): World;
+        static add(world: World, body: Body | Composite | Constraint | MouseConstraint | Array<Body | Composite | Constraint | MouseConstraint>): World;
 
         /**
          * An alias for Composite.addBody since World is also a Composite

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -1,8 +1,9 @@
-import Matter = require("matter-js");
+import Matter = require('matter-js');
 var Engine = Matter.Engine,
     World = Matter.World,
     Body = Matter.Body,
     Bodies = Matter.Bodies,
+    Composite = Matter.Composite,
     Composites = Matter.Composites,
     Constraint = Matter.Constraint,
     Events = Matter.Events,
@@ -12,35 +13,34 @@ var Engine = Matter.Engine,
     Mouse = Matter.Mouse,
     MouseConstraint = Matter.MouseConstraint;
 
-
 Matter.use('matter-attractors');
-Plugin.use(Matter, ["matter-wrap"]);
+Plugin.use(Matter, ['matter-wrap']);
 
 var engine = Engine.create();
 
 //Bodies
-var box1 = Bodies.rectangle(400,200,80,80);
-var box2 = Bodies.rectangle(400,610,810,60, {
+var box1 = Bodies.rectangle(400, 200, 80, 80);
+var box2 = Bodies.rectangle(400, 610, 810, 60, {
     angle: 10,
     angularSpeed: 11,
     angularVelocity: 1,
     density: 4,
-    isStatic: true
+    isStatic: true,
 });
 
-var circle1 = Bodies.circle(100,100,50, {
+var circle1 = Bodies.circle(100, 100, 50, {
     plugin: {
         wrap: {
             min: {
                 x: 0,
-                y: 0
+                y: 0,
             },
             max: {
                 x: 1024,
-                y: 1024
-            }
-        }
-    }
+                y: 1024,
+            },
+        },
+    },
 });
 var radius = circle1.circleRadius;
 Body.setCentre(circle1, Matter.Vector.create(10, 10), true);
@@ -49,21 +49,20 @@ World.addBody(engine.world, box1);
 World.add(engine.world, [box2, circle1]);
 
 // Body - collision filter
-var box3 = Bodies.rectangle(400,200,80,80, {
+var box3 = Bodies.rectangle(400, 200, 80, 80, {
     collisionFilter: {
-        category: 1 // Allows only one option to be defined
-    }
+        category: 1, // Allows only one option to be defined
+    },
 });
 
-var box4 = Bodies.rectangle(400,200,80,80, {
-    collisionFilter: {} // Or none
+var box4 = Bodies.rectangle(400, 200, 80, 80, {
+    collisionFilter: {}, // Or none
 });
-
 
 //Composites
-var stack = Composites.stack(0, 100, 5, 1, 20, 0, function(x:number, y:number, column:number, row:number) {
-            return Bodies.circle(x, y, 75, { restitution: 0.9 });
-        });
+var stack = Composites.stack(0, 100, 5, 1, 20, 0, function (x: number, y: number, column: number, row: number) {
+    return Bodies.circle(x, y, 75, { restitution: 0.9 });
+});
 
 const cradle = Composites.newtonsCradle(200, 50, 5, 20, 250);
 
@@ -74,22 +73,18 @@ var constraint1 = Constraint.create({
     bodyA: box1,
     bodyB: box2,
     stiffness: 0.02,
-    damping: 0.01
+    damping: 0.01,
 });
 
 World.addConstraint(engine.world, constraint1);
 
 //Query
-var collisions = Query.ray([box1, box2, circle1], {x:1, y:2}, {x:3, y:4});
+var collisions = Query.ray([box1, box2, circle1], { x: 1, y: 2 }, { x: 3, y: 4 });
 
-collisions = Query.collides(box1, [box2, circle1])
-
+collisions = Query.collides(box1, [box2, circle1]);
 
 //events
-Events.on(engine, "beforeTick", (e:Matter.IEventTimestamped<Matter.Engine>)=>{
-
-});
-
+Events.on(engine, 'beforeTick', (e: Matter.IEventTimestamped<Matter.Engine>) => {});
 
 Engine.run(engine);
 
@@ -99,27 +94,44 @@ var render = Render.create({
     bounds: {
         min: {
             x: -500,
-            y: -500
+            y: -500,
         },
         max: {
             x: 500,
-            y: 500
-        }
-    }
-})
+            y: 500,
+        },
+    },
+});
 
 // Runner
 const runner1 = Matter.Runner.create({
     delta: 1000 / 60,
     isFixed: false,
-    enabled: true
+    enabled: true,
 });
 const runner2 = Matter.Runner.create({});
 const runner3 = Matter.Runner.create();
 
 // Mouse
-
 const mouse = Mouse.create(render.canvas);
 const mouseConstraint = MouseConstraint.create(engine, { mouse });
 
-Events.on(mouseConstraint, 'mousemove', (e: Matter.IMouseEvent<Matter.MouseConstraint>) => {})
+Events.on(mouseConstraint, 'mousemove', (e: Matter.IMouseEvent<Matter.MouseConstraint>) => {});
+
+// Composite
+// $ExpectType Composite
+var composite1 = Composite.create();
+// $ExpectType Composite
+var composite2 = Composite.create();
+// $ExpectType Composite
+var composite3 = Composite.create();
+// $ExpectType Composite
+Composite.add(composite1, box1);
+// $ExpectType Composite
+Composite.add(composite2, composite1);
+// $ExpectType Composite
+Composite.add(composite1, constraint1);
+// $ExpectType Composite
+Composite.add(composite1, mouseConstraint);
+// $ExpectType Composite
+Composite.add(composite3, [box1, composite2, constraint1, mouseConstraint]);


### PR DESCRIPTION
Hello, the signature for the function Composite.add was missing a couple of types in the union; the documentation indicates that Composite.add accepts arrays in addition to a single Body/Composite/Constraint (https://brm.io/matter-js/docs/classes/Composite.html) and the definition of the function indicates that it also accepts MouseConstraint (see the last case of the switch statement: https://github.com/liabru/matter-js/blob/e909b0466cea2051267bab92a38ccaa9bf7f154e/src/body/Composite.js#L84)

I also changed World.add because World is an alias for Composite (https://brm.io/matter-js/docs/classes/World.html) and World subclasses Composite in the type definitions. Composite.add accepts mixed-type arrays (see definition) but the old signature of World did not reflect this