### PR TITLE
fix: Missing type definition in React Native

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9407,6 +9407,19 @@ export interface KeyboardStatic extends NativeEventEmitter {
      * position changes with keyboard movements.
      */
     scheduleLayoutAnimation: (event: KeyboardEvent) => void;
+    /**
+     * Removes a specific listener.
+     *
+     * @param {string} eventName The `nativeEvent` is the string that identifies the event you're listening for.
+     * @param {function} callback function to be called when the event fires.
+     */
+    removeListener: (eventName: KeyboardEventName, callback: KeyboardEventListener) => void;
+    /**
+     * Removes all listeners for a specific event type.
+     *
+     * @param {string} eventType The native event string listeners are watching which will be removed.
+     */
+    removeAllListeners: (eventName: KeyboardEventName) => void;
 }
 
 /**

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -49,6 +49,7 @@ import {
     InteractionManager,
     Keyboard,
     KeyboardAvoidingView,
+    KeyboardEventListener,
     LayoutChangeEvent,
     Linking,
     ListRenderItemInfo,
@@ -1384,6 +1385,11 @@ const KeyboardTest = () => {
         startCoordinates: { screenX: 0, screenY: 0, width: 0, height: 0 },
         isEventFromThisApp: true,
     });
+
+    const listener: KeyboardEventListener = (event) => { event; };
+    Keyboard.addListener('keyboardDidShow', listener);
+    Keyboard.removeListener('keyboardDidShow', listener);
+    Keyboard.removeAllListeners('keyboardDidShow');
 };
 
 const PermissionsAndroidTest = () => {


### PR DESCRIPTION
Definition of some methods was missing. I am trying to update the type definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactnative.dev/docs/keyboard#removelistener>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
