### PR TITLE
Add undefined to optional properties, part TA

### DIFF
--- a/types/tabbable/index.d.ts
+++ b/types/tabbable/index.d.ts
@@ -7,7 +7,7 @@ declare function T(el: Element | Document, options?: T.Options): HTMLElement[];
 
 declare namespace T {
     interface Options {
-        includeContainer?: boolean;
+        includeContainer?: boolean | undefined;
     }
 
     function isTabbable(el: HTMLElement): boolean;

--- a/types/tableau-js-api/viz.d.ts
+++ b/types/tableau-js-api/viz.d.ts
@@ -94,16 +94,16 @@ export class Viz {
 }
 
 export interface VizCreateOptions {
-    disableUrlActionsPopups?: boolean;
-    hideTabs?: boolean;
-    hideToolbar?: boolean;
-    instanceIdToClone?: string;
-    width?: string;
-    height?: string;
-    device?: DeviceType;
-    onFirstInteractive?: (event: TableauEvent) => void;
-    onFirstVizSizeKnown?: (event: VizResizeEvent) => void;
-    toolbarPosition?: ToolbarPosition;
+    disableUrlActionsPopups?: boolean | undefined;
+    hideTabs?: boolean | undefined;
+    hideToolbar?: boolean | undefined;
+    instanceIdToClone?: string | undefined;
+    width?: string | undefined;
+    height?: string | undefined;
+    device?: DeviceType | undefined;
+    onFirstInteractive?: ((event: TableauEvent) => void) | undefined;
+    onFirstVizSizeKnown?: ((event: VizResizeEvent) => void) | undefined;
+    toolbarPosition?: ToolbarPosition | undefined;
 }
 
 export class ToolbarState {

--- a/types/tableau/index.d.ts
+++ b/types/tableau/index.d.ts
@@ -264,36 +264,36 @@ declare namespace tableau {
 
     interface VizCreateOptions {
         /** Undoes action on sheet, defaults to a single undo unless optional parameters is specified. */
-        hideTabs?: boolean;
+        hideTabs?: boolean | undefined;
         /** Indicates whether the toolbar is hidden or shown. */
-        hideToolbar?: boolean;
+        hideToolbar?: boolean | undefined;
         /**
          * Specifies the ID of an existing instance to make a copy (clone) of.
          * This is useful if the user wants to continue analysis of an existing visualization without losing the state of the original.
          * If the ID does not refer to an existing visualization, the cloned version is derived from the original visualization.
          */
-        instanceIdToClone?: string;
+        instanceIdToClone?: string | undefined;
         /** Can be any valid CSS size specifier. If not specified, defaults to the published height of the view. */
-        height?: string;
+        height?: string | undefined;
         /** Can be any valid CSS size specifier. If not specified, defaults to the published height of the view. */
-        width?: string;
+        width?: string | undefined;
         /**
          * Specifies a device layout for a dashboard, if it exists.
          * Values can be desktop, tablet, or phone.
          * If not specified, defaults to loading a layout based on the smallest dimension of the hosting iframe element.
          */
-        device?: string;
+        device?: string | undefined;
         /**
          * Callback function that is invoked when the Viz object first becomes interactive.
          * This is only called once, but it’s guaranteed to be called.
          * If the Viz object is already interactive, it will be called immediately, but on a separate "thread."
          */
-        onFirstInteractive?: (e: TableauEvent) => void;
+        onFirstInteractive?: ((e: TableauEvent) => void) | undefined;
         /**
          * Callback function that's invoked when the size of the Viz object is known.
          * You can use this callback to perform tasks such as resizing the elements surrounding the Viz object once the object's size has been established.
          */
-        onFirstVizSizeKnown?: (e: VizResizeEvent) => void;
+        onFirstVizSizeKnown?: ((e: VizResizeEvent) => void) | undefined;
         /**
          * Apply a filter that you specify to the view when it is first rendered.
          * For example, if you have an Academic Year filter and only want to display data for 2017,
@@ -606,20 +606,20 @@ declare namespace tableau {
 
     interface getSummaryDataOptions {
         /** Do not use aliases specified in the data source in Tableau. Default is false. */
-        ignoreAliases?: boolean;
+        ignoreAliases?: boolean | undefined;
         /** Only return data for the currently selected marks. Default is false. */
-        ignoreSelection?: boolean;
+        ignoreSelection?: boolean | undefined;
         /** The number of rows of data that you want to return. Enter 0 to return all rows. */
         maxRows: number;
     }
 
     interface getUnderlyingDataOptions {
         /** Do not use aliases specified in the data source in Tableau. Default is false. */
-        ignoreAliases?: boolean;
+        ignoreAliases?: boolean | undefined;
         /** Only return data for the currently selected marks. Default is false. */
-        ignoreSelection?: boolean;
+        ignoreSelection?: boolean | undefined;
         /** Return all the columns for the data source. Default is false. */
-        ignoreAllColumns?: boolean;
+        ignoreAllColumns?: boolean | undefined;
         /** The number of rows of data that you want to return. Enter 0 to return all rows. */
         maxRows: number;
     }

--- a/types/tableify/index.d.ts
+++ b/types/tableify/index.d.ts
@@ -14,8 +14,8 @@ declare function tableify<T extends Record<string, any>>(
 declare function tableify(obj: any): string;
 declare namespace tableify {
     interface Config {
-        classes?: boolean;
-        classPrefix?: string;
+        classes?: boolean | undefined;
+        classPrefix?: string | undefined;
     }
     function defaults(config: Config): {
         <T extends Record<string, any>>(

--- a/types/tablesorter/Filtering/Formatter/Options/ComparableOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/ComparableOptions.d.ts
@@ -5,5 +5,5 @@ export interface ComparableOptions {
     /**
      * The compare-operators supported by the control.
      */
-    compare?: string | string[];
+    compare?: string | string[] | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/ControlOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/ControlOptions.d.ts
@@ -5,5 +5,5 @@ export interface ControlOptions {
     /**
      * The label of the control.
      */
-    cellText?: string;
+    cellText?: string | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/DateOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/DateOptions.d.ts
@@ -5,5 +5,5 @@ export interface DateOptions {
     /**
      * A value indicating whether the filter's time-value should be set to the end of the day.
      */
-    endOfDay?: boolean;
+    endOfDay?: boolean | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/DefaultValueOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/DefaultValueOptions.d.ts
@@ -5,5 +5,5 @@ export interface DefaultValueOptions<T> {
     /**
      * The default value of the control.
      */
-    value?: T;
+    value?: T | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/DelayableOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/DelayableOptions.d.ts
@@ -5,5 +5,5 @@ export interface DelayableOptions {
     /**
      * A value indicating whether the value of the filter should be set delayed.
      */
-    delayed?: boolean;
+    delayed?: boolean | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/IntervalOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/IntervalOptions.d.ts
@@ -7,5 +7,5 @@ export interface IntervalOptions extends NumericOptions {
     /**
      * The interval of the control.
      */
-    step?: number;
+    step?: number | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/NumericOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/NumericOptions.d.ts
@@ -5,10 +5,10 @@ export interface NumericOptions {
     /**
      * The minimum value of the control.
      */
-    min?: number;
+    min?: number | undefined;
 
     /**
      * The maximum value of the control.
      */
-    max?: number;
+    max?: number | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/PreviewableOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/PreviewableOptions.d.ts
@@ -5,5 +5,5 @@ export interface PreviewableOptions {
     /**
      * A value indicating whether the value should be visible in the table header.
      */
-    valueToHeader?: boolean;
+    valueToHeader?: boolean | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/RangeOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/RangeOptions.d.ts
@@ -7,5 +7,5 @@ export interface RangeOptions extends IntervalOptions {
     /**
      * The text indicating the whole range.
      */
-    allText?: string;
+    allText?: string | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/StrictOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/StrictOptions.d.ts
@@ -5,5 +5,5 @@ export interface StrictOptions {
     /**
      * A value indicatin whether only exact matching values should be included.
      */
-    exactMatch?: boolean;
+    exactMatch?: boolean | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/TestableOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/TestableOptions.d.ts
@@ -5,5 +5,5 @@ export interface TestableOptions {
     /**
      * A value indicating whether tests should be skipped.
      */
-    skipTest?: boolean;
+    skipTest?: boolean | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/ToggleableOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/ToggleableOptions.d.ts
@@ -5,10 +5,10 @@ export interface ToggleableOptions {
     /**
      * A value indicating whether the control is initially disabled.
      */
-    disabled?: boolean;
+    disabled?: boolean | undefined;
 
     /**
      * A value indicating whether to add a box for enabling/disabling the control.
      */
-    addToggle?: boolean;
+    addToggle?: boolean | undefined;
 }

--- a/types/tablesorter/Filtering/Formatter/Options/UIDateRangeOptions.d.ts
+++ b/types/tablesorter/Filtering/Formatter/Options/UIDateRangeOptions.d.ts
@@ -10,20 +10,20 @@ export interface UIDateRangeOptions extends
     /**
      * The label of the "from"-input.
      */
-    textFrom?: string;
+    textFrom?: string | undefined;
 
     /**
      * The label of the "to"-input.
      */
-    textTo?: string;
+    textTo?: string | undefined;
 
     /**
      * The default `from`-value.
      */
-    from?: Date;
+    from?: Date | undefined;
 
     /**
      * The default `to`-value.
      */
-    to?: Date;
+    to?: Date | undefined;
 }

--- a/types/tablesorter/Filtering/MatchTypeSettings.d.ts
+++ b/types/tablesorter/Filtering/MatchTypeSettings.d.ts
@@ -7,10 +7,10 @@ export interface MatchTypeSettings {
     /**
      * The match-type for `input`-controls.
      */
-    input?: MatchType;
+    input?: MatchType | undefined;
 
     /**
      * The match-type for `select`-controls.
      */
-    select?: MatchType;
+    select?: MatchType | undefined;
 }

--- a/types/tablesorter/Filtering/SelectSource.d.ts
+++ b/types/tablesorter/Filtering/SelectSource.d.ts
@@ -10,10 +10,10 @@ export interface SelectSource {
     /**
      * The filter-value.
      */
-    value?: string;
+    value?: string | undefined;
 
     /**
      * Classes to add to the dropdown-entries.
      */
-    "data-class"?: string;
+    "data-class"?: string | undefined;
 }

--- a/types/tablesorter/Paging/PagerClasses.d.ts
+++ b/types/tablesorter/Paging/PagerClasses.d.ts
@@ -5,15 +5,15 @@ export interface PagerClasses {
     /**
      * A set of css-classes to apply to the container.
      */
-    container?: string;
+    container?: string | undefined;
 
     /**
      * The css-class to apply to disabled pager-controls.
      */
-    disabled?: string;
+    disabled?: string | undefined;
 
     /**
      * The css-class to apply to the table-row which displays the error-message in case of an ajax-error.
      */
-    errorRow?: string;
+    errorRow?: string | undefined;
 }

--- a/types/tablesorter/Paging/PagerConfiguration.d.ts
+++ b/types/tablesorter/Paging/PagerConfiguration.d.ts
@@ -23,22 +23,22 @@ export interface PagerConfiguration<TElement = HTMLElement> {
      * | `{sortList:name}` or `{sort:name}`     | A GET-variable called `name` containing the current sorting.           |
      * | `{filterList:name}` or `{filter:name}` | A GET-variable called `name` containing all currently applied filters. |
      */
-    ajaxUrl?: string;
+    ajaxUrl?: string | undefined;
 
     /**
      * Pre-processes the url for `ajax`.
      */
-    customAjaxUrl?: AjaxUrlProcessor<TElement>;
+    customAjaxUrl?: AjaxUrlProcessor<TElement> | undefined;
 
     /**
      * The settings for the api-interaction of the pager.
      */
-    ajaxObject?: JQueryAjaxSettings;
+    ajaxObject?: JQueryAjaxSettings | undefined;
 
     /**
      * Handles errors caused by an ajax-request.
      */
-    ajaxError?: AjaxErrorHandler<TElement>;
+    ajaxError?: AjaxErrorHandler<TElement> | undefined;
 
     /**
      * Processes the ajax-result for the `pager`-widget.
@@ -55,7 +55,7 @@ export interface PagerConfiguration<TElement = HTMLElement> {
      * @return
      * The data for the pager to show.
      */
-    ajaxProcessing?: AjaxDataProcessor<TElement>;
+    ajaxProcessing?: AjaxDataProcessor<TElement> | undefined;
 
     /**
      * The output to display in the output-area.
@@ -75,110 +75,110 @@ export interface PagerConfiguration<TElement = HTMLElement> {
      * | `{filteredRows}`   | The amount of filtered rows.                 |
      * | `{totalRows}`      | The total amount of rows.                    |
      */
-    output?: string | PagerOutputProcessor<TElement>;
+    output?: string | PagerOutputProcessor<TElement> | undefined;
 
     /**
      * The number of the first page to show.
      */
-    page?: number;
+    page?: number | undefined;
 
     /**
      * The number of the first page to show after applying a filter.
      */
-    pageReset?: number | boolean;
+    pageReset?: number | boolean | undefined;
 
     /**
      * The initial page-size.
      */
-    size?: PageSize;
+    size?: PageSize | undefined;
 
     /**
      * A value indicating whether to split child-rows on page-breaks.
      */
-    countChildRows?: boolean;
+    countChildRows?: boolean | undefined;
 
     /**
      * A value indicating whether an ajax-request should be executed after the initialization of the table.
      */
-    processAjaxOnInit?: boolean;
+    processAjaxOnInit?: boolean | undefined;
 
     /**
      * The initial amount of rows to show.
      */
-    initialRows?: PagerInitialRows;
+    initialRows?: PagerInitialRows | undefined;
 
     /**
      * A value indicating whether to remove the rows while performing sortings for speed up.
      */
-    removeRows?: boolean;
+    removeRows?: boolean | undefined;
 
     /**
      * The key to of the local storage to save data to.
      */
-    storageKey?: string;
+    storageKey?: string | undefined;
 
     /**
      * A value indicating whether to save the current page locally.
      */
-    savePages?: boolean;
+    savePages?: boolean | undefined;
 
     /**
      * The selector for querying the pager-container.
      */
-    container?: JQuery.Selector | JQuery;
+    container?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the first page.
      */
-    cssFirst?: JQuery.Selector | JQuery;
+    cssFirst?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the previous page.
      */
-    cssPrev?: JQuery.Selector | JQuery;
+    cssPrev?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the next page.
      */
-    cssNext?: JQuery.Selector | JQuery;
+    cssNext?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the last page.
      */
-    cssLast?: JQuery.Selector | JQuery;
+    cssLast?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the dropdown-control to jump to a specific page.
      */
-    cssGoto?: JQuery.Selector | JQuery;
+    cssGoto?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to set the page-size.
      */
-    cssPageSize?: JQuery.Selector | JQuery;
+    cssPageSize?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the container to print the output to.
      */
-    cssPageDisplay?: JQuery.Selector | JQuery;
+    cssPageDisplay?: JQuery.Selector | JQuery | undefined;
 
     /**
      * A value indicating whether the table should always have the same number of rows even if there is a lesser number of records to show.
      */
-    fixedHeight?: boolean;
+    fixedHeight?: boolean | undefined;
 
     /**
      * A value indicating whether the `cssDisabled` class should be applied to non-applicable buttons.
      */
-    updateArrows?: boolean;
+    updateArrows?: boolean | undefined;
 
     /**
      * The css-class to apply to disabled pager-controls.
      */
-    cssDisabled?: string;
+    cssDisabled?: string | undefined;
 
     /**
      * The css-class to apply to the table-row which displays the error-message in case of an ajax-error.
      */
-    cssErrorRow?: string;
+    cssErrorRow?: string | undefined;
 }

--- a/types/tablesorter/Paging/PagerDataPart.d.ts
+++ b/types/tablesorter/Paging/PagerDataPart.d.ts
@@ -22,7 +22,7 @@ export interface PagerDataPart<TElement = HTMLElement> {
      * | `{filteredRows}`   | The amount of filtered rows.                 |
      * | `{totalRows}`      | The total amount of rows.                    |
      */
-    output?: string | PagerOutputProcessor<TElement>;
+    output?: string | PagerOutputProcessor<TElement> | undefined;
 
     /**
      * The number of total rows.
@@ -32,15 +32,15 @@ export interface PagerDataPart<TElement = HTMLElement> {
     /**
      * The number of filtered rows.
      */
-    filteredRows?: number;
+    filteredRows?: number | undefined;
 
     /**
      * The column-names of the table.
      */
-    headers?: string[];
+    headers?: string[] | undefined;
 
     /**
      * The data to show.
      */
-    rows?: any[][] | JQuery;
+    rows?: any[][] | JQuery | undefined;
 }

--- a/types/tablesorter/Paging/PagerInitialRows.d.ts
+++ b/types/tablesorter/Paging/PagerInitialRows.d.ts
@@ -5,10 +5,10 @@ export interface PagerInitialRows {
     /**
      * The total number of rows.
      */
-    total?: number;
+    total?: number | undefined;
 
     /**
      * The filtered number of rows.
      */
-    filtered?: number;
+    filtered?: number | undefined;
 }

--- a/types/tablesorter/Paging/PagerSelectors.d.ts
+++ b/types/tablesorter/Paging/PagerSelectors.d.ts
@@ -7,40 +7,40 @@ export interface PagerSelectors {
     /**
      * The selector for querying the pager-container.
      */
-    container?: JQuery.Selector | JQuery;
+    container?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the first page.
      */
-    first?: JQuery.Selector | JQuery;
+    first?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the previous page.
      */
-    prev?: JQuery.Selector | JQuery;
+    prev?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the next page.
      */
-    next?: JQuery.Selector | JQuery;
+    next?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to jump to the last page.
      */
-    last?: JQuery.Selector | JQuery;
+    last?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the dropdown-control to jump to a specific page.
      */
-    gotoPage?: JQuery.Selector | JQuery;
+    gotoPage?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the control to set the page-size.
      */
-    pageSize?: JQuery.Selector | JQuery;
+    pageSize?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The selector for querying the container to print the output to.
      */
-    pageDisplay?: JQuery.Selector | JQuery;
+    pageDisplay?: JQuery.Selector | JQuery | undefined;
 }

--- a/types/tablesorter/Storage/StorageConfiguration.d.ts
+++ b/types/tablesorter/Storage/StorageConfiguration.d.ts
@@ -7,25 +7,25 @@ export interface StorageConfiguration {
     /**
      * The id of the storage to save to.
      */
-    id?: string;
+    id?: string | undefined;
 
     /**
      * The `data-attribute`-name to automatically get the id of the table from.
      */
-    group?: string;
+    group?: string | undefined;
 
     /**
      * The url to save the storage to.
      */
-    url?: string;
+    url?: string | undefined;
 
     /**
      * The `data-attribute`-name to automatically get the url of the table from.
      */
-    page?: string;
+    page?: string | undefined;
 
     /**
      * The medium to save the storage to.
      */
-    storageType?: StorageType;
+    storageType?: StorageType | undefined;
 }

--- a/types/tablesorter/System/TablesorterConfigBase.d.ts
+++ b/types/tablesorter/System/TablesorterConfigBase.d.ts
@@ -7,10 +7,10 @@ export interface TablesorterConfigBase {
     /**
      * The date-format for dates inside the table.
      */
-    dateFormat?: string;
+    dateFormat?: string | undefined;
 
     /**
      * The order which will be applied when clicking on the heading the first time.
      */
-    sortInitialOrder?: SortOrder;
+    sortInitialOrder?: SortOrder | undefined;
 }

--- a/types/tablesorter/System/TablesorterConfiguration.d.ts
+++ b/types/tablesorter/System/TablesorterConfiguration.d.ts
@@ -24,112 +24,112 @@ export interface TablesorterConfiguration<TElement = HTMLElement> extends Tables
     /**
      * The namespace of the table.
      */
-    namespace?: string;
+    namespace?: string | undefined;
 
     /**
      * The initial sorting after the initialization of the table.
      */
-    sortList?: SortDefinition[];
+    sortList?: SortDefinition[] | undefined;
 
     /**
      * A value indicating whether sortings other than the ones in the `sortList` should be prevented.
      */
-    sortRestart?: boolean;
+    sortRestart?: boolean | undefined;
 
     /**
      * A value indicating whether to apply the original sorting when two cells have the same value.
      */
-    sortStable?: boolean;
+    sortStable?: boolean | undefined;
 
     /**
      * The key which is used for selecting multiple columns.
      */
-    sortMultiSortKey?: keyof MouseEvent;
+    sortMultiSortKey?: keyof MouseEvent | undefined;
 
     /**
      * The key to hold while clicking on a heading for reseting the sorting for the whole table.
      */
-    sortResetKey?: keyof MouseEvent;
+    sortResetKey?: keyof MouseEvent | undefined;
 
     /**
      * A value indicating whether the user can reset a sorting of a column by clicking on it a third time.
      */
-    sortReset?: boolean;
+    sortReset?: boolean | undefined;
 
     /**
      * Sortings to prepend to the current sorting.
      */
-    sortForce?: SortDefinition[];
+    sortForce?: SortDefinition[] | undefined;
 
     /**
      * Sortings to append to the current sorting.
      */
-    sortAppend?: SortDefinition[] | { [index: number]: RelativeSortDefinition[] };
+    sortAppend?: SortDefinition[] | { [index: number]: RelativeSortDefinition[] } | undefined;
 
     /**
      * A value indicating whether accent character should be converted to their equivalent characters during sort.
      */
-    sortLocaleCompare?: boolean;
+    sortLocaleCompare?: boolean | undefined;
 
     /**
      * The order which will be applied when clicking on a heading the first time.
      */
-    sortInitialOrder?: SortOrder;
+    sortInitialOrder?: SortOrder | undefined;
 
     /**
      * A value indicating whether tabbing through table headings is enabled.
      */
-    tabIndex?: boolean;
+    tabIndex?: boolean | undefined;
 
     /**
      * The sorting to apply for empty cells.
      */
-    emptyTo?: EmptySorting;
+    emptyTo?: EmptySorting | undefined;
 
     /**
      * The sorting to apply to text cells in numeric columns.
      */
-    stringTo?: StringSorting;
+    stringTo?: StringSorting | undefined;
 
     /**
      * A value indicating whether letter-case should be considered while sorting.
      */
-    ignoreCase?: boolean;
+    ignoreCase?: boolean | undefined;
 
     /**
      * A value indicating whether the sorting should be reapplied after an update of the table-data.
      */
-    resort?: boolean;
+    resort?: boolean | undefined;
 
     /**
      * A value indicating whether the selection of the text in the table headers should be disabled.
      */
-    cancelSelection?: boolean;
+    cancelSelection?: boolean | undefined;
 
     /**
      * A value indicating whether the width of the columns should be fixed.
      */
-    widthFixed?: boolean;
+    widthFixed?: boolean | undefined;
 
     /**
      * A value indicating whether the table should be initialized upon the initial sort-action.
      */
-    delayInit?: boolean;
+    delayInit?: boolean | undefined;
 
     /**
      * A value indicating whether widgets should be initialized.
      */
-    initWidgets?: boolean;
+    initWidgets?: boolean | undefined;
 
     /**
      * A value indicating whether contents of spanned cells should be sortable and filterable in all table headers.
      */
-    duplicateSpan?: boolean;
+    duplicateSpan?: boolean | undefined;
 
     /**
      * Specific configurations for separate headers.
      */
-    headers?: { [index: number]: TablesorterHeading };
+    headers?: { [index: number]: TablesorterHeading } | undefined;
 
     /**
      * A template for generating headers.
@@ -140,109 +140,109 @@ export interface TablesorterConfiguration<TElement = HTMLElement> extends Tables
      *
      * This template may also contain html-code.
      */
-    headerTemplate?: string;
+    headerTemplate?: string | undefined;
 
     /**
      * One or more events which should be considered as a `mousedown`-event.
      */
-    pointerDown?: string;
+    pointerDown?: string | undefined;
 
     /**
      * One or more events which should be considered as a `mouseup`-event.
      */
-    pointerUp?: string;
+    pointerUp?: string | undefined;
 
     /**
      * One or more events which should be considered as a `click`-event.
      */
-    pointerClick?: string;
+    pointerClick?: string | undefined;
 
     /**
      * The `data-attribute` to automatically read text from cells.
      */
-    textAttribute?: string;
+    textAttribute?: string | undefined;
 
     /**
      * The methods for extracting text from cells.
      */
-    textExtraction?: "basic" | TextExtractor<TElement> | MappedSettings<"basic" | TextExtractor<TElement>>;
+    textExtraction?: "basic" | TextExtractor<TElement> | MappedSettings<"basic" | TextExtractor<TElement>> | undefined;
 
     /**
      * The attribute to read the text-value from `img`-tags.
      */
-    imgAttr?: string;
+    imgAttr?: string | undefined;
 
     /**
      * Either global `Globalize`-settings or per-column `Globalize`-settings to apply.
      */
-    globalize?: GlobalizeSettings | {[index: number]: GlobalizeSettings};
+    globalize?: GlobalizeSettings | {[index: number]: GlobalizeSettings} | undefined;
 
     /**
      * A value indicating whether changes to child-rows are ignored by the table-sorter.
      */
-    ignoreChildRow?: boolean;
+    ignoreChildRow?: boolean | undefined;
 
     /**
      * The widgets to initialize.
      */
-    widgets?: string[];
+    widgets?: string[] | undefined;
 
     /**
      * The options for the widgets.
      */
-    widgetOptions?: WidgetOptions<TElement>;
+    widgetOptions?: WidgetOptions<TElement> | undefined;
 
     /**
      * The format of the class-names for automatically loading the widget with the id `{name}`.
      *
      * The default setting is `widget-{name}`.
      */
-    widgetClass?: string;
+    widgetClass?: string | undefined;
 
     /**
      * A class to add to checked rows.
      */
-    checkboxClass?: string;
+    checkboxClass?: string | undefined;
 
     /**
      * A value indicating whether only visible rows should be affected by the checkbox located in the header.
      */
-    cehckboxVisible?: boolean;
+    cehckboxVisible?: boolean | undefined;
 
     /**
      * The storage for the `build-table` widget.
      */
-    data?: object | any[][];
+    data?: object | any[][] | undefined;
 
     /**
      * The date-range for two-digit years.
      */
-    dateRange?: number;
+    dateRange?: number | undefined;
 
     /**
      * Either value indicating whether debug-information should be printed or a set of plugin-names to print debug-information from.
      */
-    debug?: boolean | string;
+    debug?: boolean | string | undefined;
 
     /**
      * A value indicating whether the sorting is performed by the server.
      */
-    serverSideSorting?: boolean;
+    serverSideSorting?: boolean | undefined;
 
     /**
      * Processes the table after the initialization.
      */
-    initialized?: InitializationEventHandler<TElement>;
+    initialized?: InitializationEventHandler<TElement> | undefined;
 
     /**
      * The text-sorting to apply.
      */
-    textSorter?: TextSorter<TElement> | MappedSettings<TextSorter<TElement>>;
+    textSorter?: TextSorter<TElement> | MappedSettings<TextSorter<TElement>> | undefined;
 
     /**
      * The number-sorting to apply.
      */
-    numberSorter?: NumberSorter;
+    numberSorter?: NumberSorter | undefined;
 
     /**
      * A function for processing the header.
@@ -256,7 +256,7 @@ export interface TablesorterConfiguration<TElement = HTMLElement> extends Tables
      * @return
      * A manipulated version of the content of the header.
      */
-    onRenderTemplate?: RenderTemplateEventHandler;
+    onRenderTemplate?: RenderTemplateEventHandler | undefined;
 
     /**
      * A function to execute after the content of the header is processed.
@@ -270,115 +270,115 @@ export interface TablesorterConfiguration<TElement = HTMLElement> extends Tables
      * @param table
      * The jQuery-object of the table.
      */
-    onRenderHeader?: RenderHeaderEventHandler<TElement>;
+    onRenderHeader?: RenderHeaderEventHandler<TElement> | undefined;
 
     /**
      * A value indicating whether a timer icon should be shown while applying sorting and filtering.
      */
-    showProcessing?: boolean;
+    showProcessing?: boolean | undefined;
 
     /**
      * A value indicating whether to use `en-US`-flavored numbers.
      */
-    usNumberFormat?: boolean;
+    usNumberFormat?: boolean | undefined;
 
     /**
      * The theme to use.
      */
-    theme?: CoreTheme | string;
+    theme?: CoreTheme | string | undefined;
 
     /**
      * A class to add to the table.
      */
-    tableClass?: string;
+    tableClass?: string | undefined;
 
     /**
      * A class to add to headers when no sort is applied.
      */
-    cssNone?: string;
+    cssNone?: string | undefined;
 
     /**
      * A class for indicating elements which don't cause a sort when clicking on them.
      */
-    cssNoSort?: string;
+    cssNoSort?: string | undefined;
 
     /**
      * A class to add to the header-row while applying a processing the table.
      */
-    cssProcessing?: string;
+    cssProcessing?: string | undefined;
 
     /**
      * A class to add to the header-row.
      */
-    cssHeaderRow?: string;
+    cssHeaderRow?: string | undefined;
 
     /**
      * A class to add to the table headers.
      */
-    cssHeader?: string;
+    cssHeader?: string | undefined;
 
     /**
      * A class to add to table headers with ascending sort.
      */
-    cssAsc?: string;
+    cssAsc?: string | undefined;
 
     /**
      * A class to add to table headers with descending sort.
      */
-    cssDesc?: string;
+    cssDesc?: string | undefined;
 
     /**
      * A class for indicating rows which should be attached to the above row.
      */
-    cssChildRow?: string;
+    cssChildRow?: string | undefined;
 
     /**
      * A class to add to the sort-icons.
      */
-    cssIcon?: string;
+    cssIcon?: string | undefined;
 
     /**
      * A class to add to sort-icons for with ascending sorting.
      */
-    cssIconAsc?: string;
+    cssIconAsc?: string | undefined;
 
     /**
      * A class to add to sort-icons with descending sorting.
      */
-    cssIconDesc?: string;
+    cssIconDesc?: string | undefined;
 
     /**
      * A class to add to sort-icons with disabled sorting.
      */
-    cssIconDisabled?: string;
+    cssIconDisabled?: string | undefined;
 
     /**
      * A class to add to sort-icons without sorting.
      */
-    cssIconNone?: string;
+    cssIconNone?: string | undefined;
 
     /**
      * A class for indicating rows which should be ignored.
      */
-    cssIgnoreRow?: string;
+    cssIgnoreRow?: string | undefined;
 
     /**
      * A class for indicating `tbody`s which should not be sortable.
      */
-    cssInfoBlock?: string;
+    cssInfoBlock?: string | undefined;
 
     /**
      * A jQuery-selector for finding cells in the header-row.
      */
-    selectorHeaders?: JQuery.Selector;
+    selectorHeaders?: JQuery.Selector | undefined;
 
     /**
      * A jQuery-selector for finding rows to remove prior to a table-update.
      */
-    selectorRemove?: JQuery.Selector;
+    selectorRemove?: JQuery.Selector | undefined;
 
     /**
      * A jQuery-selector to find clickable elements inside the result of `selectorHeaders` for triggering a sort.
      */
-    selectorSort?: JQuery.Selector;
+    selectorSort?: JQuery.Selector | undefined;
 }

--- a/types/tablesorter/System/TablesorterHeading.d.ts
+++ b/types/tablesorter/System/TablesorterHeading.d.ts
@@ -11,35 +11,35 @@ export interface TablesorterHeading extends TablesorterConfigBase {
     /**
      * Either the name of the parser to use for sorting or a value indicating whether sorting is enabled.
      */
-    sorter?: string | boolean;
+    sorter?: string | boolean | undefined;
 
     /**
      * Either the name of the parser to use for text-extraction or a value indicating whether text-extraction is enabled.
      */
-    parser?: string | boolean;
+    parser?: string | boolean | undefined;
 
     /**
      * A value indicating whether the column should be resizable.
      */
-    resizable?: boolean;
+    resizable?: boolean | undefined;
 
     /**
      * The sorting to apply for empty cells.
      */
-    empty?: EmptySorting;
+    empty?: EmptySorting | undefined;
 
     /**
      * The sorting to apply for text-cells.
      */
-    string?: StringSorting;
+    string?: StringSorting | undefined;
 
     /**
      * The filter-concept for the column.
      */
-    filter?: ColumnFilter;
+    filter?: ColumnFilter | undefined;
 
     /**
      * The locked sort-order of the heading.
      */
-    lockedOrder?: SortOrder;
+    lockedOrder?: SortOrder | undefined;
 }

--- a/types/tablesorter/Widgets/ColumnWidgetOptions.d.ts
+++ b/types/tablesorter/Widgets/ColumnWidgetOptions.d.ts
@@ -5,15 +5,15 @@ export interface ColumnOptions {
     /**
      * The names of the classes to apply when sorting in chronological order.
      */
-    columns?: string[];
+    columns?: string[] | undefined;
 
     /**
      * A value indicating whether the class specified in `columns` should also be applied to the table-head.
      */
-    columns_thead?: boolean;
+    columns_thead?: boolean | undefined;
 
     /**
      * A value indicating whether the class specified in `columns` should also be applied to the table-foot.
      */
-    columns_tfoot?: boolean;
+    columns_tfoot?: boolean | undefined;
 }

--- a/types/tablesorter/Widgets/FilterOptions.d.ts
+++ b/types/tablesorter/Widgets/FilterOptions.d.ts
@@ -15,160 +15,160 @@ export interface FilterOptions<TElement = HTMLElement> {
     /**
      * A value indicating whether filtering is enabled.
      */
-    filter_columnFilters?: boolean;
+    filter_columnFilters?: boolean | undefined;
 
     /**
      * A value indicating whether the letter-case should be ignored.
      */
-    filter_ignoreCase?: boolean;
+    filter_ignoreCase?: boolean | undefined;
 
     /**
      * A value indicating whether the filters should be saved to the client.
      */
-    filter_saveFilters?: boolean;
+    filter_saveFilters?: boolean | undefined;
 
     /**
      * A value indicating whether a search should be performed without having to hit `Enter`.
      */
-    filter_liveSearch?: (boolean | number) | MappedSettings<(boolean | number)>;
+    filter_liveSearch?: (boolean | number) | MappedSettings<(boolean | number)> | undefined;
 
     /**
      * A value indicating whether only filtered rows should be considered while searching.
      */
-    filter_searchFiltered?: boolean;
+    filter_searchFiltered?: boolean | undefined;
 
     /**
      * A jQuery-selector for querying the button for resetting the filter.
      */
-    filter_reset?: JQuery.Selector | JQuery;
+    filter_reset?: JQuery.Selector | JQuery | undefined;
 
     /**
      * A value indicating whether the filter should be resetted when `ESC` is hit.
      */
-    filter_resetOnEsc?: boolean;
+    filter_resetOnEsc?: boolean | undefined;
 
     /**
      * A value indicating whether the filter-controls should be hidden when the table is empty.
      */
-    filter_hideEmpty?: boolean;
+    filter_hideEmpty?: boolean | undefined;
 
     /**
      * A value indicating whether the filter should hide automatically.
      */
-    filter_hideFilters?: boolean | ((config: TablesorterConfigurationStore<TElement>) => boolean);
+    filter_hideFilters?: boolean | ((config: TablesorterConfigurationStore<TElement>) => boolean) | undefined;
 
     /**
      * The default filters to apply.
      */
-    filter_defaultFilter?: MappedSettings<string>;
+    filter_defaultFilter?: MappedSettings<string> | undefined;
 
     /**
      * A set of filters to prevent.
      */
-    filter_excludeFilter?: MappedSettings<string>;
+    filter_excludeFilter?: MappedSettings<string> | undefined;
 
     /**
      * The jQuery-selector for querying the external search-box.
      */
-    filter_external?: JQuery.Selector;
+    filter_external?: JQuery.Selector | undefined;
 
     /**
      * The filter-controls to apply.
      */
-    filter_formatter?: MappedSettings<FilterControlFactory>;
+    filter_formatter?: MappedSettings<FilterControlFactory> | undefined;
 
     /**
      * A value indicating whether searches using the `{index}:{query}` in the anyMatch-textbox is allowed.
      */
-    filter_columnAnyMatch?: boolean;
+    filter_columnAnyMatch?: boolean | undefined;
 
     /**
      * A set of classes to apply to the filter-cells.
      */
-    filter_cellFilter?: string | string[];
+    filter_cellFilter?: string | string[] | undefined;
 
     /**
      * A value indicating whether child-rows should be considered when filtering.
      */
-    filter_childRows?: boolean;
+    filter_childRows?: boolean | undefined;
 
     /**
      * A value indicating whether only the filtered column of child-rows should be considered when filtering.
      */
-    filter_childByColumn?: boolean;
+    filter_childByColumn?: boolean | undefined;
 
     /**
      * A value indicating whether siblings should be displayed when filtering.
      */
-    filter_childWithSibs?: boolean;
+    filter_childWithSibs?: boolean | undefined;
 
     /**
      * The attribute-name which is used for querying the default filter-value.
      */
-    filter_defaultAttrib?: string;
+    filter_defaultAttrib?: string | undefined;
 
     /**
      * The template for generating the ARIA-label of the filter-control.
      */
-    filter_filterLabel?: string;
+    filter_filterLabel?: string | undefined;
 
     /**
      * A set of filter-functions to apply for the columns.
      */
-    filter_functions?: MappedSettings<FilterFunctionCollection<TElement> | FilterFunction<TElement>>;
+    filter_functions?: MappedSettings<FilterFunctionCollection<TElement> | FilterFunction<TElement>> | undefined;
 
     /**
      * The match-types to apply to the controls.
      */
-    filter_matchType?: MatchTypeSettings;
+    filter_matchType?: MatchTypeSettings | undefined;
 
     /**
      * A value indicating whether searches should be performed with the `starts with`-logic.
      */
-    filter_startsWith?: boolean;
+    filter_startsWith?: boolean | undefined;
 
     /**
      * A class for indicating whether only visible entries should be available in `select`-controls.
      */
-    filter_onlyAvail?: string;
+    filter_onlyAvail?: string | undefined;
 
     /**
      * The placeholders to set initially.
      */
-    filter_placeholder?: FilterPlaceholders;
+    filter_placeholder?: FilterPlaceholders | undefined;
 
     /**
      * The sources for the select-controls.
      */
-    filter_selectSource?: SelectSources<TElement> | MappedSettings<SelectSources<TElement>>;
+    filter_selectSource?: SelectSources<TElement> | MappedSettings<SelectSources<TElement>> | undefined;
 
     /**
      * The character for separating display-name and value inside the `filter_selectSource`.
      */
-    filter_selectSourceSeparator?: string;
+    filter_selectSourceSeparator?: string | undefined;
 
     /**
      * A value indicating whether filtering is performed server-side.
      */
-    filter_serversideFiltering?: boolean;
+    filter_serversideFiltering?: boolean | undefined;
 
     /**
      * The number of miliseconds to wait before performing a search.
      */
-    filter_searchDelay?: number;
+    filter_searchDelay?: number | undefined;
 
     /**
      * A value indicating whether filtering should be perormed using parsed data.
      */
-    filter_useParsedData?: boolean;
+    filter_useParsedData?: boolean | undefined;
 
     /**
      * A CSS class which is applied to each filter-cell.
      */
-    filter_cssFilter?: string | string[];
+    filter_cssFilter?: string | string[] | undefined;
 
     /**
      * A CSS class which is applied for each cel which is filtered.
      */
-    filter_filteredRow?: string;
+    filter_filteredRow?: string | undefined;
 }

--- a/types/tablesorter/Widgets/PagerOptions.d.ts
+++ b/types/tablesorter/Widgets/PagerOptions.d.ts
@@ -25,22 +25,22 @@ export interface PagerOptions<TElement = HTMLElement> {
      * | `{sortList:name}` or `{sort:name}`     | A GET-variable called `name` containing the current sorting.           |
      * | `{filterList:name}` or `{filter:name}` | A GET-variable called `name` containing all currently applied filters. |
      */
-    pager_ajaxUrl?: string;
+    pager_ajaxUrl?: string | undefined;
 
     /**
      * Pre-processes the url for `ajax`.
      */
-    pager_customAjaxUrl?: AjaxUrlProcessor<TElement>;
+    pager_customAjaxUrl?: AjaxUrlProcessor<TElement> | undefined;
 
     /**
      * The settings for the api-interaction of the pager.
      */
-    pager_ajaxObject?: JQueryAjaxSettings;
+    pager_ajaxObject?: JQueryAjaxSettings | undefined;
 
     /**
      * Handles errors caused by an ajax-request.
      */
-    pager_ajaxError?: AjaxErrorHandler<TElement>;
+    pager_ajaxError?: AjaxErrorHandler<TElement> | undefined;
 
     /**
      * Processes the ajax-result for the `pager`-widget.
@@ -57,7 +57,7 @@ export interface PagerOptions<TElement = HTMLElement> {
      * @return
      * The data for the pager to show.
      */
-    pager_ajaxProcessing?: AjaxDataProcessor<TElement>;
+    pager_ajaxProcessing?: AjaxDataProcessor<TElement> | undefined;
 
     /**
      * The output to display in the output-area.
@@ -77,70 +77,70 @@ export interface PagerOptions<TElement = HTMLElement> {
      * | `{filteredRows}`   | The amount of filtered rows.                 |
      * | `{totalRows}`      | The total amount of rows.                    |
      */
-    pager_output?: string | PagerOutputProcessor<TElement>;
+    pager_output?: string | PagerOutputProcessor<TElement> | undefined;
 
     /**
      * The number of the first page to show.
      */
-    pager_startPage?: number;
+    pager_startPage?: number | undefined;
 
     /**
      * The number of the first page to show after applying a filter.
      */
-    pager_pageReset?: number | boolean;
+    pager_pageReset?: number | boolean | undefined;
 
     /**
      * The initial page-size.
      */
-    pager_size?: PageSize;
+    pager_size?: PageSize | undefined;
 
     /**
      * A value indicating whether to split child-rows on page-breaks.
      */
-    pager_countChildRows?: boolean;
+    pager_countChildRows?: boolean | undefined;
 
     /**
      * A value indicating whether an ajax-request should be executed after the initialization of the table.
      */
-    pager_processAjaxOnInit?: boolean;
+    pager_processAjaxOnInit?: boolean | undefined;
 
     /**
      * The initial amount of rows to show.
      */
-    pager_initialRows?: PagerInitialRows;
+    pager_initialRows?: PagerInitialRows | undefined;
 
     /**
      * The key to of the local storage to save data to.
      */
-    pager_storageKey?: string;
+    pager_storageKey?: string | undefined;
 
     /**
      * A value indicating whether to save the current page locally.
      */
-    pager_savePages?: boolean;
+    pager_savePages?: boolean | undefined;
 
     /**
      * A value indicating whether to remove the rows while performing sortings for speed up.
      */
-    pager_removeRows?: boolean;
+    pager_removeRows?: boolean | undefined;
 
     /**
      * The selectors for for handling click-events.
      */
-    pager_selectors?: PagerSelectors;
+    pager_selectors?: PagerSelectors | undefined;
 
     /**
      * The css-classes to apply to the pager-controls.
      */
-    pager_css?: PagerClasses;
+    pager_css?: PagerClasses | undefined;
 
     /**
      * A value indicating whether the table should always have the same number of rows even if there is a lesser number of records to show.
      */
-    pager_fixedHeight?: boolean;
+    pager_fixedHeight?: boolean | undefined;
 
     /**
      * A value indicating whether the `pager_css.disabled` class should be applied to non-applicable buttons.
      */
-    pager_updateArrows?: boolean;
+    pager_updateArrows?: boolean | undefined;
 }

--- a/types/tablesorter/Widgets/ResizingOptions.d.ts
+++ b/types/tablesorter/Widgets/ResizingOptions.d.ts
@@ -5,30 +5,30 @@ export interface ResizingOptions {
     /**
      * A value indicating whether column widths are saved locally.
      */
-    resizable?: boolean;
+    resizable?: boolean | undefined;
 
     /**
      * A value indicating whether the last column should have a resize-handle.
      */
-    resizable_addLastColumn?: boolean;
+    resizable_addLastColumn?: boolean | undefined;
 
     /**
      * A value indicating whether the user can resize the columns inside the footer.
      */
-    resizable_includeFooter?: boolean;
+    resizable_includeFooter?: boolean | undefined;
 
     /**
      * A value indicating whether always the last column should shrink when resizing.
      */
-    resizable_targetLast?: boolean;
+    resizable_targetLast?: boolean | undefined;
 
     /**
      * The number of milliseconds to wait before raising the `mousemove`-event.
      */
-    resizable_throttle?: boolean | number;
+    resizable_throttle?: boolean | number | undefined;
 
     /**
      * The initial widths of the columns.
      */
-    resizable_widths?: string[];
+    resizable_widths?: string[] | undefined;
 }

--- a/types/tablesorter/Widgets/SaveSortOptions.d.ts
+++ b/types/tablesorter/Widgets/SaveSortOptions.d.ts
@@ -7,30 +7,30 @@ export interface SaveSortOptions {
     /**
      * A value indicating whether the sorting should be saved locally.
      */
-    saveSort?: boolean;
+    saveSort?: boolean | undefined;
 
     /**
      * The id of the `saveSort`-settings.
      */
-    storage_tableId?: string;
+    storage_tableId?: string | undefined;
 
     /**
      * A url to a table for grouping settings together.
      */
-    storage_fixedUrl?: string;
+    storage_fixedUrl?: string | undefined;
 
     /**
      * The name of the data-attribute to obtain an id for the table which allows grouping multiple tables together.
      */
-    storage_group?: string;
+    storage_group?: string | undefined;
 
     /**
      * The name of the data-attribute to obtain a table url which allows grouping tables together across pages.
      */
-    storage_page?: string;
+    storage_page?: string | undefined;
 
     /**
      * The storage-type to use.
      */
-    storage_storageType?: StorageType;
+    storage_storageType?: StorageType | undefined;
 }

--- a/types/tablesorter/Widgets/StickyHeaderOptions.d.ts
+++ b/types/tablesorter/Widgets/StickyHeaderOptions.d.ts
@@ -7,55 +7,55 @@ export interface StickyHeaderOptions {
     /**
      * A set of classes to add to the sticky header.
      */
-    stickyHeaders?: string;
+    stickyHeaders?: string | undefined;
 
     /**
      * A value indicating whether the table should be resized automatically when data is added to or removed from the table.
      */
-    stickyHeaders_addResizeEvent?: boolean;
+    stickyHeaders_addResizeEvent?: boolean | undefined;
 
     /**
      * A value indicating whether the caption should be included in the sticky header.
      */
-    stickyHeaders_includeCaption?: boolean;
+    stickyHeaders_includeCaption?: boolean | undefined;
 
     /**
      * A jQuery-selector to get an element to append the sticky header to.
      */
-    stickyHeaders_appendTo?: JQuery.Selector | JQuery;
+    stickyHeaders_appendTo?: JQuery.Selector | JQuery | undefined;
 
     /**
      * A jQuery-selector to get an element to attach the sticky header to.
      */
-    stickyHeaders_attachTo?: JQuery.Selector | JQuery;
+    stickyHeaders_attachTo?: JQuery.Selector | JQuery | undefined;
 
     /**
      * A string to append to the table-id for the cloned sticky table.
      */
-    stickyHeaders_cloneId?: string;
+    stickyHeaders_cloneId?: string | undefined;
 
     /**
      * A value indicating whether the filter should be scrolled into view when inputing a filter.
      */
-    stickyHeaders_filteredToTop?: boolean;
+    stickyHeaders_filteredToTop?: boolean | undefined;
 
     /**
      * Either a number of the offset to the top of the browser-window or a jQuery-selector or -object for the elemtn which represents the offset.
      */
-    stickyHeaders_offset?: number | JQuery.Selector | JQuery;
+    stickyHeaders_offset?: number | JQuery.Selector | JQuery | undefined;
 
     /**
      * The jQuery-selector or -object to monitor for horizontal scrolling.
      */
-    stickyHeaders_xScroll?: JQuery.Selector | JQuery;
+    stickyHeaders_xScroll?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The jQuery-selector or -object to monitor for vertical scrolling.
      */
-    stickyHeaders_yScroll?: JQuery.Selector | JQuery;
+    stickyHeaders_yScroll?: JQuery.Selector | JQuery | undefined;
 
     /**
      * The z-index of the sticky header.
      */
-    stickyHeaders_zindex?: number;
+    stickyHeaders_zindex?: number | undefined;
 }

--- a/types/tablesorter/Widgets/ZebraOptions.d.ts
+++ b/types/tablesorter/Widgets/ZebraOptions.d.ts
@@ -5,5 +5,5 @@ export interface ZebraOptions {
     /**
      * The classes to add to even and odd rows.
      */
-    zebra?: [string, string];
+    zebra?: [string, string] | undefined;
 }

--- a/types/tabtab/index.d.ts
+++ b/types/tabtab/index.d.ts
@@ -77,7 +77,7 @@ export interface CompletionItem {
     /**
      * The optional description of the completion.
      */
-    description?: string;
+    description?: string | undefined;
 }
 
 // Legacy aliases:

--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -44,32 +44,32 @@ declare namespace Tabulator {
 
     interface OptionsCells extends CellCallbacks {
         /** The validationFailed event is triggered when the value entered into a cell during an edit fails to pass validation. */
-        validationFailed?: (cell: CellComponent, value: any, validators: Validator[] | StandardValidatorType[]) => void;
+        validationFailed?: ((cell: CellComponent, value: any, validators: Validator[] | StandardValidatorType[]) => void) | undefined;
     }
     interface OptionsDataTree {
         /** To enable data trees in your table, set the dataTree property to true in your table constructor: */
-        dataTree?: boolean;
+        dataTree?: boolean | undefined;
         /**  By default the toggle element will be inserted into the first column on the table. If you want the toggle element to be inserted in a different column you can pass the feild name of the column to the dataTreeElementColumn setup option*/
-        dataTreeElementColumn?: boolean | string;
+        dataTreeElementColumn?: boolean | string | undefined;
         /** Show tree branch icon     */
-        dataTreeBranchElement?: boolean | string;
+        dataTreeBranchElement?: boolean | string | undefined;
         /** Tree level indent in pixels     */
-        dataTreeChildIndent?: number;
+        dataTreeChildIndent?: number | undefined;
         /** By default Tabulator will look for child rows in the _children field of a row data object. You can change this to look in a different field using the dataTreeChildField property in your table constructor: */
-        dataTreeChildField?: string;
+        dataTreeChildField?: string | undefined;
         /** The toggle button that allows users to collapse and expand the column can be customised to meet your needs. There are two options, dataTreeExpandElement and dataTreeCollapseElement, that can be set to replace the default toggle elements with your own.
 
       Both options can take either an html string representing the contents of the toggle element */
-        dataTreeCollapseElement?: string | HTMLElement | boolean;
+        dataTreeCollapseElement?: string | HTMLElement | boolean | undefined;
         /** The toggle button that allows users to expand the column */
-        dataTreeExpandElement?: string | HTMLElement | boolean;
+        dataTreeExpandElement?: string | HTMLElement | boolean | undefined;
         /**  By default all nodes on the tree will start collapsed, you can customize the initial expansion state of the tree using the dataTreeStartExpanded option.*
         This option can take one of three possible value types, either a boolean to indicate whether all nodes should start expanded or collapsed: */
-        dataTreeStartExpanded?: boolean | boolean[] | ((row: RowComponent, level: number) => boolean);
+        dataTreeStartExpanded?: boolean | boolean[] | ((row: RowComponent, level: number) => boolean) | undefined;
         /**Propagte selection events from parent rows to children */
-        dataTreeSelectPropagate?: boolean;
-        dataTreeFilter?: boolean;
-        dataTreeSort?: boolean;
+        dataTreeSelectPropagate?: boolean | undefined;
+        dataTreeFilter?: boolean | undefined;
+        dataTreeSort?: boolean | undefined;
     }
     interface OptionsClipboard {
         /** You can enable clipboard functionality using the clipboard config option. It can take one of four possible values:
@@ -78,15 +78,15 @@ declare namespace Tabulator {
       "copy" - enable only copy functionality
       "paste" - enable only paste functionality
       false - disable all clipboard functionality (default) */
-        clipboard?: boolean | 'copy' | 'paste';
+        clipboard?: boolean | 'copy' | 'paste' | undefined;
 
         /**The clipboardCopyRowRange option takes a Row Range Lookup value and allows you to choose which rows are included in the clipboard output: */
-        clipboardCopyRowRange?: RowRangeLookup;
+        clipboardCopyRowRange?: RowRangeLookup | undefined;
 
         /**You can alter the finished output to the clipboard using the clipboardCopyFormatter callback. The callback function receives two arguments, the first is a string representing the type of content to be formatted (either "plain" or "html" depending on the type of data entering the clipboard). The second argument is the string that is about to be insered into the clipboard. The function and should return a string that will be inserted into the clipboard */
-        clipboardCopyFormatter?: 'table' | ((type: 'plain' | 'html', output: string) => string);
+        clipboardCopyFormatter?: 'table' | ((type: 'plain' | 'html', output: string) => string) | undefined;
         /** By default Tabulator will include the column header titles in any clipboard data, this can be turned off by passing a value of false to the clipboardCopyHeader property: */
-        clipboardCopyHeader?: boolean;
+        clipboardCopyHeader?: boolean | undefined;
         /**  Tabulator has one built in paste parser, that is designed to take a table formatted text string from the clipboard and turn it into row data. it breaks the tada into rows on a newline character \n and breaks the rows down to columns on a tab character \t.
 
       It will then attempt to work out which columns in the data correspond to columns in the table. It tries three different ways to achieve this. First it checks the values of all columns in the first row of data to see if they match the titles of columns in the table. If any of the columns don't match it then tries the same approach but with the column fields. If either of those options match, Tabulator will map those columns to the incoming data and import it into rows. If there is no match then Tabulator will assume the columns in the data are in the same order as the visible columns in the table and import them that way.
@@ -94,101 +94,101 @@ declare namespace Tabulator {
       The inbuilt parser will reject any clipboard data that does not contain at least one row and two columns, in that case the clipboardPasteError will be triggered.
 
       If you extend the clipboard module to add your own parser, you can set it to be used as default with the clipboardPasteParser property.*/
-        clipboardPasteParser?: string | ((clipboard: any) => any[]);
+        clipboardPasteParser?: string | ((clipboard: any) => any[]) | undefined;
         /** Once the data has been parsed into row data, it will be passed to a paste action to be added to the table. There are three inbuilt paste actions:
 
       insert - Inserts data into the table using the addRows function (default)
       update - Updates data in the table using the updateOrAddData function
       replace - replaces all data in the table using the setData function */
-        clipboardPasteAction?: 'insert' | 'update' | 'replace';
+        clipboardPasteAction?: 'insert' | 'update' | 'replace' | undefined;
 
         /** By default Tabulator will copy some of the tables styling along with the data to give a better visual appearance when pasted into other documents.
 
     If you want to only copy the unstyled data then you should set the clipboardCopyStyled option to false in the table options object:  */
-        clipboardCopyStyled?: boolean;
+        clipboardCopyStyled?: boolean | undefined;
 
         /** By default Tabulator includes column headers, row groups and column calculations in the clipboard output.
 
     You can choose to remove column headers groups, row groups or column calculations from the output data by setting the values in the clipboardCopyConfig option in the table definition: */
-        clipboardCopyConfig?: AddditionalExportOptions | boolean;
+        clipboardCopyConfig?: AddditionalExportOptions | boolean | undefined;
 
         /** The clipboardCopied event is triggered whenever data is copied to the clipboard. */
-        clipboardCopied?: () => void;
+        clipboardCopied?: (() => void) | undefined;
         /** The clipboardPasted event is triggered whenever data is successfuly pasted into the table. */
-        clipboardPasted?: () => void;
+        clipboardPasted?: (() => void) | undefined;
         /** The clipboardPasteError event is triggered whenever an atempt to paste data into the table has failed because it was rejected by the paste parser. */
-        clipboardPasteError?: () => void;
+        clipboardPasteError?: (() => void) | undefined;
 
         /**When copying to clipboard you may want to apply a different group header from the one usualy used in the table. You can now do this using the groupHeaderClipboard table option, which takes the same inputs as the standard groupHeader property. */
         groupHeaderClipboard?:
             | ((value: any, count: number, data: any, group: GroupComponent) => string)
-            | Array<(value: any, count: number, data: any) => string>;
+            | Array<(value: any, count: number, data: any) => string> | undefined;
 
         /**When the getHtml function is called you may want to apply a different group header from the one usualy used in the table. You can now do this using the groupHeaderHtmlOutput table option, which takes the same inputs as the standard groupHeader property. */
         groupHeaderHtmlOutput?:
             | ((value: any, count: number, data: any, group: GroupComponent) => string)
-            | Array<(value: any, count: number, data: any) => string>;
+            | Array<(value: any, count: number, data: any) => string> | undefined;
     }
 
     interface OptionsPersistentConfiguration {
         /** ID tag used to identify persistent storage information     */
-        persistenceID?: string;
+        persistenceID?: string | undefined;
         /**  Persistence information can either be stored in a cookie or in the localSotrage object, you can use the persistenceMode to choose which. It can take three possible values:
 
       local - (string) Store the persistence information in the localStorage object
       cookie - (string) Store the persistence information in a cookie
       true - (boolean) check if localStorage is available and store persistence information, otherwise store in cookie (Default option)    */
-        persistenceMode?: 'local' | 'cookie' | true;
+        persistenceMode?: 'local' | 'cookie' | true | undefined;
         /** Enable persistsnt storage of column layout information     */
-        persistentLayout?: boolean;
+        persistentLayout?: boolean | undefined;
         /** You can ensure the data sorting is stored for the next page load by setting the persistentSort option to true */
-        persistentSort?: boolean;
+        persistentSort?: boolean | undefined;
         /**  You can ensure the data filtering is stored for the next page load by setting the persistentFilter option to true*/
-        persistentFilter?: boolean;
+        persistentFilter?: boolean | undefined;
         /**By setting the persistence property to true the table will persist the sort, filter, group (groupBy, groupStartOpen, groupHeader), pagination (paginationSize), and column (title, width, visibility, order) configuration of the table */
-        persistence?: true | PersistenceOptions;
+        persistence?: true | PersistenceOptions | undefined;
         /**The persistenceWriterFunc function will receive three arguments, the persistance id of the table, the type of data to be written and an object or array representing the data */
-        persistenceWriterFunc?: (id: string, type: keyof PersistenceOptions, data: any) => any;
+        persistenceWriterFunc?: ((id: string, type: keyof PersistenceOptions, data: any) => any) | undefined;
         /**The persistenceReaderFunc function will receive two arguments, the persistance id of the table, and the type of data to be written. This function must synchronously return the data in the format in which it was passed to the persistenceWriterFunc function. It should return a value of false if no data was present */
-        persistenceReaderFunc?: (id: string, type: keyof PersistenceOptions) => any;
+        persistenceReaderFunc?: ((id: string, type: keyof PersistenceOptions) => any) | undefined;
     }
     interface PersistenceOptions {
-        sort?: boolean;
-        filter?: boolean;
-        group?: boolean | PersistenceGroupOptions;
-        page?: boolean | PersistencePageOptions;
-        columns?: boolean | string[];
+        sort?: boolean | undefined;
+        filter?: boolean | undefined;
+        group?: boolean | PersistenceGroupOptions | undefined;
+        page?: boolean | PersistencePageOptions | undefined;
+        columns?: boolean | string[] | undefined;
     }
 
     interface PersistenceGroupOptions {
-        groupBy?: boolean;
-        groupStartOpen?: boolean;
-        groupHeader?: boolean;
+        groupBy?: boolean | undefined;
+        groupStartOpen?: boolean | undefined;
+        groupHeader?: boolean | undefined;
     }
 
     interface PersistencePageOptions {
-        size?: boolean;
-        page?: boolean;
+        size?: boolean | undefined;
+        page?: boolean | undefined;
     }
 
     interface OptionsPagination {
         /** Choose pagination method, "local" or "remote"     */
-        pagination?: 'remote' | 'local';
+        pagination?: 'remote' | 'local' | undefined;
         /** Set the number of rows in each page     */
-        paginationSize?: number;
+        paginationSize?: number | undefined;
         /**  Setting this option to true will cause Tabulator to create a list of page size options, that are multiples of the current page size. In the example below, the list will have the values of 5, 10, 15 and 20.
 
     When using the page size selector like this, if you use the setPageSize function to set the page size to a value not in the list, the list will be regenerated using the new page size as the starting valuer    */
-        paginationSizeSelector?: true | number[] | any[];
+        paginationSizeSelector?: true | number[] | any[] | undefined;
         /**  By default the pagination controls are added to the footer of the table. If you wish the controls to be created in another element pass a DOM node or a CSS selector for that element to the paginationElement option.*/
-        paginationElement?: HTMLElement | string;
+        paginationElement?: HTMLElement | string | undefined;
         /** Lookup list to link expected data feilds from the server to their function    * default* {
         "current_page":"current_page",
         "last_page":"last_page",
         "data":"data",
         }* *
      */
-        paginationDataReceived?: Record<string, string>;
+        paginationDataReceived?: Record<string, string> | undefined;
         /** Lookup list to link fields expected by the server to their function* default:* {
         "page":"page",
         "size":"size",
@@ -196,39 +196,39 @@ declare namespace Tabulator {
         "filters":"filters",
         }
          */
-        paginationDataSent?: Record<string, string>;
+        paginationDataSent?: Record<string, string> | undefined;
         /** When using the addRow function on a paginated table, rows will be added relative to the current page (ie to the top or bottom of the current page), with overflowing rows being shifted onto the next page.
 
       If you would prefer rows to be added relative to the table (firs/last page) then you can use the paginationAddRow option. it can take one of two values:
 
       page - add rows relative to current page (default)
       table - add rows relative to the table */
-        paginationAddRow?: 'table' | 'page';
+        paginationAddRow?: 'table' | 'page' | undefined;
         /**  The number of pagination page buttons shown in the footer using the paginationButtonCount option. By default this has a value of 5.*/
-        paginationButtonCount?: number;
+        paginationButtonCount?: number | undefined;
         /** Specify that a specific page should be loaded when the table first load */
-        paginationInitialPage?: number;
+        paginationInitialPage?: number | undefined;
     }
 
     type GroupArg = string | string[] | ((data: any) => any);
 
     interface OptionsRowGrouping {
         /** String/function to select field to group rows by     */
-        groupBy?: GroupArg;
+        groupBy?: GroupArg | undefined;
         /** By default Tabulator will create groups for rows based on the values contained in the row data. if you want to explicitly define which field values groups should be created for at each level, you can use the groupValues option.
 
     This option takes an array of value arrays, each item in the first array should be a list of acceptable field values for groups at that level     */
-        groupValues?: GroupValuesArg;
+        groupValues?: GroupValuesArg | undefined;
 
         /** You can use the setGroupHeader function to change the header generation function for each group. This function has one argument and takes the same values as passed to the groupHeader setup option.     */
         groupHeader?:
             | ((value: any, count: number, data: any, group: GroupComponent) => string)
-            | Array<(value: any, count: number, data: any) => string>;
+            | Array<(value: any, count: number, data: any) => string> | undefined;
 
         /**When printing you may want to apply a different group header from the one usualy used in the table. You can now do this using the groupHeaderPrint table option, which takes the same inputs as the standard groupHeader property. */
         groupHeaderPrint?:
             | ((value: any, count: number, data: any, group: GroupComponent) => string)
-            | Array<(value: any, count: number, data: any) => string>;
+            | Array<(value: any, count: number, data: any) => string> | undefined;
 
         /** You can set the default open state of groups using the groupStartOpen property* * This can take one of three possible values:
 
@@ -238,40 +238,40 @@ declare namespace Tabulator {
         Group Open Function
         If you want to decide on a group by group basis which should start open or closed then you can pass a function to the groupStartOpen property. This should return true if the group should start open or false if the group should start closed.
      */
-        groupStartOpen?: boolean | ((value: any, count: number, data: any, group: GroupComponent) => boolean);
+        groupStartOpen?: boolean | ((value: any, count: number, data: any, group: GroupComponent) => boolean) | undefined;
 
         /** By default Tabulator allows users to toggle a group open or closed by clicking on the arrow icon in the left of the group header. If you would prefer a different behaviour you can use the groupToggleElement option to choose a different option:* * The option can take one of three values:
       arrow - togggle group on arrow element click
       header - toggle group on click anywhere on the group header element
       false - prevent clicking anywhere in the group toggling the group
      */
-        groupToggleElement?: 'arrow' | 'header' | false;
+        groupToggleElement?: 'arrow' | 'header' | false | undefined;
 
         /** show/hide column calculations when group is closed     */
-        groupClosedShowCalcs?: boolean;
+        groupClosedShowCalcs?: boolean | undefined;
 
         /** The dataGrouping callback is triggered whenever a data grouping event occurs, before grouping happens. */
-        dataGrouping?: () => void;
+        dataGrouping?: (() => void) | undefined;
         /** The dataGrouping callback is triggered whenever a data grouping event occurs, after grouping happens. */
-        dataGrouped?: () => void;
+        dataGrouped?: (() => void) | undefined;
         /** The groupVisibilityChanged callback is triggered whenever a group changes between hidden and visible states. */
-        groupVisibilityChanged?: (group: GroupComponent, visible: boolean) => void;
+        groupVisibilityChanged?: ((group: GroupComponent, visible: boolean) => void) | undefined;
 
         /** The groupClick callback is triggered when a user clicks on a group header. */
-        groupClick?: GroupEventCallback;
+        groupClick?: GroupEventCallback | undefined;
         /** The groupDblClick callback is triggered when a user double clicks on a group header. */
-        groupDblClick?: GroupEventCallback;
+        groupDblClick?: GroupEventCallback | undefined;
         /** The groupContext callback is triggered when a user right clicks on a group header.
 
     If you want to prevent the browsers context menu being triggered in this event you will need to include the preventDefault() function in your callback. */
-        groupContext?: GroupEventCallback;
+        groupContext?: GroupEventCallback | undefined;
         /** The groupTap callback is triggered when a user taps on a group header on a touch display. */
-        groupTap?: GroupEventCallback;
+        groupTap?: GroupEventCallback | undefined;
         /** The groupDblTap callback is triggered when a user taps on a group header on a touch display twice in under 300ms. */
-        groupDblTap?: GroupEventCallback;
+        groupDblTap?: GroupEventCallback | undefined;
         /** The groupTapHold callback is triggered when a user taps on a group header on a touch display and holds their finger down for over 1 second */
-        groupTapHold?: GroupEventCallback;
-        groupUpdateOnCellEdit?: boolean;
+        groupTapHold?: GroupEventCallback | undefined;
+        groupUpdateOnCellEdit?: boolean | undefined;
     }
 
     interface Filter {
@@ -281,32 +281,32 @@ declare namespace Tabulator {
     }
 
     interface FilterParams {
-        separator?: string;
-        matchAll?: boolean;
+        separator?: string | undefined;
+        matchAll?: boolean | undefined;
     }
     type FilterFunction = (field: string, type: FilterType, value: any, filterParams?: FilterParams) => void;
 
     interface OptionsFiltering {
         /** Array of filters to be applied on load.     */
-        initialFilter?: Filter[];
+        initialFilter?: Filter[] | undefined;
 
         /** array of initial values for header filters.     */
-        initialHeaderFilter?: Array<Pick<Filter, 'field' | 'value'>>;
+        initialHeaderFilter?: Array<Pick<Filter, 'field' | 'value'>> | undefined;
 
         /** The dataFiltering callback is triggered whenever a filter event occurs, before the filter happens. */
-        dataFiltering?: (filters: Filter[]) => void;
+        dataFiltering?: ((filters: Filter[]) => void) | undefined;
         /** The dataFiltered callback is triggered after the table dataset is filtered. */
-        dataFiltered?: (filters: Filter[], rows: RowComponent[]) => void;
+        dataFiltered?: ((filters: Filter[], rows: RowComponent[]) => void) | undefined;
 
         /**When using real time header filtering, Tabulator will wait 300 miliseconds after a keystroke before triggering the filter. You can customise this delay by using the headerFilterLiveFilterDelay table setup option */
-        headerFilterLiveFilterDelay?: number;
+        headerFilterLiveFilterDelay?: number | undefined;
     }
     interface OptionsSorting {
         /** Array of sorters to be applied on load.     */
-        initialSort?: Sorter[];
+        initialSort?: Sorter[] | undefined;
 
         /** reverse the order that multiple sorters are applied to the table.     */
-        sortOrderReverse?: boolean;
+        sortOrderReverse?: boolean | undefined;
     }
 
     interface Sorter {
@@ -323,18 +323,18 @@ declare namespace Tabulator {
     }
     interface OptionsData {
         /** A unique index value should be present for each row of data if you want to be able to programatically alter that data at a later point, this should be either numeric or a string. By default Tabulator will look for this value in the id field for the data. If you wish to use a different field as the index, set this using the index option parameter. */
-        index?: number | string;
+        index?: number | string | undefined;
         /** Array to hold data that should be loaded on table creation     */
-        data?: any[];
+        data?: any[] | undefined;
 
         /** If you wish to retrieve your data from a remote source you can set the URL for the request in the ajaxURL option. */
-        ajaxURL?: string;
+        ajaxURL?: string | undefined;
 
         /** Parameters to be passed to remote Ajax data loading request     */
-        ajaxParams?: {};
+        ajaxParams?: {} | undefined;
 
         /** The HTTP request type for Ajax requests or config object for the request     */
-        ajaxConfig?: HttpMethod | AjaxConfig;
+        ajaxConfig?: HttpMethod | AjaxConfig | undefined;
 
         /** When using a request method other than "GET" Tabulator will send any parameters with a content type of form data. You can change the content type with the ajaxContentType option. This will ensure parameters are sent in the format you expect, with the correct headers. * * The ajaxContentType option can take one of two values:
       "form" - send parameters as form data (default option)
@@ -342,21 +342,21 @@ declare namespace Tabulator {
       If you want to use a custom content type then you can pass a content type formatter object into the ajaxContentType option. this object must have two properties, the headers property should contain all headers that should be sent with the request and the body property should contain a function that returns the body content of the request
     */
 
-        ajaxContentType?: 'form' | 'json' | AjaxContentType;
+        ajaxContentType?: 'form' | 'json' | AjaxContentType | undefined;
 
         /** If you need more control over the url of the request that you can get from the ajaxURL and ajaxParams properties, the you can use the ajaxURLGenerator property to pass in a callback that will generate the URL for you.
 
     The callback should return a string representing the URL to be requested. */
-        ajaxURLGenerator?: (url: string, config: any, params: any) => string;
+        ajaxURLGenerator?: ((url: string, config: any, params: any) => string) | undefined;
 
         /** callback function to replace inbuilt ajax request functionality     */
-        ajaxRequestFunc?: (url: string, config: any, params: any) => Promise<any>;
+        ajaxRequestFunc?: ((url: string, config: any, params: any) => Promise<any>) | undefined;
 
         /** Send filter config to server instead of processing locally     */
-        ajaxFiltering?: boolean;
+        ajaxFiltering?: boolean | undefined;
 
         /** Send sorter config to server instead of processing locally     */
-        ajaxSorting?: boolean;
+        ajaxSorting?: boolean | undefined;
 
         /** If you are loading a lot of data from a remote source into your table in one go, it can sometimes take a long time for the server to return the request, which can slow down the user experience.
 
@@ -365,26 +365,26 @@ declare namespace Tabulator {
       With this mode enabled, all of the settings outlined in the Ajax Documentation are still available
 
       There are two different progressive loading modes, to give you a choice of how data is loaded into the table.     */
-        ajaxProgressiveLoad?: 'load' | 'scroll';
+        ajaxProgressiveLoad?: 'load' | 'scroll' | undefined;
         /** By default tabulator will make the requests to fill the table as quickly as possible. On some servers these repeates requests from the same client may trigger rate limiting or security systems. In this case you can use the ajaxProgressiveLoadDelay option to add a delay in milliseconds between each page request. */
-        ajaxProgressiveLoadDelay?: number;
+        ajaxProgressiveLoadDelay?: number | undefined;
         /** The ajaxProgressiveLoadScrollMargin property determines how close to the bottom of the table in pixels, the scroll bar must be before the next page worth of data is loaded, by default it is set to twice the height of the table. */
-        ajaxProgressiveLoadScrollMargin?: number;
+        ajaxProgressiveLoadScrollMargin?: number | undefined;
 
         /** Show loader while data is loading, can also take a function that must return a boolean     */
-        ajaxLoader?: boolean | (() => boolean);
+        ajaxLoader?: boolean | (() => boolean) | undefined;
 
         /** html for loader element     */
-        ajaxLoaderLoading?: string;
+        ajaxLoaderLoading?: string | undefined;
         /** html for the loader element in the event of an error     */
-        ajaxLoaderError?: string;
+        ajaxLoaderError?: string | undefined;
 
         /** The ajaxRequesting callback is triggered when ever an ajax request is made. */
-        ajaxRequesting?: (url: string, params: any) => boolean;
+        ajaxRequesting?: ((url: string, params: any) => boolean) | undefined;
         /** The ajaxResponse callback is triggered when a successful ajax request has been made. This callback can also be used to modify the received data before it is parsed by the table. If you use this callback it must return the data to be parsed by Tabulator, otherwise no data will be rendered */
-        ajaxResponse?: (url: string, params: any, response: any) => any;
+        ajaxResponse?: ((url: string, params: any, response: any) => any) | undefined;
         /** The ajaxError callback is triggered there is an error response to an ajax request. */
-        ajaxError?: (xhr: any, textStatus: any, errorThrown: any) => void;
+        ajaxError?: ((xhr: any, textStatus: any, errorThrown: any) => void) | undefined;
     }
 
     interface AjaxContentType {
@@ -394,29 +394,29 @@ declare namespace Tabulator {
 
     type HttpMethod = 'GET' | 'POST';
     interface AjaxConfig {
-        method?: HttpMethod;
-        headers?: JSONRecord;
-        mode?: string;
-        credentials?: string;
+        method?: HttpMethod | undefined;
+        headers?: JSONRecord | undefined;
+        mode?: string | undefined;
+        credentials?: string | undefined;
     }
 
     interface OptionsRows {
         /** Tabulator also allows you to define a row level formatter using the rowFormatter option. this lets you alter each row of the table based on the data it contains.
 
     The function accepts one argument, the RowComponent for the row being formatted. */
-        rowFormatter?: (row: RowComponent) => any;
+        rowFormatter?: ((row: RowComponent) => any) | undefined;
 
         /**When printing you may want to apply a different formatter may want to apply a different formatter from the one usualy used to format the row. */
-        rowFormatterPrint?: false | ((row: RowComponent) => any);
+        rowFormatterPrint?: false | ((row: RowComponent) => any) | undefined;
 
         /**When the getHtml function is called you may want to apply a different formatter may want to apply a different formatter from the one usualy used to format the row */
-        rowFormatterHtmlOutput?: false | ((row: RowComponent) => any);
+        rowFormatterHtmlOutput?: false | ((row: RowComponent) => any) | undefined;
 
         /**When copying to the clipboard you may want to apply a different formatter may want to apply a different formatter from the one usualy used to format the row. You can now do this using the rowFormatterClipboard table option, which takes the same inputs as the standard rowFormatter property. Passing a value of false into the formatter prevent the default row formatter from being run when the table is copied to the clipboard*/
-        rowFormatterClipboard?: false | ((row: RowComponent) => any);
+        rowFormatterClipboard?: false | ((row: RowComponent) => any) | undefined;
 
         /** The position in the table for new rows to be added, "bottom" or "top" */
-        addRowPos?: 'bottom' | 'top';
+        addRowPos?: 'bottom' | 'top' | undefined;
 
         /** The selectable option can take one of a several values:
 
@@ -424,27 +424,27 @@ declare namespace Tabulator {
       true - selectable rows are enabled, and you can select as many as you want
       integer - any integer value, this sets the maximum number of rows that can be selected (when the maximum number of selected rows is exeded, the first selected row will be deselected to allow the next row to be selected).
       "highlight" (default) - rows have the same hover stylings as selectable rows but do not change state when clicked. This is great for when you want to show that a row is clickable but don't want it to be selectable. */
-        selectable?: boolean | number | 'highlight';
+        selectable?: boolean | number | 'highlight' | undefined;
 
         /** By default you can select a range of rows by holding down the shift key and click dragging over a number of rows to toggle the selected state state of all rows the cursor passes over.
 
     If you would prefere to select a range of row by clicking on the first row then holding down shift and clicking on the end row then you can acheive this by setting the selectableRangeMode to click */
-        selectableRangeMode?: 'click';
+        selectableRangeMode?: 'click' | undefined;
 
         /** By default, row selection works on a rolling basis, if you set the selectable option to a numeric value then when you select past this number of rows, the first row to be selected will be deselected. If you want to disable this behaviour and instead prevent selection of new rows once the limit is reached you can set the selectableRollingSelection option to false. */
-        selectableRollingSelection?: boolean;
+        selectableRollingSelection?: boolean | undefined;
 
         /** By default Tabulator will maintain selected rows when the table is filtered, sorted or paginated (but NOT when the setData function is used). If you want the selected rows to be cleared whenever the table view is updated then set the selectablePersistence option to false. */
-        selectablePersistence?: boolean;
+        selectablePersistence?: boolean | undefined;
 
         /** You many want to exclude certain rows from being selected. The selectableCheck options allows you to pass a function to check if the current row should be selectable, returning true will allow row selection, false will result in nothing happening. The function should accept a RowComponent as its first argument. */
-        selectableCheck?: (row: RowComponent) => boolean;
+        selectableCheck?: ((row: RowComponent) => boolean) | undefined;
 
         /** To allow the user to move rows up and down the table, set the movableRows parameter in the options: */
-        movableRows?: boolean;
+        movableRows?: boolean | undefined;
 
         /** Tabulator also allows you to move rows between tables. To enable this you should supply either a valid CSS selector string a DOM node for the table or the Tabuator object for the table to the movableRowsConnectedTables option. if you want to connect to multple tables then you can pass in an array of values to this option. */
-        movableRowsConnectedTables?: string | string[] | HTMLElement | HTMLElement[];
+        movableRowsConnectedTables?: string | string[] | HTMLElement | HTMLElement[] | undefined;
 
         /** The movableRowsSender option should be set on the sending table, and sets the action that should be taken after the row has been successfuly dropped into the receiving table.
 
@@ -457,7 +457,7 @@ declare namespace Tabulator {
         movableRowsSender?:
             | false
             | 'delete'
-            | ((fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => any);
+            | ((fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => any) | undefined;
 
         /**  The movableRowsReceiver option should be set on the receiving tables, and sets the action that should be taken when the row is dropped into the table.
       There are several inbuilt receiver functions:
@@ -471,15 +471,15 @@ declare namespace Tabulator {
             | 'add'
             | 'update'
             | 'replace'
-            | ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => any);
+            | ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => any) | undefined;
 
-        movableRowsConnectedElements?: string | HTMLElement;
+        movableRowsConnectedElements?: string | HTMLElement | undefined;
 
         /**When a row is dropped on element from from the movableRowsConnectedElements option the movableRowsElementDrop callback will be triggered. You can use this callback to trigger any changes as a result of the drop */
-        movableRowsElementDrop?: (e: MouseEvent, element: HTMLElement, row: RowComponent) => any;
+        movableRowsElementDrop?: ((e: MouseEvent, element: HTMLElement, row: RowComponent) => any) | undefined;
 
         /** You can allow the user to manually resize rows by dragging the top or bottom border of a row. To enable this functionality, set the resizableRows property to true */
-        resizableRows?: boolean;
+        resizableRows?: boolean | undefined;
 
         /** * The default ScrollTo position can be set using the scrollToRowPosition option. It can take one of four possible values:
 
@@ -488,109 +488,109 @@ declare namespace Tabulator {
         bottom - position row with its bottom edge at the bottom of the table
         nearest - position row on the edge of the table it is closest to
      */
-        scrollToRowPosition?: ScrollToRowPostition;
+        scrollToRowPosition?: ScrollToRowPostition | undefined;
 
         /** The default option for triggering a ScrollTo on a visible element can be set using the scrollToRowIfVisible option. It can take a boolean value:
 
       true - scroll to row, even if it is visible (default)
       false - scroll to row, unless it is currently visible, then don't move */
-        scrollToRowIfVisible?: boolean;
+        scrollToRowIfVisible?: boolean | undefined;
 
         /** The dataTreeRowExpanded callback is triggered when a row with child rows is expanded to reveal the children. */
-        dataTreeRowExpanded?: (row: RowComponent, level: number) => void;
+        dataTreeRowExpanded?: ((row: RowComponent, level: number) => void) | undefined;
 
         /** The dataTreeRowCollapsed callback is triggered when a row with child rows is collapsed to hide its children.*/
-        dataTreeRowCollapsed?: (row: RowComponent, level: number) => void;
+        dataTreeRowCollapsed?: ((row: RowComponent, level: number) => void) | undefined;
 
         /** The movableRowsSendingStart callback is triggered on the sending table when a row is picked up from a sending table. */
-        movableRowsSendingStart?: (toTables: any[]) => void;
+        movableRowsSendingStart?: ((toTables: any[]) => void) | undefined;
 
         /** The movableRowsSent callback is triggered on the sending table when a row has been successfuly received by a receiving table. */
-        movableRowsSent?: (fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => void;
+        movableRowsSent?: ((fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => void) | undefined;
 
         /** The movableRowsSentFailed callback is triggered on the sending table when a row has failed to be received by the receiving table.*/
-        movableRowsSentFailed?: (fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => void;
+        movableRowsSentFailed?: ((fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => void) | undefined;
 
         /** The movableRowsSendingStop callback is triggered on the sending table after a row has been dropped and any senders and receivers have been handled. */
-        movableRowsSendingStop?: (toTables: any[]) => void;
+        movableRowsSendingStop?: ((toTables: any[]) => void) | undefined;
 
         /** The movableRowsReceivingStart callback is triggered on a receiving table when a connection is established with a sending table. */
-        movableRowsReceivingStart?: (fromRow: RowComponent, toTable: Tabulator) => void;
+        movableRowsReceivingStart?: ((fromRow: RowComponent, toTable: Tabulator) => void) | undefined;
 
         /** The movableRowsReceived callback is triggered on a receiving table when a row has been successfuly received.*/
-        movableRowsReceived?: (fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => void;
+        movableRowsReceived?: ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => void) | undefined;
 
         /** The movableRowsReceivedFailed callback is triggered on a receiving table when a row receiver has returned false.*/
-        movableRowsReceivedFailed?: (fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => void;
+        movableRowsReceivedFailed?: ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => void) | undefined;
 
         /** The movableRowsReceivingStop callback is triggered on a receiving table after a row has been dropped and any senders and receivers have been handled.*/
-        movableRowsReceivingStop?: (fromTable: Tabulator) => void;
+        movableRowsReceivingStop?: ((fromTable: Tabulator) => void) | undefined;
 
         /** The rowClick callback is triggered when a user clicks on a row. */
-        rowClick?: RowEventCallback;
+        rowClick?: RowEventCallback | undefined;
         /** The rowDblClick callback is triggered when a user double clicks on a row. */
-        rowDblClick?: RowEventCallback;
+        rowDblClick?: RowEventCallback | undefined;
         /** The rowContext callback is triggered when a user right clicks on a row.
 
     If you want to prevent the browsers context menu being triggered in this event you will need to include the preventDefault() function in your callback. */
-        rowContext?: RowEventCallback;
+        rowContext?: RowEventCallback | undefined;
         /** The rowTap callback is triggered when a user taps on a row on a touch display. */
-        rowTap?: RowEventCallback;
+        rowTap?: RowEventCallback | undefined;
         /** The rowDblTap callback is triggered when a user taps on a row on a touch display twice in under 300ms. */
-        rowDblTap?: RowEventCallback;
+        rowDblTap?: RowEventCallback | undefined;
         /** The rowTapHold callback is triggered when a user taps on a row on a touch display and holds their finger down for over 1 second. */
-        rowTapHold?: RowEventCallback;
+        rowTapHold?: RowEventCallback | undefined;
         /** The rowMouseEnter callback is triggered when the mouse pointer enters a row. */
-        rowMouseEnter?: RowEventCallback;
+        rowMouseEnter?: RowEventCallback | undefined;
         /** The rowMouseLeave callback is triggered when the mouse pointer leaves a row. */
-        rowMouseLeave?: RowEventCallback;
+        rowMouseLeave?: RowEventCallback | undefined;
         /**  The rowMouseOver callback is triggered when the mouse pointer enters a row or any of its child elements.*/
-        rowMouseOver?: RowEventCallback;
+        rowMouseOver?: RowEventCallback | undefined;
         /** The rowMouseOut callback is triggered when the mouse pointer leaves a row or any of its child elements. */
-        rowMouseOut?: RowEventCallback;
+        rowMouseOut?: RowEventCallback | undefined;
         /** The rowMouseMove callback is triggered when the mouse pointer moves over a row. */
-        rowMouseMove?: RowEventCallback;
+        rowMouseMove?: RowEventCallback | undefined;
         /** The rowAdded callback is triggered when a row is added to the table by the addRow and updateOrAddRow functions. */
-        rowAdded?: RowChangedCallback;
+        rowAdded?: RowChangedCallback | undefined;
         /** The rowUpdated callback is triggered when a row is updated by the updateRow, updateOrAddRow, updateData or updateOrAddData, functions. */
-        rowUpdated?: RowChangedCallback;
+        rowUpdated?: RowChangedCallback | undefined;
         /** The rowDeleted callback is triggered when a row is deleted from the table by the deleteRow function. */
-        rowDeleted?: RowChangedCallback;
+        rowDeleted?: RowChangedCallback | undefined;
         /** The rowMoved callback will be triggered when a row has been successfuly moved. */
-        rowMoved?: RowChangedCallback;
+        rowMoved?: RowChangedCallback | undefined;
         /** The rowResized callback will be triggered when a row has been resized by the user. */
-        rowResized?: RowChangedCallback;
+        rowResized?: RowChangedCallback | undefined;
         /** Whenever the number of selected rows changes, through selection or deselection, the rowSelectionChanged event is triggered. This passes an array of the data objects for each row in the order they were selected as the first argument, and an array of row components for each of the rows in order of selection as the second argument. */
-        rowSelectionChanged?: (data: any[], rows: RowComponent[]) => void;
+        rowSelectionChanged?: ((data: any[], rows: RowComponent[]) => void) | undefined;
         /** The rowSelected event is triggered when a row is selected, either by the user or programatically. */
-        rowSelected?: RowChangedCallback;
+        rowSelected?: RowChangedCallback | undefined;
         /** The rowDeselected event is triggered when a row is deselected, either by the user or programatically. */
-        rowDeselected?: RowChangedCallback;
+        rowDeselected?: RowChangedCallback | undefined;
 
         /**  Allows you to specifcy the behaviour when the user tabs from the last editable cell on the last row of the table */
-        tabEndNewRow?: boolean | JSONRecord | ((row: RowComponent) => any);
+        tabEndNewRow?: boolean | JSONRecord | ((row: RowComponent) => any) | undefined;
     }
 
     interface OptionsColumns {
         /** The column definitions are provided to Tabluator in the columns property of the table constructor object and should take the format of an array of objects, with each object representing the configuration of one column. */
-        columns?: ColumnDefinition[];
+        columns?: ColumnDefinition[] | undefined;
 
         /**
          * If you set the autoColumns option to true, every time data is loaded into the table through the data option or through the setData function, Tabulator will examine the first row of the data and build columns to match that data.
          */
-        autoColumns?: boolean;
+        autoColumns?: boolean | undefined;
         autoColumnsDefinitions?:
             | ((columnDefinitions?: ColumnDefinition[]) => ColumnDefinition[])
             | ColumnDefinition[]
-            | Record<string, Partial<ColumnDefinition>>;
+            | Record<string, Partial<ColumnDefinition>> | undefined;
 
         /** By default Tabulator will use the fitData layout mode, which will resize the tables columns to fit the data held in each column, unless you specify a width or minWidth in the column constructor. If the width of all columns exceeds the width of the containing element, a scroll bar will appear. */
-        layout?: 'fitData' | 'fitColumns' | 'fitDataFill' | 'fitDataStretch' | 'fitDataTable';
+        layout?: 'fitData' | 'fitColumns' | 'fitDataFill' | 'fitDataStretch' | 'fitDataTable' | undefined;
 
         /** To keep the layout of the columns consistent, once the column widths have been set on the first data load (either from the data property in the constructor or the setData function) they will not be changed when new data is loaded.
 
         If you would prefer that the column widths adjust to the data each time you load it into the table you can set the layoutColumnsOnNewData property to true. */
-        layoutColumnsOnNewData?: boolean;
+        layoutColumnsOnNewData?: boolean | undefined;
 
         /** Responsive layout will automatically hide/show columns to fit the width of the Tabulator element. This allows for clean rendering of tables on smaller mobile devices, showing important data while avoiding horizontal scroll bars. You can enable responsive layouts using the responsiveLayout option.
 
@@ -603,15 +603,15 @@ declare namespace Tabulator {
       By default, columns will be hidden from right to left as the width of the table decreases. You can choose exactlyhow columns are hidden using the responsive property in the column definition object.
 
       When responsive layout is enabled, all columns are given a default responsive value of 1. The higher you set this value the sooner that column will be hidden as the table width decreases. If two columns have the same responsive value then they are hidden from right to left (as defined in the column definition array, ignoring user moving of the columns). If you set the value to 0 then the column will never be hidden regardless of how narrow the table gets. */
-        responsiveLayout?: boolean | 'hide' | 'collapse';
+        responsiveLayout?: boolean | 'hide' | 'collapse' | undefined;
 
         /** Collapsed lists are displayed to the user by default, if you would prefer they start closed so the user can open them you can use the responsiveLayoutCollapseStartOpen option */
-        responsiveLayoutCollapseStartOpen?: boolean;
+        responsiveLayoutCollapseStartOpen?: boolean | undefined;
 
         /** By default any formatter set on the column is applied to the value that will appear in the list. while this works for most formatters it can cause issues with the progress formatter which relies on being inside a cell.
 
     If you would like to disable column formatting in the collapsed list, you can use the responsiveLayoutCollapseUseFormatters option: */
-        responsiveLayoutCollapseUseFormatters?: boolean;
+        responsiveLayoutCollapseUseFormatters?: boolean | undefined;
 
         /** If you set the responsiveLayout option to collapse the values from hidden columns will be displayed in a title/value list under the row.
 
@@ -620,44 +620,44 @@ declare namespace Tabulator {
       The inbuilt collapse formatter creates a table to neatly display the hidden columns. If you would like to format the data in your own way you can use the responsiveLayoutCollapseFormatter, it take an object of the column values as an argument and must return the HTML content of the div.
 
       This function should return an empty string if there is no data to display. */
-        responsiveLayoutCollapseFormatter?: (data: any[]) => any;
+        responsiveLayoutCollapseFormatter?: ((data: any[]) => any) | undefined;
 
         /** It is possible to set a minimum column width to prevent resizing columns from becoming too small.
 
         This can be set globally, by setting the columnMinWidth option to the column width when you create your Tabulator.
 
         This option can be overridden on a per column basis by setting the minWidth property on the column definition. */
-        columnMinWidth?: number;
+        columnMinWidth?: number | undefined;
 
         /** By default it is possible to manually resize columns by dragging the borders of the column in both the column headers and the cells of the column.
 
         If you want to alter this behaviour you can use the resizableColumns to choose where the resize handles are available.  */
-        resizableColumns?: true | false | 'header' | 'cell';
+        resizableColumns?: true | false | 'header' | 'cell' | undefined;
 
         /** To allow the user to move columns along the table, set the movableColumns parameter in the options: */
-        movableColumns?: boolean;
+        movableColumns?: boolean | undefined;
 
         /** Header tooltips can be set globally using the tooltipsHeader options parameter */
-        tooltipsHeader?: boolean;
+        tooltipsHeader?: boolean | undefined;
 
         /** You can use the columnHeaderVertAlign option to set how the text in your column headers should be vertically  */
-        columnHeaderVertAlign?: VerticalAlign;
+        columnHeaderVertAlign?: VerticalAlign | undefined;
 
         /** The default placeholder text used for input elements can be set using the headerFilterPlaceholder option in the table definition */
-        headerFilterPlaceholder?: string;
+        headerFilterPlaceholder?: string | undefined;
 
         /** The default ScrollTo position can be set using the scrollToColumnPosition option. It can take one of three possible values:
 
     left - position column with its left edge at the left of the table (default)
     center - position column with its left edge in the center of the table
     right - position column with its right edge at the right of the table */
-        scrollToColumnPosition?: ScrollToColumnPosition;
+        scrollToColumnPosition?: ScrollToColumnPosition | undefined;
 
         /** The default option for triggering a ScrollTo on a visible element can be set using the scrollToColumnIfVisible option. It can take a boolean value:
 
     true - scroll to column, even if it is visible (default)
     false - scroll to column, unless it is currently visible, then don't move */
-        scrollToColumnIfVisible?: boolean;
+        scrollToColumnIfVisible?: boolean | undefined;
 
         /** By default column calculations are shown at the top and bottom of the table, unless row grouping is enabled, in which case they are shown at the top and bottom of each group.
 
@@ -667,88 +667,88 @@ declare namespace Tabulator {
       both - show calcs at top and bottom of the table and show in groups
       table - show calcs at top and bottom of the table only
       group - show calcs in groups only */
-        columnCalcs?: boolean | 'both' | 'table' | 'group';
+        columnCalcs?: boolean | 'both' | 'table' | 'group' | undefined;
 
         /** If you need to use the . character as part of your field name, you can change the separator to any other character using the nestedFieldSeparator option
          * Set to false to disable nested data parsing
          */
-        nestedFieldSeparator?: string | boolean;
+        nestedFieldSeparator?: string | boolean | undefined;
 
         /** multiple or single column sorting */
-        columnHeaderSortMulti?: boolean;
+        columnHeaderSortMulti?: boolean | undefined;
 
         /** The columnMoved callback will be triggered when a column has been successfuly moved. */
-        columnMoved?: (column: ColumnComponent, columns: any[]) => void;
-        columnResized?: (column: ColumnComponent) => void;
+        columnMoved?: ((column: ColumnComponent, columns: any[]) => void) | undefined;
+        columnResized?: ((column: ColumnComponent) => void) | undefined;
         /** The columnVisibilityChanged callback is triggered whenever a column changes between hidden and visible states. */
-        columnVisibilityChanged?: (column: ColumnComponent, visible: boolean) => void;
+        columnVisibilityChanged?: ((column: ColumnComponent, visible: boolean) => void) | undefined;
 
         /** The columnTitleChanged callback is triggered whenever a user edits a column title when the editableTitle parameter has been enabled in the column definition array. */
-        columnTitleChanged?: (column: ColumnComponent) => void;
+        columnTitleChanged?: ((column: ColumnComponent) => void) | undefined;
 
         /**By setting the headerVisible option to false you can hide the column headers and present the table as a simple list if needed. */
-        headerVisible?: boolean;
-        headerHozAlign?: ColumnDefinitionAlign;
+        headerVisible?: boolean | undefined;
+        headerHozAlign?: ColumnDefinitionAlign | undefined;
 
         /**If you don't want to show a particular column in the print table you can set the print property in its column definition object to false */
-        print?: boolean;
+        print?: boolean | undefined;
 
         /** The headerSort option can now be set in the table options to affect all columns as well as in column definitions. */
-        headerSort?: boolean;
+        headerSort?: boolean | undefined;
 
         /** The headerSortTristate option can now be set in the table options to affect all columns as well as in column definitions.*/
-        headerSortTristate?: boolean;
-        headerSortElement?: string;
-        columnMaxWidth?: number;
+        headerSortTristate?: boolean | undefined;
+        headerSortElement?: string | undefined;
+        columnMaxWidth?: number | undefined;
     }
 
     interface OptionsCell {
         /** The cellClick callback is triggered when a user left clicks on a cell, it can be set on a per column basis using the option in the columns definition object. */
-        cellClick?: CellEventCallback;
-        cellDblClick?: CellEventCallback;
-        cellContext?: CellEventCallback;
-        cellTap?: CellEventCallback;
-        cellDblTap?: CellEventCallback;
-        cellTapHold?: CellEventCallback;
-        cellMouseEnter?: CellEventCallback;
-        cellMouseLeave?: CellEventCallback;
-        cellMouseOver?: CellEventCallback;
-        cellMouseOut?: CellEventCallback;
-        cellMouseMove?: CellEventCallback;
-        cellEditing?: CellEditEventCallback;
-        cellEdited?: CellEditEventCallback;
-        cellEditCancelled?: CellEditEventCallback;
-        cellHozAlign?: ColumnDefinitionAlign;
-        cellVertAlign?: VerticalAlign;
+        cellClick?: CellEventCallback | undefined;
+        cellDblClick?: CellEventCallback | undefined;
+        cellContext?: CellEventCallback | undefined;
+        cellTap?: CellEventCallback | undefined;
+        cellDblTap?: CellEventCallback | undefined;
+        cellTapHold?: CellEventCallback | undefined;
+        cellMouseEnter?: CellEventCallback | undefined;
+        cellMouseLeave?: CellEventCallback | undefined;
+        cellMouseOver?: CellEventCallback | undefined;
+        cellMouseOut?: CellEventCallback | undefined;
+        cellMouseMove?: CellEventCallback | undefined;
+        cellEditing?: CellEditEventCallback | undefined;
+        cellEdited?: CellEditEventCallback | undefined;
+        cellEditCancelled?: CellEditEventCallback | undefined;
+        cellHozAlign?: ColumnDefinitionAlign | undefined;
+        cellVertAlign?: VerticalAlign | undefined;
     }
 
     interface OptionsGeneral {
         /** Sets the height of the containing element, can be set to any valid height css value. If set to false (the default), the height of the table will resize to fit the table data.     */
-        height?: string | number | false;
+        height?: string | number | false | undefined;
         /** Can be set to any valid CSS value. By setting this you can allow your table to expand to fit the data, but not overflow its parent element. Whene there are too many rows to fit in the available space, the vertical scroll bar will be shown. This has the added benefit of improving load times on larger tables */
-        maxHeight?: string | number;
+        maxHeight?: string | number | undefined;
         /** With a variable table height you can set the minimum height of the table either defined in the min-height CSS property for the element or set it using the minHeight option in the table constructor, this can be set to any valid CSS value  */
-        minHeight?: string | number;
+        minHeight?: string | number | undefined;
 
         /** Enable rendering using the Virtual DOM engine     */
-        virtualDom?: boolean;
+        virtualDom?: boolean | undefined;
 
         /** Manually set the size of the virtual DOM buffer     */
-        virtualDomBuffer?: boolean | number;
-        virtualDomHoz?: boolean;
+        virtualDomBuffer?: boolean | number | undefined;
+        virtualDomHoz?: boolean | undefined;
         /** placeholder element to display on empty table     */
-        placeholder?: string | HTMLElement;
+        placeholder?: string | HTMLElement | undefined;
 
         /** Footer  element to display for the table     */
-        footerElement?: string | HTMLElement;
+        footerElement?: string | HTMLElement | undefined;
 
         /** Function to generate tooltips for cells     */
-        tooltips?: GlobalTooltipOption;
+        tooltips?: GlobalTooltipOption | undefined;
         /** When to regenerate cell tooltip value     */
-        tooltipGenerationMode?: 'load' | 'hover';
+        tooltipGenerationMode?: 'load' | 'hover' | undefined;
 
         /** Keybinding configuration object     */
-        keybindings?: false | KeyBinding;
+        keybindings?: false | KeyBinding | undefined;
 
         /** * The reactivity systems allow Tabulator to watch arrays and objects passed into the table for changes and then automatically update the table.
 
@@ -758,17 +758,17 @@ declare namespace Tabulator {
 
         Once the table is built any changes to the array will automatically be replicated to the table without needing to call any functions on the table itself*/
 
-        reactiveData?: boolean;
+        reactiveData?: boolean | undefined;
 
         // Not listed in options--------------------
         /** Tabulator will automatically attempt to redraw the data contained in the table if the containing element for the table is resized. To disable this functionality, set the autoResize property to false */
-        autoResize?: boolean;
+        autoResize?: boolean | undefined;
 
         /** When a the tabulator constructor is called, the tableBuilding callback will triggered */
-        tableBuilding?: () => void;
+        tableBuilding?: (() => void) | undefined;
 
         /** When a the tabulator constructor is called and the table has finished being rendered, the tableBuilt callback will triggered: */
-        tableBuilt?: () => void;
+        tableBuilt?: (() => void) | undefined;
 
         /** The renderStarted callback is triggered whenever all the rows in the table are about to be rendered. This can include:
       Data is loaded into the table when setData is called
@@ -778,41 +778,41 @@ declare namespace Tabulator {
       The data is filtered
       The data is sorted
       The redraw function is called */
-        renderStarted?: () => void;
+        renderStarted?: (() => void) | undefined;
 
         /** The renderComplete callback is triggered after the table has been rendered */
-        renderComplete?: () => void;
+        renderComplete?: (() => void) | undefined;
 
         /** The htmlImporting callback is triggered when Tabulator starts importing data from an HTML table. */
-        htmlImporting?: EmptyCallback;
+        htmlImporting?: EmptyCallback | undefined;
 
         /** The htmlImported callback is triggered when Tabulator finishes importing data from an HTML table. */
-        htmlImported?: EmptyCallback;
+        htmlImported?: EmptyCallback | undefined;
 
         /** The dataLoading callback is triggered whenever new data is loaded into the table. */
-        dataLoading?: (data: any) => void;
+        dataLoading?: ((data: any) => void) | undefined;
         /** The dataLoaded callback is triggered when a new set of data is loaded into the table. */
-        dataLoaded?: (data: any) => void;
+        dataLoaded?: ((data: any) => void) | undefined;
         /** The dataChanged callback is triggered whenever the table data is changed by the user. Triggers for this include editing any cell in the table, adding a row and deleting a row. */
-        dataChanged?: (data: any) => void;
+        dataChanged?: ((data: any) => void) | undefined;
 
         /** Whenever a page has been loaded, the pageLoaded callback is called, passing the current page number as an argument. */
-        pageLoaded?: (pageno: number) => void;
+        pageLoaded?: ((pageno: number) => void) | undefined;
 
         /** The dataSorting callback is triggered whenever a sort event occurs, before sorting happens. */
-        dataSorting?: (sorters: Sorter[]) => void;
+        dataSorting?: ((sorters: Sorter[]) => void) | undefined;
 
         /** The dataSorted callback is triggered after the table dataset is sorted. */
-        dataSorted?: (sorters: Sorter[], rows: RowComponent[]) => void;
+        dataSorted?: ((sorters: Sorter[], rows: RowComponent[]) => void) | undefined;
 
         /** Setting the invalidOptionWarnings option to false will disable console warning messages for invalid properties in the table constructor and column definition object */
-        invalidOptionWarnings?: boolean;
+        invalidOptionWarnings?: boolean | undefined;
 
         /** Callback is triggered when the table is vertically scrolled. */
-        scrollVertical?: (top: any) => void;
+        scrollVertical?: ((top: any) => void) | undefined;
 
         /** Callback is triggered when the table is horizontally scrolled. */
-        scrollHorizontal?: (left: any) => void;
+        scrollHorizontal?: ((left: any) => void) | undefined;
 
         /**There are now three different validation modes available to customise the validation experience:
 
@@ -821,16 +821,16 @@ declare namespace Tabulator {
         highlight - if a user enters an invalid value, then the edit will complete as usual and they are allowed to exit the cell but a highlight is applied to the cell using the tabulator-validation-fail class
 
         manual - no vaildation is automatically performed on edit, but it can be triggered by calling the validate funtion on the table or any Component Object */
-        validationMode?: 'blocking' | 'highlight' | 'manual';
-        textDirection?: TextDirection;
+        validationMode?: 'blocking' | 'highlight' | 'manual' | undefined;
+        textDirection?: TextDirection | undefined;
     }
 
     interface OptionsMenu {
-        rowContextMenu?: RowContextMenuSignature;
-        rowClickMenu?: RowContextMenuSignature;
-        groupClickMenu?: GroupContextMenuSignature;
+        rowContextMenu?: RowContextMenuSignature | undefined;
+        rowClickMenu?: RowContextMenuSignature | undefined;
+        groupClickMenu?: GroupContextMenuSignature | undefined;
 
-        groupContextMenu?: Array<MenuObject<GroupComponent>>;
+        groupContextMenu?: Array<MenuObject<GroupComponent>> | undefined;
     }
 
     type RowContextMenuSignature =
@@ -843,12 +843,12 @@ declare namespace Tabulator {
 
     interface MenuObject<T extends RowComponent | CellComponent | ColumnComponent | GroupComponent> {
         label: string | HTMLElement | ((component: T) => string | HTMLElement);
-        action?: (e: any, component: T) => any;
-        disabled?: boolean | ((component: T) => boolean);
-        menu?: Array<MenuObject<T>>;
+        action?: ((e: any, component: T) => any) | undefined;
+        disabled?: boolean | ((component: T) => boolean) | undefined;
+        menu?: Array<MenuObject<T>> | undefined;
     }
     interface MenuSeparator {
-        separator?: boolean;
+        separator?: boolean | undefined;
     }
 
     type DownloadType = 'csv' | 'json' | 'xlsx' | 'pdf' | 'html';
@@ -857,32 +857,32 @@ declare namespace Tabulator {
 
     interface DownloadCSV {
         /** By default CSV files are created using a comma (,) delimiter. If you need to change this for any reason the you can pass the options object with a delimiter property to the download function which will then use this delimiter instead of the comma. */
-        delimiter?: string;
+        delimiter?: string | undefined;
         /** If you need the output CSV to include a byte order mark (BOM) to ensure that output with UTF-8 characters can be correctly interpereted across didfferent applications, you should set the bom option to true */
-        bom?: boolean;
+        bom?: boolean | undefined;
     }
 
     interface DownloadHTML {
         /** By default the HTML output is a simple unstyled table. if you would like to match the current table styling you can set the style property to true  */
-        style?: boolean;
+        style?: boolean | undefined;
     }
 
     interface DownloadXLXS {
         /** The sheet name must be a valid Excel sheet name, and cannot include any of the following characters \, /, *, [, ], :,  */
-        sheetName?: string;
-        documentProcessing?: (input: any) => any;
+        sheetName?: string | undefined;
+        documentProcessing?: ((input: any) => any) | undefined;
     }
 
     interface DownloadPDF {
-        orientation?: 'portrait' | 'landscape';
-        title?: string;
+        orientation?: 'portrait' | 'landscape' | undefined;
+        title?: string | undefined;
         rowGroupStyles?: any;
         rowCalcStyles?: any;
         jsPDF?: any;
-        autoTable?: {} | ((doc: any) => any);
+        autoTable?: {} | ((doc: any) => any) | undefined;
 
         /**An optional callback documentProcessing can be set on the download config object, that is passed the jsPDF document object after the auto-table creation to allow full customisation of the PDF */
-        documentProcessing?: (doc: any) => any;
+        documentProcessing?: ((doc: any) => any) | undefined;
     }
 
     interface OptionsDownload {
@@ -891,23 +891,23 @@ declare namespace Tabulator {
     In order for the download to proceed the downloadReady callback is expected to return a blob of file to be downloaded.
 
     If you would prefer to abort the download you can return false from this callback. This could be useful for example if you want to send the created file to a server via ajax rather than allowing the user to download the file. */
-        downloadReady?: (fileContents: any, blob: any) => any;
+        downloadReady?: ((fileContents: any, blob: any) => any) | undefined;
 
         /** The downloadComplete callback is triggered when the user has been prompted to download the file. */
-        downloadComplete?: () => void;
+        downloadComplete?: (() => void) | undefined;
 
         /** By default Tabulator includes column headers, row groups and column calculations in the download output.
 
     You can choose to remove column headers groups, row groups or column calculations from the output data by setting the values in the downloadConfig option in the table definition: */
 
-        downloadConfig?: AddditionalExportOptions;
+        downloadConfig?: AddditionalExportOptions | undefined;
 
         /**By deafault, only the active rows (rows that have passed filtering) will be included in the download the downloadRowRange option takes a Row Range Lookup value and allows you to choose which rows are included in the download output */
-        downloadRowRange?: RowRangeLookup;
+        downloadRowRange?: RowRangeLookup | undefined;
     }
 
     interface OptionsHTML {
-        htmlOutputConfig?: AddditionalExportOptions;
+        htmlOutputConfig?: AddditionalExportOptions | undefined;
         /**By Default when a page is printed that includes a Tabulator it will be rendered on the page exactly as the table is drawn. While this ise useful in most cases, some users prefer tohave more controll over the print output, for example showing all rows of the table, instead of just those visible with the current position of the scroll bar.
 
         Tabulator provides a print styling mode that will replace the Tabulator with an HTML table for the printout giving you much more control over the look and feel of the table for the print out., to enable this mode, set the printAsHtml option to true in the table constructor.
@@ -916,48 +916,48 @@ declare namespace Tabulator {
 
         It also has the benifit that because it is an HTML table, if it corsses a page break your browser will uatomatically add the column headers in at the top of the next page.
         */
-        printAsHtml?: boolean;
+        printAsHtml?: boolean | undefined;
 
         /**The HTML table will contain column header groups, row groups, and column calculations.
 
         You can choose to remove any of these from the output data by setting the values in the printConfig option in the table definition */
-        printConfig?: AddditionalExportOptions;
+        printConfig?: AddditionalExportOptions | undefined;
 
         /**If you want your printed table to be styled to match your Tabulator you can set the printCopyStyle to true, this will copy key layout styling to the printed table */
-        printStyled?: boolean;
+        printStyled?: boolean | undefined;
 
         /**By default, only the rows currently visible in the Tabulator will be added to the HTML table. For custom row ranges it is also possible to pass a function into the printRowRange option that should return an array of Row Components */
-        printRowRange?: RowRangeLookup | (() => RowComponent[]);
+        printRowRange?: RowRangeLookup | (() => RowComponent[]) | undefined;
 
         /**You can use the printHeader table setup option to define a header to be displayed when the table is printed. */
-        printHeader?: StandardStringParam;
+        printHeader?: StandardStringParam | undefined;
 
         /**You can use the printFooter table setup option to define a footer to be displayed when the table is printed. */
-        printFooter?: StandardStringParam;
+        printFooter?: StandardStringParam | undefined;
 
         /**The printFormatter table setup option allows you to carry out any manipulation of the print output before it is displayed to the user for printing*/
-        printFormatter?: (tableHolderElement: any, tableElement: any) => any;
+        printFormatter?: ((tableHolderElement: any, tableElement: any) => any) | undefined;
 
         groupHeaderDownload?:
             | ((value: any, count: number, data: any, group: GroupComponent) => string)
-            | Array<(value: any, count: number, data: any) => string>;
+            | Array<(value: any, count: number, data: any) => string> | undefined;
     }
 
     type StandardStringParam = string | HTMLElement | (() => string | HTMLElement);
 
     interface AddditionalExportOptions {
-        columnHeaders?: boolean;
-        columnGroups?: boolean;
-        rowGroups?: boolean;
-        columnCalcs?: boolean;
-        dataTree?: boolean;
+        columnHeaders?: boolean | undefined;
+        columnGroups?: boolean | undefined;
+        rowGroups?: boolean | undefined;
+        columnCalcs?: boolean | undefined;
+        dataTree?: boolean | undefined;
         /**Show only raw unformatted cell values in the clipboard output */
-        formatCells?: boolean;
+        formatCells?: boolean | undefined;
     }
 
     interface OptionsLocale {
         /** You can set the current local in one of two ways. If you want to set it when the table is created, simply include the locale option in your Tabulator constructor. You can either pass in a string matching one of the language options you have defined, or pass in the boolean true which will cause Tabulator to auto-detect the browsers language settings from the navigator.language object. */
-        locale?: boolean | string;
+        locale?: boolean | string | undefined;
 
         /** You can store as many languages as you like, creating an object inside the langs object with a property of the locale code for that language. A list of locale codes can be found here.
 
@@ -967,67 +967,67 @@ declare namespace Tabulator {
         langs?: any;
 
         /** When a localization event has occurred , the localized callback will triggered, passing the current locale code and language object: */
-        localized?: (locale: string, lang: any) => void;
+        localized?: ((locale: string, lang: any) => void) | undefined;
     }
 
     type HistoryAction = 'cellEdit' | 'rowAdd' | 'rowDelete' | 'rowMoved';
     interface OptionsHistory {
         /** Enable user interaction history functionality     */
-        history?: boolean;
+        history?: boolean | undefined;
 
         /** The historyUndo event is triggered when the undo action is triggered. */
-        historyUndo?: (action: HistoryAction, component: CellComponent | RowComponent, data: any) => void;
+        historyUndo?: ((action: HistoryAction, component: CellComponent | RowComponent, data: any) => void) | undefined;
         /** The historyRedo event is triggered when the redo action is triggered. */
-        historyRedo?: (action: HistoryAction, component: CellComponent | RowComponent, data: any) => void;
+        historyRedo?: ((action: HistoryAction, component: CellComponent | RowComponent, data: any) => void) | undefined;
     }
 
     interface ColumnLayout {
         /** title - Required This is the title that will be displayed in the header for this column */
         title: string;
         /** field - Required (not required in icon/button columns) this is the key for this column in the data array*/
-        field?: string;
+        field?: string | undefined;
         /** visible - (boolean, default - true) determines if the column is visible. (see Column Visibility for more details */
-        visible?: boolean;
+        visible?: boolean | undefined;
 
         /** sets the width of this column, this can be set in pixels or as a percentage of total table width (if not set the system will determine the best) */
-        width?: number | string;
+        width?: number | string | undefined;
     }
 
     interface ColumnDefinition extends ColumnLayout, CellCallbacks {
         /**If you want to set the horizontal alignment on a column by column basis, */
-        hozAlign?: ColumnDefinitionAlign;
-        headerHozAlign?: ColumnDefinitionAlign;
+        hozAlign?: ColumnDefinitionAlign | undefined;
+        headerHozAlign?: ColumnDefinitionAlign | undefined;
         /**If you want to set the vertical alignment on a column by column basis */
-        vertAlign?: VerticalAlign;
+        vertAlign?: VerticalAlign | undefined;
 
         /** sets the minimum width of this column, this should be set in pixels (this takes priority over the global option of columnMinWidth) */
-        minWidth?: number;
+        minWidth?: number | undefined;
 
         /** The widthGrow property should be used on columns without a width property set. The value is used to work out what fraction of the available will be allocated to the column. The value should be set to a number greater than 0, by default any columns with no width set have a widthGrow value of 1 */
-        widthGrow?: number;
+        widthGrow?: number | undefined;
 
         /** The widthShrink property should be used on columns with a width property set. The value is used to work out how to shrink columns with a fixed width when the table is too narrow to fit in all the columns. The value should be set to a number greater than 0, by default columns with a width set have a widthShrink value of 0, meaning they will not be shrunk if the table gets too narrow, and may cause the horizontal scrollbar to appear. */
-        widthShrink?: number;
+        widthShrink?: number | undefined;
 
         /** set whether column can be resized by user dragging its edges */
-        resizable?: boolean;
+        resizable?: boolean | undefined;
         /** You can freeze the position of columns on the left and right of the table using the frozen property in the column definition array. This will keep the column still when the table is scrolled horizontally. */
-        frozen?: boolean;
+        frozen?: boolean | undefined;
         /** an integer to determine when the column should be hidden in responsive mode */
-        responsive?: number;
+        responsive?: number | undefined;
         /** sets the on hover tooltip for each cell in this column * * The tooltip parameter can take three different types of value
         boolean - a value of false disables the tooltip, a value of true sets the tooltip of the cell to its value
         string - a string that will be displayed for all cells in the matching column/table.
         function - a callback function that returns the string for the cell
         * Note: setting a tooltip value on a column will override the global setting.
     */
-        tooltip?: string | GlobalTooltipOption;
+        tooltip?: string | GlobalTooltipOption | undefined;
         /** sets css classes on header and cells in this column. (value should be a string containing space separated class names) */
-        cssClass?: string;
+        cssClass?: string | undefined;
         /** sets the column as a row handle, allowing it to be used to drag movable rows. */
-        rowHandle?: boolean;
+        rowHandle?: boolean | undefined;
         /** When the getHtml function is called, hide the column from the output. */
-        hideInHtml?: boolean;
+        hideInHtml?: boolean | undefined;
 
         // Data Manipulation
         /**  By default Tabulator will attempt to guess which sorter should be applied to a column based on the data contained in the first row. It can determine sorters for strings, numbers, alphanumeric sequences and booleans, anything else will be treated as a string.
@@ -1053,140 +1053,140 @@ You can pass an optional additional property with sorter, sorterParams that shou
                   column: ColumnComponent,
                   dir: SortDirection,
                   sorterParams: {},
-              ) => number);
+              ) => number) | undefined;
         /** If you want to dynamically generate the sorterParams at the time the sort is called you can pass a function into the property that should return the params object. */
-        sorterParams?: ColumnDefinitionSorterParams | ColumnSorterParamLookupFunction;
+        sorterParams?: ColumnDefinitionSorterParams | ColumnSorterParamLookupFunction | undefined;
         /**  set how you would like the data to be formatted*/
-        formatter?: Formatter;
+        formatter?: Formatter | undefined;
         /**  You can pass an optional additional parameter with the formatter, formatterParams that should contain an object with additional information for configuring the formatter.*/
-        formatterParams?: FormatterParams;
+        formatterParams?: FormatterParams | undefined;
         /** alter the row height to fit the contents of the cell instead of hiding overflow */
-        variableHeight?: boolean;
+        variableHeight?: boolean | undefined;
         /**  There are some circumstances where you may want to block editibility of a cell for one reason or another. To meet this need you can use the editable option. This lets you set a callback that is executed before the editor is built, if this callback returns true the editor is added, if it returns false the edit is aborted and the cell remains a non editable cell. The function is passed one parameter, the CellComponent of the cell about to be edited. You can also pass a boolean value instead of a function to this property.*/
-        editable?: boolean | ((cell: CellComponent) => boolean);
+        editable?: boolean | ((cell: CellComponent) => boolean) | undefined;
         /** When a user clicks on an editable column the will be able to edit the value for that cell.
 
     By default Tabulator will use an editor that matches the current formatter for that cell. if you wish to specify a specific editor, you can set them per column using the editor option in the column definition. Passing a value of true to this option will result in Tabulator applying the editor that best matches the columns formatter, if present.
 
     You can pass an optional additional parameter with the editor, editorParams that should contain an object with additional information for configuring the editor. */
-        editor?: Editor;
+        editor?: Editor | undefined;
         /** additional parameters you can pass to the editor   */
-        editorParams?: EditorParams;
+        editorParams?: EditorParams | undefined;
 
         /** Validators are used to ensure that any user input into your editable cells matches your requirements.
 
     Validators can be applied by using the validator property in a columns definition object (see Define Columns for more details). */
-        validator?: StandardValidatorType | StandardValidatorType[] | Validator | Validator[] | string;
+        validator?: StandardValidatorType | StandardValidatorType[] | Validator | Validator[] | string | undefined;
 
         /** Mutators are used to alter data as it is parsed into Tabulator. For example if you wanted to convert a numeric column into a boolean based on its value, before the data is used to build the table.
 
     You can set mutators on a per column basis using the mutator option in the column definition object.
 
     You can pass an optional additional parameter with mutator, mutatorParams that should contain an object with additional information for configuring the mutator. */
-        mutator?: CustomMutator;
+        mutator?: CustomMutator | undefined;
         /** You can pass an optional additional parameter with mutator, mutatorParams that should contain an object with additional information for configuring the mutator. */
-        mutatorParams?: CustomMutatorParams;
+        mutatorParams?: CustomMutatorParams | undefined;
         /**  only called when data is loaded via a command {eg. setData). */
-        mutatorData?: CustomMutator;
-        mutatorDataParams?: CustomMutatorParams;
+        mutatorData?: CustomMutator | undefined;
+        mutatorDataParams?: CustomMutatorParams | undefined;
 
         /** only called when data is changed via a user editing a cell. */
-        mutatorEdit?: CustomMutator;
-        mutatorEditParams?: CustomMutatorParams;
+        mutatorEdit?: CustomMutator | undefined;
+        mutatorEditParams?: CustomMutatorParams | undefined;
 
         /** only called when data is changed via a user editing a cell. */
-        mutatorClipboard?: CustomMutator;
-        mutatorClipboardParams?: CustomMutatorParams;
+        mutatorClipboard?: CustomMutator | undefined;
+        mutatorClipboardParams?: CustomMutatorParams | undefined;
 
         /**  Accessors are used to alter data as it is extracted from the table, through commands, the clipboard, or download.
 
     You can set accessors on a per column basis using the accessor option in the column definition object.*/
-        accessor?: CustomAccessor;
+        accessor?: CustomAccessor | undefined;
         /**  Each accessor function has its own matching params option, for example accessorDownload has accessorDownloadParams.*/
-        accessorParams?: CustomAccessorParams;
+        accessorParams?: CustomAccessorParams | undefined;
         /** only called when data is being converted into a downloadable file. */
-        accessorDownload?: CustomAccessor;
+        accessorDownload?: CustomAccessor | undefined;
         /** additional parameters you can pass to the accessorDownload */
-        accessorDownloadParams?: CustomAccessorParams;
+        accessorDownloadParams?: CustomAccessorParams | undefined;
 
         /** only called when data is being copied into the clipboard. */
-        accessorClipboard?: CustomAccessor;
+        accessorClipboard?: CustomAccessor | undefined;
         /**  additional parameters you can pass to the accessorClipboard*/
-        accessorClipboardParams?: CustomAccessorParams;
+        accessorClipboardParams?: CustomAccessorParams | undefined;
 
         /** show or hide column in downloaded data */
-        download?: boolean;
+        download?: boolean | undefined;
         /** set custom title for column in download */
-        titleDownload?: string;
+        titleDownload?: string | undefined;
 
         /**  the column calculation to be displayed at the top of this column(see Column Calculations for more details) */
-        topCalc?: ColumnCalc;
+        topCalc?: ColumnCalc | undefined;
         /** additional parameters you can pass to the topCalc calculation function (see Column Calculations for more details) */
-        topCalcParams?: ColumnCalcParams;
+        topCalcParams?: ColumnCalcParams | undefined;
         /** formatter for the topCalc calculation cell  */
-        topCalcFormatter?: Formatter;
+        topCalcFormatter?: Formatter | undefined;
         /**  additional parameters you can pass to the topCalcFormatter function */
-        topCalcFormatterParams?: FormatterParams;
+        topCalcFormatterParams?: FormatterParams | undefined;
 
-        bottomCalc?: ColumnCalc;
-        bottomCalcParams?: ColumnCalcParams;
-        bottomCalcFormatter?: Formatter;
+        bottomCalc?: ColumnCalc | undefined;
+        bottomCalcParams?: ColumnCalcParams | undefined;
+        bottomCalcFormatter?: Formatter | undefined;
         /**  additional parameters you can pass to the bottomCalcFormatter function */
-        bottomCalcFormatterParams?: FormatterParams;
+        bottomCalcFormatterParams?: FormatterParams | undefined;
 
         // Column Header
         /** By default all columns in a table are sortable by clicking on the column header, if you want to disable this behaviour, set the headerSort property to false in the column definition array: */
-        headerSort?: boolean;
+        headerSort?: boolean | undefined;
         /** set the starting sort direction when a user first clicks on a header */
-        headerSortStartingDir?: SortDirection;
+        headerSortStartingDir?: SortDirection | undefined;
 
         /** allow tristate toggling of column header sort direction */
-        headerSortTristate?: boolean;
+        headerSortTristate?: boolean | undefined;
 
         /**   callback for when user clicks on the header for this column*/
-        headerClick?: ColumnEventCallback;
+        headerClick?: ColumnEventCallback | undefined;
         /**  callback for when user double clicks on the header for this column */
-        headerDblClick?: ColumnEventCallback;
+        headerDblClick?: ColumnEventCallback | undefined;
         /** callback for when user right clicks on the header for this column  */
-        headerContext?: ColumnEventCallback;
+        headerContext?: ColumnEventCallback | undefined;
         /**  callback for when user taps on a header for this column, triggered in touch displays. */
-        headerTap?: ColumnEventCallback;
+        headerTap?: ColumnEventCallback | undefined;
         /** callback for when user double taps on a header for this column, triggered in touch displays when a user taps the same header twice in under 300ms */
-        headerDblTap?: ColumnEventCallback;
+        headerDblTap?: ColumnEventCallback | undefined;
         /** callback for when user taps and holds on a header for this column, triggered in touch displays when a user taps and holds the same header for 1 second. */
-        headerTapHold?: ColumnEventCallback;
+        headerTapHold?: ColumnEventCallback | undefined;
         /** sets the on hover tooltip for the column header* * The tooltip headerTooltip can take three different types of value
 
       boolean - a value of false disables the tooltip, a value of true sets the tooltip of the column header to its title value.
       string - a string that will be displayed for the tooltip.
       function - a callback function that returns the string for the column header*
      */
-        headerTooltip?: boolean | string | ((column: ColumnComponent) => string);
+        headerTooltip?: boolean | string | ((column: ColumnComponent) => string) | undefined;
         /** change the orientation of the column header to vertical* * The headerVertical property can take one of three values:
 
       false - vertical columns disabled (default value)
       true - vertical columns enabled
       "flip" - vertical columns enabled, with text direction flipped by 180 degrees*
      */
-        headerVertical?: boolean | 'flip';
+        headerVertical?: boolean | 'flip' | undefined;
 
         /** allows the user to edit the header titles */
-        editableTitle?: boolean;
+        editableTitle?: boolean | undefined;
         /**  formatter function for header title */
-        titleFormatter?: Formatter;
+        titleFormatter?: Formatter | undefined;
 
         /** additional parameters you can pass to the header title formatter */
-        titleFormatterParams?: FormatterParams;
+        titleFormatterParams?: FormatterParams | undefined;
         /**  filtering of columns from elements in the header */
-        headerFilter?: Editor;
+        headerFilter?: Editor | undefined;
         /** additional parameters you can pass to the header filter */
-        headerFilterParams?: EditorParams;
+        headerFilterParams?: EditorParams | undefined;
 
         /**  placeholder text for the header filter */
-        headerFilterPlaceholder?: string;
+        headerFilterPlaceholder?: string | undefined;
 
         /**  function to check when the header filter is empty */
-        headerFilterEmptyCheck?: ValueBooleanCallback;
+        headerFilterEmptyCheck?: ValueBooleanCallback | undefined;
         /**  By default Tabulator will try and match the comparison type to the type of element used for the header filter.
 
     Standard input elements will use the "like" filter, this allows for the matches to be displayed as the user types.
@@ -1194,98 +1194,98 @@ You can pass an optional additional property with sorter, sorterParams that shou
     For all other element types (select boxes, check boxes, input elements of type number) an "=" filter type is used.
 
     If you want to specify the type of filter used you can pass it to the headerFilterFunc option in the column definition object. This will take any of the standard filters outlined above or a custom function*/
-        headerFilterFunc?: FilterType | ((headerValue: any, rowValue: any, rowdata: any, filterparams: any) => boolean);
+        headerFilterFunc?: FilterType | ((headerValue: any, rowValue: any, rowdata: any, filterparams: any) => boolean) | undefined;
         /**  additional parameters object passed to the headerFilterFunc function  */
         headerFilterFuncParams?: any;
 
         /** disable live filtering of the table  */
-        headerFilterLiveFilter?: boolean;
+        headerFilterLiveFilter?: boolean | undefined;
 
         /** Show/Hide a particular column in the HTML output*/
-        htmlOutput?: boolean;
+        htmlOutput?: boolean | undefined;
 
         /** If you don't want to show a particular column in the clipboard output you can set the clipboard property in its column definition object to false */
-        clipboard?: boolean;
+        clipboard?: boolean | undefined;
 
         /** A column can be a "group" of columns (Example: group header column -> Measurements, grouped column -> Length, Width, Height) */
-        columns?: ColumnDefinition[];
+        columns?: ColumnDefinition[] | undefined;
 
         /**You can add a menu to any column by passing an array of menu items to the headerMenu option in that columns definition. */
-        headerMenu?: Array<MenuObject<ColumnComponent> | MenuSeparator>;
+        headerMenu?: Array<MenuObject<ColumnComponent> | MenuSeparator> | undefined;
         /**You can add a right click context menu to any column by passing an array of menu items to the headerContextMenu option in that columns definition. */
-        headerContextMenu?: Array<MenuObject<ColumnComponent> | MenuSeparator>;
+        headerContextMenu?: Array<MenuObject<ColumnComponent> | MenuSeparator> | undefined;
         /**You can add a right click context menu to any columns cells by passing an array of menu items to the contextMenu option in that columns definition. */
-        contextMenu?: Array<MenuObject<CellComponent> | MenuSeparator>;
-        clickMenu?: Array<MenuObject<CellComponent> | MenuSeparator>;
+        contextMenu?: Array<MenuObject<CellComponent> | MenuSeparator> | undefined;
+        clickMenu?: Array<MenuObject<CellComponent> | MenuSeparator> | undefined;
         /**When copying to the clipboard you may want to apply a different formatter from the one usualy used to format the cell, you can do this using the formatterClipboard column definition option. You can use the formatterClipboardParams to pass in any additional params to the formatter */
-        formatterClipboard?: Formatter | false;
-        formatterClipboardParams?: FormatterParams;
+        formatterClipboard?: Formatter | false | undefined;
+        formatterClipboardParams?: FormatterParams | undefined;
         /**When printing you may want to apply a different formatter from the one usualy used to format the cell, you can do this using the formatterPrint column definition option. You can use the formatterPrintParams to pass in any additional params to the formatter */
-        formatterPrint?: Formatter | false;
-        formatterPrintParams?: FormatterParams;
+        formatterPrint?: Formatter | false | undefined;
+        formatterPrintParams?: FormatterParams | undefined;
         /**You can use the accessorPrint and accessorPrintParams options on a column definition to alter the value of data in a column before it is printed */
-        accessorPrint?: CustomAccessor;
-        accessorPrintParams?: CustomAccessorParams;
+        accessorPrint?: CustomAccessor | undefined;
+        accessorPrintParams?: CustomAccessorParams | undefined;
         /**You can use the accessorHtmlOutput and accessorHtmlOutputParams options on a column definition to alter the value of data in a column before the html is generated. */
-        accessorHtmlOutput?: CustomAccessor;
-        accessorHtmlOutputParams?: CustomAccessorParams;
+        accessorHtmlOutput?: CustomAccessor | undefined;
+        accessorHtmlOutputParams?: CustomAccessorParams | undefined;
         /**When the getHtml function is called you may want to apply a different formatter from the one usualy used to format the cell, you can do this using the formatterHtmlOutput column definition option */
-        formatterHtmlOutput?: Formatter | false;
-        formatterHtmlOutputParams?: FormatterParams;
+        formatterHtmlOutput?: Formatter | false | undefined;
+        formatterHtmlOutputParams?: FormatterParams | undefined;
         /**When copying to clipboard you may want to apply a different columnheader title from the one usualy used in the table. You can now do this using the titleClipboard column definition option, which takes the same inputs as the standard title property. */
-        titleClipboard?: string;
+        titleClipboard?: string | undefined;
         /**When the getHtml function is called you may want to apply a different columnheader title from the one usualy used in the table. You can now do this using the titleHtmlOutput column definition option, which takes the same inputs as the standard title property. */
-        titleHtmlOutput?: string;
+        titleHtmlOutput?: string | undefined;
         /**When printing you may want to apply a different columnheader title from the one usualy used in the table. You can now do this using the titlePrint column definition option, which takes the same inputs as the standard title property. */
-        titlePrint?: string;
-        maxWidth?: number | false;
+        titlePrint?: string | undefined;
+        maxWidth?: number | false | undefined;
     }
 
     interface CellCallbacks {
         // Cell Events
         /** callback for when user clicks on a cell in this column  */
-        cellClick?: CellEventCallback;
+        cellClick?: CellEventCallback | undefined;
         /**  callback for when user double clicks on a cell in this column */
-        cellDblClick?: CellEventCallback;
+        cellDblClick?: CellEventCallback | undefined;
         /** callback for when user right clicks on a cell in this column */
-        cellContext?: CellEventCallback;
+        cellContext?: CellEventCallback | undefined;
         /** callback for when user taps on a cell in this column, triggered in touch displays.  */
-        cellTap?: CellEventCallback;
+        cellTap?: CellEventCallback | undefined;
         /**  callback for when user double taps on a cell in this column, triggered in touch displays when a user taps the same cell twice in under 300ms.  */
-        cellDblTap?: CellEventCallback;
+        cellDblTap?: CellEventCallback | undefined;
         /**  callback for when user taps and holds on a cell in this column, triggered in touch displays when a user taps and holds the same cell for 1 second.*/
-        cellTapHold?: CellEventCallback;
+        cellTapHold?: CellEventCallback | undefined;
 
         /** callback for when the mouse pointer enters a cell */
-        cellMouseEnter?: CellEventCallback;
+        cellMouseEnter?: CellEventCallback | undefined;
         /**  callback for when the mouse pointer leaves a cell */
-        cellMouseLeave?: CellEventCallback;
+        cellMouseLeave?: CellEventCallback | undefined;
 
         /**  callback for when the mouse pointer enters a cell or one of its child elements */
-        cellMouseOver?: CellEventCallback;
+        cellMouseOver?: CellEventCallback | undefined;
 
         /** callback for when the mouse pointer enters a cell or one of its child elements */
-        cellMouseOut?: CellEventCallback;
+        cellMouseOut?: CellEventCallback | undefined;
 
         /** callback for when the mouse pointer moves over a cell  */
-        cellMouseMove?: CellEventCallback;
+        cellMouseMove?: CellEventCallback | undefined;
 
         // Cell editing
         /** callback for when a cell in this column is being edited by the user */
-        cellEditing?: CellEditEventCallback;
+        cellEditing?: CellEditEventCallback | undefined;
 
         /** callback for when a cell in this column has been edited by the user */
-        cellEdited?: CellEditEventCallback;
+        cellEdited?: CellEditEventCallback | undefined;
 
         /**  callback for when an edit on a cell in this column is aborted by the user  */
-        cellEditCancelled?: CellEditEventCallback;
+        cellEditCancelled?: CellEditEventCallback | undefined;
     }
 
     interface ColumnDefinitionSorterParams {
-        format?: string;
-        locale?: string | boolean;
-        alignEmptyValues?: 'top' | 'bottom';
-        type?: 'length' | 'sum' | 'max' | 'min' | 'avg';
+        format?: string | undefined;
+        locale?: string | boolean | undefined;
+        alignEmptyValues?: 'top' | 'bottom' | undefined;
+        type?: 'length' | 'sum' | 'max' | 'min' | 'avg' | undefined;
     }
 
     type GroupValuesArg = any[][];
@@ -1394,78 +1394,78 @@ You can pass an optional additional property with sorter, sorterParams that shou
 
     interface MoneyParams {
         // Money
-        decimal?: string;
-        thousand?: string;
-        symbol?: string;
-        symbolAfter?: boolean;
-        precision?: boolean | number;
+        decimal?: string | undefined;
+        thousand?: string | undefined;
+        symbol?: string | undefined;
+        symbolAfter?: boolean | undefined;
+        precision?: boolean | number | undefined;
     }
     interface ImageParams {
         // Image
-        height?: string;
-        width?: string;
-        urlPrefix?: string;
-        urlSuffix?: string;
+        height?: string | undefined;
+        width?: string | undefined;
+        urlPrefix?: string | undefined;
+        urlSuffix?: string | undefined;
     }
 
     interface LinkParams {
         // Link
-        labelField?: string;
-        label?: string | ((cell: CellComponent) => string);
-        urlPrefix?: string;
-        urlField?: string;
-        url?: string | ((cell: CellComponent) => string);
-        target?: string;
-        download?: boolean;
+        labelField?: string | undefined;
+        label?: string | ((cell: CellComponent) => string) | undefined;
+        urlPrefix?: string | undefined;
+        urlField?: string | undefined;
+        url?: string | ((cell: CellComponent) => string) | undefined;
+        target?: string | undefined;
+        download?: boolean | undefined;
     }
 
     interface DateTimeParams {
         // datetime
-        inputFormat?: string;
-        outputFormat?: string;
-        invalidPlaceholder?: true | string | number | ValueStringCallback;
-        timezone?: string;
+        inputFormat?: string | undefined;
+        outputFormat?: string | undefined;
+        invalidPlaceholder?: true | string | number | ValueStringCallback | undefined;
+        timezone?: string | undefined;
     }
 
     interface DateTimeDifferenceParams extends DateTimeParams {
         // Date Time Difference
         date?: any;
-        humanize?: boolean;
-        unit?: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';
-        suffix?: boolean;
+        humanize?: boolean | undefined;
+        unit?: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds' | undefined;
+        suffix?: boolean | undefined;
     }
     interface TickCrossParams {
         // Tick Cross
-        allowEmpty?: boolean;
-        allowTruthy?: boolean;
-        tickElement?: boolean | string;
-        crossElement?: boolean | string;
+        allowEmpty?: boolean | undefined;
+        allowTruthy?: boolean | undefined;
+        tickElement?: boolean | string | undefined;
+        crossElement?: boolean | string | undefined;
     }
 
     interface TrafficParams {
         // Traffic
-        min?: number;
-        max?: number;
-        color?: Color;
+        min?: number | undefined;
+        max?: number | undefined;
+        color?: Color | undefined;
     }
     interface ProgressBarParams extends TrafficParams {
         // Progress Bar
-        legend?: string | true | ValueStringCallback;
-        legendColor?: Color;
-        legendAlign?: Align;
+        legend?: string | true | ValueStringCallback | undefined;
+        legendColor?: Color | undefined;
+        legendAlign?: Align | undefined;
     }
 
     interface StarRatingParams {
         // Star Rating
-        stars?: number;
+        stars?: number | undefined;
     }
 
     interface RowSelectionParams {
-        rowRange?: RowRangeLookup;
+        rowRange?: RowRangeLookup | undefined;
     }
 
     interface SharedEditorParams {
-        elementAttributes?: JSONRecord;
+        elementAttributes?: JSONRecord | undefined;
         /**Built in editors based on input elements such as the input, number, textarea and autocomplete editors have the ability to mask the users input to restrict it to match a given pattern.
 
         This can be set by passing a string to the the mask option in the columns editorParams
@@ -1479,54 +1479,54 @@ You can pass an optional additional property with sorter, sorterParams that shou
         For example, a mask string of "AAA-999" would require the user to enter three letters followed by a hyphen followed by three numbers
 
         f you want to use the characters A, 9 or * as fixed characters then it is possible to change the characters looked for in the mask by using the maskLetterChar, maskNumberChar and maskWildcardChar options in the editorParams*/
-        mask?: string;
+        mask?: string | undefined;
         /** you are using fixed characters in your mask (any character other that A, 9 or *), then you can get the mask to automatically fill in these characters for you as you type by setting the maskAutoFill option in the editorParams to true */
-        maskAutoFill?: boolean;
-        maskLetterChar?: string;
-        maskNumberChar?: string;
-        maskWildcardChar?: string;
+        maskAutoFill?: boolean | undefined;
+        maskLetterChar?: string | undefined;
+        maskNumberChar?: string | undefined;
+        maskWildcardChar?: string | undefined;
     }
 
     interface NumberParams extends SharedEditorParams {
         // range,number
-        min?: number;
-        max?: number;
-        step?: number;
-        verticalNavigation?: 'editor' | 'table';
+        min?: number | undefined;
+        max?: number | undefined;
+        step?: number | undefined;
+        verticalNavigation?: 'editor' | 'table' | undefined;
     }
 
     interface InputParams extends SharedEditorParams {
         /**Changes input type to 'search' and shows an 'X' clear button to clear the cell value easily */
-        search?: boolean;
+        search?: boolean | undefined;
     }
 
     interface TextAreaParams extends SharedEditorParams {
-        verticalNavigation?: 'editor' | 'table' | 'hybrid';
+        verticalNavigation?: 'editor' | 'table' | 'hybrid' | undefined;
     }
 
     interface CheckboxParams extends SharedEditorParams {
         // tick
-        tristate?: boolean;
-        indeterminateValue?: string;
+        tristate?: boolean | undefined;
+        indeterminateValue?: string | undefined;
     }
 
     interface SharedSelectAutoCompleteEditorParams {
-        defaultValue?: string;
-        sortValuesList?: 'asc' | 'desc';
+        defaultValue?: string | undefined;
+        sortValuesList?: 'asc' | 'desc' | undefined;
     }
 
     interface SelectParams extends SharedEditorParams, SharedSelectAutoCompleteEditorParams {
         values: true | string[] | JSONRecord | SelectParamsGroup[] | string;
-        listItemFormatter?: (value: string, text: string) => string;
-        verticalNavigation?: 'editor' | 'table' | 'hybrid';
-        multiselect?: boolean | number;
+        listItemFormatter?: ((value: string, text: string) => string) | undefined;
+        verticalNavigation?: 'editor' | 'table' | 'hybrid' | undefined;
+        multiselect?: boolean | number | undefined;
     }
 
     interface SelectParamsGroup {
         label: string;
-        value?: string | number | boolean;
-        options?: SelectLabelValue[];
-        elementAttributes?: {};
+        value?: string | number | boolean | undefined;
+        options?: SelectLabelValue[] | undefined;
+        elementAttributes?: {} | undefined;
     }
     interface SelectLabelValue {
         label: string;
@@ -1535,17 +1535,17 @@ You can pass an optional additional property with sorter, sorterParams that shou
 
     interface AutoCompleteParams extends SharedEditorParams, SharedSelectAutoCompleteEditorParams {
         values: true | string[] | JSONRecord | string | any[];
-        listItemFormatter?: (value: string, text: string) => string;
-        searchFunc?: (term: string, values: string[]) => string[] | Promise<string[]>;
-        allowEmpty?: boolean;
-        freetext?: boolean;
-        showListOnEmpty?: boolean;
-        verticalNavigation?: 'editor' | 'table' | 'hybrid';
+        listItemFormatter?: ((value: string, text: string) => string) | undefined;
+        searchFunc?: ((term: string, values: string[]) => string[] | Promise<string[]>) | undefined;
+        allowEmpty?: boolean | undefined;
+        freetext?: boolean | undefined;
+        showListOnEmpty?: boolean | undefined;
+        verticalNavigation?: 'editor' | 'table' | 'hybrid' | undefined;
         /**If you return a promise from the searchFunc callback then a "Searching..." placeholder will be displayed until the promise resolved.
 
         You can customise this placeholder using the searchingPlaceholder option. */
-        searchingPlaceholder?: string | HTMLElement;
-        emptyPlaceholder?: string | HTMLElement;
+        searchingPlaceholder?: string | HTMLElement | undefined;
+        emptyPlaceholder?: string | HTMLElement | undefined;
     }
 
     type ValueStringCallback = (value: any) => string;
@@ -1579,19 +1579,19 @@ You can pass an optional additional property with sorter, sorterParams that shou
     type RowRangeLookup = 'visible' | 'active' | 'selected' | 'all';
 
     interface KeyBinding {
-        navPrev?: string | boolean;
-        navNext?: string | boolean;
-        navLeft?: string | boolean;
-        navRight?: string | boolean;
-        navUp?: string | boolean;
-        navDown?: string | boolean;
-        undo?: string | boolean;
-        redo?: string | boolean;
-        scrollPageUp?: string | boolean;
-        scrollPageDown?: string | boolean;
-        scrollToStart?: string | boolean;
-        scrollToEnd?: string | boolean;
-        copyToClipboard?: string | boolean;
+        navPrev?: string | boolean | undefined;
+        navNext?: string | boolean | undefined;
+        navLeft?: string | boolean | undefined;
+        navRight?: string | boolean | undefined;
+        navUp?: string | boolean | undefined;
+        navDown?: string | boolean | undefined;
+        undo?: string | boolean | undefined;
+        redo?: string | boolean | undefined;
+        scrollPageUp?: string | boolean | undefined;
+        scrollPageDown?: string | boolean | undefined;
+        scrollToStart?: string | boolean | undefined;
+        scrollToEnd?: string | boolean | undefined;
+        copyToClipboard?: string | boolean | undefined;
     }
 
     // Components-------------------------------------------------------------------

--- a/types/tail/index.d.ts
+++ b/types/tail/index.d.ts
@@ -5,15 +5,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface TailOptions {
-    separator?: string | RegExp | null;
-    fromBeginning?: boolean;
-    fsWatchOptions?: Record<string, any>;
-    follow?: boolean;
+    separator?: string | RegExp | null | undefined;
+    fromBeginning?: boolean | undefined;
+    fsWatchOptions?: Record<string, any> | undefined;
+    follow?: boolean | undefined;
     logger?: any;
-    encoding?: string;
-    useWatchFile?: boolean;
-    flushAtEOF?: boolean;
-    nLines?: number;
+    encoding?: string | undefined;
+    useWatchFile?: boolean | undefined;
+    flushAtEOF?: boolean | undefined;
+    nLines?: number | undefined;
 }
 
 export class Tail {

--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -74,9 +74,9 @@ export type TailwindStandardNegativeSpacing = {
 
 export interface TailwindAnimationConfig {
     [key: string]: {
-        transform?: string;
-        opacity?: string;
-        animationTimingFunction?: string;
+        transform?: string | undefined;
+        opacity?: string | undefined;
+        animationTimingFunction?: string | undefined;
     };
 }
 
@@ -112,21 +112,21 @@ export interface TailwindPurgeConfig {
     /**
      * @see https://tailwindcss.com/docs/optimizing-for-production#enabling-manually
      */
-    enabled?: boolean;
+    enabled?: boolean | undefined;
     /**
      * @see https://tailwindcss.com/docs/optimizing-for-production#preserving-html-elements
      */
-    preserveHtmlElements?: boolean;
+    preserveHtmlElements?: boolean | undefined;
     /**
      * Purge specific layers
      * @see https://tailwindcss.com/docs/optimizing-for-production#purging-specific-layers
      */
-    layers?: TailwindValidLayers[];
+    layers?: TailwindValidLayers[] | undefined;
     /**
      * Remove all unused styles
      * @see https://tailwindcss.com/docs/optimizing-for-production#removing-all-unused-styles
      */
-    mode?: 'all';
+    mode?: 'all' | undefined;
 }
 
 export interface TailwindConfig {

--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -70,59 +70,59 @@ declare namespace Tampermonkey {
     ) => void;
 
     interface Request<TContext = object> {
-        method?: 'GET' | 'HEAD' | 'POST';
+        method?: 'GET' | 'HEAD' | 'POST' | undefined;
         /** Destination URL */
         url: string;
         /**
          * i.e. user-agent, referer... (some special headers are not supported
          * by Safari and Android browsers)
          */
-        headers?: RequestHeaders;
+        headers?: RequestHeaders | undefined;
         /** String to send via a POST request */
-        data?: string;
+        data?: string | undefined;
         /** A cookie to be patched into the sent cookie set */
-        cookie?: string;
+        cookie?: string | undefined;
         /** Send the data string in binary mode */
-        binary?: boolean;
+        binary?: boolean | undefined;
         /** Don't cache the resource */
-        nocache?: boolean;
+        nocache?: boolean | undefined;
         /** Revalidate maybe cached content */
-        revalidate?: boolean;
+        revalidate?: boolean | undefined;
         /** Timeout in ms */
-        timeout?: number;
+        timeout?: number | undefined;
         /** Property which will be added to the response object */
-        context?: TContext;
-        responseType?: 'arraybuffer' | 'blob' | 'json';
+        context?: TContext | undefined;
+        responseType?: 'arraybuffer' | 'blob' | 'json' | undefined;
         /** MIME type for the request */
-        overrideMimeType?: string;
+        overrideMimeType?: string | undefined;
         /** Don't send cookies with the requests (please see the fetch notes) */
-        anonymous?: boolean;
+        anonymous?: boolean | undefined;
         /**
          * (Beta) Use a fetch instead of a xhr request(at Chrome this causes
          * `xhr.abort`, `details.timeout` and `xhr.onprogress` to not work and
          * makes `xhr.onreadystatechange` receive only readyState 4 events)
          */
-        fetch?: boolean;
+        fetch?: boolean | undefined;
         /** Username for authentication */
-        user?: string;
-        password?: string;
+        user?: string | undefined;
+        password?: string | undefined;
 
         // Events
 
         /** Callback to be executed if the request was aborted */
         onabort?(): void;
         /** Callback to be executed if the request ended up with an error */
-        onerror?: RequestEventListener<ErrorResponse>;
+        onerror?: RequestEventListener<ErrorResponse> | undefined;
         /** Callback to be executed if the request started to load */
-        onloadstart?: RequestEventListener<Response<TContext>>;
+        onloadstart?: RequestEventListener<Response<TContext>> | undefined;
         /** Callback to be executed if the request made some progress */
-        onprogress?: RequestEventListener<ProgressResponse<TContext>>;
+        onprogress?: RequestEventListener<ProgressResponse<TContext>> | undefined;
         /** Callback to be executed if the request's ready state changed */
-        onreadystatechange?: RequestEventListener<Response<TContext>>;
+        onreadystatechange?: RequestEventListener<Response<TContext>> | undefined;
         /** Callback to be executed if the request failed due to a timeout */
         ontimeout?(): void;
         /** Callback to be executed if the request was loaded */
-        onload?: RequestEventListener<Response<TContext>>;
+        onload?: RequestEventListener<Response<TContext>> | undefined;
     }
 
     // Download Response
@@ -151,7 +151,7 @@ declare namespace Tampermonkey {
             | 'not_supported'
             | 'not_succeeded';
         /** Detail about that error */
-        details?: string;
+        details?: string | undefined;
     }
 
     // Download Request
@@ -164,18 +164,18 @@ declare namespace Tampermonkey {
          * whitelisted at Tampermonkey options page
          */
         name: string;
-        headers?: RequestHeaders;
+        headers?: RequestHeaders | undefined;
         /** Show 'Save As' dialog */
-        saveAs?: boolean;
-        timeout?: number;
+        saveAs?: boolean | undefined;
+        timeout?: number | undefined;
         /** Callback to be executed if this download ended up with an error */
-        onerror?: RequestEventListener<DownloadErrorResponse>;
+        onerror?: RequestEventListener<DownloadErrorResponse> | undefined;
         /** Callback to be executed if this download finished */
         ontimeout?(): void;
         /** Callback to be executed if this download finished */
         onload?(): void;
         /** Callback to be executed if this download failed due to a timeout */
-        onprogress?: RequestEventListener<DownloadProgressResponse>;
+        onprogress?: RequestEventListener<DownloadProgressResponse> | undefined;
     }
 
     interface AbortHandle<TReturn> {
@@ -184,11 +184,11 @@ declare namespace Tampermonkey {
 
     interface OpenTabOptions {
         /** Decides whether the new tab should be focused */
-        active?: boolean;
+        active?: boolean | undefined;
         /** Inserts the new tab after the current one */
-        insert?: boolean;
+        insert?: boolean | undefined;
         /** Makes the browser re-focus the current tab on close */
-        setParent?: boolean;
+        setParent?: boolean | undefined;
     }
 
     interface OpenTabObject {
@@ -209,23 +209,23 @@ declare namespace Tampermonkey {
 
     interface Notification {
         /** Text of the notification (optional if highlight is set) */
-        text?: string;
+        text?: string | undefined;
         /** Notification title. If not specified the script name is used */
-        title?: string;
-        image?: string;
+        title?: string | undefined;
+        image?: string | undefined;
         /** Flag whether to highlight the tab that sends the notification */
-        highlight?: boolean;
+        highlight?: boolean | undefined;
         /** Whether to play or not play a sound */
-        silent?: boolean;
+        silent?: boolean | undefined;
         /** Time after that the notification will be hidden. `0` = disabled */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * Called when the notification is closed (no matter if this was
          * triggered by a timeout or a click) or the tab was highlighted
          */
-        onclick?: NotificationOnClick;
+        onclick?: NotificationOnClick | undefined;
         /** Called in case the user clicks the notification */
-        ondone?: NotificationOnDone;
+        ondone?: NotificationOnDone | undefined;
     }
 
     interface TextNotification extends Notification {
@@ -401,5 +401,5 @@ declare function GM_notification(
  */
 declare function GM_setClipboard(
     data: string,
-    info?: string | { type?: string; mimetype?: string }
+    info?: string | { type?: string | undefined; mimetype?: string | undefined }
 ): void;

--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -358,25 +358,25 @@ declare namespace Options {
     }
 
     interface Assert extends Bag {
-        todo?: boolean | string;
-        skip?: boolean | string;
-        diagnostic?: boolean;
+        todo?: boolean | string | undefined;
+        skip?: boolean | string | undefined;
+        diagnostic?: boolean | undefined;
     }
 
     interface Spawn extends Assert {
-        bail?: boolean;
-        timeout?: number;
+        bail?: boolean | undefined;
+        timeout?: number | undefined;
     }
 
     interface Test extends Assert {
-        timeout?: number;
-        bail?: boolean;
-        autoend?: boolean;
-        buffered?: boolean;
-        jobs?: number;
-        grep?: RegExp[];
-        only?: boolean;
-        runOnly?: boolean;
+        timeout?: number | undefined;
+        bail?: boolean | undefined;
+        autoend?: boolean | undefined;
+        buffered?: boolean | undefined;
+        jobs?: number | undefined;
+        grep?: RegExp[] | undefined;
+        only?: boolean | undefined;
+        runOnly?: boolean | undefined;
     }
 }
 

--- a/types/tapable/v1/index.d.ts
+++ b/types/tapable/v1/index.d.ts
@@ -247,32 +247,32 @@ export interface Tap<TTapType extends TapType = TapType, TArg1 = any, TArg2 = an
     name: string;
     type: TTapType;
     fn: TapFunction<TTapType, TArg1, TArg2, TArg3, THookResult>;
-    stage?: number;
-    context?: boolean;
-    before?: string | string[];
+    stage?: number | undefined;
+    context?: boolean | undefined;
+    before?: string | string[] | undefined;
 }
 
 export type TapOptions<TTapType extends TapType = TapType, TArg1 = any, TArg2 = any, TArg3 = any, THookResult = any> = {
     name: string;
-    stage?: number;
-    context?: boolean;
-    before?: string | string[];
+    stage?: number | undefined;
+    context?: boolean | undefined;
+    before?: string | string[] | undefined;
 } & (
     TTapType extends "sync" ? {
-        type?: "sync";
-        fn?: TapFunction<"sync", TArg1, TArg2, TArg3, THookResult>;
+        type?: "sync" | undefined;
+        fn?: TapFunction<"sync", TArg1, TArg2, TArg3, THookResult> | undefined;
     } :
     TTapType extends "async" ? {
-        type?: "async";
-        fn?: TapFunction<"async", TArg1, TArg2, TArg3, THookResult>;
+        type?: "async" | undefined;
+        fn?: TapFunction<"async", TArg1, TArg2, TArg3, THookResult> | undefined;
     } :
     TTapType extends "promise" ? {
-        type?: "promise";
-        fn?: TapFunction<"promise", TArg1, TArg2, TArg3, THookResult>;
+        type?: "promise" | undefined;
+        fn?: TapFunction<"promise", TArg1, TArg2, TArg3, THookResult> | undefined;
     } :
     {
-        type?: TTapType;
-        fn?: TapFunction<TTapType, TArg1, TArg2, TArg3, THookResult>;
+        type?: TTapType | undefined;
+        fn?: TapFunction<TTapType, TArg1, TArg2, TArg3, THookResult> | undefined;
     }
 );
 
@@ -305,11 +305,11 @@ export class AsyncSeriesBailHook<T1 = any, T2 = any, T3 = any, THookResult = any
 export class AsyncSeriesWaterfallHook<T1 = any, T2 = any, T3 = any> extends Hook<T1, T2, T3, T1, T1> {}
 
 export class HookInterceptor {
-    call?: (...args: any[]) => void;
-    loop?: (...args: any[]) => void;
-    tap?: (tap: Tap) => void;
-    register?: (tap: Tap) => Tap | undefined;
-    context?: boolean;
+    call?: ((...args: any[]) => void) | undefined;
+    loop?: ((...args: any[]) => void) | undefined;
+    tap?: ((tap: Tap) => void) | undefined;
+    register?: ((tap: Tap) => Tap | undefined) | undefined;
+    context?: boolean | undefined;
 }
 
 /** A HookMap is a helper class for a Map with Hooks */

--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -31,25 +31,25 @@ declare namespace tape {
      * Available opts options for the tape function.
      */
     interface TestOptions {
-        skip?: boolean; // true/false. See test.skip.
-        todo?: boolean; // true/false. Test will be allowed to fail.
-        timeout?: number; // Set a timeout for the test, after which it will fail. See tape.timeoutAfter.
+        skip?: boolean | undefined; // true/false. See test.skip.
+        todo?: boolean | undefined; // true/false. Test will be allowed to fail.
+        timeout?: number | undefined; // Set a timeout for the test, after which it will fail. See tape.timeoutAfter.
     }
 
     /**
      * Available options for tape assertions.
      */
     interface AssertOptions {
-        skip?: boolean | string; // Skip the assertion. Can also be a message explaining why the test is skipped.
-        todo?: boolean | string; // Allows the assertion to fail.
-        message?: string; // An optional description of the assertion.
+        skip?: boolean | string | undefined; // Skip the assertion. Can also be a message explaining why the test is skipped.
+        todo?: boolean | string | undefined; // Allows the assertion to fail.
+        message?: string | undefined; // An optional description of the assertion.
     }
 
     /**
      * Options for the createStream function.
      */
     interface StreamOptions {
-        objectMode?: boolean;
+        objectMode?: boolean | undefined;
     }
 
     /**

--- a/types/tar-fs/index.d.ts
+++ b/types/tar-fs/index.d.ts
@@ -18,29 +18,29 @@ export type Pack = tarStream.Pack;
 export type Extract = tarStream.Extract;
 
 export interface Options {
-    ignore?: (name: string) => boolean;
-    filter?: (name: string) => boolean;
-    map?: (header: Headers) => Headers;
-    mapStream?: (fileStream: ReadStream, header: Headers) => ReadStream;
-    dmode?: number;
-    fmode?: number;
-    readable?: boolean;
-    writable?: boolean;
-    strict?: boolean;
+    ignore?: ((name: string) => boolean) | undefined;
+    filter?: ((name: string) => boolean) | undefined;
+    map?: ((header: Headers) => Headers) | undefined;
+    mapStream?: ((fileStream: ReadStream, header: Headers) => ReadStream) | undefined;
+    dmode?: number | undefined;
+    fmode?: number | undefined;
+    readable?: boolean | undefined;
+    writable?: boolean | undefined;
+    strict?: boolean | undefined;
 }
 
 export interface PackOptions extends Options {
-    entries?: string[];
-    dereference?: boolean;
-    finalize?: boolean;
-    finish?: (pack: tarStream.Pack) => void;
-    pack?: tarStream.Pack;
+    entries?: string[] | undefined;
+    dereference?: boolean | undefined;
+    finalize?: boolean | undefined;
+    finish?: ((pack: tarStream.Pack) => void) | undefined;
+    pack?: tarStream.Pack | undefined;
 }
 
 export interface ExtractOptions extends Options {
-    ignore?: (name: string, header?: Headers) => boolean;
-    filter?: (name: string, header?: Headers) => boolean;
-    strip?: number;
+    ignore?: ((name: string, header?: Headers) => boolean) | undefined;
+    filter?: ((name: string, header?: Headers) => boolean) | undefined;
+    strip?: number | undefined;
 }
 
 export interface Headers {

--- a/types/tar-js/index.d.ts
+++ b/types/tar-js/index.d.ts
@@ -14,12 +14,12 @@ declare class Tar {
 
 declare namespace Tar {
     interface TarOptions {
-        mode?: number;
-        mtime?: number;
-        uid?: number;
-        gid?: number;
-        owner?: string;
-        group?: string;
+        mode?: number | undefined;
+        mtime?: number | undefined;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        owner?: string | undefined;
+        group?: string | undefined;
     }
 }
 

--- a/types/tar-stream/index.d.ts
+++ b/types/tar-stream/index.d.ts
@@ -14,12 +14,12 @@ export type Callback = (err?: Error | null) => any;
 // see https://github.com/mafintosh/tar-stream/blob/master/headers.js
 export interface Headers {
     name: string;
-    mode?: number;
-    uid?: number;
-    gid?: number;
-    size?: number;
-    mtime?: Date;
-    linkname?: string | null;
+    mode?: number | undefined;
+    uid?: number | undefined;
+    gid?: number | undefined;
+    size?: number | undefined;
+    mtime?: Date | undefined;
+    linkname?: string | null | undefined;
     type?:
         | 'file'
         | 'link'
@@ -33,11 +33,11 @@ export interface Headers {
         | 'pax-global-header'
         | 'gnu-long-link-path'
         | 'gnu-long-path'
-        | null;
-    uname?: string;
-    gname?: string;
-    devmajor?: number;
-    devminor?: number;
+        | null | undefined;
+    uname?: string | undefined;
+    gname?: string | undefined;
+    devmajor?: number | undefined;
+    devminor?: number | undefined;
 }
 
 export interface Pack extends stream.Readable {
@@ -59,11 +59,11 @@ export interface ExtractOptions extends stream.WritableOptions {
      * Whether or not to attempt to extract a file that does not have an
      * officially supported format in the `magic` header, such as `ustar`.
      */
-    allowUnknownFormat?: boolean;
+    allowUnknownFormat?: boolean | undefined;
     /**
      * The encoding of the file name header.
      */
-    filenameEncoding?: BufferEncoding;
+    filenameEncoding?: BufferEncoding | undefined;
 }
 export function extract(opts?: ExtractOptions): Extract;
 

--- a/types/tar-stream/v1/index.d.ts
+++ b/types/tar-stream/v1/index.d.ts
@@ -13,18 +13,18 @@ export type Callback = (err?: Error | null) => any;
 // see https://github.com/mafintosh/tar-stream/blob/master/headers.js
 export interface Headers {
     name: string;
-    mode?: number;
-    uid?: number;
-    gid?: number;
-    size?: number;
-    mtime?: Date;
-    linkname?: string | null;
+    mode?: number | undefined;
+    uid?: number | undefined;
+    gid?: number | undefined;
+    size?: number | undefined;
+    mtime?: Date | undefined;
+    linkname?: string | null | undefined;
     type?: 'file' | 'link' | 'symlink' | 'character-device' | 'block-device' | 'directory' | 'fifo' |
-        'contiguous-file' | 'pax-header' | 'pax-global-header' | 'gnu-long-link-path' | 'gnu-long-path' | null;
-    uname?: string;
-    gname?: string;
-    devmajor?: number;
-    devminor?: number;
+        'contiguous-file' | 'pax-header' | 'pax-global-header' | 'gnu-long-link-path' | 'gnu-long-path' | null | undefined;
+    uname?: string | undefined;
+    gname?: string | undefined;
+    devmajor?: number | undefined;
+    devminor?: number | undefined;
 }
 
 export interface Pack extends stream.Readable {

--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -15,24 +15,24 @@ import MiniPass = require('minipass');
 
 export interface HeaderProperties {
     path: string;
-    mode?: number;
-    noProprietary?: boolean;
-    uid?: number;
-    gid?: number;
-    size?: number;
-    mtime?: number;
-    type?: string;
-    uname?: string;
-    gname?: string;
-    devmaj?: number;
-    devmin?: number;
+    mode?: number | undefined;
+    noProprietary?: boolean | undefined;
+    uid?: number | undefined;
+    gid?: number | undefined;
+    size?: number | undefined;
+    mtime?: number | undefined;
+    type?: string | undefined;
+    uname?: string | undefined;
+    gname?: string | undefined;
+    devmaj?: number | undefined;
+    devmin?: number | undefined;
 }
 
 export interface ExtractOptions {
-    type?: string;
-    Directory?: boolean;
-    path?: string;
-    strip?: number;
+    type?: string | undefined;
+    Directory?: boolean | undefined;
+    path?: string | undefined;
+    strip?: number | undefined;
 }
 
 export interface ParseStream extends NodeJS.ReadWriteStream {
@@ -264,28 +264,28 @@ export interface CreateOptions {
     /**
      * Treat warnings as crash-worthy errors. Default false.
      */
-    strict?: boolean;
+    strict?: boolean | undefined;
 
     /**
      * The current working directory for creating the archive. Defaults to process.cwd().
      */
-    cwd?: string;
+    cwd?: string | undefined;
 
     /**
      * Alias for cwd.
      */
-    C?: string;
+    C?: string | undefined;
 
     /**
      * Set to any truthy value to create a gzipped archive,
      * or an object with settings for zlib.Gzip()
      */
-    gzip?: boolean | zlib.ZlibOptions;
+    gzip?: boolean | zlib.ZlibOptions | undefined;
 
     /**
      * Alias for gzip.
      */
-    z?: boolean | zlib.ZlibOptions;
+    z?: boolean | zlib.ZlibOptions | undefined;
 
     /**
      * A function that gets called with (path, stat) for each entry being
@@ -298,55 +298,55 @@ export interface CreateOptions {
      * gname, dev, ino, and nlink. Note that mtime is still included,
      * because this is necessary other time-based operations.
      */
-    portable?: boolean;
+    portable?: boolean | undefined;
 
     /**
      * Allow absolute paths. By default, / is stripped from absolute paths.
      */
-    preservePaths?: boolean;
+    preservePaths?: boolean | undefined;
 
     /**
      * Alias for presevePaths.
      */
-    P?: boolean;
+    P?: boolean | undefined;
 
     /**
      * The mode to set on the created file archive.
      */
-    mode?: number;
+    mode?: number | undefined;
 
     /**
      * Do not recursively archive the contents of directories.
      */
-    noDirRecurse?: boolean;
+    noDirRecurse?: boolean | undefined;
 
     /**
      * Set to true to pack the targets of symbolic links. Without this
      * option, symbolic links are archived as such.
      */
-    follow?: boolean;
+    follow?: boolean | undefined;
 
     /**
      * Alias for follow.
      */
-    L?: boolean;
+    L?: boolean | undefined;
 
     /**
      * Alias for follow.
      */
-    h?: boolean;
+    h?: boolean | undefined;
 
     /**
      * Suppress pax extended headers. Note that this means that long paths and
      * linkpaths will be truncated, and large or negative numeric values
      * may be interpreted incorrectly.
      */
-    noPax?: boolean;
+    noPax?: boolean | undefined;
 
     /**
      * A path portion to prefix onto the entries in the archive.
      */
-    prefix?: string;
+    prefix?: string | undefined;
 }
 
 export interface ExtractOptions {
@@ -359,18 +359,18 @@ export interface ExtractOptions {
     /**
      * Treat warnings as crash-worthy errors. Default false.
      */
-    strict?: boolean;
+    strict?: boolean | undefined;
 
     /**
      * Extract files relative to the specified directory. Defaults to
      * process.cwd(). If provided, this must exist and must be a directory.
      */
-    cwd?: string;
+    cwd?: string | undefined;
 
     /**
      * Alias for cwd.
      */
-    C?: string;
+    C?: string | undefined;
 
     /**
      * A function that gets called with (path, stat) for each entry being
@@ -382,33 +382,33 @@ export interface ExtractOptions {
      * Set to true to keep the existing file on disk if it's newer than
      * the file in the archive.
      */
-    newer?: boolean;
+    newer?: boolean | undefined;
 
     /**
      * Alias for newer.
      */
-    'keep-newer'?: boolean;
+    'keep-newer'?: boolean | undefined;
 
     /**
      * Alias for newer.
      */
-    'keep-newer-files'?: boolean;
+    'keep-newer-files'?: boolean | undefined;
 
     /**
      * Do not overwrite existing files. In particular, if a file appears more
      * than once in an archive, later copies will not overwrite earlier copies
      */
-    keep?: boolean;
+    keep?: boolean | undefined;
 
     /**
      * Alias for keep.
      */
-    k?: boolean;
+    k?: boolean | undefined;
 
     /**
      * Alias for keep.
      */
-    'keep-existing'?: boolean;
+    'keep-existing'?: boolean | undefined;
 
     /**
      * Unlink files before creating them. Without this option, tar overwrites
@@ -416,24 +416,24 @@ export interface ExtractOptions {
      * existing hardlinks will be broken, as will any symlink that would
      * affect the location of an extracted file.
      */
-    unlink?: boolean;
+    unlink?: boolean | undefined;
 
     /**
      * Remove the specified number of leading path elements. Pathnames with
      * fewer elements will be silently skipped. Note that the pathname
      * is edited after applying the filter, but before security checks.
      */
-    strip?: number;
+    strip?: number | undefined;
 
     /**
      * Alias for strip.
      */
-    'strip-components'?: number;
+    'strip-components'?: number | undefined;
 
     /**
      * Alias for strip.
      */
-    stripComponents?: number;
+    stripComponents?: number | undefined;
 
     /**
      * If true, tar will set the uid and gid of extracted entries to the uid
@@ -444,12 +444,12 @@ export interface ExtractOptions {
      * never unpacked in this implementation, and modes
      * are set by default already.
      */
-    preserveOwner?: boolean;
+    preserveOwner?: boolean | undefined;
 
     /**
      * Alias for preserveOwner.
      */
-    p?: boolean;
+    p?: boolean | undefined;
 
     /**
      * Set to a number to force ownership of all extracted files and folders,
@@ -457,7 +457,7 @@ export interface ExtractOptions {
      * user id, regardless of the uid field in the archive. Cannot be used
      * along with preserveOwner. Requires also setting a gid option.
      */
-    uid?: number;
+    uid?: number | undefined;
 
     /**
      * Set to a number to force ownership of all extracted files and folders,
@@ -465,15 +465,15 @@ export interface ExtractOptions {
      * group id, regardless of the gid field in the archive. Cannot be used
      * along with preserveOwner. Requires also setting a uid option
      */
-    gid?: number;
+    gid?: number | undefined;
 
     /**
      * Set to true to omit writing mtime value for extracted entries.
      * [Alias: m, no-mtime]
      */
-    noMtime?: boolean;
-    m?: boolean;
-    'no-mtime'?: boolean;
+    noMtime?: boolean | undefined;
+    m?: boolean | undefined;
+    'no-mtime'?: boolean | undefined;
 
     /**
      * Provide a function that takes an entry object, and returns a stream,
@@ -496,30 +496,30 @@ export interface ExtractOptions {
     /**
      * The maximum buffer size for fs.read() operations (in bytes). Defaults to 16 MB.
      */
-    maxReadSize?: number;
+    maxReadSize?: number | undefined;
 
     /**
      * The maximum size of meta entries that is supported. Defaults to 1 MB.
      */
-    maxMetaEntrySize?: number;
+    maxMetaEntrySize?: number | undefined;
 }
 
 export interface ListOptions {
     /**
      * Treat warnings as crash-worthy errors. Default false.
      */
-    strict?: boolean;
+    strict?: boolean | undefined;
 
     /**
      * Extract files relative to the specified directory. Defaults to
      * process.cwd(). If provided, this must exist and must be a directory.
      */
-    cwd?: string;
+    cwd?: string | undefined;
 
     /**
      * Alias for cwd.
      */
-    C?: string;
+    C?: string | undefined;
 
     /**
      * A function that gets called with (path, stat) for each entry being
@@ -537,7 +537,7 @@ export interface ListOptions {
     /**
      * The maximum buffer size for fs.read() operations. Defaults to 16 MB.
      */
-    maxReadSize?: number;
+    maxReadSize?: number | undefined;
 
     /**
      * By default, entry streams are resumed immediately after the call to
@@ -545,7 +545,7 @@ export interface ListOptions {
      * opting into this, the stream will never complete until the entry
      * data is consumed.
      */
-    noResume?: boolean;
+    noResume?: boolean | undefined;
 }
 
 export interface ReplaceOptions {
@@ -558,7 +558,7 @@ export interface ReplaceOptions {
      * Act synchronously. If this is set, then any provided file will be
      * fully written after the call to tar.c.
      */
-    sync?: boolean;
+    sync?: boolean | undefined;
 
     /**
      * A function that will get called with (message, data)
@@ -569,29 +569,29 @@ export interface ReplaceOptions {
     /**
      * Treat warnings as crash-worthy errors. Default false.
      */
-    strict?: boolean;
+    strict?: boolean | undefined;
 
     /**
      * Extract files relative to the specified directory. Defaults to
      * process.cwd(). If provided, this must exist and must be a directory.
      */
-    cwd?: string;
+    cwd?: string | undefined;
 
     /**
      * Alias for cwd.
      */
-    C?: string;
+    C?: string | undefined;
 
     /**
      * A path portion to prefix onto the entries in the archive.
      */
-    prefix?: string;
+    prefix?: string | undefined;
 
     /**
      * Set to any truthy value to create a gzipped archive,
      * or an object with settings for zlib.Gzip()
      */
-    gzip?: boolean | zlib.ZlibOptions;
+    gzip?: boolean | zlib.ZlibOptions | undefined;
 
     /**
      * A function that gets called with (path, stat) for each entry being
@@ -602,52 +602,52 @@ export interface ReplaceOptions {
     /**
      * Allow absolute paths. By default, / is stripped from absolute paths.
      */
-    preservePaths?: boolean;
+    preservePaths?: boolean | undefined;
 
     /**
      * The maximum buffer size for fs.read() operations. Defaults to 16 MB.
      */
-    maxReadSize?: number;
+    maxReadSize?: number | undefined;
 
     /**
      * Do not recursively archive the contents of directories.
      */
-    noDirRecurse?: boolean;
+    noDirRecurse?: boolean | undefined;
 
     /**
      * Set to true to pack the targets of symbolic links. Without this
      * option, symbolic links are archived as such.
      */
-    follow?: boolean;
+    follow?: boolean | undefined;
 
     /**
      * Alias for follow.
      */
-    L?: boolean;
+    L?: boolean | undefined;
 
     /**
      * Alias for follow.
      */
-    h?: boolean;
+    h?: boolean | undefined;
 
     /**
      * uppress pax extended headers. Note that this means that long paths and
      * linkpaths will be truncated, and large or negative numeric values
      * may be interpreted incorrectly.
      */
-    noPax?: boolean;
+    noPax?: boolean | undefined;
 }
 
 export interface FileOptions {
     /**
      * Uses the given file as the input or output of this function.
      */
-    file?: string;
+    file?: string | undefined;
 
     /**
      * Alias for file.
      */
-    f?: string;
+    f?: string | undefined;
 }
 
 /**

--- a/types/tarantool-driver/index.d.ts
+++ b/types/tarantool-driver/index.d.ts
@@ -7,15 +7,15 @@ import { EventEmitter } from "events";
 
 declare namespace TarantoolConnection {
   interface TarantoolOptions {
-    host?: string;
-    port?: number;
-    username?: string;
-    password?: string;
-    reserveHosts?: string[];
-    beforeReserve?: number;
-    timeout?: number;
-    retryStrategy?: (times: number) => number;
-    lazyConnect?: boolean;
+    host?: string | undefined;
+    port?: number | undefined;
+    username?: string | undefined;
+    password?: string | undefined;
+    reserveHosts?: string[] | undefined;
+    beforeReserve?: number | undefined;
+    timeout?: number | undefined;
+    retryStrategy?: ((times: number) => number) | undefined;
+    lazyConnect?: boolean | undefined;
   }
 }
 

--- a/types/targz/index.d.ts
+++ b/types/targz/index.d.ts
@@ -10,8 +10,8 @@ import * as zlib from 'zlib';
 export interface options {
     src: string;
     dest: string;
-    tar?: tar.ExtractOptions;
-    gz?: zlib.ZlibOptions;
+    tar?: tar.ExtractOptions | undefined;
+    gz?: zlib.ZlibOptions | undefined;
 }
 
 export function compress(opts?: options, callback?: (error: Error | string | null) => void): void;

--- a/types/task-graph-runner/index.d.ts
+++ b/types/task-graph-runner/index.d.ts
@@ -12,7 +12,7 @@ declare namespace taskGraphRunner {
     interface Opts<Item, Result> {
         graph: Map<Item, Item[]>;
         task: (item: Item) => Result;
-        force?: boolean;
+        force?: boolean | undefined;
     }
 
     interface Results<Item, Result> {

--- a/types/task-worklet/index.d.ts
+++ b/types/task-worklet/index.d.ts
@@ -10,7 +10,7 @@ declare class TaskQueue<T extends TaskQueue.TaskDescriptor = any> {
 }
 
 interface Options {
-    size?: number;
+    size?: number | undefined;
 }
 
 declare namespace TaskQueue {

--- a/types/tcp-ping/index.d.ts
+++ b/types/tcp-ping/index.d.ts
@@ -5,16 +5,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Options {
-    address?: string;
-    port?: number;
-    attempts?: number;
-    timeout?: number;
+    address?: string | undefined;
+    port?: number | undefined;
+    attempts?: number | undefined;
+    timeout?: number | undefined;
 }
 
 export interface Results {
     seq: number;
     time: number | undefined;
-    err?: Error;
+    err?: Error | undefined;
 }
 
 export interface Result {

--- a/types/tdweb/index.d.ts
+++ b/types/tdweb/index.d.ts
@@ -6,7 +6,7 @@
 
 export interface TdObject {
     '@type': string;
-    '@extra'?: string;
+    '@extra'?: string | undefined;
     [key: string]: TdObject | TdObject[] | number | number[] | string | string[] | boolean | boolean[] | undefined;
 }
 
@@ -15,7 +15,7 @@ export interface TdObject {
  */
 export interface TdError {
     '@type': 'error';
-    '@extra'?: 'string';
+    '@extra'?: 'string' | undefined;
     /**
      * Error code; subject to future changes. If the error code is 406, the error message
      * must not be processed in any way and must not be displayed to the user
@@ -29,40 +29,40 @@ export interface TdOptions {
     /**
      * Callback for all incoming updates.
      */
-    onUpdate?: (update: TdObject) => any;
+    onUpdate?: ((update: TdObject) => any) | undefined;
     /**
      * Name of the TDLib instance. Currently only one instance of TdClient with a given name is allowed.
      * All but one instances with the same name will be automatically closed. Usually, the newest non-background instance is kept alive.
      * Files will be stored in an IndexedDb table with the same name.
      */
-    instanceName?: string;
+    instanceName?: string | undefined;
     /**
      * Pass true, if the instance is opened from the background.
      */
-    isBackground?: boolean;
+    isBackground?: boolean | undefined;
     /**
      * The initial verbosity level for the TDLib internal logging (0-1023).
      */
-    logVerbosityLevel?: number;
+    logVerbosityLevel?: number | undefined;
     /**
      * The initial verbosity level of the JavaScript part of the code (one of 'error', 'warning', 'info', 'log', 'debug').
      */
-    jsLogVerbosityLevel?: 'error' | 'warning' | 'info' | 'log' | 'debug';
+    jsLogVerbosityLevel?: 'error' | 'warning' | 'info' | 'log' | 'debug' | undefined;
     /**
      * Pass false to use TDLib without database and secret chats. It will significantly improve loading time, but some functionality will be unavailable.
      */
-    useDatabase?: boolean;
+    useDatabase?: boolean | undefined;
     /**
      * For debug only. PaPass false to use TDLib without database and secret chats.
      * It will significantly improve loading time, but some functionality will be unavailable.ss true
      * to open TDLib database in read-only mode
      */
-    readOnly?: boolean;
+    readOnly?: boolean | undefined;
     /**
      * For debug only. The type of the TDLib build to use. 'asmjs' for asm.js and 'wasm' for WebAssembly.
      * If mode == 'auto' WebAbassembly will be used if supported by browser, asm.js otherwise.
      */
-    mode?: 'auto' | 'asmjs' | 'wasm';
+    mode?: 'auto' | 'asmjs' | 'wasm' | undefined;
 }
 
 /**

--- a/types/tedious-connection-pool/index.d.ts
+++ b/types/tedious-connection-pool/index.d.ts
@@ -33,32 +33,32 @@ declare namespace tcp {
         /**
          * Minimum concurrent connections
          */
-        min?: number;
+        min?: number | undefined;
 
         /**
          * Maximum concurrent connections
          */
-        max?: number;
+        max?: number | undefined;
 
         /**
          * Defines if logging is activated
          */
-        log?: boolean;
+        log?: boolean | undefined;
 
         /**
          * Idle timeout
          */
-        idleTimeout?: number;
+        idleTimeout?: number | undefined;
 
         /**
          * Retry delay
          */
-        retryDelay?: number;
+        retryDelay?: number | undefined;
 
         /**
          * Acquire timeout
          */
-        acquireTimeout?: number;
+        acquireTimeout?: number | undefined;
     }
 }
 

--- a/types/tedious/index.d.ts
+++ b/types/tedious/index.d.ts
@@ -35,39 +35,39 @@ export interface ColumnMetaData {
     /**
      * The precision. Only applicable to numeric and decimal.
      */
-    precision?: number;
+    precision?: number | undefined;
 
     /**
      * The scale. Only applicable to numeric, decimal, time, datetime2 and datetimeoffset.
      */
-    scale?: number;
+    scale?: number | undefined;
 
     /**
      * The length, for char, varchar, nvarchar and varbinary.
      */
-    dataLength?: number;
+    dataLength?: number | undefined;
 }
 
 export interface DebugOptions {
     /**
      * A boolean, controlling whether debug events will be emitted with text describing packet details (default: false).
      */
-    packet?: boolean;
+    packet?: boolean | undefined;
 
     /**
      * A boolean, controlling whether debug events will be emitted with text describing packet data details (default: false).
      */
-    data?: boolean;
+    data?: boolean | undefined;
 
     /**
      * A boolean, controlling whether debug events will be emitted with text describing packet payload details (default: false).
      */
-    payload?: boolean;
+    payload?: boolean | undefined;
 
     /**
      * A boolean, controlling whether debug events will be emitted with text describing token stream tokens (default: false).
      */
-    token?: boolean;
+    token?: boolean | undefined;
 }
 
 export declare enum ISOLATION_LEVEL {
@@ -136,73 +136,73 @@ export interface ConnectionOptions {
     /**
      * Port to connect to (default: 1433). Mutually exclusive with options.instanceName.
      */
-    port?: number;
+    port?: number | undefined;
 
     /**
      * The instance name to connect to. The SQL Server Browser service must be running on the database server,
      * and UDP port 1444 on the database server must be reachable. (no default) Mutually exclusive with options.port.
      */
-    instanceName?: string;
+    instanceName?: string | undefined;
 
     /**
      * Database to connect to (default: dependent on server configuration).
      */
-    database?: string;
+    database?: string | undefined;
 
     /**
      * By default, if the database requested by options.database cannot be accessed,
      * the connection will fail with an error. However, if options.fallbackToDefaultDb is set to true,
      * then the user's default database will be  * used instead (Default: false).
      */
-    fallbackToDefaultDb?: boolean;
+    fallbackToDefaultDb?: boolean | undefined;
 
     /**
      * The number of milliseconds before the attempt to connect is considered failed (default: 15000).
      */
-    connectTimeout?: number;
+    connectTimeout?: number | undefined;
 
     /**
      * The number of milliseconds before a request is considered failed, or 0 for no timeout (default: 15000).
      */
-    requestTimeout?: number;
+    requestTimeout?: number | undefined;
 
     /**
      * The number of milliseconds before the cancel (abort) of a request is considered failed (default: 5000).
      */
-    cancelTimeout?: number;
+    cancelTimeout?: number | undefined;
 
     /**
      * The size of TDS packets (subject to negotiation with the server). Should be a power of 2. (default: 4096).
      */
-    packetSize?: number;
+    packetSize?: number | undefined;
 
     /**
      * A boolean determining whether to pass time values in UTC or local time. (default: true).
      */
-    useUTC?: boolean;
+    useUTC?: boolean | undefined;
 
     /**
      * A boolean determining whether to rollback a transaction automatically if any error is encountered
      * during the given transaction's execution. This sets the value for SET XACT_ABORT during the initial
      * SQL phase of a connection (documentation).
      */
-    abortTransactionOnError?: boolean;
+    abortTransactionOnError?: boolean | undefined;
 
     /**
      * A string indicating which network interface (ip address) to use when connecting to SQL Server.
      */
-    localAddress?: string;
+    localAddress?: string | undefined;
 
     /**
      * A boolean determining whether to return rows as arrays or key-value collections. (default: false).
      */
-    useColumnNames?: boolean;
+    useColumnNames?: boolean | undefined;
 
     /**
      * A boolean, controlling whether the column names returned will have the first letter converted
      * to lower case (true) or not. This value is ignored if you provide a columnNameReplacer. (default: false).
      */
-    camelCaseColumns?: boolean;
+    camelCaseColumns?: boolean | undefined;
 
     /**
      * A function with parameters (columnName, index, columnMetaData) and returning a string. If provided,
@@ -210,174 +210,174 @@ export interface ConnectionOptions {
      * SQL-provided column name on row and meta data objects. This allows you to dynamically convert between
      * naming conventions. (default: null).
      */
-    columnNameReplacer?: (columnName: string, index: number, columnMetaData: ColumnMetaData) => string;
+    columnNameReplacer?: ((columnName: string, index: number, columnMetaData: ColumnMetaData) => string) | undefined;
 
     /**
      * Debug options
      */
-    debug?: DebugOptions;
+    debug?: DebugOptions | undefined;
 
     /**
      * The default isolation level that transactions will be run with. (default: READ_COMMITTED).
      */
-    isolationLevel?: ISOLATION_LEVEL;
+    isolationLevel?: ISOLATION_LEVEL | undefined;
 
     /**
      * The default isolation level for new connections. All out-of-transaction queries are executed with this setting. (default: READ_COMMITED)
      */
-    connectionIsolationLevel?: ISOLATION_LEVEL;
+    connectionIsolationLevel?: ISOLATION_LEVEL | undefined;
 
     /**
      * A boolean, determining whether the connection will request read only access from a SQL Server Availability Group. For more information, see here. (default: false).
      */
-    readOnlyIntent?: boolean;
+    readOnlyIntent?: boolean | undefined;
 
     /**
      * A boolean determining whether or not the connection will be encrypted. Set to true if you're on Windows Azure. (default: false).
      */
-    encrypt?: boolean;
+    encrypt?: boolean | undefined;
 
     /**
      * When encryption is used, an object may be supplied that will be used for the first argument when calling tls.createSecurePair (default: {}).
      */
-    cryptoCredentialsDetails?: SecureContextOptions;
+    cryptoCredentialsDetails?: SecureContextOptions | undefined;
 
     /**
      * A boolean, that when true will expose received rows in Requests' done* events. See done, doneInProc and doneProc. (default: false)
      * Caution: If many row are received, enabling this option could result in excessive memory usage.
      */
-    rowCollectionOnDone?: boolean;
+    rowCollectionOnDone?: boolean | undefined;
 
     /**
      * A boolean, that when true will expose received rows in Requests' completion callback. See new Request. (default: false)
      * Caution: If many row are received, enabling this option could result in excessive memory usage.
      */
-    rowCollectionOnRequestCompletion?: boolean;
+    rowCollectionOnRequestCompletion?: boolean | undefined;
 
     /**
      * The version of TDS to use. If server doesn't support specified version, negotiated version is used instead. (default: 7_4).
      * Take this from tedious.TDS_VERSION.7_4 .
      */
-    tdsVersion?: number;
+    tdsVersion?: number | undefined;
 
     /**
      * Application name used for identifying a specific application in profiling, logging or tracing tools of SQL Server. (default: Tedious)
      */
-    appName?: string;
+    appName?: string | undefined;
 
     /**
      * Number of milliseconds before retrying to establish connection, in case of transient failure. (default: 500)
      */
-    connectionRetryInterval?: number;
+    connectionRetryInterval?: number | undefined;
 
     /**
      * Number that sets to the first day of the week, it can be a number from 1 through 7.(default: 7, i.e, first day of the week is Sunday)
      */
-    datefirst?: number;
+    datefirst?: number | undefined;
 
     /**
      * A string representing position of month, day and year in temporal datatypes. (default: mdy)
      */
-    dateFormat?: string;
+    dateFormat?: string | undefined;
 
     /**
      * A boolean, controls the way null values should be used during comparison operation. (default: true)
      */
-    enableAnsiNull?: boolean;
+    enableAnsiNull?: boolean | undefined;
 
     /**
      * If true, SET ANSI_NULL_DFLT_ON ON will be set in the initial sql. This means new columns will be nullable by default. See the T-SQL documentation for more details. (Default: true).
      */
-    enableAnsiNullDefault?: boolean;
+    enableAnsiNullDefault?: boolean | undefined;
 
     /**
      * A boolean, controls if padding should be applied for values shorter than the size of defined column. (default: true)
      */
-    enableAnsiPadding?: boolean;
+    enableAnsiPadding?: boolean | undefined;
 
     /**
      * If true, SQL Server will follow ISO standard behavior during various error conditions. For details, see documentation. (default: true)
      */
-    enableAnsiWarnings?: boolean;
+    enableAnsiWarnings?: boolean | undefined;
 
     /**
      * A boolean, determines if query execution should be terminated during overflow or divide-by-zero error. (default: false)
      */
-    enableArithAbort?: boolean;
+    enableArithAbort?: boolean | undefined;
 
     /**
      * A boolean, determines if concatenation with NULL should result in NULL or empty string value, more details in documentation. (default: true)
      */
-    enableConcatNullYieldsNull?: boolean;
+    enableConcatNullYieldsNull?: boolean | undefined;
 
     /**
      * A boolean, controls whether cursor should be closed, if the transaction opening it gets committed or rolled back. (default: false)
      */
-    enableCursorCloseOnCommit?: boolean;
+    enableCursorCloseOnCommit?: boolean | undefined;
 
     /**
      * A boolean, sets the connection to either implicit or autocommit transaction mode. (default: false)
      */
-    enableImplicitTransactions?: boolean;
+    enableImplicitTransactions?: boolean | undefined;
 
     /**
      * If false, error is not generated during loss of precession. (default: false)
      */
-    enableNumericRoundabort?: boolean;
+    enableNumericRoundabort?: boolean | undefined;
 
     /**
      * If true, characters enclosed in single quotes are treated as literals and those enclosed double quotes are treated as identifiers. (default: true)
      */
-    enableQuotedIdentifier?: boolean;
+    enableQuotedIdentifier?: boolean | undefined;
 
     /**
      * A string, sets the language of the session (default: us_english)
      */
-    language?: string;
+    language?: string | undefined;
 
     /**
      * Number of retries on transient error (default: 3)
      */
-    maxRetriesOnTransientErrors?: number;
+    maxRetriesOnTransientErrors?: number | undefined;
 
     /**
      * Size of data to be returned by SELECT statement for varchar(max), nvarchar(max), varbinary(max), text, ntext, and image type. (default: 2147483647)
      */
-    textsize?: number;
+    textsize?: number | undefined;
 
     /**
      * A boolean, that verifies whether server's identity matches it's certificate's names (default: true)
      */
-    trustServerCertificate?: boolean;
+    trustServerCertificate?: boolean | undefined;
 }
 
 export interface ConnectionAuthenticationOptions {
     /**
      * Once you set domain, driver will connect to SQL Server using domain login.
      */
-    domain?: string;
+    domain?: string | undefined;
 
     /**
      * User name to use for authentication.
      */
-    userName?: string;
+    userName?: string | undefined;
 
     /**
      * Password to use for authentication.
      */
-    password?: string;
+    password?: string | undefined;
 
     /**
      * Authentication token used when type is 'azure-active-directory-access-token'
      */
-    token?: string;
+    token?: string | undefined;
 }
 
 export interface ConnectionAuthentication {
     /**
      * Authentication Type. Default value is 'default'.
      */
-    type?: string;
+    type?: string | undefined;
 
     /**
      * Authentication Options
@@ -389,31 +389,31 @@ export interface ConnectionConfig {
     /**
      * Hostname to connect to.
      */
-    server?: string;
+    server?: string | undefined;
 
     /**
      * Once you set domain, driver will connect to SQL Server using domain login.
      */
-    domain?: string;
+    domain?: string | undefined;
 
     /**
      * Further options
      */
-    options?: ConnectionOptions;
+    options?: ConnectionOptions | undefined;
 
     /**
      * Authentication Options
      */
-    authentication?: ConnectionAuthentication;
+    authentication?: ConnectionAuthentication | undefined;
 }
 
 export interface ParameterOptions {
     //  for VarChar, NVarChar, VarBinary
-    length?: number | 'max';
+    length?: number | 'max' | undefined;
     // precision for Numeric, Decimal
-    precision?: number;
+    precision?: number | undefined;
     // scale for Numeric, Decimal, Time, DateTime2, DateTimeOffset
-    scale?: number;
+    scale?: number | undefined;
 }
 
 /**
@@ -534,7 +534,7 @@ export interface BulkLoadColumnOpts extends ParameterOptions {
     //  Indicates whether the column accepts NULL values.
     nullable: boolean;
     //  If the name of the column is different from the name of the property found on rowObj arguments passed to , then you can use this option to specify the property name.
-    objName?: string;
+    objName?: string | undefined;
 }
 
 export interface BulkLoad {

--- a/types/telebot/index.d.ts
+++ b/types/telebot/index.d.ts
@@ -11,24 +11,24 @@ declare namespace telebot {
         token: string; // Required. Telegram Bot API token.
         polling?: {
             // Optional. Use polling.
-            interval?: number; // Optional. How often check updates (in ms).
-            timeout?: number; // Optional. Update polling timeout (0 - short polling).
-            limit?: number; // Optional. Limits the number of updates to be retrieved.
-            retryTimeout?: number; // Optional. Reconnecting timeout (in ms).
-            proxy?: string; // Optional. An HTTP proxy to be used.
-        };
+            interval?: number | undefined; // Optional. How often check updates (in ms).
+            timeout?: number | undefined; // Optional. Update polling timeout (0 - short polling).
+            limit?: number | undefined; // Optional. Limits the number of updates to be retrieved.
+            retryTimeout?: number | undefined; // Optional. Reconnecting timeout (in ms).
+            proxy?: string | undefined; // Optional. An HTTP proxy to be used.
+        } | undefined;
         webhook?: {
             // Optional. Use webhook instead of polling.
-            key?: string; // Optional. Private key for server.
-            cert?: string; // Optional. key.
-            url?: string; // HTTPS url to send updates to.
-            host?: string; // Webhook server host.
-            port?: number; // Server port.
-            maxConnections?: number; // Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
-        };
-        allowedUpdates?: string[]; // Optional. List the types of updates you want your bot to receive. Specify an empty list to receive all updates.
-        usePlugins?: string[]; // Optional. Use build-in plugins from pluginFolder.
-        pluginFolder?: string; // Optional. Plugin folder location relative to telebot package.
+            key?: string | undefined; // Optional. Private key for server.
+            cert?: string | undefined; // Optional. key.
+            url?: string | undefined; // HTTPS url to send updates to.
+            host?: string | undefined; // Webhook server host.
+            port?: number | undefined; // Server port.
+            maxConnections?: number | undefined; // Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
+        } | undefined;
+        allowedUpdates?: string[] | undefined; // Optional. List the types of updates you want your bot to receive. Specify an empty list to receive all updates.
+        usePlugins?: string[] | undefined; // Optional. Use build-in plugins from pluginFolder.
+        pluginFolder?: string | undefined; // Optional. Plugin folder location relative to telebot package.
         pluginConfig?: any;
     }
 
@@ -141,11 +141,11 @@ declare class telebot {
         chat_id: number | string,
         text: string,
         opt?: {
-            parseMode?: string;
-            replyToMessage?: number;
+            parseMode?: string | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
-            webPreview?: boolean;
+            notification?: boolean | undefined;
+            webPreview?: boolean | undefined;
         }
     ): any;
 
@@ -153,7 +153,7 @@ declare class telebot {
         chat_id: number | string,
         from_chat_id: number | string,
         message_id: number,
-        opt?: { notification?: boolean }
+        opt?: { notification?: boolean | undefined }
     ): any;
 
     deleteMessage(
@@ -165,12 +165,12 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            caption?: string;
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            caption?: string | undefined;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -178,15 +178,15 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            title?: string;
-            performer?: string;
-            duration?: number;
-            caption?: string;
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            title?: string | undefined;
+            performer?: string | undefined;
+            duration?: number | undefined;
+            caption?: string | undefined;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -194,12 +194,12 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            caption?: string;
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            caption?: string | undefined;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -207,11 +207,11 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -219,15 +219,15 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            duration?: number;
-            width?: number;
-            height?: number;
-            caption?: string;
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            duration?: number | undefined;
+            width?: number | undefined;
+            height?: number | undefined;
+            caption?: string | undefined;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -235,12 +235,12 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            duration?: number;
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            duration?: number | undefined;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -248,20 +248,20 @@ declare class telebot {
         chat_id: number | string,
         file: string | Buffer | NodeJS.ReadableStream | any,
         opt?: {
-            duration?: number;
-            caption?: string;
-            fileName?: string;
-            serverDownload?: boolean;
-            replyToMessage?: number;
+            duration?: number | undefined;
+            caption?: string | undefined;
+            fileName?: string | undefined;
+            serverDownload?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
     sendLocation(
         chat_id: number | string,
         coords: [number, number],
-        opt?: { replyToMessage?: number; replyMarkup?: any; notification?: boolean }
+        opt?: { replyToMessage?: number | undefined; replyMarkup?: any; notification?: boolean | undefined }
     ): any;
 
     sendVenue(
@@ -270,10 +270,10 @@ declare class telebot {
         title: string,
         address: string,
         opt?: {
-            foursquareId?: string;
-            replyToMessage?: number;
+            foursquareId?: string | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
-            notification?: boolean;
+            notification?: boolean | undefined;
         }
     ): any;
 
@@ -282,7 +282,7 @@ declare class telebot {
         number: string,
         firstName: string,
         lastName?: string,
-        opt?: { replyToMessage?: number; replyMarkup?: any; notification?: boolean }
+        opt?: { replyToMessage?: number | undefined; replyMarkup?: any; notification?: boolean | undefined }
     ): any;
 
     sendAction(chat_id: number | string, action: string): boolean;
@@ -290,29 +290,29 @@ declare class telebot {
     sendGame(
         chat_id: number | string,
         game_short_name: string,
-        opt?: { replyToMessage?: number; replyMarkup?: any; notification?: boolean }
+        opt?: { replyToMessage?: number | undefined; replyMarkup?: any; notification?: boolean | undefined }
     ): any;
 
     setGameScore(
         user_id: number,
         score: number,
         opt?: {
-            force?: boolean;
-            disableEditMessage?: boolean;
-            chatId?: number;
-            messageId?: number;
-            inlineMessageId?: string;
+            force?: boolean | undefined;
+            disableEditMessage?: boolean | undefined;
+            chatId?: number | undefined;
+            messageId?: number | undefined;
+            inlineMessageId?: string | undefined;
         }
     ): boolean | Error | any;
 
     getGameHighScores(
         user_id: number,
-        opt?: { chatId?: number; messageId?: number; inlineMessageId?: string }
+        opt?: { chatId?: number | undefined; messageId?: number | undefined; inlineMessageId?: string | undefined }
     ): any[];
 
     getUserProfilePhotos(
         user_id: number,
-        opt?: { offset?: number; limit?: number }
+        opt?: { offset?: number | undefined; limit?: number | undefined }
     ): any;
 
     getFile(file_id: string): any;
@@ -327,16 +327,16 @@ declare class telebot {
             startParameter: string;
             currency: string;
             prices: any[];
-            photo?: { url?: string; width?: number; height?: number };
+            photo?: { url?: string | undefined; width?: number | undefined; height?: number | undefined } | undefined;
             need?: {
-                name?: boolean;
-                phoneNumber?: boolean;
-                email?: boolean;
-                shippingAddress?: boolean;
-            };
-            isFlexible?: boolean;
-            notification?: boolean;
-            replyToMessage?: number;
+                name?: boolean | undefined;
+                phoneNumber?: boolean | undefined;
+                email?: boolean | undefined;
+                shippingAddress?: boolean | undefined;
+            } | undefined;
+            isFlexible?: boolean | undefined;
+            notification?: boolean | undefined;
+            replyToMessage?: number | undefined;
             replyMarkup?: any;
         }
     ): any;
@@ -359,15 +359,15 @@ declare class telebot {
         config: {
             chatId: number | string;
             messageId: number;
-            inlineMsgId?: number;
+            inlineMsgId?: number | undefined;
         }|{
-            chatId?: number | string;
-            messageId?: number;
+            chatId?: number | string | undefined;
+            messageId?: number | undefined;
             inlineMsgId: number;
         },
         text: string,
         opt?: {
-            parseMode?: string;
+            parseMode?: string | undefined;
         }
     ): any | boolean;
 
@@ -375,10 +375,10 @@ declare class telebot {
         config: {
             chatId: number | string;
             messageId: number;
-            inlineMsgId?: number;
+            inlineMsgId?: number | undefined;
         }|{
-            chatId?: number | string;
-            messageId?: number;
+            chatId?: number | string | undefined;
+            messageId?: number | undefined;
             inlineMsgId: number;
         },
         caption: string
@@ -388,10 +388,10 @@ declare class telebot {
         config: {
             chatId: number | string;
             messageId: number;
-            inlineMsgId?: number;
+            inlineMsgId?: number | undefined;
         }|{
-            chatId?: number | string;
-            messageId?: number;
+            chatId?: number | string | undefined;
+            messageId?: number | undefined;
             inlineMsgId: number;
         },
         replyMarkup: any
@@ -400,23 +400,23 @@ declare class telebot {
     answerCallbackQuery(
         callback_query_id: string,
         opt?: {
-            text?: string;
-            url?: string;
-            showAlert?: boolean;
-            cacheTime?: number;
+            text?: string | undefined;
+            url?: string | undefined;
+            showAlert?: boolean | undefined;
+            cacheTime?: number | undefined;
         }
     ): boolean;
 
     answerShippingQuery(
         shipping_query_id: string,
         ok: boolean,
-        opt?: { shippingOptions?: any[]; errorMessage?: string }
+        opt?: { shippingOptions?: any[] | undefined; errorMessage?: string | undefined }
     ): boolean;
 
     answerPreCheckoutQuery(
         pre_checkout_query_id: string,
         ok: boolean,
-        opt?: { errorMessage?: string }
+        opt?: { errorMessage?: string | undefined }
     ): boolean;
 
     setWebhook(

--- a/types/temp-fs/index.d.ts
+++ b/types/temp-fs/index.d.ts
@@ -69,47 +69,47 @@ declare namespace tempfs {
          *
          * Also see {@link options#name}. Default: <code>tempfs.dir()</code>
          */
-        dir?: String;
+        dir?: String | undefined;
 
         /**
          * The maximum number of chance to retry before throwing an error.
          *
          * It should be a finite number. Default: 5
          */
-        limit?: Number;
+        limit?: Number | undefined;
 
         /**
          * File mode (default: 0600) or directory mode (default: 0700) to use.
          */
-        mode?: Number;
+        mode?: Number | undefined;
 
         /**
          * If set, join the two paths <code>{@link options#dir} ||
          * tempfs.dir()</code> and {@link options#name} together and use the
          * result as the customized filename/pathname.
          */
-        name?: String;
+        name?: String | undefined;
 
         /**
          * The prefix for the generated random name.
          *
          * Default: "tmp-"
          */
-        prefix?: String;
+        prefix?: String | undefined;
 
         /**
          * Whether {@link dir#unlink} should remove a directory recursively.
          *
          * Default: false
          */
-        recursive?: Boolean;
+        recursive?: Boolean | undefined;
 
         /**
          * The suffix for the generated random name.
          *
          * Default: ""
          */
-        suffix?: String;
+        suffix?: String | undefined;
 
         /**
          * A string containing some capital letters Xs for substitution with
@@ -118,7 +118,7 @@ declare namespace tempfs {
          * Then it is used as part of the filename/dirname. Just like what you
          * do with the <code>mktemp(3)</code> function in the C library.
          */
-        template?: String;
+        template?: String | undefined;
 
         /**
          * If set to true, let temp-fs manage the the current file/directory for
@@ -126,7 +126,7 @@ declare namespace tempfs {
          * temp-fs manage it even if the global tracking is on. Otherwise, use
          * the current global setting.
          */
-        track?: Boolean;
+        track?: Boolean | undefined;
     }
 
     /**

--- a/types/temp/index.d.ts
+++ b/types/temp/index.d.ts
@@ -19,9 +19,9 @@ declare namespace temp {
   }
 
   interface AffixOptions {
-    prefix?: string;
-    suffix?: string;
-    dir?: string;
+    prefix?: string | undefined;
+    suffix?: string | undefined;
+    dir?: string | undefined;
   }
 
   let dir: string;

--- a/types/terminal-kit/Rect.d.ts
+++ b/types/terminal-kit/Rect.d.ts
@@ -27,7 +27,7 @@ declare class Rect {
     dstRect: Rect;
     offsetX: number;
     offsetY: number;
-    wrapOnly?: "x" | "y";
+    wrapOnly?: "x" | "y" | undefined;
   }): void;
 
   set(obj: Rect.Region): void;
@@ -48,8 +48,8 @@ declare namespace Rect {
   interface AbsoluteOptions {
     width: number;
     height: number;
-    x?: number;
-    y?: number;
+    x?: number | undefined;
+    y?: number | undefined;
   }
 
   interface Region {

--- a/types/terminal-kit/ScreenBuffer.d.ts
+++ b/types/terminal-kit/ScreenBuffer.d.ts
@@ -30,7 +30,7 @@ declare class ScreenBuffer extends NextGenEvents {
       shrink?: {
         width: number;
         height: number;
-      };
+      } | undefined;
     },
     calback: (error: any, image: ScreenBufferHD) => void
   ): void;
@@ -50,7 +50,7 @@ declare class ScreenBuffer extends NextGenEvents {
 
   fill(options?: {
     attr: ScreenBuffer.Attributes | number;
-    char?: string;
+    char?: string | undefined;
   }): void;
 
   clear(): void;
@@ -85,46 +85,46 @@ export = ScreenBuffer;
 
 declare namespace ScreenBuffer {
   interface Options {
-    width?: number;
-    height?: number;
+    width?: number | undefined;
+    height?: number | undefined;
     dst: Terminal | ScreenBuffer;
-    x?: number;
-    y?: number;
-    blending?: boolean;
-    wrap?: boolean;
-    noFill?: boolean;
+    x?: number | undefined;
+    y?: number | undefined;
+    blending?: boolean | undefined;
+    wrap?: boolean | undefined;
+    noFill?: boolean | undefined;
   }
 
   interface DrawOptions {
-    dst?: Terminal | ScreenBuffer;
-    x?: number;
-    y?: number;
-    srcClipRect?: Rect;
-    dstClipRect?: Rect;
-    blending?: boolean;
-    delta?: boolean;
-    wrap?: boolean | "x" | "y";
-    tile?: boolean;
+    dst?: Terminal | ScreenBuffer | undefined;
+    x?: number | undefined;
+    y?: number | undefined;
+    srcClipRect?: Rect | undefined;
+    dstClipRect?: Rect | undefined;
+    blending?: boolean | undefined;
+    delta?: boolean | undefined;
+    wrap?: boolean | "x" | "y" | undefined;
+    tile?: boolean | undefined;
   }
 
   interface Attributes {
-    color?: number;
-    defaultColor?: boolean;
-    bgColor?: number;
-    bgDefaultColor?: boolean;
-    bold?: boolean;
-    dim?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-    blink?: boolean;
-    inverse?: boolean;
-    hidden?: boolean;
-    strike?: boolean;
-    transparency?: boolean;
-    fgTransparency?: boolean;
-    bgTransparency?: boolean;
-    styleTransparency?: boolean;
-    charTransparency?: boolean;
+    color?: number | undefined;
+    defaultColor?: boolean | undefined;
+    bgColor?: number | undefined;
+    bgDefaultColor?: boolean | undefined;
+    bold?: boolean | undefined;
+    dim?: boolean | undefined;
+    italic?: boolean | undefined;
+    underline?: boolean | undefined;
+    blink?: boolean | undefined;
+    inverse?: boolean | undefined;
+    hidden?: boolean | undefined;
+    strike?: boolean | undefined;
+    transparency?: boolean | undefined;
+    fgTransparency?: boolean | undefined;
+    bgTransparency?: boolean | undefined;
+    styleTransparency?: boolean | undefined;
+    charTransparency?: boolean | undefined;
   }
 
   interface PutOptions {
@@ -132,7 +132,7 @@ declare namespace ScreenBuffer {
     y: number;
     attr: Attributes | number;
     wrap: boolean;
-    direction?: "right" | "left" | "up" | "down" | null;
+    direction?: "right" | "left" | "up" | "down" | null | undefined;
     dx: number;
     dy: number;
   }

--- a/types/terminal-kit/ScreenBufferHD.d.ts
+++ b/types/terminal-kit/ScreenBufferHD.d.ts
@@ -14,7 +14,7 @@ declare class ScreenBufferHD extends ScreenBuffer {
 
   static loadImage(
     url: string,
-    options: { shrink?: { height: number; width: number } },
+    options: { shrink?: { height: number; width: number } | undefined },
     callback: (error: any, image: ScreenBufferHD) => void
   ): void;
 
@@ -26,11 +26,11 @@ declare class ScreenBufferHD extends ScreenBuffer {
     options?:
       | {
           attr: ScreenBuffer.Attributes | number;
-          char?: string;
+          char?: string | undefined;
         }
       | {
           attr: ScreenBufferHD.Attributes | number;
-          char?: string;
+          char?: string | undefined;
         }
   ): void;
 }
@@ -42,24 +42,24 @@ declare namespace ScreenBufferHD {
     r: number;
     g: number;
     b: number;
-    a?: number;
-    defaultColor?: boolean;
+    a?: number | undefined;
+    defaultColor?: boolean | undefined;
     bgR: number;
     bgG: number;
     bgB: number;
-    bgA?: number;
-    bgDefaultColor?: boolean;
-    bold?: boolean;
-    dim?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-    blink?: boolean;
-    inverse?: boolean;
-    hidden?: boolean;
-    strike?: boolean;
-    transparency?: boolean;
-    styleTransparency?: boolean;
-    charTransparency?: boolean;
+    bgA?: number | undefined;
+    bgDefaultColor?: boolean | undefined;
+    bold?: boolean | undefined;
+    dim?: boolean | undefined;
+    italic?: boolean | undefined;
+    underline?: boolean | undefined;
+    blink?: boolean | undefined;
+    inverse?: boolean | undefined;
+    hidden?: boolean | undefined;
+    strike?: boolean | undefined;
+    transparency?: boolean | undefined;
+    styleTransparency?: boolean | undefined;
+    charTransparency?: boolean | undefined;
   }
 
   type IsBlending = false | Blending;

--- a/types/terminal-kit/Terminal.d.ts
+++ b/types/terminal-kit/Terminal.d.ts
@@ -166,8 +166,8 @@ declare namespace Terminal {
       options:
         | boolean
         | {
-            mouse?: "button" | "drag" | "motion";
-            safe?: boolean;
+            mouse?: "button" | "drag" | "motion" | undefined;
+            safe?: boolean | undefined;
           },
       safeCallback?: boolean
     ): void;
@@ -197,8 +197,8 @@ declare namespace Terminal {
     wrapColumn(options?: {
       width: null | number;
       x: number;
-      continue?: boolean;
-      offset?: number;
+      continue?: boolean | undefined;
+      offset?: number | undefined;
     }): void;
     wrapColumn(x: undefined | number, width: number): void;
 
@@ -208,7 +208,7 @@ declare namespace Terminal {
       options?: YesOrNoOptions
     ): {
       abort: () => void;
-      promise?: Promise<boolean>;
+      promise?: Promise<boolean> | undefined;
     };
 
     inputField(options: InputFieldOptions, callback?: Callback<string | undefined>): {
@@ -299,16 +299,16 @@ declare namespace Terminal {
 
     bar(
       value: number,
-      options?: { innerSize?: number; barStyle?: CTerminal }
+      options?: { innerSize?: number | undefined; barStyle?: CTerminal | undefined }
     ): void;
 
     slowTyping(
       str: string,
       options: {
-        style?: CTerminal;
-        flashStyle?: CTerminal;
-        delay?: number;
-        flashDelay?: number;
+        style?: CTerminal | undefined;
+        flashStyle?: CTerminal | undefined;
+        delay?: number | undefined;
+        flashDelay?: number | undefined;
       },
       callback: Callback<void>
     ): void;
@@ -317,10 +317,10 @@ declare namespace Terminal {
     slowTyping(
       str: string,
       options?: {
-        style?: CTerminal;
-        flashStyle?: CTerminal;
-        delay?: number;
-        flashDelay?: number;
+        style?: CTerminal | undefined;
+        flashStyle?: CTerminal | undefined;
+        delay?: number | undefined;
+        flashDelay?: number | undefined;
       }
     ): Promise<void>;
 
@@ -330,7 +330,7 @@ declare namespace Terminal {
         shrink?: {
           width: number;
           height: number;
-        };
+        } | undefined;
       },
       callback: Callback<void>
     ): void;
@@ -343,7 +343,7 @@ declare namespace Terminal {
         shrink?: {
           width: number;
           height: number;
-        };
+        } | undefined;
       }
     ): Promise<void>;
   }
@@ -367,8 +367,8 @@ declare namespace Terminal {
   interface YesOrNoOptions {
     yes: string | ReadonlyArray<string>;
     no: string | ReadonlyArray<string>;
-    echoYes?: string;
-    echoNo?: string;
+    echoYes?: string | undefined;
+    echoNo?: string | undefined;
   }
 
   type Autocompletion =
@@ -379,60 +379,60 @@ declare namespace Terminal {
     | ((inputString: string) => Promise<string | AutocompletionArray<string>>);
 
   interface CreateOptions {
-    stdin?: NodeJS.Process;
-    stdout?: NodeJS.Process;
-    stderr?: NodeJS.Process;
-    generic?: string;
+    stdin?: NodeJS.Process | undefined;
+    stdout?: NodeJS.Process | undefined;
+    stderr?: NodeJS.Process | undefined;
+    generic?: string | undefined;
     appId: string;
     appName: string;
-    isTTY?: boolean;
-    isSSH?: boolean;
+    isTTY?: boolean | undefined;
+    isSSH?: boolean | undefined;
     pid?: any;
-    preferProcessSigwinch?: boolean;
-    processSigwinch?: boolean;
+    preferProcessSigwinch?: boolean | undefined;
+    processSigwinch?: boolean | undefined;
   }
 
   class AutocompletionArray<T> extends Array<T> {
-    prefix?: string;
-    postfix?: string;
+    prefix?: string | undefined;
+    postfix?: string | undefined;
   }
 
   interface HookConfig {
-    style?: CTerminal;
-    hintStyle?: CTerminal;
-    tokenRegExp?: RegExp;
-    autoComplete?: string[] | Autocompletion;
-    autoCompleteMenu?: boolean | Autocompletion;
-    autoCompleteHint?: boolean;
+    style?: CTerminal | undefined;
+    hintStyle?: CTerminal | undefined;
+    tokenRegExp?: RegExp | undefined;
+    autoComplete?: string[] | Autocompletion | undefined;
+    autoCompleteMenu?: boolean | Autocompletion | undefined;
+    autoCompleteHint?: boolean | undefined;
   }
 
   interface InputFieldOptions {
-    echo?: boolean;
-    echoChar?: string | true;
-    default?: string;
-    cursorPosition?: number;
-    cancelable?: boolean;
-    style?: CTerminal;
-    hintStyle?: CTerminal;
-    maxLength?: number;
-    minLength?: number;
-    history?: string[];
-    autoComplete?: string[] | Autocompletion;
-    autoCompleteMenu?: boolean | Autocompletion;
-    autoCompleteHint?: boolean;
-    keyBindings?: { [key: string]: string };
-    tokenHook?: (
+    echo?: boolean | undefined;
+    echoChar?: string | true | undefined;
+    default?: string | undefined;
+    cursorPosition?: number | undefined;
+    cancelable?: boolean | undefined;
+    style?: CTerminal | undefined;
+    hintStyle?: CTerminal | undefined;
+    maxLength?: number | undefined;
+    minLength?: number | undefined;
+    history?: string[] | undefined;
+    autoComplete?: string[] | Autocompletion | undefined;
+    autoCompleteMenu?: boolean | Autocompletion | undefined;
+    autoCompleteHint?: boolean | undefined;
+    keyBindings?: { [key: string]: string } | undefined;
+    tokenHook?: ((
       token: string,
       isEndOfInput: boolean,
       previousTokens: ReadonlyArray<string>,
       term: Terminal,
       config: HookConfig
-    ) => string | CTerminal | null | void;
-    tokenResetHook?: (
+    ) => string | CTerminal | null | void) | undefined;
+    tokenResetHook?: ((
       term: Terminal,
       config?: HookConfig
-    ) => string | CTerminal;
-    tokenRegExp?: RegExp;
+    ) => string | CTerminal) | undefined;
+    tokenRegExp?: RegExp | undefined;
   }
 
   type IFileInputOptions = InputFieldOptions & { baseDir: string };
@@ -447,33 +447,33 @@ declare namespace Terminal {
   }
 
   interface SingleLineMenuOptions {
-    y?: number;
-    separator?: string;
-    nextPageHint?: string;
-    previousPageHint?: string;
-    style?: CTerminal;
-    selectedStyle?: CTerminal;
-    keyBindings?: { [key: string]: string };
-    cancelable?: boolean;
-    exitOnUnexpectedKey?: boolean;
+    y?: number | undefined;
+    separator?: string | undefined;
+    nextPageHint?: string | undefined;
+    previousPageHint?: string | undefined;
+    style?: CTerminal | undefined;
+    selectedStyle?: CTerminal | undefined;
+    keyBindings?: { [key: string]: string } | undefined;
+    cancelable?: boolean | undefined;
+    exitOnUnexpectedKey?: boolean | undefined;
   }
 
   interface SingleColumnMenuOptions {
-    y?: number;
-    style?: CTerminal;
-    selectedStyle?: CTerminal;
-    submittedStyle?: CTerminal;
-    leftPadding?: string;
-    selectedLeftPadding?: string;
-    submittedLeftPadding?: string;
-    extraLines?: number;
-    oneLineItem?: boolean;
-    itemMaxWidth?: number;
-    continueOnSubmit?: boolean;
-    selectedIndex?: number;
-    keyBindings?: { [key: string]: string };
-    cancelable?: boolean;
-    exitOnUnexpectedKey?: boolean;
+    y?: number | undefined;
+    style?: CTerminal | undefined;
+    selectedStyle?: CTerminal | undefined;
+    submittedStyle?: CTerminal | undefined;
+    leftPadding?: string | undefined;
+    selectedLeftPadding?: string | undefined;
+    submittedLeftPadding?: string | undefined;
+    extraLines?: number | undefined;
+    oneLineItem?: boolean | undefined;
+    itemMaxWidth?: number | undefined;
+    continueOnSubmit?: boolean | undefined;
+    selectedIndex?: number | undefined;
+    keyBindings?: { [key: string]: string } | undefined;
+    cancelable?: boolean | undefined;
+    exitOnUnexpectedKey?: boolean | undefined;
   }
 
   interface SingleColumnMenuResponse {
@@ -487,18 +487,18 @@ declare namespace Terminal {
   }
 
   interface GridMenuOptions {
-    y?: number;
-    x?: number;
-    width?: number;
-    style?: CTerminal;
-    selectedStyle?: CTerminal;
-    leftPadding?: string;
-    selectedLeftPadding?: string;
-    rightPadding?: string;
-    selectedRightPadding?: string;
-    itemMaxWidth?: number;
-    keyBindings?: { [key: string]: string };
-    exitOnUnexpectedKey?: boolean;
+    y?: number | undefined;
+    x?: number | undefined;
+    width?: number | undefined;
+    style?: CTerminal | undefined;
+    selectedStyle?: CTerminal | undefined;
+    leftPadding?: string | undefined;
+    selectedLeftPadding?: string | undefined;
+    rightPadding?: string | undefined;
+    selectedRightPadding?: string | undefined;
+    itemMaxWidth?: number | undefined;
+    keyBindings?: { [key: string]: string } | undefined;
+    exitOnUnexpectedKey?: boolean | undefined;
   }
 
   interface GridMenuResponse {
@@ -510,32 +510,32 @@ declare namespace Terminal {
   }
 
   interface ProgressBarOptions {
-    width?: number;
-    percent?: boolean;
-    eta?: boolean;
-    items?: number;
-    title?: string;
-    barStyle?: CTerminal;
-    barBracketStyle?: CTerminal;
-    percentStyle?: CTerminal;
-    etaStyle?: CTerminal;
-    itemStyle?: CTerminal;
-    titleStyle?: CTerminal;
-    itemSize?: number;
-    titleSize?: number;
-    barChar?: string;
-    barHeadChar?: string;
-    maxRefreshTime?: number;
-    minRefreshTime?: number;
-    inline?: boolean;
-    syncMode?: boolean;
+    width?: number | undefined;
+    percent?: boolean | undefined;
+    eta?: boolean | undefined;
+    items?: number | undefined;
+    title?: string | undefined;
+    barStyle?: CTerminal | undefined;
+    barBracketStyle?: CTerminal | undefined;
+    percentStyle?: CTerminal | undefined;
+    etaStyle?: CTerminal | undefined;
+    itemStyle?: CTerminal | undefined;
+    titleStyle?: CTerminal | undefined;
+    itemSize?: number | undefined;
+    titleSize?: number | undefined;
+    barChar?: string | undefined;
+    barHeadChar?: string | undefined;
+    maxRefreshTime?: number | undefined;
+    minRefreshTime?: number | undefined;
+    inline?: boolean | undefined;
+    syncMode?: boolean | undefined;
   }
 
   interface ProgressBarController {
     update: (
       updateObject:
         | number
-        | { progress: number | null; items?: number; title?: string }
+        | { progress: number | null; items?: number | undefined; title?: string | undefined }
     ) => void;
     startItem: (name: string) => void;
     itemDone: (name: string) => void;

--- a/types/terminal-kit/TextBuffer.d.ts
+++ b/types/terminal-kit/TextBuffer.d.ts
@@ -82,13 +82,13 @@ export = TextBuffer;
 declare namespace TextBuffer {
   interface Options {
     dst: ScreenBuffer;
-    width?: number;
-    height?: number;
-    x?: number;
-    y?: number;
-    tabWidth?: number;
-    forceInBound?: number;
-    hidden?: boolean;
-    wrap?: boolean;
+    width?: number | undefined;
+    height?: number | undefined;
+    x?: number | undefined;
+    y?: number | undefined;
+    tabWidth?: number | undefined;
+    forceInBound?: number | undefined;
+    hidden?: boolean | undefined;
+    wrap?: boolean | undefined;
   }
 }

--- a/types/terminal-menu/index.d.ts
+++ b/types/terminal-menu/index.d.ts
@@ -54,31 +54,31 @@ declare module "terminal-menu" {
              * Menu width in columns.
              * Default = 50.
              */
-            width?: number;
+            width?: number | undefined;
 
             /**
              * Horizontal offset for top-left corner.
              * Default = 1
              */
-            x?: number;
+            x?: number | undefined;
 
             /**
              * Vertical offset for top-left corner.
              * Default = 1
              */
-            y?: number;
+            y?: number | undefined;
 
             /**
              * Foreground color for the menu.
              * Default = 'white'
              */
-            fg?: string;
+            fg?: string | undefined;
 
             /**
              * Background color for the menu.
              * Default = 'blue'
              */
-            bg?: string;
+            bg?: string | undefined;
 
             /**
              * Padding for the bounding rectangle.
@@ -91,13 +91,13 @@ declare module "terminal-menu" {
              *      bottom: 1
              * }
              */
-            padding?: number | Thickness;
+            padding?: number | Thickness | undefined;
 
             /**
              * Index of the menu item to be selected.
              * Default = 0
              */
-            selected?: number
+            selected?: number | undefined
         }
 
         /**

--- a/types/tern/lib/infer/index.d.ts
+++ b/types/tern/lib/infer/index.d.ts
@@ -8,7 +8,7 @@ interface ContextConstructor {
 }
 export const Context: ContextConstructor;
 export interface Context {
-    parent?: Server;
+    parent?: Server | undefined;
     topScope: Scope;
     /** The primitive number type. */
     num: Prim & { name: "number" };
@@ -84,9 +84,9 @@ interface FnConstructor {
 /** Constructor for the type that implements functions. Inherits from `Obj`. The `AVal` types are used to track the input and output types of the function. */
 export const Fn: FnConstructor;
 export interface Fn extends Obj {
-    readonly args?: AVal[];
-    readonly argNames?: string[];
-    self?: Type;
+    readonly args?: AVal[] | undefined;
+    readonly argNames?: string[] | undefined;
+    self?: Type | undefined;
     readonly retval: AVal;
     /**
      * Asks the AVal if it contains a function type. Useful when
@@ -136,7 +136,7 @@ export interface IType extends ANull {
      * and even for those it may be missing (if the type was created by a type definition file,
      * or synthesized in some other way).
      */
-    originNode?: ESTree.Node;
+    originNode?: ESTree.Node | undefined;
     /** Return a string that describes the type. maxDepth indicates the depth to which inner types should be shown. */
     toString(maxDepth: number): string;
     /** Queries whether the AVal _currently_ holds the given type. */
@@ -211,13 +211,13 @@ export interface AVal extends ANull {
      * property pointing to an AST node.
      */
     gatherProperties(f: (...args: any[]) => void, depth: number): void;
-    originNode?: ESTree.Node;
+    originNode?: ESTree.Node | undefined;
     /** An object mapping the object’s known properties to AVals. Don’t manipulate this directly (ever), only use it if you have to iterate over the properties. */
     props: Partial<Readonly<{
         [key: string]: AVal;
     }>>;
     readonly types: Type[];
-    readonly propertyOf?: Obj;
+    readonly propertyOf?: Obj | undefined;
 }
 
 /**

--- a/types/tern/lib/tern/index.d.ts
+++ b/types/tern/lib/tern/index.d.ts
@@ -8,18 +8,18 @@ export type ConstructorOptions = CtorOptions & (SyncConstructorOptions | ASyncCo
 
 export interface CtorOptions {
     /** The definition objects to load into the server’s environment. */
-    defs?: Def[];
+    defs?: Def[] | undefined;
     /** The ECMAScript version to parse. Should be either 5 or 6. Default is 6. */
-    ecmaVersion?: 5 | 6;
+    ecmaVersion?: 5 | 6 | undefined;
     /** Indicates the maximum amount of milliseconds to wait for an asynchronous getFile before giving up on it. Defaults to 1000. */
-    fetchTimeout?: number;
+    fetchTimeout?: number | undefined;
     /** Specifies the set of plugins that the server should load. The property names of the object name the plugins, and their values hold options that will be passed to them. */
-    plugins?: { [key: string]: object };
+    plugins?: { [key: string]: object } | undefined;
 }
 
 export interface SyncConstructorOptions {
     /** Indicates whether `getFile` is asynchronous. Default is `false`. */
-    async?: false;
+    async?: false | undefined;
     /**
      * Provides a way for the server to try and fetch the content of files.
      * Depending on the `async` option, this is either a function that takes a filename and returns a string (when not `async`), or
@@ -95,7 +95,7 @@ export interface Server {
      * When the server hasn’t been configured to be asynchronous, the callback will be called before request returns.
      */
     request<Q extends Query, D extends Document>(
-        doc: D & { query?: Q },
+        doc: D & { query?: Q | undefined },
         callback: (
             error: string | null,
             response: (D extends { query: undefined } ? {} : D extends { query: Query } ? QueryResult<Q> : {}) | undefined
@@ -151,9 +151,9 @@ export interface Def {
 }
 
 export interface Document {
-    query?: Query;
-    files?: File[];
-    timeout?: number;
+    query?: Query | undefined;
+    files?: File[] | undefined;
+    timeout?: number | undefined;
 }
 
 export interface File {
@@ -161,14 +161,14 @@ export interface File {
     text: string;
     scope: Scope;
     ast: ESTree.Program;
-    type?: "full" | "part" | "delete";
+    type?: "full" | "part" | "delete" | undefined;
     asLineChar?(nodePosition: number): Position;
 }
 
 export interface BaseQuery {
     type: string;
-    lineCharPositions?: boolean;
-    docFormat?: "full";
+    lineCharPositions?: boolean | undefined;
+    docFormat?: "full" | undefined;
 }
 
 export interface BaseQueryWithFile extends BaseQuery {
@@ -188,34 +188,34 @@ export interface CompletionsQuery extends BaseQueryWithFile {
     /** Specify the location to complete at. */
     end: number | Position;
     /** Whether to include the types of the completions in the result data. Default `false` */
-    types?: boolean;
+    types?: boolean | undefined;
     /** Whether to include the distance (in scopes for variables, in prototypes for properties) between the completions and the origin position in the result data. Default `false` */
-    depths?: boolean;
+    depths?: boolean | undefined;
     /** Whether to include documentation strings in the result data. Default `false` */
-    docs?: boolean;
+    docs?: boolean | undefined;
     /** Whether to include urls in the result data. Default `false` */
-    urls?: boolean;
+    urls?: boolean | undefined;
     /** Whether to include origin files (if found) in the result data. Default `false` */
-    origins?: boolean;
+    origins?: boolean | undefined;
     /** When on, only completions that match the current word at the given point will be returned. Turn this off to get all results, so that you can filter on the client side. Default `true` */
-    filter?: boolean;
+    filter?: boolean | undefined;
     /** Whether to use a case-insensitive compare between the current word and potential completions. Default `false` */
-    caseInsensitive?: boolean;
+    caseInsensitive?: boolean | undefined;
     /** When completing a property and no completions are found, Tern will use some heuristics to try and return some properties anyway. Set this to `false` to turn that off. Default `true` */
-    guess?: boolean;
+    guess?: boolean | undefined;
     /** Determines whether the result set will be sorted. Default `true` */
-    sort?: boolean;
+    sort?: boolean | undefined;
     /**
      * When disabled, only the text before the given position is considered part of the word. When enabled (the default),
      * the whole variable name that the cursor is on will be included. Default `true`
      */
-    expandWordForward?: boolean;
+    expandWordForward?: boolean | undefined;
     /** Whether to ignore the properties of `Object.prototype` unless they have been spelled out by at least two characters. Default `true` */
-    omitObjectPrototype?: boolean;
+    omitObjectPrototype?: boolean | undefined;
     /** Whether to include JavaScript keywords when completing something that is not a property. Default `false` */
-    includeKeywords?: boolean;
+    includeKeywords?: boolean | undefined;
     /** If completions should be returned when inside a literal. Default `true` */
-    inLiteral?: boolean;
+    inLiteral?: boolean | undefined;
 }
 
 export interface CompletionsQueryResult {
@@ -234,11 +234,11 @@ export interface CompletionsQueryResult {
      */
     completions: string[] | Array<{
         name: string,
-        type?: string,
-        depth?: number,
-        doc?: string,
-        url?: string,
-        origin?: string
+        type?: string | undefined,
+        depth?: number | undefined,
+        doc?: string | undefined,
+        url?: string | undefined,
+        origin?: string | undefined
     }>;
 }
 
@@ -249,20 +249,20 @@ export interface TypeQuery extends BaseQueryWithFile {
     /** Specify the location of the expression. */
     end: number | Position;
     /** Specify the location of the expression. */
-    start?: number | Position;
+    start?: number | Position | undefined;
     /**
      * Set to `true` when you are interested in a function type.
      * This will cause function types to win when something has multiple types.
      * Default `false`
      */
-    preferFunction?: boolean;
+    preferFunction?: boolean | undefined;
     /**
      * Determines how deep the type string must be expanded.
      * Nested objects will only display property types up to this depth,
      * and be represented by their type name or a representation showing
      * only property names below it. Default `0`
      */
-    depth?: number;
+    depth?: number | undefined;
 }
 
 export interface TypeQueryResult {
@@ -271,15 +271,15 @@ export interface TypeQueryResult {
     /** Whether the given type was guessed, or should be considered reliable. */
     guess: boolean;
     /** The name associated with the type. */
-    name?: string;
+    name?: string | undefined;
     /** When the inspected expression was an identifier or a property access, this will hold the name of the variable or property. */
-    exprName?: string;
+    exprName?: string | undefined;
     /** If the type had documentation associated with it, these will also be returned. */
-    doc?: string;
+    doc?: string | undefined;
     /** If the type had urls associated with it, these will also be returned. */
-    url?: string;
+    url?: string | undefined;
     /** If the type had origin information associated with it, these will also be returned. */
-    origin?: string;
+    origin?: string | undefined;
 }
 
 /**
@@ -303,26 +303,26 @@ export interface DefinitionQuery extends BaseQueryWithFile {
     /** Specify the location of the expression. */
     end: number | Position;
     /** Specify the location of the expression. */
-    start?: number | Position;
+    start?: number | Position | undefined;
 }
 
 export interface DefinitionQueryResult {
     /** The start position of the expression. */
-    start?: number | Position;
+    start?: number | Position | undefined;
     /** The end position of the expression. */
-    end?: number | Position;
+    end?: number | Position | undefined;
     /** The file in which the definition was defined. */
-    file?: string;
+    file?: string | undefined;
     /** A slice of the code in front of the definition Can be used to find a definition’s location in a modified file. */
-    context?: string;
+    context?: string | undefined;
     /** The offset from the start of the context to the actual definition. Can be used to find a definition’s location in a modified file. */
-    contextOffset?: number;
+    contextOffset?: number | undefined;
     /** If the definition had documentation associated with it, these will also be returned. */
-    doc?: string;
+    doc?: string | undefined;
     /** If the definition had urls associated with it, these will also be returned. */
-    url?: string;
+    url?: string | undefined;
     /** If the definition had origin information associated with it, these will also be returned. */
-    origin?: string;
+    origin?: string | undefined;
 }
 
 /** Get the documentation string and URL for a given expression, if any. */
@@ -332,16 +332,16 @@ export interface DocumentationQuery extends BaseQueryWithFile {
     /** Specify the location of the expression. */
     end: number | Position;
     /** Specify the location of the expression. */
-    start?: number | Position;
+    start?: number | Position | undefined;
 }
 
 export interface DocumentationQueryResult {
     /** The documentation string of the definition or value, if any. */
-    doc?: string;
+    doc?: string | undefined;
     /** The url of the definition or value, if any. */
-    url?: string;
+    url?: string | undefined;
     /** The origin of the definition or value, if any. */
-    origin?: string;
+    origin?: string | undefined;
 }
 
 /** Used to find all references to a given variable or property. */
@@ -351,7 +351,7 @@ export interface RefsQuery extends BaseQueryWithFile {
     /** Specify the location of the expression. */
     end: number | Position;
     /** Specify the location of the expression. */
-    start?: number | Position;
+    start?: number | Position | undefined;
 }
 
 export interface RefsQueryResult {
@@ -363,7 +363,7 @@ export interface RefsQueryResult {
         end: number | Position
     }>;
     /** for variables: a type property holding either "global" or "local". */
-    type?: "global" | "local";
+    type?: "global" | "local" | undefined;
 }
 
 /** Rename a variable in a scope-aware way. */
@@ -373,7 +373,7 @@ export interface RenameQuery extends BaseQueryWithFile {
     /** Specify the location of the variable. */
     end: number | Position;
     /** Specify the location of the variable. */
-    start?: number | Position;
+    start?: number | Position | undefined;
     /** The new name of the variable */
     newName: string;
 }
@@ -397,9 +397,9 @@ export interface PropertiesQuery extends BaseQuery {
     /** Get a list of all known object property names (for any object). */
     type: "properties";
     /** Causes the server to only return properties that start with the given string. */
-    prefix?: string;
+    prefix?: string | undefined;
     /** Whether the result should be sorted. Default `true` */
-    sort?: boolean;
+    sort?: boolean | undefined;
 }
 
 export interface PropertiesQueryResult {
@@ -411,8 +411,8 @@ export interface PropertiesQueryResult {
 export interface FilesQuery extends BaseQuery {
     /** Get the files that the server currently holds in its set of analyzed files. */
     type: "files";
-    docFormat?: never;
-    lineCharPositions?: never;
+    docFormat?: never | undefined;
+    lineCharPositions?: never | undefined;
 }
 
 export interface FilesQueryResult {
@@ -467,7 +467,7 @@ export function registerPlugin(name: string, init: (server: Server, options?: Co
 
 export interface Desc<T extends Query["type"]> {
     run(Server: Server, query: QueryRegistry[T]["query"], file?: File): QueryRegistry[T]["result"];
-    takesFile?: boolean;
+    takesFile?: boolean | undefined;
 }
 
 /**

--- a/types/terra-action-footer/lib/ActionFooter.d.ts
+++ b/types/terra-action-footer/lib/ActionFooter.d.ts
@@ -6,11 +6,11 @@ export interface ActionFooterProps extends BlockActionFooterProps {
   /**
    * Actions to be displayed in the start socket
    */
-  start?: React.ReactNode;
+  start?: React.ReactNode | undefined;
   /**
    * Actions to be displayed in the end socket
    */
-  end?: React.ReactNode;
+  end?: React.ReactNode | undefined;
 }
 
 declare const ActionFooter: React.FC<ActionFooterProps>;

--- a/types/terra-action-footer/lib/CenteredActionFooter.d.ts
+++ b/types/terra-action-footer/lib/CenteredActionFooter.d.ts
@@ -6,7 +6,7 @@ export interface CenteredActionFooterProps extends BlockActionFooterProps {
   /**
    * Actions to be displayed in the center socket
    */
-  center?: React.ReactNode;
+  center?: React.ReactNode | undefined;
 }
 
 declare const CenteredActionFooter: React.FC<CenteredActionFooterProps>;

--- a/types/terra-action-header/lib/ActionHeader.d.ts
+++ b/types/terra-action-header/lib/ActionHeader.d.ts
@@ -5,16 +5,16 @@ export interface ActionHeaderProps extends React.HTMLAttributes<HTMLDivElement> 
    * Optionally sets the heading level. One of `1`, `2`, `3`, `4`, `5`, `6`. Default `level=1`. This helps screen readers to announce appropriate heading levels.
    * Changing 'level' will not visually change the style of the content.
    */
-  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  level?: 1 | 2 | 3 | 4 | 5 | 6 | undefined;
   /**
    * Callback function for when the close button is clicked.
    * On small viewports, this will be triggered by a back button if onBack is not set.
    */
-  onClose?: React.MouseEventHandler<HTMLButtonElement>;
+  onClose?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   /**
    * Callback function for when the back button is clicked. The back button will not display if this is not set.
    */
-  onBack?: React.MouseEventHandler<HTMLButtonElement>;
+  onBack?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   /**
    * Callback function for when the expand button is clicked.
    * The expand button will not display if this is not set or on small viewports.
@@ -23,7 +23,7 @@ export interface ActionHeaderProps extends React.HTMLAttributes<HTMLDivElement> 
    * *Note: If `onBack` is set, the maximize button will not appear and a custom maximize button must be provided
    * as a child inside a `Collapsible Menu View`.*
    */
-  onMaximize?: React.MouseEventHandler<HTMLButtonElement>;
+  onMaximize?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   /**
    * Callback function for when the minimize button is clicked.
    * The minimize button will not display if this is not set or on small viewports.
@@ -32,19 +32,19 @@ export interface ActionHeaderProps extends React.HTMLAttributes<HTMLDivElement> 
    * *Note: If `onBack` is set, the minimize button will not appear and a custom minimize button must be provided
    * as a child inside a `Collapsible Menu View`.*
    */
-  onMinimize?: React.MouseEventHandler<HTMLButtonElement>;
+  onMinimize?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   /**
    * Callback function for when the next button is clicked. The previous-next button group will display if either this or onPrevious is set but the button for the one not set will be disabled.
    */
-  onNext?: React.MouseEventHandler<HTMLButtonElement>;
+  onNext?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   /**
    * Callback function for when the previous button is clicked. The previous-next button group will display if either this or onNext is set but the button for the one not set will be disabled.
    */
-  onPrevious?: React.MouseEventHandler<HTMLButtonElement>;
+  onPrevious?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   /**
    * Text to be displayed as the title in the header bar.
    */
-  title?: string;
+  title?: string | undefined;
 }
 
 declare const ActionHeader: React.FC<ActionHeaderProps>;

--- a/types/terra-button/lib/Button.d.ts
+++ b/types/terra-button/lib/Button.d.ts
@@ -33,59 +33,59 @@ export interface ButtonProps<T extends HTMLButtonElement | HTMLAnchorElement> ex
   /**
    * Sets the href. When set will render the component as an anchor tag.
    */
-  href?: string;
+  href?: string | undefined;
   /**
    * An optional icon. Nested inline with the text when provided.
    */
-  icon?: React.ReactElement;
+  icon?: React.ReactElement | undefined;
   /**
    * Whether or not the button should only display as an icon.
    */
-  isIconOnly?: boolean;
+  isIconOnly?: boolean | undefined;
   /**
    * Whether or not the button should display as a block.
    */
-  isBlock?: boolean;
+  isBlock?: boolean | undefined;
   /**
    * Whether or not the button has reduced padding
    */
-  isCompact?: boolean;
+  isCompact?: boolean | undefined;
   /**
    * Whether or not the button should be disabled.
    */
-  isDisabled?: boolean;
+  isDisabled?: boolean | undefined;
   /**
    * Reverses the position of the icon and text.
    */
-  isReversed?: boolean;
+  isReversed?: boolean | undefined;
   /**
    * Callback function triggered when mouse is pressed.
    */
-  onMouseDown?: React.MouseEventHandler<T>;
+  onMouseDown?: React.MouseEventHandler<T> | undefined;
   /**
    * Callback function triggered when clicked.
    */
-  onClick?: React.MouseEventHandler<T>;
+  onClick?: React.MouseEventHandler<T> | undefined;
   /**
    * Callback function triggered when button loses focus.
    */
-  onBlur?: React.FocusEventHandler<T>;
+  onBlur?: React.FocusEventHandler<T> | undefined;
   /**
    * Callback function triggered when button gains focus.
    */
-  onFocus?: React.FocusEventHandler<T>;
+  onFocus?: React.FocusEventHandler<T> | undefined;
   /**
    * Callback function triggered when key is pressed.
    */
-  onKeyDown?: React.KeyboardEventHandler<T>;
+  onKeyDown?: React.KeyboardEventHandler<T> | undefined;
   /**
    * Callback function triggered when key is released.
    */
-  onKeyUp?: React.KeyboardEventHandler<T>;
+  onKeyUp?: React.KeyboardEventHandler<T> | undefined;
   /**
    * Callback ref to pass into the dom element.
    */
-  refCallback?: React.Ref<T>;
+  refCallback?: React.Ref<T> | undefined;
   /**
    * Sets the button text.
    * If the button is `isIconOnly` or variant `utility` this text is set as the aria-label and title for accessibility.
@@ -95,15 +95,15 @@ export interface ButtonProps<T extends HTMLButtonElement | HTMLAnchorElement> ex
    * Additional information to display as a native tooltip on hover.
    * Buttons declared as `isIconOnly` or `utility` will fallback to using `text` if not provided.
    */
-  title?: string;
+  title?: string | undefined;
   /**
    * Sets the button type. One of `button`; `submit`; or `reset`.
    */
-  type?: ButtonTypes;
+  type?: ButtonTypes | undefined;
   /**
    * Sets the button variant. One of `neutral`;  `emphasis`; `ghost`; `de-emphasis`; `action` or `utility`.
    */
-  variant?: ButtonVariants;
+  variant?: ButtonVariants | undefined;
 }
 
 export default class Button<T extends HTMLAnchorElement | HTMLButtonElement> extends React.Component<ButtonProps<T>> {

--- a/types/terra-content-container/lib/ContentContainer.d.ts
+++ b/types/terra-content-container/lib/ContentContainer.d.ts
@@ -4,19 +4,19 @@ export interface ContentContainerProps extends React.HTMLAttributes<HTMLDivEleme
   /**
    * The header element to be placed within the header area of the container.
    */
-  header?: React.ReactNode;
+  header?: React.ReactNode | undefined;
   /**
    * The footer element to be placed within the footer area of the container.
    */
-  footer?: React.ReactNode;
+  footer?: React.ReactNode | undefined;
   /**
    * Whether or not the container should expanded to fill its parent element.
    */
-  fill?: boolean;
+  fill?: boolean | undefined;
   /**
    * Ref callback for the scrollable area of the content container.
    */
-  scrollRefCallback?: React.Ref<HTMLDivElement>;
+  scrollRefCallback?: React.Ref<HTMLDivElement> | undefined;
 }
 
 declare const ContentContainer: React.FC<ContentContainerProps>;

--- a/types/terra-spacer/lib/Spacer.d.ts
+++ b/types/terra-spacer/lib/Spacer.d.ts
@@ -22,48 +22,48 @@ export interface SpacerProps extends React.HTMLAttributes<HTMLDivElement> {
    * Sets margin in a syntax similar to the standard CSS spec https://developer.mozilla.org/en-US/docs/Web/CSS/margin.
    * One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  margin?: SpacerShorthand;
+  margin?: SpacerShorthand | undefined;
   /**
    * Sets top margin. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  marginTop?: SpacerSizes[keyof SpacerSizes];
+  marginTop?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets bottom margin. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  marginBottom?: SpacerSizes[keyof SpacerSizes];
+  marginBottom?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets left margin One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  marginLeft?: SpacerSizes[keyof SpacerSizes];
+  marginLeft?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets right margin. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  marginRight?: SpacerSizes[keyof SpacerSizes];
+  marginRight?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets padding in a syntax similar to the standard CSS spec https://developer.mozilla.org/en-US/docs/Web/CSS/padding.
    * One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  padding?: SpacerShorthand;
+  padding?: SpacerShorthand | undefined;
   /**
    * Sets top padding. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  paddingTop?: SpacerSizes[keyof SpacerSizes];
+  paddingTop?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets bottom padding. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  paddingBottom?: SpacerSizes[keyof SpacerSizes];
+  paddingBottom?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets left padding. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  paddingLeft?: SpacerSizes[keyof SpacerSizes];
+  paddingLeft?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets right padding. One of 'none', 'small-2', 'small-1', 'small', 'medium', 'large', 'large+1', 'large+2', 'large+3', 'large+4'.
    */
-  paddingRight?: SpacerSizes[keyof SpacerSizes];
+  paddingRight?: SpacerSizes[keyof SpacerSizes] | undefined;
   /**
    * Sets the display to be inline-block.
    */
-  isInlineBlock?: boolean;
+  isInlineBlock?: boolean | undefined;
 }
 
 declare const Spacer: React.FC<SpacerProps> & { Opts: { Sizes: SpacerSizes } };

--- a/types/terra-theme-context/lib/ThemeContext.d.ts
+++ b/types/terra-theme-context/lib/ThemeContext.d.ts
@@ -10,7 +10,7 @@ declare const ThemeProviderContext: React.Context<{
    * The current application theme className.
    * The default theme is indicated as undefined.
    */
-  className?: string;
+  className?: string | undefined;
 }>;
 
 export default ThemeProviderContext;

--- a/types/terra-theme-context/lib/ThemeContextProvider.d.ts
+++ b/types/terra-theme-context/lib/ThemeContextProvider.d.ts
@@ -9,9 +9,9 @@ export interface ThemeContextProviderProps {
    * An object containing the name and className of the selected theme.
    */
   theme?: {
-    name?: string;
-    className?: string;
-  };
+    name?: string | undefined;
+    className?: string | undefined;
+  } | undefined;
 }
 
 declare const ThemeContextProvider: React.FC<ThemeContextProviderProps>;

--- a/types/terser-webpack-plugin/index.d.ts
+++ b/types/terser-webpack-plugin/index.d.ts
@@ -27,8 +27,8 @@ declare namespace TerserPlugin {
 
     interface ExtractCommentOptions {
         condition: string | RegExp | ExtractCommentFn;
-        filename?: string | FilenameFn;
-        banner?: boolean | string | FormatFn;
+        filename?: string | FilenameFn | undefined;
+        banner?: boolean | string | FormatFn | undefined;
     }
 
     type ExtractCommentFn = (astNode: any, comment: any) => boolean | object;
@@ -42,38 +42,38 @@ declare namespace TerserPlugin {
          * Test to match files against.
          * @default /\.m?js(\?.*)?$/i
          */
-        test?: string | RegExp | Array<string | RegExp>;
+        test?: string | RegExp | Array<string | RegExp> | undefined;
 
         /**
          * Files to include.
          * @default undefined
          */
-        include?: string | RegExp | Array<string | RegExp>;
+        include?: string | RegExp | Array<string | RegExp> | undefined;
 
         /**
          * Files to exclude.
          * @default undefined
          */
-        exclude?: string | RegExp | Array<string | RegExp>;
+        exclude?: string | RegExp | Array<string | RegExp> | undefined;
 
         /**
          * Enable/disable multi-process parallel running.
          * Use multi-process parallel running to improve the build speed. Default number of concurrent runs: os.cpus().length - 1.
          * @default true
          */
-        parallel?: boolean | number;
+        parallel?: boolean | number | undefined;
 
         /**
          * Allows you to override default minify function.
          * By default plugin uses terser package. Useful for using and testing unpublished versions or forks
          * @default undefined
          */
-        minify?: (file: any, sourceMap: any, minimizerOptions?: MinifyOptions) => MinifyResult;
+        minify?: ((file: any, sourceMap: any, minimizerOptions?: MinifyOptions) => MinifyResult) | undefined;
 
         /**
          * Terser minify {@link https://github.com/terser/terser#minify-options|options}.
          */
-        terserOptions?: MinifyOptions;
+        terserOptions?: MinifyOptions | undefined;
 
         /**
          * Whether comments shall be extracted to a separate file, (see details).
@@ -83,7 +83,7 @@ declare namespace TerserPlugin {
          * i.e. it is possible to preserve some comments (e.g. annotations) while extracting others or even preserving comments that have been extracted
          * @default true
          */
-        extractComments?: boolean | string | RegExp | ExtractCommentFn | ExtractCommentOptions;
+        extractComments?: boolean | string | RegExp | ExtractCommentFn | ExtractCommentOptions | undefined;
     }
 }
 

--- a/types/terser-webpack-plugin/v2/index.d.ts
+++ b/types/terser-webpack-plugin/v2/index.d.ts
@@ -25,8 +25,8 @@ declare namespace TerserPlugin {
 
     interface ExtractCommentOptions {
         condition: boolean | string | RegExp | ExtractCommentFn | object;
-        filename?: string | FormatFn;
-        banner?: boolean | string | FormatFn;
+        filename?: string | FormatFn | undefined;
+        banner?: boolean | string | FormatFn | undefined;
     }
 
     type ExtractCommentFn = (node: any, comment: any) => (boolean | object);
@@ -34,21 +34,21 @@ declare namespace TerserPlugin {
     type FormatFn = (input: string) => string;
 
     interface TerserPluginOptions {
-        test?: string | RegExp | Array<string | RegExp>;
-        include?: string | RegExp | Array<string | RegExp>;
-        exclude?: string | RegExp | Array<string | RegExp>;
-        chunkFilter?: (chunk: webpack.compilation.Chunk) => boolean;
-        cache?: boolean | string;
-        cacheKeys?: (defaultCacheKeys: any, file: any) => object;
-        parallel?: boolean | number;
-        sourceMap?: boolean;
-        minify?: (file: any, sourceMap: any) => MinifyResult;
-        terserOptions?: MinifyOptions;
+        test?: string | RegExp | Array<string | RegExp> | undefined;
+        include?: string | RegExp | Array<string | RegExp> | undefined;
+        exclude?: string | RegExp | Array<string | RegExp> | undefined;
+        chunkFilter?: ((chunk: webpack.compilation.Chunk) => boolean) | undefined;
+        cache?: boolean | string | undefined;
+        cacheKeys?: ((defaultCacheKeys: any, file: any) => object) | undefined;
+        parallel?: boolean | number | undefined;
+        sourceMap?: boolean | undefined;
+        minify?: ((file: any, sourceMap: any) => MinifyResult) | undefined;
+        terserOptions?: MinifyOptions | undefined;
         extractComments?: boolean
         | string
         | RegExp
         | ExtractCommentFn
-        | ExtractCommentOptions;
-        warningsFilter?: (warning: string, source: string | undefined, file: string) => boolean;
+        | ExtractCommentOptions | undefined;
+        warningsFilter?: ((warning: string, source: string | undefined, file: string) => boolean) | undefined;
     }
 }

--- a/types/terser-webpack-plugin/v4/index.d.ts
+++ b/types/terser-webpack-plugin/v4/index.d.ts
@@ -26,8 +26,8 @@ declare namespace TerserPlugin {
 
     interface ExtractCommentOptions {
         condition: string | RegExp | ExtractCommentFn;
-        filename?: string | FilenameFn;
-        banner?: boolean | string | FormatFn;
+        filename?: string | FilenameFn | undefined;
+        banner?: boolean | string | FormatFn | undefined;
     }
 
     type ExtractCommentFn = (astNode: any, comment: any) => boolean | object;
@@ -41,19 +41,19 @@ declare namespace TerserPlugin {
          * Test to match files against.
          * @default /\.m?js(\?.*)?$/i
          */
-        test?: string | RegExp | Array<string | RegExp>;
+        test?: string | RegExp | Array<string | RegExp> | undefined;
 
         /**
          * Files to include.
          * @default undefined
          */
-        include?: string | RegExp | Array<string | RegExp>;
+        include?: string | RegExp | Array<string | RegExp> | undefined;
 
         /**
          * Files to exclude.
          * @default undefined
          */
-        exclude?: string | RegExp | Array<string | RegExp>;
+        exclude?: string | RegExp | Array<string | RegExp> | undefined;
 
         /**
          * ⚠ Ignored in webpack 5! Please use {@link webpack.js.org/configuration/other-options/#cache.}
@@ -61,39 +61,39 @@ declare namespace TerserPlugin {
          * Default path to cache directory: `node_modules/.cache/terser-webpack-plugin`.
          * @default true
          */
-        cache?: boolean | string;
+        cache?: boolean | string | undefined;
 
         /**
          * ⚠ Ignored in webpack 5! Please use {@link webpack.js.org/configuration/other-options/#cache}.
          * Allows you to override default cache keys.
          */
-        cacheKeys?: (defaultCacheKeys: any, file: any) => object;
+        cacheKeys?: ((defaultCacheKeys: any, file: any) => object) | undefined;
 
         /**
          * Enable/disable multi-process parallel running.
          * Use multi-process parallel running to improve the build speed. Default number of concurrent runs: os.cpus().length - 1.
          * @default true
          */
-        parallel?: boolean | number;
+        parallel?: boolean | number | undefined;
 
         /**
          * Use source maps to map error message locations to modules (this slows down the compilation).
          * If you use your own minify function please read the minify section for handling source maps correctly.
          * @default false
          */
-        sourceMap?: boolean;
+        sourceMap?: boolean | undefined;
 
         /**
          * Allows you to override default minify function.
          * By default plugin uses terser package. Useful for using and testing unpublished versions or forks
          * @default undefined
          */
-        minify?: (file: any, sourceMap: any, minimizerOptions?: MinifyOptions) => MinifyResult;
+        minify?: ((file: any, sourceMap: any, minimizerOptions?: MinifyOptions) => MinifyResult) | undefined;
 
         /**
          * Terser minify {@link https://github.com/terser/terser#minify-options|options}.
          */
-        terserOptions?: MinifyOptions;
+        terserOptions?: MinifyOptions | undefined;
 
         /**
          * Whether comments shall be extracted to a separate file, (see details).
@@ -103,7 +103,7 @@ declare namespace TerserPlugin {
          * i.e. it is possible to preserve some comments (e.g. annotations) while extracting others or even preserving comments that have been extracted
          * @default true
          */
-        extractComments?: boolean | string | RegExp | ExtractCommentFn | ExtractCommentOptions;
+        extractComments?: boolean | string | RegExp | ExtractCommentFn | ExtractCommentOptions | undefined;
     }
 }
 

--- a/types/teslajs/index.d.ts
+++ b/types/teslajs/index.d.ts
@@ -18,7 +18,7 @@ export type nodeBack = (error: Error, data: any) => any;
 export interface optionsType {
     authToken: string;
     vehicleID: string;
-    carIndex?: number;
+    carIndex?: number | undefined;
 }
 export interface Result {
     reason: string;

--- a/types/test-console/index.d.ts
+++ b/types/test-console/index.d.ts
@@ -14,7 +14,7 @@ export type NoOutputCallback = () => void;
 export type Restore = () => void;
 
 export interface Options {
-    isTTY?: boolean;
+    isTTY?: boolean | undefined;
 }
 
 export interface Inspector {

--- a/types/testing-library__cypress/index.d.ts
+++ b/types/testing-library__cypress/index.d.ts
@@ -19,8 +19,8 @@ import {
 } from '@testing-library/dom';
 
 export interface CTLMatcherOptions {
-    timeout?: number;
-    container?: HTMLElement | JQuery;
+    timeout?: number | undefined;
+    container?: HTMLElement | JQuery | undefined;
 }
 
 export type MatcherOptions = DTLMatcherOptions | CTLMatcherOptions;

--- a/types/testingbot-api/index.d.ts
+++ b/types/testingbot-api/index.d.ts
@@ -8,30 +8,30 @@ declare namespace TestingBot {
     type TestSuccess = true | false | 0 | 1;
 
     interface TestingBotOptions {
-        api_key?: string;
-        api_secret?: string;
+        api_key?: string | undefined;
+        api_secret?: string | undefined;
     }
 
     interface UserInfo {
-        first_name?: string;
-        last_name?: string;
-        email?: string;
+        first_name?: string | undefined;
+        last_name?: string | undefined;
+        email?: string | undefined;
     }
 
     interface TestData {
-        'test[success]'?: TestSuccess;
-        'test[status_message]'?: string;
-        'test[name]'?: string;
-        'test[extra]'?: string;
-        build?: string;
-        groups?: string;
+        'test[success]'?: TestSuccess | undefined;
+        'test[status_message]'?: string | undefined;
+        'test[name]'?: string | undefined;
+        'test[extra]'?: string | undefined;
+        build?: string | undefined;
+        groups?: string | undefined;
     }
 
     interface TestLabData {
-        'test[url]'?: string;
-        'test[name]'?: string;
-        'test[cron]'?: string;
-        'test[enabled]'?: boolean;
+        'test[url]'?: string | undefined;
+        'test[name]'?: string | undefined;
+        'test[cron]'?: string | undefined;
+        'test[enabled]'?: boolean | undefined;
     }
 
     interface TestingBot {

--- a/types/tether-drop/index.d.ts
+++ b/types/tether-drop/index.d.ts
@@ -35,26 +35,26 @@ declare class Drop {
 
 declare namespace Drop {
     interface IDropContextOptions {
-        classPrefix?: string;
-        defaults?: IDropOptions;
+        classPrefix?: string | undefined;
+        defaults?: IDropOptions | undefined;
     }
 
     interface IDropOptions {
-        target?: Element;
-        content?: Element | string | ((drop?: Drop) => string) | ((drop?: Drop) => Element);
-        position?: string;
-        openOn?: string;
-        classes?: string;
-        constrainToWindow?: boolean;
-        constrainToScrollParent?: boolean;
-        remove?: boolean;
-        beforeClose?: (event: Event, drop: Drop) => boolean;
-        openDelay?: number;
-        closeDelay?: number;
-        focusDelay?: number;
-        blurDelay?: number;
-        hoverOpenDelay?: number;
-        hoverCloseDelay?: number;
-        tetherOptions?: Tether.ITetherOptions;
+        target?: Element | undefined;
+        content?: Element | string | ((drop?: Drop) => string) | ((drop?: Drop) => Element) | undefined;
+        position?: string | undefined;
+        openOn?: string | undefined;
+        classes?: string | undefined;
+        constrainToWindow?: boolean | undefined;
+        constrainToScrollParent?: boolean | undefined;
+        remove?: boolean | undefined;
+        beforeClose?: ((event: Event, drop: Drop) => boolean) | undefined;
+        openDelay?: number | undefined;
+        closeDelay?: number | undefined;
+        focusDelay?: number | undefined;
+        blurDelay?: number | undefined;
+        hoverOpenDelay?: number | undefined;
+        hoverCloseDelay?: number | undefined;
+        tetherOptions?: Tether.ITetherOptions | undefined;
     }
 }

--- a/types/tether-shepherd/index.d.ts
+++ b/types/tether-shepherd/index.d.ts
@@ -15,8 +15,8 @@ declare namespace TetherShepherd {
     }
 
     interface IShepherdTourOptions {
-        steps?: IShepherdTourStep[];
-        defaults?: IShepherdTourStepOptions;
+        steps?: IShepherdTourStep[] | undefined;
+        defaults?: IShepherdTourStepOptions | undefined;
     }
 
     interface IShepherdTour {
@@ -140,16 +140,16 @@ declare namespace TetherShepherd {
 
     interface IShepherdTourStepOptions {
         text?: any;
-        title?: string;
+        title?: string | undefined;
         attachTo?: any;
         beforeShowPromise?: any;
-        classes?: string;
-        buttons?: IShepherdTourButton[];
+        classes?: string | undefined;
+        buttons?: IShepherdTourButton[] | undefined;
         advanceOn?: any;
-        showCancelLink?: boolean;
-        scrollTo?: boolean;
+        showCancelLink?: boolean | undefined;
+        scrollTo?: boolean | undefined;
         when?: any;
-        showOn?: () => boolean;
+        showOn?: (() => boolean) | undefined;
 
         // TODO: Tie this in with the tether.d.ts
         tetherOptions?: any;
@@ -157,9 +157,9 @@ declare namespace TetherShepherd {
 
     interface IShepherdTourButton {
         text: string;
-        classes?: string;
-        action?: Function;
-        events?: IShepherdTourButtonEventHash;
+        classes?: string | undefined;
+        action?: Function | undefined;
+        events?: IShepherdTourButtonEventHash | undefined;
     }
 
     interface IShepherdTourButtonEventHash {

--- a/types/tether/index.d.ts
+++ b/types/tether/index.d.ts
@@ -23,25 +23,25 @@ declare class Tether {
 declare namespace Tether {
     interface ITetherOptions {
         attachment: string;
-        bodyElement?: HTMLElement;
-        classes?: {[className: string]: boolean | string};
-        classPrefix?: string;
-        constraints?: ITetherConstraint[];
-        element?: HTMLElement | string | any /* JQuery */;
-        enabled?: boolean;
-        offset?: string;
+        bodyElement?: HTMLElement | undefined;
+        classes?: {[className: string]: boolean | string} | undefined;
+        classPrefix?: string | undefined;
+        constraints?: ITetherConstraint[] | undefined;
+        element?: HTMLElement | string | any | undefined /* JQuery */;
+        enabled?: boolean | undefined;
+        offset?: string | undefined;
         optimizations?: any;
-        target?: HTMLElement | string | any /* JQuery */;
-        targetAttachment?: string;
-        targetOffset?: string;
-        targetModifier?: string;
+        target?: HTMLElement | string | any | undefined /* JQuery */;
+        targetAttachment?: string | undefined;
+        targetOffset?: string | undefined;
+        targetModifier?: string | undefined;
     }
 
     interface ITetherConstraint {
-        attachment?: string;
-        outOfBoundsClass?: string;
-        pin?: boolean | string[];
-        pinnedClass?: string;
-        to?: string | HTMLElement | number[];
+        attachment?: string | undefined;
+        outOfBoundsClass?: string | undefined;
+        pin?: boolean | string[] | undefined;
+        pinnedClass?: string | undefined;
+        to?: string | HTMLElement | number[] | undefined;
     }
 }

--- a/types/text-buffer/index.d.ts
+++ b/types/text-buffer/index.d.ts
@@ -162,7 +162,7 @@ declare global {
         namespace Options {
             interface BufferLoad {
                 /** The file's encoding. */
-                encoding?: string;
+                encoding?: string | undefined;
 
                 /**
                  *  A function that returns a boolean indicating whether the buffer should
@@ -173,130 +173,130 @@ declare global {
 
             interface FindMarker {
                 /** Only include markers that start at the given Point. */
-                startPosition?: PointCompatible;
+                startPosition?: PointCompatible | undefined;
 
                 /** Only include markers that end at the given Point. */
-                endPosition?: PointCompatible;
+                endPosition?: PointCompatible | undefined;
 
                 /** Only include markers that start inside the given Range. */
-                startsInRange?: RangeCompatible;
+                startsInRange?: RangeCompatible | undefined;
 
                 /** Only include markers that end inside the given Range. */
-                endsInRange?: RangeCompatible;
+                endsInRange?: RangeCompatible | undefined;
 
                 /** Only include markers that contain the given Point, inclusive. */
-                containsPoint?: PointCompatible;
+                containsPoint?: PointCompatible | undefined;
 
                 /** Only include markers that contain the given Range, inclusive. */
-                containsRange?: RangeCompatible;
+                containsRange?: RangeCompatible | undefined;
 
                 /** Only include markers that start at the given row number. */
-                startRow?: number;
+                startRow?: number | undefined;
 
                 /** Only include markers that end at the given row number. */
-                endRow?: number;
+                endRow?: number | undefined;
 
                 /** Only include markers that intersect the given row number. */
-                intersectsRow?: number;
+                intersectsRow?: number | undefined;
             }
 
             interface FindDisplayMarker {
                 /** Only include markers starting at this Point in buffer coordinates. */
-                startBufferPosition?: PointCompatible;
+                startBufferPosition?: PointCompatible | undefined;
 
                 /** Only include markers ending at this Point in buffer coordinates. */
-                endBufferPosition?: PointCompatible;
+                endBufferPosition?: PointCompatible | undefined;
 
                 /** Only include markers starting at this Point in screen coordinates. */
-                startScreenPosition?: PointCompatible;
+                startScreenPosition?: PointCompatible | undefined;
 
                 /** Only include markers ending at this Point in screen coordinates. */
-                endScreenPosition?: PointCompatible;
+                endScreenPosition?: PointCompatible | undefined;
 
                 /** Only include markers starting inside this Range in buffer coordinates. */
-                startsInBufferRange?: RangeCompatible;
+                startsInBufferRange?: RangeCompatible | undefined;
 
                 /** Only include markers ending inside this Range in buffer coordinates. */
-                endsInBufferRange?: RangeCompatible;
+                endsInBufferRange?: RangeCompatible | undefined;
 
                 /** Only include markers starting inside this Range in screen coordinates. */
-                startsInScreenRange?: RangeCompatible;
+                startsInScreenRange?: RangeCompatible | undefined;
 
                 /** Only include markers ending inside this Range in screen coordinates. */
-                endsInScreenRange?: RangeCompatible;
+                endsInScreenRange?: RangeCompatible | undefined;
 
                 /** Only include markers starting at this row in buffer coordinates. */
-                startBufferRow?: number;
+                startBufferRow?: number | undefined;
 
                 /** Only include markers ending at this row in buffer coordinates. */
-                endBufferRow?: number;
+                endBufferRow?: number | undefined;
 
                 /** Only include markers starting at this row in screen coordinates. */
-                startScreenRow?: number;
+                startScreenRow?: number | undefined;
 
                 /** Only include markers ending at this row in screen coordinates. */
-                endScreenRow?: number;
+                endScreenRow?: number | undefined;
 
                 /**
                  *  Only include markers intersecting this Array of [startRow, endRow] in
                  *  buffer coordinates.
                  */
-                intersectsBufferRowRange?: [number, number];
+                intersectsBufferRowRange?: [number, number] | undefined;
 
                 /**
                  *  Only include markers intersecting this Array of [startRow, endRow] in
                  *  screen coordinates.
                  */
-                intersectsScreenRowRange?: [number, number];
+                intersectsScreenRowRange?: [number, number] | undefined;
 
                 /** Only include markers containing this Range in buffer coordinates. */
-                containsBufferRange?: RangeCompatible;
+                containsBufferRange?: RangeCompatible | undefined;
 
                 /** Only include markers containing this Point in buffer coordinates. */
-                containsBufferPosition?: PointCompatible;
+                containsBufferPosition?: PointCompatible | undefined;
 
                 /** Only include markers contained in this Range in buffer coordinates. */
-                containedInBufferRange?: RangeCompatible;
+                containedInBufferRange?: RangeCompatible | undefined;
 
                 /** Only include markers contained in this Range in screen coordinates. */
-                containedInScreenRange?: RangeCompatible;
+                containedInScreenRange?: RangeCompatible | undefined;
 
                 /** Only include markers intersecting this Range in buffer coordinates. */
-                intersectsBufferRange?: RangeCompatible;
+                intersectsBufferRange?: RangeCompatible | undefined;
 
                 /** Only include markers intersecting this Range in screen coordinates. */
-                intersectsScreenRange?: RangeCompatible;
+                intersectsScreenRange?: RangeCompatible | undefined;
             }
 
             interface CopyMarker {
                 /** Whether or not the marker should be tailed. */
-                tailed?: boolean;
+                tailed?: boolean | undefined;
 
                 /** Creates the marker in a reversed orientation. */
-                reversed?: boolean;
+                reversed?: boolean | undefined;
 
                 /** Determines the rules by which changes to the buffer invalidate the marker. */
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch";
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined;
 
                 /**
                  *  Indicates whether insertions at the start or end of the marked range should
                  *  be interpreted as happening outside the marker.
                  */
-                exclusive?: boolean;
+                exclusive?: boolean | undefined;
 
                 /**
                  *  Custom properties to be associated with the marker.
                  *  @deprecated
                  */
-                properties?: object;
+                properties?: object | undefined;
             }
 
             interface ScanContext {
                 /** The number of lines before the matched line to include in the results object. */
-                leadingContextLineCount?: number;
+                leadingContextLineCount?: number | undefined;
 
                 /** The number of lines after the matched line to include in the results object. */
-                trailingContextLineCount?: number;
+                trailingContextLineCount?: number | undefined;
             }
         }
 
@@ -407,8 +407,8 @@ declare global {
              *  Sets the range of the marker.
              *  Returns a boolean indicating whether or not the marker was updated.
              */
-            setRange(range: RangeCompatible, params?: { reversed?: boolean, exclusive?:
-                boolean }): boolean;
+            setRange(range: RangeCompatible, params?: { reversed?: boolean | undefined, exclusive?:
+                boolean | undefined }): boolean;
 
             /**
              *  Sets the head position of the marker.
@@ -481,15 +481,15 @@ declare global {
             // Marker Creation
             /** Create a marker with the given range. */
             markRange(range: RangeCompatible, options?: {
-                reversed?: boolean,
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean,
+                reversed?: boolean | undefined,
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined,
             }): Marker;
 
             /** Create a marker at with its head at the given position with no tail. */
             markPosition(position: PointCompatible, options?: {
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean,
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined,
             }): Marker;
 
             // Event Subscription
@@ -594,8 +594,8 @@ declare global {
                 void;
 
             /** Modifies the screen range of this marker. */
-            setScreenRange(screenRange: RangeCompatible, options?: { reversed?: boolean,
-                clipDirection?: "backward"|"forward"|"closest" }): void;
+            setScreenRange(screenRange: RangeCompatible, options?: { reversed?: boolean | undefined,
+                clipDirection?: "backward"|"forward"|"closest" | undefined }): void;
 
             /**
              *  Retrieves the screen position of the marker's start. This will always be
@@ -706,10 +706,10 @@ declare global {
             // Marker creation
             /** Create a marker with the given screen range. */
             markScreenRange(range: RangeCompatible, options?: {
-                reversed?: boolean,
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean,
-                clipDirection?: "backward"|"forward"|"closest"
+                reversed?: boolean | undefined,
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined,
+                clipDirection?: "backward"|"forward"|"closest" | undefined
             }): DisplayMarker;
 
             /**
@@ -717,16 +717,16 @@ declare global {
              *  and no tail.
              */
             markScreenPosition(screenPosition: PointCompatible, options?: {
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean,
-                clipDirection?: "backward"|"forward"|"closest"
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined,
+                clipDirection?: "backward"|"forward"|"closest" | undefined
             }): DisplayMarker;
 
             /** Create a marker with the given buffer range. */
             markBufferRange(range: RangeCompatible, options?: {
-                reversed?: boolean,
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean
+                reversed?: boolean | undefined,
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined
             }): DisplayMarker;
 
             /**
@@ -734,8 +734,8 @@ declare global {
              *  and no tail.
              */
             markBufferPosition(bufferPosition: PointCompatible, options?: {
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined
             }): DisplayMarker;
 
             // Querying
@@ -1217,15 +1217,15 @@ declare global {
 
             /** Set the text in the given range. */
             setTextInRange(range: RangeCompatible, text: string, options?:
-                { normalizeLineEndings?: boolean, undo?: "skip" }): Range;
+                { normalizeLineEndings?: boolean | undefined, undo?: "skip" | undefined }): Range;
 
             /** Insert text at the given position. */
             insert(position: PointCompatible, text: string, options?:
-                { normalizeLineEndings?: boolean, undo?: "skip" }): Range;
+                { normalizeLineEndings?: boolean | undefined, undo?: "skip" | undefined }): Range;
 
             /** Append text to the end of the buffer. */
-            append(text: string, options?: { normalizeLineEndings?: boolean, undo?:
-                "skip" }): Range;
+            append(text: string, options?: { normalizeLineEndings?: boolean | undefined, undo?:
+                "skip" | undefined }): Range;
 
             /** Delete the text in the given range. */
             delete(range: RangeCompatible): Range;
@@ -1238,8 +1238,10 @@ declare global {
 
             // Markers
             /** Create a layer to contain a set of related markers. */
-            addMarkerLayer(options?: { maintainHistory?: boolean, persistent?: boolean }):
-                MarkerLayer;
+            addMarkerLayer(options?: {
+                maintainHistory?: boolean | undefined,
+                persistent?: boolean | undefined
+            }): MarkerLayer;
 
             /**
              *  Get a MarkerLayer by id.
@@ -1251,13 +1253,13 @@ declare global {
             getDefaultMarkerLayer(): MarkerLayer;
 
             /** Create a marker with the given range in the default marker layer. */
-            markRange(range: RangeCompatible, properties?: { reversed?: boolean,
-                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch",
-                exclusive?: boolean }): Marker;
+            markRange(range: RangeCompatible, properties?: { reversed?: boolean | undefined,
+                invalidate?: "never"|"surround"|"overlap"|"inside"|"touch" | undefined,
+                exclusive?: boolean | undefined }): Marker;
 
             /** Create a marker at the given position with no tail in the default marker layer. */
             markPosition(position: PointCompatible, options?: { invalidate?: "never"|"surround"
-                |"overlap"|"inside"|"touch", exclusive?: boolean }): Marker;
+                |"overlap"|"inside"|"touch" | undefined, exclusive?: boolean | undefined }): Marker;
 
             /** Get all existing markers on the default marker layer. */
             getMarkers(): Marker[];
@@ -1465,7 +1467,7 @@ declare global {
             /** Create a new buffer with the given params. */
             new (params?: {
                 /** The initial string text of the buffer. */
-                text?: string
+                text?: string | undefined
                 /**
                  *  A function that returns a Boolean indicating whether the buffer should
                  *  be destroyed if its file is deleted.

--- a/types/text-encoding-utf-8/index.d.ts
+++ b/types/text-encoding-utf-8/index.d.ts
@@ -5,16 +5,16 @@
 
 export namespace TextEncoding {
     interface TextDecoderOptions {
-        fatal?: boolean;
-        ignoreBOM?: boolean;
+        fatal?: boolean | undefined;
+        ignoreBOM?: boolean | undefined;
     }
 
     interface TextDecodeOptions {
-        stream?: boolean;
+        stream?: boolean | undefined;
     }
 
     interface TextEncoderOptions {
-        NONSTANDARD_allowLegacyEncoding?: boolean;
+        NONSTANDARD_allowLegacyEncoding?: boolean | undefined;
     }
 
     interface TextDecoder {
@@ -30,7 +30,7 @@ export namespace TextEncoding {
     }
 
     interface TextEncodeOptions {
-        stream?: boolean;
+        stream?: boolean | undefined;
     }
 
     interface TextEncoderStatic {

--- a/types/text-encoding/index.d.ts
+++ b/types/text-encoding/index.d.ts
@@ -8,7 +8,7 @@
 
 declare namespace TextEncoding {
     interface TextEncoderOptions {
-        NONSTANDARD_allowLegacyEncoding?: boolean;
+        NONSTANDARD_allowLegacyEncoding?: boolean | undefined;
     }
     interface TextEncoderStatic {
         (utfLabel?: string, options?: TextEncoderOptions): TextEncoder;
@@ -29,11 +29,11 @@ declare namespace TextEncoding {
 }
 
 interface TextEncodeOptions {
-    stream?: boolean;
+    stream?: boolean | undefined;
 }
 
 interface TextDecoderOptions {
-    stream?: boolean;
+    stream?: boolean | undefined;
 }
 
 interface TextEncoder {

--- a/types/text-mask-core/index.d.ts
+++ b/types/text-mask-core/index.d.ts
@@ -15,11 +15,11 @@ export type Pipe = (conformedValue: string, config: any) => PipeResult;
 export interface CreateTextMaskConfig {
     inputElement: HTMLInputElement;
     mask: Mask;
-    guide?: string;
-    pipe?: Pipe;
-    placeholderChar?: string;
-    keepCharPositions?: boolean;
-    showMask?: boolean;
+    guide?: string | undefined;
+    pipe?: Pipe | undefined;
+    placeholderChar?: string | undefined;
+    keepCharPositions?: boolean | undefined;
+    showMask?: boolean | undefined;
 }
 
 export interface TextMaskInputElement {

--- a/types/text-table/index.d.ts
+++ b/types/text-table/index.d.ts
@@ -17,10 +17,10 @@ declare function table(
 declare namespace table {
     interface Options {
         /** Separator to use between columns, (default: ' '). */
-        hsep?: string;
+        hsep?: string | undefined;
 
         /** An array of alignment types for each column, default ['l','l',...]. */
-        align?: Array<'l' | 'r' | 'c' | '.' | null | undefined>;
+        align?: Array<'l' | 'r' | 'c' | '.' | null | undefined> | undefined;
 
         /** A callback function to use when calculating the string length. */
         stringLength?(str: string): number;

--- a/types/text-to-svg/index.d.ts
+++ b/types/text-to-svg/index.d.ts
@@ -131,47 +131,47 @@ declare namespace TextToSVG {
          * Horizontal position of the beginning of the text.
          * @default 0
          */
-        x?: number | null;
+        x?: number | null | undefined;
 
         /**
          * Vertical position of the baseline of the text.
          * @default 0
          */
-        y?: number | null;
+        y?: number | null | undefined;
 
         /**
          * Size of the text.
          * @default 72
          */
-        fontSize?: number | null;
+        fontSize?: number | null | undefined;
 
         /**
          * If true takes kerning information into account.
          * @default true
          */
-        kerning?: boolean | null;
+        kerning?: boolean | null | undefined;
 
         /**
          * Letter-spacing value in em.
          */
-        letterSpacing?: number | null;
+        letterSpacing?: number | null | undefined;
 
         /**
          * Tracking value in (em / 1000).
          */
-        tracking?: number | null;
+        tracking?: number | null | undefined;
 
         /**
          * @default "left baseline"
          */
-        anchor?: Anchor | null;
+        anchor?: Anchor | null | undefined;
     }
 
     interface GenerationOptions extends FontOptions {
         /**
          * Key-value pairs of attributes for `<path>` element.
          */
-        attributes?: { [key: string]: string } | null;
+        attributes?: { [key: string]: string } | null | undefined;
     }
 
     type LoadCallback = (error: Error | null, textToSVG: TextToSVG | null) => void;

--- a/types/textarea-caret/index.d.ts
+++ b/types/textarea-caret/index.d.ts
@@ -13,7 +13,7 @@ interface Caret {
 }
 
 interface Options {
-    debug?: boolean;
+    debug?: boolean | undefined;
 }
 
 declare function textarea_caret(element: HTMLElement, position: number, options?: Options): Caret;

--- a/types/textfit/index.d.ts
+++ b/types/textfit/index.d.ts
@@ -13,53 +13,53 @@ declare namespace textFit {
          *  if true, textFit will align vertically using css tables
          *  @default false
          */
-        alignVert?: boolean;
+        alignVert?: boolean | undefined;
 
         /**
          *  if true, textFit will set text-align: center
          *  @default false
          */
-        alignHoriz?: boolean;
+        alignHoriz?: boolean | undefined;
 
         /**
          *  if true, textFit will not set white-space: no-wrap
          *  @default false
          */
-        multiLine?: boolean;
+        multiLine?: boolean | undefined;
 
         /**
          *  disable to turn off automatic multi-line sensing
          *  @default true
          */
-        detectMultiLine?: boolean;
+        detectMultiLine?: boolean | undefined;
 
         /**
          *  @default 6
          */
-        minFontSize?: number;
+        minFontSize?: number | undefined;
 
         /**
          *  @default 80
          */
-        maxFontSize?: number;
+        maxFontSize?: number | undefined;
 
         /**
          *  if true, textFit will re-process already-fit nodes. Set to 'false' for better performance
          *  @default true
          */
-        reProcess?: boolean;
+        reProcess?: boolean | undefined;
 
         /**
          *  if true, textFit will fit text to element width, regardless of text height
          *  @default false
          */
-        widthOnly?: boolean;
+        widthOnly?: boolean | undefined;
 
         /**
          *  if true, textFit will use flexbox for vertical alignment
          *  @default false
          */
-        alignVertWithFlexbox?: boolean;
+        alignVertWithFlexbox?: boolean | undefined;
     }
 }
 

--- a/types/textract/index.d.ts
+++ b/types/textract/index.d.ts
@@ -17,41 +17,41 @@ export interface Config {
      * Pass this in as true and textract will not strip any line breaks.
      * @default false
      */
-    preserveLineBreaks?: boolean;
+    preserveLineBreaks?: boolean | undefined;
     /**
      * Some extractors, like PDF, insert line breaks at the end of every line, even if the middle of a sentence.
      * If this option is set to true, then any instances of a single line break are removed but multiple line breaks are preserved.
      * Check your output with this option, though, this doesn't preserve paragraphs unless there are multiple breaks.
      * @default false
      */
-    preserveOnlyMultipleLineBreaks?: boolean;
+    preserveOnlyMultipleLineBreaks?: boolean | undefined;
     /**
      * Some extractors (dxf) use node's exec functionality.
      * This setting allows for providing config to exec execution.
      * One reason you might want to provide this config is if you are dealing with very large files.
      * You might want to increase the exec maxBuffer setting.
      */
-    exec?: ChildProc.ExecException;
+    exec?: ChildProc.ExecException | undefined;
     /**
      * Doc extractor options for non OS X.
      * See `drawingtotext` manual for available options
      */
-    doc?: extractorExecOpts;
+    doc?: extractorExecOpts | undefined;
     /**
      * DXF extractor options.
      * See `antiword` manual for available options
      */
-    dxf?: extractorExecOpts;
+    dxf?: extractorExecOpts | undefined;
     /**
      * Images (png, jpg, gif) extractor options.
      * See `tesseract` manual for available options
      */
-    images?: extractorExecOpts;
+    images?: extractorExecOpts | undefined;
     /**
      * RTF extractor options.
      * See `unrtf` manual for available options
      */
-    rtf?: extractorExecOpts;
+    rtf?: extractorExecOpts | undefined;
     tesseract?: {
         /**
          *  A pass-through to tesseract allowing for setting of language for extraction.
@@ -66,7 +66,7 @@ export interface Config {
          * you would pass `{ tesseract: { cmd:"-l chi_sim -psm 10" } }`
          */
         cmd: string
-    };
+    } | undefined;
     /**
      * This is a proxy options object to the library textract uses for pdf extraction: pdf-text-extract.
      * Options include ownerPassword, userPassword if you are extracting text from password protected PDFs.
@@ -75,41 +75,41 @@ export interface Config {
      * See [this GH issue](https://github.com/dbashford/textract/issues/75) for why textract overrides that library's default.
      */
     pdftotextOptions?: {
-        firstPage?: number,
-        lastPage?: number,
-        resolution?: number,
+        firstPage?: number | undefined,
+        lastPage?: number | undefined,
+        resolution?: number | undefined,
         crop?: {
             x: number, y: number, w: number, h: number
-        },
+        } | undefined,
         /**
          * Do not change unless you know what you are doing!
          * @default "raw"
          */
-        layout?: "layout" | "raw" | "htmlmeta",
+        layout?: "layout" | "raw" | "htmlmeta" | undefined,
         /**
          * @default "UTF-8"
          */
-        encoding?: "UCS-2" | "ASCII7" | "Latin1" | "UTF-8" | "ZapfDingbats" | "Symbol";
-        eol?: "unix" | "dos" | "mac",
-        ownerPassword?: string,
-        userPassword?: string,
+        encoding?: "UCS-2" | "ASCII7" | "Latin1" | "UTF-8" | "ZapfDingbats" | "Symbol" | undefined;
+        eol?: "unix" | "dos" | "mac" | undefined,
+        ownerPassword?: string | undefined,
+        userPassword?: string | undefined,
         /**
          * @default true
          */
-        splitPages?: boolean
-    };
+        splitPages?: boolean | undefined
+    } | undefined;
     /**
      * When extracting HTML, whether or not to include `alt` text with the extracted text.
      * @default false
      */
-    includeAltText?: boolean;
+    includeAltText?: boolean | undefined;
 }
 
 export interface URLConfig extends Config {
     /**
      * Used with fromUrl, if set, rather than using the content-type from the URL request, will use the provided typeOverride.
      */
-    typeOverride?: string;
+    typeOverride?: string | undefined;
 }
 
 /**

--- a/types/textversionjs/index.d.ts
+++ b/types/textversionjs/index.d.ts
@@ -15,14 +15,14 @@ declare namespace textversionjs {
     type imgProcess = (src: string, alt: string) => string;
 
     interface styleConfig {
-        linkProcess?: linkProcess;
-        imgProcess?: imgProcess;
-        headingStyle?: 'underline' | 'linebreak' |  'hashify';
-        listStyle?: 'indentation' | 'linebreak';
-        uIndentionChar?: string;
-        oIndentionChar?: string;
-        listIndentionTabs?: number;
-        keepNbsps?: boolean;
+        linkProcess?: linkProcess | undefined;
+        imgProcess?: imgProcess | undefined;
+        headingStyle?: 'underline' | 'linebreak' |  'hashify' | undefined;
+        listStyle?: 'indentation' | 'linebreak' | undefined;
+        uIndentionChar?: string | undefined;
+        oIndentionChar?: string | undefined;
+        listIndentionTabs?: number | undefined;
+        keepNbsps?: boolean | undefined;
     }
 }
 


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers packages starting with ta--te-.
microsoft/dtslint#335