### PR TITLE
slick-carousel: Rename argument of slickGoTo according to the documentation

### DIFF
--- a/types/slick-carousel/index.d.ts
+++ b/types/slick-carousel/index.d.ts
@@ -607,9 +607,9 @@ interface JQuery {
      * Navigates to a slide by index
      * @param methodName The name of the method
      * @param slide
-     * @param animate
+     * @param dontAnimate
      */
-    slick(methodName: "slickGoTo", slide: number, animate?: boolean): JQuery;
+    slick(methodName: "slickGoTo", slide: number, dontAnimate?: boolean): JQuery;
 
     /**
      * Navigates to the next slide

--- a/types/slick-carousel/slick-carousel-tests.ts
+++ b/types/slick-carousel/slick-carousel-tests.ts
@@ -260,3 +260,5 @@ $("#diaporama").on('beforeChange', function(event, slick: JQuerySlick, currentSl
    slick.swiping; // $ExpectedType boolean
    slick.initials.swiping; // $ExpectedType boolean
 });
+
+$("#diaporama").slick("slickGoTo", 0, true);


### PR DESCRIPTION
The argument `animate` doesn't reflect [what the documentation says](https://kenwheeler.github.io/slick/#settings).
It sounds like Slick **SHOULD** animate when `true` is given, but it actually won't.

The argument indicates whether Slick **SHOULD NOT** apply animations, and so is [named `dontAnimate`](https://github.com/kenwheeler/slick/blob/7daf56cb83e1365e7b7b0ef551f4a6b6b82a0f78/slick/slick.js#L1275). 
This PR conforms the naming to the original one.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://kenwheeler.github.io/slick/#settings (see `Methods` > `slickGoTo` section)
  - https://github.com/kenwheeler/slick/blob/7daf56cb83e1365e7b7b0ef551f4a6b6b82a0f78/slick/slick.js#L1275
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

