### PR TITLE
[@types/dns-packet] Support for more answer types

### DIFF
--- a/types/dns-packet/dns-packet-tests.ts
+++ b/types/dns-packet/dns-packet-tests.ts
@@ -10,6 +10,7 @@ const answer: Answer = {
 const question: Question = {
     type: "A",
     name: "localhost",
+    class: "IN",
 };
 
 const inPacket: Packet = {
@@ -27,3 +28,84 @@ const length: number = encodingLength(inPacket);
 const out: Buffer = encode(inPacket, inputBuf, length - length);
 const outPacket: Packet = decode(out, 0);
 encode(outPacket);
+
+const records: Answer[] = [
+    {
+        type: "A",
+        name: "localhost",
+        data: "127.0.0.1",
+    },
+    {
+        type: "AAAA",
+        name: "localhost",
+        data: "::1",
+    },
+    {
+        type: "CNAME",
+        name: "localhost",
+        data: "example.com",
+    },
+    {
+        type: "NS",
+        name: "localhost",
+        data: "ns1.localhost",
+    },
+    {
+        type: "MX",
+        name: "localhost",
+        data: {
+            preference: 10,
+            exchange: "mx.localhost",
+        },
+    },
+    {
+        type: "TXT",
+        name: "localhost",
+        data: "test",
+    },
+    {
+        type: "TXT",
+        name: "localhost",
+        data: Buffer.from("test"),
+    },
+    {
+        type: "TXT",
+        name: "localhost",
+        data: ["foo", "bar"],
+    },
+    {
+        type: "SRV",
+        name: "_imap._tcp.localhost",
+        data: {
+            priority: 10,
+            weight: 60,
+            port: 5060,
+            target: "imap.example.com",
+        },
+    },
+    {
+        type: "SOA",
+        name: "localhost",
+        data: {
+            mname: "localhost",
+            rname: "hostmaster.localhost",
+            serial: 2021122101,
+        },
+    },
+    {
+        type: "CAA",
+        name: "localhost",
+        data: {
+            issuerCritical: false,
+            tag: "issue",
+            value: "ca.example.com",
+        },
+    },
+    {
+        type: "TXT",
+        name: "version.bind",
+        class: "CH",
+        data: "1.2.3",
+    },
+];
+encode({ answers: records });

--- a/types/dns-packet/index.d.ts
+++ b/types/dns-packet/index.d.ts
@@ -53,9 +53,12 @@ export type RecordType =
     | "TXT"
     | "URI";
 
+export type RecordClass = "IN" | "CS" | "CH" | "HS" | "ANY";
+
 export interface Question {
     type: RecordType;
     name: string;
+    class?: RecordClass | undefined;
 }
 
 export interface SrvData {
@@ -70,17 +73,42 @@ export interface HInfoData {
     os: string;
 }
 
+export interface SoaData {
+    mname: string;
+    rname: string;
+    serial?: number | undefined;
+    refresh?: number | undefined;
+    retry?: number | undefined;
+    expire?: number | undefined;
+    minimum?: number | undefined;
+}
+
+export type TxtData = string | Buffer | Array<string | Buffer>;
+
+export interface CaaData {
+    issuerCritical?: boolean | undefined;
+    flags?: number | undefined;
+    tag: string;
+    value: string;
+}
+
+export interface MxData {
+    preference?: number | undefined;
+    exchange: string;
+}
+
 export interface BaseAnswer<T, D> {
     type: T;
     name: string;
     ttl?: number | undefined;
+    class?: RecordClass | undefined;
     data: D;
 }
 
 /**
  * Record types for which the library will provide a string in the data field.
  */
-export type StringRecordType = "A" | "AAAA" | "CNAME" | "DNAME" | "PTR";
+export type StringRecordType = "A" | "AAAA" | "CNAME" | "DNAME" | "NS" | "PTR";
 
 /**
  * Record types for which the library does not attempt to process the data
@@ -90,7 +118,6 @@ export type OtherRecordType =
     | "AFSDB"
     | "APL"
     | "AXFR"
-    | "CAA"
     | "CDNSKEY"
     | "CDS"
     | "CERT"
@@ -104,9 +131,7 @@ export type OtherRecordType =
     | "KEY"
     | "KX"
     | "LOC"
-    | "MX"
     | "NAPTR"
-    | "NS"
     | "NSEC"
     | "NSEC3"
     | "NSEC3PARAM"
@@ -115,21 +140,31 @@ export type OtherRecordType =
     | "RRSIG"
     | "RP"
     | "SIG"
-    | "SOA"
     | "SSHFP"
     | "TA"
     | "TKEY"
     | "TLSA"
     | "TSIG"
-    | "TXT"
     | "URI";
 
 export type StringAnswer = BaseAnswer<StringRecordType, string>;
 export type SrvAnswer = BaseAnswer<"SRV", SrvData>;
 export type HInfoAnswer = BaseAnswer<"HINFO", HInfoData>;
+export type SoaAnswer = BaseAnswer<"SOA", SoaData>;
+export type TxtAnswer = BaseAnswer<"TXT", TxtData>;
+export type CaaAnswer = BaseAnswer<"CAA", CaaData>;
+export type MxAnswer = BaseAnswer<"MX", MxData>;
 export type BufferAnswer = BaseAnswer<OtherRecordType, Buffer>;
 
-export type Answer = StringAnswer | SrvAnswer | HInfoAnswer | BufferAnswer;
+export type Answer =
+    | StringAnswer
+    | SrvAnswer
+    | HInfoAnswer
+    | SoaAnswer
+    | TxtAnswer
+    | CaaAnswer
+    | MxAnswer
+    | BufferAnswer;
 
 export interface Packet {
     /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  https://github.com/mafintosh/dns-packet/blob/master/index.js
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
  This is update for already supported features.

Changes:

- Added typings for more answer types: SOA, TXT, CAA, MX, NS
- Added `class` field to question and answer
- Tests for added and some existing types

Still missing DNSSEC related records and OPT.