### PR TITLE
[google-apps-script] add url methods to SpreadsheetApp.RichTextValue and SpreadsheetApp.RichTextValueBuilder

### DIFF
--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -142,6 +142,35 @@ const request: GoogleAppsScript.Data_Studio.Request<any> = {
     ],
 };
 
+// Spreadsheet Rich Text Value & Builder
+// starting with sample code from
+// https://developers.google.com/apps-script/reference/spreadsheet/rich-text-value-builder
+const richTextStyle = SpreadsheetApp.newTextStyle()
+    .setUnderline(false)
+    .build();
+const richTextValue = SpreadsheetApp.newRichTextValue()
+    .setText("foo no baz")
+    .setLinkUrl(0, 3, "https://bar.foo")
+    .setLinkUrl(7, 10, "https://abc.xyz")
+    .setTextStyle(7, 10, richTextStyle)
+    .build();
+for (let richTextRun of richTextValue.getRuns()) {
+    let start = richTextRun.getStartIndex();
+    let end = richTextRun.getEndIndex();
+    let newValueBuilder = SpreadsheetApp.newRichTextValue();
+    if (richTextRun.getTextStyle() === richTextValue.getTextStyle(start, end)) {
+        newValueBuilder = richTextRun.copy();
+    }
+    if (richTextRun.getLinkUrl() === richTextValue.getLinkUrl(start, end)) {
+        newValueBuilder.setLinkUrl(richTextRun.getLinkUrl());
+    }
+    if (richTextRun.getTextStyle() === richTextValue.getTextStyle(start, end)) {
+        newValueBuilder.setTextStyle(richTextRun.getTextStyle());
+    }
+    // $ExpectType string
+    newValueBuilder.build().getText();
+}
+
 const tableCell = DocumentApp.create("").getCursor().getElement().asTableCell();
 tableCell.getParentRow().getChildIndex(tableCell);
 

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -1591,7 +1591,7 @@ declare namespace GoogleAppsScript {
     interface RichTextValueBuilder {
       build(): RichTextValue;
       setLinkUrl(startOffset: Integer, endOffset: Integer, linkUrl: string | null): RichTextValueBuilder;
-      setLinkUrl(linkUrl: string | null): RichTextValueBuilder; 
+      setLinkUrl(linkUrl: string | null): RichTextValueBuilder;
       setText(text: string): RichTextValueBuilder;
       setTextStyle(startOffset: Integer, endOffset: Integer, textStyle: TextStyle | null): RichTextValueBuilder;
       setTextStyle(textStyle: TextStyle | null): RichTextValueBuilder;

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -1577,6 +1577,8 @@ declare namespace GoogleAppsScript {
     interface RichTextValue {
       copy(): RichTextValueBuilder;
       getEndIndex(): Integer;
+      getLinkUrl(): string | null;
+      getLinkUrl(startOffset: Integer, endOffset: Integer): string | null;
       getRuns(): RichTextValue[];
       getStartIndex(): Integer;
       getText(): string;

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -1588,6 +1588,8 @@ declare namespace GoogleAppsScript {
      */
     interface RichTextValueBuilder {
       build(): RichTextValue;
+      setLinkUrl(startOffset: Integer, endOffset: Integer, linkUrl: string | null): RichTextValueBuilder;
+      setLinkUrl(linkUrl: string | null): RichTextValueBuilder; 
       setText(text: string): RichTextValueBuilder;
       setTextStyle(startOffset: Integer, endOffset: Integer, textStyle: TextStyle | null): RichTextValueBuilder;
       setTextStyle(textStyle: TextStyle | null): RichTextValueBuilder;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/spreadsheet/rich-text-value & https://developers.google.com/apps-script/reference/spreadsheet/rich-text-value-builder
- [ ***unknown*** ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Fixes #54271  and adds tests for SpreadsheetApp.RichTextValue and SpreadsheetApp.RichTextValueBuilder