### PR TITLE
argparse: Add required: boolean to SubparserOptions

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -179,6 +179,7 @@ const subparserExample = new ArgumentParser({
 const subparsers = subparserExample.add_subparsers({
     title: "subcommands",
     dest: "subcommand_name",
+    required: true,
 });
 
 let bar = subparsers.add_parser("c1", { add_help: true, help: "c1 help" });

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -51,6 +51,7 @@ export interface SubparserOptions {
     dest?: string;
     help?: string;
     metavar?: string;
+    required?: boolean;
 }
 
 export interface SubArgumentParserOptions extends ArgumentParserOptions {


### PR DESCRIPTION
The required option was added in python 3.7.0a2 as a way to make
subparsers required again (the default behaviour in Python 2.7).

* https://bugs.python.org/issue9253
* https://github.com/python/cpython/pull/3027

Since npm argparse 2.0.1 is a straight conversion of the Python
3.9.0rc1 version of argparse the required flag is valid here too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/python/cpython/pull/3027
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
