### PR TITLE
fix: wordpress__components - value and onChange are supposed to be string instead of Color

### DIFF
--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -271,9 +271,9 @@ be.withFontSizes('fontSize')(() => <h1>Hello World</h1>);
     initialOpen={false}
     colorSettings={[
         {
-            value: { name: 'Red', color: '#ff0000' },
+            value: '#ff0000',
             onChange(color) {
-                color && console.log(color.name);
+                color && console.log(color);
             },
             label: 'Background Color',
             disableCustomColors: true,
@@ -293,9 +293,9 @@ be.withFontSizes('fontSize')(() => <h1>Hello World</h1>);
 <be.PanelColorSettings
     colorSettings={[
         {
-            value: { name: 'Red', color: '#ff0000' },
+            value: '#ff0000' ,
             onChange(color) {
-                color && console.log(color.name);
+                color && console.log(color);
             },
             label: 'Background Color',
         },

--- a/types/wordpress__components/color-palette/index.d.ts
+++ b/types/wordpress__components/color-palette/index.d.ts
@@ -25,12 +25,12 @@ declare namespace ColorPalette {
         /**
          * Current active color value.
          */
-        value: Color;
+        value: string;
         /**
          * Function to be called when color is changed. `color` may be
          * `undefined` if the color selection is the same as the current `value`.
          */
-        onChange(color?: Color): void;
+        onChange(color?: string): void;
         /**
          * Whether the palette should have a clearing button or not.
          * @defaultValue `true`

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -176,8 +176,8 @@ const buttonGroupRef = createRef<HTMLDivElement>();
         { name: 'green', color: '#00ff00' },
         { name: 'blue', color: '#0000ff' },
     ]}
-    value={{ name: 'red', color: '#ff0000' }}
-    onChange={color => color && console.log(color.name)}
+    value={'#ff0000'}
+    onChange={color => color && console.log(color)}
 />;
 
 <C.ColorPalette
@@ -188,8 +188,8 @@ const buttonGroupRef = createRef<HTMLDivElement>();
         { name: 'green', color: '#00ff00' },
         { name: 'blue', color: '#0000ff' },
     ]}
-    value={{ name: 'red', color: '#ff0000' }}
-    onChange={color => color && console.log(color.name)}
+    value={'#ff0000'}
+    onChange={color => color && console.log(color)}
 />;
 
 //


### PR DESCRIPTION
-> https://developer.wordpress.org/block-editor/reference-guides/components/color-palette/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.wordpress.org/block-editor/reference-guides/components/color-palette/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
