### PR TITLE
Add undefined to optional properties, part ST

### DIFF
--- a/types/stack-utils/index.d.ts
+++ b/types/stack-utils/index.d.ts
@@ -20,9 +20,9 @@ declare class StackUtils {
 
 declare namespace StackUtils {
     interface Options {
-        internals?: RegExp[];
-        ignoredPackages?: string[];
-        cwd?: string;
+        internals?: RegExp[] | undefined;
+        ignoredPackages?: string[] | undefined;
+        cwd?: string | undefined;
         wrapCallSite?(callSite: CallSite): CallSite;
     }
 
@@ -43,23 +43,23 @@ declare namespace StackUtils {
     }
 
     interface CallSiteLike extends StackData {
-        type?: string;
+        type?: string | undefined;
     }
 
     interface StackLineData extends StackData {
-        evalLine?: number;
-        evalColumn?: number;
-        evalFile?: string;
+        evalLine?: number | undefined;
+        evalColumn?: number | undefined;
+        evalFile?: string | undefined;
     }
 
     interface StackData {
-        line?: number;
-        column?: number;
-        file?: string;
-        constructor?: boolean;
-        evalOrigin?: string;
-        native?: boolean;
-        function?: string;
-        method?: string;
+        line?: number | undefined;
+        column?: number | undefined;
+        file?: string | undefined;
+        constructor?: boolean | undefined;
+        evalOrigin?: string | undefined;
+        native?: boolean | undefined;
+        function?: string | undefined;
+        method?: string | undefined;
     }
 }

--- a/types/stale-lru-cache/index.d.ts
+++ b/types/stale-lru-cache/index.d.ts
@@ -26,17 +26,17 @@ declare namespace Cache {
     type RevalidationCallback<K, V> = (key: K, callback: OptionsCallback<K, V>) => void;
 
     interface CacheOptions<K, V> {
-        maxAge?: number;
-        staleWhileRevalidate?: number;
-        revalidate?: RevalidationCallback<K, V>;
-        maxSize?: number;
+        maxAge?: number | undefined;
+        staleWhileRevalidate?: number | undefined;
+        revalidate?: RevalidationCallback<K, V> | undefined;
+        maxSize?: number | undefined;
         getSize?(value: V, key: K): number;
     }
 
     interface SetOptions<K, V> {
-        maxAge?: number;
-        staleWhileRevalidate?: number;
-        revalidate?: RevalidationCallback<K, V>;
+        maxAge?: number | undefined;
+        staleWhileRevalidate?: number | undefined;
+        revalidate?: RevalidationCallback<K, V> | undefined;
     }
 }
 

--- a/types/stampit/index.d.ts
+++ b/types/stampit/index.d.ts
@@ -225,27 +225,27 @@ declare namespace stampit {
      */
     interface Descriptor<Obj, S̤t̤a̤m̤p̤ extends StampSignature = Stamp<Obj>> {
         /** A set of methods that will be added to the object's delegate prototype. */
-        methods?: MethodMap<Obj>;
+        methods?: MethodMap<Obj> | undefined;
         /** A set of properties that will be added to new object instances by assignment. */
-        properties?: PropertyMap;
+        properties?: PropertyMap | undefined;
         /** A set of properties that will be added to new object instances by deep property merge. */
-        deepProperties?: PropertyMap;
+        deepProperties?: PropertyMap | undefined;
         /** A set of object property descriptors (`PropertyDescriptor`) used for fine-grained control over object property behaviors. */
-        propertyDescriptors?: PropertyDescriptorMap;
+        propertyDescriptors?: PropertyDescriptorMap | undefined;
         /** A set of static properties that will be copied by assignment to the `Stamp`. */
-        staticProperties?: PropertyMap /* & ThisType<S> */;
+        staticProperties?: PropertyMap | undefined /* & ThisType<S> */;
         /** A set of static properties that will be added to the `Stamp` by deep property merge. */
-        staticDeepProperties?: PropertyMap /* & ThisType<S> */;
+        staticDeepProperties?: PropertyMap | undefined /* & ThisType<S> */;
         /** A set of object property descriptors (`PropertyDescriptor`) to apply to the `Stamp`. */
-        staticPropertyDescriptors?: PropertyDescriptorMap /* & ThisType<S> */;
+        staticPropertyDescriptors?: PropertyDescriptorMap | undefined /* & ThisType<S> */;
         /** An array of functions that will run in sequence while creating an object instance from a `Stamp`. `Stamp` details and arguments get passed to initializers. */
-        initializers?: Initializer<Obj, S̤t̤a̤m̤p̤> | Array<Initializer<Obj, S̤t̤a̤m̤p̤>>;
+        initializers?: Initializer<Obj, S̤t̤a̤m̤p̤> | Array<Initializer<Obj, S̤t̤a̤m̤p̤>> | undefined;
         /** An array of functions that will run in sequence while creating a new `Stamp` from a list of `Composable`s. The resulting `Stamp` and the `Composable`s get passed to composers. */
-        composers?: Array<Composer<S̤t̤a̤m̤p̤>>;
+        composers?: Array<Composer<S̤t̤a̤m̤p̤>> | undefined;
         /** A set of options made available to the `Stamp` and its initializers during object instance creation. These will be copied by assignment. */
-        configuration?: PropertyMap /* & ThisType<S> */;
+        configuration?: PropertyMap | undefined /* & ThisType<S> */;
         /** A set of options made available to the `Stamp` and its initializers during object instance creation. These will be deep merged. */
-        deepConfiguration?: PropertyMap /* & ThisType<S> */;
+        deepConfiguration?: PropertyMap | undefined /* & ThisType<S> */;
     }
 
     /**
@@ -255,21 +255,21 @@ declare namespace stampit {
      */
     interface ExtendedDescriptor<Obj, S̤t̤a̤m̤p̤ extends StampSignature = Stamp<Obj>> extends Descriptor<Obj, S̤t̤a̤m̤p̤> {
         /** A set of properties that will be added to new object instances by assignment. */
-        props?: PropertyMap;
+        props?: PropertyMap | undefined;
         /** A set of properties that will be added to new object instances by deep property merge. */
-        deepProps?: PropertyMap;
+        deepProps?: PropertyMap | undefined;
         /** A set of static properties that will be copied by assignment to the `Stamp`. */
-        statics?: PropertyMap /* & ThisType<S> */;
+        statics?: PropertyMap | undefined /* & ThisType<S> */;
         /** A set of static properties that will be added to the `Stamp` by deep property merge. */
-        deepStatics?: PropertyMap /* & ThisType<S> */;
+        deepStatics?: PropertyMap | undefined /* & ThisType<S> */;
         /** An array of functions that will run in sequence while creating an object instance from a `Stamp`. `Stamp` details and arguments get passed to initializers. */
-        init?: Initializer<Obj, S̤t̤a̤m̤p̤> | Array<Initializer<Obj, S̤t̤a̤m̤p̤>>;
+        init?: Initializer<Obj, S̤t̤a̤m̤p̤> | Array<Initializer<Obj, S̤t̤a̤m̤p̤>> | undefined;
         /** A set of options made available to the `Stamp` and its initializers during object instance creation. These will be copied by assignment. */
-        conf?: PropertyMap /* & ThisType<S> */;
+        conf?: PropertyMap | undefined /* & ThisType<S> */;
         /** A set of options made available to the `Stamp` and its initializers during object instance creation. These will be deep merged. */
-        deepConf?: PropertyMap /* & ThisType<S> */;
+        deepConf?: PropertyMap | undefined /* & ThisType<S> */;
         // TODO: Add description
-        name?: string;
+        name?: string | undefined;
     }
 
     /**

--- a/types/stampit/v2/index.d.ts
+++ b/types/stampit/v2/index.d.ts
@@ -59,27 +59,27 @@ interface Options {
     /**
      * A hash containing methods (functions) of any future created instance.
      */
-    methods?: {} | {}[];
+    methods?: {} | {}[] | undefined;
 
     /**
      * A hash containing references to the object. This hash will be shallow mixed into any future created instance.
      */
-    refs?: {} | {}[];
+    refs?: {} | {}[] | undefined;
 
     /**
      * Initialization function which will be called per each newly created instance.
      */
-    init?: Init | Init[];
+    init?: Init | Init[] | undefined;
 
     /**
      * Properties which will be deeply (but safely, no data override) merged into any future created instance.
      */
-    props?: {} | {}[];
+    props?: {} | {}[] | undefined;
 
     /**
      * Properties which will be mixed to the new and any other stamp which this stamp will be composed with.
      */
-    static?: {} | {}[];
+    static?: {} | {}[] | undefined;
 }
 
 /**

--- a/types/stampit/v3/index.d.ts
+++ b/types/stampit/v3/index.d.ts
@@ -21,32 +21,32 @@ interface Descriptor {
     /**
      * A hash containing methods (functions) of any future created instance.
      */
-    methods?: {};
+    methods?: {} | undefined;
     /**
      * Initialization function(s) which will be called per each newly created
      * instance.
      */
-    initializers?: Init[];
+    initializers?: Init[] | undefined;
     /**
      * Properties which will shallowly copied into any future created instance.
      */
-    properties?: {};
+    properties?: {} | undefined;
     /**
      * Properties which will be mixed to the new and any other stamp which this stamp will be composed with.
      */
-    staticProperties?: {};
+    staticProperties?: {} | undefined;
     /** Deeply merged properties of object instances */
-    deepProperties?: {};
+    deepProperties?: {} | undefined;
     /** ES5 Property Descriptors applied to object instances */
-    propertyDescriptors?: {};
+    propertyDescriptors?: {} | undefined;
     /** Deeply merged properties of Stamps */
-    staticDeepProperties?: {};
+    staticDeepProperties?: {} | undefined;
     /** ES5 Property Descriptors applied to Stamps */
-    staticPropertyDescriptors?: {};
+    staticPropertyDescriptors?: {} | undefined;
     /** A configuration object to be shallowly assigned to Stamps */
-    configuration?: {};
+    configuration?: {} | undefined;
     /** A configuration object to be deeply merged to Stamps */
-    deepConfiguration?: {};
+    deepConfiguration?: {} | undefined;
 }
 
 /** Any composable object (stamp or descriptor) */
@@ -76,61 +76,61 @@ interface Options {
     /**
      * A hash containing methods (functions) of any future created instance.
      */
-    methods?: {};
+    methods?: {} | undefined;
     /**
      * Initialization function(s) which will be called per each newly created
      * instance.
      */
-    init?: Init | Init[];
+    init?: Init | Init[] | undefined;
     /**
      * Initialization function(s) which will be called per each newly created
      * instance.
      */
-    initializers?: Init | Init[];
+    initializers?: Init | Init[] | undefined;
     /**
      * Properties which will shallowly copied into any future created instance.
      */
-    props?: {};
+    props?: {} | undefined;
     /**
      * Properties which will shallowly copied into any future created instance.
      */
-    properties?: {};
+    properties?: {} | undefined;
     /**
      * A hash containing references to the object. This hash will be shallow mixed into any future created instance.
      */
-    refs?: {};
+    refs?: {} | undefined;
     /**
      * Properties which will be mixed to the new and any other stamp which this
      * stamp will be composed with.
      */
-    staticProperties?: {};
+    staticProperties?: {} | undefined;
     /**
      * Properties which will be mixed to the new and any other stamp which this
      * stamp will be composed with.
      */
-    statics?: {};
+    statics?: {} | undefined;
     /** Deeply merged properties of object instances */
-    deepProperties?: {};
+    deepProperties?: {} | undefined;
     /** Deeply merged properties of object instances */
-    deepProps?: {};
+    deepProps?: {} | undefined;
     /** ES5 Property Descriptors applied to object instances */
-    propertyDescriptors?: {};
+    propertyDescriptors?: {} | undefined;
     /** Deeply merged properties of Stamps */
-    staticDeepProperties?: {};
+    staticDeepProperties?: {} | undefined;
     /** Deeply merged properties of Stamps */
-    deepStatics?: {};
+    deepStatics?: {} | undefined;
     /** ES5 Property Descriptors applied to Stamps */
-    staticPropertyDescriptors?: {};
+    staticPropertyDescriptors?: {} | undefined;
     /** A configuration object to be shallowly assigned to Stamps */
-    configuration?: {};
+    configuration?: {} | undefined;
     /** A configuration object to be shallowly assigned to Stamps */
-    conf?: {};
+    conf?: {} | undefined;
     /** A configuration object to be deeply merged to Stamps */
-    deepConfiguration?: {};
+    deepConfiguration?: {} | undefined;
     /** A configuration object to be deeply merged to Stamps */
-    deepConf?: {};
+    deepConf?: {} | undefined;
     /** Callback functions to execute each time a composition occurs */
-    composers?: Composer[];
+    composers?: Composer[] | undefined;
 }
 
 /** Stampit Composable for main stampit() function */

--- a/types/standard-engine/index.d.ts
+++ b/types/standard-engine/index.d.ts
@@ -38,13 +38,13 @@ export type ParseOptions = PickWithSomeRequired<
 >;
 
 export interface LinterOptions {
-    bugs?: string;
+    bugs?: string | undefined;
     cmd: string;
     /** @default process.cwd() */
-    cwd?: string;
+    cwd?: string | undefined;
     eslint: typeof eslint;
-    eslintConfig?: ESLintConfig;
-    homepage?: string;
+    eslintConfig?: ESLintConfig | undefined;
+    homepage?: string | undefined;
     /**
      * This function is called with the current options object (opts),
      * any options extracted from the project's package.json (packageOpts),
@@ -52,29 +52,29 @@ export interface LinterOptions {
      * (rootDir, equivalent to opts.cwd if no file was found).
      * Modify and return opts, or return a new object with the options that are to be used.
      */
-    parseOpts?: (opts: ParseOptions, packageOpts: any, rootDir: string) => ParseOptions;
-    tagline?: string;
-    version?: string;
+    parseOpts?: ((opts: ParseOptions, packageOpts: any, rootDir: string) => ParseOptions) | undefined;
+    tagline?: string | undefined;
+    version?: string | undefined;
 }
 
 export interface ESLintConfig {
     /** @default true */
-    cache?: boolean;
+    cache?: boolean | undefined;
     /** @default  path.join(HOME_OR_TMP, `.${this.cmd}-v${majorVersion}-cache/` */
-    cacheLocation?: string;
-    configFile?: string;
+    cacheLocation?: string | undefined;
+    configFile?: string | undefined;
     /** @default [] */
-    envs?: string[];
+    envs?: string[] | undefined;
     /** @default false */
-    fix?: boolean;
+    fix?: boolean | undefined;
     /** @default [] */
-    globals?: string[];
+    globals?: string[] | undefined;
     /** @default false */
-    ignore?: boolean;
+    ignore?: boolean | undefined;
     /** @default [] */
-    plugins?: string[];
+    plugins?: string[] | undefined;
     /** @default false */
-    useEslintrc?: boolean;
+    useEslintrc?: boolean | undefined;
 }
 
 /**
@@ -86,51 +86,51 @@ export interface Options {
      * file globs to ignore
      * @default []
      */
-    ignore?: string[];
+    ignore?: string[] | undefined;
     /**
      * current working directory
      * @default process.cwd()
      */
-    cwd?: string;
+    cwd?: string | undefined;
     /** path of the file containing the text being linted */
-    filename?: string;
+    filename?: string | undefined;
     /**
      * automatically fix problems
      * @default false
      */
-    fix?: boolean;
+    fix?: boolean | undefined;
     /**
      * custom global variables to declare
      * @default [];
      */
-    global?: string | string[];
+    global?: string | string[] | undefined;
     /**
      * custom global variables to declare
      * @default [];
      */
-    globals?: string | string[];
+    globals?: string | string[] | undefined;
     /**
      * custom eslint plugins
      * @default []
      */
-    plugin?: string | string[];
+    plugin?: string | string[] | undefined;
     /**
      * custom eslint plugins
      * @default []
      */
-    plugins?: string | string[];
+    plugins?: string | string[] | undefined;
     /**
      * custom eslint environment
      * @default []
      */
-    env?: string | string[];
+    env?: string | string[] | undefined;
     /**
      * custom eslint environment
      * @default []
      */
-    envs?: string | string[];
+    envs?: string | string[] | undefined;
     /** custom js parser (e.g. babel-eslint) */
-    parser?: string;
+    parser?: string | undefined;
 }
 
 export interface LintDefaultOptions {
@@ -138,7 +138,7 @@ export interface LintDefaultOptions {
      * use options from nearest package.json?
      * @default true
      */
-    usePackageJson?: boolean;
+    usePackageJson?: boolean | undefined;
 }
 
 export type LintTextOptions = Exclude<Options, 'ignore' | 'cwd'> & LintDefaultOptions;

--- a/types/standard-version/index.d.ts
+++ b/types/standard-version/index.d.ts
@@ -21,7 +21,7 @@ declare namespace standardVersion {
          *   'composer.json'
          * ]
          */
-        packageFiles?: string[];
+        packageFiles?: string[] | undefined;
 
         /**
          * @default
@@ -31,17 +31,17 @@ declare namespace standardVersion {
          *   'composer.lock'
          * ]
          */
-        bumpFiles?: string[];
+        bumpFiles?: string[] | undefined;
 
         /**
          * Specify the release type manually (like npm version <major|minor|patch>).
          */
-        releaseAs?: string;
+        releaseAs?: string | undefined;
 
         /**
          * Make a pre-release with optional option value to specify a tag id.
          */
-        prerelease?: string;
+        prerelease?: string | undefined;
 
         /**
          * Read the CHANGELOG from this file.
@@ -49,7 +49,7 @@ declare namespace standardVersion {
          * @default
          * 'CHANGELOG.md'
          */
-        infile?: string | Buffer | URL | number;
+        infile?: string | Buffer | URL | number | undefined;
 
         /**
          * Commit message, replaces %s with new version.
@@ -58,7 +58,7 @@ declare namespace standardVersion {
          * This option will be removed in the next major version, please use
          * `releaseCommitMessageFormat`.
          */
-        message?: string;
+        message?: string | undefined;
 
         /**
          * Is this the first release?
@@ -66,7 +66,7 @@ declare namespace standardVersion {
          * @default
          * false
          */
-        firstRelease?: boolean;
+        firstRelease?: boolean | undefined;
 
         /**
          * Should the git commit and tag be signed?
@@ -74,7 +74,7 @@ declare namespace standardVersion {
          * @default
          * false
          */
-        sign?: boolean;
+        sign?: boolean | undefined;
 
         /**
          * Bypass pre-commit or commit-msg git hooks during the commit phase.
@@ -82,7 +82,7 @@ declare namespace standardVersion {
          * @default
          * false
          */
-        noVerify?: boolean;
+        noVerify?: boolean | undefined;
 
         /**
          * Commit all staged changes, not just files affected by standard-version.
@@ -90,7 +90,7 @@ declare namespace standardVersion {
          * @default
          * false
          */
-        commitAll?: boolean;
+        commitAll?: boolean | undefined;
 
         /**
          * Don't print logs and errors.
@@ -98,7 +98,7 @@ declare namespace standardVersion {
          * @default
          * false
          */
-        silent?: boolean;
+        silent?: boolean | undefined;
 
         /**
          * Set a custom prefix for the git tag to be created.
@@ -106,7 +106,7 @@ declare namespace standardVersion {
          * @default
          * 'v'
          */
-        tagPrefix?: string;
+        tagPrefix?: string | undefined;
 
         /**
          * Provide scripts to execute for lifecycle events (prebump, precommit, etc.,).
@@ -114,7 +114,7 @@ declare namespace standardVersion {
          * @default
          * {}
          */
-        scripts?: Options.Scripts;
+        scripts?: Options.Scripts | undefined;
 
         /**
          * Map of steps in the release process that should be skipped.
@@ -122,7 +122,7 @@ declare namespace standardVersion {
          * @default
          * {}
          */
-        skip?: Options.Skip;
+        skip?: Options.Skip | undefined;
 
         /**
          * See the commands that running standard-version would run.
@@ -130,7 +130,7 @@ declare namespace standardVersion {
          * @default
          * false
          */
-        dryRun?: boolean;
+        dryRun?: boolean | undefined;
 
         /**
          * Fallback to git tags for version, if no meta-information file is found (e.g.,
@@ -139,12 +139,12 @@ declare namespace standardVersion {
          * @default
          * true
          */
-        gitTagFallback?: boolean;
+        gitTagFallback?: boolean | undefined;
 
         /**
          * Only populate commits made under this path.
          */
-        path?: string;
+        path?: string | undefined;
 
         /**
          * Use a custom header when generating and updating changelog.
@@ -152,7 +152,7 @@ declare namespace standardVersion {
          * @deprecated
          * This option will be removed in the next major version, please use `header`.
          */
-        changelogHeader?: string;
+        changelogHeader?: string | undefined;
 
         /**
          * Commit message guideline preset.
@@ -160,7 +160,7 @@ declare namespace standardVersion {
          * @default
          * require.resolve('conventional-changelog-conventionalcommits')
          */
-        preset?: string;
+        preset?: string | undefined;
     }
 
     namespace Options {
@@ -170,49 +170,49 @@ declare namespace standardVersion {
              * non-zero exit code, versioning will be aborted, but it has no other effect on
              * the process.
              */
-            prerelease?: string;
+            prerelease?: string | undefined;
 
             /**
              * Executed before the version is bumped. If the `prebump` script returns a
              * version #, it will be used rather than the version calculated by
              * `standard-version`.
              */
-            prebump?: string;
+            prebump?: string | undefined;
 
             /**
              * Executed after the version is bumped.
              */
-            postbump?: string;
+            postbump?: string | undefined;
 
             /**
              * Executes before the CHANGELOG is generated.
              */
-            prechangelog?: string;
+            prechangelog?: string | undefined;
 
             /**
              * Executes after the CHANGELOG is generated.
              */
-            postchangelog?: string;
+            postchangelog?: string | undefined;
 
             /**
              * Called before the commit step.
              */
-            precommit?: string;
+            precommit?: string | undefined;
 
             /**
              * Called after the commit step.
              */
-            postcommit?: string;
+            postcommit?: string | undefined;
 
             /**
              * Called before the tagging step.
              */
-            pretag?: string;
+            pretag?: string | undefined;
 
             /**
              * Called after the tagging step.
              */
-            posttag?: string;
+            posttag?: string | undefined;
         }
 
         type Skip = Partial<Record<"bump" | "changelog" | "commit" | "tag", boolean>>;

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -18,26 +18,26 @@ declare namespace StartServerWebpackPlugin {
          * Name of the server to start (built asset from webpack).
          * If not provided, the plugin will tell you the available names.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * Arguments for node.
          * Default: `[]`.
          */
-        nodeArgs?: string[];
+        nodeArgs?: string[] | undefined;
         /**
          * Arguments for the script.
          * Default: `[]`.
          */
-        args?: string[];
+        args?: string[] | undefined;
         /**
          * Signal to send for HMR.
          * Default: 'false'.
          */
-        signal?: false | true | 'SIGUSR2';
+        signal?: false | true | 'SIGUSR2' | undefined;
         /**
          * Allow typing 'rs' to restart the server.
          * Default: 'true' if in 'development' mode, 'false' otherwise.
          */
-        keyboard?: boolean;
+        keyboard?: boolean | undefined;
     }
 }

--- a/types/staticmaps/index.d.ts
+++ b/types/staticmaps/index.d.ts
@@ -32,32 +32,32 @@ declare namespace StaticMaps {
     interface StaticMapsOptions {
         width: number;
         height: number;
-        paddingX?: number;
-        paddingY?: number;
-        tileUrl?: string;
-        tileSize?: number;
+        paddingX?: number | undefined;
+        paddingY?: number | undefined;
+        tileUrl?: string | undefined;
+        tileSize?: number | undefined;
         /**
          * Subdomains of tile server
          * @default []
          */
-        subdomains?: string[];
-        tileRequestTimeout?: number;
-        tileRequestHeader?: object;
+        subdomains?: string[] | undefined;
+        tileRequestTimeout?: number | undefined;
+        tileRequestHeader?: object | undefined;
         /**
          * Limit concurrent connections to the tiles server
          * @default 2
          */
-        tileRequestLimit?: number;
+        tileRequestLimit?: number | undefined;
         /**
          * Defines the range of zoom levels to try
          */
         zoomRange?: {
-            min?: ZoomLevel;
-            max?: ZoomLevel;
-        };
+            min?: ZoomLevel | undefined;
+            max?: ZoomLevel | undefined;
+        } | undefined;
         /** @deprecated Use zoomRange.max instead: */
-        maxZoom?: number;
-        reverseY?: boolean;
+        maxZoom?: number | undefined;
+        reverseY?: boolean | undefined;
     }
 
     interface AddMarkerOptions {
@@ -65,25 +65,25 @@ declare namespace StaticMaps {
         img: string;
         height: number;
         width: number;
-        offsetX?: number;
-        offsetY?: number;
+        offsetX?: number | undefined;
+        offsetY?: number | undefined;
     }
 
     interface AddLineOptions {
         coords: ReadonlyArray<[number, number]>;
-        color?: string;
-        width?: number;
+        color?: string | undefined;
+        width?: number | undefined;
     }
 
     interface AddPolygonOptions extends AddLineOptions {
-        fill?: string;
+        fill?: string | undefined;
     }
 
     interface AddMultiPolygonOptions {
         coords: ReadonlyArray<Array<[number, number]>>;
-        color?: string;
-        width?: number;
-        fill?: string;
+        color?: string | undefined;
+        width?: number | undefined;
+        fill?: string | undefined;
     }
 
     interface AddTextOptions {
@@ -91,14 +91,14 @@ declare namespace StaticMaps {
          * Anchor of the text
          * @default 'start'
          */
-        anchor?: TextAnchor;
+        anchor?: TextAnchor | undefined;
         coord: [number, number];
         text: string;
-        font?: string;
-        size?: number;
-        color?: string;
-        width?: number;
-        fill?: string;
+        font?: string | undefined;
+        size?: number | undefined;
+        color?: string | undefined;
+        width?: number | undefined;
+        fill?: string | undefined;
     }
 
     type TextAnchor =

--- a/types/statsd-client/index.d.ts
+++ b/types/statsd-client/index.d.ts
@@ -16,24 +16,24 @@ declare namespace StatsdClient {
         /**
          * Prefix all stats with this value (default "").
          */
-        prefix?: string;
+        prefix?: string | undefined;
 
         /**
          * Print what is being sent to stderr (default false).
          */
-        debug?: boolean;
+        debug?: boolean | undefined;
 
         /**
          * Object of string key/value pairs which will be appended on
          * to all StatsD payloads (excluding raw payloads)
          * (default {})
          */
-        tags?: Tags;
+        tags?: Tags | undefined;
 
         /**
          * User specifically wants to use tcp (default false)
          */
-        tcp?: boolean;
+        tcp?: boolean | undefined;
 
         /**
          * Dual-use timer. Will flush metrics every interval. For UDP,
@@ -42,19 +42,19 @@ declare namespace StatsdClient {
          * the socket after socketTimeoutsToClose number of timeouts
          * have elapsed without activity.
          */
-        socketTimeout?: number;
+        socketTimeout?: number | undefined;
     }
 
     interface TcpOptions extends CommonOptions {
         /**
          * Where to send the stats (default localhost).
          */
-        host?: string;
+        host?: string | undefined;
 
         /**
          * Port to contact the statsd-daemon on (default 8125).
          */
-        port?: number;
+        port?: number | undefined;
 
         /**
          * Number of timeouts in which the socket auto-closes if it
@@ -68,29 +68,29 @@ declare namespace StatsdClient {
         /**
          * Where to send the stats (default localhost).
          */
-        host?: string;
+        host?: string | undefined;
 
         /**
          * Port to contact the statsd-daemon on (default 8125).
          */
-        port?: number;
+        port?: number | undefined;
     }
 
     interface HttpOptions extends CommonOptions {
         /**
          * Where to send the stats (default localhost).
          */
-        host?: string;
+        host?: string | undefined;
 
         /**
          * Additional headers to send (default {}).
          */
-        headers?: { [index: string]: string };
+        headers?: { [index: string]: string } | undefined;
 
         /**
          * What HTTP method to use (default "PUT").
          */
-        method?: string;
+        method?: string | undefined;
     }
 
     interface ExpressMiddlewareOptions {
@@ -98,19 +98,19 @@ declare namespace StatsdClient {
          * Metric name to use for reporting if a matching route is not
          * found (default "unknown_express_route").
          */
-        notFoundRouteName?: string;
+        notFoundRouteName?: string | undefined;
 
         /**
          * Optional callback called after reporting metrics for an
          * express route.
          */
-        onResponseEnd?: (client: StatsdClient, startTime: Date, req: express.Request, res: express.Response) => void;
+        onResponseEnd?: ((client: StatsdClient, startTime: Date, req: express.Request, res: express.Response) => void) | undefined;
 
         /**
          * Enables inclusion of per-URL response code and timing
          * metrics (default false).
          */
-        timeByUrl?: boolean;
+        timeByUrl?: boolean | undefined;
     }
 }
 

--- a/types/std-mocks/index.d.ts
+++ b/types/std-mocks/index.d.ts
@@ -4,14 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Options {
-    stdout?: boolean;
-    stderr?: boolean;
+    stdout?: boolean | undefined;
+    stderr?: boolean | undefined;
 }
 
 /**
  * Start mocking std output
  */
-export function use(opts?: Options & {print?: boolean}): void;
+export function use(opts?: Options & {print?: boolean | undefined}): void;
 
 /**
  * Restore std output

--- a/types/steam-client/index.d.ts
+++ b/types/steam-client/index.d.ts
@@ -108,7 +108,7 @@ export type SendMessage = (
         /**
          * A CMsgProtoBufHeader object if this message is protobuf-backed, otherwise header.proto is falsy.
          */
-        proto?: CMsgProtoBufHeader | false
+        proto?: CMsgProtoBufHeader | false | undefined
     },
 
     /**
@@ -185,12 +185,12 @@ export interface CMsgClientLogon {
     /**
      * Steam Guard code. Must be valid if provided, otherwise the logon will fail. Note that Steam Guard codes expire after a short while
      */
-    auth_code?: string;
+    auth_code?: string | undefined;
 
     /**
      * Two-factor authentication code provided by the Steam mobile application. You will have to provide this code every time you log in if your account uses 2FA.
      */
-    two_factor_code?: string;
+    two_factor_code?: string | undefined;
 
     /**
      * SHA1 hash of your sentry file.
@@ -199,7 +199,7 @@ export interface CMsgClientLogon {
      * If no Steam Guard code is provided, the hash must be already registered with this account, otherwise it's ignored.
      * This value will be ignored if you enable 2FA.
      */
-    sha_sentryfile?: string;
+    sha_sentryfile?: string | undefined;
 }
 
 export interface CMsgClientLogonPassword extends CMsgClientLogon {
@@ -229,27 +229,27 @@ export interface CMsgClientLogonResponse {
 }
 
 export interface CMsgProtoBufHeader {
-    steamid?: string;
-    client_sessionid?: number;
-    routing_appid?: number;
-    jobid_source?: string;
-    jobid_target?: string;
-    target_job_name?: string;
-    seq_num?: number;
-    eresult?: number;
-    error_message?: string;
-    ip?: number;
-    auth_account_flags?: number;
-    token_source?: number;
-    admin_spoofing_user?: boolean;
-    transport_error?: number;
-    messageid?: string;
-    publisher_group_id?: number;
-    sysid?: number;
-    trace_tag?: string;
-    webapi_key_id?: number;
-    is_from_external_source?: boolean;
-    forward_to_sysid?: number[];
+    steamid?: string | undefined;
+    client_sessionid?: number | undefined;
+    routing_appid?: number | undefined;
+    jobid_source?: string | undefined;
+    jobid_target?: string | undefined;
+    target_job_name?: string | undefined;
+    seq_num?: number | undefined;
+    eresult?: number | undefined;
+    error_message?: string | undefined;
+    ip?: number | undefined;
+    auth_account_flags?: number | undefined;
+    token_source?: number | undefined;
+    admin_spoofing_user?: boolean | undefined;
+    transport_error?: number | undefined;
+    messageid?: string | undefined;
+    publisher_group_id?: number | undefined;
+    sysid?: number | undefined;
+    trace_tag?: string | undefined;
+    webapi_key_id?: number | undefined;
+    is_from_external_source?: boolean | undefined;
+    forward_to_sysid?: number[] | undefined;
 }
 
 // Enums

--- a/types/steam-login/index.d.ts
+++ b/types/steam-login/index.d.ts
@@ -10,7 +10,7 @@ export interface MiddlewareOptions {
     verify: string;
     realm: string;
     apiKey: string;
-    useSession?: boolean;
+    useSession?: boolean | undefined;
 }
 
 export interface SteamUser {
@@ -23,18 +23,18 @@ export interface SteamUser {
         avatarfull: string;
         personastate: number;
         communityvisibilitystate: number;
-        profilestate?: number;
+        profilestate?: number | undefined;
         lastlogoff: number;
-        commentpermission?: number;
-        realname?: string;
-        primaryclanid?: string;
-        timecreated?: number;
-        gameid?: string;
-        gameserverip?: string;
-        gameextrainfo?: string;
-        loccountrycode?: string;
-        locstatecode?: string;
-        loccityid?: number;
+        commentpermission?: number | undefined;
+        realname?: string | undefined;
+        primaryclanid?: string | undefined;
+        timecreated?: number | undefined;
+        gameid?: string | undefined;
+        gameserverip?: string | undefined;
+        gameextrainfo?: string | undefined;
+        loccountrycode?: string | undefined;
+        locstatecode?: string | undefined;
+        loccityid?: number | undefined;
     };
     steamid: string;
     username: string;
@@ -49,7 +49,7 @@ export interface SteamUser {
 
 export interface SteamRequest extends Request {
     logout?(): (req: Request) => () => void;
-    user?: SteamUser;
+    user?: SteamUser | undefined;
 }
 
 export function middleware(opts: MiddlewareOptions): RequestHandler;

--- a/types/steam/index.d.ts
+++ b/types/steam/index.d.ts
@@ -15,8 +15,8 @@ declare namespace Steam {
     export interface LogonOptions {
         accountName: string;
         password: string;
-        shaSentryfile?: string;
-        authCode?: string;
+        shaSentryfile?: string | undefined;
+        authCode?: string | undefined;
     }
 
     export enum EResult {

--- a/types/steelseries/index.d.ts
+++ b/types/steelseries/index.d.ts
@@ -304,68 +304,68 @@ export function drawForeground(
 
 // Frame, Background and Foreground
 interface FrameStruct {
-    frameDesign?: FrameDesign;
-    frameVisible?: boolean;
-    backgroundColor?: BackgroundColor; // Omit<> in Horizon
-    backgroundVisible?: boolean; 			 // Omit<> in Horizon
-    foregroundType?: ForegroundType; // Omit<> in Linear*
-    foregroundVisible?: boolean;
+    frameDesign?: FrameDesign | undefined;
+    frameVisible?: boolean | undefined;
+    backgroundColor?: BackgroundColor | undefined; // Omit<> in Horizon
+    backgroundVisible?: boolean | undefined; 			 // Omit<> in Horizon
+    foregroundType?: ForegroundType | undefined; // Omit<> in Linear*
+    foregroundVisible?: boolean | undefined;
 }
 
 // Pointer & Knob
 interface PointKnob {
-    knobType?: KnobType; // Omit<> in Clock
-    knobStyle?: KnobStyle; // Omit<> in Clock
-    pointerType?: PointerType; // Omit<> in Altimeter, WindDir
-    pointerColor?: ColorDef; // Omit<> in Altimeter
+    knobType?: KnobType | undefined; // Omit<> in Clock
+    knobStyle?: KnobStyle | undefined; // Omit<> in Clock
+    pointerType?: PointerType | undefined; // Omit<> in Altimeter, WindDir
+    pointerColor?: ColorDef | undefined; // Omit<> in Altimeter
 }
 
 // Lcd
 interface Lcd {
-    lcdColor?: LcdColor;
-    digitalFont?: boolean;
-    lcdVisible?: boolean; // Omit<> in DisplayMulti, DisplaySingle
-    lcdDecimals?: number; // Omit<> in Altimeter, WindDir
+    lcdColor?: LcdColor | undefined;
+    digitalFont?: boolean | undefined;
+    lcdVisible?: boolean | undefined; // Omit<> in DisplayMulti, DisplaySingle
+    lcdDecimals?: number | undefined; // Omit<> in Altimeter, WindDir
 }
 
 // All Linear and Radial common parameters
 interface LinearRadialCommon {
-    minValue?: number;
-    maxValue?: number;
-    minMeasuredValueVisible?: boolean; // Omit<> in RadialBargraph
-    maxMeasuredValueVisible?: boolean; // Omit<> in RadialBargraph
-    niceScale?: boolean;
-    labelNumberFormat?: LabelNumberFormat;
-    threshold?: number;
-    thresholdRising?: boolean;
-    thresholdVisible?: boolean;
-    fullScaleDeflectionTime?: number; // & WindDir
-    playAlarm?: boolean;
-    alarmSound?: string;
+    minValue?: number | undefined;
+    maxValue?: number | undefined;
+    minMeasuredValueVisible?: boolean | undefined; // Omit<> in RadialBargraph
+    maxMeasuredValueVisible?: boolean | undefined; // Omit<> in RadialBargraph
+    niceScale?: boolean | undefined;
+    labelNumberFormat?: LabelNumberFormat | undefined;
+    threshold?: number | undefined;
+    thresholdRising?: boolean | undefined;
+    thresholdVisible?: boolean | undefined;
+    fullScaleDeflectionTime?: number | undefined; // & WindDir
+    playAlarm?: boolean | undefined;
+    alarmSound?: string | undefined;
 
-    titleString?: string;
-    unitString?: string;
+    titleString?: string | undefined;
+    unitString?: string | undefined;
 
-    ledColor?: LedColor;
-    ledVisible?: boolean;
+    ledColor?: LedColor | undefined;
+    ledVisible?: boolean | undefined;
 }
 
 /* Gauges */
 
 export interface RadialParams extends FrameStruct, PointKnob, Lcd, LinearRadialCommon {
-    size?: number;
-    gaugeType?: GaugeType;
-    fractionalScaleDecimals?: number;
-    tickLabelOrientation?: TickLabelOrientation;
-    trendVisible?: boolean;
-    trendColors?: [LedColor, LedColor, LedColor];
-    userLedColor?: LedColor;
-    userLedVisible?: boolean;
-    section?: Section[];
-    area?: Section[];
-    useOdometer?: boolean;
-    odometerParams?: OdometerParams;
-    odometerUseValue?: boolean;
+    size?: number | undefined;
+    gaugeType?: GaugeType | undefined;
+    fractionalScaleDecimals?: number | undefined;
+    tickLabelOrientation?: TickLabelOrientation | undefined;
+    trendVisible?: boolean | undefined;
+    trendColors?: [LedColor, LedColor, LedColor] | undefined;
+    userLedColor?: LedColor | undefined;
+    userLedVisible?: boolean | undefined;
+    section?: Section[] | undefined;
+    area?: Section[] | undefined;
+    useOdometer?: boolean | undefined;
+    odometerParams?: OdometerParams | undefined;
+    odometerUseValue?: boolean | undefined;
 
     customLayer?: any;
 }
@@ -416,19 +416,19 @@ export class Radial {
 }
 
 export interface  RadialBargraphParams extends FrameStruct, Lcd, Omit<LinearRadialCommon, "minMeasuredValueVisible"|"maxMeasuredValueVisible"|"thresholdVisible"> {
-    size?: number;
-    gaugeType?: GaugeType;
-    fractionalScaleDecimals?: number;
-    tickLabelOrientation?: TickLabelOrientation;
-    trendVisible?: boolean;
-    trendColors?: [LedColor, LedColor, LedColor];
-    userLedColor?: LedColor;
-    userLedVisible?: boolean;
-    valueColor?: ColorDef;
-    section?: Section[];
-    useSectionColors?: boolean;
-    valueGradient?: gradientWrapper | null;
-    useValueGradient?: boolean;
+    size?: number | undefined;
+    gaugeType?: GaugeType | undefined;
+    fractionalScaleDecimals?: number | undefined;
+    tickLabelOrientation?: TickLabelOrientation | undefined;
+    trendVisible?: boolean | undefined;
+    trendColors?: [LedColor, LedColor, LedColor] | undefined;
+    userLedColor?: LedColor | undefined;
+    userLedVisible?: boolean | undefined;
+    valueColor?: ColorDef | undefined;
+    section?: Section[] | undefined;
+    useSectionColors?: boolean | undefined;
+    valueGradient?: gradientWrapper | null | undefined;
+    useValueGradient?: boolean | undefined;
 
     customLayer?: any;
 }
@@ -470,10 +470,10 @@ export class RadialBargraph {
 }
 
 export interface RadialVerticalParams extends FrameStruct, PointKnob, LinearRadialCommon {
-    size?: number;
-    orientation?: Orientation;
-    section?: Section[];
-    area?: Section[];
+    size?: number | undefined;
+    orientation?: Orientation | undefined;
+    section?: Section[] | undefined;
+    area?: Section[] | undefined;
 }
 export class RadialVertical {
     constructor(canvas: HTMLCanvasElement|string, parameters?: RadialVerticalParams)
@@ -504,10 +504,10 @@ export class RadialVertical {
 }
 
 export interface LinearParams extends Omit<FrameStruct, "foregroundType">, Lcd, LinearRadialCommon {
-    width?: number;
-    height?: number;
-    gaugeType?: GaugeType;
-    valueColor?: ColorDef;
+    width?: number | undefined;
+    height?: number | undefined;
+    gaugeType?: GaugeType | undefined;
+    valueColor?: ColorDef | undefined;
 }
 export class Linear {
     constructor(canvas: HTMLCanvasElement|string, parameters?: LinearParams)
@@ -541,12 +541,12 @@ export class Linear {
 }
 
 export interface LinearBargraphParams extends Omit<FrameStruct, "foregroundType">, Lcd, LinearRadialCommon {
-    width?: number;
-    height?: number;
-    section?: Section[];
-    valueColor?: ColorDef;
-    valueGradient?: gradientWrapper | null;
-    useValueGradient?: boolean;
+    width?: number | undefined;
+    height?: number | undefined;
+    section?: Section[] | undefined;
+    valueColor?: ColorDef | undefined;
+    valueGradient?: gradientWrapper | null | undefined;
+    useValueGradient?: boolean | undefined;
 }
 export class LinearBargraph {
     constructor(canvas: HTMLCanvasElement|string, parameters?: LinearBargraphParams)
@@ -584,17 +584,17 @@ export class LinearBargraph {
 }
 
 export interface DisplaySingleParams extends Omit<Lcd, "lcdVisible"> {
-    width?: number;
-    height?: number;
-    section?: Section[];
-    unitString?: string;
-    unitStringVisible?: boolean;
-    headerString?: string;
-    headerStringVisible?: boolean;
-    valuesNumeric?: boolean;
-    value?: string | number;
-    alwaysScroll?: boolean;
-    autoScroll?: boolean;
+    width?: number | undefined;
+    height?: number | undefined;
+    section?: Section[] | undefined;
+    unitString?: string | undefined;
+    unitStringVisible?: boolean | undefined;
+    headerString?: string | undefined;
+    headerStringVisible?: boolean | undefined;
+    valuesNumeric?: boolean | undefined;
+    value?: string | number | undefined;
+    alwaysScroll?: boolean | undefined;
+    autoScroll?: boolean | undefined;
 }
 export class DisplaySingle {
     constructor(canvas: HTMLCanvasElement | string, parameters?: DisplaySingleParams)
@@ -606,18 +606,18 @@ export class DisplaySingle {
 }
 
 export interface DisplayMultiParams extends Omit<Lcd, "lcdVisible"> {
-    width?: number;
-    height?: number;
-    headerString?: string;
-    headerStringVisible?: boolean;
-    detailString?: string;
-    detailStringVisible?: boolean;
-    linkAltValue?: boolean;
-    unitString?: string;
-    unitStringVisible?: boolean;
-    valuesNumeric?: boolean;
-    value?: string | number;
-    altValue?: string | number;
+    width?: number | undefined;
+    height?: number | undefined;
+    headerString?: string | undefined;
+    headerStringVisible?: boolean | undefined;
+    detailString?: string | undefined;
+    detailStringVisible?: boolean | undefined;
+    linkAltValue?: boolean | undefined;
+    unitString?: string | undefined;
+    unitStringVisible?: boolean | undefined;
+    valuesNumeric?: boolean | undefined;
+    value?: string | number | undefined;
+    altValue?: string | number | undefined;
 }
 export class DisplayMulti {
     constructor(canvas: HTMLCanvasElement|string, parameters?: DisplayMultiParams)
@@ -628,11 +628,11 @@ export class DisplayMulti {
 }
 
 export interface LevelParams extends FrameStruct {
-    size?: number;
-    decimalsVisible?: boolean;
-    textOrientationFixed?: boolean;
-    pointerColor?: ColorDef;
-    rotateFace?: boolean;
+    size?: number | undefined;
+    decimalsVisible?: boolean | undefined;
+    textOrientationFixed?: boolean | undefined;
+    pointerColor?: ColorDef | undefined;
+    rotateFace?: boolean | undefined;
 }
 export class Level {
     constructor(canvas: HTMLCanvasElement|string, parameters?: LevelParams)
@@ -647,12 +647,12 @@ export class Level {
 }
 
 export interface CompassParams extends FrameStruct, PointKnob {
-    size?: number;
-    pointSymbols?: string[];
-    pointSymbolsVisible?: boolean;
-    degreeScale?: boolean;
-    roseVisible?: boolean;
-    rotateFace?: boolean;
+    size?: number | undefined;
+    pointSymbols?: string[] | undefined;
+    pointSymbolsVisible?: boolean | undefined;
+    degreeScale?: boolean | undefined;
+    roseVisible?: boolean | undefined;
+    rotateFace?: boolean | undefined;
 
     customLayer?: any;
 }
@@ -671,21 +671,21 @@ export class Compass {
 }
 
 export interface WindDirectionParams extends FrameStruct, Omit<PointKnob, "pointerType">, Omit<Lcd, "lcdDecimals"> {
-    size?: number;
-    section?: Section[];
-    area?: Section[];
-    fullScaleDeflectionTime?: number;
-    pointerTypeLatest?: PointerType;
-    pointerTypeAverage?: PointerType;
-    pointerColorAverage?: ColorDef;
-    pointSymbols?: string[];
-    pointSymbolsVisible?: boolean;
-    degreeScale?: boolean;
-    degreeScaleHalf?: boolean;
-    roseVisible?: boolean;
-    lcdTitleStrings?: string[];
-    titleString?: string;
-    useColorLabels?: boolean;
+    size?: number | undefined;
+    section?: Section[] | undefined;
+    area?: Section[] | undefined;
+    fullScaleDeflectionTime?: number | undefined;
+    pointerTypeLatest?: PointerType | undefined;
+    pointerTypeAverage?: PointerType | undefined;
+    pointerColorAverage?: ColorDef | undefined;
+    pointSymbols?: string[] | undefined;
+    pointSymbolsVisible?: boolean | undefined;
+    degreeScale?: boolean | undefined;
+    degreeScaleHalf?: boolean | undefined;
+    roseVisible?: boolean | undefined;
+    lcdTitleStrings?: string[] | undefined;
+    titleString?: string | undefined;
+    useColorLabels?: boolean | undefined;
 
     customLayer?: any;
 }
@@ -713,8 +713,8 @@ export class WindDirection {
 }
 
 export interface HorizonParams extends Omit<FrameStruct, "backgroundColor"|"backgroundVisible"> {
-    size?: number;
-    pointerColor?: ColorDef;
+    size?: number | undefined;
+    pointerColor?: ColorDef | undefined;
 }
 export class Horizon {
     constructor(canvas: HTMLCanvasElement|string, parameters?: HorizonParams)
@@ -731,8 +731,8 @@ export class Horizon {
 }
 
 export interface LedParams {
-    size?: number;
-    ledColor?: LedColor;
+    size?: number | undefined;
+    ledColor?: LedColor | undefined;
 }
 export class Led {
     constructor(canvas: HTMLCanvasElement|string, parameters?: LedParams)
@@ -782,8 +782,8 @@ export class Clock {
 }
 
 export interface BatteryParams {
-    size?: number;
-    value?: number;
+    size?: number | undefined;
+    value?: number | undefined;
 }
 export class Battery {
     constructor(canvas: HTMLCanvasElement|string, parameters?: BatteryParams)
@@ -793,8 +793,8 @@ export class Battery {
 }
 
 export interface StopwatchParams extends FrameStruct {
-    size?: number;
-    pointerColor?: ColorDef;
+    size?: number | undefined;
+    pointerColor?: ColorDef | undefined;
     customLayer?: any;
 }
 export class Stopwatch {
@@ -813,8 +813,8 @@ export class Stopwatch {
 }
 
 export interface AltimeterParams extends FrameStruct, Omit<PointKnob, "pointerType"|"pointerColor">, Omit<Lcd, "lcdDecimals"> {
-    size?: number;
-    unitAltPos?: boolean;
+    size?: number | undefined;
+    unitAltPos?: boolean | undefined;
 
     customLayer?: any;
 }
@@ -833,8 +833,8 @@ export class Altimeter {
 }
 
 export interface TrafficlightParams {
-    width?: number;
-    height?: number;
+    width?: number | undefined;
+    height?: number | undefined;
 }
 export class Trafficlight {
     constructor(canvas: HTMLCanvasElement|string, parameters?: TrafficlightParams)
@@ -864,17 +864,17 @@ export class Lightbulb {
 }
 
 export interface OdometerParams {
-    _context?: RenderingContext;
-    height?: number;
-    digits?: number;
-    decimals?: number;
-    decimalBackColor?: string;
-    decimalForeColor?: string;
-    font?: string;
-    value?: number;
-    valueBackColor?: string;
-    valueForeColor?: string;
-    wobbleFactor?: number;
+    _context?: RenderingContext | undefined;
+    height?: number | undefined;
+    digits?: number | undefined;
+    decimals?: number | undefined;
+    decimalBackColor?: string | undefined;
+    decimalForeColor?: string | undefined;
+    font?: string | undefined;
+    value?: number | undefined;
+    valueBackColor?: string | undefined;
+    valueForeColor?: string | undefined;
+    wobbleFactor?: number | undefined;
 }
 export class Odometer {
     constructor(canvas: HTMLCanvasElement|string, parameters?: OdometerParams)

--- a/types/sticky-cluster/index.d.ts
+++ b/types/sticky-cluster/index.d.ts
@@ -11,13 +11,13 @@ declare namespace stickyCluster {
     type InitializeFn = (callback: Callback) => void;
     type Callback = (server: http.Server) => void;
     interface Options {
-        concurrency?: number;
-        port?: number;
-        debug?: boolean;
-        prefix?: string;
-        env?: (index: number) => { stickycluster_worker_index: number };
-        hardShutdownDelay?: number;
-        errorHandler?: (err: any) => void;
+        concurrency?: number | undefined;
+        port?: number | undefined;
+        debug?: boolean | undefined;
+        prefix?: string | undefined;
+        env?: ((index: number) => { stickycluster_worker_index: number }) | undefined;
+        hardShutdownDelay?: number | undefined;
+        errorHandler?: ((err: any) => void) | undefined;
     }
 }
 

--- a/types/sticky-session/index.d.ts
+++ b/types/sticky-session/index.d.ts
@@ -17,7 +17,7 @@ export function listen(
     server: Server,
     port?: number,
     options?: {
-        readonly workers?: number,
+        readonly workers?: number | undefined,
         readonly env?: any
     }
 ): boolean;

--- a/types/stompit/lib/Channel.d.ts
+++ b/types/stompit/lib/Channel.d.ts
@@ -29,8 +29,8 @@ export = Channel;
 
 declare namespace Channel {
     interface ChannelOptions {
-        alwaysConnected?: boolean;
-        recoverAfterApplicationError?: boolean;
+        alwaysConnected?: boolean | undefined;
+        recoverAfterApplicationError?: boolean | undefined;
     }
 
     type Body = string | Buffer | (() => Readable);

--- a/types/stompit/lib/ChannelPool.d.ts
+++ b/types/stompit/lib/ChannelPool.d.ts
@@ -14,11 +14,11 @@ export = ChannelPool;
 
 declare namespace ChannelPool {
     interface ChannelPoolOptions {
-        minChannels?: number;
-        minFreeChannels?: number;
-        maxChannels?: number;
-        freeExcessTimeout?: number;
-        requestChannelTimeout?: number;
-        channelOptions?: ChannelOptions;
+        minChannels?: number | undefined;
+        minFreeChannels?: number | undefined;
+        maxChannels?: number | undefined;
+        freeExcessTimeout?: number | undefined;
+        requestChannelTimeout?: number | undefined;
+        channelOptions?: ChannelOptions | undefined;
     }
 }

--- a/types/stompit/lib/ConnectFailover.d.ts
+++ b/types/stompit/lib/ConnectFailover.d.ts
@@ -24,25 +24,25 @@ export = ConnectFailover;
 declare namespace ConnectFailover {
     interface ConnectFailoverOptions {
         // Milliseconds delay of the first reconnect
-        initialReconnectDelay?: number;
+        initialReconnectDelay?: number | undefined;
 
         // Maximum milliseconds delay of any reconnect
-        maxReconnectDelay?: number;
+        maxReconnectDelay?: number | undefined;
 
         // Exponential increase of the reconnect delay
-        useExponentialBackOff?: boolean;
+        useExponentialBackOff?: boolean | undefined;
 
         // The exponent used in the exponential backoff attempts
-        reconnectDelayExponent?: number;
+        reconnectDelayExponent?: number | undefined;
 
         // Maximum number of reconnects
-        maxReconnects?: number;
+        maxReconnects?: number | undefined;
 
         // Randomly choose a server to use for reconnect
-        randomize?: boolean;
+        randomize?: boolean | undefined;
 
         // Override the connect function
-        connectFunction?: (options: ConnectOptions, connectionListener?: ConnectionListener) => Client;
+        connectFunction?: ((options: ConnectOptions, connectionListener?: ConnectionListener) => Client) | undefined;
     }
 
     interface Server {

--- a/types/stompit/lib/Socket.d.ts
+++ b/types/stompit/lib/Socket.d.ts
@@ -38,13 +38,13 @@ declare namespace Socket {
     }
 
     interface SocketOptions {
-        commandHandlers?: CommandHandlers;
-        unknownCommand?: () => void;
-        outgoingFrameStream?: OutgoingFrameStream;
-        heartbeat?: Heartbeat;
-        heartbeatDelayMargin?: number;
-        heartbeatOutputMargin?: number;
-        resetDisconnect?: boolean;
+        commandHandlers?: CommandHandlers | undefined;
+        unknownCommand?: (() => void) | undefined;
+        outgoingFrameStream?: OutgoingFrameStream | undefined;
+        heartbeat?: Heartbeat | undefined;
+        heartbeatDelayMargin?: number | undefined;
+        heartbeatOutputMargin?: number | undefined;
+        resetDisconnect?: boolean | undefined;
     }
 
     interface SocketError extends Error {

--- a/types/stompit/lib/connect-failover/getAddressInfo.d.ts
+++ b/types/stompit/lib/connect-failover/getAddressInfo.d.ts
@@ -9,9 +9,9 @@ declare namespace getAddressInfo {
         connectArgs: ConnectOptions;
         transport: string;
         transportPath: string;
-        path?: string;
-        host?: string;
-        port?: number;
+        path?: string | undefined;
+        host?: string | undefined;
+        port?: number | undefined;
         pseudoUri: string;
     }
 }

--- a/types/stompit/lib/connect.d.ts
+++ b/types/stompit/lib/connect.d.ts
@@ -13,26 +13,26 @@ export = connect;
 
 declare namespace connect {
     interface ConnectHeaders {
-        "accept-version"?: string;
-        "heart-beat"?: string;
-        host?: string;
-        login?: string;
-        passcode?: string;
+        "accept-version"?: string | undefined;
+        "heart-beat"?: string | undefined;
+        host?: string | undefined;
+        login?: string | undefined;
+        passcode?: string | undefined;
     }
 
     interface BaseConnectOptions extends SocketOptions {
-        connectHeaders?: ConnectHeaders;
-        ssl?: boolean;
+        connectHeaders?: ConnectHeaders | undefined;
+        ssl?: boolean | undefined;
         // This connectionListener type comes from @types/node
-        connect?: (options: ConnectOptions, connectionListener?: () => void) => Socket;
+        connect?: ((options: ConnectOptions, connectionListener?: () => void) => Socket) | undefined;
     }
 
     interface NetTcpConnectOptions extends BaseConnectOptions, TcpNetConnectOpts {
-        ssl?: false;
+        ssl?: false | undefined;
     }
 
     interface NetIpcConnectOptions extends BaseConnectOptions, IpcNetConnectOpts {
-        ssl?: false;
+        ssl?: false | undefined;
     }
 
     interface SslConnectOptions extends BaseConnectOptions, TlsConnectionOptions {

--- a/types/stompjs/index.d.ts
+++ b/types/stompjs/index.d.ts
@@ -26,7 +26,7 @@ export class Client {
 
     debug(...args: string[]): any;
 
-    connect(headers: { login: string, passcode: string, host?: string }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: Frame | string) => any): any;
+    connect(headers: { login: string, passcode: string, host?: string | undefined }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: Frame | string) => any): any;
     connect(headers: { }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: Frame | string) => any): any;
     connect(login: string, passcode: string, connectCallback: (frame?: Frame) => any, errorCallback?: (error: Frame | string) => any, host?: string): any;
     disconnect(disconnectCallback: () => any, headers?: {}): any;

--- a/types/storefront-ui__vue/index.d.ts
+++ b/types/storefront-ui__vue/index.d.ts
@@ -72,10 +72,10 @@ export interface Breadcrumb {
 }
 
 export interface Source {
-    mobile?: { url: string };
-    desktop?: { url: string };
-    big?: { url: string };
-    zoom?: { url: string };
+    mobile?: { url: string } | undefined;
+    desktop?: { url: string } | undefined;
+    big?: { url: string } | undefined;
+    zoom?: { url: string } | undefined;
 }
 
 export interface Image extends Source {

--- a/types/storybook-addon-jsx/index.d.ts
+++ b/types/storybook-addon-jsx/index.d.ts
@@ -10,10 +10,10 @@ import { ReactElement, ReactNode } from 'react';
 export type displayNameFunc = (element: ReactElement) => string;
 
 export interface AddonParameters {
-    skip?: number;
-    enableBeautify?: boolean;
-    onBeforeRender?: (domString: string) => string;
-    displayName?: string | displayNameFunc;
+    skip?: number | undefined;
+    enableBeautify?: boolean | undefined;
+    onBeforeRender?: ((domString: string) => string) | undefined;
+    displayName?: string | displayNameFunc | undefined;
 }
 
 export type AddWithJSXFunc<StoryFnReturnType> = (

--- a/types/storybook-readme/index.d.ts
+++ b/types/storybook-readme/index.d.ts
@@ -23,12 +23,12 @@ export const addReadme: MakeDecoratorResult;
 export function addFooter(md: string): void;
 export function addHeader(md: string): void;
 export interface ConfigureReadmeConfig {
-    header?: string;
-    footer?: string;
-    StoryPreview?: (props: { children: ReactNode }) => ReactNode;
-    DocPreview?: (props: { children: ReactNode }) => ReactNode;
-    HeaderPreview?: (props: { children: ReactNode }) => ReactNode;
-    FooterPreview?: (props: { children: ReactNode }) => ReactNode;
+    header?: string | undefined;
+    footer?: string | undefined;
+    StoryPreview?: ((props: { children: ReactNode }) => ReactNode) | undefined;
+    DocPreview?: ((props: { children: ReactNode }) => ReactNode) | undefined;
+    HeaderPreview?: ((props: { children: ReactNode }) => ReactNode) | undefined;
+    FooterPreview?: ((props: { children: ReactNode }) => ReactNode) | undefined;
 }
 
 export function configureReadme(config: ConfigureReadmeConfig): void;
@@ -43,8 +43,8 @@ export function withReadme(
 
 // WithDocs Types
 export interface CustomComponents {
-  PreviewComponent?: (props: { children: JSX.Element }) => JSX.Element;
-  FooterComponent?: (props: { children: JSX.Element }) => JSX.Element;
+  PreviewComponent?: ((props: { children: JSX.Element }) => JSX.Element) | undefined;
+  FooterComponent?: ((props: { children: JSX.Element }) => JSX.Element) | undefined;
 }
 
 export function withDocs(

--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -10,9 +10,9 @@ import { ComponentType, ReactElement } from 'react';
 import { DecoratorFunction, StoryFn, StoryContext, Parameters, StoryApi } from '@storybook/addons';
 
 export interface WrapStoryProps {
-    storyFn?: StoryFn;
-    context?: object;
-    options?: object;
+    storyFn?: StoryFn | undefined;
+    context?: object | undefined;
+    options?: object | undefined;
 }
 
 export interface TableComponentOptionProps {
@@ -26,26 +26,26 @@ export interface TableComponentOptionProps {
 }
 
 export interface Options {
-    text?: string;
-    header?: boolean;
-    inline?: boolean;
-    source?: boolean;
-    propTables?: Array<ComponentType<any>> | false;
-    propTablesExclude?: Array<ComponentType<any>>;
-    styles?: object;
+    text?: string | undefined;
+    header?: boolean | undefined;
+    inline?: boolean | undefined;
+    source?: boolean | undefined;
+    propTables?: Array<ComponentType<any>> | false | undefined;
+    propTablesExclude?: Array<ComponentType<any>> | undefined;
+    styles?: object | undefined;
     components?: {
         [key: string]: ComponentType<any>
-    };
+    } | undefined;
     /**
      * @deprecated "marksyConf" option has been renamed to "components"
      */
-    marksyConf?: object;
-    maxPropsIntoLine?: number;
-    maxPropObjectKeys?: number;
-    maxPropArrayLength?: number;
-    maxPropStringLength?: number;
-    TableComponent?: ComponentType<TableComponentOptionProps>;
-    excludedPropTypes?: string[];
+    marksyConf?: object | undefined;
+    maxPropsIntoLine?: number | undefined;
+    maxPropObjectKeys?: number | undefined;
+    maxPropArrayLength?: number | undefined;
+    maxPropStringLength?: number | undefined;
+    TableComponent?: ComponentType<TableComponentOptionProps> | undefined;
+    excludedPropTypes?: string[] | undefined;
 }
 
 export function withInfo<A = unknown>(

--- a/types/strange/index.d.ts
+++ b/types/strange/index.d.ts
@@ -130,12 +130,12 @@ interface Range<T extends Range.Endpoint> {
     /**
      * Range's beginning, or left endpoint.
      */
-    begin?: T | null;
+    begin?: T | null | undefined;
 
     /**
      * Range's end, or right endpoint.
      */
-    end?: T | null;
+    end?: T | null | undefined;
 
     /**
      * Range's bounds.

--- a/types/stream-buffers/index.d.ts
+++ b/types/stream-buffers/index.d.ts
@@ -7,8 +7,8 @@
 import * as stream from 'stream';
 
 export interface WritableStreamBufferOptions extends stream.WritableOptions {
-    initialSize?: number;
-    incrementAmount?: number;
+    initialSize?: number | undefined;
+    incrementAmount?: number | undefined;
 }
 
 export class WritableStreamBuffer extends stream.Writable {
@@ -20,10 +20,10 @@ export class WritableStreamBuffer extends stream.Writable {
 }
 
 export interface ReadableStreamBufferOptions extends stream.ReadableOptions {
-    frequency?: number;
-    chunkSize?: number;
-    initialSize?: number;
-    incrementAmount?: number;
+    frequency?: number | undefined;
+    chunkSize?: number | undefined;
+    initialSize?: number | undefined;
+    incrementAmount?: number | undefined;
 }
 
 export class ReadableStreamBuffer extends stream.Readable {

--- a/types/stream-chain/index.d.ts
+++ b/types/stream-chain/index.d.ts
@@ -23,7 +23,7 @@ declare class Chain extends Duplex {
 
 declare namespace Chain {
     interface ChainOptions extends DuplexOptions {
-        skipEvents?: boolean;
+        skipEvents?: boolean | undefined;
     }
 
     function chain(fns: StreamItem[], options?: ChainOptions): Chain;

--- a/types/stream-csv-as-json/AsObjects.d.ts
+++ b/types/stream-csv-as-json/AsObjects.d.ts
@@ -11,13 +11,13 @@ declare class AsObjects extends Transform {
 
 declare namespace AsObjects {
     interface AsObjectOptions extends TransformOptions {
-        packValues?: boolean;
-        packStrings?: boolean;
-        streamValues?: boolean;
-        streamStrings?: boolean;
-        useValues?: boolean;
-        useStringValues?: boolean;
-        fieldPrefix?: string;
+        packValues?: boolean | undefined;
+        packStrings?: boolean | undefined;
+        streamValues?: boolean | undefined;
+        streamStrings?: boolean | undefined;
+        useValues?: boolean | undefined;
+        useStringValues?: boolean | undefined;
+        fieldPrefix?: string | undefined;
     }
 
     function make(options?: AsObjectOptions): AsObjects;

--- a/types/stream-csv-as-json/Parser.d.ts
+++ b/types/stream-csv-as-json/Parser.d.ts
@@ -10,11 +10,11 @@ declare class Parser extends Transform {
 
 declare namespace Parser {
     interface ParserOptions extends TransformOptions {
-        packValues?: boolean;
-        packStrings?: boolean;
-        streamValues?: boolean;
-        streamStrings?: boolean;
-        separator?: string;
+        packValues?: boolean | undefined;
+        packStrings?: boolean | undefined;
+        streamValues?: boolean | undefined;
+        streamStrings?: boolean | undefined;
+        separator?: string | undefined;
     }
 
     function make(options?: ParserOptions): Parser;

--- a/types/stream-csv-as-json/Stringer.d.ts
+++ b/types/stream-csv-as-json/Stringer.d.ts
@@ -10,9 +10,9 @@ declare class Stringer extends Transform {
 
 declare namespace Stringer {
     interface StringerOptions extends TransformOptions {
-        useValues?: boolean;
-        useStringValues?: boolean;
-        separator?: string;
+        useValues?: boolean | undefined;
+        useStringValues?: boolean | undefined;
+        separator?: string | undefined;
     }
 
     function make(options?: StringerOptions): Stringer;

--- a/types/stream-fork/index.d.ts
+++ b/types/stream-fork/index.d.ts
@@ -35,6 +35,6 @@ declare namespace Fork {
          * ignoreErrors is a flag. When its value is truthy, a Fork instance never fails on write() silently ignoring downstream errors.
          * Otherwise, the first encountered downstream error is reported upstream as its own error. The default: false.
          */
-        ignoreErrors?: boolean;
+        ignoreErrors?: boolean | undefined;
     }
 }

--- a/types/stream-json/Assembler.d.ts
+++ b/types/stream-json/Assembler.d.ts
@@ -5,7 +5,7 @@ export = Assembler;
 
 interface Token {
     name: string;
-    value?: string;
+    value?: string | undefined;
 }
 
 declare class Assembler extends EventEmitter {
@@ -34,7 +34,7 @@ declare class Assembler extends EventEmitter {
 
 declare namespace Assembler {
     interface AssemblerOptions {
-        reviver?: (key: string, value: any) => any;
+        reviver?: ((key: string, value: any) => any) | undefined;
     }
 
     function connectTo(stream: Readable): Assembler;

--- a/types/stream-json/Disassembler.d.ts
+++ b/types/stream-json/Disassembler.d.ts
@@ -12,16 +12,16 @@ declare namespace Disassembler {
     type ReplaceArray = Array<string | number>;
 
     interface DisassemblerOptions extends TransformOptions {
-        packValues?: boolean;
-        packKeys?: boolean;
-        packStrings?: boolean;
-        packNumbers?: boolean;
-        streamValues?: boolean;
-        streamKeys?: boolean;
-        streamStrings?: boolean;
-        streamNumbers?: boolean;
-        jsonStreaming?: boolean;
-        replacer?: ReplacerFunction | ReplaceArray;
+        packValues?: boolean | undefined;
+        packKeys?: boolean | undefined;
+        packStrings?: boolean | undefined;
+        packNumbers?: boolean | undefined;
+        streamValues?: boolean | undefined;
+        streamKeys?: boolean | undefined;
+        streamStrings?: boolean | undefined;
+        streamNumbers?: boolean | undefined;
+        jsonStreaming?: boolean | undefined;
+        replacer?: ReplacerFunction | ReplaceArray | undefined;
     }
 
     function make(options?: DisassemblerOptions): Disassembler;

--- a/types/stream-json/Parser.d.ts
+++ b/types/stream-json/Parser.d.ts
@@ -9,15 +9,15 @@ declare class Parser extends Utf8Stream {
 
 declare namespace Parser {
     interface ParserOptions extends TransformOptions {
-        packValues?: boolean;
-        packKeys?: boolean;
-        packStrings?: boolean;
-        packNumbers?: boolean;
-        streamValues?: boolean;
-        streamKeys?: boolean;
-        streamStrings?: boolean;
-        streamNumbers?: boolean;
-        jsonStreaming?: boolean;
+        packValues?: boolean | undefined;
+        packKeys?: boolean | undefined;
+        packStrings?: boolean | undefined;
+        packNumbers?: boolean | undefined;
+        streamValues?: boolean | undefined;
+        streamKeys?: boolean | undefined;
+        streamStrings?: boolean | undefined;
+        streamNumbers?: boolean | undefined;
+        jsonStreaming?: boolean | undefined;
     }
 
     function make(options?: ParserOptions): Parser;

--- a/types/stream-json/Stringer.d.ts
+++ b/types/stream-json/Stringer.d.ts
@@ -8,11 +8,11 @@ declare class Stringer extends Transform {
 
 declare namespace Stringer {
     interface StringerOptions extends TransformOptions {
-        useValues?: boolean;
-        useKeyValues?: boolean;
-        useStringValues?: boolean;
-        useNumberValues?: boolean;
-        makeArray?: boolean;
+        useValues?: boolean | undefined;
+        useKeyValues?: boolean | undefined;
+        useStringValues?: boolean | undefined;
+        useNumberValues?: boolean | undefined;
+        makeArray?: boolean | undefined;
     }
 
     function make(options?: StringerOptions): Stringer;

--- a/types/stream-json/filters/FilterBase.d.ts
+++ b/types/stream-json/filters/FilterBase.d.ts
@@ -11,7 +11,7 @@ declare namespace FilterBase {
 
     interface Token {
         readonly name: string;
-        readonly value?: string | null | boolean;
+        readonly value?: string | null | boolean | undefined;
     }
 
     type FilterFunction = (stack: Stack, token: Token) => boolean;
@@ -19,11 +19,11 @@ declare namespace FilterBase {
 
     interface FilterOptions extends TransformOptions {
         filter: string | RegExp | FilterFunction;
-        once?: boolean;
-        pathSeparator?: string;
-        streamValues?: boolean;
-        streamKeys?: boolean;
-        replacement?: ReadonlyArray<Token> | ReplacementFunction;
-        allowEmptyReplacement?: boolean;
+        once?: boolean | undefined;
+        pathSeparator?: string | undefined;
+        streamValues?: boolean | undefined;
+        streamKeys?: boolean | undefined;
+        replacement?: ReadonlyArray<Token> | ReplacementFunction | undefined;
+        allowEmptyReplacement?: boolean | undefined;
     }
 }

--- a/types/stream-json/jsonl/Parser.d.ts
+++ b/types/stream-json/jsonl/Parser.d.ts
@@ -9,7 +9,7 @@ declare class JsonlParser extends Utf8Stream {
 
 declare namespace JsonlParser {
     interface JsonlParserOptions extends TransformOptions {
-        reviver?: (this: any, key: string, value: any) => any;
+        reviver?: ((this: any, key: string, value: any) => any) | undefined;
     }
 
     function make(options?: JsonlParserOptions): JsonlParser;

--- a/types/stream-json/jsonl/Stringer.d.ts
+++ b/types/stream-json/jsonl/Stringer.d.ts
@@ -8,7 +8,7 @@ declare class JsonlStringer extends Transform {
 
 declare namespace JsonlStringer {
     interface JsonlStringerOptions extends TransformOptions {
-        replacer?: (this: any, key: string, value: any) => any;
+        replacer?: ((this: any, key: string, value: any) => any) | undefined;
     }
 
     function make(options?: JsonlStringerOptions): JsonlStringer;

--- a/types/stream-json/streamers/StreamBase.d.ts
+++ b/types/stream-json/streamers/StreamBase.d.ts
@@ -11,7 +11,7 @@ declare namespace StreamBase {
     type ObjectFilterFunction = (asm: Assembler) => boolean | undefined;
 
     interface StreamOptions extends TransformOptions {
-        objectFilter?: ObjectFilterFunction;
-        includeUndecided?: boolean;
+        objectFilter?: ObjectFilterFunction | undefined;
+        includeUndecided?: boolean | undefined;
     }
 }

--- a/types/stream-json/utils/Batch.d.ts
+++ b/types/stream-json/utils/Batch.d.ts
@@ -13,7 +13,7 @@ declare namespace Batch {
          * The size of each batch. Defaults to 1000. Ignored
          * if not a positive number.
          */
-        batchSize?: number;
+        batchSize?: number | undefined;
     }
 
     function make(options?: BatchOptions): Batch;

--- a/types/stream-json/utils/Verifier.d.ts
+++ b/types/stream-json/utils/Verifier.d.ts
@@ -8,7 +8,7 @@ declare class Verifier extends Writable {
 
 declare namespace Verifier {
     interface VerifierOptions extends WritableOptions {
-        jsonStreaming?: boolean;
+        jsonStreaming?: boolean | undefined;
     }
 
     function make(options?: VerifierOptions): Verifier;

--- a/types/stream-json/utils/withParser.d.ts
+++ b/types/stream-json/utils/withParser.d.ts
@@ -20,27 +20,27 @@ declare function withParser(fn: (options?: TransformOptions) => Transform, optio
 declare namespace withParser {
     interface FilterOptions extends FilterBase.FilterOptions {
         // copied from ParserOptions
-        packValues?: boolean;
-        packKeys?: boolean;
-        packStrings?: boolean;
-        packNumbers?: boolean;
-        streamValues?: boolean;
-        streamKeys?: boolean;
-        streamStrings?: boolean;
-        streamNumbers?: boolean;
-        jsonStreaming?: boolean;
+        packValues?: boolean | undefined;
+        packKeys?: boolean | undefined;
+        packStrings?: boolean | undefined;
+        packNumbers?: boolean | undefined;
+        streamValues?: boolean | undefined;
+        streamKeys?: boolean | undefined;
+        streamStrings?: boolean | undefined;
+        streamNumbers?: boolean | undefined;
+        jsonStreaming?: boolean | undefined;
     }
 
     interface StreamOptions extends StreamBase.StreamOptions {
         // copied from ParserOptions
-        packValues?: boolean;
-        packKeys?: boolean;
-        packStrings?: boolean;
-        packNumbers?: boolean;
-        streamValues?: boolean;
-        streamKeys?: boolean;
-        streamStrings?: boolean;
-        streamNumbers?: boolean;
-        jsonStreaming?: boolean;
+        packValues?: boolean | undefined;
+        packKeys?: boolean | undefined;
+        packStrings?: boolean | undefined;
+        packNumbers?: boolean | undefined;
+        streamValues?: boolean | undefined;
+        streamKeys?: boolean | undefined;
+        streamStrings?: boolean | undefined;
+        streamNumbers?: boolean | undefined;
+        jsonStreaming?: boolean | undefined;
     }
 }

--- a/types/stream-throttle/index.d.ts
+++ b/types/stream-throttle/index.d.ts
@@ -9,7 +9,7 @@ import { Transform } from 'stream';
 
 export interface ThrottleOptions {
   readonly rate: number;
-  readonly chunksize?: number;
+  readonly chunksize?: number | undefined;
 }
 
 export class Throttle extends Transform {

--- a/types/stream-to-array/stream-to-array-tests.ts
+++ b/types/stream-to-array/stream-to-array-tests.ts
@@ -9,7 +9,7 @@ toArray(stream1, (err, arr) => {
     arr; // $ExpectType any[]
 });
 
-const stream2: stream.Readable & { toArray?: typeof toArray } = new stream.Readable();
+const stream2: stream.Readable & { toArray?: typeof toArray | undefined } = new stream.Readable();
 stream2.toArray = toArray;
 stream2.toArray(); // $ExpectType Promise<any[]>
 stream2.toArray((err, arr) => {

--- a/types/streamsaver/index.d.ts
+++ b/types/streamsaver/index.d.ts
@@ -18,14 +18,14 @@ export interface CreateWriteStreamOptions<I = any, O = any> {
     /**
      * Indicates the size of the streamed data and allows the browser to show progress while downloading.
      */
-    size?: number;
+    size?: number | undefined;
     /**
      * URL to serve the stream from. This is the URL that the browser is going to request from the service worker.
      * You might need to provide this if you're using a custom service worker.
      */
-    pathname?: string;
-    writableStrategy?: QueuingStrategy<I>;
-    readableStrategy?: QueuingStrategy<O>;
+    pathname?: string | undefined;
+    writableStrategy?: QueuingStrategy<I> | undefined;
+    readableStrategy?: QueuingStrategy<O> | undefined;
 }
 
 export interface Version {

--- a/types/streamx/index.d.ts
+++ b/types/streamx/index.d.ts
@@ -28,12 +28,12 @@ export interface ResultCallback<T> {
 }
 
 export interface StreamOptions<TStream extends Stream<TByteType>, TByteType = any> {
-    highWaterMark?: number;
-    byteLength?: ByteLengthFunction<TStream, TByteType>;
-    open?: (this: TStream, cb: Callback) => void;
-    destroy?: (this: TStream, cb: Callback) => void;
-    predestroy?: (this: TStream, cb: Callback) => void;
-    signal?: AbortSignalLike;
+    highWaterMark?: number | undefined;
+    byteLength?: ByteLengthFunction<TStream, TByteType> | undefined;
+    open?: ((this: TStream, cb: Callback) => void) | undefined;
+    destroy?: ((this: TStream, cb: Callback) => void) | undefined;
+    predestroy?: ((this: TStream, cb: Callback) => void) | undefined;
+    signal?: AbortSignalLike | undefined;
 }
 
 /* tslint:disable-next-line interface-over-type-literal - cause: https://github.com/microsoft/TypeScript/issues/15300 */
@@ -101,8 +101,8 @@ export interface BaseReadableOptions<
     TMapType,
     TByteType
 > extends StreamOptions<TStream, TByteType> {
-    read?: (this: TStream, cb: ResultCallback<TType>) => void;
-    byteLengthReadable?: ByteLengthFunction<TStream, TByteType>;
+    read?: ((this: TStream, cb: ResultCallback<TType>) => void) | undefined;
+    byteLengthReadable?: ByteLengthFunction<TStream, TByteType> | undefined;
 }
 
 export type ReadableOptions<
@@ -115,7 +115,7 @@ export type ReadableOptions<
     (
         | {}
         | {
-              map?: TMapFallback;
+              map?: TMapFallback | undefined;
               mapReadable: MapFunction<TStream, TType, TMapType>;
           }
         | {
@@ -170,10 +170,10 @@ export interface BaseWritableOptions<
     TMapType,
     TByteType
 > extends StreamOptions<TStream, TByteType> {
-    writev?: (this: TStream, batch: TMapType[], cb: Callback) => void;
-    write?: (this: TStream, data: TMapType, cb: Callback) => void;
-    final?: (this: TStream, cb: Callback) => void;
-    byteLengthWritable?: ByteLengthFunction<TStream, TByteType>;
+    writev?: ((this: TStream, batch: TMapType[], cb: Callback) => void) | undefined;
+    write?: ((this: TStream, data: TMapType, cb: Callback) => void) | undefined;
+    final?: ((this: TStream, cb: Callback) => void) | undefined;
+    byteLengthWritable?: ByteLengthFunction<TStream, TByteType> | undefined;
 }
 
 export type WritableOptions<
@@ -186,7 +186,7 @@ export type WritableOptions<
     (
         | {}
         | {
-              map?: TMapFallback;
+              map?: TMapFallback | undefined;
               mapWritable: MapFunction<TStream, TType, TMapType>;
           }
         | {
@@ -228,9 +228,9 @@ export type DuplexOptions<
     TWritable extends boolean = boolean
 > = BaseReadableOptions<TStream, TInternal, TReadType, TByteType> &
     BaseWritableOptions<TStream, TWriteType, TInternal, TInternal> & {
-        map?: MapFunction<TStream, TByteType, TByteType>;
-        mapReadable?: MapFunction<TStream, TInternal, TReadType>;
-        mapWritable?: MapFunction<TStream, TWriteType, TInternal>;
+        map?: MapFunction<TStream, TByteType, TByteType> | undefined;
+        mapReadable?: MapFunction<TStream, TInternal, TReadType> | undefined;
+        mapWritable?: MapFunction<TStream, TWriteType, TInternal> | undefined;
     };
 
 export type DuplexEvents<TWriteType, TReadType> = ReadableEvents<TReadType> & WritableEvents<TWriteType>;
@@ -273,8 +273,8 @@ export interface TransformOptions<
     TReadable extends boolean = true,
     TWritable extends boolean = true
 > extends DuplexOptions<TStream, TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable> {
-    transform?: (this: TStream, data: TWriteType, cb: ResultCallback<TReadType>) => void;
-    flush?: (this: TStream, cb: Callback) => void;
+    transform?: ((this: TStream, data: TWriteType, cb: ResultCallback<TReadType>) => void) | undefined;
+    flush?: ((this: TStream, cb: Callback) => void) | undefined;
 }
 
 export class Transform<

--- a/types/stremio-addon-sdk/index.d.ts
+++ b/types/stremio-addon-sdk/index.d.ts
@@ -113,15 +113,15 @@ export interface Cache {
      * (in seconds) sets the Cache-Control header to max-age=$cacheMaxAge
      * and overwrites the global cache time set in serveHTTP options.
      */
-    cacheMaxAge?: number;
+    cacheMaxAge?: number | undefined;
     /**
      * (in seconds) sets the Cache-Control header to stale-while-revalidate=$staleRevalidate.
      */
-    staleRevalidate?: number;
+    staleRevalidate?: number | undefined;
     /**
      * (in seconds) sets the Cache-Control header to stale-if-error=$staleError.
      */
-    staleError?: number;
+    staleError?: number | undefined;
 }
 
 /**
@@ -153,13 +153,13 @@ export interface MetaPreview {
      * You can use any resolution, as long as the file size is below 100kb.
      * Below 50kb is recommended
      */
-    poster?: string;
+    poster?: string | undefined;
     /**
      * Poster can be square (1:1 aspect) or regular (1:0.675) or landscape (1:1.77).
      *
      * Defaults to 'regular'.
      */
-    posterShape?: 'square' | 'regular' | 'landscape';
+    posterShape?: 'square' | 'regular' | 'landscape' | undefined;
     /**
      * The background shown on the stremio detail page.
      *
@@ -167,7 +167,7 @@ export interface MetaPreview {
      *
      * URL to PNG, max file size 500kb.
      */
-    background?: string;
+    background?: string | undefined;
     /**
      * The logo shown on the stremio detail page.
      *
@@ -175,11 +175,11 @@ export interface MetaPreview {
      *
      * URL to PNG.
      */
-    logo?: string;
+    logo?: string | undefined;
     /**
      * A few sentences describing your content.
      */
-    description?: string;
+    description?: string | undefined;
 }
 
 /**
@@ -195,8 +195,8 @@ export interface MetaDetail extends MetaPreview {
      *
      * **WARNING: this will soon be deprecated, use 'links' instead**
      */
-    genres?: string[];
-    releaseInfo?: string;
+    genres?: string[] | undefined;
+    releaseInfo?: string | undefined;
     /**
      * Array of directors.
      *
@@ -204,7 +204,7 @@ export interface MetaDetail extends MetaPreview {
      *
      * @deprecated
      */
-    director?: string[];
+    director?: string[] | undefined;
     /**
      * Array of members of the cast.
      *
@@ -212,11 +212,11 @@ export interface MetaDetail extends MetaPreview {
      *
      * @deprecated
      */
-    cast?: string[];
+    cast?: string[] | undefined;
     /**
      * IMDb rating, which should be a number from 0.0 to 10.0.
      */
-    imdbRating?: string;
+    imdbRating?: string | undefined;
     /**
      * ISO 8601, initial release date.
      *
@@ -224,47 +224,47 @@ export interface MetaDetail extends MetaPreview {
      *
      * e.g. "2010-12-06T05:00:00.000Z"
      */
-    released?: string;
+    released?: string | undefined;
     /**
      * Can be used to link to internal pages of Stremio.
      *
      * example: array of actor / genre / director links.
      */
-    links?: MetaLink[];
+    links?: MetaLink[] | undefined;
     /**
      * Used for channel and series.
      *
      * If you do not provide this (e.g. for movie), Stremio assumes this meta item has one video, and it's ID is equal to the meta item id.
      */
-    videos?: MetaVideo[];
+    videos?: MetaVideo[] | undefined;
     /**
      * Human-readable expected runtime.
      *
      * e.g. "120m"
      */
-    runtime?: string;
+    runtime?: string | undefined;
     /**
      * Spoken language.
      */
-    language?: string;
+    language?: string | undefined;
     /**
      * Official country of origin.
      */
-    country?: string;
+    country?: string | undefined;
     /**
      * Human-readable that describes all the significant awards.
      */
-    awards?: string;
+    awards?: string | undefined;
     /**
      * URL to official website.
      */
-    website?: string;
+    website?: string | undefined;
     behaviourHints?: {
         /**
          * Set to a Video Object id in order to open the Detail page directly to that video's streams.
          */
-        defaultVideo?: boolean | string;
-    };
+        defaultVideo?: boolean | string | undefined;
+    } | undefined;
 }
 
 export interface MetaLink {
@@ -307,7 +307,7 @@ export interface MetaVideo {
      *
      * max file size 5kb.
      */
-    thumbnail?: string;
+    thumbnail?: string | undefined;
     /**
      * In case you can return links to streams while forming meta response,
      * you can pass and array of Stream Objects to point the video to a HTTP URL, BitTorrent,
@@ -317,29 +317,29 @@ export interface MetaVideo {
      * from other addons for that video.
      * If you return streams that way, it is still recommended to implement the streams resource.
      */
-    streams?: Stream[];
+    streams?: Stream[] | undefined;
     /**
      * Set to true to explicitly state that this video is available for streaming, from your addon.
      *
      * No need to use this if you've passed stream.
      */
-    available?: boolean;
+    available?: boolean | undefined;
     /**
      * Episode number, if applicable.
      */
-    episode?: number;
+    episode?: number | undefined;
     /**
      * Season number, if applicable.
      */
-    season?: number;
+    season?: number | undefined;
     /**
      * YouTube ID of the trailer video; use if this is an episode for a series.
      */
-    trailer?: string;
+    trailer?: string | undefined;
     /**
      * Video overview/summary
      */
-    overview?: string;
+    overview?: string | undefined;
 }
 
 /**
@@ -351,58 +351,58 @@ export interface Stream {
     /**
      * Direct URL to a video stream - http, https, rtmp protocols are supported.
      */
-    url?: string;
+    url?: string | undefined;
     /**
      * Youtube video ID, plays using the built-in YouTube player.
      */
-    ytId?: string;
+    ytId?: string | undefined;
     /**
      * Info hash of a torrent file, and fileIdx is the index of the video file within the torrent.
      *
      * If fileIdx is not specified, the largest file in the torrent will be selected.
      */
-    infoHash?: string;
+    infoHash?: string | undefined;
     /**
      * The index of the video file within the torrent (from infoHash).
      *
      * If fileIdx is not specified, the largest file in the torrent will be selected.
      */
-    fileIdx?: number;
+    fileIdx?: number | undefined;
     /**
      * Meta Link or an external URL to the video, which should be opened in a browser (webpage).
      *
      * e.g. a link to Netflix.
      */
-    externalUrl?: string;
+    externalUrl?: string | undefined;
     /**
      * Title of the stream
      *
      * Usually used for stream quality.
      */
-    title?: string;
+    title?: string | undefined;
     /**
      * Name of the stream
      *
      * Usually a short name to identify the addon that provided the stream
      */
-    name?: string;
+    name?: string | undefined;
     /**
      * Array of Subtitle objects representing subtitles for this stream.
      */
-    subtitles?: Subtitle[];
+    subtitles?: Subtitle[] | undefined;
     behaviorHints?: {
         /**
          * Hints it's restricted to particular countries.
          *
          * Array of ISO 3166-1 alpha-3 country codes in lowercase in which the stream is accessible.
          */
-        countryWhitelist?: string[];
+        countryWhitelist?: string[] | undefined;
         /**
          * Applies if the protocol of the url is http(s).
          *
          * Needs to be set to true if the URL does not support https or is not an MP4 file.
          */
-        notWebReady?: boolean;
+        notWebReady?: boolean | undefined;
         /**
          * If defined, addons with the same behaviorHints.group will be chosen automatically for binge watching.
          *
@@ -410,7 +410,7 @@ export interface Stream {
          * For example, if your addon is called "gobsAddon", and the stream is 720p, the group should be "gobsAddon-720p".
          * If the next episode has a stream with the same group, stremio should select that stream implicitly.
          */
-        group?: string;
+        group?: string | undefined;
         /**
          * **Not implemented yet!**
          *
@@ -420,7 +420,7 @@ export interface Stream {
          * @ignore
          */
         headers?: any;
-    };
+    } | undefined;
 }
 
 /**
@@ -476,7 +476,7 @@ export interface Manifest {
      *
      * For example, if you set this to ["yt_id:", "tt"], your addon will only be called for id values that start with 'yt_id:' or 'tt'.
      */
-    idPrefixes?: string[];
+    idPrefixes?: string[] | undefined;
     /**
      * A list of the content catalogs your addon provides.
      *
@@ -488,37 +488,37 @@ export interface Manifest {
      *
      * This can be used for an addon to act just as a catalog of other addons.
      */
-    addonCatalogs?: ManifestCatalog[];
+    addonCatalogs?: ManifestCatalog[] | undefined;
     /**
      * Background image for the addon.
      *
      * URL to png/jpg, at least 1024x786 resolution.
      */
-    background?: string;
+    background?: string | undefined;
     /**
      * Logo icon, URL to png, monochrome, 256x256.
      */
-    logo?: string;
+    logo?: string | undefined;
     /**
      * Contact email for addon issues.
      * Used for the Report button in the app.
      * Also, the Stremio team may reach you on this email for anything relating your addon.
      */
-    contactEmail?: string;
+    contactEmail?: string | undefined;
     behaviorHints?: {
         /**
          * If the addon includes adult content.
          *
          * Defaults to false.
          */
-        adult?: boolean;
+        adult?: boolean | undefined;
         /**
          * If the addon includes P2P content, such as BitTorrent, which may reveal the user's IP to other streaming parties.
          *
          * Used to provide an adequate warning to the user.
          */
-        p2p?: boolean;
-    };
+        p2p?: boolean | undefined;
+    } | undefined;
 }
 
 /**
@@ -553,7 +553,7 @@ export interface FullManifestResource {
      *
      * For example, if you set this to ["yt_id:", "tt"], your addon will only be called for id values that start with 'yt_id:' or 'tt'.
      */
-    idPrefixes?: string[];
+    idPrefixes?: string[] | undefined;
 }
 
 export interface ManifestCatalog {
@@ -575,11 +575,11 @@ export interface ManifestCatalog {
      * Use the 'options' property of 'extra' instead.
      * @deprecated
      */
-    genres?: string[];
+    genres?: string[] | undefined;
     /**
      * All extra properties related to this catalog.
      */
-    extra?: ManifestExtra[];
+    extra?: ManifestExtra[] | undefined;
 }
 
 export interface ManifestExtra {
@@ -592,7 +592,7 @@ export interface ManifestExtra {
     /**
      * Set to true if this property must always be passed.
      */
-    isRequired?: boolean;
+    isRequired?: boolean | undefined;
     /**
      * Possible values for this property.
      * This is useful for things like genres, where you need the user to select from a pre-set list of options.
@@ -604,13 +604,13 @@ export interface ManifestExtra {
      *
      * e.g. { name: "skip", options: ["0", "100", "200"] }
      */
-    options?: string[];
+    options?: string[] | undefined;
     /**
      * The limit of values a user may select from the pre-set options list
      *
      * By default this is set to 1.
      */
-    optionsLimit?: number;
+    optionsLimit?: number | undefined;
 }
 
 /**
@@ -638,14 +638,14 @@ export function publishToCentral(url: string): void;
 export function serveHTTP(
     addonInterface: AddonInterface,
     options: {
-        port?: number;
+        port?: number | undefined;
         /**
          * (in seconds) cacheMaxAge means the Cache-Control header being set to max-age=$cacheMaxAge
          */
-        cacheMaxAge?: number;
+        cacheMaxAge?: number | undefined;
         /**
          * Static directory to serve.
          */
-        static?: string;
+        static?: string | undefined;
     },
 ): void;

--- a/types/strftime/index.d.ts
+++ b/types/strftime/index.d.ts
@@ -26,15 +26,15 @@ declare module "strftime" {
          * @interface
          */
         export interface LocaleFormats {
-            D?: string;
-            F?: string;
-            R?: string;
-            T?: string;
-            X?: string;
-            c?: string;
-            r?: string;
-            v?: string;
-            x?: string;
+            D?: string | undefined;
+            F?: string | undefined;
+            R?: string | undefined;
+            T?: string | undefined;
+            X?: string | undefined;
+            c?: string | undefined;
+            r?: string | undefined;
+            v?: string | undefined;
+            x?: string | undefined;
         }
 
         /**
@@ -42,14 +42,14 @@ declare module "strftime" {
          * @interface
          */
         export interface Locale {
-            days?: Array<string>;
-            shortDays?: Array<string>;
-            months?: Array<string>;
-            shortMonths?: Array<string>;
-            AM?: string;
-            PM?: string;
-            am?: string;
-            pm?: string;
+            days?: Array<string> | undefined;
+            shortDays?: Array<string> | undefined;
+            months?: Array<string> | undefined;
+            shortMonths?: Array<string> | undefined;
+            AM?: string | undefined;
+            PM?: string | undefined;
+            am?: string | undefined;
+            pm?: string | undefined;
             formats: LocaleFormats
         }
     }

--- a/types/string-natural-compare/index.d.ts
+++ b/types/string-natural-compare/index.d.ts
@@ -6,7 +6,7 @@
 declare function naturalCompare(
     a: string,
     b: string,
-    options?: { caseInsensitive?: boolean; alphabet?: string },
+    options?: { caseInsensitive?: boolean | undefined; alphabet?: string | undefined },
 ): number;
 
 export = naturalCompare;

--- a/types/string-pixel-width/index.d.ts
+++ b/types/string-pixel-width/index.d.ts
@@ -11,8 +11,8 @@ declare function getWidth(
 ): number;
 
 interface Settings {
-    bold?: boolean;
-    font?: "andale mono"|"arial"|"avenir next"|"avenir"|"comic sans ms"|"courier new"|"georgia"|"impact"|"open sans"|"tahoma"|"times new roman"|"trebuchet ms"|"verdana"|"webdings";
-    italic?: boolean;
-    size?: number;
+    bold?: boolean | undefined;
+    font?: "andale mono"|"arial"|"avenir next"|"avenir"|"comic sans ms"|"courier new"|"georgia"|"impact"|"open sans"|"tahoma"|"times new roman"|"trebuchet ms"|"verdana"|"webdings" | undefined;
+    italic?: boolean | undefined;
+    size?: number | undefined;
 }

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -7,10 +7,10 @@
 declare function template(str: string, data: Readonly<unknown>, options?: Readonly<Options>): string;
 
 interface Options {
-    before?: string;
-    after?: string;
-    escape?: string;
-    clean?: boolean;
+    before?: string | undefined;
+    after?: string | undefined;
+    escape?: string | undefined;
+    clean?: boolean | undefined;
 }
 
 export = template;

--- a/types/string-replace-loader/index.d.ts
+++ b/types/string-replace-loader/index.d.ts
@@ -18,8 +18,8 @@ declare namespace loader {
     interface ReplaceEntry {
         search: string | RegExp;
         replace: string | ReplaceCallback;
-        flags?: string;
-        strict?: boolean;
+        flags?: string | undefined;
+        strict?: boolean | undefined;
     }
 
     interface ReplaceCallback {

--- a/types/string/index.d.ts
+++ b/types/string/index.d.ts
@@ -98,11 +98,11 @@ interface StringJS {
     
     toCSV(delimiter?: string, qualifier?: string): StringJS;
     toCSV(options: {
-        delimiter?: string,
-        qualifier?: string,
-        escape?: string,
-        encloseNumbers?: boolean,
-        keys?: boolean
+        delimiter?: string | undefined,
+        qualifier?: string | undefined,
+        escape?: string | undefined,
+        encloseNumbers?: boolean | undefined,
+        keys?: boolean | undefined
     }): StringJS;
     
     toFloat(precision?: number): number;

--- a/types/stringify-object/index.d.ts
+++ b/types/stringify-object/index.d.ts
@@ -11,12 +11,12 @@ declare function stringifyObject(input: any, options?: {
      * Preferred indentation
      * @default '\t'
      */
-    indent?: string,
+    indent?: string | undefined,
     /**
      * Set to false to get double-quoted strings
      * @default true
      */
-    singleQuotes?: boolean,
+    singleQuotes?: boolean | undefined,
     /**
      * Expected to return a boolean of whether to include the property property of the object object in the output.
      */
@@ -24,13 +24,13 @@ declare function stringifyObject(input: any, options?: {
     /**
      * When set, will inline values up to inlineCharacterLimit length for the sake of more terse output.
      */
-    inlineCharacterLimit?: number,
+    inlineCharacterLimit?: number | undefined,
     /**
      * Expected to return a string that transforms the string that resulted from stringifying object[property].
      * This can be used to detect special types of objects that need to be stringified in a particular way.
      * The transform function might return an alternate string in this case, otherwise returning the originalResult.
      */
-    transform?: (input: any[] | object, prop: number | string | symbol, originalResult: string) => string,
+    transform?: ((input: any[] | object, prop: number | string | symbol, originalResult: string) => string) | undefined,
 }, pad?: string): string;
 
 export = stringifyObject;

--- a/types/strip-comments/index.d.ts
+++ b/types/strip-comments/index.d.ts
@@ -68,24 +68,24 @@ declare namespace strip {
          * if `false` strip only block comments
          * @default true
          */
-        line?: boolean;
+        line?: boolean | undefined;
         /**
          * if `false` strip only line comments
          * @default true
          */
-        block?: boolean;
+        block?: boolean | undefined;
         /**
          * Keep ignored comments (e.g. `/*!` and `//!`)
          */
-        keepProtected?: boolean;
+        keepProtected?: boolean | undefined;
         /**
          * Preserve newlines after comments are stripped
          */
-        preserveNewlines?: boolean;
+        preserveNewlines?: boolean | undefined;
         /**
          * @default 'javascript'
          */
-        language?: string;
+        language?: string | undefined;
     }
 }
 

--- a/types/stripe-checkout/index.d.ts
+++ b/types/stripe-checkout/index.d.ts
@@ -15,25 +15,25 @@ interface StripeCheckoutHandler {
 }
 
 interface StripeCheckoutOptions {
-    key?: string;
+    key?: string | undefined;
     token?(token: stripe.Token): void;
     source?(source: stripe.Source): void;
-    image?: string;
-    name?: string;
-    description?: string;
-    amount?: number;
-    locale?: string;
-    currency?: string;
-    panelLabel?: string;
-    zipCode?: boolean;
-    billingAddress?: boolean;
-    email?: string;
-    shippingAddress?: boolean;
-    label?: string;
-    allowRememberMe?: boolean;
-    bitcoin?: boolean;
-    alipay?: boolean | 'auto';
-    alipayReusable?: boolean;
+    image?: string | undefined;
+    name?: string | undefined;
+    description?: string | undefined;
+    amount?: number | undefined;
+    locale?: string | undefined;
+    currency?: string | undefined;
+    panelLabel?: string | undefined;
+    zipCode?: boolean | undefined;
+    billingAddress?: boolean | undefined;
+    email?: string | undefined;
+    shippingAddress?: boolean | undefined;
+    label?: string | undefined;
+    allowRememberMe?: boolean | undefined;
+    bitcoin?: boolean | undefined;
+    alipay?: boolean | 'auto' | undefined;
+    alipayReusable?: boolean | undefined;
     opened?(): void;
     closed?(): void;
 }

--- a/types/stripe-v2/index.d.ts
+++ b/types/stripe-v2/index.d.ts
@@ -26,17 +26,17 @@ declare namespace stripe {
 
     interface StripeCardTokenData {
         number: string;
-        exp_month?: number;
-        exp_year?: number;
-        exp?: string;
-        cvc?: string;
-        name?: string;
-        address_line1?: string;
-        address_line2?: string;
-        address_city?: string;
-        address_state?: string;
-        address_zip?: string;
-        address_country?: string;
+        exp_month?: number | undefined;
+        exp_year?: number | undefined;
+        exp?: string | undefined;
+        cvc?: string | undefined;
+        name?: string | undefined;
+        address_line1?: string | undefined;
+        address_line2?: string | undefined;
+        address_city?: string | undefined;
+        address_state?: string | undefined;
+        address_zip?: string | undefined;
+        address_country?: string | undefined;
     }
 
     interface StripeTokenResponse {
@@ -47,7 +47,7 @@ declare namespace stripe {
         object: string;
         type: string;
         used: boolean;
-        error?: StripeError;
+        error?: StripeError | undefined;
     }
 
     interface StripeCardTokenResponse extends StripeTokenResponse {
@@ -58,7 +58,7 @@ declare namespace stripe {
         type: string;
         code: string;
         message: string;
-        param?: string;
+        param?: string | undefined;
     }
 
     type StripeCardDataBrand = 'Visa' | 'American Express' | 'MasterCard' | 'Discover' | 'JCB' | 'Diners Club' | 'Unknown';
@@ -70,16 +70,16 @@ declare namespace stripe {
         last4: string;
         exp_month: number;
         exp_year: number;
-        country?: string;
-        name?: string;
-        address_line1?: string;
-        address_line2?: string;
-        address_city?: string;
-        address_state?: string;
-        address_zip?: string;
-        address_country?: string;
-        brand?: StripeCardDataBrand;
-        funding?: StripeCardDataFunding;
+        country?: string | undefined;
+        name?: string | undefined;
+        address_line1?: string | undefined;
+        address_line2?: string | undefined;
+        address_city?: string | undefined;
+        address_state?: string | undefined;
+        address_zip?: string | undefined;
+        address_country?: string | undefined;
+        brand?: StripeCardDataBrand | undefined;
+        funding?: StripeCardDataFunding | undefined;
         createToken(data: StripeCardTokenData, responseHandler: (status: number, response: StripeCardTokenResponse) => void): void;
         validateCardNumber(cardNumber: string): boolean;
         validateExpiry(month: string, year: string): boolean;
@@ -96,7 +96,7 @@ declare namespace stripe {
         country: string;
         currency: string;
         account_number: number | string;
-        routing_number?: number | string;
+        routing_number?: number | string | undefined;
         account_holder_name: string;
         account_holder_type: string;
     }
@@ -127,12 +127,12 @@ declare namespace stripe {
         countryCode: string;
         currencyCode: string;
         total: StripeApplePayLineItem;
-        lineItems?: StripeApplePayLineItem[];
-        requiredBillingContactFields?: StripeApplePayBillingContactField[];
-        requiredShippingContactFields?: StripeApplePayShippingContactField[];
-        shippingContact?: StripeApplePayPaymentContact;
-        shippingMethods?: StripeApplePayShippingMethod[];
-        shippingType?: StripeApplePayShipping[];
+        lineItems?: StripeApplePayLineItem[] | undefined;
+        requiredBillingContactFields?: StripeApplePayBillingContactField[] | undefined;
+        requiredShippingContactFields?: StripeApplePayShippingContactField[] | undefined;
+        shippingContact?: StripeApplePayPaymentContact | undefined;
+        shippingMethods?: StripeApplePayShippingMethod[] | undefined;
+        shippingType?: StripeApplePayShipping[] | undefined;
     }
 
     // https://developer.apple.com/reference/applepayjs/1916082-applepay_js_data_types
@@ -144,8 +144,8 @@ declare namespace stripe {
 
     interface StripeApplePaySessionResult {
         token: StripeCardTokenResponse;
-        shippingContact?: StripeApplePayPaymentContact;
-        shippingMethod?: StripeApplePayShippingMethod;
+        shippingContact?: StripeApplePayPaymentContact | undefined;
+        shippingMethod?: StripeApplePayShippingMethod | undefined;
     }
 
     interface StripeApplePayShippingMethod {

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -32,7 +32,7 @@ declare namespace stripe {
         createToken(element: elements.Element, options?: TokenOptions | BankAccountTokenOptions): Promise<TokenResponse>;
         createToken(name: 'bank_account', options: BankAccountTokenOptions): Promise<TokenResponse>;
         createToken(name: 'pii', options: PiiTokenOptions): Promise<TokenResponse>;
-        createSource(element: elements.Element, options?: { owner?: OwnerInfo }): Promise<SourceResponse>;
+        createSource(element: elements.Element, options?: { owner?: OwnerInfo | undefined }): Promise<SourceResponse>;
         createSource(options: SourceOptions): Promise<SourceResponse>;
         retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
         // We use function overloading instead of a union here to ensure that redirectToCheckout can only be
@@ -125,10 +125,10 @@ declare namespace stripe {
         items: StripeCheckoutItem[];
         successUrl: string;
         cancelUrl: string;
-        clientReferenceId?: string;
-        customerEmail?: string;
-        billingAddressCollection?: billingAddressCollectionType;
-        locale?: string;
+        clientReferenceId?: string | undefined;
+        customerEmail?: string | undefined;
+        billingAddressCollection?: billingAddressCollectionType | undefined;
+        locale?: string | undefined;
     }
 
     interface StripeServerCheckoutOptions {
@@ -136,27 +136,27 @@ declare namespace stripe {
     }
 
     interface StripeCheckoutItem {
-        sku?: string;
-        plan?: string;
+        sku?: string | undefined;
+        plan?: string | undefined;
         quantity: number;
     }
 
     interface StripeOptions {
-        stripeAccount?: string;
-        apiVersion?: string;
-        betas?: string[];
-        locale?: string;
+        stripeAccount?: string | undefined;
+        apiVersion?: string | undefined;
+        betas?: string[] | undefined;
+        locale?: string | undefined;
     }
 
     interface TokenOptions {
-        name?: string;
-        address_line1?: string;
-        address_line2?: string;
-        address_city?: string;
-        address_state?: string;
-        address_zip?: string;
-        address_country?: string;
-        currency?: string;
+        name?: string | undefined;
+        address_line1?: string | undefined;
+        address_line2?: string | undefined;
+        address_city?: string | undefined;
+        address_state?: string | undefined;
+        address_zip?: string | undefined;
+        address_country?: string | undefined;
+        currency?: string | undefined;
     }
 
     interface BankAccountTokenOptions {
@@ -171,7 +171,7 @@ declare namespace stripe {
         /**
          * The bank routing number (e.g., 111000025). Optional if the currency is eur, as the account number is an IBAN.
          */
-        routing_number?: string;
+        routing_number?: string | undefined;
         /**
          * The bank account number (e.g., 000123456789).
          */
@@ -191,19 +191,19 @@ declare namespace stripe {
     }
 
     interface OwnerAddress {
-        city?: string;
-        country?: string;
-        line1?: string;
-        line2?: string;
-        postal_code?: string;
-        state?: string;
+        city?: string | undefined;
+        country?: string | undefined;
+        line1?: string | undefined;
+        line2?: string | undefined;
+        postal_code?: string | undefined;
+        state?: string | undefined;
     }
 
     interface OwnerInfo {
-        address?: OwnerAddress;
-        name?: string;
-        email?: string;
-        phone?: string;
+        address?: OwnerAddress | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+        phone?: string | undefined;
     }
 
     interface OfflineAcceptanceMandate {
@@ -219,52 +219,52 @@ declare namespace stripe {
     interface SourceMandateAcceptance {
         date: number;
         status: 'accepted' | 'refused';
-        ip?: string;
-        offline?: OfflineAcceptanceMandate;
-        online?: OnlineAcceptanceMandate;
-        type?: 'online'| 'offline';
-        user_agent?: string;
+        ip?: string | undefined;
+        offline?: OfflineAcceptanceMandate | undefined;
+        online?: OnlineAcceptanceMandate | undefined;
+        type?: 'online'| 'offline' | undefined;
+        user_agent?: string | undefined;
     }
 
     interface SourceMandate {
-        acceptance?: SourceMandateAcceptance;
-        amount?: number;
-        currency?: string;
-        interval?: 'one_time' | 'scheduled' | 'variable';
-        notification_method?: 'email' | 'manual' | 'none';
+        acceptance?: SourceMandateAcceptance | undefined;
+        amount?: number | undefined;
+        currency?: string | undefined;
+        interval?: 'one_time' | 'scheduled' | 'variable' | undefined;
+        notification_method?: 'email' | 'manual' | 'none' | undefined;
     }
 
     interface SourceOptions {
         type: string;
-        flow?: 'redirect' | 'receiver' | 'code_verification' | 'none';
+        flow?: 'redirect' | 'receiver' | 'code_verification' | 'none' | undefined;
         sepa_debit?: {
             iban: string;
-        };
-        currency?: string;
-        amount?: number;
-        owner?: OwnerInfo;
-        mandate?: SourceMandate;
-        metadata?: {};
-        statement_descriptor?: string;
+        } | undefined;
+        currency?: string | undefined;
+        amount?: number | undefined;
+        owner?: OwnerInfo | undefined;
+        mandate?: SourceMandate | undefined;
+        metadata?: {} | undefined;
+        statement_descriptor?: string | undefined;
         redirect?: {
             return_url: string;
-        };
-        token?: string;
-        usage?: 'reusable' | 'single_use';
+        } | undefined;
+        token?: string | undefined;
+        usage?: 'reusable' | 'single_use' | undefined;
         three_d_secure?: {
             card: string;
-        };
+        } | undefined;
         sofort?: {
             country: string;
-            preferred_language?: 'de' | 'en' | 'es' | 'it' | 'fr' | 'nl' | 'pl';
-        };
+            preferred_language?: 'de' | 'en' | 'es' | 'it' | 'fr' | 'nl' | 'pl' | undefined;
+        } | undefined;
     }
 
     interface Token {
         id: string;
         object: string;
-        bank_account?: BankAccount;
-        card?: Card;
+        bank_account?: BankAccount | undefined;
+        card?: Card | undefined;
         client_ip: string;
         created: number;
         livemode: boolean;
@@ -273,8 +273,8 @@ declare namespace stripe {
     }
 
     interface TokenResponse {
-        token?: Token;
-        error?: Error;
+        token?: Token | undefined;
+        error?: Error | undefined;
     }
 
     interface Source {
@@ -298,21 +298,21 @@ declare namespace stripe {
             fingerprint: string;
             last4: string;
             mandate_reference: string;
-        };
-        card?: Card;
-        status?: string;
+        } | undefined;
+        card?: Card | undefined;
+        status?: string | undefined;
         redirect?: {
             status: string;
             url: string;
-        };
+        } | undefined;
         three_d_secure?: {
             authenticated: boolean;
-        };
+        } | undefined;
     }
 
     interface SourceResponse {
-        source?: Source;
-        error?: Error;
+        source?: Source | undefined;
+        error?: Error | undefined;
     }
 
     type ErrorType = 'api_connection_error'
@@ -339,51 +339,51 @@ declare namespace stripe {
          * For some errors that could be handled programmatically,
          * a short string indicating the error code reported.
          */
-        code?: string;
+        code?: string | undefined;
 
         /**
          * For card errors resulting from a card issuer decline,
          * a short string indicating the card issuer’s reason for
          * the decline if they provide one.
          */
-        decline_code?: string;
+        decline_code?: string | undefined;
 
         /**
          * A URL to more information about the error code reported.
          */
-        doc_url?: string;
+        doc_url?: string | undefined;
 
         /**
          * A human-readable message providing more details about the
          * error. For card errors, these messages can be shown to
          * your users.
          */
-        message?: string;
+        message?: string | undefined;
 
         /**
          * If the error is parameter-specific, the parameter related
          * to the error. For example, you can use this to display a
          * message near the correct form field.
          */
-        param?: string;
+        param?: string | undefined;
 
         /**
          * The PaymentIntent object for errors returned on a request
          * involving a PaymentIntent.
          */
-        payment_intent?: paymentIntents.PaymentIntent;
+        payment_intent?: paymentIntents.PaymentIntent | undefined;
 
         /**
          * The PaymentMethod object for errors returned on a
          * request involving a PaymentMethod.
          */
-        payment_method?: paymentMethod.PaymentMethod;
+        payment_method?: paymentMethod.PaymentMethod | undefined;
 
         /**
          * The source object for errors returned on a request involving
          * a source.
          */
-        source?: Source;
+        source?: Source | undefined;
     }
 
     type statusType = 'new' | 'validated' | 'verified' | 'verification_failed' | 'errored';
@@ -408,18 +408,18 @@ declare namespace stripe {
     interface Card {
         id: string;
         object: string;
-        address_city?: string;
-        address_country?: string;
-        address_line1?: string;
-        address_line1_check?: checkType;
-        address_line2?: string;
-        address_state?: string;
-        address_zip?: string;
-        address_zip_check?: checkType;
+        address_city?: string | undefined;
+        address_country?: string | undefined;
+        address_line1?: string | undefined;
+        address_line1_check?: checkType | undefined;
+        address_line2?: string | undefined;
+        address_state?: string | undefined;
+        address_zip?: string | undefined;
+        address_zip_check?: checkType | undefined;
         brand: brandType;
         country: string;
-        currency?: string;
-        cvc_check?: checkType;
+        currency?: string | undefined;
+        cvc_check?: checkType | undefined;
         dynamic_last4: string;
         exp_month: number;
         exp_year: number;
@@ -427,9 +427,9 @@ declare namespace stripe {
         funding: fundingType;
         last4: string;
         metadata: any;
-        name?: string;
-        tokenization_method?: tokenizationType;
-        three_d_secure?: 'required' | 'recommended' | 'optional' | 'not_supported';
+        name?: string | undefined;
+        tokenization_method?: tokenizationType | undefined;
+        three_d_secure?: 'required' | 'recommended' | 'optional' | 'not_supported' | undefined;
     }
 
     interface RetrieveSourceOptions {
@@ -468,28 +468,28 @@ declare namespace stripe {
     }
 
     interface BillingDetailsAddress {
-        city?: string;
-        country?: string;
-        line1?: string;
-        line2?: string;
-        postal_code?: string;
-        state?: string;
+        city?: string | undefined;
+        country?: string | undefined;
+        line1?: string | undefined;
+        line2?: string | undefined;
+        postal_code?: string | undefined;
+        state?: string | undefined;
     }
 
     interface BillingDetails {
-        address?: BillingDetailsAddress | null;
-        email?: string | null;
-        name?: string | null;
-        phone?: string | null;
+        address?: BillingDetailsAddress | null | undefined;
+        email?: string | null | undefined;
+        name?: string | null | undefined;
+        phone?: string | null | undefined;
     }
 
     interface ShippingDetailsAddress {
         line1: string;
-        city?: string;
-        country?: string;
-        line2?: string;
-        postal_code?: string;
-        state?: string;
+        city?: string | undefined;
+        country?: string | undefined;
+        line2?: string | undefined;
+        postal_code?: string | undefined;
+        state?: string | undefined;
     }
 
     interface ShippingDetails {
@@ -498,14 +498,14 @@ declare namespace stripe {
         /** Recipient name. */
         name: string;
         /** The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. */
-        carrier?: string;
+        carrier?: string | undefined;
         /** Recipient phone (including extension). */
-        phone?: string;
+        phone?: string | undefined;
         /**
          * The tracking number for a physical product, obtained from the delivery service.
          * If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
-        tracking_number?: string;
+        tracking_number?: string | undefined;
     }
 
     interface CreatePaymentMethodOptions {
@@ -514,8 +514,8 @@ declare namespace stripe {
          * that may be used or required by particular types of
          * payment methods.
          */
-        billing_details?: BillingDetails;
-        metadata?: Metadata;
+        billing_details?: BillingDetails | undefined;
+        metadata?: Metadata | undefined;
     }
 
     interface PaymentMethodData {
@@ -525,10 +525,10 @@ declare namespace stripe {
          * payment methods.
          */
         type: string;
-        card?: elements.Element;
-        ideal?: elements.Element | { bank: string };
-        sepa_debit?: elements.Element | { iban: string };
-        billing_details?: BillingDetails;
+        card?: elements.Element | undefined;
+        ideal?: elements.Element | { bank: string } | undefined;
+        sepa_debit?: elements.Element | { iban: string } | undefined;
+        billing_details?: BillingDetails | undefined;
     }
 
     interface HandleCardPaymentOptions {
@@ -540,22 +540,22 @@ declare namespace stripe {
             /**
              * The billing details associated with the card. [Recommended]
              */
-            billing_details?: BillingDetails,
-        };
+            billing_details?: BillingDetails | undefined,
+        } | undefined;
         /**
          * The shipping details for the payment, if collected. [Recommended]
          */
-        shipping?: ShippingDetails;
+        shipping?: ShippingDetails | undefined;
         /**
          * Email address that the receipt for the resulting payment will be sent to.
          */
-        receipt_email?: string;
+        receipt_email?: string | undefined;
         /**
          * If the PaymentIntent is associated with a customer and this parameter
          * is set to true, the provided payment method will be attached to the
          * customer. Default is false.
          */
-        save_payment_method?: boolean;
+        save_payment_method?: boolean | undefined;
     }
 
     interface HandleCardPaymentWithoutElementsOptions extends HandleCardPaymentOptions {
@@ -564,7 +564,7 @@ declare namespace stripe {
          * Use payment_method to specify an existing PaymentMethod to use
          * for this payment.
          */
-        payment_method?: string;
+        payment_method?: string | undefined;
         /**
          * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
@@ -573,20 +573,20 @@ declare namespace stripe {
             /**
              * The billing details associated with the card. [Recommended]
              */
-            billing_details?: BillingDetails,
+            billing_details?: BillingDetails | undefined,
             card?: {
                 /**
                  * Converts the provided token into a PaymentMethod to
                  * use for the payment.
                  */
                 token: string;
-            }
-        };
+            } | undefined
+        } | undefined;
         /**
          * Instead of payment_method, the ID of a Source may be passed in.
          * (Note that this is undocumented as of August 2019).
          */
-       source?: string;
+       source?: string | undefined;
     }
 
     /**
@@ -615,32 +615,32 @@ declare namespace stripe {
             /**
              * The billing_details associated with the card.
              */
-            billing_details?: BillingDetails,
-        };
+            billing_details?: BillingDetails | undefined,
+        } | undefined;
         /**
          * The shipping details for the payment, if collected.
          * Recomended
          */
-        shipping?: ShippingDetails;
+        shipping?: ShippingDetails | undefined;
         /**
          * If you are handling next actions yourself,
          * pass in a return_url. If the subsequent action is redirect_to_url,
          * this URL will be used on the return path for the redirect.
          */
-        return_url?: string;
+        return_url?: string | undefined;
         /**
          * Email address that the receipt for the resulting payment will be sent to.
          */
-        receipt_email?: string;
+        receipt_email?: string | undefined;
         /**
          * If the PaymentIntent is associated with a customer and this parameter is set to true,
          * the provided payment method will be attached to the customer. Default is false.
          */
-        save_payment_method?: boolean;
+        save_payment_method?: boolean | undefined;
         /**
          * Indicates that you intend to make future payments with this PaymentIntent's payment method.
          */
-        setup_future_usage?: "on_session" | "off_session";
+        setup_future_usage?: "on_session" | "off_session" | undefined;
     }
     interface ConfirmCardPaymentOptions {
         /*
@@ -648,7 +648,7 @@ declare namespace stripe {
          * you want to defer next action handling until later (e.g. for use in
          * the PaymentRequest API). Default is true.
          */
-        handleActions?: boolean;
+        handleActions?: boolean | undefined;
     }
 
     interface ConfirmSepaDebitPaymentData {
@@ -674,7 +674,7 @@ declare namespace stripe {
                 name: string,
                 email: string,
             }
-        };
+        } | undefined;
     }
 
     interface HandleCardSetupOptions {
@@ -686,8 +686,8 @@ declare namespace stripe {
             /**
              * The billing details associated with the card. [Recommended]
              */
-            billing_details?: BillingDetails,
-        };
+            billing_details?: BillingDetails | undefined,
+        } | undefined;
     }
     interface HandleCardSetupOptionsWithoutElementsOptions extends HandleCardPaymentOptions {
         /**
@@ -695,7 +695,7 @@ declare namespace stripe {
          * Use payment_method to specify an existing PaymentMethod to use
          * for this payment.
          */
-        payment_method?: string;
+        payment_method?: string | undefined;
     }
 
     interface ConfirmPaymentIntentOptions {
@@ -704,7 +704,7 @@ declare namespace stripe {
          * If the subsequent action is redirect_to_url, this URL will be used
          * on the return path for the redirect.
          */
-        return_url?: string;
+        return_url?: string | undefined;
         /**
          * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
@@ -713,26 +713,26 @@ declare namespace stripe {
             /**
              * The billing details associated with the card. [Recommended]
              */
-            billing_details?: BillingDetails,
-        };
+            billing_details?: BillingDetails | undefined,
+        } | undefined;
         /**
          * The shipping details for the payment, if collected. [Recommended]
          */
-        shipping?: ShippingDetails;
+        shipping?: ShippingDetails | undefined;
         /**
          * Email address that the receipt for the resulting payment will be sent to.
          */
-        receipt_email?: string;
+        receipt_email?: string | undefined;
         /**
          * If the PaymentIntent is associated with a customer and this parameter
          * is set to true, the provided payment method will be attached to the
          * customer. Default is false.
          */
-        save_payment_method?: boolean;
+        save_payment_method?: boolean | undefined;
         /**
          * Indicates that you intend to make future payments with this PaymentIntent's payment method.
          */
-        setup_future_usage?: string;
+        setup_future_usage?: string | undefined;
     }
 
     interface ConfirmPaymentIntentWithoutElementsOptions extends ConfirmPaymentIntentOptions {
@@ -741,7 +741,7 @@ declare namespace stripe {
          * Use payment_method to specify an existing PaymentMethod to use
          * for this payment.
          */
-        payment_method?: string;
+        payment_method?: string | undefined;
         /**
          * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
@@ -750,15 +750,15 @@ declare namespace stripe {
             /**
              * The billing details associated with the card. [Recommended]
              */
-            billing_details?: BillingDetails,
+            billing_details?: BillingDetails | undefined,
             card?: {
                 /**
                  * Converts the provided token into a PaymentMethod to
                  * use for the payment.
                  */
                 token: string;
-            }
-        };
+            } | undefined
+        } | undefined;
     }
 
     interface ConfirmCardSetupData {
@@ -783,8 +783,8 @@ declare namespace stripe {
             /**
              * The billing_details associated with the card.
              */
-            billing_details?: BillingDetails,
-        };
+            billing_details?: BillingDetails | undefined,
+        } | undefined;
     }
     interface ConfirmCardSetupOptions {
         /*
@@ -792,7 +792,7 @@ declare namespace stripe {
          * you want to defer next action handling until later (e.g. for use in
          * the PaymentRequest API). Default is true.
          */
-        handleActions?: boolean;
+        handleActions?: boolean | undefined;
     }
 
     interface ConfirmSepaDebitSetupData {
@@ -818,21 +818,21 @@ declare namespace stripe {
                 name: string,
                 email: string,
             }
-        };
+        } | undefined;
     }
 
     interface PaymentMethodResponse {
-        paymentMethod?: paymentMethod.PaymentMethod;
-        error?: Error;
+        paymentMethod?: paymentMethod.PaymentMethod | undefined;
+        error?: Error | undefined;
     }
 
     interface PaymentIntentResponse {
-        paymentIntent?: paymentIntents.PaymentIntent;
-        error?: Error;
+        paymentIntent?: paymentIntents.PaymentIntent | undefined;
+        error?: Error | undefined;
     }
     interface SetupIntentResponse {
-        setupIntent?: setupIntents.SetupIntent;
-        error?: Error;
+        setupIntent?: setupIntents.SetupIntent | undefined;
+        error?: Error | undefined;
     }
 
     // Container for all payment request related types
@@ -840,35 +840,35 @@ declare namespace stripe {
         interface DisplayItem {
             amount: number;
             label: string;
-            pending?: boolean;
+            pending?: boolean | undefined;
         }
 
         interface StripePaymentRequestUpdateOptions {
             currency: string;
             total: DisplayItem;
-            displayItems?: DisplayItem[];
-            shippingOptions?: ShippingOption[];
+            displayItems?: DisplayItem[] | undefined;
+            shippingOptions?: ShippingOption[] | undefined;
         }
 
         interface StripePaymentRequestOptions extends StripePaymentRequestUpdateOptions {
             country: string;
-            requestPayerName?: boolean;
-            requestPayerEmail?: boolean;
-            requestPayerPhone?: boolean;
-            requestShipping?: boolean;
+            requestPayerName?: boolean | undefined;
+            requestPayerEmail?: boolean | undefined;
+            requestPayerPhone?: boolean | undefined;
+            requestShipping?: boolean | undefined;
         }
 
         interface UpdateDetails {
             status: 'success' | 'fail' | 'invalid_shipping_address';
-            total?: DisplayItem;
-            displayItems?: DisplayItem[];
-            shippingOptions?: ShippingOption[];
+            total?: DisplayItem | undefined;
+            displayItems?: DisplayItem[] | undefined;
+            shippingOptions?: ShippingOption[] | undefined;
         }
 
         interface ShippingOption {
             id: string;
             label: string;
-            detail?: string;
+            detail?: string | undefined;
             amount: number;
         }
 
@@ -880,17 +880,17 @@ declare namespace stripe {
             postalCode: string;
             recipient: string;
             phone: string;
-            sortingCode?: string;
-            dependentLocality?: string;
+            sortingCode?: string | undefined;
+            dependentLocality?: string | undefined;
         }
 
         interface StripePaymentResponse {
             complete: (status: string) => void;
-            payerName?: string;
-            payerEmail?: string;
-            payerPhone?: string;
-            shippingAddress?: ShippingAddress;
-            shippingOption?: ShippingOption;
+            payerName?: string | undefined;
+            payerEmail?: string | undefined;
+            payerPhone?: string | undefined;
+            shippingAddress?: ShippingAddress | undefined;
+            shippingOption?: ShippingOption | undefined;
             methodName: string;
         }
 
@@ -907,7 +907,7 @@ declare namespace stripe {
         }
 
         interface StripePaymentRequest {
-            canMakePayment(): Promise<{ applePay?: boolean, googlePay?: boolean } | null>;
+            canMakePayment(): Promise<{ applePay?: boolean | undefined, googlePay?: boolean | undefined } | null>;
             show(): void;
             update(options: StripePaymentRequestUpdateOptions): void;
             on(event: 'token', handler: (response: StripeTokenPaymentResponse) => void): void;
@@ -922,8 +922,8 @@ declare namespace stripe {
     // Container for all elements related types
     namespace elements {
         interface ElementsCreateOptions {
-            fonts?: Font[];
-            locale?: string;
+            fonts?: Font[] | undefined;
+            locale?: string | undefined;
         }
 
         type handler = (response?: ElementChangeResponse) => void;
@@ -949,15 +949,15 @@ declare namespace stripe {
             brand: string;
             complete: boolean;
             empty: boolean;
-            value?: { postalCode: string | number } | string;
-            country?: string;
-            bankName?: string;
-            error?: Error;
+            value?: { postalCode: string | number } | string | undefined;
+            country?: string | undefined;
+            bankName?: string | undefined;
+            error?: Error | undefined;
         }
 
         interface ElementOptions {
-            fonts?: Font[];
-            locale?: string;
+            fonts?: Font[] | undefined;
+            locale?: string | undefined;
         }
 
         type elementsType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'postalCode' | 'paymentRequestButton' | 'iban' | 'idealBank';
@@ -968,72 +968,72 @@ declare namespace stripe {
 
         interface ElementsOptions {
             classes?: {
-                base?: string;
-                complete?: string;
-                empty?: string;
-                focus?: string;
-                invalid?: string;
-                webkitAutofill?: string;
-            };
-            hidePostalCode?: boolean;
-            hideIcon?: boolean;
-            showIcon?: boolean;
-            iconStyle?: 'solid' | 'default';
-            placeholder?: string;
-            placeholderCountry?: string;
+                base?: string | undefined;
+                complete?: string | undefined;
+                empty?: string | undefined;
+                focus?: string | undefined;
+                invalid?: string | undefined;
+                webkitAutofill?: string | undefined;
+            } | undefined;
+            hidePostalCode?: boolean | undefined;
+            hideIcon?: boolean | undefined;
+            showIcon?: boolean | undefined;
+            iconStyle?: 'solid' | 'default' | undefined;
+            placeholder?: string | undefined;
+            placeholderCountry?: string | undefined;
             style?: {
-                base?: Style;
-                complete?: Style;
-                empty?: Style;
-                invalid?: Style;
-                paymentRequestButton?: PaymentRequestButtonStyleOptions;
-            };
-            value?: string | { [objectKey: string]: string; };
-            paymentRequest?: paymentRequest.StripePaymentRequest;
-            supportedCountries?: string[];
-            disabled?: boolean;
+                base?: Style | undefined;
+                complete?: Style | undefined;
+                empty?: Style | undefined;
+                invalid?: Style | undefined;
+                paymentRequestButton?: PaymentRequestButtonStyleOptions | undefined;
+            } | undefined;
+            value?: string | { [objectKey: string]: string; } | undefined;
+            paymentRequest?: paymentRequest.StripePaymentRequest | undefined;
+            supportedCountries?: string[] | undefined;
+            disabled?: boolean | undefined;
         }
 
         interface Style extends StyleOptions {
-            ':hover'?: StyleOptions;
-            ':focus'?: StyleOptions;
-            '::placeholder'?: StyleOptions;
-            '::selection'?: StyleOptions;
-            ':-webkit-autofill'?: StyleOptions;
-            ':disabled'?: StyleOptions;
-            '::-ms-clear'?: StyleOptions;
+            ':hover'?: StyleOptions | undefined;
+            ':focus'?: StyleOptions | undefined;
+            '::placeholder'?: StyleOptions | undefined;
+            '::selection'?: StyleOptions | undefined;
+            ':-webkit-autofill'?: StyleOptions | undefined;
+            ':disabled'?: StyleOptions | undefined;
+            '::-ms-clear'?: StyleOptions | undefined;
         }
 
         interface Font {
-            family?: string;
-            src?: string;
-            display?: string;
-            style?: string;
-            unicodeRange?: string;
-            weight?: string;
-            cssSrc?: string;
+            family?: string | undefined;
+            src?: string | undefined;
+            display?: string | undefined;
+            style?: string | undefined;
+            unicodeRange?: string | undefined;
+            weight?: string | undefined;
+            cssSrc?: string | undefined;
         }
 
         interface StyleOptions {
-            color?: string;
-            backgroundColor?: string;
-            fontFamily?: string;
-            fontSize?: string;
-            fontSmoothing?: string;
-            fontStyle?: string;
-            fontVariant?: string;
-            fontWeight?: string | number;
-            iconColor?: string;
-            lineHeight?: string;
-            letterSpacing?: string;
-            textAlign?: string;
-            textDecoration?: string;
-            textShadow?: string;
-            textTransform?: string;
+            color?: string | undefined;
+            backgroundColor?: string | undefined;
+            fontFamily?: string | undefined;
+            fontSize?: string | undefined;
+            fontSmoothing?: string | undefined;
+            fontStyle?: string | undefined;
+            fontVariant?: string | undefined;
+            fontWeight?: string | number | undefined;
+            iconColor?: string | undefined;
+            lineHeight?: string | undefined;
+            letterSpacing?: string | undefined;
+            textAlign?: string | undefined;
+            textDecoration?: string | undefined;
+            textShadow?: string | undefined;
+            textTransform?: string | undefined;
         }
 
         interface PaymentRequestButtonStyleOptions {
-            type?: 'default' | 'donate' | 'buy';
+            type?: 'default' | 'donate' | 'buy' | undefined;
             theme: 'dark' | 'light' | 'light-outline';
             height: string;
         }
@@ -1181,7 +1181,7 @@ declare namespace stripe {
             /**
              * An arbitrary string attached to the object. Often useful for displaying to users.
              */
-            description?: string;
+            description?: string | undefined;
 
             /**
              * The payment error encountered in the previous PaymentIntent confirmation.
@@ -1368,12 +1368,12 @@ declare namespace stripe {
                 /**
                  * Assessments reported by you have the key user_report and, if set, possible values of "safe" and "fraudulent".
                  */
-                user_report?: "fraudulent" | "safe";
+                user_report?: "fraudulent" | "safe" | undefined;
 
                 /**
                  * Assessments from Stripe have the key stripe_report and, if set, the value "fraudulent".
                  */
-                stripe_report?: "fraudulent";
+                stripe_report?: "fraudulent" | undefined;
             };
 
             /**
@@ -1411,7 +1411,7 @@ declare namespace stripe {
                 reason: 'highest_risk_level' | 'elevated_risk_level' | 'rule' | null;
                 risk_level: 'normal' | 'elevated' | 'highest' | 'not_assessed' | 'unknown';
                 risk_score: number;
-                rule?: string;
+                rule?: string | undefined;
                 seller_message: string;
                 type: 'authorized' | 'manual_review' | 'issuer_declined' | 'blocked' | 'invalid';
             } | null;
@@ -1464,18 +1464,18 @@ declare namespace stripe {
             /**
              * ID of the review associated with this charge if one exists.
              */
-            review?: string | null;
+            review?: string | null | undefined;
 
             /**
              * Shipping information for the charge.
              */
-            shipping?: ShippingDetails | null;
+            shipping?: ShippingDetails | null | undefined;
 
             /**
              * For most Stripe users, the source of every charge is a credit or debit card.
              * This hash is then the card object describing that card.
              */
-            source?: Source;
+            source?: Source | undefined;
 
             /**
              * The transfer ID which created this charge. Only present if the charge came
@@ -1498,13 +1498,13 @@ declare namespace stripe {
              * ID of the transfer to the destination account (only applicable if the
              * charge was created using the destination parameter).
              */
-            transfer?: string | null;
+            transfer?: string | null | undefined;
 
             /**
              * A string that identifies this transaction as part of a group.
              * See the Connect documentation for details.
              */
-            transfer_group?: string | null;
+            transfer_group?: string | null | undefined;
         }
 
         interface Refund {
@@ -1547,21 +1547,21 @@ declare namespace stripe {
              * An arbitrary string attached to the object. Often useful for
              * displaying to users. (Available on non-card refunds only)
              */
-            description?: string;
+            description?: string | undefined;
 
             /**
              * If the refund failed, this balance transaction describes the
              * adjustment made on your account balance that reverses the
              * initial balance transaction.
              */
-            failure_balance_transaction?: string;
+            failure_balance_transaction?: string | undefined;
 
             /**
              * If the refund failed, the reason for refund failure if known
              */
             failure_reason?: 'lost_or_stolen_card'
             | 'expired_or_canceled_card'
-            | 'unknown';
+            | 'unknown' | undefined;
 
             metadata: Metadata;
 
@@ -1622,7 +1622,7 @@ declare namespace stripe {
             /**
              * If this is a card PaymentMethod, this hash contains details about the card.
              */
-            card?: PaymentMethodCard;
+            card?: PaymentMethodCard | undefined;
 
             /**
              * If this is an card_present PaymentMethod, this hash contains details
@@ -1715,8 +1715,8 @@ declare namespace stripe {
              * Details of the original PaymentMethod that created this object.
              */
             generated_from: {
-                charge?: string | null;
-                payment_method_details?: PaymentMethodDetails | null;
+                charge?: string | null | undefined;
+                payment_method_details?: PaymentMethodDetails | null | undefined;
             };
 
             /**
@@ -1728,8 +1728,8 @@ declare namespace stripe {
              * Contains details on how this Card maybe be used for 3D Secure authentication.
              */
             three_d_secure_usage?: {
-                supported?: boolean;
-            };
+                supported?: boolean | undefined;
+            } | undefined;
 
             /**
              * If this Card is part of a card wallet, this contains the details of
@@ -1774,20 +1774,20 @@ declare namespace stripe {
             | 'stripe_account'
             | 'wechat';
 
-            ach_credit_transfer?: AchCreditTransferDetails | null;
-            ach_debit?: AchDebitDetails | null;
-            alipay?: any | null;
-            bancontact?: BanContactDetails | null;
-            card?: PaymentMethodCard | null;
-            eps?: EpsDetails | null;
-            giropay?: GiropayDetails | null;
-            ideal?: IdealDetails | null;
-            multibanco?: MultibancoDetails | null;
-            p24?: P24Details | null;
-            sepa_debit?: SepaDebitDetails | null;
-            sofort?: SofortDetails | null;
-            stripe_account?: any | null;
-            wechat?: any | null;
+            ach_credit_transfer?: AchCreditTransferDetails | null | undefined;
+            ach_debit?: AchDebitDetails | null | undefined;
+            alipay?: any | null | undefined;
+            bancontact?: BanContactDetails | null | undefined;
+            card?: PaymentMethodCard | null | undefined;
+            eps?: EpsDetails | null | undefined;
+            giropay?: GiropayDetails | null | undefined;
+            ideal?: IdealDetails | null | undefined;
+            multibanco?: MultibancoDetails | null | undefined;
+            p24?: P24Details | null | undefined;
+            sepa_debit?: SepaDebitDetails | null | undefined;
+            sofort?: SofortDetails | null | undefined;
+            stripe_account?: any | null | undefined;
+            wechat?: any | null | undefined;
         }
 
         interface AchCreditTransferDetails {
@@ -1969,7 +1969,7 @@ declare namespace stripe {
             /**
              * An arbitrary string attached to the object. Often useful for displaying to users.
              */
-            description?: string;
+            description?: string | undefined;
 
             /**
              * The error encountered in the previous SetupIntent confirmation.

--- a/types/stripejs/customer.d.ts
+++ b/types/stripejs/customer.d.ts
@@ -91,7 +91,7 @@ export interface Card {
      */
     object: 'card';
 
-    account?: string;
+    account?: string | undefined;
 
     /**
      * City/District/Suburb/Town/Village
@@ -155,7 +155,7 @@ export interface Card {
      * Only applicable on accounts (not customers or recipients).
      * The card can be used as a transfer destination for funds in this currency
      */
-    currency?: string;
+    currency?: string | undefined;
 
     /**
      * The customer that this card belongs to
@@ -172,7 +172,7 @@ export interface Card {
      * Only applicable on accounts (not customers or recipients)
      * This indicates whether this card is the default external account for its currency
      */
-    default_for_currency?: boolean;
+    default_for_currency?: boolean | undefined;
 
     /**
      * The last four digits of the device account number.
@@ -214,7 +214,7 @@ export interface Card {
      * The recipient that this card belongs to.
      * NOTE: This attribute will not be in the card object if the card belongs to a customer or account instead
      */
-    recipient?: string;
+    recipient?: string | undefined;
 
     /**
      * If the card number is tokenized, this is the method that was used

--- a/types/stripejs/element.d.ts
+++ b/types/stripejs/element.d.ts
@@ -41,7 +41,7 @@ export interface ElementCreatorOptions {
      * Fonts that should be used for styling the element
      * @see https://stripe.com/docs/stripe-js/reference#stripe-elements
      */
-    fonts?: FontCSSElement[] | FontConfigElement[];
+    fonts?: FontCSSElement[] | FontConfigElement[] | undefined;
 
     /**
      * The translation that should be used for the element text
@@ -49,7 +49,7 @@ export interface ElementCreatorOptions {
      *
      * @default 'auto'
      */
-    locale?: 'auto' | 'da' | 'de' | 'en' | 'es' | 'fi' | 'fr' | 'it' | 'ja' | 'no' | 'nl' | 'sv' | 'zh' | string;
+    locale?: 'auto' | 'da' | 'de' | 'en' | 'es' | 'fi' | 'fr' | 'it' | 'ja' | 'no' | 'nl' | 'sv' | 'zh' | string | undefined;
 }
 
 export interface FontCSSElement {
@@ -65,7 +65,7 @@ export interface FontConfigElement {
      * The name of the font family
      * @example 'Times New Roman'
      */
-    family?: string;
+    family?: string | undefined;
 
     /**
      * A src value pointing to your custom font file.
@@ -73,25 +73,25 @@ export interface FontConfigElement {
      * 'url(https://somewebsite.com/path/to/font.woff)'
      * 'url(path/to/font.woff)'
      */
-    src?: string;
+    src?: string | undefined;
 
     /**
      * The style of the text
      * @default 'normal'
      */
-    style?: 'normal' | 'italic' | 'oblique';
+    style?: 'normal' | 'italic' | 'oblique' | undefined;
 
     /**
      * A unicode range for the font that should be used
      * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range
      */
-    unicodeRange?: string;
+    unicodeRange?: string | undefined;
 
     /**
      * The weight of the font
      * NOTE: This cannot be a number!
      */
-    weight?: 'initial' | 'inherit' | 'bold' | 'bolder' | 'lighter' | 'normal' | 'revert' | 'unset';
+    weight?: 'initial' | 'inherit' | 'bold' | 'bolder' | 'lighter' | 'normal' | 'revert' | 'unset' | undefined;
 }
 
 // --- ELEMENT --- //
@@ -205,13 +205,13 @@ export interface OnChange {
      * @example 'visa'
      * NOTE: This is only available when the element is of Card or Cardnumber type
      */
-    brand?: string;
+    brand?: string | undefined;
 
     /**
      * The country code of the entered IBAN
      * NOTE: This is only available when the element is of IBAN type
      */
-    country?: string;
+    country?: string | undefined;
 
     /**
      * The financial institution that services the account whose IBAN was entered into the Element.
@@ -236,18 +236,18 @@ export interface CardElementOptions extends BaseOptions {
      * NOTE: If you are already collecting a full billing address or postal code elsewhere, set this to `true`
      * @default false
      */
-    hidePostalCode?: boolean;
+    hidePostalCode?: boolean | undefined;
 
     /**
      * Appearance of the icon in the Element
      */
-    iconStyle?: 'solid' | 'default';
+    iconStyle?: 'solid' | 'default' | undefined;
 
     /**
      * A placeholder text
      * NOTE: This is only available for `cardNumber`, `cardExpiry` & `cardCvc` elements
      */
-    placeholder?: string;
+    placeholder?: string | undefined;
 }
 
 // --- IBAN ELEMENT --- //
@@ -255,18 +255,18 @@ export interface IBANElementOptions extends BaseOptions {
     /**
      * Specify the list of countries or country-groups whose IBANs you want to allow
      */
-    supportedCountries?: string[];
+    supportedCountries?: string[] | undefined;
 
     /**
      * Customize the country and format of the placeholder IBAN
      * @default 'DE"
      */
-    placeholderCountry?: string;
+    placeholderCountry?: string | undefined;
 
     /**
      * Appearance of the icon in the Element
      */
-    iconStyle?: 'solid' | 'default';
+    iconStyle?: 'solid' | 'default' | undefined;
 }
 
 // --- IDEAL ELEMENT --- //
@@ -277,7 +277,7 @@ export interface IdealBankOptions extends BaseOptions {
      *
      * @example 'abn_amro'
      */
-    value?: string;
+    value?: string | undefined;
 }
 
 // --- PAYMENT BUTTON ELEMENT --- //
@@ -289,19 +289,19 @@ export interface PaymentButtonOptions {
      * particular state.
      */
     classes?: {
-        base?: string; /** @default StripeElement */
-        complete?: string; /** @default StripeElement--complete */
+        base?: string | undefined; /** @default StripeElement */
+        complete?: string | undefined; /** @default StripeElement--complete */
         focus: string; /** @default StripeElement--focus */
         invalid: string; /** @default StripeElement--invalid */
-    };
+    } | undefined;
 
     style?: {
-        base?: PaymentRequestButtonStyle;
-        complete?: PaymentRequestButtonStyle;
-        empty?: PaymentRequestButtonStyle;
-        invalid?: PaymentRequestButtonStyle;
-        paymentRequestButton?: PaymentRequestButtonStyle;
-    };
+        base?: PaymentRequestButtonStyle | undefined;
+        complete?: PaymentRequestButtonStyle | undefined;
+        empty?: PaymentRequestButtonStyle | undefined;
+        invalid?: PaymentRequestButtonStyle | undefined;
+        paymentRequestButton?: PaymentRequestButtonStyle | undefined;
+    } | undefined;
 }
 
 export interface PaymentRequestButtonStyle {
@@ -309,19 +309,19 @@ export interface PaymentRequestButtonStyle {
      * The type of button that should be shown
      * @default 'default'
      */
-    type?: 'default' | 'donate' | 'buy';
+    type?: 'default' | 'donate' | 'buy' | undefined;
 
     /**
      * The theme of the button that should be used
      * @default 'dark'
      */
-    theme?: 'dark' | 'light' | 'light-outline';
+    theme?: 'dark' | 'light' | 'light-outline' | undefined;
 
     /**
      * The height of the button
      * @example '25px'
      */
-    height?: string;
+    height?: string | undefined;
 }
 
 // --- BASE OPTIONS FOR ELEMENTS --- //
@@ -334,75 +334,75 @@ export interface BaseOptions {
      * particular state.
      */
     classes?: {
-        base?: string; /** @default StripeElement */
-        complete?: string; /** @default StripeElement--complete */
-        empty?: string; /** @default StripeElement--empty */
-        focus?: string; /** @default StripeElement--focus */
-        invalid?: string; /** @default StripeElement--invalid */
-        webkitAutofill?: string; /** @default StripeElement--webkit-autofill */
-    };
+        base?: string | undefined; /** @default StripeElement */
+        complete?: string | undefined; /** @default StripeElement--complete */
+        empty?: string | undefined; /** @default StripeElement--empty */
+        focus?: string | undefined; /** @default StripeElement--focus */
+        invalid?: string | undefined; /** @default StripeElement--invalid */
+        webkitAutofill?: string | undefined; /** @default StripeElement--webkit-autofill */
+    } | undefined;
 
     /**
      * Customize appearance using CSS properties
      */
     style?: {
-        base?: StyleAttributes;
-        complete?: StyleAttributes;
-        empty?: StyleAttributes;
-        invalid?: StyleAttributes;
-    };
+        base?: StyleAttributes | undefined;
+        complete?: StyleAttributes | undefined;
+        empty?: StyleAttributes | undefined;
+        invalid?: StyleAttributes | undefined;
+    } | undefined;
 
     /**
      * Whether or not the icon should be hidden
      * @default false
      */
-    hideIcon?: boolean;
+    hideIcon?: boolean | undefined;
 
     /**
      * Whether or not the input is disabled
      * @default false
      */
-    disabled?: boolean;
+    disabled?: boolean | undefined;
 }
 
 /**
  * Styling settings for a Stripe Element
  */
 export interface StyleAttributes {
-    color?: string;
-    fontFamily?: string;
-    fontSize?: string;
-    fontSmoothing?: string;
-    fontStyle?: string;
+    color?: string | undefined;
+    fontFamily?: string | undefined;
+    fontSize?: string | undefined;
+    fontSmoothing?: string | undefined;
+    fontStyle?: string | undefined;
     fontVariant?: any;
-    iconColor?: string;
-    lineHeight?: string;
-    letterSpacing?: string;
+    iconColor?: string | undefined;
+    lineHeight?: string | undefined;
+    letterSpacing?: string | undefined;
 
     /**
      * Align text inside the element
      * NOTE: Only available for the `cardNumber`, `cardExpiry`, and `cardCvc` Elements
      */
-    textAlign?: string;
-    '::-ms-clear'?: MSClearAttributes;
+    textAlign?: string | undefined;
+    '::-ms-clear'?: MSClearAttributes | undefined;
 
     /**
      * Add padding to the element
      * NOTE: Only available for the `idealBank` Element
      */
-    padding?: string;
+    padding?: string | undefined;
 
-    textDecoration?: string;
-    textShadow?: string;
-    textTransform?: string;
-    ':hover'?: StyleAttributes;
-    ':focus'?: StyleAttributes;
-    '::placeholder'?: StyleAttributes;
-    '::selection'?: StyleAttributes;
-    ':-webkit-autofill'?: StyleAttributes;
-    ':disabled'?: StyleAttributes;
+    textDecoration?: string | undefined;
+    textShadow?: string | undefined;
+    textTransform?: string | undefined;
+    ':hover'?: StyleAttributes | undefined;
+    ':focus'?: StyleAttributes | undefined;
+    '::placeholder'?: StyleAttributes | undefined;
+    '::selection'?: StyleAttributes | undefined;
+    ':-webkit-autofill'?: StyleAttributes | undefined;
+    ':disabled'?: StyleAttributes | undefined;
 }
 
 export interface MSClearAttributes extends StyleAttributes {
-    display?: string;
+    display?: string | undefined;
 }

--- a/types/stripejs/index.d.ts
+++ b/types/stripejs/index.d.ts
@@ -107,35 +107,35 @@ export interface StripeError {
     /**
      * For card errors, the ID of the failed charge
      */
-    charge?: string;
+    charge?: string | undefined;
 
     /**
      * For some errors that could be handled programmatically,
      * a short string indicating the error code reported
      */
-    code?: string;
+    code?: string | undefined;
 
     /**
      * For card errors resulting from a card issuer decline,
      * a short string indicating the card issuer’s reason for the decline if they provide one
      */
-    decline_code?: string;
+    decline_code?: string | undefined;
 
     /**
      * A URL to more information about the error code reported
      */
-    doc_url?: string;
+    doc_url?: string | undefined;
 
     /**
      * A human-readable message providing more details about the error.
      * NOTE: For card errors, these messages can be shown to your users
      */
-    message?: string;
+    message?: string | undefined;
 
     /**
      * If the error is parameter-specific, the parameter related to the error
      */
-    param?: string;
+    param?: string | undefined;
 }
 
 export type errorType =

--- a/types/stripejs/payment.d.ts
+++ b/types/stripejs/payment.d.ts
@@ -107,7 +107,7 @@ export interface UpdateOptions {
      *
      * @default []
      */
-    displayItems?: PaymentItem[];
+    displayItems?: PaymentItem[] | undefined;
 
     /**
      * An array of possible shipping options
@@ -115,7 +115,7 @@ export interface UpdateOptions {
      *
      * @default []
      */
-    shippingOptions?: ShippingOption[];
+    shippingOptions?: ShippingOption[] | undefined;
 }
 
 /**
@@ -133,26 +133,26 @@ export interface StripePaymentOptions extends UpdateOptions {
      * Whether or not the form should ask for the payer's name
      * @default false
      */
-    requestPayerName?: boolean;
+    requestPayerName?: boolean | undefined;
 
     /**
      * Whether or not the form should ask for the payer's email address
      * @default false
      */
-    requestPayerEmail?: boolean;
+    requestPayerEmail?: boolean | undefined;
 
     /**
      * Whether or not the form should ask for the payer's phone number
      * @default false
      */
-    requestPayerPhone?: boolean;
+    requestPayerPhone?: boolean | undefined;
 
     /**
      * Whether or not a shipping address should be requested
      * NOTE: Setting this to true requires `shippingOptions` to be set with at least one option!
      * @see shippingOptions
      */
-    requestShipping?: boolean;
+    requestShipping?: boolean | undefined;
 }
 
 export interface PaymentItem {
@@ -171,7 +171,7 @@ export interface PaymentItem {
      * Whether or not the payment should be executed immediately
      * If you might change this amount later (for example, after you have calculated shipping costs), set this to `true`
      */
-    pending?: boolean;
+    pending?: boolean | undefined;
 }
 
 // --- PAYMENT RESPONSE FROM STRIPE --- //
@@ -205,9 +205,9 @@ export interface StripePaymentResponse {
      * @see PaymentOptions.requestPayerEmail
      * @see PaymentOptions.requestPayerPhone
      */
-    readonly payerName?: string;
-    readonly payerEmail?: string;
-    readonly payerPhone?: string;
+    readonly payerName?: string | undefined;
+    readonly payerEmail?: string | undefined;
+    readonly payerPhone?: string | undefined;
 
     /**
      * The shipping address the payer selected

--- a/types/stripejs/source.d.ts
+++ b/types/stripejs/source.d.ts
@@ -30,7 +30,7 @@ export interface Source {
      * Information related to the code verification flow
      * Present if the source is authenticated by a verification code
      */
-    code_verification?: CodeVerification;
+    code_verification?: CodeVerification | undefined;
 
     /**
      * Time at which the object was created.
@@ -70,13 +70,13 @@ export interface Source {
      * Information related to the receiver flow.
      * Present if the source is a receiver
      */
-    receiver?: Receiver;
+    receiver?: Receiver | undefined;
 
     /**
      * Information related to the redirect flow.
      * Present if the source is authenticated by a redirect
      */
-    redirect?: Redirect;
+    redirect?: Redirect | undefined;
 
     /**
      * Extra information about a source
@@ -146,7 +146,7 @@ export interface Redirect {
      * The failure reason for the redirect
      * Present only if the redirect status is `'failed'`
      */
-    failure_reason?: 'user_abort' | 'declined' | 'processing_error';
+    failure_reason?: 'user_abort' | 'declined' | 'processing_error' | undefined;
 
     /**
      * The URL you provide to redirect the customer to after they authenticated their payment
@@ -229,46 +229,46 @@ export interface SourceData {
      * Information about a mandate possiblity attached to a source object
      * (generally for bank debits) as well as its acceptance status
      */
-    mandate?: Mandate;
+    mandate?: Mandate | undefined;
 
     /**
      * Extra data you want to add to the source object
      */
-    metadata?: { [key: string]: string };
+    metadata?: { [key: string]: string } | undefined;
 
     /**
      * Information about the owner of the payment instrument that may be used or
      * required by particular source types.
      */
-    owner?: Customer;
+    owner?: Customer | undefined;
 
     /**
      * Can be set only if the source is a receiver
      */
-    receiver?: Receiver;
+    receiver?: Receiver | undefined;
 
     /**
      * Required if the source is authenticated by a redirect
      */
-    redirect?: Redirect;
+    redirect?: Redirect | undefined;
 
     /**
      * An arbitrary string to be displayed on your customer’s statement
      * @example if your website is RunClub and the item you’re charging for is a race ticket,
      * you may want to specify a statement_descriptor of RunClub 5K race ticket.
      */
-    statement_descriptor?: string;
+    statement_descriptor?: string | undefined;
 
     three_d_secure_2_eap?: any;
 
     /**
      * When passed, token properties will override source parameters
      */
-    token?: Token;
+    token?: Token | undefined;
 }
 
 export interface Mandate {
-    acceptance?: Acceptance;
+    acceptance?: Acceptance | undefined;
 
     /**
      * The method Stripe should use to notify the customer
@@ -276,7 +276,7 @@ export interface Mandate {
      * - manual: a source.mandate_notification event is sent to your webhooks endpoint and you should handle the notification
      * - none: the underlying debit network does not require any notification
      */
-    notification_method?: 'email' | 'manual' | 'none';
+    notification_method?: 'email' | 'manual' | 'none' | undefined;
 }
 
 export interface Acceptance {
@@ -312,5 +312,5 @@ export interface SourceResult {
     /**
      * There was an error. This includes client-side validation errors.
      */
-    error?: StripeError;
+    error?: StripeError | undefined;
 }

--- a/types/stripejs/token.d.ts
+++ b/types/stripejs/token.d.ts
@@ -15,12 +15,12 @@ export interface Token {
     /**
      * Hash describing the bank account
      */
-    bank_account?: BankAccount;
+    bank_account?: BankAccount | undefined;
 
     /**
      * Hash describing the card used to make the charge
      */
-    card?: Card;
+    card?: Card | undefined;
 
     /**
      * IP address of the client that generated the token
@@ -59,13 +59,13 @@ export interface TokenData {
     /**
      * The amount paid, not a decimal. In USD this is in cents.
      */
-    amount?: number;
+    amount?: number | undefined;
 
     /**
      * Fields for billing address information.
      */
     address_line1: string;
-    address_line2?: string;
+    address_line2?: string | undefined;
     address_city: string;
     address_state: string;
     address_zip: string;
@@ -74,13 +74,13 @@ export interface TokenData {
      * A two character country code identifying the country
      * @example 'US'
      */
-    address_country?: string;
+    address_country?: string | undefined;
 
     /**
      * Used to add a card to an account
      * NOTE: Currently, the only supported currency for debit card payouts is 'usd'
      */
-    currency?: string;
+    currency?: string | undefined;
 }
 
 // --- RESPONSE FROM STRIPE WHEN CREATING OR FETCHING A TOKEN --- //
@@ -88,12 +88,12 @@ export interface TokenResult {
     /**
      * The generated string that can be used for communication with the backend
      */
-    token?: Token;
+    token?: Token | undefined;
 
     /**
      * There was an error. This includes client-side validation errors.
      */
-    error?: StripeError;
+    error?: StripeError | undefined;
 }
 
 // --- DATA TO CREATE A PERSONAL TOKEN --- //
@@ -139,5 +139,5 @@ export interface BankTokenData extends IBANTokenData {
      * The routing transit number for the bank account
      * NOTE: This is optional if the {@link BankTokenData.currency} is 'eur'
      */
-    routing_number?: string;
+    routing_number?: string | undefined;
 }

--- a/types/strong-cluster-control/index.d.ts
+++ b/types/strong-cluster-control/index.d.ts
@@ -8,16 +8,16 @@ declare namespace StrongClusterControl {
     type pid = number;
 
     interface StartOptions {
-        size?: number;
-        env?: {};
-        shutdownTimeout?: number;
-        terminateTimeout?: number;
-        throttleDelay?: number;
+        size?: number | undefined;
+        env?: {} | undefined;
+        shutdownTimeout?: number | undefined;
+        terminateTimeout?: number | undefined;
+        throttleDelay?: number | undefined;
     }
 
     interface ClusterMaster {
         pid: number;
-        setSize?: number;
+        setSize?: number | undefined;
         startTime: number;
     }
 

--- a/types/stronghold-pay-js/index.d.ts
+++ b/types/stronghold-pay-js/index.d.ts
@@ -76,7 +76,7 @@ declare global {
         interface ClientOptions {
             environment: ENVIRONMENT;
             publishableKey: string;
-            host?: string;
+            host?: string | undefined;
         }
         type AddPaymentSourceOnSuccess = (paymentSource: PaymentSource) => void;
         type UpdatePaymentSourceOnSuccess = (paymentSource: PaymentSource) => void;
@@ -87,27 +87,27 @@ declare global {
         type OnError = (error: StrongholdPayError) => void;
         type OnEvent = (event: StrongholdMessageEvent) => void;
         interface Options {
-            onExit?: OnExit;
-            onError?: OnError;
-            onEvent?: OnEvent;
-            onReady?: OnReady;
+            onExit?: OnExit | undefined;
+            onError?: OnError | undefined;
+            onEvent?: OnEvent | undefined;
+            onReady?: OnReady | undefined;
         }
         interface AddPaymentSourceOptions extends Options {
             onSuccess: AddPaymentSourceOnSuccess;
         }
         interface UpdatePaymentSourceOptions extends Options {
-            onSuccess?: UpdatePaymentSourceOnSuccess;
+            onSuccess?: UpdatePaymentSourceOnSuccess | undefined;
             paymentSourceId: string;
         }
         interface ChargeOptions extends Options {
             charge: ChargeDropin;
-            tip?: TipDataDropin;
-            authorizeOnly?: boolean;
+            tip?: TipDataDropin | undefined;
+            authorizeOnly?: boolean | undefined;
             onSuccess: ChargeOnSuccess;
         }
         interface TipOptions extends Options {
             tip: TipDropin;
-            authorizeOnly?: boolean;
+            authorizeOnly?: boolean | undefined;
             onSuccess: TipOnSuccess;
         }
         interface StrongholdMessageEvent extends MessageEvent {
@@ -125,7 +125,7 @@ declare global {
              */
             amount: number;
             paymentSourceId: string;
-            externalId?: string;
+            externalId?: string | undefined;
         }
         interface TipDataDropin {
             /**
@@ -134,10 +134,10 @@ declare global {
             amount: number;
             beneficiaryName: string;
             details?: {
-                displayMessage?: string;
-                terminalId?: string;
-                drawerId?: string;
-            };
+                displayMessage?: string | undefined;
+                terminalId?: string | undefined;
+                drawerId?: string | undefined;
+            } | undefined;
         }
         interface TipDropin extends TipDataDropin {
             chargeId: string;
@@ -176,10 +176,10 @@ declare global {
             amount: number;
             beneficiary_name: string;
             details?: {
-                display_message?: string;
-                terminal_id?: string;
-                drawer_id?: string;
-            };
+                display_message?: string | undefined;
+                terminal_id?: string | undefined;
+                drawer_id?: string | undefined;
+            } | undefined;
             charge_id: string;
             payment_source_id: string;
         }

--- a/types/strophe.js/index.d.ts
+++ b/types/strophe.js/index.d.ts
@@ -539,9 +539,9 @@ export namespace Strophe {
     }
 
     interface ConnectionOptions {
-        keepalive?: boolean;
-        protocol?: string;
-        sync?: boolean;
+        keepalive?: boolean | undefined;
+        protocol?: string | undefined;
+        sync?: boolean | undefined;
     }
 
     /** Class: Strophe.Connection

--- a/types/strophe.js/muc.d.ts
+++ b/types/strophe.js/muc.d.ts
@@ -727,12 +727,12 @@ declare module "strophe.js" {
 
 
       interface OccupantInfo {
-        nick?:        string;
-        affiliation?: string;
-        role?:        string;
-        jid?:         string;
-        status?:      string;
-        show?:        string;
+        nick?:        string | undefined;
+        affiliation?: string | undefined;
+        role?:        string | undefined;
+        jid?:         string | undefined;
+        status?:      string | undefined;
+        show?:        string | undefined;
       }
 
 

--- a/types/strophe/index.d.ts
+++ b/types/strophe/index.d.ts
@@ -540,9 +540,9 @@ export namespace Strophe {
     }
 
     interface ConnectionOptions {
-        keepalive?: boolean;
-        protocol?: string;
-        sync?: boolean;
+        keepalive?: boolean | undefined;
+        protocol?: string | undefined;
+        sync?: boolean | undefined;
     }
 
     /** Class: Strophe.Connection

--- a/types/strophe/muc.d.ts
+++ b/types/strophe/muc.d.ts
@@ -732,12 +732,12 @@ declare module "strophe" {
 
 
       interface OccupantInfo {
-        nick?:        string;
-        affiliation?: string;
-        role?:        string;
-        jid?:         string;
-        status?:      string;
-        show?:        string
+        nick?:        string | undefined;
+        affiliation?: string | undefined;
+        role?:        string | undefined;
+        jid?:         string | undefined;
+        status?:      string | undefined;
+        show?:        string | undefined
       }
 
 

--- a/types/stubby/index.d.ts
+++ b/types/stubby/index.d.ts
@@ -35,7 +35,7 @@ export interface StubbyRequest {
      *   - etc.
      * - it can also be an array of values.
      */
-    method?: StubbyMethod | StubbyMethod[];
+    method?: StubbyMethod | StubbyMethod[] | undefined;
     /**
      * - values are full-fledged **regular expressions**
      * - if omitted, stubby ignores query parameters for the given url.
@@ -48,13 +48,13 @@ export interface StubbyRequest {
      * **NOTE**: repeated querystring keys (often array representations) will
      * have their values converted to a comma-separated list.
      */
-    query?: { [key: string]: string };
+    query?: { [key: string]: string } | undefined;
     /**
      * - is a full-fledged **regular expression**
      * - if omitted, any post data is ignored.
      * - the body contents of the server request, such as form data.
      */
-    post?: string;
+    post?: string | undefined;
     /**
      * - if supplied, replaces `post` with the contents of the locally given
      *   file.
@@ -63,21 +63,21 @@ export interface StubbyRequest {
      *   for matching.
      * - allows you to split up stubby data across multiple files
      */
-    file?: string;
+    file?: string | undefined;
     /**
      * - not used if `post` or `file` are present.
      * - will be parsed into a JavaScript object.
      * - allows you to specify a JSON string that will be deeply compared with a
      *   JSON request
      */
-    json?: string;
+    json?: string | undefined;
     /**
      * - values are full-fledged **regular expressions**
      * - if omitted, stubby ignores headers for the given url.
      * - case-insensitive matching of header names.
      * - a hashmap of header/value pairs similar to `query`.
      */
-    headers?: { [key: string]: string };
+    headers?: { [key: string]: string } | undefined;
 }
 
 export interface StubbyResponse {
@@ -86,27 +86,27 @@ export interface StubbyResponse {
      * - integer or integer-like string.
      * - defaults to `200`.
      */
-    status?: number | string;
+    status?: number | string | undefined;
     /**
      * - contents of the response body
      * - defaults to an empty content body
      */
-    body?: string;
+    body?: string | undefined;
     /**
      * - similar to `request.file`, but the contents of the file are used as the
      *   `body`.
      */
-    file?: string;
+    file?: string | undefined;
     /**
      * - similar to `request.headers` except that these are sent back to the
      *   client.
      */
-    headers?: { [key: string]: string };
+    headers?: { [key: string]: string } | undefined;
     /**
      * - time to wait, in milliseconds, before sending back the response
      * - good for testing timeouts, or slow connections
      */
-    latency?: number;
+    latency?: number | undefined;
 }
 
 export interface StubbyData {
@@ -128,27 +128,27 @@ export interface StubbyData {
      * portion of the endpoint will be used to assemble a request to the url
      * given as the `response`.
      */
-    response?: string | StubbyResponse | Array<string | StubbyResponse>;
+    response?: string | StubbyResponse | Array<string | StubbyResponse> | undefined;
 }
 
 export interface StubbyCommonOptions {
     /** port number to run the stubs portal */
-    stubs?: number;
+    stubs?: number | undefined;
     /** port number to run the admin portal */
-    admin?: number;
+    admin?: number | undefined;
     /** port number to run the stubs portal over https */
-    tls?: number;
+    tls?: number | undefined;
     /** JavaScript Object/Array containing endpoint data */
-    data?: StubbyData | StubbyData[];
+    data?: StubbyData | StubbyData[] | undefined;
     /** address/hostname at which to run stubby */
-    location?: string;
+    location?: string | undefined;
     /** filename to monitor and load as stubby's data when changes occur */
-    watch?: string;
+    watch?: string | undefined;
     /** defaults to `true`. Pass in `false` to have console output (if available) */
-    quiet?: boolean;
+    quiet?: boolean | undefined;
     /** additional options to pass to the underlying tls server */
-    _httpsOptions?: tls.TlsOptions;
-    datadir?: string;
+    _httpsOptions?: tls.TlsOptions | undefined;
+    datadir?: string | undefined;
 }
 
 export interface StubbyWithKeyCertOptions extends StubbyCommonOptions {
@@ -160,7 +160,7 @@ export interface StubbyWithKeyCertOptions extends StubbyCommonOptions {
 
 export interface StubbyWithPfxOptions extends StubbyCommonOptions {
     /** pfx file contents (mutually exclusive with key/cert options) */
-    pfx?: string | Buffer | Array<string | Buffer | Object>; // tslint:disable-line:ban-types
+    pfx?: string | Buffer | Array<string | Buffer | Object> | undefined; // tslint:disable-line:ban-types
 }
 
 export type StubbyOptions = StubbyWithKeyCertOptions | StubbyWithPfxOptions;

--- a/types/style-search/index.d.ts
+++ b/types/style-search/index.d.ts
@@ -53,31 +53,31 @@ declare namespace styleSearch {
          * If true, the search will stop after one match is found.
          * @default false
          */
-        once?: boolean;
+        once?: boolean | undefined;
         /**
          * This includes both standard `/* CSS comments *\/`
          * and non-standard but widely used `// single line comments`.
          * @default 'skip'
          */
-        comments?: SyntaxFeatureOption;
+        comments?: SyntaxFeatureOption | undefined;
         /**
          * @default 'skip'
          */
-        strings?: SyntaxFeatureOption;
+        strings?: SyntaxFeatureOption | undefined;
         /**
          * @default 'skip'
          */
-        functionNames?: SyntaxFeatureOption;
+        functionNames?: SyntaxFeatureOption | undefined;
         /**
          * @default 'check'
          */
-        functionArguments?: SyntaxFeatureOption;
+        functionArguments?: SyntaxFeatureOption | undefined;
         /**
          * This designates anything inside parentheses, which includes standard functions,but also Sass maps and other non-standard constructs.
          * `parentheticals` is a broader category than `functionArguments`
          * @default 'check'
          */
-        parentheticals?: SyntaxFeatureOption;
+        parentheticals?: SyntaxFeatureOption | undefined;
     }
 }
 

--- a/types/styled-components-react-native/styled-components-react-native-tests.tsx
+++ b/types/styled-components-react-native/styled-components-react-native-tests.tsx
@@ -41,7 +41,7 @@ interface MyTheme {
 
 interface ButtonProps {
     name: string;
-    primary?: boolean;
+    primary?: boolean | undefined;
     theme: MyTheme;
 }
 

--- a/types/styled-components/cssprop.d.ts
+++ b/types/styled-components/cssprop.d.ts
@@ -14,6 +14,6 @@ declare module 'react' {
          * `babel-plugin-styled-components` into a styled component
          * with the given css as its styles.
          */
-        css?: CSSProp;
+        css?: CSSProp | undefined;
     }
 }

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -99,7 +99,7 @@ export type StyledComponentProps<
 type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> = C extends React.ComponentClass<
     any
 >
-    ? { children?: React.ReactNode }
+    ? { children?: React.ReactNode | undefined }
     : {};
 
 type StyledComponentPropsWithAs<
@@ -109,7 +109,7 @@ type StyledComponentPropsWithAs<
     A extends keyof any,
     AsC extends string | React.ComponentType<any> = C,
     FAsC extends string | React.ComponentType<any> = C
-> = StyledComponentProps<C, T, O, A, AsC, FAsC> & { as?: AsC; forwardedAs?: FAsC };
+> = StyledComponentProps<C, T, O, A, AsC, FAsC> & { as?: AsC | undefined; forwardedAs?: FAsC | undefined };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> = InterpolationValue | InterpolationFunction<P> | FlattenInterpolation<P>;
@@ -125,7 +125,7 @@ export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 type Attrs<P, A extends Partial<P>, T> = ((props: ThemedStyledProps<P, T>) => A) | A;
 
 export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
-    suppressMultiMountWarning?: boolean;
+    suppressMultiMountWarning?: boolean | undefined;
 };
 
 export interface GlobalStyleComponent<P, T> extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
@@ -141,7 +141,7 @@ type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof Re
 // Config to be used with withConfig
 export interface StyledConfig<O extends object = {}> {
     // TODO: Add all types from the original StyledComponentWrapperProperties
-    shouldForwardProp?: (prop: keyof O, defaultValidatorFn: (prop: keyof O) => boolean) => boolean;
+    shouldForwardProp?: ((prop: keyof O, defaultValidatorFn: (prop: keyof O) => boolean) => boolean) | undefined;
 }
 
 // extracts React defaultProps
@@ -168,7 +168,7 @@ export interface StyledComponentBase<
     A extends keyof any = never
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
     // add our own fake call signature to implement the polymorphic 'as' prop
-    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+    (props: StyledComponentProps<C, T, O, A> & { as?: never | undefined; forwardedAs?: never | undefined }): React.ReactElement<
         StyledComponentProps<C, T, O, A>
     >;
     <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = C>(
@@ -304,8 +304,8 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmp
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
-    theme?: T;
+type WithOptionalTheme<P extends { theme?: T | undefined }, T> = Omit<P, 'theme'> & {
+    theme?: T | undefined;
 };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
@@ -342,7 +342,7 @@ export const css: ThemedCssFunction<DefaultTheme>;
 export type BaseWithThemeFnInterface<T extends object> = <C extends React.ComponentType<any>>(
     // this check is roundabout because the extends clause above would
     // not allow any component that accepts _more_ than theme as a prop
-    component: React.ComponentProps<C> extends { theme?: T } ? C : never,
+    component: React.ComponentProps<C> extends { theme?: T | undefined } ? C : never,
 ) => React.ForwardRefExoticComponent<WithOptionalTheme<React.ComponentPropsWithRef<C>, T>>;
 export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<AnyIfEmpty<T>>;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
@@ -359,7 +359,7 @@ export function useTheme(): DefaultTheme;
 export interface DefaultTheme {}
 
 export interface ThemeProviderProps<T extends object, U extends object = T> {
-    children?: React.ReactNode;
+    children?: React.ReactNode | undefined;
     theme: T | ((theme: U) => T);
 }
 export type BaseThemeProviderComponent<T extends object, U extends object = T> = React.ComponentClass<
@@ -411,11 +411,11 @@ export type StylisPlugin = (
 ) => string | void;
 
 export interface StyleSheetManagerProps {
-    disableCSSOMInjection?: boolean;
-    disableVendorPrefixes?: boolean;
-    stylisPlugins?: StylisPlugin[];
-    sheet?: ServerStyleSheet;
-    target?: HTMLElement;
+    disableCSSOMInjection?: boolean | undefined;
+    disableVendorPrefixes?: boolean | undefined;
+    stylisPlugins?: StylisPlugin[] | undefined;
+    sheet?: ServerStyleSheet | undefined;
+    target?: HTMLElement | undefined;
 }
 
 export class StyleSheetManager extends React.Component<StyleSheetManagerProps> {}

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -59,7 +59,7 @@ interface MyTheme {
 
 interface ButtonProps {
     name: string;
-    primary?: boolean;
+    primary?: boolean | undefined;
     theme: MyTheme;
 }
 
@@ -587,10 +587,10 @@ const AnchorContainer = () => (
 
 const WithComponentRandomHeading = WithComponentH1.withComponent(Random);
 
-const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({ className }) => (
+const WithComponentCompA: React.SFC<{ a: number; className?: string | undefined }> = ({ className }) => (
     <div className={className} />
 );
-const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({ className }) => (
+const WithComponentCompB: React.SFC<{ b: number; className?: string | undefined }> = ({ className }) => (
     <div className={className} />
 );
 const WithComponentStyledA = styled(WithComponentCompA)`
@@ -640,7 +640,7 @@ const forwardedAsTest = (
 );
 
 interface ExternalAsComponentProps {
-    as?: string | React.ComponentType<any>;
+    as?: string | React.ComponentType<any> | undefined;
     type: 'primitive' | 'complex';
 }
 const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
@@ -676,7 +676,7 @@ const HasAttributesOfAsOrForwardedAsComponent = (
 
 interface TestContainerProps {
     size: 'big' | 'small';
-    test?: boolean;
+    test?: boolean | undefined;
 }
 const TestContainer = ({ size, test }: TestContainerProps) => {
     return null;
@@ -1088,7 +1088,7 @@ function validateDefaultProps() {
 }
 
 interface WrapperProps {
-    className?: string;
+    className?: string | undefined;
 }
 export class WrapperClass extends React.Component<WrapperProps> {
     render() {
@@ -1125,10 +1125,10 @@ function staticPropertyPassthrough() {
         a: number;
     }
     interface BProps {
-        b?: string;
+        b?: string | undefined;
     }
     interface BState {
-        b?: string;
+        b?: string | undefined;
     }
     class A extends React.Component<AProps> {}
     class B extends React.Component {

--- a/types/styled-components/v3/index.d.ts
+++ b/types/styled-components/v3/index.d.ts
@@ -17,8 +17,8 @@ export type ThemedStyledProps<P, T> = P & ThemeProps<T>;
 export type StyledProps<P> = ThemedStyledProps<P, any>;
 
 export type ThemedOuterStyledProps<P, T> = P & {
-    theme?: T;
-    innerRef?: ((instance: any) => void) | React.RefObject<HTMLElement | SVGElement | React.Component>;
+    theme?: T | undefined;
+    innerRef?: ((instance: any) => void) | React.RefObject<HTMLElement | SVGElement | React.Component> | undefined;
 };
 export type OuterStyledProps<P> = ThemedOuterStyledProps<P, any>;
 
@@ -77,7 +77,7 @@ export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFacto
         P & JSX.IntrinsicElements[TTag]
     >;
     <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<P, T, O>;
-    <P extends { [prop: string]: any; theme?: T }>(component: React.ComponentType<P>): ThemedStyledFunction<
+    <P extends { [prop: string]: any; theme?: T | undefined }>(component: React.ComponentType<P>): ThemedStyledFunction<
         P,
         T,
         WithOptionalTheme<P, T>
@@ -90,7 +90,7 @@ export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 export interface DefaultTheme {}
 
 export interface ThemeProviderProps<T> {
-    theme?: T | ((theme: T) => T);
+    theme?: T | ((theme: T) => T) | undefined;
 }
 export type BaseThemeProviderComponent<T> = React.ComponentClass<ThemeProviderProps<T>>;
 export type ThemeProviderComponent<T> = BaseThemeProviderComponent<Extract<keyof T, string> extends never ? any : T>;
@@ -107,8 +107,8 @@ type KeyofBase = keyof any;
 type Diff<T extends KeyofBase, U extends KeyofBase> = ({ [P in T]: P } & { [P in U]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 type DiffBetween<T, U> = Pick<T, Diff<keyof T, keyof U>> & Pick<U, Diff<keyof U, keyof T>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
-    theme?: T;
+type WithOptionalTheme<P extends { theme?: T | undefined }, T> = Omit<P, 'theme'> & {
+    theme?: T | undefined;
 };
 
 export interface ThemedStyledComponentsModule<T> {
@@ -126,7 +126,7 @@ declare const styled: StyledInterface;
 
 export const css: ThemedCssFunction<DefaultTheme>;
 
-export type BaseWithThemeFnInterface<T> = <P extends { theme?: T }>(
+export type BaseWithThemeFnInterface<T> = <P extends { theme?: T | undefined }>(
     component: React.ComponentType<P>,
 ) => React.ComponentClass<WithOptionalTheme<P, T>>;
 export type WithThemeFnInterface<T> = BaseWithThemeFnInterface<Extract<keyof T, string> extends never ? any : T>;
@@ -147,8 +147,8 @@ interface StylesheetComponentProps {
 }
 
 interface StyleSheetManagerProps {
-    sheet?: StyleSheet;
-    target?: Node;
+    sheet?: StyleSheet | undefined;
+    target?: Node | undefined;
 }
 
 export class StyleSheetManager extends React.Component<StyleSheetManagerProps> {}

--- a/types/styled-components/v3/styled-components-tests.tsx
+++ b/types/styled-components/v3/styled-components-tests.tsx
@@ -53,7 +53,7 @@ interface MyTheme {
 
 interface ButtonProps {
     name: string;
-    primary?: boolean;
+    primary?: boolean | undefined;
     theme: MyTheme;
 }
 
@@ -507,10 +507,10 @@ const AnchorContainer = () => (
 
 const WithComponentRandomHeading = WithComponentH1.withComponent(Random);
 
-const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({ className }) => (
+const WithComponentCompA: React.SFC<{ a: number; className?: string | undefined }> = ({ className }) => (
     <div className={className} />
 );
-const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({ className }) => (
+const WithComponentCompB: React.SFC<{ b: number; className?: string | undefined }> = ({ className }) => (
     <div className={className} />
 );
 const WithComponentStyledA = styled(WithComponentCompA)`

--- a/types/styled-jsx/index.d.ts
+++ b/types/styled-jsx/index.d.ts
@@ -11,7 +11,7 @@ import * as server from "./server";
 
 declare module "react" {
     interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
-        jsx?: boolean;
-        global?: boolean;
+        jsx?: boolean | undefined;
+        global?: boolean | undefined;
     }
 }

--- a/types/styled-jsx/server.d.ts
+++ b/types/styled-jsx/server.d.ts
@@ -1,10 +1,10 @@
 import { ReactElement } from "react";
 
 declare function flushToHTML(opts?: {
-  nonce?: string;
+  nonce?: string | undefined;
 }): string;
 declare function flushToReact<T>(opts?: {
-  nonce?: string;
+  nonce?: string | undefined;
 }): Array<ReactElement<T>>;
 
 export { flushToHTML };

--- a/types/styled-react-modal/index.d.ts
+++ b/types/styled-react-modal/index.d.ts
@@ -11,16 +11,16 @@ import { StyledComponent, AnyStyledComponent, CSSObject, InterpolationFunction }
 declare const BaseModalBackground: StyledComponent<'div', any>;
 
 export interface ModalProps {
-  children?: React.ReactNode;
+  children?: React.ReactNode | undefined;
   isOpen: boolean;
-  allowScroll?: boolean;
-  backgroundProps?: object;
-  afterOpen?: () => void;
-  afterClose?: () => void;
-  beforeOpen?: Promise<void> | (() => void);
-  beforeClose?: Promise<void> | (() => void);
-  onEscapeKeydown?: (event: Event) => void;
-  onBackgroundClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  allowScroll?: boolean | undefined;
+  backgroundProps?: object | undefined;
+  afterOpen?: (() => void) | undefined;
+  afterClose?: (() => void) | undefined;
+  beforeOpen?: Promise<void> | (() => void) | undefined;
+  beforeClose?: Promise<void> | (() => void) | undefined;
+  onEscapeKeydown?: ((event: Event) => void) | undefined;
+  onBackgroundClick?: ((event: React.MouseEvent<HTMLDivElement>) => void) | undefined;
 }
 
 declare class Modal extends React.Component<ModalProps> {
@@ -34,7 +34,7 @@ declare class Modal extends React.Component<ModalProps> {
 }
 
 interface ModalProviderProps {
-  backgroundComponent?: AnyStyledComponent;
+  backgroundComponent?: AnyStyledComponent | undefined;
   children: React.ReactNode;
 }
 

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -34,25 +34,25 @@ export type Scale = ObjectOrArray<number | string>;
 export type TLengthStyledSystem = string | 0 | number;
 
 export interface Theme<TLength = TLengthStyledSystem> {
-    breakpoints?: ObjectOrArray<number | string | symbol>;
-    mediaQueries?: { [size: string]: string };
-    space?: ObjectOrArray<CSS.Property.Margin<number | string>>;
-    fontSizes?: ObjectOrArray<CSS.Property.FontSize<number>>;
-    colors?: ObjectOrArray<CSS.Property.Color>;
-    fonts?: ObjectOrArray<CSS.Property.FontFamily>;
-    fontWeights?: ObjectOrArray<CSS.Property.FontWeight>;
-    lineHeights?: ObjectOrArray<CSS.Property.LineHeight<TLength>>;
-    letterSpacings?: ObjectOrArray<CSS.Property.LetterSpacing<TLength>>;
-    sizes?: ObjectOrArray<CSS.Property.Height<{}> | CSS.Property.Width<{}>>;
-    borders?: ObjectOrArray<CSS.Property.Border<{}>>;
-    borderStyles?: ObjectOrArray<CSS.Property.Border<{}>>;
-    borderWidths?: ObjectOrArray<CSS.Property.BorderWidth<TLength>>;
-    radii?: ObjectOrArray<CSS.Property.BorderRadius<TLength>>;
-    shadows?: ObjectOrArray<CSS.Property.BoxShadow>;
-    zIndices?: ObjectOrArray<CSS.Property.ZIndex>;
-    buttons?: ObjectOrArray<CSS.StandardProperties>;
-    colorStyles?: ObjectOrArray<CSS.StandardProperties>;
-    textStyles?: ObjectOrArray<CSS.StandardProperties>;
+    breakpoints?: ObjectOrArray<number | string | symbol> | undefined;
+    mediaQueries?: { [size: string]: string } | undefined;
+    space?: ObjectOrArray<CSS.Property.Margin<number | string>> | undefined;
+    fontSizes?: ObjectOrArray<CSS.Property.FontSize<number>> | undefined;
+    colors?: ObjectOrArray<CSS.Property.Color> | undefined;
+    fonts?: ObjectOrArray<CSS.Property.FontFamily> | undefined;
+    fontWeights?: ObjectOrArray<CSS.Property.FontWeight> | undefined;
+    lineHeights?: ObjectOrArray<CSS.Property.LineHeight<TLength>> | undefined;
+    letterSpacings?: ObjectOrArray<CSS.Property.LetterSpacing<TLength>> | undefined;
+    sizes?: ObjectOrArray<CSS.Property.Height<{}> | CSS.Property.Width<{}>> | undefined;
+    borders?: ObjectOrArray<CSS.Property.Border<{}>> | undefined;
+    borderStyles?: ObjectOrArray<CSS.Property.Border<{}>> | undefined;
+    borderWidths?: ObjectOrArray<CSS.Property.BorderWidth<TLength>> | undefined;
+    radii?: ObjectOrArray<CSS.Property.BorderRadius<TLength>> | undefined;
+    shadows?: ObjectOrArray<CSS.Property.BoxShadow> | undefined;
+    zIndices?: ObjectOrArray<CSS.Property.ZIndex> | undefined;
+    buttons?: ObjectOrArray<CSS.StandardProperties> | undefined;
+    colorStyles?: ObjectOrArray<CSS.StandardProperties> | undefined;
+    textStyles?: ObjectOrArray<CSS.StandardProperties> | undefined;
 }
 
 export type RequiredTheme = Required<Theme>;
@@ -69,74 +69,74 @@ export type ThemeValue<K extends keyof ThemeType, ThemeType, TVal = any> =
 
 export interface SpaceProps<ThemeType extends Theme = RequiredTheme, TVal = ThemeValue<'space', ThemeType>> {
     /** Margin on top, left, bottom and right */
-    m?: ResponsiveValue<TVal, ThemeType>;
+    m?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on top, left, bottom and right */
-    margin?: ResponsiveValue<TVal, ThemeType>;
+    margin?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on top */
-    mt?: ResponsiveValue<TVal, ThemeType>;
+    mt?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on top */
-    marginTop?: ResponsiveValue<TVal, ThemeType>;
+    marginTop?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on right */
-    mr?: ResponsiveValue<TVal, ThemeType>;
+    mr?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on right */
-    marginRight?: ResponsiveValue<TVal, ThemeType>;
+    marginRight?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on bottom */
-    mb?: ResponsiveValue<TVal, ThemeType>;
+    mb?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on bottom */
-    marginBottom?: ResponsiveValue<TVal, ThemeType>;
+    marginBottom?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on left */
-    ml?: ResponsiveValue<TVal, ThemeType>;
+    ml?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on left */
-    marginLeft?: ResponsiveValue<TVal, ThemeType>;
+    marginLeft?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on left and right */
-    mx?: ResponsiveValue<TVal, ThemeType>;
+    mx?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on left and right */
-    marginX?: ResponsiveValue<TVal, ThemeType>;
+    marginX?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on top and bottom */
-    my?: ResponsiveValue<TVal, ThemeType>;
+    my?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Margin on top and bottom */
-    marginY?: ResponsiveValue<TVal, ThemeType>;
+    marginY?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on top, left, bottom and right */
-    p?: ResponsiveValue<TVal, ThemeType>;
+    p?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on top, left, bottom and right */
-    padding?: ResponsiveValue<TVal, ThemeType>;
+    padding?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on top */
-    pt?: ResponsiveValue<TVal, ThemeType>;
+    pt?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on top */
-    paddingTop?: ResponsiveValue<TVal, ThemeType>;
+    paddingTop?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on right */
-    pr?: ResponsiveValue<TVal, ThemeType>;
+    pr?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on right */
-    paddingRight?: ResponsiveValue<TVal, ThemeType>;
+    paddingRight?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on bottom */
-    pb?: ResponsiveValue<TVal, ThemeType>;
+    pb?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on bottom */
-    paddingBottom?: ResponsiveValue<TVal, ThemeType>;
+    paddingBottom?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on left */
-    pl?: ResponsiveValue<TVal, ThemeType>;
+    pl?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on left */
-    paddingLeft?: ResponsiveValue<TVal, ThemeType>;
+    paddingLeft?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on left and right */
-    px?: ResponsiveValue<TVal, ThemeType>;
+    px?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on left and right */
-    paddingX?: ResponsiveValue<TVal, ThemeType>;
+    paddingX?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on top and bottom */
-    py?: ResponsiveValue<TVal, ThemeType>;
+    py?: ResponsiveValue<TVal, ThemeType> | undefined;
     /** Padding on top and bottom */
-    paddingY?: ResponsiveValue<TVal, ThemeType>;
+    paddingY?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 // Preserved to support v4 shim:
 // https://github.com/styled-system/styled-system/blob/master/packages/styled-system/src/index.js#L108
 export interface LowLevelStyleFunctionArguments<N, S> {
     prop: string;
-    cssProperty?: string;
-    alias?: string;
-    key?: string;
-    transformValue?: (n: N, scale?: S) => any;
-    scale?: S;
+    cssProperty?: string | undefined;
+    alias?: string | undefined;
+    key?: string | undefined;
+    transformValue?: ((n: N, scale?: S) => any) | undefined;
+    scale?: S | undefined;
     // new v5 api
-    properties?: string[];
+    properties?: string[] | undefined;
 }
 
 export function style<N = string | number, S = Scale>(
@@ -147,25 +147,25 @@ export function style<N = string | number, S = Scale>(
 export interface styleFn {
     (...args: any[]): any;
 
-    config?: object;
-    propNames?: string[];
-    cache?: object;
+    config?: object | undefined;
+    propNames?: string[] | undefined;
+    cache?: object | undefined;
 }
 
 export interface ConfigStyle {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
-    property?: keyof CSS.Properties;
+    property?: keyof CSS.Properties | undefined;
     /**
      * An array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
      * assigned (overrides `property` when present).
      */
-    properties?: Array<keyof CSS.Properties>;
+    properties?: Array<keyof CSS.Properties> | undefined;
     /** A string referencing a key in the `theme` object. */
-    scale?: string;
+    scale?: string | undefined;
     /** A fallback scale object for when there isn't one defined in the `theme` object. */
-    defaultScale?: Scale;
+    defaultScale?: Scale | undefined;
     /** A function to transform the raw value based on the scale. */
-    transform?: (value: any, scale?: Scale) => any;
+    transform?: ((value: any, scale?: Scale) => any) | undefined;
 }
 
 export interface Config {
@@ -186,15 +186,15 @@ export interface VariantArgs<
     K extends string = string,
     TPropName = string,
     > {
-    key?: string;
+    key?: string | undefined;
     /** Component prop, defaults to "variant" */
-    prop?: TPropName;
+    prop?: TPropName | undefined;
     /** theme key for variant definitions */
-    scale?: string;
+    scale?: string | undefined;
     /** inline theme aware variants definitions  */
     variants?: {
         [key in K]: TStyle;
-    };
+    } | undefined;
 }
 
 export function variant<
@@ -303,7 +303,7 @@ export interface TextColorProps<ThemeType extends Theme = RequiredTheme, TVal = 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
      */
-    color?: ResponsiveValue<TVal, ThemeType>;
+    color?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const textColor: styleFn;
@@ -318,8 +318,8 @@ export interface BackgroundColorProps<ThemeType extends Theme = RequiredTheme, T
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color)
      */
-    bg?: ResponsiveValue<TVal, ThemeType>;
-    backgroundColor?: ResponsiveValue<TVal, ThemeType>;
+    bg?: ResponsiveValue<TVal, ThemeType> | undefined;
+    backgroundColor?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const backgroundColor: styleFn;
@@ -348,13 +348,13 @@ export interface FontSizeProps<ThemeType extends Theme = RequiredTheme, TVal = T
      * - And array values are converted into responsive values.
      *
      */
-    fontSize?: ResponsiveValue<TVal, ThemeType>;
+    fontSize?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const fontSize: styleFn;
 
 export interface FontFamilyProps<ThemeType extends Theme = RequiredTheme> {
-    fontFamily?: ResponsiveValue<CSS.Property.FontFamily, ThemeType>;
+    fontFamily?: ResponsiveValue<CSS.Property.FontFamily, ThemeType> | undefined;
 }
 
 export const fontFamily: styleFn;
@@ -367,7 +367,7 @@ export interface FontWeightProps<ThemeType extends Theme = RequiredTheme, TVal =
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
      */
-    fontWeight?: ResponsiveValue<TVal, ThemeType>;
+    fontWeight?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const fontWeight: styleFn;
@@ -381,7 +381,7 @@ export interface LineHeightProps<ThemeType extends Theme = RequiredTheme, TVal =
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height)
      */
-    lineHeight?: ResponsiveValue<TVal, ThemeType>;
+    lineHeight?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const lineHeight: styleFn;
@@ -392,7 +392,7 @@ export interface TextAlignProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align)
      */
-    textAlign?: ResponsiveValue<CSS.Property.TextAlign, ThemeType>;
+    textAlign?: ResponsiveValue<CSS.Property.TextAlign, ThemeType> | undefined;
 }
 
 export const textAlign: styleFn;
@@ -404,7 +404,7 @@ export interface FontStyleProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
      */
-    fontStyle?: ResponsiveValue<CSS.Property.FontStyle, ThemeType>;
+    fontStyle?: ResponsiveValue<CSS.Property.FontStyle, ThemeType> | undefined;
 }
 
 export const fontStyle: styleFn;
@@ -415,7 +415,7 @@ export interface LetterSpacingProps<ThemeType extends Theme = RequiredTheme, TVa
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing)
      */
-    letterSpacing?: ResponsiveValue<TVal, ThemeType>;
+    letterSpacing?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const letterSpacing: styleFn;
@@ -450,7 +450,7 @@ export interface DisplayProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    display?: ResponsiveValue<CSS.Property.Display, ThemeType>;
+    display?: ResponsiveValue<CSS.Property.Display, ThemeType> | undefined;
 }
 
 export const display: styleFn;
@@ -464,7 +464,7 @@ export interface WidthProps<ThemeType extends Theme = RequiredTheme, TVal = CSS.
      *   - String values are passed as raw CSS values.
      *   - And arrays are converted to responsive width styles.
      */
-    width?: ResponsiveValue<TVal, ThemeType>;
+    width?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const width: styleFn;
@@ -476,7 +476,7 @@ export interface MaxWidthProps<ThemeType extends Theme = RequiredTheme, TVal = C
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width)
      */
-    maxWidth?: ResponsiveValue<TVal, ThemeType>;
+    maxWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const maxWidth: styleFn;
@@ -488,7 +488,7 @@ export interface MinWidthProps<ThemeType extends Theme = RequiredTheme, TVal = C
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)
      */
-    minWidth?: ResponsiveValue<TVal, ThemeType>;
+    minWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const minWidth: styleFn;
@@ -500,7 +500,7 @@ export interface HeightProps<ThemeType extends Theme = RequiredTheme, TVal = CSS
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/height)
      */
-    height?: ResponsiveValue<TVal, ThemeType>;
+    height?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const height: styleFn;
@@ -512,7 +512,7 @@ export interface MaxHeightProps<ThemeType extends Theme = RequiredTheme, TVal = 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-height)
      */
-    maxHeight?: ResponsiveValue<TVal, ThemeType>;
+    maxHeight?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const maxHeight: styleFn;
@@ -524,13 +524,13 @@ export interface MinHeightProps<ThemeType extends Theme = RequiredTheme, TVal = 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    minHeight?: ResponsiveValue<TVal, ThemeType>;
+    minHeight?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const minHeight: styleFn;
 
 export interface SizeProps<ThemeType extends Theme = RequiredTheme, TVal = CSS.Property.Height<TLengthStyledSystem>> {
-    size?: ResponsiveValue<TVal, ThemeType>;
+    size?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const size: styleFn;
@@ -541,7 +541,7 @@ export interface VerticalAlignProps<ThemeType extends Theme = RequiredTheme, TVa
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)
      */
-    verticalAlign?: ResponsiveValue<TVal, ThemeType>;
+    verticalAlign?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const verticalAlign: styleFn;
@@ -559,7 +559,7 @@ export interface AlignItemsProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
      */
-    alignItems?: ResponsiveValue<CSS.Property.AlignItems, ThemeType>;
+    alignItems?: ResponsiveValue<CSS.Property.AlignItems, ThemeType> | undefined;
 }
 
 export const alignItems: styleFn;
@@ -571,7 +571,7 @@ export interface AlignContentProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)
      */
-    alignContent?: ResponsiveValue<CSS.Property.AlignContent, ThemeType>;
+    alignContent?: ResponsiveValue<CSS.Property.AlignContent, ThemeType> | undefined;
 }
 
 export const alignContent: styleFn;
@@ -583,7 +583,7 @@ export interface JustifyItemsProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
      */
-    justifyItems?: ResponsiveValue<CSS.Property.JustifyItems, ThemeType>;
+    justifyItems?: ResponsiveValue<CSS.Property.JustifyItems, ThemeType> | undefined;
 }
 
 export const justifyItems: styleFn;
@@ -595,7 +595,7 @@ export interface JustifyContentProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
      */
-    justifyContent?: ResponsiveValue<CSS.Property.JustifyContent, ThemeType>;
+    justifyContent?: ResponsiveValue<CSS.Property.JustifyContent, ThemeType> | undefined;
 }
 
 export const justifyContent: styleFn;
@@ -607,7 +607,7 @@ export interface FlexWrapProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap)
      */
-    flexWrap?: ResponsiveValue<CSS.Property.FlexWrap, ThemeType>;
+    flexWrap?: ResponsiveValue<CSS.Property.FlexWrap, ThemeType> | undefined;
 }
 
 export const flexWrap: styleFn;
@@ -617,7 +617,7 @@ export interface FlexBasisProps<ThemeType extends Theme = RequiredTheme, TVal = 
     //       purposes, because flex-basis also accepts `Nem` and `Npx` strings.
     //       Not sure there’s a way to still have the union values show up as
     //       auto-completion results.
-    flexBasis?: ResponsiveValue<TVal, ThemeType>;
+    flexBasis?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const flexBasis: styleFn;
@@ -629,7 +629,7 @@ export interface FlexDirectionProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction)
      */
-    flexDirection?: ResponsiveValue<CSS.Property.FlexDirection, ThemeType>;
+    flexDirection?: ResponsiveValue<CSS.Property.FlexDirection, ThemeType> | undefined;
 }
 
 export const flexDirection: styleFn;
@@ -641,7 +641,7 @@ export interface FlexProps<ThemeType extends Theme = RequiredTheme, TVal = CSS.P
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex)
      */
-    flex?: ResponsiveValue<TVal, ThemeType>;
+    flex?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const flex: styleFn;
@@ -653,7 +653,7 @@ export interface JustifySelfProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self)
      */
-    justifySelf?: ResponsiveValue<CSS.Property.JustifySelf, ThemeType>;
+    justifySelf?: ResponsiveValue<CSS.Property.JustifySelf, ThemeType> | undefined;
 }
 
 export const justifySelf: styleFn;
@@ -667,7 +667,7 @@ export interface AlignSelfProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self)
      */
-    alignSelf?: ResponsiveValue<CSS.Property.AlignSelf, ThemeType>;
+    alignSelf?: ResponsiveValue<CSS.Property.AlignSelf, ThemeType> | undefined;
 }
 
 export const alignSelf: styleFn;
@@ -679,7 +679,7 @@ export interface OrderProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/order)
      */
-    order?: ResponsiveValue<CSS.Property.Order, ThemeType>;
+    order?: ResponsiveValue<CSS.Property.Order, ThemeType> | undefined;
 }
 
 export const order: styleFn;
@@ -691,7 +691,7 @@ export interface FlexGrowProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow)
      */
-    flexGrow?: ResponsiveValue<CSS.Property.FlexGrow, ThemeType>;
+    flexGrow?: ResponsiveValue<CSS.Property.FlexGrow, ThemeType> | undefined;
 }
 
 export const flexGrow: styleFn;
@@ -703,7 +703,7 @@ export interface FlexShrinkProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink)
      */
-    flexShrink?: ResponsiveValue<CSS.Property.FlexShrink, ThemeType>;
+    flexShrink?: ResponsiveValue<CSS.Property.FlexShrink, ThemeType> | undefined;
 }
 
 export const flexShrink: styleFn;
@@ -745,7 +745,7 @@ export interface GridGapProps<ThemeType extends Theme = RequiredTheme, TVal = CS
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
      */
-    gridGap?: ResponsiveValue<TVal, ThemeType>;
+    gridGap?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridGap: styleFn;
@@ -758,7 +758,7 @@ export interface GridColumnGapProps<ThemeType extends Theme = RequiredTheme, TVa
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap)
      */
-    gridColumnGap?: ResponsiveValue<TVal, ThemeType>;
+    gridColumnGap?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridColumnGap: styleFn;
@@ -771,7 +771,7 @@ export interface GridRowGapProps<ThemeType extends Theme = RequiredTheme, TVal =
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap)
      */
-    gridRowGap?: ResponsiveValue<TVal, ThemeType>;
+    gridRowGap?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridRowGap: styleFn;
@@ -784,7 +784,7 @@ export interface GridColumnProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column)
      */
-    gridColumn?: ResponsiveValue<CSS.Property.GridColumn, ThemeType>;
+    gridColumn?: ResponsiveValue<CSS.Property.GridColumn, ThemeType> | undefined;
 }
 
 export const gridColumn: styleFn;
@@ -797,7 +797,7 @@ export interface GridRowProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row)
      */
-    gridRow?: ResponsiveValue<CSS.Property.GridRow, ThemeType>;
+    gridRow?: ResponsiveValue<CSS.Property.GridRow, ThemeType> | undefined;
 }
 
 export const gridRow: styleFn;
@@ -809,7 +809,7 @@ export interface GridAutoFlowProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow)
      */
-    gridAutoFlow?: ResponsiveValue<CSS.Property.GridAutoFlow, ThemeType>;
+    gridAutoFlow?: ResponsiveValue<CSS.Property.GridAutoFlow, ThemeType> | undefined;
 }
 
 export const gridAutoFlow: styleFn;
@@ -820,7 +820,7 @@ export interface GridAutoColumnsProps<ThemeType extends Theme = RequiredTheme, T
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns)
      */
-    gridAutoColumns?: ResponsiveValue<TVal, ThemeType>;
+    gridAutoColumns?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridAutoColumns: styleFn;
@@ -831,7 +831,7 @@ export interface GridAutoRowsProps<ThemeType extends Theme = RequiredTheme, TVal
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows)
      */
-    gridAutoRows?: ResponsiveValue<TVal, ThemeType>;
+    gridAutoRows?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridAutoRows: styleFn;
@@ -842,7 +842,7 @@ export interface GridTemplateColumnsProps<ThemeType extends Theme = RequiredThem
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
      */
-    gridTemplateColumns?: ResponsiveValue<TVal, ThemeType>;
+    gridTemplateColumns?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridTemplateColumns: styleFn;
@@ -853,7 +853,7 @@ export interface GridTemplateRowsProps<ThemeType extends Theme = RequiredTheme, 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-template-rows)
      */
-    gridTemplateRows?: ResponsiveValue<TVal, ThemeType>;
+    gridTemplateRows?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const gridTemplateRows: styleFn;
@@ -864,7 +864,7 @@ export interface GridTemplateAreasProps<ThemeType extends Theme = RequiredTheme>
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas)
      */
-    gridTemplateAreas?: ResponsiveValue<CSS.Property.GridTemplateAreas, ThemeType>;
+    gridTemplateAreas?: ResponsiveValue<CSS.Property.GridTemplateAreas, ThemeType> | undefined;
 }
 
 export const gridTemplateAreas: styleFn;
@@ -877,7 +877,7 @@ export interface GridAreaProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area)
      */
-    gridArea?: ResponsiveValue<CSS.Property.GridArea, ThemeType>;
+    gridArea?: ResponsiveValue<CSS.Property.GridArea, ThemeType> | undefined;
 }
 
 export const gridArea: styleFn;
@@ -938,31 +938,31 @@ export interface BorderWidthProps<ThemeType extends Theme = RequiredTheme, TVal 
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width)
      */
-    borderWidth?: ResponsiveValue<TVal, ThemeType>;
+    borderWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-top-width CSS property sets the width of the top border of an element.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width)
      */
-    borderTopWidth?: ResponsiveValue<TVal, ThemeType>;
+    borderTopWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-bottom-width CSS property sets the width of the bottom border of an element.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-width)
      */
-    borderBottomWidth?: ResponsiveValue<TVal, ThemeType>;
+    borderBottomWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-left-width CSS property sets the width of the left border of an element.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width)
      */
-    borderLeftWidth?: ResponsiveValue<TVal, ThemeType>;
+    borderLeftWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-right-width CSS property sets the width of the right border of an element.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-width)
      */
-    borderRightWidth?: ResponsiveValue<TVal, ThemeType>;
+    borderRightWidth?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderWidth: styleFn;
@@ -973,31 +973,31 @@ export interface BorderStyleProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style)
      */
-    borderStyle?: ResponsiveValue<CSS.Property.BorderStyle, ThemeType>;
+    borderStyle?: ResponsiveValue<CSS.Property.BorderStyle, ThemeType> | undefined;
     /**
      * The border-top-style CSS property sets the line style of an element's top border.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-style)
      */
-    borderTopStyle?: ResponsiveValue<CSS.Property.BorderTopStyle, ThemeType>;
+    borderTopStyle?: ResponsiveValue<CSS.Property.BorderTopStyle, ThemeType> | undefined;
     /**
      * The border-bottom-style CSS property sets the line style of an element's bottom border.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-style)
      */
-    borderBottomStyle?: ResponsiveValue<CSS.Property.BorderBottomStyle, ThemeType>;
+    borderBottomStyle?: ResponsiveValue<CSS.Property.BorderBottomStyle, ThemeType> | undefined;
     /**
      * The border-left-style CSS property sets the line style of an element's left border.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style)
      */
-    borderLeftStyle?: ResponsiveValue<CSS.Property.BorderLeftStyle, ThemeType>;
+    borderLeftStyle?: ResponsiveValue<CSS.Property.BorderLeftStyle, ThemeType> | undefined;
     /**
      * The border-right-style CSS property sets the line style of an element's right border.
      *
      * [MDN * reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-style)
      */
-    borderRightStyle?: ResponsiveValue<CSS.Property.BorderRightStyle, ThemeType>;
+    borderRightStyle?: ResponsiveValue<CSS.Property.BorderRightStyle, ThemeType> | undefined;
 }
 
 export const borderStyle: styleFn;
@@ -1008,31 +1008,31 @@ export interface BorderColorProps<ThemeType extends Theme = RequiredTheme, TVal 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
      */
-    borderColor?: ResponsiveValue<TVal, ThemeType>;
+    borderColor?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-top-color CSS property sets the color of an element's top border. It can also be set with the shorthand CSS properties border-color or border-top.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color)
      */
-    borderTopColor?: ResponsiveValue<TVal, ThemeType>;
+    borderTopColor?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-bottom-color CSS property sets the color of an element's bottom border. It can also be set with the shorthand CSS properties border-color or border-bottom.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color)
      */
-    borderBottomColor?: ResponsiveValue<TVal, ThemeType>;
+    borderBottomColor?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-left-color CSS property sets the color of an element's left border. It can also be set with the shorthand CSS properties border-color or border-left.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color)
      */
-    borderLeftColor?: ResponsiveValue<TVal, ThemeType>;
+    borderLeftColor?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-right-color CSS property sets the color of an element's right border. It can also be set with the shorthand CSS properties border-color or border-right.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color)
      */
-    borderRightColor?: ResponsiveValue<TVal, ThemeType>;
+    borderRightColor?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderColor: styleFn;
@@ -1044,7 +1044,7 @@ export interface BorderTopProps<ThemeType extends Theme = RequiredTheme, TVal = 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
      */
-    borderTop?: ResponsiveValue<TVal, ThemeType>;
+    borderTop?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderTop: styleFn;
@@ -1056,7 +1056,7 @@ export interface BorderRightProps<ThemeType extends Theme = RequiredTheme, TVal 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
      */
-    borderRight?: ResponsiveValue<TVal, ThemeType>;
+    borderRight?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderRight: styleFn;
@@ -1068,7 +1068,7 @@ export interface BorderBottomProps<ThemeType extends Theme = RequiredTheme, TVal
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
      */
-    borderBottom?: ResponsiveValue<TVal, ThemeType>;
+    borderBottom?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderBottom: styleFn;
@@ -1080,7 +1080,7 @@ export interface BorderLeftProps<ThemeType extends Theme = RequiredTheme, TVal =
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
      */
-    borderLeft?: ResponsiveValue<TVal, ThemeType>;
+    borderLeft?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderLeft: styleFn;
@@ -1092,31 +1092,31 @@ export interface BorderRadiusProps<ThemeType extends Theme = RequiredTheme, TVal
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
      */
-    borderRadius?: ResponsiveValue<TVal, ThemeType>;
+    borderRadius?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-top-left-radius CSS property rounds the top-left corner of an element.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius)
      */
-    borderTopLeftRadius?: ResponsiveValue<TVal, ThemeType>;
+    borderTopLeftRadius?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-top-right-radius CSS property rounds the top-right corner of an element.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius)
      */
-    borderTopRightRadius?: ResponsiveValue<TVal, ThemeType>;
+    borderTopRightRadius?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-bottom-left-radius CSS property rounds the bottom-left corner of an element.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius)
      */
-    borderBottomLeftRadius?: ResponsiveValue<TVal, ThemeType>;
+    borderBottomLeftRadius?: ResponsiveValue<TVal, ThemeType> | undefined;
     /**
      * The border-bottom-right-radius CSS property rounds the bottom-right corner of an element.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius)
      */
-    borderBottomRightRadius?: ResponsiveValue<TVal, ThemeType>;
+    borderBottomRightRadius?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const borderRadius: styleFn;
@@ -1150,9 +1150,9 @@ export interface BorderProps<ThemeType extends Theme = RequiredTheme, TVal = CSS
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
      */
-    border?: ResponsiveValue<TVal, ThemeType>;
-    borderX?: ResponsiveValue<TVal, ThemeType>;
-    borderY?: ResponsiveValue<TVal, ThemeType>;
+    border?: ResponsiveValue<TVal, ThemeType> | undefined;
+    borderX?: ResponsiveValue<TVal, ThemeType> | undefined;
+    borderY?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const border: styleFn;
@@ -1164,7 +1164,7 @@ export interface BoxShadowProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow)
      */
-    boxShadow?: ResponsiveValue<CSS.Property.BoxShadow | number, ThemeType>;
+    boxShadow?: ResponsiveValue<CSS.Property.BoxShadow | number, ThemeType> | undefined;
 }
 
 export const boxShadow: styleFn;
@@ -1177,7 +1177,7 @@ export interface TextShadowProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow)
      */
-    textShadow?: ResponsiveValue<CSS.Property.TextShadow | number, ThemeType>;
+    textShadow?: ResponsiveValue<CSS.Property.TextShadow | number, ThemeType> | undefined;
 }
 
 export const textShadow: styleFn;
@@ -1194,7 +1194,7 @@ export interface OpacityProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity)
      */
-    opacity?: ResponsiveValue<CSS.Property.Opacity, ThemeType>;
+    opacity?: ResponsiveValue<CSS.Property.Opacity, ThemeType> | undefined;
 }
 
 export const opacity: styleFn;
@@ -1206,21 +1206,21 @@ export interface OverflowProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)
      */
-    overflow?: ResponsiveValue<CSS.Property.Overflow, ThemeType>;
+    overflow?: ResponsiveValue<CSS.Property.Overflow, ThemeType> | undefined;
     /**
      * The overflow-x CSS property sets what shows when content overflows a block-level element's left
      * and right edges. This may be nothing, a scroll bar, or the overflow content.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x)
      */
-    overflowX?: ResponsiveValue<CSS.Property.OverflowX, ThemeType>;
+    overflowX?: ResponsiveValue<CSS.Property.OverflowX, ThemeType> | undefined;
     /**
      * The overflow-y CSS property sets what shows when content overflows a block-level element's top
      * and bottom edges. This may be nothing, a scroll bar, or the overflow content.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y)
      */
-    overflowY?: ResponsiveValue<CSS.Property.OverflowY, ThemeType>;
+    overflowY?: ResponsiveValue<CSS.Property.OverflowY, ThemeType> | undefined;
 }
 
 export const overflow: styleFn;
@@ -1237,7 +1237,7 @@ export interface BackgroundImageProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image)
      */
-    backgroundImage?: ResponsiveValue<CSS.Property.BackgroundImage, ThemeType>;
+    backgroundImage?: ResponsiveValue<CSS.Property.BackgroundImage, ThemeType> | undefined;
 }
 
 export const backgroundImage: styleFn;
@@ -1249,7 +1249,7 @@ export interface BackgroundSizeProps<ThemeType extends Theme = RequiredTheme, TV
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size)
      */
-    backgroundSize?: ResponsiveValue<TVal, ThemeType>;
+    backgroundSize?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const backgroundSize: styleFn;
@@ -1261,7 +1261,7 @@ export interface BackgroundPositionProps<ThemeType extends Theme = RequiredTheme
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)
      */
-    backgroundPosition?: ResponsiveValue<TVal, ThemeType>;
+    backgroundPosition?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const backgroundPosition: styleFn;
@@ -1273,7 +1273,7 @@ export interface BackgroundRepeatProps<ThemeType extends Theme = RequiredTheme> 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat)
      */
-    backgroundRepeat?: ResponsiveValue<CSS.Property.BackgroundRepeat, ThemeType>;
+    backgroundRepeat?: ResponsiveValue<CSS.Property.BackgroundRepeat, ThemeType> | undefined;
 }
 
 export const backgroundRepeat: styleFn;
@@ -1289,7 +1289,7 @@ export interface BackgroundProps<ThemeType extends Theme = RequiredTheme, TVal =
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background)
      */
-    background?: ResponsiveValue<TVal, ThemeType>;
+    background?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const background: styleFn;
@@ -1305,7 +1305,7 @@ export interface ZIndexProps<ThemeType extends Theme = RequiredTheme> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)
      */
-    zIndex?: ResponsiveValue<CSS.Property.ZIndex, ThemeType>;
+    zIndex?: ResponsiveValue<CSS.Property.ZIndex, ThemeType> | undefined;
 }
 
 export const zIndex: styleFn;
@@ -1317,7 +1317,7 @@ export interface TopProps<ThemeType extends Theme = RequiredTheme, TVal = CSS.Pr
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    top?: ResponsiveValue<TVal, ThemeType>;
+    top?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const top: styleFn;
@@ -1329,7 +1329,7 @@ export interface RightProps<ThemeType extends Theme = RequiredTheme, TVal = CSS.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/right)
      */
-    right?: ResponsiveValue<TVal, ThemeType>;
+    right?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const right: styleFn;
@@ -1341,7 +1341,7 @@ export interface BottomProps<ThemeType extends Theme = RequiredTheme, TVal = CSS
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    bottom?: ResponsiveValue<TVal, ThemeType>;
+    bottom?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const bottom: styleFn;
@@ -1353,7 +1353,7 @@ export interface LeftProps<ThemeType extends Theme = RequiredTheme, TVal = CSS.P
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/left)
      */
-    left?: ResponsiveValue<TVal, ThemeType>;
+    left?: ResponsiveValue<TVal, ThemeType> | undefined;
 }
 
 export const left: styleFn;
@@ -1370,25 +1370,25 @@ export interface PositionProps<ThemeType extends Theme = RequiredTheme> extends
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
      */
-    position?: ResponsiveValue<CSS.Property.Position, ThemeType>;
+    position?: ResponsiveValue<CSS.Property.Position, ThemeType> | undefined;
 }
 
 export const position: styleFn;
 
 export interface ButtonStyleProps<ThemeType extends Theme = RequiredTheme> {
-    variant?: ResponsiveValue<string, ThemeType>;
+    variant?: ResponsiveValue<string, ThemeType> | undefined;
 }
 
 export const buttonStyle: styleFn;
 
 export interface TextStyleProps<ThemeType extends Theme = RequiredTheme> {
-    textStyle?: ResponsiveValue<string, ThemeType>;
+    textStyle?: ResponsiveValue<string, ThemeType> | undefined;
 }
 
 export const textStyle: styleFn;
 
 export interface ColorStyleProps<ThemeType extends Theme = RequiredTheme> {
-    colors?: ResponsiveValue<string, ThemeType>;
+    colors?: ResponsiveValue<string, ThemeType> | undefined;
 }
 
 export const colorStyle: styleFn;

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -59,7 +59,7 @@ interface BoxProps
         TypographyProps,
         ColorStyleProps,
         ColorProps {
-    boxStyle?: string;
+    boxStyle?: string | undefined;
 }
 
 const boxStyles = compose(

--- a/types/styled-system__core/index.d.ts
+++ b/types/styled-system__core/index.d.ts
@@ -15,25 +15,25 @@ export type Scale = ObjectOrArray<number | string>;
 export interface styleFn {
     (...args: any[]): any;
 
-    config?: object;
-    propNames?: string[];
-    cache?: object;
+    config?: object | undefined;
+    propNames?: string[] | undefined;
+    cache?: object | undefined;
 }
 
 export interface ConfigStyle {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
-    property?: keyof CSS.Properties;
+    property?: keyof CSS.Properties | undefined;
     /**
      * An array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
      * assigned (overrides `property` when present).
      */
-    properties?: Array<keyof CSS.Properties>;
+    properties?: Array<keyof CSS.Properties> | undefined;
     /** A string referencing a key in the `theme` object. */
-    scale?: string;
+    scale?: string | undefined;
     /** A fallback scale object for when there isn't one defined in the `theme` object. */
-    defaultScale?: Scale;
+    defaultScale?: Scale | undefined;
     /** A function to transform the raw value based on the scale. */
-    transform?: (value: any, scale?: Scale) => any;
+    transform?: ((value: any, scale?: Scale) => any) | undefined;
 }
 
 export interface Config {

--- a/types/styled-system__css/index.d.ts
+++ b/types/styled-system__css/index.d.ts
@@ -72,7 +72,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/background-color
      */
-    bg?: StandardCSSProperties['backgroundColor'];
+    bg?: StandardCSSProperties['backgroundColor'] | undefined;
     /**
      * The **`margin`** CSS property sets the margin area on all four sides of an element. It is a shorthand for `margin-top`, `margin-right`, `margin-bottom`, and `margin-left`.
      *
@@ -82,7 +82,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/margin
      */
-    m?: StandardCSSProperties['margin'];
+    m?: StandardCSSProperties['margin'] | undefined;
     /**
      * The **`margin-top`** CSS property sets the margin area on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
      *
@@ -94,7 +94,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-top
      */
-    mt?: StandardCSSProperties['marginTop'];
+    mt?: StandardCSSProperties['marginTop'] | undefined;
     /**
      * The **`margin-right`** CSS property sets the margin area on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
      *
@@ -106,7 +106,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-right
      */
-    mr?: StandardCSSProperties['marginRight'];
+    mr?: StandardCSSProperties['marginRight'] | undefined;
     /**
      * The **`margin-bottom`** CSS property sets the margin area on the bottom of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
      *
@@ -118,7 +118,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-bottom
      */
-    mb?: StandardCSSProperties['marginBottom'];
+    mb?: StandardCSSProperties['marginBottom'] | undefined;
     /**
      * The **`margin-left`** CSS property sets the margin area on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
      *
@@ -130,7 +130,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-left
      */
-    ml?: StandardCSSProperties['marginLeft'];
+    ml?: StandardCSSProperties['marginLeft'] | undefined;
     /**
      * The **`mx`** is shorthand for using both **`margin-left`** and **`margin-right`** CSS properties. They set the margin area on the left and right side of an element. A positive value placesit
      * farther from its neighbors, while a negative value places it closer.
@@ -145,7 +145,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-left
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-right
      */
-    mx?: StandardCSSProperties['marginLeft'];
+    mx?: StandardCSSProperties['marginLeft'] | undefined;
     /**
      * The **`marginX`** is shorthand for using both **`margin-left`** and **`margin-right`** CSS properties. They set the margin area on the left and right side of an element. A positive value
      * places it farther from its neighbors, while a negative value places it closer.
@@ -160,7 +160,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-left
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-right
      */
-    marginX?: StandardCSSProperties['marginLeft'];
+    marginX?: StandardCSSProperties['marginLeft'] | undefined;
     /**
      * The **`my`** is shorthard for using both **`margin-top`** and **`margin-bottom`** CSS properties. They set the margin area on the top and bottom of an element. A positive value places it
      * farther from its neighbors, while a negative value places it closer.
@@ -175,7 +175,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-top
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-bottom
      */
-    my?: StandardCSSProperties['marginTop'];
+    my?: StandardCSSProperties['marginTop'] | undefined;
     /**
      * The **`marginY`** is shorthard for using both **`margin-top`** and **`margin-bottom`** CSS properties. They set the margin area on the top and bottom of an element. A positive value places
      * it farther from its neighbors, while a negative value places it closer.
@@ -190,7 +190,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-top
      * @see https://developer.mozilla.org/docs/Web/CSS/margin-bottom
      */
-    marginY?: StandardCSSProperties['marginTop'];
+    marginY?: StandardCSSProperties['marginTop'] | undefined;
     /**
      * The **`padding`** CSS property sets the padding area on all four sides of an element. It is a shorthand for `padding-top`, `padding-right`, `padding-bottom`, and `padding-left`.
      *
@@ -200,7 +200,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/padding
      */
-    p?: StandardCSSProperties['padding'];
+    p?: StandardCSSProperties['padding'] | undefined;
     /**
      * The **`padding-top`** padding area on the top of an element.
      *
@@ -212,7 +212,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-top
      */
-    pt?: StandardCSSProperties['paddingTop'];
+    pt?: StandardCSSProperties['paddingTop'] | undefined;
     /**
      * The **`padding-right`** CSS property sets the width of the padding area on the right side of an element.
      *
@@ -224,7 +224,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-right
      */
-    pr?: StandardCSSProperties['paddingRight'];
+    pr?: StandardCSSProperties['paddingRight'] | undefined;
     /**
      * The **`padding-bottom`** CSS property sets the height of the padding area on the bottom of an element.
      *
@@ -236,7 +236,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
      */
-    pb?: StandardCSSProperties['paddingBottom'];
+    pb?: StandardCSSProperties['paddingBottom'] | undefined;
     /**
      * The **`padding-left`** CSS property sets the width of the padding area on the left side of an element.
      *
@@ -248,7 +248,7 @@ export interface AliasesCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-left
      */
-    pl?: StandardCSSProperties['paddingLeft'];
+    pl?: StandardCSSProperties['paddingLeft'] | undefined;
     /**
      * The **`px`** is shorthand property for CSS properties **`padding-left`** and **`padding-right`**. They set the width of the padding area on the left and right side of an element.
      *
@@ -262,7 +262,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-left
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-right
      */
-    px?: StandardCSSProperties['paddingLeft'];
+    px?: StandardCSSProperties['paddingLeft'] | undefined;
     /**
      * The **`paddingX`** is shorthand property for CSS properties **`padding-left`** and **`padding-right`**. They set the width of the padding area on the left and right side of an element.
      *
@@ -276,7 +276,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-left
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-right
      */
-    paddingX?: StandardCSSProperties['paddingLeft'];
+    paddingX?: StandardCSSProperties['paddingLeft'] | undefined;
     /**
      * The **`py`** is shorthand property for CSS properties **`padding-top`** and **`padding-bottom`**. They set the width of the padding area on the top and bottom of an element.
      *
@@ -290,7 +290,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-top
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
      */
-    py?: StandardCSSProperties['paddingTop'];
+    py?: StandardCSSProperties['paddingTop'] | undefined;
     /**
      * The **`paddingY`** is shorthand property for CSS properties **`padding-top`** and **`padding-bottom`**. They set the width of the padding area on the top and bottom of an element.
      *
@@ -304,7 +304,7 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-top
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
      */
-    paddingY?: StandardCSSProperties['paddingTop'];
+    paddingY?: StandardCSSProperties['paddingTop'] | undefined;
 }
 
 export interface OverwriteCSSProperties {
@@ -321,7 +321,7 @@ export interface OverwriteCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/box-shadow
      */
-    boxShadow?: CSS.Property.BoxShadow | number;
+    boxShadow?: CSS.Property.BoxShadow | number | undefined;
     /**
      * The **`font-weight`** CSS property specifies the weight (or boldness) of the font. The font weights available to you will depend on the `font-family` you are using. Some fonts are only
      * available in `normal` and `bold`.
@@ -334,7 +334,7 @@ export interface OverwriteCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/font-weight
      */
-    fontWeight?: CSS.Property.FontWeight | string;
+    fontWeight?: CSS.Property.FontWeight | string | undefined;
     /**
      * The **`z-index`** CSS property sets the z-order of a positioned element and its descendants or flex items. Overlapping elements with a larger z-index cover those with a smaller one.
      *
@@ -346,7 +346,7 @@ export interface OverwriteCSSProperties {
      *
      * @see https://developer.mozilla.org/docs/Web/CSS/z-index
      */
-    zIndex?: CSS.Property.ZIndex | string;
+    zIndex?: CSS.Property.ZIndex | string | undefined;
 }
 
 /**
@@ -396,7 +396,7 @@ export interface UseThemeFunction {
 }
 
 export interface EmotionLabel {
-    label?: string;
+    label?: string | undefined;
 }
 
 /**
@@ -449,7 +449,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#color
      */
-    colors?: ThemeValue<CSS.Property.Color>;
+    colors?: ThemeValue<CSS.Property.Color> | undefined;
     /**
      * | Prop              | CSS Property                   | Theme Field |
      * | :---------------- | :----------------------------- | :---------- |
@@ -470,7 +470,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#space
      */
-    space?: ThemeValue<CSS.Property.Margin<number> & CSS.Property.Padding<number>>;
+    space?: ThemeValue<CSS.Property.Margin<number> & CSS.Property.Padding<number>> | undefined;
     /**
      * | Prop       | CSS Property | Theme Field |
      * | :--------- | :----------- | :---------- |
@@ -478,7 +478,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#typography
      */
-    fonts?: ThemeValue<CSS.Property.FontFamily>;
+    fonts?: ThemeValue<CSS.Property.FontFamily> | undefined;
     /**
      * | Prop     | CSS Property | Theme Field |
      * | :------- | :----------- | :---------- |
@@ -486,7 +486,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#typography
      */
-    fontSizes?: ThemeValue<CSS.Property.FontSize<number>>;
+    fontSizes?: ThemeValue<CSS.Property.FontSize<number>> | undefined;
     /**
      * | Prop       | CSS Property | Theme Field |
      * | :--------- | :----------- | :---------- |
@@ -494,7 +494,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#typography
      */
-    fontWeights?: ThemeValue<CSS.Property.FontWeight>;
+    fontWeights?: ThemeValue<CSS.Property.FontWeight> | undefined;
     /**
      * | Prop       | CSS Property | Theme Field |
      * | :--------- | :----------- | :---------- |
@@ -502,7 +502,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#typography
      */
-    lineHeights?: ThemeValue<CSS.Property.LineHeight<string>>;
+    lineHeights?: ThemeValue<CSS.Property.LineHeight<string>> | undefined;
     /**
      * | Prop          | CSS Property   | Theme Field    |
      * | :------------ | :------------- | :------------- |
@@ -510,7 +510,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#typography
      */
-    letterSpacings?: ThemeValue<CSS.Property.LetterSpacing<string | number>>;
+    letterSpacings?: ThemeValue<CSS.Property.LetterSpacing<string | number>> | undefined;
     /**
      * | Prop         | CSS Property               | Theme Field |
      * | :----------- | :------------------------- | :---------- |
@@ -524,7 +524,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#border
      */
-    borders?: ThemeValue<CSS.Property.Border<{}>>;
+    borders?: ThemeValue<CSS.Property.Border<{}>> | undefined;
     /**
      * | Prop        | CSS Property | Theme Field  |
      * | :---------- | :----------- | :----------- |
@@ -532,7 +532,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#border
      */
-    borderWidths?: ThemeValue<CSS.Property.BorderWidth<{}>>;
+    borderWidths?: ThemeValue<CSS.Property.BorderWidth<{}>> | undefined;
     /**
      * | Prop        | CSS Property | Theme Field  |
      * | :---------- | :----------- | :----------- |
@@ -540,7 +540,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#border
      */
-    borderStyles?: ThemeValue<CSS.Property.BorderStyle>;
+    borderStyles?: ThemeValue<CSS.Property.BorderStyle> | undefined;
     /**
      * | Prop         | CSS Property  | Theme Field |
      * | :----------- | :------------ | :---------- |
@@ -548,7 +548,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#border
      */
-    radii?: ThemeValue<CSS.Property.BorderRadius<{}>>;
+    radii?: ThemeValue<CSS.Property.BorderRadius<{}>> | undefined;
     /**
      * | Prop       | CSS Property | Theme Field |
      * | :--------- | :----------- | :---------- |
@@ -557,7 +557,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#shadow
      */
-    shadows?: ThemeValue<CSS.Property.BoxShadow>;
+    shadows?: ThemeValue<CSS.Property.BoxShadow> | undefined;
     /**
      * | Prop    | CSS Property | Theme Field |
      * | :------ | :----------- | :---------- |
@@ -565,7 +565,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#position
      */
-    zIndices?: ThemeValue<CSS.Property.ZIndex>;
+    zIndices?: ThemeValue<CSS.Property.ZIndex> | undefined;
     /**
      * | Prop      | CSS Property | Theme Field |
      * | :-------- | :----------- | :---------- |
@@ -579,7 +579,7 @@ export interface ScaleThemeProperties {
      *
      * @see https://styled-system.com/table#layout
      */
-    sizes?: ThemeValue<CSS.Property.Height<{}> | CSS.Property.Width<{}>>;
+    sizes?: ThemeValue<CSS.Property.Height<{}> | CSS.Property.Width<{}>> | undefined;
 }
 
 /**

--- a/types/styled-theming/styled-theming-tests.ts
+++ b/types/styled-theming/styled-theming-tests.ts
@@ -36,7 +36,7 @@ const cssPropsTheme = theme('mode', {
 });
 
 interface buttonProps {
-    hidden?: boolean;
+    hidden?: boolean | undefined;
 }
 
 const button = theme.variants('mode', 'kind', {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -97,7 +97,7 @@ export function lint(options?: Partial<LinterOptions>): Promise<LinterResult>;
 export type ValidateOptionsAssertion = {
     actual: any;
     possible?: any;
-    optional?: false;
+    optional?: false | undefined;
 } | {
     actual?: any;
     possible: any;
@@ -112,9 +112,9 @@ export namespace utils {
         result: postcss.Result;
         message: string;
         node: postcss.Node;
-        index?: number;
-        word?: string;
-        line?: number;
+        index?: number | undefined;
+        word?: string | undefined;
+        line?: number | undefined;
     }): void;
 
     function ruleMessages<T extends {[key: string]: RuleMessageValue}>(
@@ -147,29 +147,29 @@ export interface RuleTesterResult {
 
 export interface RuleTesterTest {
     code: string;
-    description?: string;
+    description?: string | undefined;
 }
 
 export interface RuleTesterTestRejected extends RuleTesterTest {
-    line?: number;
-    column?: number;
-    only?: boolean;
-    message?: string;
+    line?: number | undefined;
+    column?: number | undefined;
+    only?: boolean | undefined;
+    message?: string | undefined;
 }
 
 export interface RuleTesterSchema {
     ruleName: string;
-    syntax?: SyntaxType;
+    syntax?: SyntaxType | undefined;
     config?: any;
-    accept?: RuleTesterTest[];
-    reject?: RuleTesterTestRejected[];
+    accept?: RuleTesterTest[] | undefined;
+    reject?: RuleTesterTestRejected[] | undefined;
 }
 
 export interface RuleTesterContext {
     comparisonCount: number;
     completeAssertionDescription: string;
     caseDescription: string;
-    only?: boolean;
+    only?: boolean | undefined;
 }
 
 export function createRuleTester(

--- a/types/stylelint/v7/index.d.ts
+++ b/types/stylelint/v7/index.d.ts
@@ -8,22 +8,22 @@ export type FormatterType = "json" | "string" | "verbose";
 export type SyntaxType = "scss" | "sass" | "less" | "sugarss";
 
 export interface LinterOptions {
-    code?: string;
-    codeFilename?: string;
-    config?: JSON;
-    configBasedir?: string;
-    configFile?: string;
-    configOverrides?: JSON;
-    cache?: boolean;
-    cacheLocation?: string;
-    files?: string | string[];
-    fix?: boolean;
-    formatter?: FormatterType;
-    ignoreDisables?: boolean;
-    reportNeedlessDisables?: boolean;
-    ignorePath?: boolean;
-    syntax?: SyntaxType;
-    customSyntax?: string;
+    code?: string | undefined;
+    codeFilename?: string | undefined;
+    config?: JSON | undefined;
+    configBasedir?: string | undefined;
+    configFile?: string | undefined;
+    configOverrides?: JSON | undefined;
+    cache?: boolean | undefined;
+    cacheLocation?: string | undefined;
+    files?: string | string[] | undefined;
+    fix?: boolean | undefined;
+    formatter?: FormatterType | undefined;
+    ignoreDisables?: boolean | undefined;
+    reportNeedlessDisables?: boolean | undefined;
+    ignorePath?: boolean | undefined;
+    syntax?: SyntaxType | undefined;
+    customSyntax?: string | undefined;
 }
 
 export interface LinterResult {

--- a/types/styletron-engine-atomic/index.d.ts
+++ b/types/styletron-engine-atomic/index.d.ts
@@ -50,13 +50,13 @@ export interface Sheet {
 }
 
 export interface ClientOptions {
-  hydrate?: hydrateType;
-  container?: Element;
-  prefix?: string;
+  hydrate?: hydrateType | undefined;
+  container?: Element | undefined;
+  prefix?: string | undefined;
 }
 
 export interface ServerOptions {
-  prefix?: string;
+  prefix?: string | undefined;
 }
 
 export class Client implements StandardEngine {

--- a/types/styletron-react/index.d.ts
+++ b/types/styletron-react/index.d.ts
@@ -52,7 +52,7 @@ export interface Styletron {
     debug?: {
         stackIndex: StackIndex;
         stackInfo: StackInfo;
-    };
+    } | undefined;
 }
 
 export type StyleObjectFn<P extends object> = (props: P) => StyleObject;
@@ -60,8 +60,8 @@ export type StyleObjectFn<P extends object> = (props: P) => StyleObject;
 export type $StyleProp<P extends object> = StyleObject | StyleObjectFn<P>;
 
 export interface StyletronComponentInjectedProps<P extends object> {
-    $as?: StyletronBase;
-    $style?: $StyleProp<P>;
+    $as?: StyletronBase | undefined;
+    $style?: $StyleProp<P> | undefined;
 }
 
 export type StyletronComponent<P extends object> = React.FC<P & StyletronComponentInjectedProps<P>> & {
@@ -121,9 +121,9 @@ export type DebugEngine = BrowserDebugEngine | NoopDebugEngine;
 export interface DevProviderProps {
     children: React.ReactNode;
     value: StandardEngine;
-    debugAfterHydration?: boolean;
+    debugAfterHydration?: boolean | undefined;
     /** DebugEngineContext */
-    debug?: DebugEngine;
+    debug?: DebugEngine | undefined;
 }
 
 export class DevProvider extends React.Component<DevProviderProps, { hydrating: boolean }> {}

--- a/types/styletron-standard/index.d.ts
+++ b/types/styletron-standard/index.d.ts
@@ -13,8 +13,8 @@ export interface KeyframesPercentageObject {
 }
 
 export type KeyframesObject = KeyframesPercentageObject & {
-    from?: Properties;
-    to?: Properties;
+    from?: Properties | undefined;
+    to?: Properties | undefined;
 };
 
 // Unrecognized properties are assumed to be media queries

--- a/types/stylis/index.d.ts
+++ b/types/stylis/index.d.ts
@@ -6,16 +6,16 @@
 export as namespace stylis;
 
 export interface Element {
-    parent?: Element;
-    children?: Element[] | string;
+    parent?: Element | undefined;
+    children?: Element[] | string | undefined;
     root: Element;
     type: string;
     props: string[] | string;
     value: string;
     length: number;
     return: string;
-    line?: number;
-    column?: number;
+    line?: number | undefined;
+    column?: number | undefined;
 }
 
 export type ArrayMapCallback = (value: string, index: number, array: string[]) => string;

--- a/types/stylus/index.d.ts
+++ b/types/stylus/index.d.ts
@@ -15,12 +15,12 @@ export = stylus;
 
 declare namespace stylus  {
     interface RenderOptions {
-        globals?: Stylus.Dictionary<any>;
-        functions?: Stylus.Dictionary<any>;
-        imports?: string[];
-        paths?: string[];
-        filename?: string;
-        Evaluator?: typeof Stylus.Evaluator;
+        globals?: Stylus.Dictionary<any> | undefined;
+        functions?: Stylus.Dictionary<any> | undefined;
+        imports?: string[] | undefined;
+        paths?: string[] | undefined;
+        filename?: string | undefined;
+        Evaluator?: typeof Stylus.Evaluator | undefined;
     }
     type RenderCallback = (err: Error, css: string, js: string) => void;
 }
@@ -1014,7 +1014,7 @@ declare namespace Stylus {
             /**
              * Return a JSON representation of this node.
              */
-            toJSON(): { __type: string; segments: Node[]; name: string; expr?: Expression; literal?: Literal; lineno: number; column: number; filename: string };
+            toJSON(): { __type: string; segments: Node[]; name: string; expr?: Expression | undefined; literal?: Literal | undefined; lineno: number; column: number; filename: string };
         }
 
         export class Each extends Node {
@@ -1226,7 +1226,7 @@ declare namespace Stylus {
             /**
              * Return a JSON representation of this node.
              */
-            toJSON(): { __type: string; left: Node; right: Node; val?: string; lineno: number; column: number; filename: string };
+            toJSON(): { __type: string; left: Node; right: Node; val?: string | undefined; lineno: number; column: number; filename: string };
         }
 
         export class Charset extends Node {
@@ -1334,7 +1334,7 @@ declare namespace Stylus {
             /**
              * Return a JSON representation of this node.
              */
-            toJSON(): { __type: string; type: string; segments: Node[]; block?: Block; lineno: number; column: number; filename: string };
+            toJSON(): { __type: string; type: string; segments: Node[]; block?: Block | undefined; lineno: number; column: number; filename: string };
         }
     }
 
@@ -1347,8 +1347,8 @@ declare namespace Stylus {
     }
 
     export interface UrlOptions {
-        limit?: number | false | null;
-        paths?: string[];
+        limit?: number | false | null | undefined;
+        paths?: string[] | undefined;
     }
 
     export interface LiteralFunction {


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add
undefined to all optional properties. #no-publishing-comment

This PR covers packages starting with st-.
microsoft/dtslint#335