### PR TITLE
Added type definitions for vite-plugin-react-svg

### DIFF
--- a/types/vite-plugin-react-svg/index.d.ts
+++ b/types/vite-plugin-react-svg/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for vite-plugin-react-svg 0.2
+// Project: https://github.com/visualfanatic/vite-svg
+// Definitions by: Priyanshu Rav <https://github.com/priyanshurav>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+import { Plugin } from 'vite';
+import { OptimizeOptions } from 'svgo';
+import * as React from 'react';
+
+interface Options {
+    /**
+     * Default behavior when importing `.svg` files, possible options are: `url` and `component`.
+     *
+     * Default value: `url`
+     */
+    defaultExport?: 'url' | 'component';
+    /** Boolean flag to enable/disable SVGO */
+    svgo?: boolean;
+    /** Specify SVGO config */
+    svgoConfig?: OptimizeOptions;
+    /** Props to be forwarded on SVG tag, possible options: `start`, `end` or `false` */
+    expandProps?: 'start' | 'end' | false;
+    /** Setting this to `true` will forward ref to the root SVG tag */
+    ref?: boolean;
+    /** Setting this to `true` will wrap the exported component in `React.memo` */
+    memo?: boolean;
+    /**
+     * Replace an attribute value by another.
+     * The main usage of this option is to change an icon color to `currentColor` in order to inherit from text color.
+     */
+    replaceAttrValues?: Record<string, unknown>;
+    /** Add props to the root SVG tag */
+    svgProps?: React.SVGAttributes<SVGSVGElement>;
+    /** Add title tag via `title` property */
+    titleProp?: boolean;
+}
+
+declare function reactSvgPlugin(options?: Options): Plugin;
+
+export = reactSvgPlugin;

--- a/types/vite-plugin-react-svg/package.json
+++ b/types/vite-plugin-react-svg/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "vite": "^2.3.8"
+    }
+}

--- a/types/vite-plugin-react-svg/tsconfig.json
+++ b/types/vite-plugin-react-svg/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vite-plugin-react-svg-tests.ts"
+    ]
+}

--- a/types/vite-plugin-react-svg/tslint.json
+++ b/types/vite-plugin-react-svg/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/vite-plugin-react-svg/vite-plugin-react-svg-tests.ts
+++ b/types/vite-plugin-react-svg/vite-plugin-react-svg-tests.ts
@@ -1,0 +1,34 @@
+import { PluginOption } from 'vite';
+import reactSvgPlugin = require('vite-plugin-react-svg');
+
+const testCases: Array<PluginOption | PluginOption[]> = [
+    reactSvgPlugin({
+        defaultExport: 'component',
+        expandProps: 'start',
+        memo: false,
+        ref: false,
+        replaceAttrValues: {
+            someKey: 42,
+            anotherKey: 'value',
+        },
+        svgProps: {
+            role: 'alert',
+        },
+        svgo: true,
+        svgoConfig: {
+            datauri: 'base64',
+        },
+        titleProp: true,
+    }),
+    reactSvgPlugin({
+        defaultExport: 'url',
+        expandProps: 'end',
+    }),
+    reactSvgPlugin({
+        expandProps: false,
+    }),
+    reactSvgPlugin({
+        // $ExpectError
+        expandProps: true,
+    }),
+];

--- a/types/vite-plugin-react-svg/vite-plugin-react-svg-tests.ts
+++ b/types/vite-plugin-react-svg/vite-plugin-react-svg-tests.ts
@@ -31,4 +31,8 @@ const testCases: Array<PluginOption | PluginOption[]> = [
         // $ExpectError
         expandProps: true,
     }),
+    reactSvgPlugin({
+        // $ExpectError
+        expandProps: 'en',
+    }),
 ];


### PR DESCRIPTION
This PR adds the type definitions for [vite-plugin-react-svg](https://www.npmjs.com/package/vite-plugin-react-svg)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
