### PR TITLE
[@types/debug] Types for custom logging

### DIFF
--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -38,3 +38,18 @@ anotherLogger("This should be printed to stdout");
 debug1.selectColor("DefinitelyTyped:log");
 // $ExpectType string | number
 debug2.selectColor("DefinitelyTyped:log");
+
+debug2.formatArgs = function(args) {
+    // $ExpectType string
+    const diff = debug2.humanize(this.diff);
+    args[0] = `[${this.namespace}] ${args[0]}`;
+    args.push(`+${diff}`);
+};
+debug2.log = function(this: debug1.Debugger, ...args) {
+    const diff = debug2.humanize(this.diff);
+    console.log({
+        namespace: this.namespace,
+        args,
+        diff,
+    });
+};

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -21,8 +21,10 @@ declare namespace debug {
         disable: () => string;
         enable: (namespaces: string) => void;
         enabled: (namespaces: string) => boolean;
+        formatArgs: (this: Debugger, args: any[]) => void;
         log: (...args: any[]) => any;
         selectColor: (namespace: string) => string | number;
+        humanize: typeof import('ms');
 
         names: RegExp[];
         skips: RegExp[];
@@ -42,6 +44,7 @@ declare namespace debug {
         (formatter: any, ...args: any[]): void;
 
         color: string;
+        diff: number;
         enabled: boolean;
         log: (...args: any[]) => any;
         namespace: string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
  _Links bellow_
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
  _PR is adding missing definitions rather than a new features._

Changes are needed to properly override logging function in debug module. This includes:
- added `formatArgs` - function is adding colors, namespace and time to messages
  [node.js#L167-L180](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/node.js#L167-L180)
  [browser.js#L146-L179](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/browser.js#L146-L179)
- typed `this` for `formatArgs` - it is needed to get namespace or diff time. Unfortunately `log` is already in use and people are calling it directly without `this`, which is causing test errors. Whereas both functions are called with `this` bound to `Debugger` instance, only `formatArgs` is using it by default.
  [common.js#L109-L113](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/common.js#L109-L113)
- added `humanize` function which is `ms` module
  [common.js#L14](https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/common.js#L14)

~Tests are failing because of the other package, details: #54278~ *(issue is now fixed)*