### PR TITLE
Updated gulp-sass definition to v5

### DIFF
--- a/types/gulp-sass-variables/gulp-sass-variables-tests.ts
+++ b/types/gulp-sass-variables/gulp-sass-variables-tests.ts
@@ -1,5 +1,4 @@
 import * as gulp from 'gulp';
-import gulpSass = require('gulp-sass');
 import sassVariables = require('gulp-sass-variables');
 
 const IS_DEVELOPMENT = true;
@@ -9,6 +8,5 @@ gulp.task('styles', () => {
         .pipe(sassVariables({
             $IS_DEVELOPMENT: IS_DEVELOPMENT
         }))
-        .pipe(gulpSass())
         .pipe(gulp.dest('./dist/css'));
 });

--- a/types/gulp-sass/gulp-sass-tests.ts
+++ b/types/gulp-sass/gulp-sass-tests.ts
@@ -1,5 +1,7 @@
 import gulp = require("gulp");
-import sass = require("gulp-sass");
+import gulpSass = require("gulp-sass");
+
+const sass = gulpSass({}); // compiler
 
 gulp.task('sass', function () {
     gulp.src('./scss/*.scss')
@@ -9,7 +11,7 @@ gulp.task('sass', function () {
 
 gulp.task('sass', function () {
     gulp.src('./scss/*.scss')
-        .pipe(sass({errLogToConsole: true}))
+        .pipe(sass({ errLogToConsole: true }))
         .pipe(sass.sync())
         .pipe(gulp.dest('./css'));
 });

--- a/types/gulp-sass/index.d.ts
+++ b/types/gulp-sass/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gulp-sass 4.0.2
+// Type definitions for gulp-sass 5.0.0
 // Project: https://github.com/dlmanning/gulp-sass
 // Definitions by: Asana <https://asana.com>
 //                 Yuma Hashimoto <https://github.com/yuma84>
@@ -34,11 +34,17 @@ interface GulpSassOptions extends SassOptions {
     sync?: boolean;
 }
 
-interface Sass {
+interface GulpSass {
     (opts?: GulpSassOptions): NodeJS.ReadWriteStream;
     logError(error?: string): void;
     sync(options?: GulpSassOptions): NodeJS.ReadWriteStream;
 }
 
-declare var _tmp: Sass;
+type Compiler = any;
+
+interface GulpSassFactory {
+    (compiler: Compiler): GulpSass
+}
+
+declare var _tmp: GulpSassFactory;
 export = _tmp;


### PR DESCRIPTION
The gulp-sass@v5 has breaking change in the main export. Now the module requires the compiler parameter.
The compiler is another module which gulp-sass wraps. Because the compiler module can have no definition (or can have wrong/outdate one), the compiler param is typed as any.
This is enough to address the breaking change, keep the typescript compiler happy and the developer experience smooth (no need to precisely type the compiler param and track such dependency).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dlmanning/gulp-sass#migrating-to-version-5
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

