### PR TITLE
Add team drives apis to google.picker types

### DIFF
--- a/types/google.picker/google.picker-tests.ts
+++ b/types/google.picker/google.picker-tests.ts
@@ -65,10 +65,11 @@ function fullExample(): void {
     };
 
     const view = new google.picker.DocsView(google.picker.ViewId.DOCS);
-    view.setMimeTypes("image/png,image/jpeg,image/jpg");
+    view.setMimeTypes("image/png,image/jpeg,image/jpg").setEnableTeamDrives(true);
     const picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
+        .enableFeature(google.picker.Feature.SUPPORT_TEAM_DRIVES)
         .setAppId("appId")
         .setOAuthToken("accessToken")
         .addView(view)

--- a/types/google.picker/index.d.ts
+++ b/types/google.picker/index.d.ts
@@ -188,6 +188,9 @@ declare namespace google {
 
             // Set the MIME types which will be included in the view. Use commas to separate MIME types if more than one is required.
             setMimeTypes(mimeTypes: string): DocsView;
+
+            // Allows the user to select folders from Shared team Drives.
+            setEnableTeamDrives(enabled: boolean): DocsView;
         }
 
         /**
@@ -235,6 +238,9 @@ declare namespace google {
 
             // Whether Shared Drive items should be included in results.
             SUPPORT_DRIVES = "sdr",
+
+            // Whether Shared team Drive items should be included in results.
+            SUPPORT_TEAM_DRIVES = 'std'
         }
 
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: I can't find these api's documented on the google docs but the methods do definitely do exist at runtime
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

