### PR TITLE
Add undefined to optional properties, part Y

### DIFF
--- a/types/ya-disk/index.d.ts
+++ b/types/ya-disk/index.d.ts
@@ -70,21 +70,21 @@ interface SystemFolders {
 }
 
 export interface Resource {
-    public_key?: string;
-    public_url?: string;
-    _embedded?: boolean;
-    preview?: string;
+    public_key?: string | undefined;
+    public_url?: string | undefined;
+    _embedded?: boolean | undefined;
+    preview?: string | undefined;
     name: string;
     custom_properties: Record<string, string>;
     created: string;
     modified: string;
     path: string;
-    origin_path?: string;
+    origin_path?: string | undefined;
     md5: string;
     type: ResourceType;
     mime_type: string;
     size: number;
-    file?: string;
+    file?: string | undefined;
 }
 
 interface FilesResourceList {
@@ -108,27 +108,27 @@ interface ApiResponse<T> {
 }
 
 interface GetProps {
-    fields?: string;
-    sort?: Sort;
-    limit?: number;
-    offset?: number;
-    preview_size?: PreviewSize;
-    preview_crop?: boolean;
+    fields?: string | undefined;
+    sort?: Sort | undefined;
+    limit?: number | undefined;
+    offset?: number | undefined;
+    preview_size?: PreviewSize | undefined;
+    preview_crop?: boolean | undefined;
 }
 
 interface ListProps {
-    limit?: number;
-    media_type?: MediaType;
-    offset?: number;
-    preview_size?: PreviewSize;
-    preview_crop?: boolean;
+    limit?: number | undefined;
+    media_type?: MediaType | undefined;
+    offset?: number | undefined;
+    preview_size?: PreviewSize | undefined;
+    preview_crop?: boolean | undefined;
 }
 
 interface RecentProps {
-    limit?: number;
-    media_type?: MediaType;
-    preview_size?: PreviewSize;
-    preview_crop?: boolean;
+    limit?: number | undefined;
+    media_type?: MediaType | undefined;
+    preview_size?: PreviewSize | undefined;
+    preview_crop?: boolean | undefined;
 }
 
 export namespace download {

--- a/types/yadda/lib/Macro.d.ts
+++ b/types/yadda/lib/Macro.d.ts
@@ -1,3 +1,3 @@
 export interface Options {
-    mode?: "promise" | "sync";
+    mode?: "promise" | "sync" | undefined;
 }

--- a/types/yadda/lib/parsers/FeatureParser.d.ts
+++ b/types/yadda/lib/parsers/FeatureParser.d.ts
@@ -2,7 +2,7 @@ import Language = require("../localisation/Language");
 
 declare namespace FeatureParser {
     interface Options {
-        language?: Language<Language.Library>;
+        language?: Language<Language.Library> | undefined;
         leftPlaceholderChar: string;
         rightPlaceholderChar: string;
     }

--- a/types/yaireo__tagify/dist/react.tagify.d.ts
+++ b/types/yaireo__tagify/dist/react.tagify.d.ts
@@ -54,13 +54,13 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default undefined
          */
-        autoFocus?: boolean;
+        autoFocus?: boolean | undefined;
 
         /**
          * Initial value, i.e. the initial tags that are shown.
          * @deprecated Specify the tags via the `value` property.
          */
-        children?: string | string[];
+        children?: string | string[] | undefined;
 
         /**
          * Optional class name to be added to the component.
@@ -69,7 +69,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default undefined
          */
-        className?: string;
+        className?: string | undefined;
 
         /**
          * Same as `value`. Initial value, i.e. the initial tags that are shown.
@@ -81,7 +81,7 @@ declare namespace Tags {
          * correspondingly.
          * @default undefined
          */
-        defaultValue?: string | string[] | T[];
+        defaultValue?: string | string[] | T[] | undefined;
 
         /**
          * Toggles loading state for the whole component.
@@ -91,7 +91,7 @@ declare namespace Tags {
          * correspondingly.
          * @default false
          */
-        loading?: boolean;
+        loading?: boolean | undefined;
 
         /**
          * Value for the `name` attribute of the `INPUT` or `TEXTAREA` element.
@@ -101,7 +101,7 @@ declare namespace Tags {
          * correspondingly.
          * @default undefined
          */
-        name?: string;
+        name?: string | undefined;
 
         /**
          * Callback invoked when a tag has been added.
@@ -110,7 +110,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onAdd?: (event: CustomEvent<AddEventData<T>>) => void;
+        onAdd?: ((event: CustomEvent<AddEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the component lost focus.
@@ -119,7 +119,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onBlur?: (event: CustomEvent<BlurEventData<T>>) => void;
+        onBlur?: ((event: CustomEvent<BlurEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when any change to the value has occurred.
@@ -128,7 +128,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onChange?: (event: CustomEvent<ChangeEventData<T>>) => void;
+        onChange?: ((event: CustomEvent<ChangeEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a tag was clicked.
@@ -137,7 +137,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onClick?: (event: CustomEvent<ClickEventData<T>>) => void;
+        onClick?: ((event: CustomEvent<ClickEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the suggestions dropdown has been removed from
@@ -147,7 +147,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onDropdownHide?: (event: CustomEvent<DropDownHideEventData<T>>) => void;
+        onDropdownHide?: ((event: CustomEvent<DropDownHideEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when no whitelist suggestion item matched for the
@@ -159,7 +159,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onDropdownNoMatch?: (event: CustomEvent<DropDownNoMatchEventData<T>>) => void;
+        onDropdownNoMatch?: ((event: CustomEvent<DropDownNoMatchEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the dropdown was scrolled by the user. Use
@@ -169,7 +169,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onDropdownScroll?: (event: CustomEvent<DropDownScrollEventData<T>>) => void;
+        onDropdownScroll?: ((event: CustomEvent<DropDownScrollEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a suggestions dropdown item was selected (by
@@ -179,7 +179,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onDropdownSelect?: (event: CustomEvent<DropDownSelectEventData<T>>) => void;
+        onDropdownSelect?: ((event: CustomEvent<DropDownSelectEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the suggestions dropdown is about to be
@@ -189,7 +189,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onDropdownShow?: (event: CustomEvent<DropDownShowEventData<T>>) => void;
+        onDropdownShow?: ((event: CustomEvent<DropDownShowEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the dropdown menu is open and its items were
@@ -199,7 +199,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onDropdownUpdated?: (event: CustomEvent<DropDownUpdatedEventData<T>>) => void;
+        onDropdownUpdated?: ((event: CustomEvent<DropDownUpdatedEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked just before a tag has been updated, while still in
@@ -209,7 +209,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onEditBeforeUpdate?: (event: CustomEvent<EditBeforeUpdateEventData<T>>) => void;
+        onEditBeforeUpdate?: ((event: CustomEvent<EditBeforeUpdateEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when typing inside an edited tag.
@@ -218,7 +218,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onEditInput?: (event: CustomEvent<EditInputEventData<T>>) => void;
+        onEditInput?: ((event: CustomEvent<EditInputEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a keydown event occurs while an edited tag is
@@ -228,7 +228,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onEditKeydown?: (event: CustomEvent<EditKeydownEventData<T>>) => void;
+        onEditKeydown?: ((event: CustomEvent<EditKeydownEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a tag is now in "edit mode".
@@ -237,7 +237,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onEditStart?: (event: CustomEvent<EditStartEventData<T>>) => void;
+        onEditStart?: ((event: CustomEvent<EditStartEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a tag has been updated (changed view editing or
@@ -247,7 +247,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onEditUpdated?: (event: CustomEvent<EditUpdatedEventData<T>>) => void;
+        onEditUpdated?: ((event: CustomEvent<EditUpdatedEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the component gained focus.
@@ -256,7 +256,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onFocus?: (event: CustomEvent<FocusEventData<T>>) => void;
+        onFocus?: ((event: CustomEvent<FocusEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a tag is being typed / edited.
@@ -265,7 +265,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onInput?: (event: CustomEvent<InputEventData<T>>) => void;
+        onInput?: ((event: CustomEvent<InputEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a tag has been added but did not pass
@@ -275,7 +275,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onInvalid?: (event: CustomEvent<InvalidTagEventData<T>>) => void;
+        onInvalid?: ((event: CustomEvent<InvalidTagEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when the tagify input element (for adding new tags
@@ -285,7 +285,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onKeydown?: (event: CustomEvent<KeydownEventData<T>>) => void;
+        onKeydown?: ((event: CustomEvent<KeydownEventData<T>>) => void) | undefined;
 
         /**
          * Callback invoked when a tag has been removed.
@@ -294,7 +294,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default () => {}
          */
-        onRemove?: (event: CustomEvent<RemoveEventData<T>>) => void;
+        onRemove?: ((event: CustomEvent<RemoveEventData<T>>) => void) | undefined;
 
         /**
          * Placeholder text for input where the user can enter more tags.
@@ -304,7 +304,7 @@ declare namespace Tags {
          * correspondingly.
          * @default ''
          */
-        placeholder?: string;
+        placeholder?: string | undefined;
 
         /**
          * Toggles read-only state. When the tagify component is read-only, the
@@ -315,7 +315,7 @@ declare namespace Tags {
          * correspondingly.
          * @default undefined
          */
-        readOnly?: boolean;
+        readOnly?: boolean | undefined;
 
         /**
          * Settings for the tagify component.
@@ -324,7 +324,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default {}
          */
-        settings?: TagifySettings;
+        settings?: TagifySettings | undefined;
 
         /**
          * If `false`, does not show the suggestions dropdown. If `true`, shows
@@ -336,7 +336,7 @@ declare namespace Tags {
          * correspondingly.
          * @default undefined
          */
-        showDropdown?: string | boolean;
+        showDropdown?: string | boolean | undefined;
 
         /**
          * An optional react ref that will be populated with the Tagify
@@ -352,7 +352,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default undefined
          */
-        tagifyRef?: MutableRefObject<Tagify | undefined>;
+        tagifyRef?: MutableRefObject<Tagify | undefined> | undefined;
 
         /**
          * Same as `defaultValue`. Initial value, i.e. the initial tags that are
@@ -364,7 +364,7 @@ declare namespace Tags {
          * correspondingly.
          * @default ''
          */
-        value?: string | string[] | T[];
+        value?: string | string[] | T[] | undefined;
 
         /**
          * Sets the whitelist which is the basis for the suggestions dropdown
@@ -375,7 +375,7 @@ declare namespace Tags {
          * correspondingly.
          * @default undefined
          */
-        whitelist?: string[] | T[];
+        whitelist?: string[] | T[] | undefined;
     }
 
     interface TagifyTagsReactProps<T extends BaseTagData = TagData> extends TagifyBaseReactProps<T> {
@@ -388,7 +388,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default 'input'
          */
-        InputMode?: InputMode;
+        InputMode?: InputMode | undefined;
     }
 
     /**

--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Tagify {
          * whitelist) by adding the rest of term as grayed-out text.
          * @default true
          */
-        enabled?: boolean;
+        enabled?: boolean | undefined;
 
         /**
          * If `true`, when the right arrow key is pressed, use the suggested
@@ -40,7 +40,7 @@ declare namespace Tagify {
          * mode this is ignored and treated as `true`.
          * @default false
          */
-        rightKey?: boolean;
+        rightKey?: boolean | undefined;
     }
 
     /**
@@ -54,7 +54,7 @@ declare namespace Tagify {
          * `false` will not render a suggestions list.
          * @default 2
          */
-        enabled?: number | false;
+        enabled?: number | false | undefined;
 
         /**
          * If `true`, match exact item when a suggestion is selected (from the
@@ -62,57 +62,57 @@ declare namespace Tagify {
          * Ensure `fuzzySearch` is `false` for this to work.
          * @default false
          */
-        caseSensitive?: boolean;
+        caseSensitive?: boolean | undefined;
 
         /**
          * Maximum items to show in the suggestions list.
          * @default 10
          */
-        maxItems?: number;
+        maxItems?: number | undefined;
 
         /**
          * Custom class name for the dropdown suggestions list.
          * @default Empty string.
          */
-        classname?: string;
+        classname?: string | undefined;
 
         /**
          * Enables filtering dropdown items values by string _containing_ and not only _beginning_.
          * @default true
          */
-        fuzzySearch?: boolean;
+        fuzzySearch?: boolean | undefined;
 
         /**
          * Enable searching for accented items in the whitelist without typing exact match.
          * @default true
          */
-        accentedSearch?: boolean;
+        accentedSearch?: boolean | undefined;
 
         /**
          * Controls where the dropdown menu is positioned.
          * @default all
          */
-        position?: DropDownPosition;
+        position?: DropDownPosition | undefined;
 
         /**
          * When a suggestions list is shown, highlight the first item,
          * and also suggest it in the input (The suggestion can be accepted with → key).
          * @default false
          */
-        highlightFirst?: boolean;
+        highlightFirst?: boolean | undefined;
 
         /**
          * Close the dropdown after selecting an item, if `enabled: 0` is set
          * (which means always show dropdown on focus).
          * @default true
          */
-        closeOnSelect?: boolean;
+        closeOnSelect?: boolean | undefined;
 
         /**
          * If `false`, keep typed text after selecting a suggestion.
          * @default true
          */
-        clearOnSelect?: boolean;
+        clearOnSelect?: boolean | undefined;
 
         /**
          * If whitelist is an array of tag objects, this setting controls which
@@ -124,7 +124,7 @@ declare namespace Tagify {
          * @param data The tag data to map.
          * @return The value that will be shown in the dropdown menu.
          */
-        ((data: T) => string);
+        ((data: T) => string) | undefined;
 
         /**
          * When a user types something and trying to match the whitelist items
@@ -132,14 +132,14 @@ declare namespace Tagify {
          * whitelist objects.
          * @default ['value', 'searchBy']
          */
-        searchKeys?: string[];
+        searchKeys?: string[] | undefined;
 
         /**
          * Target node to which the suggestions dropdown is appended (only when
          * rendered). When `null`, appends to `document.body`.
          * @default null
          */
-        appendTarget?: HTMLElement | null;
+        appendTarget?: HTMLElement | null | undefined;
 
         /**
          * If defined, will force the placement of the dropdown:
@@ -151,7 +151,7 @@ declare namespace Tagify {
          * where opening it below the input is preferred.
          * @default undefined
          */
-        placeAbove?: boolean;
+        placeAbove?: boolean | undefined;
     }
 
     /**
@@ -163,7 +163,7 @@ declare namespace Tagify {
          * Add after the added tag.
          * @default '\u00A0'
          */
-        insertAfterTag?: string | HTMLElement;
+        insertAfterTag?: string | HTMLElement | undefined;
     }
 
     /**
@@ -174,7 +174,7 @@ declare namespace Tagify {
          * If `true`, allows to focus tags via tab navigation.
          * @default false
          */
-        focusableTags?: boolean;
+        focusableTags?: boolean | undefined;
     }
 
     /**
@@ -348,7 +348,7 @@ declare namespace Tagify {
          * @returns HTML string with the wrapper for the tags. Defaults to a
          * `TAGS` DOM element.
          */
-        (this: Tagify<T>, input: HTMLInputElement | HTMLTextAreaElement, settings: TagifySettings<T>) => string;
+        ((this: Tagify<T>, input: HTMLInputElement | HTMLTextAreaElement, settings: TagifySettings<T>) => string) | undefined;
 
         /**
          * Template for the rendered tags.
@@ -359,7 +359,7 @@ declare namespace Tagify {
          * @returns HTML string with the rendered tag. Defaults to a `TAG` DOM
          * element.
          */
-        (this: Tagify<T>, tagData: T) => string;
+        ((this: Tagify<T>, tagData: T) => string) | undefined;
 
         /**
          * This callback is called when the dropdown menu is about to be shown.
@@ -372,7 +372,7 @@ declare namespace Tagify {
          * @returns HTML string with the dropdown menu container to use for the
          * dropdown menu.
          */
-        (this: Tagify<T>, settings: TagifySettings<T>) => string;
+        ((this: Tagify<T>, settings: TagifySettings<T>) => string) | undefined;
 
         /**
          * This callback is called once for each item in the dropdown list. It
@@ -384,7 +384,7 @@ declare namespace Tagify {
          * @returns HTML string with the rendered dropdown item that will be
          * shown in the dropdown menu.
          */
-        (this: Tagify<T>, item: T) => string;
+        ((this: Tagify<T>, item: T) => string) | undefined;
 
         /**
          * Callback invoked when no matching dropdown item was found. If there
@@ -398,7 +398,7 @@ declare namespace Tagify {
          * @returns HTML string that is displayed in the dropdown suggestions
          * list when no matching suggestions are found.
          */
-        (this: Tagify<T>, data: { value: string }) => string;
+        ((this: Tagify<T>, data: { value: string }) => string) | undefined;
     }
 
     /**
@@ -461,7 +461,7 @@ declare namespace Tagify {
          * promise resolves, the tags are removed if the promise was fulfilled,
          * or kept when the promise was rejected.
          */
-        (tags: T[]) => Promise<void>;
+        ((tags: T[]) => Promise<void>) | undefined;
 
         /**
          * Hook invoked when the user clicks on (or selects via Enter key) a suggestion in the dropdown
@@ -479,7 +479,7 @@ declare namespace Tagify {
          * When the promise resolves, the suggestion is accepted if the promise
          * was fulfilled, and declined when the promise was rejected.
          */
-        (event: MouseEvent | KeyboardEvent, data: SuggestionClickData<T>) => Promise<void>;
+        ((event: MouseEvent | KeyboardEvent, data: SuggestionClickData<T>) => Promise<void>) | undefined;
 
         /**
          * Hook invoked when the user pastes a string into Tagify. It can be used to changed
@@ -489,7 +489,7 @@ declare namespace Tagify {
          * @return Promise with optional string value. If the promise resolves with a string value,
          * this value gets added to Tagify. Without any value, the original paste value gets added.
          */
-        beforePaste?: (event: ClipboardEvent, data: BeforePasteData<T>) => Promise<string|undefined>;
+        beforePaste?: ((event: ClipboardEvent, data: BeforePasteData<T>) => Promise<string|undefined>) | undefined;
     }
 
     /**
@@ -503,11 +503,11 @@ declare namespace Tagify {
          * Adds a required attribute to the Tagify wrapper element. Does nothing
          * more.
          */
-        required?: boolean;
+        required?: boolean | undefined;
         /**
          * No user-interaction (add / remove / edit) is allowed when `true`.
          */
-        readonly?: boolean;
+        readonly?: boolean | undefined;
     }
 
     /**
@@ -521,72 +521,72 @@ declare namespace Tagify {
          * Remember to keep `value` property unique.
          * @default 'value'
          */
-        tagTextProp?: keyof T;
+        tagTextProp?: keyof T | undefined;
 
         /**
          * Placeholder text. If this attribute is set on an input / textarea
          * element it will override this setting.
          * @default Unset (no placeholder)
          */
-        placeholder?: string;
+        placeholder?: string | undefined;
 
         /**
          * RegEx string. Split tags by any of these delimiters.
          * Example delimiters: ",|.| " (comma, dot, or whitespace)
          * @default ','
          */
-        delimiters?: string | RegExp;
+        delimiters?: string | RegExp | undefined;
 
         /**
          * Validate input by RegEx pattern (can also be applied on the input itself as an attribute).
          * Example: /[1-9]/
          */
-        pattern?: string | RegExp | null;
+        pattern?: string | RegExp | null | undefined;
 
         /**
          * Use `select` for single-value dropdown-like select box.
          * See `mix` as value to allow mixed-content. The `pattern` setting must be set to some character.
          * @default null
          */
-        mode?: TagifyMode | null;
+        mode?: TagifyMode | null | undefined;
 
         /**
          * Interpolation for mix mode. Everything between these will become a
          * tag.
          * @default ['[[', ']]']
          */
-        mixTagsInterpolator?: [string, string];
+        mixTagsInterpolator?: [string, string] | undefined;
 
         /**
          * Define conditions in which typed mix-tags content is allowing a tag
          * to be created after.
          * @default /,|\.|\:|\s/
          */
-        mixTagsAllowedAfter?: RegExp;
+        mixTagsAllowedAfter?: RegExp | undefined;
 
         /**
          * Should duplicate tags be allowed or not?
          * @default false
          */
-        duplicates?: boolean;
+        duplicates?: boolean | undefined;
 
         /**
          * If `true` trim the tag's value (remove before / after white spaces).
          * @default true
          */
-        trim?: boolean;
+        trim?: boolean | undefined;
 
         /**
          * Should ONLY use tags allowed in whitelist.
          * In `mix` mode, setting it to `false` will not allow creating new tags.
          * @default false
          */
-        enforceWhitelist?: boolean;
+        enforceWhitelist?: boolean | undefined;
 
         /**
          * Options for offering autocomplete suggestions as the user types.
          */
-        autoComplete?: AutoCompleteSettings;
+        autoComplete?: AutoCompleteSettings | undefined;
 
         /**
          * An array of allowed tags.
@@ -594,26 +594,26 @@ declare namespace Tagify {
          * Also used for auto-completion when `autocomplete.enabled` is `true`.
          * @default Empty array.
          */
-        whitelist?: string[] | T[];
+        whitelist?: string[] | T[] | undefined;
 
         /**
          * An array of tags which aren't allowed.
          * @default Empty array.
          */
-        blacklist?: string[];
+        blacklist?: string[] | undefined;
 
         /**
          * Automatically adds the text which was entered as a tag when a blur
          * event happens.
          * @default true
          */
-        addTagOnBlur?: boolean;
+        addTagOnBlur?: boolean | undefined;
 
         /**
          * Automatically converts pasted text into tags.
          * @default true
          */
-        pasteAsTags?: boolean;
+        pasteAsTags?: boolean | undefined;
 
         /**
          * Callbacks that are invoked when the event specified by the key
@@ -621,7 +621,7 @@ declare namespace Tagify {
          */
         callbacks?: {
             [K in keyof EventDataMap]?: (event: CustomEvent<EventDataMap[K]>) => void;
-        };
+        } | undefined;
 
         /**
          * Maximum number of allowed tags.
@@ -629,7 +629,7 @@ declare namespace Tagify {
          * When reached, adds a class `tagify--hasMaxTags` to `<tags>`.
          * @default Infinity
          */
-        maxTags?: number;
+        maxTags?: number | undefined;
 
         /**
          * Number of clicks to enter `edit` mode: 1 for single click, `2` for a
@@ -638,13 +638,13 @@ declare namespace Tagify {
          * `false` or `null` will disallow editing.
          * @default {clicks: 2, keepInvalid: true}
          */
-        editTags?: 1 | 2 | false | null | EditTagsSettings;
+        editTags?: 1 | 2 | false | null | EditTagsSettings | undefined;
 
         /**
          * Functions that return template strings. Can be used to customize how
          * tags, drop down menus etc. are rendered.
          */
-        templates?: Templates<T>;
+        templates?: Templates<T> | undefined;
 
         /**
          * If the `pattern` setting does not meet your needs, use this function
@@ -657,7 +657,7 @@ declare namespace Tagify {
          * When a string is returned, the tag is considered invalid and the
          * string will be used as an error message.
          */
-        (tagData: T) => boolean | string;
+        ((tagData: T) => boolean | string) | undefined;
 
         /**
          * Takes a tag data as an argument and allows mutating it before a tag
@@ -669,20 +669,20 @@ declare namespace Tagify {
         /**
          * @param tagData The tag to transform. May be mutated by this method.
          */
-        (tagData: T) => void;
+        ((tagData: T) => void) | undefined;
 
         /**
          * If `true`, do not remove tags which did not pass validation.
          * @default false
          */
-        keepInvalidTags?: boolean;
+        keepInvalidTags?: boolean | undefined;
 
         /**
          * If `true`, do not add invalid, temporary tags before automatically
          * removing them.
          * @default false
          */
-        skipInvalid?: boolean;
+        skipInvalid?: boolean | undefined;
 
         /**
          * When the backspace key is pressed:
@@ -691,7 +691,7 @@ declare namespace Tagify {
          * `false` - do nothing (useful for outside style)
          * @default true
          */
-        backspace?: boolean | 'edit';
+        backspace?: boolean | 'edit' | undefined;
 
         /**
          * If you wish your original input / textarea `value` property format to
@@ -704,28 +704,28 @@ declare namespace Tagify {
          * @returns The stringified value representing all tags. This value is
          * set on the hidden input or textarea element.
          */
-        (value: T[]) => string;
+        ((value: T[]) => string) | undefined;
 
         /**
          * Optional settings to configure how mixed mode behaves, see also the
          * `mode` setting.
          */
-        mixMode?: MixModeSettings;
+        mixMode?: MixModeSettings | undefined;
 
         /**
          * Options related to accessibility.
          */
-        a11y?: A11ySettings;
+        a11y?: A11ySettings | undefined;
 
         /**
          * Optional class names that are added to the corresponding elements.
          */
-        classNames?: ClassNameSettings;
+        classNames?: ClassNameSettings | undefined;
 
         /**
          * Options for offering a dropdown menu with available tags.
          */
-        dropdown?: DropDownSettings<T>;
+        dropdown?: DropDownSettings<T> | undefined;
 
         /**
          * Promise-based hooks for async program flow scenarios. Allows to
@@ -733,7 +733,7 @@ declare namespace Tagify {
          * selected as a suitable place to pause the program flow and wait for
          * further instructions on how / if to proceed.
          */
-        hooks?: Hooks<T>;
+        hooks?: Hooks<T> | undefined;
     }
 
     /**
@@ -791,8 +791,8 @@ declare namespace Tagify {
      * @template T Type of the tag data. See the Tagify class for more details.
      */
     interface TagEventData<T extends BaseTagData = TagData> extends EventData<T> {
-        data?: T;
-        index?: number;
+        data?: T | undefined;
+        index?: number | undefined;
         tag: HTMLElement;
     }
 
@@ -1137,7 +1137,7 @@ declare namespace Tagify {
          * change.
          * @default false
          */
-        withoutChangeEvent?: boolean;
+        withoutChangeEvent?: boolean | undefined;
     }
 
     /**
@@ -1152,7 +1152,7 @@ declare namespace Tagify {
          * change.
          * @default false
          */
-        withoutChangeEvent?: boolean;
+        withoutChangeEvent?: boolean | undefined;
     }
 }
 
@@ -1202,7 +1202,7 @@ declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
     /**
      * List with the currently available options for the dropdown.
      */
-    suggestedListItems?: T[];
+    suggestedListItems?: T[] | undefined;
 
     /**
      * Get or dynamically set whitelist.

--- a/types/yallist/index.d.ts
+++ b/types/yallist/index.d.ts
@@ -60,6 +60,6 @@ declare namespace Yallist {
         prev: Node<T> | null;
         next: Node<T> | null;
         value: T;
-        list?: Yallist<T>;
+        list?: Yallist<T> | undefined;
     }
 }

--- a/types/yallist/yallist-tests.ts
+++ b/types/yallist/yallist-tests.ts
@@ -3,7 +3,7 @@ import Yallist = require('yallist');
 const forEachIterable = {
     forEach(fn: (item: string, idx: number) => void, thisArg?: any) {},
 };
-const thisArg: {someProp?: number} = {};
+const thisArg: {someProp?: number | undefined} = {};
 const node = new Yallist.Node('foo');
 
 Yallist.create<string | number>([1, 2, 3]); // $ExpectType Yallist<string | number>

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -46,8 +46,8 @@ declare namespace ymaps {
         }
 
         interface IDblClickZoomOptions extends IMapMarginOptions {
-            centering?: boolean;
-            duration?: number;
+            centering?: boolean | undefined;
+            duration?: number | undefined;
         }
 
         class Drag implements IBehavior {
@@ -68,11 +68,11 @@ declare namespace ymaps {
         }
 
         interface IDragOptions {
-            actionCursor?: string;
-            cursor?: string;
-            inertia?: boolean;
-            inertiaDuration?: number;
-            tremor?: number;
+            actionCursor?: string | undefined;
+            cursor?: string | undefined;
+            inertia?: boolean | undefined;
+            inertiaDuration?: number | undefined;
+            tremor?: number | undefined;
         }
 
         class LeftMouseButtonMagnifier implements IBehavior {
@@ -93,9 +93,9 @@ declare namespace ymaps {
         }
 
         interface ILeftMouseButtonMagnifierOptions {
-            actionCursor?: string;
-            cursor?: string;
-            duration?: number;
+            actionCursor?: string | undefined;
+            cursor?: string | undefined;
+            duration?: number | undefined;
         }
 
         class MultiTouch implements IBehavior {
@@ -116,7 +116,7 @@ declare namespace ymaps {
         }
 
         interface IMultiTouchOptions {
-            tremor?: number;
+            tremor?: number | undefined;
         }
 
         class RightMouseButtonMagnifier implements IBehavior {
@@ -137,8 +137,8 @@ declare namespace ymaps {
         }
 
         interface IRightMouseButtonMagnifierOptions {
-            actionCursor?: string;
-            duration?: number;
+            actionCursor?: string | undefined;
+            duration?: number | undefined;
         }
 
         class RouteEditor implements IBehavior {
@@ -186,7 +186,7 @@ declare namespace ymaps {
         }
 
         interface IRulerOptions {
-            balloonAutoPan?: boolean;
+            balloonAutoPan?: boolean | undefined;
         }
 
         class ScrollZoom implements IBehavior {
@@ -207,8 +207,8 @@ declare namespace ymaps {
         }
 
         interface IScrollZoomOptions {
-            maximumDelta?: number;
-            speed?: number;
+            maximumDelta?: number | undefined;
+            speed?: number | undefined;
         }
 
         const storage: util.Storage;
@@ -324,34 +324,34 @@ declare namespace ymaps {
         }
 
         interface IBaseButtonParametersOptions {
-            adjustMapMargin?: boolean;
-            float?: "none" | "left" | "right";
-            floatIndex?: number;
-            layout?: IClassConstructor<ISelectableControlLayout> | string;
-            maxWidth?: number[][] | number[] | number;
+            adjustMapMargin?: boolean | undefined;
+            float?: "none" | "left" | "right" | undefined;
+            floatIndex?: number | undefined;
+            layout?: IClassConstructor<ISelectableControlLayout> | string | undefined;
+            maxWidth?: number[][] | number[] | number | undefined;
             position?: {
-                bottom?: number | string;
-                left?: number | string;
-                right?: number | string;
-                top?: number | string;
-            };
-            visible?: boolean;
+                bottom?: number | string | undefined;
+                left?: number | string | undefined;
+                right?: number | string | undefined;
+                top?: number | string | undefined;
+            } | undefined;
+            visible?: boolean | undefined;
         }
 
         interface IButtonParameters {
             data?: {
-                content?: string;
-                image?: string;
-                title?: string;
-            };
+                content?: string | undefined;
+                image?: string | undefined;
+                title?: string | undefined;
+            } | undefined;
             options?: IBaseButtonParametersOptions & {
-                selectOnClick?: boolean;
-                size?: "auto" | "small" | "medium" | "large";
-            };
+                selectOnClick?: boolean | undefined;
+                size?: "auto" | "small" | "medium" | "large" | undefined;
+            } | undefined;
             state?: {
-                enabled?: boolean;
-                selected?: boolean;
-            };
+                enabled?: boolean | undefined;
+                selected?: boolean | undefined;
+            } | undefined;
         }
 
         class FullscreenControl extends Button {
@@ -364,16 +364,16 @@ declare namespace ymaps {
 
         interface IFullscreenControlParameters {
             data?: {
-                title?: string;
-            };
+                title?: string | undefined;
+            } | undefined;
             options?: IBaseButtonParametersOptions & {
-                collapseOnBlur?: boolean;
-                expandOnClick?: boolean;
-                popupFloat?: "left" | "right";
-            };
+                collapseOnBlur?: boolean | undefined;
+                expandOnClick?: boolean | undefined;
+                popupFloat?: "left" | "right" | undefined;
+            } | undefined;
             state?: {
-                expanded?: boolean;
-            };
+                expanded?: boolean | undefined;
+            } | undefined;
         }
 
         class GeolocationControl extends Button {
@@ -382,10 +382,10 @@ declare namespace ymaps {
 
         interface IGeolocationControlParameters extends IButtonParameters {
             data?: {
-                image?: string;
-                title?: string;
-            };
-            options?: IBaseButtonParametersOptions;
+                image?: string | undefined;
+                title?: string | undefined;
+            } | undefined;
+            options?: IBaseButtonParametersOptions | undefined;
         }
 
         class ListBox implements ICollection, IControl, ICustomizable {
@@ -409,8 +409,8 @@ declare namespace ymaps {
 
         interface IListBoxParameters extends IButtonParameters {
             options?: IBaseButtonParametersOptions & {
-                noPlacemark?: boolean;
-            };
+                noPlacemark?: boolean | undefined;
+            } | undefined;
         }
 
         class ListBoxItem implements ICustomizable, ISelectableControl {
@@ -442,19 +442,19 @@ declare namespace ymaps {
 
         interface IListBoxItemParameters {
             data?: {
-                content?: string;
-            };
+                content?: string | undefined;
+            } | undefined;
             options?: {
-                layout?: string | IClassConstructor<ISelectableControlLayout>;
-                selectableLayout?: string | IClassConstructor<ISelectableControlLayout>;
-                selectOnClick?: boolean;
-                separatorLayout?: string | IClassConstructor<ISelectableControlLayout>;
-                type?: "selectable" | "separator";
-                visible?: boolean;
-            };
+                layout?: string | IClassConstructor<ISelectableControlLayout> | undefined;
+                selectableLayout?: string | IClassConstructor<ISelectableControlLayout> | undefined;
+                selectOnClick?: boolean | undefined;
+                separatorLayout?: string | IClassConstructor<ISelectableControlLayout> | undefined;
+                type?: "selectable" | "separator" | undefined;
+                visible?: boolean | undefined;
+            } | undefined;
             state?: {
-                selected?: boolean;
-            };
+                selected?: boolean | undefined;
+            } | undefined;
         }
 
         class Manager {
@@ -482,20 +482,20 @@ declare namespace ymaps {
         }
 
         interface IManagerOptions {
-            margin?: number;
-            pane?: IPane;
-            states?: string[];
+            margin?: number | undefined;
+            pane?: IPane | undefined;
+            states?: string[] | undefined;
         }
 
         interface IManagerControlOptions {
-            float?: "none" | "left" | "right";
-            floatIndex?: number;
+            float?: "none" | "left" | "right" | undefined;
+            floatIndex?: number | undefined;
             position?: {
-                bottom?: number | string;
-                left?: number | string;
-                right?: number | string;
-                top?: number | string;
-            };
+                bottom?: number | string | undefined;
+                left?: number | string | undefined;
+                right?: number | string | undefined;
+                top?: number | string | undefined;
+            } | undefined;
         }
 
         class RouteButton implements IControl, ICustomizable {
@@ -512,25 +512,25 @@ declare namespace ymaps {
 
         interface IRouteButtonParameters {
             options?: {
-                adjustMapMargin?: boolean;
-                collapseOnBlur?: boolean;
-                float?: "none" | "left" | "right";
-                floatIndex?: number;
-                popupAnimate?: boolean;
-                popupFloat?: "auto" | "left" | "right";
-                popupWidth?: string;
+                adjustMapMargin?: boolean | undefined;
+                collapseOnBlur?: boolean | undefined;
+                float?: "none" | "left" | "right" | undefined;
+                floatIndex?: number | undefined;
+                popupAnimate?: boolean | undefined;
+                popupFloat?: "auto" | "left" | "right" | undefined;
+                popupWidth?: string | undefined;
                 position?: {
-                    bottom?: number | string;
-                    left?: number | string;
-                    right?: number | string;
-                    top?: number | string;
-                };
-                size?: "auto" | "small" | "medium" | "large";
-                visible?: boolean;
-            };
+                    bottom?: number | string | undefined;
+                    left?: number | string | undefined;
+                    right?: number | string | undefined;
+                    top?: number | string | undefined;
+                } | undefined;
+                size?: "auto" | "small" | "medium" | "large" | undefined;
+                visible?: boolean | undefined;
+            } | undefined;
             state?: {
-                expanded?: boolean;
-            };
+                expanded?: boolean | undefined;
+            } | undefined;
         }
 
         class RouteEditor extends Button {
@@ -541,11 +541,11 @@ declare namespace ymaps {
 
         interface IRouteEditorParameters {
             data?: {
-                image?: string;
-                title?: string;
-            };
-            options?: IBaseButtonParametersOptions;
-            state?: {};
+                image?: string | undefined;
+                title?: string | undefined;
+            } | undefined;
+            options?: IBaseButtonParametersOptions | undefined;
+            state?: {} | undefined;
         }
 
         class RulerControl extends Button {
@@ -553,19 +553,19 @@ declare namespace ymaps {
         }
 
         interface IRulerControlParameters {
-            data?: {};
+            data?: {} | undefined;
             options?: {
-                adjustMapMargin?: boolean;
+                adjustMapMargin?: boolean | undefined;
                 position?: {
-                    bottom?: number | string;
-                    left?: number | string;
-                    right?: number | string;
-                    top?: number | string;
-                };
-                scaleLine?: boolean;
-                visible?: boolean;
-            };
-            state?: {};
+                    bottom?: number | string | undefined;
+                    left?: number | string | undefined;
+                    right?: number | string | undefined;
+                    top?: number | string | undefined;
+                } | undefined;
+                scaleLine?: boolean | undefined;
+                visible?: boolean | undefined;
+            } | undefined;
+            state?: {} | undefined;
         }
 
         class SearchControl implements IControl, ICustomizable {
@@ -603,41 +603,41 @@ declare namespace ymaps {
         }
 
         interface ISearchControlParameters {
-            data?: {};
+            data?: {} | undefined;
             options?: {
-                adjustMapMargin?: boolean;
-                boundedBy?: number[][];
-                fitMaxWidth?: boolean;
-                float?: "none" | "left" | "right";
-                floatIndex?: number;
-                formLayout?: string | IClassConstructor<ILayout>;
-                kind?: "house" | "street" | "metro" | "district" | "locality";
-                layout?: string | IClassConstructor<ISearchControlLayout>;
-                maxWidth?: number[][] | number[] | number;
-                noCentering?: boolean;
-                noPlacemark?: boolean;
-                noPopup?: boolean;
-                noSelect?: boolean;
-                noSuggestPanel?: boolean;
-                placeholderContent?: string;
-                popupItemLayout?: string | IClassConstructor<ILayout>;
-                popupLayout?: string | IClassConstructor<ILayout>;
+                adjustMapMargin?: boolean | undefined;
+                boundedBy?: number[][] | undefined;
+                fitMaxWidth?: boolean | undefined;
+                float?: "none" | "left" | "right" | undefined;
+                floatIndex?: number | undefined;
+                formLayout?: string | IClassConstructor<ILayout> | undefined;
+                kind?: "house" | "street" | "metro" | "district" | "locality" | undefined;
+                layout?: string | IClassConstructor<ISearchControlLayout> | undefined;
+                maxWidth?: number[][] | number[] | number | undefined;
+                noCentering?: boolean | undefined;
+                noPlacemark?: boolean | undefined;
+                noPopup?: boolean | undefined;
+                noSelect?: boolean | undefined;
+                noSuggestPanel?: boolean | undefined;
+                placeholderContent?: string | undefined;
+                popupItemLayout?: string | IClassConstructor<ILayout> | undefined;
+                popupLayout?: string | IClassConstructor<ILayout> | undefined;
                 position?: {
-                    bottom?: number | string;
-                    left?: number | string;
-                    right?: number | string;
-                    top?: number | string;
-                };
-                provider?: IGeocodeProvider | "yandex#map" | "yandex#search";
-                searchCoordOrder?: "latlong" | "longlat";
-                size?: "auto" | "small" | "medium" | "large";
-                strictBounds?: boolean;
-                suppressYandexSearch?: boolean;
-                useMapBounds?: boolean;
-                zoomMargin?: number;
-                visible?: boolean;
-            };
-            state?: {};
+                    bottom?: number | string | undefined;
+                    left?: number | string | undefined;
+                    right?: number | string | undefined;
+                    top?: number | string | undefined;
+                } | undefined;
+                provider?: IGeocodeProvider | "yandex#map" | "yandex#search" | undefined;
+                searchCoordOrder?: "latlong" | "longlat" | undefined;
+                size?: "auto" | "small" | "medium" | "large" | undefined;
+                strictBounds?: boolean | undefined;
+                suppressYandexSearch?: boolean | undefined;
+                useMapBounds?: boolean | undefined;
+                zoomMargin?: number | undefined;
+                visible?: boolean | undefined;
+            } | undefined;
+            state?: {} | undefined;
         }
 
         class ZoomControl implements IControl, ICustomizable {
@@ -677,12 +677,12 @@ declare namespace ymaps {
         interface IZoomControlParameters {
             options?: {
                 position?: {
-                    top?: number | string | 'auto';
-                    right?: number | string | 'auto';
-                    bottom?: number | string | 'auto';
-                    left?: number | string | 'auto';
-                }
-            };
+                    top?: number | string | 'auto' | undefined;
+                    right?: number | string | 'auto' | undefined;
+                    bottom?: number | string | 'auto' | undefined;
+                    left?: number | string | 'auto' | undefined;
+                } | undefined
+            } | undefined;
         }
 
         class TypeSelector extends ListBox {
@@ -692,7 +692,7 @@ declare namespace ymaps {
         interface ITypeSelectorParameters {
             options?: {
                 panoramasItemMode: 'on' | 'off' | 'ifMercator';
-            };
+            } | undefined;
         }
     }
 
@@ -736,7 +736,7 @@ declare namespace ymaps {
 
     namespace event {
         class Manager<TargetGeometry = {}> implements IEventManager<TargetGeometry> {
-            constructor(params?: { context?: object; controllers?: IEventWorkflowController[]; parent?: IEventManager });
+            constructor(params?: { context?: object | undefined; controllers?: IEventWorkflowController[] | undefined; parent?: IEventManager | undefined });
 
             add(types: 'mousedown', callback: (event: (IEvent<MouseEvent, TargetGeometry>)) => void, context?: object, priority?: number): this;
             add(types: string[][] | string[] | string, callback: (event: (IEvent<{}, TargetGeometry>)) => void, context?: object, priority?: number): this;
@@ -869,11 +869,11 @@ declare namespace ymaps {
 
         class LineString implements ILineStringGeometry {
             constructor(coordinates?: number[][], options?: {
-                coordRendering?: "shortestPath" | "straightPath";
-                geodesic?: boolean;
-                pixelRendering?: "jumpy" | "static";
-                projection?: IProjection;
-                simplification?: boolean;
+                coordRendering?: "shortestPath" | "straightPath" | undefined;
+                geodesic?: boolean | undefined;
+                pixelRendering?: "jumpy" | "static" | undefined;
+                projection?: IProjection | undefined;
+                simplification?: boolean | undefined;
             });
 
             events: IEventManager;
@@ -1611,9 +1611,9 @@ declare namespace ymaps {
         namespace layer {
             class Manager implements ILayer, IMapObjectCollection {
                 constructor(map: Map, options?: {
-                    trafficImageZIndex?: number;
-                    trafficInfoZIndex?: number;
-                    trafficJamZIndex?: number;
+                    trafficImageZIndex?: number | undefined;
+                    trafficInfoZIndex?: number | undefined;
+                    trafficJamZIndex?: number | undefined;
                 });
 
                 events: IEventManager;
@@ -2128,12 +2128,12 @@ declare namespace ymaps {
 
         class MultiRoute implements IGeoObject {
             constructor(model: MultiRouteModel | IMultiRouteModelJson, options?: {
-                activeRouteAutoSelection?: boolean;
-                boundsAutoApply?: boolean;
-                dragUpdateInterval?: string | number;
-                preventDragUpdate?: boolean;
-                useMapMargin?: boolean;
-                zoomMargin?: number[][] | number[] | number;
+                activeRouteAutoSelection?: boolean | undefined;
+                boundsAutoApply?: boolean | undefined;
+                dragUpdateInterval?: string | number | undefined;
+                preventDragUpdate?: boolean | undefined;
+                useMapMargin?: boolean | undefined;
+                zoomMargin?: number[][] | number[] | number | undefined;
                 [index: string]: any;
             });
 
@@ -2355,8 +2355,8 @@ declare namespace ymaps {
 
             static createPanorama(params: {
                 angularBBox: number[],
-                coordSystem?: ICoordSystem;
-                name?: string;
+                coordSystem?: ICoordSystem | undefined;
+                name?: string | undefined;
                 position: number[];
                 tilesLevels: IPanoramaTileLevel[];
                 tileSize: number[];
@@ -2370,14 +2370,14 @@ declare namespace ymaps {
         }
 
         function createPlayer(element: HTMLElement | string, point: number[], options?: {
-            direction?: number[] | string;
-            layer?: Layer;
-            span?: number[] | string;
+            direction?: number[] | string | undefined;
+            layer?: Layer | undefined;
+            span?: number[] | string | undefined;
         }): Promise<Player>;
 
         function isSupported(): boolean;
 
-        function locate(point: number[], options?: { layer?: Layer; }): Promise<IPanorama[]>;
+        function locate(point: number[], options?: { layer?: Layer | undefined; }): Promise<IPanorama[]>;
 
         class Manager implements IEventEmitter {
             events: IEventManager;
@@ -2397,13 +2397,13 @@ declare namespace ymaps {
 
         class Player implements IEventEmitter {
             constructor(element: HTMLElement | string, panorama: IPanorama, options?: {
-                autoFitToViewport?: "none" | "ifNull" | "always";
-                controls?: string[];
-                direction?: number[] | string;
-                hotkeysEnabled?: boolean;
-                scrollZoomBehavior?: boolean;
-                span?: number[] | string;
-                suppressMapOpenBlock?: boolean;
+                autoFitToViewport?: "none" | "ifNull" | "always" | undefined;
+                controls?: string[] | undefined;
+                direction?: number[] | string | undefined;
+                hotkeysEnabled?: boolean | undefined;
+                scrollZoomBehavior?: boolean | undefined;
+                span?: number[] | string | undefined;
+                suppressMapOpenBlock?: boolean | undefined;
             })
 
             events: IEventManager;
@@ -2421,9 +2421,9 @@ declare namespace ymaps {
             lookAt(point: number[]): this;
 
             moveTo(point: number[], options?: {
-                direction?: number[] | string;
-                layer?: Layer;
-                span?: number[] | string;
+                direction?: number[] | string | undefined;
+                layer?: Layer | undefined;
+                span?: number[] | string | undefined;
             }): Promise<void>;
 
             setDirection(direction: number[] | string): this;
@@ -2440,12 +2440,12 @@ declare namespace ymaps {
             events: IEventManager;
 
             start(options?: {
-                addViaPoints?: boolean;
-                addWayPoints?: boolean;
-                editViaPoints?: boolean;
-                editWayPoints?: boolean;
-                removeViaPoints?: boolean;
-                removeWayPoints?: boolean;
+                addViaPoints?: boolean | undefined;
+                addWayPoints?: boolean | undefined;
+                editViaPoints?: boolean | undefined;
+                editWayPoints?: boolean | undefined;
+                removeViaPoints?: boolean | undefined;
+                removeWayPoints?: boolean | undefined;
             }): void;
 
             stop(): void;
@@ -2494,9 +2494,9 @@ declare namespace ymaps {
             constructor(
                 pixelGeometry: IPixelCircleGeometry,
                 params?: {
-                    fill?: boolean;
-                    outline?: boolean;
-                    strokeWidth?: number;
+                    fill?: boolean | undefined;
+                    outline?: boolean | undefined;
+                    strokeWidth?: number | undefined;
                 }
             );
 
@@ -2519,7 +2519,7 @@ declare namespace ymaps {
             constructor(
                 pixelGeometry: IPixelLineStringGeometry,
                 params?: {
-                    strokeWidth?: number;
+                    strokeWidth?: number | undefined;
                 }
             );
 
@@ -2542,9 +2542,9 @@ declare namespace ymaps {
             constructor(
                 pixelGeometry: IPixelMultiPolygonGeometry,
                 params?: {
-                    fill?: boolean;
-                    outline?: boolean;
-                    strokeWidth?: number;
+                    fill?: boolean | undefined;
+                    outline?: boolean | undefined;
+                    strokeWidth?: number | undefined;
                 }
             );
 
@@ -2567,9 +2567,9 @@ declare namespace ymaps {
             constructor(
                 pixelGeometry: IPixelPolygonGeometry,
                 params?: {
-                    fill?: boolean;
-                    outline?: boolean;
-                    strokeWidth?: number;
+                    fill?: boolean | undefined;
+                    outline?: boolean | undefined;
+                    strokeWidth?: number | undefined;
                 }
             );
 
@@ -2592,9 +2592,9 @@ declare namespace ymaps {
             constructor(
                 geometry: IPixelRectangleGeometry,
                 params?: {
-                    fill?: boolean;
-                    outline?: boolean;
-                    strokeWidth?: number;
+                    fill?: boolean | undefined;
+                    outline?: boolean | undefined;
+                    strokeWidth?: number | undefined;
                 }
             );
 
@@ -2649,26 +2649,26 @@ declare namespace ymaps {
     }
 
     interface IBalloonOptions {
-        autoPan?: boolean;
-        autoPanCheckZoomRange?: boolean;
-        autoPanDuration?: number;
-        autoPanMargin?: number[][] | number[] | number;
-        autoPanUseMapMargin?: boolean;
-        closeButton?: boolean;
-        contentLayout?: IClassConstructor<ILayout> | string;
-        layout?: IClassConstructor<ILayout> | string;
-        maxHeight?: number;
-        maxWidth?: number;
-        minHeight?: number;
-        minWidth?: number;
-        offset?: number[];
-        pane?: string;
-        panelContentLayout?: IClassConstructor<ILayout> | string;
-        panelMaxHeightRatio?: number;
-        panelMaxMapArea?: number;
-        shadow?: boolean;
-        shadowLayout?: IClassConstructor<ILayout> | string;
-        shadowOffset?: number[];
+        autoPan?: boolean | undefined;
+        autoPanCheckZoomRange?: boolean | undefined;
+        autoPanDuration?: number | undefined;
+        autoPanMargin?: number[][] | number[] | number | undefined;
+        autoPanUseMapMargin?: boolean | undefined;
+        closeButton?: boolean | undefined;
+        contentLayout?: IClassConstructor<ILayout> | string | undefined;
+        layout?: IClassConstructor<ILayout> | string | undefined;
+        maxHeight?: number | undefined;
+        maxWidth?: number | undefined;
+        minHeight?: number | undefined;
+        minWidth?: number | undefined;
+        offset?: number[] | undefined;
+        pane?: string | undefined;
+        panelContentLayout?: IClassConstructor<ILayout> | string | undefined;
+        panelMaxHeightRatio?: number | undefined;
+        panelMaxMapArea?: number | undefined;
+        shadow?: boolean | undefined;
+        shadowLayout?: IClassConstructor<ILayout> | string | undefined;
+        shadowOffset?: number[] | undefined;
     }
 
     class Circle implements GeoObject<ICircleGeometry> {
@@ -2698,37 +2698,37 @@ declare namespace ymaps {
     }
 
     interface ICircleOptions {
-        circleOverlay?: string | ((geometry: IPixelCircleGeometry, data: object, options: object) => Promise<IOverlay>);
-        cursor?: string;
-        draggable?: boolean;
-        fill?: boolean;
-        fillColor?: string;
-        fillImageHref?: string;
-        fillMethod?: "stretch" | "tile";
-        fillOpacity?: number;
-        hasBalloon?: boolean;
-        hasHint?: boolean;
-        hideIconOnBalloonOpen?: boolean;
-        interactiveZIndex?: boolean;
-        interactivityModel?: InteractivityModelKey;
-        opacity?: number;
-        openBalloonOnClick?: boolean;
-        openEmptyBalloon?: boolean;
-        openEmptyHint?: boolean;
-        openHintOnHover?: boolean;
-        outline?: boolean;
-        pane?: string;
-        strokeColor?: string[][] | string[] | string;
-        strokeOpacity?: number[][] | number[] | number;
-        strokeStyle?: string[][][] | object[][] | string[] | object[] | string | object;
-        strokeWidth?: number[][] | number[] | number;
-        syncOverlayInit?: boolean;
-        useMapMarginInDragging?: boolean;
-        visible?: boolean;
-        zIndex?: number;
-        zIndexActive?: number;
-        zIndexDrag?: number;
-        zIndexHover?: number;
+        circleOverlay?: string | ((geometry: IPixelCircleGeometry, data: object, options: object) => Promise<IOverlay>) | undefined;
+        cursor?: string | undefined;
+        draggable?: boolean | undefined;
+        fill?: boolean | undefined;
+        fillColor?: string | undefined;
+        fillImageHref?: string | undefined;
+        fillMethod?: "stretch" | "tile" | undefined;
+        fillOpacity?: number | undefined;
+        hasBalloon?: boolean | undefined;
+        hasHint?: boolean | undefined;
+        hideIconOnBalloonOpen?: boolean | undefined;
+        interactiveZIndex?: boolean | undefined;
+        interactivityModel?: InteractivityModelKey | undefined;
+        opacity?: number | undefined;
+        openBalloonOnClick?: boolean | undefined;
+        openEmptyBalloon?: boolean | undefined;
+        openEmptyHint?: boolean | undefined;
+        openHintOnHover?: boolean | undefined;
+        outline?: boolean | undefined;
+        pane?: string | undefined;
+        strokeColor?: string[][] | string[] | string | undefined;
+        strokeOpacity?: number[][] | number[] | number | undefined;
+        strokeStyle?: string[][][] | object[][] | string[] | object[] | string | object | undefined;
+        strokeWidth?: number[][] | number[] | number | undefined;
+        syncOverlayInit?: boolean | undefined;
+        useMapMarginInDragging?: boolean | undefined;
+        visible?: boolean | undefined;
+        zIndex?: number | undefined;
+        zIndexActive?: number | undefined;
+        zIndexDrag?: number | undefined;
+        zIndexHover?: number | undefined;
     }
 
     class Clusterer implements IChildOnMap, ICustomizable, IEventEmitter, IParentOnMap {
@@ -2775,18 +2775,18 @@ declare namespace ymaps {
     }
 
     interface IClustererOptions {
-        gridSize?: number;
-        groupByCoordinates?: boolean;
-        hasBalloon?: boolean;
-        hasHint?: boolean;
-        margin?: number[][] | number[] | number;
-        maxZoom?: number[] | number;
-        minClusterSize?: number;
-        preset?: PresetKey;
-        showInAlphabeticalOrder?: boolean;
-        useMapMargin?: boolean;
-        viewportMargin?: number[][] | number[] | number;
-        zoomMargin?: number[][] | number[] | number;
+        gridSize?: number | undefined;
+        groupByCoordinates?: boolean | undefined;
+        hasBalloon?: boolean | undefined;
+        hasHint?: boolean | undefined;
+        margin?: number[][] | number[] | number | undefined;
+        maxZoom?: number[] | number | undefined;
+        minClusterSize?: number | undefined;
+        preset?: PresetKey | undefined;
+        showInAlphabeticalOrder?: boolean | undefined;
+        useMapMargin?: boolean | undefined;
+        viewportMargin?: number[][] | number[] | number | undefined;
+        zoomMargin?: number[][] | number[] | number | undefined;
     }
 
     class ClusterPlacemark implements IGeoObject, collection.Item {
@@ -2822,30 +2822,30 @@ declare namespace ymaps {
     }
 
     interface IClusterPlacemarkOptions {
-        balloonContentLayout?: "cluster#balloonTwoColumns" | "cluster#balloonCarousel" | "cluster#balloonAccordion" | string | IClassConstructor<ILayout>;
-        balloonContentLayoutHeight?: number;
-        balloonContentLayoutWidth?: number;
-        balloonItemContentLayout?: ILayout | string;
-        balloonPanelContentLayout?: string | IClassConstructor<ILayout>;
-        cursor?: string;
-        disableClickZoom?: boolean;
-        hideIconOnBalloonOpen?: boolean;
-        iconColor?: string;
-        iconContentLayout?: string | IClassConstructor<ILayout>;
-        iconLayout?: string | IClassConstructor<ILayout>;
+        balloonContentLayout?: "cluster#balloonTwoColumns" | "cluster#balloonCarousel" | "cluster#balloonAccordion" | string | IClassConstructor<ILayout> | undefined;
+        balloonContentLayoutHeight?: number | undefined;
+        balloonContentLayoutWidth?: number | undefined;
+        balloonItemContentLayout?: ILayout | string | undefined;
+        balloonPanelContentLayout?: string | IClassConstructor<ILayout> | undefined;
+        cursor?: string | undefined;
+        disableClickZoom?: boolean | undefined;
+        hideIconOnBalloonOpen?: boolean | undefined;
+        iconColor?: string | undefined;
+        iconContentLayout?: string | IClassConstructor<ILayout> | undefined;
+        iconLayout?: string | IClassConstructor<ILayout> | undefined;
         icons?: Array<{
             href: string;
             size: number[];
             ooffset: number[];
-            shape?: IShape | IGeometryJson;
-        }>;
-        iconShape?: IGeometryJson;
-        interactivityModel?: InteractivityModelKey;
-        numbers?: number[];
-        openBalloonOnClick?: boolean;
-        openEmptyHint?: boolean;
-        openHintOnHover?: boolean;
-        zIndexHover?: number;
+            shape?: IShape | IGeometryJson | undefined;
+        }> | undefined;
+        iconShape?: IGeometryJson | undefined;
+        interactivityModel?: InteractivityModelKey | undefined;
+        numbers?: number[] | undefined;
+        openBalloonOnClick?: boolean | undefined;
+        openEmptyHint?: boolean | undefined;
+        openHintOnHover?: boolean | undefined;
+        zIndexHover?: number | undefined;
     }
 
     class Collection<T = {}> implements ICollection, collection.Item {
@@ -2914,7 +2914,7 @@ declare namespace ymaps {
                 originalEvent: OriginalEvent;
             }
             target: {
-                geometry?: TargetGeometry;
+                geometry?: TargetGeometry | undefined;
             };
         };
     }
@@ -2943,46 +2943,46 @@ declare namespace ymaps {
     }
 
     interface IGeoObjectFeature {
-        geometry?: IGeometry | IGeometryJson;
-        properties?: IDataManager | object;
+        geometry?: IGeometry | IGeometryJson | undefined;
+        properties?: IDataManager | object | undefined;
     }
 
     interface IGeoObjectOptions extends ICircleOptions {
-        iconCaptionMaxWidth?: number;
-        iconColor?: string;
-        iconContentLayout?: string | IClassConstructor<ILayout>;
-        iconContentOffset?: number[];
-        iconContentPadding?: number[];
-        iconContentSize?: number[];
-        iconImageClipRect?: number[][];
-        iconImageHref?: string;
-        iconImageOffset?: number[];
-        iconImageShape?: IShape | null;
-        iconImageSize?: number[];
-        iconLayout?: string | IClassConstructor<ILayout>;
-        iconMaxHeight?: number;
-        iconMaxWidth?: number;
-        iconOffset?: number[];
-        iconShadow?: boolean;
-        iconShadowImageClipRect?: number[][];
-        iconShadowImageHref?: string;
-        iconShadowImageOffset?: number[];
-        iconShadowImageSize?: number[];
-        iconShadowLayout?: string | IClassConstructor<ILayout>;
-        iconShadowOffset?: number[];
-        lineStringOverlay?: OverlayKey;
-        pointOverlay?: OverlayKey;
-        polygonOverlay?: OverlayKey;
-        preset?: string;
-        rectangleOverlay?: OverlayKey;
-        setMapCursorInDragging?: boolean;
+        iconCaptionMaxWidth?: number | undefined;
+        iconColor?: string | undefined;
+        iconContentLayout?: string | IClassConstructor<ILayout> | undefined;
+        iconContentOffset?: number[] | undefined;
+        iconContentPadding?: number[] | undefined;
+        iconContentSize?: number[] | undefined;
+        iconImageClipRect?: number[][] | undefined;
+        iconImageHref?: string | undefined;
+        iconImageOffset?: number[] | undefined;
+        iconImageShape?: IShape | null | undefined;
+        iconImageSize?: number[] | undefined;
+        iconLayout?: string | IClassConstructor<ILayout> | undefined;
+        iconMaxHeight?: number | undefined;
+        iconMaxWidth?: number | undefined;
+        iconOffset?: number[] | undefined;
+        iconShadow?: boolean | undefined;
+        iconShadowImageClipRect?: number[][] | undefined;
+        iconShadowImageHref?: string | undefined;
+        iconShadowImageOffset?: number[] | undefined;
+        iconShadowImageSize?: number[] | undefined;
+        iconShadowLayout?: string | IClassConstructor<ILayout> | undefined;
+        iconShadowOffset?: number[] | undefined;
+        lineStringOverlay?: OverlayKey | undefined;
+        pointOverlay?: OverlayKey | undefined;
+        polygonOverlay?: OverlayKey | undefined;
+        preset?: string | undefined;
+        rectangleOverlay?: OverlayKey | undefined;
+        setMapCursorInDragging?: boolean | undefined;
     }
 
     class GeoObjectCollection implements IGeoObject, IGeoObjectCollection {
         constructor(feature?: {
-            children?: IGeoObject[];
-            geometry?: IGeometry | object;
-            properties?: IDataManager | object;
+            children?: IGeoObject[] | undefined;
+            geometry?: IGeometry | object | undefined;
+            properties?: IDataManager | object | undefined;
         }, options?: object);
 
         geometry: IGeometry | null;
@@ -3099,30 +3099,30 @@ declare namespace ymaps {
     }
 
     interface IMapMarginOptions {
-        useMapMargin?: boolean;
+        useMapMargin?: boolean | undefined;
     }
 
     interface IMapCheckZoomRangeOptions {
-        checkZoomRange?: boolean;
+        checkZoomRange?: boolean | undefined;
     }
 
     interface IMapZoomOptions extends IMapMarginOptions, IMapCheckZoomRangeOptions {
-        duration?: number;
+        duration?: number | undefined;
     }
 
     interface IMapPositionOptions extends IMapZoomOptions {
-        timingFunction?: string;
+        timingFunction?: string | undefined;
     }
 
     interface IMapBoundsOptions extends IMapPositionOptions {
-        preciseZoom?: boolean;
-        zoomMargin?: number[][] | number[];
+        preciseZoom?: boolean | undefined;
+        zoomMargin?: number[][] | number[] | undefined;
     }
 
     interface IMapPanOptions extends IMapPositionOptions {
-        delay?: number;
-        flying?: boolean;
-        safe?: boolean;
+        delay?: number | undefined;
+        flying?: boolean | undefined;
+        safe?: boolean | undefined;
     }
 
     class MapType {
@@ -3130,40 +3130,40 @@ declare namespace ymaps {
     }
 
     interface IMapState {
-        behaviors?: string[];
-        bounds?: number[][];
-        center?: number[];
+        behaviors?: string[] | undefined;
+        bounds?: number[][] | undefined;
+        center?: number[] | undefined;
         controls?: Array<
             string
             | control.ZoomControl
             | control.RulerControl
             | control.TypeSelector
-        >;
-        margin?: number[][] | number[];
-        type?: "yandex#map" | "yandex#satellite" | "yandex#hybrid";
-        zoom?: number;
+        > | undefined;
+        margin?: number[][] | number[] | undefined;
+        type?: "yandex#map" | "yandex#satellite" | "yandex#hybrid" | undefined;
+        zoom?: number | undefined;
     }
 
     interface IMapOptions {
-        autoFitToViewport?: "none" | "ifNull" | "always";
-        avoidFractionalZoom?: boolean;
-        exitFullscreenByEsc?: boolean;
-        fullscreenZIndex?: number;
-        mapAutoFocus?: boolean;
-        maxAnimationZoomDifference?: number;
-        maxZoom?: number;
-        minZoom?: number;
-        nativeFullscreen?: boolean;
-        projection?: IProjection;
-        restrictMapArea?: boolean;
-        suppressMapOpenBlock?: boolean;
-        suppressObsoleteBrowserNotifier?: boolean;
-        yandexMapAutoSwitch?: boolean;
-        yandexMapDisablePoiInteractivity?: boolean;
+        autoFitToViewport?: "none" | "ifNull" | "always" | undefined;
+        avoidFractionalZoom?: boolean | undefined;
+        exitFullscreenByEsc?: boolean | undefined;
+        fullscreenZIndex?: number | undefined;
+        mapAutoFocus?: boolean | undefined;
+        maxAnimationZoomDifference?: number | undefined;
+        maxZoom?: number | undefined;
+        minZoom?: number | undefined;
+        nativeFullscreen?: boolean | undefined;
+        projection?: IProjection | undefined;
+        restrictMapArea?: boolean | undefined;
+        suppressMapOpenBlock?: boolean | undefined;
+        suppressObsoleteBrowserNotifier?: boolean | undefined;
+        yandexMapAutoSwitch?: boolean | undefined;
+        yandexMapDisablePoiInteractivity?: boolean | undefined;
 
-        copyrightLogoVisible?: boolean;
-        copyrightProvidersVisible?: boolean;
-        copyrightUaVisible?: boolean;
+        copyrightLogoVisible?: boolean | undefined;
+        copyrightProvidersVisible?: boolean | undefined;
+        copyrightUaVisible?: boolean | undefined;
     }
 
     class Placemark extends GeoObject<IPointGeometry, geometry.Point> {
@@ -3171,28 +3171,28 @@ declare namespace ymaps {
     }
 
     interface IPlacemarkOptions {
-        cursor?: string;
-        draggable?: boolean;
-        hasBalloon?: boolean;
-        hasHint?: boolean;
-        hideIconOnBalloonOpen?: boolean;
-        iconOffset?: number[];
-        iconShape?: IGeometryJson | null;
-        interactiveZIndex?: boolean;
-        interactivityModel?: string;
-        openBalloonOnClick?: boolean;
-        openEmptyBalloon?: boolean;
-        openEmptyHint?: boolean;
-        openHintOnHover?: boolean;
-        pane?: string;
-        pointOverlay?: string;
-        syncOverlayInit?: boolean;
-        useMapMarginInDragging?: boolean;
-        visible?: boolean;
-        zIndex?: number;
-        zIndexActive?: number;
-        zIndexDrag?: number;
-        zIndexHover?: number;
+        cursor?: string | undefined;
+        draggable?: boolean | undefined;
+        hasBalloon?: boolean | undefined;
+        hasHint?: boolean | undefined;
+        hideIconOnBalloonOpen?: boolean | undefined;
+        iconOffset?: number[] | undefined;
+        iconShape?: IGeometryJson | null | undefined;
+        interactiveZIndex?: boolean | undefined;
+        interactivityModel?: string | undefined;
+        openBalloonOnClick?: boolean | undefined;
+        openEmptyBalloon?: boolean | undefined;
+        openEmptyHint?: boolean | undefined;
+        openHintOnHover?: boolean | undefined;
+        pane?: string | undefined;
+        pointOverlay?: string | undefined;
+        syncOverlayInit?: boolean | undefined;
+        useMapMarginInDragging?: boolean | undefined;
+        visible?: boolean | undefined;
+        zIndex?: number | undefined;
+        zIndexActive?: number | undefined;
+        zIndexDrag?: number | undefined;
+        zIndexHover?: number | undefined;
     }
 
     class Polygon extends GeoObject<IPolygonGeometry> {
@@ -3200,36 +3200,36 @@ declare namespace ymaps {
     }
 
     interface IPolygonOptions {
-        cursor?: string;
-        draggable?: boolean;
-        fill?: boolean;
-        fillColor?: string;
-        fillImageHref?: string;
-        fillMethod?: 'stretch' | 'tile';
-        fillOpacity?: number;
-        hasBalloon?: boolean;
-        hasHint?: boolean;
-        interactiveZIndex?: boolean;
-        interactivityModel?: string;
-        opacity?: number;
-        openBalloonOnClick?: boolean;
-        openEmptyBalloon?: boolean;
-        openEmptyHint?: boolean;
-        openHintOnHover?: boolean;
-        outline?: boolean;
-        pane?: string;
-        polygonOverlay?: string;
-        strokeColor?: string | string[];
-        strokeOpacity?: number | number[];
-        strokeStyle?: string | string[] | object | object[];
-        strokeWidth?: number | number[];
-        syncOverlayInit?: boolean;
-        useMapMarginInDragging?: boolean;
-        visible?: boolean;
-        zIndex?: number;
-        zIndexActive?: number;
-        zIndexDrag?: number;
-        zIndexHover?: number;
+        cursor?: string | undefined;
+        draggable?: boolean | undefined;
+        fill?: boolean | undefined;
+        fillColor?: string | undefined;
+        fillImageHref?: string | undefined;
+        fillMethod?: 'stretch' | 'tile' | undefined;
+        fillOpacity?: number | undefined;
+        hasBalloon?: boolean | undefined;
+        hasHint?: boolean | undefined;
+        interactiveZIndex?: boolean | undefined;
+        interactivityModel?: string | undefined;
+        opacity?: number | undefined;
+        openBalloonOnClick?: boolean | undefined;
+        openEmptyBalloon?: boolean | undefined;
+        openEmptyHint?: boolean | undefined;
+        openHintOnHover?: boolean | undefined;
+        outline?: boolean | undefined;
+        pane?: string | undefined;
+        polygonOverlay?: string | undefined;
+        strokeColor?: string | string[] | undefined;
+        strokeOpacity?: number | number[] | undefined;
+        strokeStyle?: string | string[] | object | object[] | undefined;
+        strokeWidth?: number | number[] | undefined;
+        syncOverlayInit?: boolean | undefined;
+        useMapMarginInDragging?: boolean | undefined;
+        visible?: boolean | undefined;
+        zIndex?: number | undefined;
+        zIndexActive?: number | undefined;
+        zIndexDrag?: number | undefined;
+        zIndexHover?: number | undefined;
     }
 
     class Polyline extends GeoObject<ILineStringGeometry> {
@@ -3237,30 +3237,30 @@ declare namespace ymaps {
     }
 
     interface IPolylineOptions {
-        cursor?: string;
-        draggable?: boolean;
-        hasBalloon?: boolean;
-        hasHint?: boolean;
-        interactiveZIndex?: boolean;
-        interactivityModel?: string;
-        lineStringOverlay?: () => object | string;
-        opacity?: number;
-        openBalloonOnClick?: boolean;
-        openEmptyBalloon?: boolean;
-        openEmptyHint?: boolean;
-        openHintOnHover?: boolean;
-        pane?: string;
-        strokeColor?: string | string[];
-        strokeOpacity?: number | number[];
-        strokeStyle?: string | string[] | object | object[];
-        strokeWidth?: number | number[];
-        syncOverlayInit?: boolean;
-        useMapMarginInDragging?: boolean;
-        visible?: boolean;
-        zIndex?: number;
-        zIndexActive?: number;
-        zIndexDrag?: number;
-        zIndexHover?: number;
+        cursor?: string | undefined;
+        draggable?: boolean | undefined;
+        hasBalloon?: boolean | undefined;
+        hasHint?: boolean | undefined;
+        interactiveZIndex?: boolean | undefined;
+        interactivityModel?: string | undefined;
+        lineStringOverlay?: (() => object | string) | undefined;
+        opacity?: number | undefined;
+        openBalloonOnClick?: boolean | undefined;
+        openEmptyBalloon?: boolean | undefined;
+        openEmptyHint?: boolean | undefined;
+        openHintOnHover?: boolean | undefined;
+        pane?: string | undefined;
+        strokeColor?: string | string[] | undefined;
+        strokeOpacity?: number | number[] | undefined;
+        strokeStyle?: string | string[] | object | object[] | undefined;
+        strokeWidth?: number | number[] | undefined;
+        syncOverlayInit?: boolean | undefined;
+        useMapMarginInDragging?: boolean | undefined;
+        visible?: boolean | undefined;
+        zIndex?: number | undefined;
+        zIndexActive?: number | undefined;
+        zIndexDrag?: number | undefined;
+        zIndexHover?: number | undefined;
     }
 
     class Popup<T> implements IPopup<T> {
@@ -3289,19 +3289,19 @@ declare namespace ymaps {
     }
 
     interface IPopupOptions {
-        closeTimeout?: number;
-        interactivityModel?: InteractivityModelKey;
-        openTimeout?: number;
-        pane?: IPane | string;
-        projection?: IProjection;
-        zIndex?: number;
+        closeTimeout?: number | undefined;
+        interactivityModel?: InteractivityModelKey | undefined;
+        openTimeout?: number | undefined;
+        pane?: IPane | string | undefined;
+        projection?: IProjection | undefined;
+        zIndex?: number | undefined;
     }
 
     function ready(successCallback?: () => any | IReadyobject, errorCallback?: () => any, context?: object): Promise<void>;
 
     interface IReadyobject {
-        require?: string[];
-        context?: object;
+        require?: string[] | undefined;
+        context?: object | undefined;
 
         successCallback?(): void;
 
@@ -3501,7 +3501,7 @@ declare namespace ymaps {
                 originalEvent: OriginalEvent;
             }
             target: {
-                geometry?: TargetGeometry;
+                geometry?: TargetGeometry | undefined;
             };
         };
     }
@@ -3561,9 +3561,9 @@ declare namespace ymaps {
     }
 
     interface IGeocodeProvider {
-        geocode(request: string, options?: { boundedBy?: number[][], results?: number, skip?: number, strictBounds?: boolean }): Promise<object>;
+        geocode(request: string, options?: { boundedBy?: number[][] | undefined, results?: number | undefined, skip?: number | undefined, strictBounds?: boolean | undefined }): Promise<object>;
 
-        suggest(request: string, options?: { boundedBy?: number[][], results?: number, strictBounds?: boolean }): Promise<object>;
+        suggest(request: string, options?: { boundedBy?: number[][] | undefined, results?: number | undefined, strictBounds?: boolean | undefined }): Promise<object>;
     }
 
     interface IGeometry extends IBaseGeometry, ICustomizable {
@@ -3763,15 +3763,15 @@ declare namespace ymaps {
     }
 
     interface IMultiRouteParams {
-        avoidTrafficJams?: boolean;
-        boundedBy?: number[][] | null;
-        requestSendInterval?: string | number;
-        results?: number;
-        reverseGeocoding?: boolean;
-        routingMode?: "auto" | "masstransit" | "pedestrian";
-        searchCoordOrder?: string;
-        strictBounds?: boolean;
-        viaIndexes?: number[];
+        avoidTrafficJams?: boolean | undefined;
+        boundedBy?: number[][] | null | undefined;
+        requestSendInterval?: string | number | undefined;
+        results?: number | undefined;
+        reverseGeocoding?: boolean | undefined;
+        routingMode?: "auto" | "masstransit" | "pedestrian" | undefined;
+        searchCoordOrder?: string | undefined;
+        strictBounds?: boolean | undefined;
+        viaIndexes?: number[] | undefined;
     }
 
     type IMultiRouteReferencePoint = string | number[] | geometry.Point;
@@ -4133,11 +4133,11 @@ declare namespace ymaps {
     }
 
     interface IObjectManagerOptions {
-        clusterize?: boolean;
-        syncOverlayInit?: boolean;
-        viewportMargin?: number | number[];
-        clusterHasBalloon?: boolean;
-        geoObjectOpenBalloonOnClick?: boolean;
+        clusterize?: boolean | undefined;
+        syncOverlayInit?: boolean | undefined;
+        viewportMargin?: number | number[] | undefined;
+        clusterHasBalloon?: boolean | undefined;
+        geoObjectOpenBalloonOnClick?: boolean | undefined;
     }
 
     class ObjectManager implements ICustomizable, IEventEmitter, IGeoObject, IParentOnMap {
@@ -4165,7 +4165,7 @@ declare namespace ymaps {
 
         getMap(): Map;
 
-        getObjectState(id: string): { found: boolean; isShown: boolean; cluster?: Cluster; isClustered: boolean; isFilteredOut: boolean };
+        getObjectState(id: string): { found: boolean; isShown: boolean; cluster?: Cluster | undefined; isClustered: boolean; isFilteredOut: boolean };
 
         getOverlay(): Promise<IOverlay | null>;
 

--- a/types/yandex-metrika-tag/index.d.ts
+++ b/types/yandex-metrika-tag/index.d.ts
@@ -42,58 +42,58 @@ declare namespace ym {
     }
 
     interface VisitParameters {
-        order_price?: number;
-        currency?: string;
+        order_price?: number | undefined;
+        currency?: string | undefined;
         [key: string]: any;
     }
 
     interface UserParameters {
-        UserID?: number;
+        UserID?: number | undefined;
         [key: string]: any;
     }
 
     interface InitParameters {
-        accurateTrackBounce?: boolean | number;
-        childIframe?: boolean;
-        clickmap?: boolean;
-        defer?: boolean;
-        ecommerce?: boolean | string | any[];
-        params?: VisitParameters | VisitParameters[];
-        userParams?: UserParameters;
-        trackHash?: boolean;
-        trackLinks?: boolean;
-        trustedDomains?: string[];
-        type?: number;
-        ut?: 'noindex';
-        webvisor?: boolean;
-        triggerEvent?: boolean;
+        accurateTrackBounce?: boolean | number | undefined;
+        childIframe?: boolean | undefined;
+        clickmap?: boolean | undefined;
+        defer?: boolean | undefined;
+        ecommerce?: boolean | string | any[] | undefined;
+        params?: VisitParameters | VisitParameters[] | undefined;
+        userParams?: UserParameters | undefined;
+        trackHash?: boolean | undefined;
+        trackLinks?: boolean | undefined;
+        trustedDomains?: string[] | undefined;
+        type?: number | undefined;
+        ut?: 'noindex' | undefined;
+        webvisor?: boolean | undefined;
+        triggerEvent?: boolean | undefined;
     }
 
     interface ExtLinkOptions<CTX> {
         callback?(this: CTX): void;
-        ctx?: CTX;
-        params?: VisitParameters;
-        title?: string;
+        ctx?: CTX | undefined;
+        params?: VisitParameters | undefined;
+        title?: string | undefined;
     }
 
     interface FileOptions<CTX> {
         callback?(this: CTX): void;
-        ctx?: CTX;
-        params?: VisitParameters;
-        referer?: string;
-        title?: string;
+        ctx?: CTX | undefined;
+        params?: VisitParameters | undefined;
+        referer?: string | undefined;
+        title?: string | undefined;
     }
 
     interface HitOptions<CTX> {
         callback?(this: CTX): void;
-        ctx?: CTX;
-        params?: VisitParameters;
-        referer?: string;
-        title?: string;
+        ctx?: CTX | undefined;
+        params?: VisitParameters | undefined;
+        referer?: string | undefined;
+        title?: string | undefined;
     }
 
     interface NotBounceOptions<CTX> {
         callback?(this: CTX): void;
-        ctx?: CTX;
+        ctx?: CTX | undefined;
     }
 }

--- a/types/yandex-money-sdk/index.d.ts
+++ b/types/yandex-money-sdk/index.d.ts
@@ -8,8 +8,8 @@
 declare namespace YandexMoneySDK {
     namespace Wallet {
         interface GetAccessTokenResult {
-            access_token?: string;
-            error?: string;
+            access_token?: string | undefined;
+            error?: string | undefined;
         }
 
         interface SendAuthenticatedRequestParams {
@@ -27,70 +27,70 @@ declare namespace YandexMoneySDK {
             avatar?: {
                 url: string;
                 ts: string;
-            };
+            } | undefined;
             balance_details?: {
                 total: number;
                 available: number;
-                deposition_pending?: number;
-                blocked?: number;
-                debt?: number;
-                hold?: number;
-            }
+                deposition_pending?: number | undefined;
+                blocked?: number | undefined;
+                debt?: number | undefined;
+                hold?: number | undefined;
+            } | undefined
             cards_linked?: {
-                pan_fragment?: string;
-                type?: string;
-            }[];
+                pan_fragment?: string | undefined;
+                type?: string | undefined;
+            }[] | undefined;
         }
 
         interface OperationHistoryOptions {
             type: string;
-            label?: string;
-            from?: string|Date;
-            till?: string|Date;
-            start_record?: string;
-            records?: number;
-            details?: boolean;
+            label?: string | undefined;
+            from?: string|Date | undefined;
+            till?: string|Date | undefined;
+            start_record?: string | undefined;
+            records?: number | undefined;
+            details?: boolean | undefined;
         }
 
         interface OperationHistoryResult {
-            error?: string;
-            next_record?: string;
+            error?: string | undefined;
+            next_record?: string | undefined;
             operations?: {
                 operation_id: string;
                 status: string;
                 datetime: string;
                 title: string;
-                pattern_id?: string;
+                pattern_id?: string | undefined;
                 direction: string;
                 amount: number;
-                label?: string;
-                type?: string;
-            }[];
+                label?: string | undefined;
+                type?: string | undefined;
+            }[] | undefined;
         }
 
         interface OperationDetailsResult {
-            error?: string;
-            operation_id?: string;
-            status?: string;
-            pattern_id?: string;
-            direction?: string;
-            amount?: number;
-            amount_due?: number;
-            fee?: number;
-            datetime?: string;
-            title?: string;
-            sender?: string;
-            recipient?: string;
-            recipient_type?: string;
-            message?: string;
-            comment?: string;
-            codepro?: boolean;
-            protection_code?: string;
-            expires?: string;
-            answer_datetime?: string;
-            label?: string;
-            details?: string;
-            type?: string;
+            error?: string | undefined;
+            operation_id?: string | undefined;
+            status?: string | undefined;
+            pattern_id?: string | undefined;
+            direction?: string | undefined;
+            amount?: number | undefined;
+            amount_due?: number | undefined;
+            fee?: number | undefined;
+            datetime?: string | undefined;
+            title?: string | undefined;
+            sender?: string | undefined;
+            recipient?: string | undefined;
+            recipient_type?: string | undefined;
+            message?: string | undefined;
+            comment?: string | undefined;
+            codepro?: boolean | undefined;
+            protection_code?: string | undefined;
+            expires?: string | undefined;
+            answer_datetime?: string | undefined;
+            label?: string | undefined;
+            details?: string | undefined;
+            type?: string | undefined;
             digital_goods?: {
                 article: {
                     merchantArticleId: string;
@@ -101,35 +101,35 @@ declare namespace YandexMoneySDK {
                     serial: string;
                     secret: string;
                 }[];
-            };
+            } | undefined;
         }
 
         interface RequestPaymentOptions {
             pattern_id: string;
-            to?: string;
-            amount?: number;
-            amount_due?: number;
-            comment?: string;
-            message?: string;
-            label?: string;
-            codepro?: boolean;
-            hold_for_pickup?: boolean;
-            expire_period?: number;
-            'phone-number'?: string;
+            to?: string | undefined;
+            amount?: number | undefined;
+            amount_due?: number | undefined;
+            comment?: string | undefined;
+            message?: string | undefined;
+            label?: string | undefined;
+            codepro?: boolean | undefined;
+            hold_for_pickup?: boolean | undefined;
+            expire_period?: number | undefined;
+            'phone-number'?: string | undefined;
             [key: string]: any
 
-            test_payment?: boolean;
-            test_card?: string;
-            test_result?: string;
+            test_payment?: boolean | undefined;
+            test_card?: string | undefined;
+            test_result?: string | undefined;
         }
 
         interface RequestPaymentResult {
             status: string;
-            error?: string;
+            error?: string | undefined;
             money_source?: {
                 wallet?: {
                     allowed: boolean;
-                };
+                } | undefined;
                 cards?: {
                     allowed: boolean;
                     csc_required: boolean;
@@ -138,48 +138,48 @@ declare namespace YandexMoneySDK {
                         pan_fragment: string;
                         type: string;
                     }[];
-                };
-            };
-            request_id?: string;
-            contract_amount?: number;
-            balance?: number;
-            recipient_account_status?: string;
-            recipient_account_type?: string;
-            protection_code?: string;
-            account_unblock_uri?: string;
-            ext_action_uri?: string;
+                } | undefined;
+            } | undefined;
+            request_id?: string | undefined;
+            contract_amount?: number | undefined;
+            balance?: number | undefined;
+            recipient_account_status?: string | undefined;
+            recipient_account_type?: string | undefined;
+            protection_code?: string | undefined;
+            account_unblock_uri?: string | undefined;
+            ext_action_uri?: string | undefined;
         }
 
         interface ProcessPaymentOptions {
             request_id: string;
-            money_source?: string;
-            csc?: string;
-            ext_auth_success_uri?: string;
-            ext_auth_fail_uri?: string;
+            money_source?: string | undefined;
+            csc?: string | undefined;
+            ext_auth_success_uri?: string | undefined;
+            ext_auth_fail_uri?: string | undefined;
 
-            test_payment?: boolean;
-            test_card?: string;
-            test_result?: string;
+            test_payment?: boolean | undefined;
+            test_card?: string | undefined;
+            test_result?: string | undefined;
         }
 
         interface ProcessPaymentResult {
             status: string;
-            error?: string;
-            payment_id?: string;
-            balance?: number;
-            invoice_id?: string;
-            payer?: string;
-            payee?: string;
-            credit_amount?: number;
-            account_unblock_uri?: string;
-            hold_for_pickup_link?: string;
-            acs_uri?: string;
+            error?: string | undefined;
+            payment_id?: string | undefined;
+            balance?: number | undefined;
+            invoice_id?: string | undefined;
+            payer?: string | undefined;
+            payee?: string | undefined;
+            credit_amount?: number | undefined;
+            account_unblock_uri?: string | undefined;
+            hold_for_pickup_link?: string | undefined;
+            acs_uri?: string | undefined;
             acs_params?: {
                 MD: string;
                 PaReq: string;
                 [key: string]: any
-            };
-            next_retry?: number;
+            } | undefined;
+            next_retry?: number | undefined;
             digital_goods?: {
                 article: {
                     merchantArticleId: string;
@@ -190,45 +190,45 @@ declare namespace YandexMoneySDK {
                     serial: string;
                     secret: string;
                 }[];
-            };
+            } | undefined;
         }
 
         interface IncomingTransferAcceptResult {
             status: string;
-            error?: string;
-            protection_code_attempts_available?: number;
-            ext_action_uri?: string;
+            error?: string | undefined;
+            protection_code_attempts_available?: number | undefined;
+            ext_action_uri?: string | undefined;
         }
 
         interface IncomingTransferRejectResult {
             status: string;
-            error?: string;
+            error?: string | undefined;
         }
     }
 
     namespace ExternalPayment {
         interface GetInstanceIdResult {
             status: string;
-            error?: string;
-            instance_id?: string;
+            error?: string | undefined;
+            instance_id?: string | undefined;
         }
 
         interface RequestOptions {
             pattern_id: string;
             // instance_id: string; // the method always overwrites this value
-            to?: string;
-            amount?: number;
-            amount_due?: number;
-            message?: string;
+            to?: string | undefined;
+            amount?: number | undefined;
+            amount_due?: number | undefined;
+            message?: string | undefined;
             [key: string]: any;
         }
 
         interface RequestResult {
             status: string;
-            error?: string;
-            request_id?: string;
-            contract_amount?: number;
-            title?: string;
+            error?: string | undefined;
+            request_id?: string | undefined;
+            contract_amount?: number | undefined;
+            title?: string | undefined;
         }
 
         interface ProcessOptions {
@@ -236,28 +236,28 @@ declare namespace YandexMoneySDK {
             // instance_id: string; // the method always overwrites this value
             ext_auth_success_uri: string;
             ext_auth_fail_uri: string;
-            request_token?: boolean;
-            money_source_token?: string;
-            csc?: string;
+            request_token?: boolean | undefined;
+            money_source_token?: string | undefined;
+            csc?: string | undefined;
         }
 
         interface ProcessResult {
             status: string;
-            error?: string;
-            acs_uri?: string;
+            error?: string | undefined;
+            acs_uri?: string | undefined;
             acs_params?: {
                 MD: string;
                 PaReq: string;
                 [key: string]: any
-            };
+            } | undefined;
             money_source?: {
                 type: string;
                 payment_card_type: string;
-                pan_fragment?: string;
-                money_source_token?: string;
-            };
-            next_retry?: number;
-            invoice_id?: string;
+                pan_fragment?: string | undefined;
+                money_source_token?: string | undefined;
+            } | undefined;
+            next_retry?: number | undefined;
+            invoice_id?: string | undefined;
         }
     }
 }

--- a/types/yar/index.d.ts
+++ b/types/yar/index.d.ts
@@ -19,31 +19,31 @@ declare namespace yar {
          * Determines the name of the cookie used to store session information.
          * Defaults to session.
          */
-        name?: string;
+        name?: string | undefined;
 
         /**
          * maximum cookie size before using server-side storage.
          * Defaults to 1K. Set to zero to always use server-side storage.
          */
-        maxCookieSize?: number;
+        maxCookieSize?: number | undefined;
 
         /**
          * determines whether to store empty session before they've been modified.
          * Defaults to true.
          */
-        storeBlank?: boolean;
+        storeBlank?: boolean | undefined;
 
         /**
          * will cause yar to throw an exception if trying to persist to cache when the cache is unavailable.
          * Setting this to false will allow applications using yar to run uninterrupted if the cache is not ready (however sessions will not be saving).
          * Defaults to true.
          */
-        errorOnCacheNotReady?: boolean;
+        errorOnCacheNotReady?: boolean | undefined;
 
         /**
          * hapi cache options which includes (among other options):
          */
-        cache?: CachePolicyOptions<any>;
+        cache?: CachePolicyOptions<any> | undefined;
 
         /**
          * the configuration for cookie-specific features:
@@ -57,7 +57,7 @@ declare namespace yar {
              * In that case you should probably change this back to true for a short time to allow session cookies to get reset for the best user experience.
              * Defaults to true.
              */
-            ignoreErrors?: boolean;
+            ignoreErrors?: boolean | undefined;
 
             /**
              * Tells Hapi that if a session cookie is invalid for any reason,
@@ -68,7 +68,7 @@ declare namespace yar {
              * other way you may set this to false.
              * Defaults to true
              */
-            clearInvalid?: boolean;
+            clearInvalid?: boolean | undefined;
             /**
              * (Required) used to encrypt and sign the cookie data.
              * Must be at least 32 chars.
@@ -78,27 +78,27 @@ declare namespace yar {
              * determines the cookie path.
              * Defaults to '/'.
              */
-            path?: string;
+            path?: string | undefined;
             /**
              * enables the same-site cookie parameter.
              * Default to 'Lax'.
              */
-            isSameSite?: 'Lax' | 'Strict' | false;
+            isSameSite?: 'Lax' | 'Strict' | false | undefined;
             /**
              * determines whether or not to transfer using TLS/SSL.
              * Defaults to true.
              */
-            isSecure?: boolean;
+            isSecure?: boolean | undefined;
             /**
              * determines whether or not to set HttpOnly option in cookie.
              * Defaults to false.
              */
-            isHttpOnly?: boolean;
+            isHttpOnly?: boolean | undefined;
             /**
              * sets the time for the cookie to live in the browser, in milliseconds.
              * Defaults to null (session time-life - cookies are deleted when the browser is closed).
              */
-            ttl?: number;
+            ttl?: number | undefined;
             /**
              * an optional function to create custom session IDs.
              * Must retun a string and have the signature function (request) where:

--- a/types/yargs-interactive/index.d.ts
+++ b/types/yargs-interactive/index.d.ts
@@ -12,9 +12,9 @@ declare namespace yargsInteractive {
     interface OptionData {
         type: 'input' | 'number' | 'confirm' | 'list' | 'rawlist' | 'expand' | 'checkbox' | 'password' | 'editor';
         describe: string;
-        default?: string | number | boolean | any[];
-        prompt?: 'always' | 'never' | 'if-no-arg' | 'if-empty';
-        choices?: string[];
+        default?: string | number | boolean | any[] | undefined;
+        prompt?: 'always' | 'never' | 'if-no-arg' | 'if-empty' | undefined;
+        choices?: string[] | undefined;
     }
     interface Option {
         [key: string]: OptionData | { default: boolean };

--- a/types/yargs-parser/index.d.ts
+++ b/types/yargs-parser/index.d.ts
@@ -68,38 +68,38 @@ declare namespace yargsParser {
 
     interface Options {
         /** An object representing the set of aliases for a key: `{ alias: { foo: ['f']} }`. */
-        alias?: { [key: string]: string | string[] };
+        alias?: { [key: string]: string | string[] } | undefined;
         /**
          * Indicate that keys should be parsed as an array: `{ array: ['foo', 'bar'] }`.
          * Indicate that keys should be parsed as an array and coerced to booleans / numbers:
          * { array: [ { key: 'foo', boolean: true }, {key: 'bar', number: true} ] }`.
          */
-        array?: string[] | Array<{ key: string; boolean?: boolean, number?: boolean }>;
+        array?: string[] | Array<{ key: string; boolean?: boolean | undefined, number?: boolean | undefined }> | undefined;
         /** Arguments should be parsed as booleans: `{ boolean: ['x', 'y'] }`. */
-        boolean?: string[];
+        boolean?: string[] | undefined;
         /** Indicate a key that represents a path to a configuration file (this file will be loaded and parsed). */
-        config?: string | string[] | { [key: string]: boolean };
+        config?: string | string[] | { [key: string]: boolean } | undefined;
         /** Provide configuration options to the yargs-parser. */
-        configuration?: Partial<Configuration>;
+        configuration?: Partial<Configuration> | undefined;
         /**
          * Provide a custom synchronous function that returns a coerced value from the argument provided (or throws an error), e.g.
          * `{ coerce: { foo: function (arg) { return modifiedArg } } }`.
          */
-        coerce?: { [key: string]: (arg: any) => any };
+        coerce?: { [key: string]: (arg: any) => any } | undefined;
         /** Indicate a key that should be used as a counter, e.g., `-vvv = {v: 3}`. */
-        count?: string[];
+        count?: string[] | undefined;
         /** Provide default values for keys: `{ default: { x: 33, y: 'hello world!' } }`. */
-        default?: { [key: string]: any };
+        default?: { [key: string]: any } | undefined;
         /** Environment variables (`process.env`) with the prefix provided should be parsed. */
-        envPrefix?: string;
+        envPrefix?: string | undefined;
         /** Specify that a key requires n arguments: `{ narg: {x: 2} }`. */
-        narg?: { [key: string]: number };
+        narg?: { [key: string]: number } | undefined;
         /** `path.normalize()` will be applied to values set to this key. */
-        normalize?: string[];
+        normalize?: string[] | undefined;
         /** Keys should be treated as strings (even if they resemble a number `-x 33`). */
-        string?: string[];
+        string?: string[] | undefined;
         /** Keys should be treated as numbers. */
-        number?: string[];
+        number?: string[] | undefined;
     }
 
     interface Parser {

--- a/types/yargs-parser/v11/index.d.ts
+++ b/types/yargs-parser/v11/index.d.ts
@@ -37,20 +37,20 @@ declare namespace yargsParser {
     }
 
     interface Options {
-        alias?: { [key: string]: string | string[] };
-        array?: string[];
-        boolean?: string[];
-        config?: string | string[] | { [key: string]: boolean };
-        configuration?: Partial<Configuration>;
-        coerce?: { [key: string]: (arg: any) => any };
-        count?: string[];
-        default?: { [key: string]: any };
-        envPrefix?: string;
-        narg?: { [key: string]: number };
-        normalize?: string[];
-        string?: string[];
-        number?: string[];
-        '--'?: boolean;
+        alias?: { [key: string]: string | string[] } | undefined;
+        array?: string[] | undefined;
+        boolean?: string[] | undefined;
+        config?: string | string[] | { [key: string]: boolean } | undefined;
+        configuration?: Partial<Configuration> | undefined;
+        coerce?: { [key: string]: (arg: any) => any } | undefined;
+        count?: string[] | undefined;
+        default?: { [key: string]: any } | undefined;
+        envPrefix?: string | undefined;
+        narg?: { [key: string]: number } | undefined;
+        normalize?: string[] | undefined;
+        string?: string[] | undefined;
+        number?: string[] | undefined;
+        '--'?: boolean | undefined;
     }
 
     interface Parser {

--- a/types/yargs-unparser/index.d.ts
+++ b/types/yargs-unparser/index.d.ts
@@ -11,9 +11,9 @@ declare namespace yargsUnparser {
     }
 
     interface UnparserOptions {
-        alias?: Record<string, string[]>;
-        default?: Record<string, string>;
-        command?: string;
+        alias?: Record<string, string[]> | undefined;
+        default?: Record<string, string> | undefined;
+        command?: string | undefined;
     }
 
     interface Unparser {

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -649,120 +649,120 @@ declare namespace yargs {
 
     interface RequireDirectoryOptions {
         /** Look for command modules in all subdirectories and apply them as a flattened (non-hierarchical) list. */
-        recurse?: boolean;
+        recurse?: boolean | undefined;
         /** The types of files to look for when requiring command modules. */
-        extensions?: ReadonlyArray<string>;
+        extensions?: ReadonlyArray<string> | undefined;
         /**
          * A synchronous function called for each command module encountered.
          * Accepts `commandObject`, `pathToFile`, and `filename` as arguments.
          * Returns `commandObject` to include the command; any falsy value to exclude/skip it.
          */
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
         /** Whitelist certain modules */
-        include?: RegExp | ((pathToFile: string) => boolean);
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
         /** Blacklist certain modules. */
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
         /** string or array of strings, alias(es) for the canonical option key, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /**  boolean, interpret option as a boolean flag, see `boolean()` */
-        boolean?: boolean;
+        boolean?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** boolean, interpret option as a path to a JSON config file, see `config()` */
-        config?: boolean;
+        config?: boolean | undefined;
         /** function, provide a custom config parsing function, see `config()` */
-        configParser?: (configPath: string) => object;
+        configParser?: ((configPath: string) => object) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, interpret option as a count of boolean flags, see `count()` */
-        count?: boolean;
+        count?: boolean | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** string, use this description for the default value in help content, see `default()` */
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
+        demand?: boolean | string | undefined;
         /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
-        deprecate?: boolean | string;
+        deprecate?: boolean | string | undefined;
         /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
-        deprecated?: boolean | string;
+        deprecated?: boolean | string | undefined;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** boolean, indicate that this key should not be reset when a command is invoked, see `global()` */
-        global?: boolean;
+        global?: boolean | undefined;
         /** string, when displaying usage instructions place the option under an alternative group heading, see `group()` */
-        group?: string;
+        group?: string | undefined;
         /** don't display option in help output. */
-        hidden?: boolean;
+        hidden?: boolean | undefined;
         /**  string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** number, specify how many arguments should be consumed for the option, see `nargs()` */
-        nargs?: number;
+        nargs?: number | undefined;
         /** boolean, apply path.normalize() to the option, see `normalize()` */
-        normalize?: boolean;
+        normalize?: boolean | undefined;
         /** boolean, interpret option as a number, `number()` */
-        number?: boolean;
+        number?: boolean | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        require?: boolean | string;
+        require?: boolean | string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        required?: boolean | string;
+        required?: boolean | string | undefined;
         /** boolean, require the option be specified with a value, see `requiresArg()` */
-        requiresArg?: boolean;
+        requiresArg?: boolean | undefined;
         /** boolean, skips validation if the option is present, see `skipValidation()` */
-        skipValidation?: boolean;
+        skipValidation?: boolean | undefined;
         /** boolean, interpret option as a string, see `string()` */
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
         /** string or array of strings, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, apply path.normalize() to the option, see normalize() */
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     /** Remove keys K in T */
@@ -823,15 +823,15 @@ declare namespace yargs {
 
     interface CommandModule<T = {}, U = {}> {
         /** array of strings (or a single string) representing aliases of `exports.command`, positional args defined in an alias are ignored */
-        aliases?: ReadonlyArray<string> | string;
+        aliases?: ReadonlyArray<string> | string | undefined;
         /** object declaring the options the command accepts, or a function accepting and returning a yargs instance */
-        builder?: CommandBuilder<T, U>;
+        builder?: CommandBuilder<T, U> | undefined;
         /** string (or array of strings) that executes this command when given on the command line, first string may contain positional args */
-        command?: ReadonlyArray<string> | string;
+        command?: ReadonlyArray<string> | string | undefined;
         /** boolean (or string) to show deprecation notice */
-        deprecated?: boolean | string;
+        deprecated?: boolean | string | undefined;
         /** string used as the description for the command in help text, use `false` for a hidden command */
-        describe?: string | false;
+        describe?: string | false | undefined;
         /** a function which will be passed the parsed argv. */
         handler: (args: Arguments<U>) => void;
     }

--- a/types/yargs/v10/index.d.ts
+++ b/types/yargs/v10/index.d.ts
@@ -239,69 +239,69 @@ declare namespace yargs {
     }
 
     interface RequireDirectoryOptions {
-        recurse?: boolean;
-        extensions?: string[];
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
-        include?: RegExp | ((pathToFile: string) => boolean);
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        recurse?: boolean | undefined;
+        extensions?: string[] | undefined;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
-        alias?: string | string[];
-        array?: boolean;
-        boolean?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        config?: boolean;
-        configParser?: (configPath: string) => object;
-        conflicts?: string | string[] | { [key: string]: string | string[] };
-        count?: boolean;
+        alias?: string | string[] | undefined;
+        array?: boolean | undefined;
+        boolean?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        config?: boolean | undefined;
+        configParser?: ((configPath: string) => object) | undefined;
+        conflicts?: string | string[] | { [key: string]: string | string[] } | undefined;
+        count?: boolean | undefined;
         default?: any;
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
-        demandOption?: boolean | string;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        global?: boolean;
-        group?: string;
-        hidden?: boolean;
-        implies?: string | string[] | { [key: string]: string | string[] };
-        nargs?: number;
-        normalize?: boolean;
-        number?: boolean;
-        require?: boolean | string;
-        required?: boolean | string;
-        requiresArg?: boolean | string;
-        skipValidation?: boolean;
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        demand?: boolean | string | undefined;
+        demandOption?: boolean | string | undefined;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        global?: boolean | undefined;
+        group?: string | undefined;
+        hidden?: boolean | undefined;
+        implies?: string | string[] | { [key: string]: string | string[] } | undefined;
+        nargs?: number | undefined;
+        normalize?: boolean | undefined;
+        number?: boolean | undefined;
+        require?: boolean | string | undefined;
+        required?: boolean | string | undefined;
+        requiresArg?: boolean | string | undefined;
+        skipValidation?: boolean | undefined;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
-        alias?: string | string[];
-        array?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        conflicts?: string | string[] | { [key: string]: string | string[] };
+        alias?: string | string[] | undefined;
+        array?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        conflicts?: string | string[] | { [key: string]: string | string[] } | undefined;
         default?: any;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        implies?: string | string[] | { [key: string]: string | string[] };
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        implies?: string | string[] | { [key: string]: string | string[] } | undefined;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     interface CommandModule {
-        aliases?: string[] | string;
-        builder?: CommandBuilder;
-        command?: string[] | string;
-        describe?: string | false;
+        aliases?: string[] | string | undefined;
+        builder?: CommandBuilder | undefined;
+        command?: string[] | string | undefined;
+        describe?: string | false | undefined;
         handler: (args: any) => void;
     }
 

--- a/types/yargs/v11/index.d.ts
+++ b/types/yargs/v11/index.d.ts
@@ -246,77 +246,77 @@ declare namespace yargs {
     }
 
     interface RequireDirectoryOptions {
-        recurse?: boolean;
-        extensions?: string[];
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
-        include?: RegExp | ((pathToFile: string) => boolean);
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        recurse?: boolean | undefined;
+        extensions?: string[] | undefined;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
-        alias?: string | string[];
-        array?: boolean;
-        boolean?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        config?: boolean;
-        configParser?: (configPath: string) => object;
-        conflicts?: string | string[] | { [key: string]: string | string[] };
-        count?: boolean;
+        alias?: string | string[] | undefined;
+        array?: boolean | undefined;
+        boolean?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        config?: boolean | undefined;
+        configParser?: ((configPath: string) => object) | undefined;
+        conflicts?: string | string[] | { [key: string]: string | string[] } | undefined;
+        count?: boolean | undefined;
         default?: any;
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
-        demandOption?: boolean | string;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        global?: boolean;
-        group?: string;
-        hidden?: boolean;
-        implies?: string | string[] | { [key: string]: string | string[] };
-        nargs?: number;
-        normalize?: boolean;
-        number?: boolean;
+        demand?: boolean | string | undefined;
+        demandOption?: boolean | string | undefined;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        global?: boolean | undefined;
+        group?: string | undefined;
+        hidden?: boolean | undefined;
+        implies?: string | string[] | { [key: string]: string | string[] } | undefined;
+        nargs?: number | undefined;
+        normalize?: boolean | undefined;
+        number?: boolean | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        require?: boolean | string;
+        require?: boolean | string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        required?: boolean | string;
-        requiresArg?: boolean;
-        skipValidation?: boolean;
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        required?: boolean | string | undefined;
+        requiresArg?: boolean | undefined;
+        skipValidation?: boolean | undefined;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
-        alias?: string | string[];
-        array?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        conflicts?: string | string[] | { [key: string]: string | string[] };
+        alias?: string | string[] | undefined;
+        array?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        conflicts?: string | string[] | { [key: string]: string | string[] } | undefined;
         default?: any;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        implies?: string | string[] | { [key: string]: string | string[] };
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        implies?: string | string[] | { [key: string]: string | string[] } | undefined;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     interface CommandModule {
-        aliases?: string[] | string;
-        builder?: CommandBuilder;
-        command?: string[] | string;
-        describe?: string | false;
+        aliases?: string[] | string | undefined;
+        builder?: CommandBuilder | undefined;
+        command?: string[] | string | undefined;
+        describe?: string | false | undefined;
         handler: (args: any) => void;
     }
 

--- a/types/yargs/v12/index.d.ts
+++ b/types/yargs/v12/index.d.ts
@@ -306,71 +306,71 @@ declare namespace yargs {
     }
 
     interface RequireDirectoryOptions {
-        recurse?: boolean;
-        extensions?: ReadonlyArray<string>;
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
-        include?: RegExp | ((pathToFile: string) => boolean);
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        recurse?: boolean | undefined;
+        extensions?: ReadonlyArray<string> | undefined;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
-        alias?: string | ReadonlyArray<string>;
-        array?: boolean;
-        boolean?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        config?: boolean;
-        configParser?: (configPath: string) => object;
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
-        count?: boolean;
+        alias?: string | ReadonlyArray<string> | undefined;
+        array?: boolean | undefined;
+        boolean?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        config?: boolean | undefined;
+        configParser?: ((configPath: string) => object) | undefined;
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
+        count?: boolean | undefined;
         default?: any;
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
-        demandOption?: boolean | string;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        global?: boolean;
-        group?: string;
-        hidden?: boolean;
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
-        nargs?: number;
-        normalize?: boolean;
-        number?: boolean;
+        demand?: boolean | string | undefined;
+        demandOption?: boolean | string | undefined;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        global?: boolean | undefined;
+        group?: string | undefined;
+        hidden?: boolean | undefined;
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
+        nargs?: number | undefined;
+        normalize?: boolean | undefined;
+        number?: boolean | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        require?: boolean | string;
+        require?: boolean | string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        required?: boolean | string;
-        requiresArg?: boolean;
-        skipValidation?: boolean;
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        required?: boolean | string | undefined;
+        requiresArg?: boolean | undefined;
+        skipValidation?: boolean | undefined;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
-        alias?: string | ReadonlyArray<string>;
-        array?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        alias?: string | ReadonlyArray<string> | undefined;
+        array?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         default?: any;
-        demandOption?: boolean | string;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        demandOption?: boolean | string | undefined;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     /** Remove keys K in T */
@@ -423,10 +423,10 @@ declare namespace yargs {
     type InferredOptionTypes<O extends { [key: string]: Options }> = { [key in keyof O]: InferredOptionType<O[key]> };
 
     interface CommandModule<T = {}, U = {}> {
-        aliases?: ReadonlyArray<string> | string;
-        builder?: CommandBuilder<T, U>;
-        command?: ReadonlyArray<string> | string;
-        describe?: string | false;
+        aliases?: ReadonlyArray<string> | string | undefined;
+        builder?: CommandBuilder<T, U> | undefined;
+        command?: ReadonlyArray<string> | string | undefined;
+        describe?: string | false | undefined;
         handler: (args: Arguments<U>) => void;
     }
 

--- a/types/yargs/v13/index.d.ts
+++ b/types/yargs/v13/index.d.ts
@@ -589,116 +589,116 @@ declare namespace yargs {
 
     interface RequireDirectoryOptions {
         /** Look for command modules in all subdirectories and apply them as a flattened (non-hierarchical) list. */
-        recurse?: boolean;
+        recurse?: boolean | undefined;
         /** The types of files to look for when requiring command modules. */
-        extensions?: ReadonlyArray<string>;
+        extensions?: ReadonlyArray<string> | undefined;
         /**
          * A synchronous function called for each command module encountered.
          * Accepts `commandObject`, `pathToFile`, and `filename` as arguments.
          * Returns `commandObject` to include the command; any falsy value to exclude/skip it.
          */
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
         /** Whitelist certain modules */
-        include?: RegExp | ((pathToFile: string) => boolean);
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
         /** Blacklist certain modules. */
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
         /** string or array of strings, alias(es) for the canonical option key, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /**  boolean, interpret option as a boolean flag, see `boolean()` */
-        boolean?: boolean;
+        boolean?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** boolean, interpret option as a path to a JSON config file, see `config()` */
-        config?: boolean;
+        config?: boolean | undefined;
         /** function, provide a custom config parsing function, see `config()` */
-        configParser?: (configPath: string) => object;
+        configParser?: ((configPath: string) => object) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, interpret option as a count of boolean flags, see `count()` */
-        count?: boolean;
+        count?: boolean | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** string, use this description for the default value in help content, see `default()` */
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
+        demand?: boolean | string | undefined;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** boolean, indicate that this key should not be reset when a command is invoked, see `global()` */
-        global?: boolean;
+        global?: boolean | undefined;
         /** string, when displaying usage instructions place the option under an alternative group heading, see `group()` */
-        group?: string;
+        group?: string | undefined;
         /** don't display option in help output. */
-        hidden?: boolean;
+        hidden?: boolean | undefined;
         /**  string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** number, specify how many arguments should be consumed for the option, see `nargs()` */
-        nargs?: number;
+        nargs?: number | undefined;
         /** boolean, apply path.normalize() to the option, see `normalize()` */
-        normalize?: boolean;
+        normalize?: boolean | undefined;
         /** boolean, interpret option as a number, `number()` */
-        number?: boolean;
+        number?: boolean | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        require?: boolean | string;
+        require?: boolean | string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        required?: boolean | string;
+        required?: boolean | string | undefined;
         /** boolean, require the option be specified with a value, see `requiresArg()` */
-        requiresArg?: boolean;
+        requiresArg?: boolean | undefined;
         /** boolean, skips validation if the option is present, see `skipValidation()` */
-        skipValidation?: boolean;
+        skipValidation?: boolean | undefined;
         /** boolean, interpret option as a string, see `string()` */
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
         /** string or array of strings, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, apply path.normalize() to the option, see normalize() */
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     /** Remove keys K in T */
@@ -752,13 +752,13 @@ declare namespace yargs {
 
     interface CommandModule<T = {}, U = {}> {
         /** array of strings (or a single string) representing aliases of `exports.command`, positional args defined in an alias are ignored */
-        aliases?: ReadonlyArray<string> | string;
+        aliases?: ReadonlyArray<string> | string | undefined;
         /** object declaring the options the command accepts, or a function accepting and returning a yargs instance */
-        builder?: CommandBuilder<T, U>;
+        builder?: CommandBuilder<T, U> | undefined;
         /** string (or array of strings) that executes this command when given on the command line, first string may contain positional args */
-        command?: ReadonlyArray<string> | string;
+        command?: ReadonlyArray<string> | string | undefined;
         /** string used as the description for the command in help text, use `false` for a hidden command */
-        describe?: string | false;
+        describe?: string | false | undefined;
         /** a function which will be passed the parsed argv. */
         handler: (args: Arguments<U>) => void;
     }

--- a/types/yargs/v15/index.d.ts
+++ b/types/yargs/v15/index.d.ts
@@ -641,120 +641,120 @@ declare namespace yargs {
 
     interface RequireDirectoryOptions {
         /** Look for command modules in all subdirectories and apply them as a flattened (non-hierarchical) list. */
-        recurse?: boolean;
+        recurse?: boolean | undefined;
         /** The types of files to look for when requiring command modules. */
-        extensions?: ReadonlyArray<string>;
+        extensions?: ReadonlyArray<string> | undefined;
         /**
          * A synchronous function called for each command module encountered.
          * Accepts `commandObject`, `pathToFile`, and `filename` as arguments.
          * Returns `commandObject` to include the command; any falsy value to exclude/skip it.
          */
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
         /** Whitelist certain modules */
-        include?: RegExp | ((pathToFile: string) => boolean);
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
         /** Blacklist certain modules. */
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
         /** string or array of strings, alias(es) for the canonical option key, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /**  boolean, interpret option as a boolean flag, see `boolean()` */
-        boolean?: boolean;
+        boolean?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** boolean, interpret option as a path to a JSON config file, see `config()` */
-        config?: boolean;
+        config?: boolean | undefined;
         /** function, provide a custom config parsing function, see `config()` */
-        configParser?: (configPath: string) => object;
+        configParser?: ((configPath: string) => object) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, interpret option as a count of boolean flags, see `count()` */
-        count?: boolean;
+        count?: boolean | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** string, use this description for the default value in help content, see `default()` */
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
+        demand?: boolean | string | undefined;
         /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
-        deprecate?: boolean | string;
+        deprecate?: boolean | string | undefined;
         /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
-        deprecated?: boolean | string;
+        deprecated?: boolean | string | undefined;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** boolean, indicate that this key should not be reset when a command is invoked, see `global()` */
-        global?: boolean;
+        global?: boolean | undefined;
         /** string, when displaying usage instructions place the option under an alternative group heading, see `group()` */
-        group?: string;
+        group?: string | undefined;
         /** don't display option in help output. */
-        hidden?: boolean;
+        hidden?: boolean | undefined;
         /**  string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** number, specify how many arguments should be consumed for the option, see `nargs()` */
-        nargs?: number;
+        nargs?: number | undefined;
         /** boolean, apply path.normalize() to the option, see `normalize()` */
-        normalize?: boolean;
+        normalize?: boolean | undefined;
         /** boolean, interpret option as a number, `number()` */
-        number?: boolean;
+        number?: boolean | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        require?: boolean | string;
+        require?: boolean | string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        required?: boolean | string;
+        required?: boolean | string | undefined;
         /** boolean, require the option be specified with a value, see `requiresArg()` */
-        requiresArg?: boolean;
+        requiresArg?: boolean | undefined;
         /** boolean, skips validation if the option is present, see `skipValidation()` */
-        skipValidation?: boolean;
+        skipValidation?: boolean | undefined;
         /** boolean, interpret option as a string, see `string()` */
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
         /** string or array of strings, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, apply path.normalize() to the option, see normalize() */
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     /** Remove keys K in T */
@@ -809,15 +809,15 @@ declare namespace yargs {
 
     interface CommandModule<T = {}, U = {}> {
         /** array of strings (or a single string) representing aliases of `exports.command`, positional args defined in an alias are ignored */
-        aliases?: ReadonlyArray<string> | string;
+        aliases?: ReadonlyArray<string> | string | undefined;
         /** object declaring the options the command accepts, or a function accepting and returning a yargs instance */
-        builder?: CommandBuilder<T, U>;
+        builder?: CommandBuilder<T, U> | undefined;
         /** string (or array of strings) that executes this command when given on the command line, first string may contain positional args */
-        command?: ReadonlyArray<string> | string;
+        command?: ReadonlyArray<string> | string | undefined;
         /** boolean (or string) to show deprecation notice */
-        deprecated?: boolean | string;
+        deprecated?: boolean | string | undefined;
         /** string used as the description for the command in help text, use `false` for a hidden command */
-        describe?: string | false;
+        describe?: string | false | undefined;
         /** a function which will be passed the parsed argv. */
         handler: (args: Arguments<U>) => void;
     }

--- a/types/yargs/v16/index.d.ts
+++ b/types/yargs/v16/index.d.ts
@@ -649,120 +649,120 @@ declare namespace yargs {
 
     interface RequireDirectoryOptions {
         /** Look for command modules in all subdirectories and apply them as a flattened (non-hierarchical) list. */
-        recurse?: boolean;
+        recurse?: boolean | undefined;
         /** The types of files to look for when requiring command modules. */
-        extensions?: ReadonlyArray<string>;
+        extensions?: ReadonlyArray<string> | undefined;
         /**
          * A synchronous function called for each command module encountered.
          * Accepts `commandObject`, `pathToFile`, and `filename` as arguments.
          * Returns `commandObject` to include the command; any falsy value to exclude/skip it.
          */
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
         /** Whitelist certain modules */
-        include?: RegExp | ((pathToFile: string) => boolean);
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
         /** Blacklist certain modules. */
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
         /** string or array of strings, alias(es) for the canonical option key, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /**  boolean, interpret option as a boolean flag, see `boolean()` */
-        boolean?: boolean;
+        boolean?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** boolean, interpret option as a path to a JSON config file, see `config()` */
-        config?: boolean;
+        config?: boolean | undefined;
         /** function, provide a custom config parsing function, see `config()` */
-        configParser?: (configPath: string) => object;
+        configParser?: ((configPath: string) => object) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, interpret option as a count of boolean flags, see `count()` */
-        count?: boolean;
+        count?: boolean | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** string, use this description for the default value in help content, see `default()` */
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        demand?: boolean | string;
+        demand?: boolean | string | undefined;
         /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
-        deprecate?: boolean | string;
+        deprecate?: boolean | string | undefined;
         /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
-        deprecated?: boolean | string;
+        deprecated?: boolean | string | undefined;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** boolean, indicate that this key should not be reset when a command is invoked, see `global()` */
-        global?: boolean;
+        global?: boolean | undefined;
         /** string, when displaying usage instructions place the option under an alternative group heading, see `group()` */
-        group?: string;
+        group?: string | undefined;
         /** don't display option in help output. */
-        hidden?: boolean;
+        hidden?: boolean | undefined;
         /**  string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** number, specify how many arguments should be consumed for the option, see `nargs()` */
-        nargs?: number;
+        nargs?: number | undefined;
         /** boolean, apply path.normalize() to the option, see `normalize()` */
-        normalize?: boolean;
+        normalize?: boolean | undefined;
         /** boolean, interpret option as a number, `number()` */
-        number?: boolean;
+        number?: boolean | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        require?: boolean | string;
+        require?: boolean | string | undefined;
         /**
          *  @deprecated since version 6.6.0
          *  Use 'demandOption' instead
          */
-        required?: boolean | string;
+        required?: boolean | string | undefined;
         /** boolean, require the option be specified with a value, see `requiresArg()` */
-        requiresArg?: boolean;
+        requiresArg?: boolean | undefined;
         /** boolean, skips validation if the option is present, see `skipValidation()` */
-        skipValidation?: boolean;
+        skipValidation?: boolean | undefined;
         /** boolean, interpret option as a string, see `string()` */
-        string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        string?: boolean | undefined;
+        type?: "array" | "count" | PositionalOptionsType | undefined;
     }
 
     interface PositionalOptions {
         /** string or array of strings, see `alias()` */
-        alias?: string | ReadonlyArray<string>;
+        alias?: string | ReadonlyArray<string> | undefined;
         /** boolean, interpret option as an array, see `array()` */
-        array?: boolean;
+        array?: boolean | undefined;
         /** value or array of values, limit valid option arguments to a predefined set, see `choices()` */
-        choices?: Choices;
+        choices?: Choices | undefined;
         /** function, coerce or transform parsed command line values into another value, see `coerce()` */
-        coerce?: (arg: any) => any;
+        coerce?: ((arg: any) => any) | undefined;
         /** string or object, require certain keys not to be set, see `conflicts()` */
-        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        conflicts?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** value, set a default value for the option, see `default()` */
         default?: any;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
-        demandOption?: boolean | string;
+        demandOption?: boolean | string | undefined;
         /** string, the option description for help content, see `describe()` */
-        desc?: string;
+        desc?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        describe?: string;
+        describe?: string | undefined;
         /** string, the option description for help content, see `describe()` */
-        description?: string;
+        description?: string | undefined;
         /** string or object, require certain keys to be set, see `implies()` */
-        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> };
+        implies?: string | ReadonlyArray<string> | { [key: string]: string | ReadonlyArray<string> } | undefined;
         /** boolean, apply path.normalize() to the option, see normalize() */
-        normalize?: boolean;
-        type?: PositionalOptionsType;
+        normalize?: boolean | undefined;
+        type?: PositionalOptionsType | undefined;
     }
 
     /** Remove keys K in T */
@@ -817,15 +817,15 @@ declare namespace yargs {
 
     interface CommandModule<T = {}, U = {}> {
         /** array of strings (or a single string) representing aliases of `exports.command`, positional args defined in an alias are ignored */
-        aliases?: ReadonlyArray<string> | string;
+        aliases?: ReadonlyArray<string> | string | undefined;
         /** object declaring the options the command accepts, or a function accepting and returning a yargs instance */
-        builder?: CommandBuilder<T, U>;
+        builder?: CommandBuilder<T, U> | undefined;
         /** string (or array of strings) that executes this command when given on the command line, first string may contain positional args */
-        command?: ReadonlyArray<string> | string;
+        command?: ReadonlyArray<string> | string | undefined;
         /** boolean (or string) to show deprecation notice */
-        deprecated?: boolean | string;
+        deprecated?: boolean | string | undefined;
         /** string used as the description for the command in help text, use `false` for a hidden command */
-        describe?: string | false;
+        describe?: string | false | undefined;
         /** a function which will be passed the parsed argv. */
         handler: (args: Arguments<U>) => void;
     }

--- a/types/yargs/v8/index.d.ts
+++ b/types/yargs/v8/index.d.ts
@@ -204,50 +204,50 @@ declare namespace yargs {
     }
 
     interface RequireDirectoryOptions {
-        recurse?: boolean;
-        extensions?: string[];
-        visit?: (commandObject: any, pathToFile?: string, filename?: string) => any;
-        include?: RegExp | ((pathToFile: string) => boolean);
-        exclude?: RegExp | ((pathToFile: string) => boolean);
+        recurse?: boolean | undefined;
+        extensions?: string[] | undefined;
+        visit?: ((commandObject: any, pathToFile?: string, filename?: string) => any) | undefined;
+        include?: RegExp | ((pathToFile: string) => boolean) | undefined;
+        exclude?: RegExp | ((pathToFile: string) => boolean) | undefined;
     }
 
     interface Options {
-        alias?: string | string[];
-        array?: boolean;
-        boolean?: boolean;
-        choices?: Choices;
-        coerce?: (arg: any) => any;
-        config?: boolean;
-        configParser?: (configPath: string) => object;
-        conflicts?: string | object;
-        count?: boolean;
+        alias?: string | string[] | undefined;
+        array?: boolean | undefined;
+        boolean?: boolean | undefined;
+        choices?: Choices | undefined;
+        coerce?: ((arg: any) => any) | undefined;
+        config?: boolean | undefined;
+        configParser?: ((configPath: string) => object) | undefined;
+        conflicts?: string | object | undefined;
+        count?: boolean | undefined;
         default?: any;
-        defaultDescription?: string;
+        defaultDescription?: string | undefined;
         /** @deprecated since version 6.6.0 */
-        demand?: boolean | string;
-        demandOption?: boolean | string;
-        desc?: string;
-        describe?: string;
-        description?: string;
-        global?: boolean;
-        group?: string;
-        implies?: string | object;
-        nargs?: number;
-        normalize?: boolean;
-        number?: boolean;
-        require?: boolean | string;
-        required?: boolean | string;
-        requiresArg?: boolean | string;
-        skipValidation?: boolean;
-        string?: boolean;
-        type?: "array" | "boolean" | "count" | "number" | "string";
+        demand?: boolean | string | undefined;
+        demandOption?: boolean | string | undefined;
+        desc?: string | undefined;
+        describe?: string | undefined;
+        description?: string | undefined;
+        global?: boolean | undefined;
+        group?: string | undefined;
+        implies?: string | object | undefined;
+        nargs?: number | undefined;
+        normalize?: boolean | undefined;
+        number?: boolean | undefined;
+        require?: boolean | string | undefined;
+        required?: boolean | string | undefined;
+        requiresArg?: boolean | string | undefined;
+        skipValidation?: boolean | undefined;
+        string?: boolean | undefined;
+        type?: "array" | "boolean" | "count" | "number" | "string" | undefined;
     }
 
     interface CommandModule {
-        aliases?: string[] | string;
-        builder?: CommandBuilder;
-        command?: string[] | string;
-        describe?: string | false;
+        aliases?: string[] | string | undefined;
+        builder?: CommandBuilder | undefined;
+        command?: string[] | string | undefined;
+        describe?: string | false | undefined;
         handler: (args: any) => void;
     }
 

--- a/types/yarnpkg__lockfile/index.d.ts
+++ b/types/yarnpkg__lockfile/index.d.ts
@@ -9,8 +9,8 @@ export interface Dependency {
 
 export interface FirstLevelDependency {
   version: string;
-  resolved?: string;
-  dependencies?: Dependency;
+  resolved?: string | undefined;
+  dependencies?: Dependency | undefined;
 }
 
 export interface LockFileObject {

--- a/types/yauzl/index.d.ts
+++ b/types/yauzl/index.d.ts
@@ -79,11 +79,11 @@ export class ZipFile extends EventEmitter {
 }
 
 export interface Options {
-    autoClose?: boolean;
-    lazyEntries?: boolean;
-    decodeStrings?: boolean;
-    validateEntrySizes?: boolean;
-    strictFileNames?: boolean;
+    autoClose?: boolean | undefined;
+    lazyEntries?: boolean | undefined;
+    decodeStrings?: boolean | undefined;
+    validateEntrySizes?: boolean | undefined;
+    strictFileNames?: boolean | undefined;
 }
 
 export function open(path: string, options: Options, callback?: (err?: Error, zipfile?: ZipFile) => void): void;

--- a/types/yayson/index.d.ts
+++ b/types/yayson/index.d.ts
@@ -42,7 +42,7 @@ declare module 'yayson' {
   }
 
   interface YaysonOptions {
-    adapter?: 'default' | 'sequelize';
+    adapter?: 'default' | 'sequelize' | undefined;
   }
 
   function y(arg?: YaysonOptions): Yayson;
@@ -50,7 +50,7 @@ declare module 'yayson' {
   namespace y {
     interface JsonOptions {
       [key: string]: any;
-      meta?: {};
+      meta?: {} | undefined;
     }
     interface Record {
       id: any;

--- a/types/ydn-db/index.d.ts
+++ b/types/ydn-db/index.d.ts
@@ -6,7 +6,7 @@
 interface FullTextSource {
   storeName: string;
   keyPath: string;
-  weight?: number;
+  weight?: number | undefined;
 }
 
 interface FullTextCatalog {
@@ -16,34 +16,34 @@ interface FullTextCatalog {
 }
 
 interface IndexSchemaJson {
-  name?: string;
+  name?: string | undefined;
   keyPath: string|string[];
-  type?: string;
-  unique?: boolean;
-  multiEntry?: boolean;
+  type?: string | undefined;
+  unique?: boolean | undefined;
+  multiEntry?: boolean | undefined;
 }
 
 interface StoreSchemaJson {
-  autoIncrement?: boolean;
-  dispatchEvents?: boolean;
-  name?: string;
-  indexes?: IndexSchemaJson[];
-  keyPath?: string;
-  type?: string;
+  autoIncrement?: boolean | undefined;
+  dispatchEvents?: boolean | undefined;
+  name?: string | undefined;
+  indexes?: IndexSchemaJson[] | undefined;
+  keyPath?: string | undefined;
+  type?: string | undefined;
 }
 
 interface DatabaseSchemaJson {
-  version?: number;
+  version?: number | undefined;
   stores: StoreSchemaJson[];
-  fullTextCatalogs?: FullTextCatalog[];
+  fullTextCatalogs?: FullTextCatalog[] | undefined;
 }
 
 interface StorageOptions {
-  mechanisms?: string[];
-  size?: number;
-  autoSchema?: boolean;
-  isSerial?: boolean;
-  requestType?: string;
+  mechanisms?: string[] | undefined;
+  size?: number | undefined;
+  autoSchema?: boolean | undefined;
+  isSerial?: boolean | undefined;
+  requestType?: string | undefined;
 }
 
 declare namespace ydn.db {

--- a/types/yeoman-environment/index.d.ts
+++ b/types/yeoman-environment/index.d.ts
@@ -465,7 +465,7 @@ declare namespace Environment {
         /**
          * The working-directory of the environment.
          */
-        cwd?: string;
+        cwd?: string | undefined;
 
         /**
          * Additional options.
@@ -510,12 +510,12 @@ declare namespace Environment {
         /**
          * The arguments to pass to the generator.
          */
-        arguments?: string | string[];
+        arguments?: string | string[] | undefined;
 
         /**
          * The options for creating the generator.
          */
-        options?: TOptions;
+        options?: TOptions | undefined;
     }
 
     /**
@@ -525,7 +525,7 @@ declare namespace Environment {
         /**
          * A value indicating whether globally installed packages should be ignored.
          */
-        localOnly?: boolean;
+        localOnly?: boolean | undefined;
     }
 
     /**
@@ -535,12 +535,12 @@ declare namespace Environment {
         /**
          * A value indicating whether the path to the package should be returned instead of the path to the generator.
          */
-        packagePath?: boolean;
+        packagePath?: boolean | undefined;
 
         /**
          * A value indicating whether only one result should be returned.
          */
-        singleResult?: boolean;
+        singleResult?: boolean | undefined;
     }
 
     /**
@@ -550,7 +550,7 @@ declare namespace Environment {
         /**
          * A value indicating whether paths which don't end with a supported directory-name should be filtered (unless they are part of `NODE_PATH`).
          */
-        filterPaths?: boolean;
+        filterPaths?: boolean | undefined;
     }
 
     /**
@@ -560,32 +560,32 @@ declare namespace Environment {
         /**
          * The paths to look for generators.
          */
-        packagePaths?: string[];
+        packagePaths?: string[] | undefined;
 
         /**
          * The repüository paths to look for generator packages.
          */
-        npmPaths?: string[];
+        npmPaths?: string[] | undefined;
 
         /**
          * The file-patterns to look for.
          */
-        filePatterns?: string[];
+        filePatterns?: string[] | undefined;
 
         /**
          * The package patterns to look for.
          */
-        packagePatterns?: string[];
+        packagePatterns?: string[] | undefined;
 
         /**
          * A value indicating whether the lookup should be stopped after finding the first result.
          */
-        singleResult?: boolean;
+        singleResult?: boolean | undefined;
 
         /**
          * The `deep` option to pass to `globby`.
          */
-        globbyDeep?: number;
+        globbyDeep?: number | undefined;
     }
 
     /**
@@ -595,7 +595,7 @@ declare namespace Environment {
         /**
          * The package-patterns to look for.
          */
-        packagePatterns?: string[];
+        packagePatterns?: string[] | undefined;
     }
 
     /**

--- a/types/yeoman-environment/lib/adapter.d.ts
+++ b/types/yeoman-environment/lib/adapter.d.ts
@@ -10,7 +10,7 @@ declare namespace TerminalAdapter {
         /**
          * A console-object for logging messages.
          */
-        console?: Console;
+        console?: Console | undefined;
     }
 
     /**

--- a/types/yeoman-environment/lib/util/log.d.ts
+++ b/types/yeoman-environment/lib/util/log.d.ts
@@ -34,22 +34,22 @@ declare namespace createLogger {
         /**
          * A set of categories and assigned `chalk`-formats.
          */
-        colors?: ColorMap<TCategories>;
+        colors?: ColorMap<TCategories> | undefined;
 
         /**
          * The console to write log-messages to.
          */
-        console?: Console;
+        console?: Console | undefined;
 
         /**
          * The stream to write other messages to.
          */
-        stderr?: WriteStream;
+        stderr?: WriteStream | undefined;
 
         /**
          * The stream to write other messages to.
          */
-        stdout?: WriteStream;
+        stdout?: WriteStream | undefined;
     }
 
     /**

--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -31,7 +31,7 @@ declare namespace Generator {
         /**
          * The name for identifying the queue.
          */
-        queueName?: string;
+        queueName?: string | undefined;
 
         /**
          * The name of the method to execute.
@@ -56,17 +56,17 @@ declare namespace Generator {
         /**
          * Gets or sets a collection of custom priorities.
          */
-        customPriorities?: Priority[];
+        customPriorities?: Priority[] | undefined;
 
         /**
          * The environment to use for creating the generator.
          */
-        env?: Environment;
+        env?: Environment | undefined;
 
         /**
          * The destination-root to write the files to.
          */
-        destinationRoot?: string;
+        destinationRoot?: string | undefined;
     }
 
     /**
@@ -87,7 +87,7 @@ declare namespace Generator {
         /**
          * A value indicating whether to store the user's previous answer.
          */
-        store?: boolean;
+        store?: boolean | undefined;
     };
 
     /**
@@ -97,12 +97,12 @@ declare namespace Generator {
         /**
          * The storage to store the answers.
          */
-        storage?: Storage;
+        storage?: Storage | undefined;
 
         /**
          * A value indicating whether an option should be exported for this question.
          */
-        exportOption?: boolean | object;
+        exportOption?: boolean | object | undefined;
     };
 
     /**
@@ -122,22 +122,22 @@ declare namespace Generator {
         /**
          * A value indicating whether to run `npm install` or options to pass to `dargs` as arguments.
          */
-        npm?: boolean | object;
+        npm?: boolean | object | undefined;
 
         /**
          * A value indicating whether to run `bower install` or options to pass to `dargs` as arguments.
          */
-        bower?: boolean | object;
+        bower?: boolean | object | undefined;
 
         /**
          * A value indicating whether to run `yarn install` or options to pass to `dargs` as arguments.
          */
-        yarn?: boolean | object;
+        yarn?: boolean | object | undefined;
 
         /**
          * A value indicating whether messages should be logged.
          */
-        skipMessage?: boolean;
+        skipMessage?: boolean | undefined;
     }
 
     /**
@@ -147,22 +147,22 @@ declare namespace Generator {
         /**
          * Description for the argument.
          */
-        description?: string;
+        description?: string | undefined;
 
         /**
          * A value indicating whether the argument is required.
          */
-        required?: boolean;
+        required?: boolean | undefined;
 
         /**
          * A value indicating whether the argument is optional.
          */
-        optional?: boolean;
+        optional?: boolean | undefined;
 
         /**
          * The type of the argument.
          */
-        type?: typeof String | typeof Number | typeof Array | typeof Object;
+        type?: typeof String | typeof Number | typeof Array | typeof Object | undefined;
 
         /**
          * The default value of the argument.
@@ -182,7 +182,7 @@ declare namespace Generator {
         /**
          * The option name alias (example `-h` and --help`).
          */
-        alias?: string;
+        alias?: string | undefined;
 
         /**
          * The default value.
@@ -192,17 +192,17 @@ declare namespace Generator {
         /**
          * The description for the option.
          */
-        description?: string;
+        description?: string | undefined;
 
         /**
          * A value indicating whether the option should be hidden from the help output.
          */
-        hide?: boolean;
+        hide?: boolean | undefined;
 
         /**
          * The storage to persist the option
          */
-        storage?: Storage;
+        storage?: Storage | undefined;
     }
 
     /**
@@ -236,33 +236,33 @@ declare namespace Generator {
         /**
          * uniqueBy calculation method (undefined/argument/namespace)
          */
-        uniqueBy?: GeneratorFeaturesUniqueBy;
+        uniqueBy?: GeneratorFeaturesUniqueBy | undefined;
 
         /**
          * The Generator instance unique identifier.
          * The Environment will ignore duplicated identifiers.
          */
-        unique?: string;
+        unique?: string | undefined;
 
         /**
          * Only queue methods that matches a priority
          */
-        tasksMatchingPriority?: boolean;
+        tasksMatchingPriority?: boolean | undefined;
 
         /**
          * Tasks methods starts with prefix. Allows api methods (non tasks) without prefix.
          */
-         taskPrefix?: string;
+         taskPrefix?: string | undefined;
 
         /**
          * Enable customCommitTask()
          */
-         customCommitTask?: boolean;
+         customCommitTask?: boolean | undefined;
 
          /**
           * Enable customInstallTask()
           */
-         customInstallTask?: boolean;
+         customInstallTask?: boolean | undefined;
     }
 
     /**
@@ -272,17 +272,17 @@ declare namespace Generator {
         /**
          * The name of the queue.
          */
-        queueName?: string;
+        queueName?: string | undefined;
 
         /**
          * A value indicating whether the queue should be executed only once per namespace and task-name.
          */
-        once?: boolean;
+        once?: boolean | undefined;
 
         /**
          * A value indicating whether the queue should be executed if not running yet.
          */
-        run?: boolean;
+        run?: boolean | undefined;
     }
 
     /**
@@ -292,7 +292,7 @@ declare namespace Generator {
         /**
          * A method for handling errors.
          */
-        reject?: Callback;
+        reject?: Callback | undefined;
     }
 
     /**
@@ -317,7 +317,7 @@ declare namespace Generator {
         /**
          * A method for determining whether the template should be rendered.
          */
-        when?: (templateData: TemplateData, generator: T) => boolean;
+        when?: ((templateData: TemplateData, generator: T) => boolean) | undefined;
 
         /**
          * The template file, absolute or relative to `templatePath()`.
@@ -327,17 +327,17 @@ declare namespace Generator {
         /**
          * The destination, absolute or relative to `destinationPath()`.
          */
-        destination?: string | string[];
+        destination?: string | string[] | undefined;
 
         /**
          * The `ejs` options.
          */
-        templateOptions?: TemplateOptions;
+        templateOptions?: TemplateOptions | undefined;
 
         /**
          * The `mem-fs-editor` copy-options.
          */
-        copyOptions?: CopyOptions;
+        copyOptions?: CopyOptions | undefined;
     }
 }
 

--- a/types/yeoman-test/index.d.ts
+++ b/types/yeoman-test/index.d.ts
@@ -147,18 +147,18 @@ export interface RunContextSettings {
      * Automatically run this generator in a tmp dir
      * @default true
      */
-    tmpdir?: boolean;
+    tmpdir?: boolean | undefined;
 
     /**
      * File path to the generator (only used if Generator is a constructor)
      */
-    resolved?: string;
+    resolved?: string | undefined;
 
     /**
      * Namespace (only used if Generator is a constructor)
      * @default 'gen:test'
      */
-    namespace?: string;
+    namespace?: string | undefined;
 }
 
 /**

--- a/types/yesql/index.d.ts
+++ b/types/yesql/index.d.ts
@@ -7,15 +7,15 @@
 declare function readSqlFiles(
     dir: string,
     options?: {
-        pg?: boolean;
-        type?: 'pg' | 'mysql';
+        pg?: boolean | undefined;
+        type?: 'pg' | 'mysql' | undefined;
     },
 ): string;
 
 declare namespace readSqlFiles {
     type AnyParams = Record<string, any>;
     interface Options {
-        useNullForMissing?: boolean;
+        useNullForMissing?: boolean | undefined;
     }
     function pg<TParams extends object = AnyParams>(
         query: string,

--- a/types/yog-bigpipe/index.d.ts
+++ b/types/yog-bigpipe/index.d.ts
@@ -9,19 +9,19 @@ import { Readable } from 'stream';
 import { RequestHandler } from 'express';
 
 interface BigPipeOption {
-    skipAnalysis?: boolean;
+    skipAnalysis?: boolean | undefined;
     tpl?: {
-        _default?: string,
-        quickling?: string
-    };
+        _default?: string | undefined,
+        quickling?: string | undefined
+    } | undefined;
 }
 
 type Callback = (done: (err: any, data: any) => any) => any;
 
 interface AddPageletConfig {
     id: string;
-    lazy?: boolean;
-    mode?: yogBigpipe.Pagelet.mode;
+    lazy?: boolean | undefined;
+    mode?: yogBigpipe.Pagelet.mode | undefined;
 }
 
 declare function yogBigpipe(option?: BigPipeOption): RequestHandler;
@@ -80,15 +80,15 @@ declare namespace yogBigpipe {
 
     interface PageletOption {
         id: string;
-        mode?: Pagelet.mode;
-        lazy?: boolean;
+        mode?: Pagelet.mode | undefined;
+        lazy?: boolean | undefined;
         reqID: string;
         skipAnalysis: boolean;
 
-        locals?: {};
-        compiled?: boolean;
-        container?: string;
-        for?: string;
+        locals?: {} | undefined;
+        compiled?: boolean | undefined;
+        container?: string | undefined;
+        for?: string | undefined;
         model: {};
     }
     interface PageletData {

--- a/types/yog-log/index.d.ts
+++ b/types/yog-log/index.d.ts
@@ -24,24 +24,24 @@ type LevelName = LEVELS[LevelInt];
 type LogReturn = undefined | false;
 
 interface LogConfig {
-    LogIdName?: string;
+    LogIdName?: string | undefined;
     // 模板文件地址，可以不填
-    data_path?: string;
+    data_path?: string | undefined;
     // 用户只需要填写log_path配置
-    log_path?: string;
+    log_path?: string | undefined;
 
-    debug?: 0 | 1;
-    intLevel?: 16;
-    auto_rotate?: 0 | 1;
-    use_sub_dir?: 0 | 1;
-    IS_ODP?: boolean;
-    IS_OMP?: 0 | 1;
+    debug?: 0 | 1 | undefined;
+    intLevel?: 16 | undefined;
+    auto_rotate?: 0 | 1 | undefined;
+    use_sub_dir?: 0 | 1 | undefined;
+    IS_ODP?: boolean | undefined;
+    IS_OMP?: 0 | 1 | undefined;
 
-    access_log_path?: string;
-    access_error_log_path?: string;
+    access_log_path?: string | undefined;
+    access_error_log_path?: string | undefined;
 
-    access?: string;
-    format_wf?: string;
+    access?: string | undefined;
+    format_wf?: string | undefined;
 }
 
 interface WriteLogConfig {

--- a/types/yog2-kernel/index.d.ts
+++ b/types/yog2-kernel/index.d.ts
@@ -15,13 +15,13 @@ export as namespace yog;
 declare namespace yog {
     interface YogBootstrapOption {
         // 设置yog根目录，默认使用启动文件的目录
-        rootPath?: string;
+        rootPath?: string | undefined;
         // 设置plugins目录
-        pluginsPath?: string;
+        pluginsPath?: string | undefined;
         // 设置conf目录
-        confPath?: string;
+        confPath?: string | undefined;
         // 设置app，未设置则直接使用express
-        app?: express.Express;
+        app?: express.Express | undefined;
     }
     interface Request extends express.Request {
         CURRENT_APP: string;
@@ -33,22 +33,22 @@ declare namespace yog {
     }
 
     interface ActionObject {
-        get?: express.RequestHandler;
-        post?: express.RequestHandler;
-        put?: express.RequestHandler;
-        delete?: express.RequestHandler;
-        del?: express.RequestHandler;
-        copy?: express.RequestHandler;
-        head?: express.RequestHandler;
-        options?: express.RequestHandler;
-        purge?: express.RequestHandler;
-        lock?: express.RequestHandler;
-        unlock?: express.RequestHandler;
-        propfind?: express.RequestHandler;
-        view?: express.RequestHandler;
-        link?: express.RequestHandler;
-        unlick?: express.RequestHandler;
-        patch?: express.RequestHandler;
+        get?: express.RequestHandler | undefined;
+        post?: express.RequestHandler | undefined;
+        put?: express.RequestHandler | undefined;
+        delete?: express.RequestHandler | undefined;
+        del?: express.RequestHandler | undefined;
+        copy?: express.RequestHandler | undefined;
+        head?: express.RequestHandler | undefined;
+        options?: express.RequestHandler | undefined;
+        purge?: express.RequestHandler | undefined;
+        lock?: express.RequestHandler | undefined;
+        unlock?: express.RequestHandler | undefined;
+        propfind?: express.RequestHandler | undefined;
+        view?: express.RequestHandler | undefined;
+        link?: express.RequestHandler | undefined;
+        unlick?: express.RequestHandler | undefined;
+        patch?: express.RequestHandler | undefined;
         [key: string]: any;
     }
 

--- a/types/yoga-layout/index.d.ts
+++ b/types/yoga-layout/index.d.ts
@@ -310,7 +310,12 @@ declare namespace Yoga {
         setMaxHeightPercent(maxHeight: number): void;
         setMaxWidth(maxWidth: number | string): void;
         setMaxWidthPercent(maxWidth: number): void;
-        setMeasureFunc(measureFunc: (width: number, widthMeasureMode: YogaMeasureMode, height: number, heightMeasureMode: YogaMeasureMode) => { width?: number; height?: number } | null): void;
+        setMeasureFunc(
+            measureFunc: (width: number, widthMeasureMode: YogaMeasureMode, height: number, heightMeasureMode: YogaMeasureMode) => {
+                width?: number | undefined;
+                height?: number | undefined
+            } | null
+        ): void;
         setMinHeight(minHeight: number | string): void;
         setMinHeightPercent(minHeight: number): void;
         setMinWidth(minWidth: number | string): void;

--- a/types/youtube-dl/index.d.ts
+++ b/types/youtube-dl/index.d.ts
@@ -28,10 +28,10 @@ declare namespace youtubedl {
     }
 
     interface Options {
-        auto?: boolean;
-        all?: boolean;
-        lang?: string;
-        cwd?: string;
+        auto?: boolean | undefined;
+        all?: boolean | undefined;
+        lang?: string | undefined;
+        cwd?: string | undefined;
     }
 
     /**

--- a/types/youtube-player/dist/types.d.ts
+++ b/types/youtube-player/dist/types.d.ts
@@ -6,35 +6,35 @@ export interface EmitterType {
 }
 
 export interface Options {
-    width?: number | string;
-    height?: number | string;
-    videoId?: string;
+    width?: number | string | undefined;
+    height?: number | string | undefined;
+    videoId?: string | undefined;
     playerVars?: {
-        autoplay?: 0 | 1,
-        cc_lang_pref?: string,
-        cc_load_policy?: 1,
-        color?: 'red' | 'white',
-        controls?: 0 | 1,
-        disablekb?: 0 | 1,
-        enablejsapi?: 0 | 1,
-        end?: number,
-        fs?: 0 | 1,
-        hl?: string,
-        iv_load_policy?: 1 | 3,
-        list?: string,
-        listType?: 'playlist' | 'search' | 'user_uploads',
-        loop?: 0 | 1,
-        modestbranding?: 1,
-        origin?: string,
-        playlist?: string,
-        playsinline?: 0 | 1,
-        rel?: 0 | 1,
-        start?: number,
-        widget_referrer?: string,
-    };
+        autoplay?: 0 | 1 | undefined,
+        cc_lang_pref?: string | undefined,
+        cc_load_policy?: 1 | undefined,
+        color?: 'red' | 'white' | undefined,
+        controls?: 0 | 1 | undefined,
+        disablekb?: 0 | 1 | undefined,
+        enablejsapi?: 0 | 1 | undefined,
+        end?: number | undefined,
+        fs?: 0 | 1 | undefined,
+        hl?: string | undefined,
+        iv_load_policy?: 1 | 3 | undefined,
+        list?: string | undefined,
+        listType?: 'playlist' | 'search' | 'user_uploads' | undefined,
+        loop?: 0 | 1 | undefined,
+        modestbranding?: 1 | undefined,
+        origin?: string | undefined,
+        playlist?: string | undefined,
+        playsinline?: 0 | 1 | undefined,
+        rel?: 0 | 1 | undefined,
+        start?: number | undefined,
+        widget_referrer?: string | undefined,
+    } | undefined;
     events?: {
         [eventType in EventType]?: (event: CustomEvent) => void
-    };
+    } | undefined;
 }
 
 export interface IframeApiType {
@@ -65,10 +65,10 @@ export interface YouTubePlayer {
     ): void;
     cuePlaylist(playlist: {
         listType: string,
-        list?: string,
-        index?: number,
-        startSeconds?: number,
-        suggestedQuality?: string,
+        list?: string | undefined,
+        index?: number | undefined,
+        startSeconds?: number | undefined,
+        suggestedQuality?: string | undefined,
     }): void;
     loadPlaylist(
         playlist: string | ReadonlyArray<string>,
@@ -78,10 +78,10 @@ export interface YouTubePlayer {
     ): void;
     loadPlaylist(playlist: {
         listType: string,
-        list?: string,
-        index?: number,
-        startSeconds?: number,
-        suggestedQuality?: string,
+        list?: string | undefined,
+        index?: number | undefined,
+        startSeconds?: number | undefined,
+        suggestedQuality?: string | undefined,
     }): void;
     getPlaylist(): ReadonlyArray<string>;
     getPlaylistIndex(): number;
@@ -95,30 +95,30 @@ export interface YouTubePlayer {
     cueVideoById(videoId: string, startSeconds?: number, suggestedQuality?: string): void;
     cueVideoById(video: {
         videoId: string,
-        startSeconds?: number,
-        endSeconds?: number,
-        suggestedQuality?: string,
+        startSeconds?: number | undefined,
+        endSeconds?: number | undefined,
+        suggestedQuality?: string | undefined,
     }): void;
     cueVideoByUrl(mediaContentUrl: string, startSeconds?: number, suggestedQuality?: string): void;
     cueVideoByUrl(video: {
         mediaContentUrl: string,
-        startSeconds?: number,
-        endSeconds?: number,
-        suggestedQuality?: string,
+        startSeconds?: number | undefined,
+        endSeconds?: number | undefined,
+        suggestedQuality?: string | undefined,
     }): void;
     loadVideoByUrl(mediaContentUrl: string, startSeconds?: number, suggestedQuality?: string): void;
     loadVideoByUrl(video: {
         mediaContentUrl: string,
-        startSeconds?: number,
-        endSeconds?: number,
-        suggestedQuality?: string,
+        startSeconds?: number | undefined,
+        endSeconds?: number | undefined,
+        suggestedQuality?: string | undefined,
     }): void;
     loadVideoById(videoId: string, startSeconds?: number, suggestedQuality?: string): void;
     loadVideoById(video: {
         videoId: string,
-        startSeconds?: number,
-        endSeconds?: number,
-        suggestedQuality?: string,
+        startSeconds?: number | undefined,
+        endSeconds?: number | undefined,
+        suggestedQuality?: string | undefined,
     }): void;
     isMuted(): boolean;
     mute(): void;

--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -375,32 +375,32 @@ declare namespace YT
         /**
          * Player width.
          */
-        width?: string | number;
+        width?: string | number | undefined;
 
         /**
          * Player height
          */
-        height?: string | number;
+        height?: string | number | undefined;
 
         /**
          * ID of the video to load.
          */
-        videoId?: string;
+        videoId?: string | undefined;
 
         /**
          * Player parameters.
          */
-        playerVars?: PlayerVars;
+        playerVars?: PlayerVars | undefined;
 
         /**
          * Handlers for events fired by the player.
          */
-        events?: Events;
+        events?: Events | undefined;
 
         /**
          * Points host to correct origin for CORS
          */
-        host?: string;
+        host?: string | undefined;
     }
 
     /**
@@ -458,114 +458,114 @@ declare namespace YT
         /**
          * Whether to autohide video controls (by default, HideProgressBar).
          */
-        autohide?: AutoHide;
+        autohide?: AutoHide | undefined;
 
         /**
          * Whether to autoplay the video (by default, NoAutoPlay).
          */
-        autoplay?: AutoPlay;
+        autoplay?: AutoPlay | undefined;
 
         /**
          * Whether to use user-preferred or forced caption loading (by default, UserDefault).
          */
-        cc_load_policy?: ClosedCaptionsLoadPolicy;
+        cc_load_policy?: ClosedCaptionsLoadPolicy | undefined;
 
         /**
          * Default caption language as an ISO 639-1 two-letter language code.
          */
-        cc_lang_pref?: string;
+        cc_lang_pref?: string | undefined;
 
         /**
          * Player progress bar color
          */
-        color?: ProgressBarColor;
+        color?: ProgressBarColor | undefined;
 
         /**
          * How video controls are shown (by default, ShowLoadPlayer).
          */
-        controls?: Controls;
+        controls?: Controls | undefined;
 
         /**
          * Whether to allow keyboard controls (by default, Enable).
          */
-        disablekb?: KeyboardControls;
+        disablekb?: KeyboardControls | undefined;
 
         /**
          * Whether the JavaScript API should be enabled (by default, Disable).
          */
-        enablejsapi?: JsApi;
+        enablejsapi?: JsApi | undefined;
 
         /**
          * Time, in seconds from the beginning of the video, when to stop playing.
          */
-        end?: number;
+        end?: number | undefined;
 
         /**
          * Whether to display the full-screen button (by default, Show).
          */
-        fs?: FullscreenButton;
+        fs?: FullscreenButton | undefined;
 
         /**
          * Player language as an ISO 639-1 two-letter language code or fully-specified locale.
          */
-        hl?: string;
+        hl?: string | undefined;
 
         /**
          * Whether to show video annotations (by default, Show).
          */
-        iv_load_policy?: IvLoadPolicy;
+        iv_load_policy?: IvLoadPolicy | undefined;
 
         /**
          * Identifies content that will load.
          * If the listType parameter value is user_uploads, then the list parameter value identifies the YouTube channel whose uploaded videos will be loaded.
          * If the listType parameter value is playlist, then the list parameter value specifies a YouTube playlist ID.
          */
-        list?: string;
+        list?: string | undefined;
 
         /**
          * Which type of content loads in the player.
          */
-        listType?: ListType;
+        listType?: ListType | undefined;
 
         /**
          * Whether a single video should be looped (by default, SinglePlay).
          */
-        loop?: Loop;
+        loop?: Loop | undefined;
 
         /**
          * Whether to hide some YouTube branding (by default, Full).
          */
-        modestbranding?: ModestBranding;
+        modestbranding?: ModestBranding | undefined;
 
         /**
          * Origin domain for additional security if using the JavaScript API.
          */
-        origin?: string;
+        origin?: string | undefined;
 
         /**
          * Comma separated list of video IDs to play after the URL path's video.
          */
-        playlist?: string;
+        playlist?: string | undefined;
 
         /**
          * Whether videos play inline or fullscreen in an HTML5 player on iOS. (currently by default, Fullscreen).
          */
-        playsinline?: PlaysInline;
+        playsinline?: PlaysInline | undefined;
 
         /**
          * Whether to show related videos after the video finishes (by default, Show).
          */
-        rel?: RelatedVideos;
+        rel?: RelatedVideos | undefined;
 
         /**
          * Whether to show video information before playing (by default, Show).
          */
-        showinfo?: ShowInfo;
+        showinfo?: ShowInfo | undefined;
 
         /**
          * Time, in seconds from the beginning of the video, when to start playing.
          */
-        start?: number;
+        start?: number | undefined;
     }
 
     /**
@@ -576,33 +576,33 @@ declare namespace YT
         /**
          * Event fired when a player has finished loading and is ready to begin receiving API calls.
          */
-        onReady?: PlayerEventHandler<PlayerEvent>;
+        onReady?: PlayerEventHandler<PlayerEvent> | undefined;
 
         /**
          * Event fired when the player's state changes.
          */
-        onStateChange?: PlayerEventHandler<OnStateChangeEvent>;
+        onStateChange?: PlayerEventHandler<OnStateChangeEvent> | undefined;
 
         /**
          * Event fired when the playback quality of the player changes.
          */
-        onPlaybackQualityChange?: PlayerEventHandler<OnPlaybackQualityChangeEvent>;
+        onPlaybackQualityChange?: PlayerEventHandler<OnPlaybackQualityChangeEvent> | undefined;
 
         /**
          * Event fired when the playback rate of the player changes.
          */
-        onPlaybackRateChange?: PlayerEventHandler<OnPlaybackRateChangeEvent>;
+        onPlaybackRateChange?: PlayerEventHandler<OnPlaybackRateChangeEvent> | undefined;
 
         /**
          * Event fired when an error in the player occurs
          */
-        onError?: PlayerEventHandler<OnErrorEvent>;
+        onError?: PlayerEventHandler<OnErrorEvent> | undefined;
 
         /**
          * Event fired to indicate thath the player has loaded, or unloaded, a module
          * with exposed API methods. This currently only occurs for closed captioning.
          */
-        onApiChange?: PlayerEventHandler<PlayerEvent>;
+        onApiChange?: PlayerEventHandler<PlayerEvent> | undefined;
     }
 
     /**
@@ -612,17 +612,17 @@ declare namespace YT
         /**
          * Time, in seconds from the beginning of the (first) video, when to start playing.
          */
-        startSeconds?: number;
+        startSeconds?: number | undefined;
 
         /**
          * Time, in seconds from the end of the (first) video, when to end playing.
          */
-        endSeconds?: number;
+        endSeconds?: number | undefined;
 
         /**
          * Suggested video player quality.
          */
-        suggestedQuality?: SuggestedVideoQuality
+        suggestedQuality?: SuggestedVideoQuality | undefined
     }
 
     /**
@@ -657,12 +657,12 @@ declare namespace YT
         /**
          * Which type of content loads in the player.
          */
-        listType?: ListType;
+        listType?: ListType | undefined;
 
         /**
          * Start index of the playlist, if not 0.
          */
-        index?: number;
+        index?: number | undefined;
     }
     
     /**
@@ -670,11 +670,11 @@ declare namespace YT
      * viewport headings and zoom level.
      */
     export interface SphericalProperties {
-      enableOrientationSensor?: boolean;
-      fov?: number;
-      pitch?: number;
-      roll?: number;
-      yaw?: number;
+      enableOrientationSensor?: boolean | undefined;
+      fov?: number | undefined;
+      pitch?: number | undefined;
+      roll?: number | undefined;
+      yaw?: number | undefined;
     }
 
     /**
@@ -760,7 +760,7 @@ declare namespace YT
          *
          * @param args   Settings to play the video.
          */
-        loadVideoByUrl(args: { mediaContentUrl: string; startSeconds?: number; endSeconds?: number; suggestedQuality?: SuggestedVideoQuality }): void;
+        loadVideoByUrl(args: { mediaContentUrl: string; startSeconds?: number | undefined; endSeconds?: number | undefined; suggestedQuality?: SuggestedVideoQuality | undefined }): void;
 
         /**
          * Queues a playlist of videos.

--- a/types/yt-player/index.d.ts
+++ b/types/yt-player/index.d.ts
@@ -7,14 +7,14 @@ import { EventEmitter } from 'events';
 
 interface YouTubePlayerOptions {
     /**  This parameter indicates the width of the player. */
-    width?: number;
+    width?: number | undefined;
     /** This parameter indicates the height of the player. */
-    height?: number;
+    height?: number | undefined;
     /**
      * This parameter indicates whether the initial video will automatically
      * start to play when the player loads. The default value is false.
      */
-    autoplay?: boolean;
+    autoplay?: boolean | undefined;
     /**
      * This parameter causes the player to begin playing the video at the given number
      * of seconds from the start of the video. The parameter value is a positive integer.
@@ -22,61 +22,61 @@ interface YouTubePlayerOptions {
      * This means that sometimes the play head may seek to just before the requested time,
      * usually no more than around two seconds. Default is 0.
      */
-    start?: number;
+    start?: number | undefined;
     /**
      * This parameter indicates whether closed captions should be shown, even if
      * the user has turned captions off. The default behavior is based on user
      * preference.
      */
-    captions?: false | string;
+    captions?: false | string | undefined;
     /**
      * This parameter indicates whether the video player controls are displayed.
      * The default value is true.
      */
-    controls?: boolean;
+    controls?: boolean | undefined;
     /**
      * This parameter indicates whether the player will respond to keyboard
      * shortcuts. The default value is true.
      */
-    keyboard?: boolean;
+    keyboard?: boolean | undefined;
     /**
      * This parameter indicates whether the player will show a fullscreen
      * button. The default value is true.
      */
-    fullscreen?: boolean;
+    fullscreen?: boolean | undefined;
     /**
      * This parameter indicates whether the player will show video annotations.
      * The default value is true.
      */
-    annotations?: boolean;
+    annotations?: boolean | undefined;
     /**
      * This parameter lets you use a YouTube player that does not show a
      * YouTube logo. Even when this option is enabled, a small YouTube text
      * label will still display in the upper-right corner of a paused video
      * when the user's mouse pointer hovers over the player.
      */
-    modestBranding?: boolean;
+    modestBranding?: boolean | undefined;
     /**
      * This parameter indicates whether the player should show related videos
      * from other channels
      */
-    related?: boolean;
+    related?: boolean | undefined;
     /**
      * The time between onTimeupdate callbacks, in milliseconds. Default is
      * 1000.
      */
-    timeupdateFrequency?: number;
+    timeupdateFrequency?: number | undefined;
     /**
      * This parameter controls whether videos play inline or fullscreen in an
      * HTML5 player on iOS. The default is true.
      */
-    playsInline?: boolean;
+    playsInline?: boolean | undefined;
     /**
      * This parameter controls the hostname that videos are loaded from.
      * Set to `https://www.youtube-nocookie.com` for enhanced privacy.
      * The default value is `https://www.youtube.com`.
      */
-    host?: string;
+    host?: string | undefined;
 }
 
 type YouTubePlayerState = 'unstarted' | 'ended' | 'playing' | 'paused' | 'buffering' | 'cued';

--- a/types/yt-search/index.d.ts
+++ b/types/yt-search/index.d.ts
@@ -27,30 +27,30 @@ declare function search(query: yts.PlaylistMetadataOptions): Promise<yts.Playlis
 
 declare namespace yts {
     interface BaseOptions {
-        pageStart?: number;
-        pageEnd?: number;
-        pages?: number;
-        userAgent?: string;
+        pageStart?: number | undefined;
+        pageEnd?: number | undefined;
+        pages?: number | undefined;
+        userAgent?: string | undefined;
 
         /**
          * The language.
          * @default 'en'
          */
-        hl?: string;
+        hl?: string | undefined;
 
         /**
          * The location.
          * @default 'US'
          */
-        gl?: string;
+        gl?: string | undefined;
 
         /**
          * The category (for example `'music'`.)
          * @default ''
          */
-        category?: string;
+        category?: string | undefined;
 
-        sp?: string;
+        sp?: string | undefined;
     }
 
     interface OptionsWithQuery extends BaseOptions {

--- a/types/yuka/src/navigation/navmesh/NavMeshLoader.d.ts
+++ b/types/yuka/src/navigation/navmesh/NavMeshLoader.d.ts
@@ -4,12 +4,12 @@ export interface NavMeshLoaderOptions {
     /**
      * The tolerance value for the coplanar test.
      */
-    epsilonCoplanarTest?: number;
+    epsilonCoplanarTest?: number | undefined;
 
     /**
      * The tolerance value for the containment test.
      */
-    epsilonContainsTest?: number;
+    epsilonContainsTest?: number | undefined;
 }
 
 /**

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -86,7 +86,7 @@ export interface MixedSchemaConstructor {
     // tslint:disable-next-line:no-unnecessary-generics
     <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
     // tslint:disable-next-line:no-unnecessary-generics
-    new <T = {} | null | undefined, C = object>(options?: { type?: string; [key: string]: any }): MixedSchema<T, C>;
+    new <T = {} | null | undefined, C = object>(options?: { type?: string | undefined; [key: string]: any }): MixedSchema<T, C>;
 }
 
 export interface MixedSchema<T extends any = {} | null | undefined, C = object> extends Schema<T, C> {
@@ -133,7 +133,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
         regex: RegExp,
         messageOrOptions?:
             | StringLocale['matches']
-            | { message?: StringLocale['matches']; excludeEmptyString?: boolean },
+            | { message?: StringLocale['matches'] | undefined; excludeEmptyString?: boolean | undefined },
     ): StringSchema<T, C>;
     email(message?: StringLocale['email']): StringSchema<T, C>;
     url(message?: StringLocale['url']): StringSchema<T, C>;
@@ -446,30 +446,30 @@ export interface TestContext<C = object> {
     schema: Schema<any, C>;
     originalValue: any;
     resolve: (value: any) => any;
-    createError: (params?: { path?: string; message?: string; params?: object }) => ValidationError;
+    createError: (params?: { path?: string | undefined; message?: string | undefined; params?: object | undefined }) => ValidationError;
 }
 
 export interface ValidateOptions<C = object> {
     /**
      * Only validate the input, and skip and coercion or transformation. Default - false
      */
-    strict?: boolean;
+    strict?: boolean | undefined;
     /**
      * Return from validation methods on the first error rather than after all validations run. Default - true
      */
-    abortEarly?: boolean;
+    abortEarly?: boolean | undefined;
     /**
      * Remove unspecified keys from objects. Default - false
      */
-    stripUnknown?: boolean;
+    stripUnknown?: boolean | undefined;
     /**
      * When false validations will not descend into nested schema (relevant for objects or arrays). Default - true
      */
-    recursive?: boolean;
+    recursive?: boolean | undefined;
     /**
      * Any context needed for validating schema conditions (see: when())
      */
-    context?: C;
+    context?: C | undefined;
 }
 
 export interface TestMessageParams {
@@ -483,7 +483,7 @@ interface BaseTestOptions<P extends Record<string, any>, C = object> {
     /**
      * Unique name identifying the test. Required for exclusive tests.
      */
-    name?: string;
+    name?: string | undefined;
 
     /**
      * Test function, determines schema validity
@@ -493,21 +493,21 @@ interface BaseTestOptions<P extends Record<string, any>, C = object> {
     /**
      * The validation error message
      */
-    message?: TestOptionsMessage<P>;
+    message?: TestOptionsMessage<P> | undefined;
 
     /**
      * Values passed to message for interpolation
      */
-    params?: P;
+    params?: P | undefined;
 
     /**
      * Mark the test as exclusive, meaning only one of the same can be active at once
      */
-    exclusive?: boolean;
+    exclusive?: boolean | undefined;
 }
 
 interface NonExclusiveTestOptions<P extends Record<string, any>, C> extends BaseTestOptions<P, C> {
-    exclusive?: false;
+    exclusive?: false | undefined;
 }
 
 interface ExclusiveTestOptions<P extends Record<string, any>, C> extends BaseTestOptions<P, C> {
@@ -538,7 +538,7 @@ export interface SchemaFieldRefDescription {
 
 export interface SchemaFieldInnerTypeDescription
     extends Pick<SchemaDescription, Exclude<keyof SchemaDescription, 'fields'>> {
-    innerType?: SchemaFieldDescription;
+    innerType?: SchemaFieldDescription | undefined;
 }
 
 export type SchemaFieldDescription = SchemaDescription | SchemaFieldRefDescription | SchemaFieldInnerTypeDescription;
@@ -574,7 +574,7 @@ export class ValidationError extends Error {
      * In the case of aggregate errors, inner is an array of ValidationErrors throw earlier in the validation chain.
      */
     inner: ValidationError[];
-    params?: object;
+    params?: object | undefined;
 
     static isError(err: any): err is ValidationError;
     static formatError(message: string | ((params?: any) => string), params?: any): string | ((params?: any) => string);
@@ -621,60 +621,60 @@ export interface FormatErrorParams {
 export type LocaleValue = string | ((params: FormatErrorParams) => string);
 
 export interface MixedLocale {
-    default?: TestOptionsMessage;
-    required?: TestOptionsMessage;
-    oneOf?: TestOptionsMessage<{ values: any }>;
-    notOneOf?: TestOptionsMessage<{ values: any }>;
-    notType?: LocaleValue;
-    defined?: TestOptionsMessage;
+    default?: TestOptionsMessage | undefined;
+    required?: TestOptionsMessage | undefined;
+    oneOf?: TestOptionsMessage<{ values: any }> | undefined;
+    notOneOf?: TestOptionsMessage<{ values: any }> | undefined;
+    notType?: LocaleValue | undefined;
+    defined?: TestOptionsMessage | undefined;
 }
 
 export interface StringLocale {
-    length?: TestOptionsMessage<{ length: number }>;
-    min?: TestOptionsMessage<{ min: number }>;
-    max?: TestOptionsMessage<{ max: number }>;
-    matches?: TestOptionsMessage<{ regex: RegExp }>;
-    email?: TestOptionsMessage<{ regex: RegExp }>;
-    url?: TestOptionsMessage<{ regex: RegExp }>;
-    uuid?: TestOptionsMessage<{ regex: RegExp }>;
-    trim?: TestOptionsMessage;
-    lowercase?: TestOptionsMessage;
-    uppercase?: TestOptionsMessage;
+    length?: TestOptionsMessage<{ length: number }> | undefined;
+    min?: TestOptionsMessage<{ min: number }> | undefined;
+    max?: TestOptionsMessage<{ max: number }> | undefined;
+    matches?: TestOptionsMessage<{ regex: RegExp }> | undefined;
+    email?: TestOptionsMessage<{ regex: RegExp }> | undefined;
+    url?: TestOptionsMessage<{ regex: RegExp }> | undefined;
+    uuid?: TestOptionsMessage<{ regex: RegExp }> | undefined;
+    trim?: TestOptionsMessage | undefined;
+    lowercase?: TestOptionsMessage | undefined;
+    uppercase?: TestOptionsMessage | undefined;
 }
 
 export interface NumberLocale {
-    min?: TestOptionsMessage<{ min: number }>;
-    max?: TestOptionsMessage<{ max: number }>;
-    lessThan?: TestOptionsMessage<{ less: number }>;
-    moreThan?: TestOptionsMessage<{ more: number }>;
-    notEqual?: TestOptionsMessage<{ notEqual: number }>;
-    positive?: TestOptionsMessage<{ more: number }>;
-    negative?: TestOptionsMessage<{ less: number }>;
-    integer?: TestOptionsMessage;
+    min?: TestOptionsMessage<{ min: number }> | undefined;
+    max?: TestOptionsMessage<{ max: number }> | undefined;
+    lessThan?: TestOptionsMessage<{ less: number }> | undefined;
+    moreThan?: TestOptionsMessage<{ more: number }> | undefined;
+    notEqual?: TestOptionsMessage<{ notEqual: number }> | undefined;
+    positive?: TestOptionsMessage<{ more: number }> | undefined;
+    negative?: TestOptionsMessage<{ less: number }> | undefined;
+    integer?: TestOptionsMessage | undefined;
 }
 
 export interface DateLocale {
-    min?: TestOptionsMessage<{ min: Date | string }>;
-    max?: TestOptionsMessage<{ max: Date | string }>;
+    min?: TestOptionsMessage<{ min: Date | string }> | undefined;
+    max?: TestOptionsMessage<{ max: Date | string }> | undefined;
 }
 
 export interface ObjectLocale {
-    noUnknown?: TestOptionsMessage<{ unknown: string }>;
+    noUnknown?: TestOptionsMessage<{ unknown: string }> | undefined;
 }
 
 export interface ArrayLocale {
-    min?: TestOptionsMessage<{ min: number }>;
-    max?: TestOptionsMessage<{ max: number }>;
+    min?: TestOptionsMessage<{ min: number }> | undefined;
+    max?: TestOptionsMessage<{ max: number }> | undefined;
 }
 
 export interface LocaleObject {
-    mixed?: MixedLocale;
-    string?: StringLocale;
-    number?: NumberLocale;
-    date?: DateLocale;
-    boolean?: {};
-    object?: ObjectLocale;
-    array?: ArrayLocale;
+    mixed?: MixedLocale | undefined;
+    string?: StringLocale | undefined;
+    number?: NumberLocale | undefined;
+    date?: DateLocale | undefined;
+    boolean?: {} | undefined;
+    object?: ObjectLocale | undefined;
+    array?: ArrayLocale | undefined;
 }
 
 export type InferType<T> = T extends Schema<infer P> ? InnerInferType<P> : never;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -1059,7 +1059,7 @@ const arrayOfOptionalExample: yup.InferType<typeof arrayOfOptional> = [{}];
 // augment locale
 declare module './index' {
     interface StringLocale {
-        chineseMobilePhoneNumber?: TestOptionsMessage;
+        chineseMobilePhoneNumber?: TestOptionsMessage | undefined;
     }
 
     interface StringSchema<T extends string | null | undefined = string | undefined, C = object> extends Schema<T, C> {


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add
undefined to all optional properties. #no-publishing-comment

This PR covers packages starting with y-. #54241