### PR TITLE
feat: add type definitions for intl-unofficial-duration-unit-format

### DIFF
--- a/types/intl-unofficial-duration-unit-format/index.d.ts
+++ b/types/intl-unofficial-duration-unit-format/index.d.ts
@@ -4,9 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.9
 
-export type DurationUnitFormatStyle = 'custom' | 'timer' | 'long' | 'short' | 'narrow';
+export type DurationUnitFormatStyle = typeof DurationUnitFormat.styles[keyof typeof DurationUnitFormat.styles];
 
-export type DurationUnitFormatUnit = 'day' | 'hour' | 'minute' | 'second';
+export type DurationUnitFormatUnit = typeof DurationUnitFormat.units[keyof typeof DurationUnitFormat.units];
 
 export type DurationUnitFormatPartType = DurationUnitFormatUnit | 'literal' | 'group' | 'unit';
 

--- a/types/intl-unofficial-duration-unit-format/index.d.ts
+++ b/types/intl-unofficial-duration-unit-format/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for intl-unofficial-duration-unit-format 3.1
+// Project: https://github.com/piuccio/intl-unofficial-duration-unit-format
+// Definitions by: Maxim Khvatalin <https://github.com/khmm12>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
+
+export type DurationUnitFormatStyle = 'custom' | 'timer' | 'long' | 'short' | 'narrow';
+
+export type DurationUnitFormatUnit = 'day' | 'hour' | 'minute' | 'second';
+
+export type DurationUnitFormatPartType = DurationUnitFormatUnit | 'literal' | 'group' | 'unit';
+
+export interface DurationUnitFormatPart {
+    type: DurationUnitFormatPartType;
+    value: string;
+}
+
+export interface DurationUnitFormatOptions {
+    style?: DurationUnitFormatStyle;
+    format?: string;
+    formatDuration?: string;
+    formatUnits?: Record<DurationUnitFormatUnit, string>;
+    round?: boolean;
+}
+
+export default class DurationUnitFormat {
+    constructor(locales?: string | ReadonlyArray<string>, options?: DurationUnitFormatOptions);
+
+    static styles: {
+        CUSTOM: 'custom';
+        TIMER: 'timer';
+        LONG: 'long';
+        SHORT: 'short';
+        NARROW: 'narrow';
+    };
+
+    static units: {
+        DAY: 'day';
+        HOUR: 'hour';
+        MINUTE: 'minute';
+        SECOND: 'second';
+    };
+
+    format: (value: number) => string;
+    formatToParts: (value: number) => DurationUnitFormatPart[];
+}

--- a/types/intl-unofficial-duration-unit-format/intl-unofficial-duration-unit-format-tests.ts
+++ b/types/intl-unofficial-duration-unit-format/intl-unofficial-duration-unit-format-tests.ts
@@ -1,0 +1,55 @@
+import DurationUnitFormat from 'intl-unofficial-duration-unit-format';
+
+new DurationUnitFormat().format(10);
+
+new DurationUnitFormat('en').format(10);
+
+new DurationUnitFormat(['en-GB', 'en-US']).format(10);
+
+// @ts-expect-error
+new DurationUnitFormat('en').format(undefined);
+
+new DurationUnitFormat('en', {
+    style: 'custom',
+});
+
+new DurationUnitFormat('en', {
+    style: DurationUnitFormat.styles.CUSTOM,
+});
+
+new DurationUnitFormat('en', {
+    // @ts-expect-error
+    style: 'wrong',
+});
+
+new DurationUnitFormat('en', {
+    formatUnits: {
+        day: '{value}',
+        hour: '{value}',
+        minute: '{value}',
+        second: '{value}',
+    },
+});
+
+new DurationUnitFormat('en', {
+    formatUnits: {
+        // @ts-expect-error
+        wrong: '{value}',
+    },
+});
+
+new DurationUnitFormat('en', {
+    // @ts-expect-error
+    formatUnits: {},
+});
+
+new DurationUnitFormat('en', {
+    formatUnits: {
+        [DurationUnitFormat.units.DAY]: '{value}',
+        [DurationUnitFormat.units.HOUR]: '{value}',
+        [DurationUnitFormat.units.MINUTE]: '{value}',
+        [DurationUnitFormat.units.SECOND]: '{value}',
+    },
+});
+
+new DurationUnitFormat().formatToParts(10);

--- a/types/intl-unofficial-duration-unit-format/intl-unofficial-duration-unit-format-tests.ts
+++ b/types/intl-unofficial-duration-unit-format/intl-unofficial-duration-unit-format-tests.ts
@@ -6,7 +6,7 @@ new DurationUnitFormat('en').format(10);
 
 new DurationUnitFormat(['en-GB', 'en-US']).format(10);
 
-// @ts-expect-error
+// $ExpectError
 new DurationUnitFormat('en').format(undefined);
 
 new DurationUnitFormat('en', {
@@ -18,7 +18,7 @@ new DurationUnitFormat('en', {
 });
 
 new DurationUnitFormat('en', {
-    // @ts-expect-error
+    // $ExpectError
     style: 'wrong',
 });
 
@@ -33,13 +33,13 @@ new DurationUnitFormat('en', {
 
 new DurationUnitFormat('en', {
     formatUnits: {
-        // @ts-expect-error
+        // $ExpectError
         wrong: '{value}',
     },
 });
 
 new DurationUnitFormat('en', {
-    // @ts-expect-error
+    // $ExpectError
     formatUnits: {},
 });
 

--- a/types/intl-unofficial-duration-unit-format/tsconfig.json
+++ b/types/intl-unofficial-duration-unit-format/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "intl-unofficial-duration-unit-format-tests.ts"]
+}

--- a/types/intl-unofficial-duration-unit-format/tslint.json
+++ b/types/intl-unofficial-duration-unit-format/tslint.json
@@ -1,0 +1,12 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [["NeedsExportEquals", false]]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
https://github.com/piuccio/intl-unofficial-duration-unit-format

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
