### PR TITLE
react-big-calendar: export Views as const

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -395,13 +395,13 @@ export interface Navigate {
     TODAY: 'TODAY';
     DATE: 'DATE';
 }
-export interface Views {
+export const Views: {
     MONTH: 'month';
     WEEK: 'week';
     WORK_WEEK: 'work_week';
     DAY: 'day';
     AGENDA: 'agenda';
-}
+};
 export function move(View: ViewStatic | ViewKey, options: MoveOptions): Date;
 
 export interface TimeGridProps<TEvent extends object = Event, TResource extends object = object> {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -527,3 +527,43 @@ class MyDay extends Day {
 {
     ReactDOM.render(<Calendar backgroundEvents={getEvents()} localizer={momentLocalizer(moment)} />, document.body);
 }
+
+// defaultView initializer
+{
+    const localizer = dateFnsLocalizer(dateFnsConfig);
+
+    const MonthView = () => (
+        <Calendar
+            defaultView={Views.MONTH}
+            localizer={localizer}
+        />
+    );
+
+    const WeekView = () => (
+        <Calendar
+            defaultView={Views.WEEK}
+            localizer={localizer}
+        />
+    );
+
+    const WorkWeekView = () => (
+        <Calendar
+            defaultView={Views.WORK_WEEK}
+            localizer={localizer}
+        />
+    );
+
+    const DAYView = () => (
+        <Calendar
+            defaultView={Views.DAY}
+            localizer={localizer}
+        />
+    );
+
+    const AgendaView = () => (
+        <Calendar
+            defaultView={Views.AGENDA}
+            localizer={localizer}
+        />
+    );
+}


### PR DESCRIPTION
Hi,

I wanted to use the exported `Views` constant to define a defaultView like this:
```tsx
import { Calendar, Views } from 'react-big-calendar';

const DayView = () => (
  <Calendar
    defaultView={Views.DAY}
  />
);
```

as seen in this example: https://github.com/jquense/react-big-calendar/blob/8e6c84db5241727548e065e4af83ef45caa734cb/examples/demos/resource.js#L49

But since Views is declared as interface/type here instead of a value, TypeScript does not let me use `Views` as value and gives me the following error:
```
'Views' only refers to a type, but is being used as a value here.
```

Reproduction in [TS-Playground](https://www.typescriptlang.org/play?ssl=13&ssc=7&pln=8&pc=1#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nAMLIA2WAdgCbIoAGjgA1YFgDuqUYJhYAYr1QAZCLm7AAXlihwAvnCIlylPDAC0AI2ABzS5p4ChtOnX5ZcXIVji4IFXh5JRV2QIJ7AC4UXgBPejoAoLguDS1dfQBeOBDlNXSuHT0ACjywiPsASkS4Ov9A1HgAWUCYAAsJaTgckqqegD44Erp6sbgAHk5nQShR8YXPAmQAVy4YLqkslk3UADpmgHkAOQAVAAkDeYWxtKdiqG27jL0rm7gAegHruBr3MeSTTgAHUsFgANabHrDfpZIYjd5Tbh8WY-d5LVbrTbbXZ7YEAUXxAGk3u96s8ipknoUHqSFl8fn8foD4MDoODQRCob1YfC0fUkTMhPzFlhlmsNpItjspftgYcMESAPoE4l0skUh7U+6ZdVjBljJkAxrwAAiAEEAJrcmGDYYiybTFHCsn1DES7Ey6T7C2WvU3TVUliB14Og31I31Flwc12Z02vp2hE3QXOuauururFSnGyvbmgDi+OOFv9CxDj2DNN1Ye+hvoQA).

The PR here fixes this by converting the exported `Views` from a type to a value as it is in the original export: https://github.com/jquense/react-big-calendar/blob/8e6c84db5241727548e065e4af83ef45caa734cb/src/index.js#L16

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
