### PR TITLE
Add undefined to optional properties, Body to Connect

### DIFF
--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -24,17 +24,17 @@ declare function bodyParser(
 declare namespace bodyParser {
     interface Options {
         /** When set to true, then deflated (compressed) bodies will be inflated; when false, deflated bodies are rejected. Defaults to true. */
-        inflate?: boolean;
+        inflate?: boolean | undefined;
         /**
          * Controls the maximum request body size. If this is a number,
          * then the value specifies the number of bytes; if it is a string,
          * the value is passed to the bytes library for parsing. Defaults to '100kb'.
          */
-        limit?: number | string;
+        limit?: number | string | undefined;
         /**
          * The type option is used to determine what media type the middleware will parse
          */
-        type?: string | string[] | ((req: http.IncomingMessage) => any);
+        type?: string | string[] | ((req: http.IncomingMessage) => any) | undefined;
         /**
          * The verify option, if supplied, is called as verify(req, res, buf, encoding),
          * where buf is a Buffer of the raw request body and encoding is the encoding of the request.
@@ -52,7 +52,7 @@ declare namespace bodyParser {
          * When set to `true`, will only accept arrays and objects;
          * when `false` will accept anything JSON.parse accepts. Defaults to `true`.
          */
-        strict?: boolean;
+        strict?: boolean | undefined;
     }
 
     interface OptionsText extends Options {
@@ -61,7 +61,7 @@ declare namespace bodyParser {
          * is not specified in the Content-Type header of the request.
          * Defaults to `utf-8`.
          */
-        defaultCharset?: string;
+        defaultCharset?: string | undefined;
     }
 
     interface OptionsUrlencoded extends Options {
@@ -69,13 +69,13 @@ declare namespace bodyParser {
          * The extended option allows to choose between parsing the URL-encoded data
          * with the querystring library (when `false`) or the qs library (when `true`).
          */
-        extended?: boolean;
+        extended?: boolean | undefined;
         /**
          * The parameterLimit option controls the maximum number of parameters
          * that are allowed in the URL-encoded data. If a request contains more parameters than this value,
          * a 413 will be returned to the client. Defaults to 1000.
          */
-        parameterLimit?: number;
+        parameterLimit?: number | undefined;
     }
 
     /**

--- a/types/body-scroll-lock/index.d.ts
+++ b/types/body-scroll-lock/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface BodyScrollOptions {
-    reserveScrollBarGap?: boolean;
-    allowTouchMove?: (el: HTMLElement | Element) => void;
+    reserveScrollBarGap?: boolean | undefined;
+    allowTouchMove?: ((el: HTMLElement | Element) => void) | undefined;
 }
 
 export function disableBodyScroll(targetElement: HTMLElement | Element, options?: BodyScrollOptions): void;

--- a/types/bonjour/index.d.ts
+++ b/types/bonjour/index.d.ts
@@ -35,21 +35,21 @@ declare namespace bonjour {
         removeAllListeners(event?: 'up' | 'down'): this;
     }
     interface BrowserOptions {
-        type?: string;
-        subtypes?: string[];
-        protocol?: string;
-        txt?: { [key: string]: string };
+        type?: string | undefined;
+        subtypes?: string[] | undefined;
+        protocol?: string | undefined;
+        txt?: { [key: string]: string } | undefined;
     }
 
     interface ServiceOptions {
         name: string;
-        host?: string;
+        host?: string | undefined;
         port: number;
         type: string;
-        subtypes?: string[];
-        protocol?: 'udp'|'tcp';
-        txt?: { [key: string]: string };
-        probe?: boolean;
+        subtypes?: string[] | undefined;
+        protocol?: 'udp'|'tcp' | undefined;
+        txt?: { [key: string]: string } | undefined;
+        probe?: boolean | undefined;
     }
 
     interface BaseService {
@@ -75,14 +75,14 @@ declare namespace bonjour {
         start(): void;
     }
     interface BonjourOptions {
-        type?: 'udp4' | 'udp6';
-        multicast?: boolean;
-        interface?: string;
-        port?: number;
-        ip?: string;
-        ttl?: number;
-        loopback?: boolean;
-        reuseAddr?: boolean;
+        type?: 'udp4' | 'udp6' | undefined;
+        multicast?: boolean | undefined;
+        interface?: string | undefined;
+        port?: number | undefined;
+        ip?: string | undefined;
+        ttl?: number | undefined;
+        loopback?: boolean | undefined;
+        reuseAddr?: boolean | undefined;
     }
     interface Bonjour {
         (opts?: BonjourOptions): Bonjour;

--- a/types/boom/index.d.ts
+++ b/types/boom/index.d.ts
@@ -33,28 +33,28 @@ declare class Boom<Data = any> extends Error {
      * isMissing will be true on the error object." mentioned in
      * @see {@link https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes}
      */
-    isMissing?: boolean;
+    isMissing?: boolean | undefined;
     /** https://github.com/hapijs/boom#createstatuscode-message-data and https://github.com/hapijs/boom/blob/v4.3.0/lib/index.js#L99 */
     data: Data;
 }
 declare namespace Boom {
     interface Options<Data> {
         /** statusCode - the HTTP status code. Defaults to 500 if no status code is already set. */
-        statusCode?: number;
+        statusCode?: number | undefined;
         /** data - additional error information (assigned to error.data). */
-        data?: Data;
+        data?: Data | undefined;
         /** decorate - an option with extra properties to set on the error object. */
-        decorate?: object;
+        decorate?: object | undefined;
         /** ctor - constructor reference used to crop the exception call stack output. */
         ctor?: any;
         /** message - error message string. If the error already has a message, the provided message is added as a prefix. Defaults to no message. */
-        message?: string;
+        message?: string | undefined;
         /**
          * override - if false, the err provided is a Boom object, and a statusCode or message are
          * provided, the values are ignored. Defaults to true (apply the provided statusCode and
          * message options to the error regardless of its type, Error or Boom object).
          */
-        override?: boolean;
+        override?: boolean | undefined;
     }
 
     interface Output {
@@ -96,7 +96,7 @@ declare namespace Boom {
      * @param options optional additional options
      * @see {@link https://github.com/hapijs/boom#boomifyerror-options}
      */
-    function boomify(error: Error, options?: { statusCode?: number, message?: string, override?: boolean }): Boom<null>;
+    function boomify(error: Error, options?: { statusCode?: number | undefined, message?: string | undefined, override?: boolean | undefined }): Boom<null>;
 
     /**
      * Identifies whether an error is a Boom object. Same as calling instanceof Boom.

--- a/types/boom/v4/index.d.ts
+++ b/types/boom/v4/index.d.ts
@@ -27,7 +27,7 @@ declare namespace Boom {
         /** reformat() - rebuilds error.output using the other object properties. */
         reformat: () => string;
         /** "If message is unset, the 'error' segment of the header will not be present and isMissing will be true on the error object." mentioned in @see {@link https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes} */
-        isMissing?: boolean;
+        isMissing?: boolean | undefined;
         /** https://github.com/hapijs/boom#createstatuscode-message-data and https://github.com/hapijs/boom/blob/v4.3.0/lib/index.js#L99 */
         data: Data;
     }
@@ -63,7 +63,7 @@ declare namespace Boom {
      * @param options optional additional options
      * @see {@link https://github.com/hapijs/boom#boomifyerror-options}
      */
-    export function boomify(error: Error, options?: { statusCode?: number, message?: string, override?: boolean }): BoomError<null>;
+    export function boomify(error: Error, options?: { statusCode?: number | undefined, message?: string | undefined, override?: boolean | undefined }): BoomError<null>;
 
     /**
      * Decorates an error with the boom properties

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -281,7 +281,7 @@ declare namespace Tooltip {
          *
          * @default ''
          */
-        customClass?: string | (() => string);
+        customClass?: string | (() => string) | undefined;
 
         /**
          * Enable or disable the sanitization. If activated 'template' and

--- a/types/bootstrap/v4/index.d.ts
+++ b/types/bootstrap/v4/index.d.ts
@@ -33,8 +33,8 @@ export interface TooltipInstance<T extends TooltipOption> {
 }
 
 export interface OffsetsExtend {
-    popper?: Partial<Popper.Offset>;
-    reference?: Partial<Popper.Offset>;
+    popper?: Partial<Popper.Offset> | undefined;
+    reference?: Partial<Popper.Offset> | undefined;
 }
 
 // --------------------------------------------------------------------------------------
@@ -47,14 +47,14 @@ export interface CarouselOption {
      *
      * @default 5000
      */
-    interval?: false | number;
+    interval?: false | number | undefined;
 
     /**
      * Whether the carousel should react to keyboard events.
      *
      * @default true
      */
-    keyboard?: boolean;
+    keyboard?: boolean | undefined;
 
     /**
      * Use to easily control the position of the carousel. It accepts the keywords prev or next, which alters the slide position
@@ -62,7 +62,7 @@ export interface CarouselOption {
      *
      * @default false
      */
-    slide?: "next" | "prev" | false;
+    slide?: "next" | "prev" | false | undefined;
 
     /**
      * If set to "hover", pauses the cycling of the carousel on `mouseenter` and resumes the cycling of the carousel on `mouseleave`.
@@ -73,28 +73,28 @@ export interface CarouselOption {
      *
      * @default "hover"
      */
-    pause?: "hover" | false;
+    pause?: "hover" | false | undefined;
 
     /**
      * Autoplays the carousel after the user manually cycles the first item.
      * If `carousel`, autoplays the carousel on load.
      * @default false
      */
-    ride?: 'carousel' | boolean;
+    ride?: 'carousel' | boolean | undefined;
 
     /**
      * Whether the carousel should cycle continuously or have hard stops.
      *
      * @default true
      */
-    wrap?: boolean;
+    wrap?: boolean | undefined;
 
     /**
      * Whether the carousel should support left/right swipe interactions on touchscreen devices.
      *
      * @default true
      */
-    touch?: boolean;
+    touch?: boolean | undefined;
 }
 
 export interface CollapseOption {
@@ -105,14 +105,14 @@ export interface CollapseOption {
      *
      * @default ""
      */
-    parent?: string | JQuery | Element;
+    parent?: string | JQuery | Element | undefined;
 
     /**
      * Toggles the collapsible element on invocation.
      *
      * @default true
      */
-    toggle?: boolean;
+    toggle?: boolean | undefined;
 }
 
 export interface DropdownOption {
@@ -122,7 +122,7 @@ export interface DropdownOption {
      *
      * @default 0
      */
-    offset?: number | string | ((this: DropdownOption, offset: OffsetsExtend) => OffsetsExtend);
+    offset?: number | string | ((this: DropdownOption, offset: OffsetsExtend) => OffsetsExtend) | undefined;
 
     /**
      * Allow Dropdown to flip in case of an overlapping on the reference element.
@@ -130,7 +130,7 @@ export interface DropdownOption {
      *
      * @default true
      */
-    flip?: boolean;
+    flip?: boolean | undefined;
 
     /**
      * Overflow constraint boundary of the dropdown menu.
@@ -139,7 +139,7 @@ export interface DropdownOption {
      *
      * @default "scrollParent"
      */
-    boundary?: Popper.Boundary | HTMLElement;
+    boundary?: Popper.Boundary | HTMLElement | undefined;
 
     /**
      * Reference element of the dropdown menu. Accepts the values of 'toggle', 'parent', or an HTMLElement reference.
@@ -147,14 +147,14 @@ export interface DropdownOption {
      *
      * @default "toggle"
      */
-    reference?: "toggle" | "parent" | HTMLElement;
+    reference?: "toggle" | "parent" | HTMLElement | undefined;
 
     /**
      * By default, we use Popper.js for dynamic positioning. Disable this with 'static'.
      *
      * @default "dynamic"
      */
-    display?: "dynamic" | "static";
+    display?: "dynamic" | "static" | undefined;
 }
 
 export interface ModalOption {
@@ -164,28 +164,28 @@ export interface ModalOption {
      *
      * @default true
      */
-    backdrop?: boolean | "static";
+    backdrop?: boolean | "static" | undefined;
 
     /**
      * Closes the modal when escape key is pressed.
      *
      * @default true
      */
-    keyboard?: boolean;
+    keyboard?: boolean | undefined;
 
     /**
      * Puts the focus on the modal when initialized.
      *
      * @default true
      */
-    focus?: boolean;
+    focus?: boolean | undefined;
 
     /**
      * Shows the modal when initialized.
      *
      * @default true
      */
-    show?: boolean;
+    show?: boolean | undefined;
 }
 
 export interface PopoverOption extends TooltipOption {
@@ -196,7 +196,7 @@ export interface PopoverOption extends TooltipOption {
      *
      * @default ""
      */
-    content?: string | Element | ((this: Element) => string | Element);
+    content?: string | Element | ((this: Element) => string | Element) | undefined;
 }
 
 export interface ScrollspyOption {
@@ -208,14 +208,14 @@ export interface ScrollspyOption {
      *
      * @default "auto"
      */
-    method?: "auto" | "offset" | "position";
+    method?: "auto" | "offset" | "position" | undefined;
 
     /**
      * Pixels to offset from top when calculating position of scroll.
      *
      * @default 10
      */
-    offset?: number;
+    offset?: number | undefined;
 
     /**
      * A selector of the parent element or the parent element itself
@@ -223,7 +223,7 @@ export interface ScrollspyOption {
      *
      * @default ""
      */
-    target?: string | JQuery<Element> | Element;
+    target?: string | JQuery<Element> | Element | undefined;
 }
 
 export interface ToastOption {
@@ -232,21 +232,21 @@ export interface ToastOption {
      *
      * @default true
      */
-    animation?: boolean;
+    animation?: boolean | undefined;
 
     /**
      * Auto hide the toast.
      *
      * @default true
      */
-    autohide?: boolean;
+    autohide?: boolean | undefined;
 
     /**
      * Delay hiding the toast in millisecond.
      *
      * @default 500
      */
-    delay?: number;
+    delay?: number | undefined;
 }
 
 export interface TooltipOption {
@@ -255,7 +255,7 @@ export interface TooltipOption {
      *
      * @default true
      */
-    animation?: boolean;
+    animation?: boolean | undefined;
 
     /**
      * Appends the tooltip or popover to a specific element. Example: `container: 'body'`.
@@ -265,7 +265,7 @@ export interface TooltipOption {
      *
      * @default false
      */
-    container?: string | Element | false;
+    container?: string | Element | false | undefined;
 
     /**
      * Delay showing and hiding the tooltip or popover (ms) - does not apply to manual trigger type.
@@ -274,7 +274,7 @@ export interface TooltipOption {
      *
      * @default 0
      */
-    delay?: number | Delay;
+    delay?: number | Delay | undefined;
 
     /**
      * Allow HTML in the tooltip or popover.
@@ -284,7 +284,7 @@ export interface TooltipOption {
      *
      * @default false
      */
-    html?: boolean;
+    html?: boolean | undefined;
 
     /**
      * How to position the tooltip or popover - auto | top | bottom | left | right.
@@ -296,7 +296,7 @@ export interface TooltipOption {
      *
      * @default tooltip: "top", popover: "right"
      */
-    placement?: Placement | ((this: TooltipInstance<this>, node: HTMLElement, trigger: Element) => Placement);
+    placement?: Placement | ((this: TooltipInstance<this>, node: HTMLElement, trigger: Element) => Placement) | undefined;
 
     /**
      * If a selector is provided, tooltip or popover objects will be delegated to the specified targets.
@@ -304,7 +304,7 @@ export interface TooltipOption {
      *
      * @default false
      */
-    selector?: string | false;
+    selector?: string | false | undefined;
 
     /**
      * Base HTML to use when creating the tooltip or popover.
@@ -315,7 +315,7 @@ export interface TooltipOption {
      * @default '<div class="tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>'
      * @default '<div class="popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
      */
-    template?: string;
+    template?: string | undefined;
 
     /**
      * Default title value if title attribute isn't present.
@@ -324,7 +324,7 @@ export interface TooltipOption {
      *
      * @default ""
      */
-    title?: string | Element | ((this: Element) => string | Element);
+    title?: string | Element | ((this: Element) => string | Element) | undefined;
 
     /**
      * How tooltip or popover is triggered - click | hover | focus | manual. You may pass multiple triggers; separate them with a space.
@@ -333,7 +333,7 @@ export interface TooltipOption {
      *
      * @default tooltip: "hover focus", popover: "click"
      */
-    trigger?: Trigger;
+    trigger?: Trigger | undefined;
 
     /**
      * Offset of the tooltip or popover relative to its target.
@@ -341,7 +341,7 @@ export interface TooltipOption {
      *
      * @default 0
      */
-    offset?: number | string;
+    offset?: number | string | undefined;
 
     /**
      * Allow to specify which position Popper will use on fallback.
@@ -349,7 +349,7 @@ export interface TooltipOption {
      *
      * @default "flip"
      */
-    fallbackPlacement?: Popper.Behavior | ReadonlyArray<Popper.Behavior>;
+    fallbackPlacement?: Popper.Behavior | ReadonlyArray<Popper.Behavior> | undefined;
 
     /**
      * Add classes to the tooltip when it is shown. Note that these classes will be added in addition to any classes specified in the template.
@@ -357,7 +357,7 @@ export interface TooltipOption {
      * You can also pass a function that should return a single string containing additional class names.
      * @default ''
      */
-    customClass?: string | (() => string);
+    customClass?: string | (() => string) | undefined;
 
     /**
      * Overflow constraint boundary of the tooltip or popover.
@@ -367,32 +367,32 @@ export interface TooltipOption {
      *
      * @default "scrollParent"
      */
-    boundary?: Popper.Boundary | HTMLElement;
+    boundary?: Popper.Boundary | HTMLElement | undefined;
 
     /**
      * Enable or disable the sanitization. If activated 'template', 'content' and 'title' options will be sanitized.
      *
      * @default true
      */
-    sanitize?: boolean;
+    sanitize?: boolean | undefined;
 
     /**
      * Object which contains allowed attributes and tags.
      */
-    whiteList?: {[key: string]: string[]};
+    whiteList?: {[key: string]: string[]} | undefined;
 
     /**
      * Here you can supply your own sanitize function. This can be useful if you prefer to use a dedicated library to perform sanitization.
      *
      * @default null
      */
-    sanitizeFn?: null | ((input: string) => string);
+    sanitizeFn?: null | ((input: string) => string) | undefined;
 
     /**
      * To change Bootstrap's default Popper.js config,
      * see {@link https://popper.js.org/docs/v1/ Popper.js's configuration}
      */
-    popperConfig?: null | object;
+    popperConfig?: null | object | undefined;
 }
 
 // --------------------------------------------------------------------------------------

--- a/types/braces/index.d.ts
+++ b/types/braces/index.d.ts
@@ -17,7 +17,7 @@ declare namespace braces {
          * console.log(braces('a/{b,c}/d', { maxLength: 3 }));
          * //=> throws an error
          */
-        maxLength?: number;
+        maxLength?: number | undefined;
         /**
          * Generate an "expanded" brace pattern (alternatively you can use the `braces.expand()` method).
          *
@@ -26,13 +26,13 @@ declare namespace braces {
          * console.log(braces('a/{b,c}/d', { expand: true }));
          * //=> [ 'a/b/d', 'a/c/d' ]
          */
-        expand?: boolean;
+        expand?: boolean | undefined;
         /**
          * Remove duplicates from the returned array.
          *
          * @default undefined
          */
-        nodupes?: boolean;
+        nodupes?: boolean | undefined;
         /**
          * To prevent malicious patterns from being passed by users, an error is thrown when `braces.expand()`
          * is used or `options.expand` is true and the generated range will exceed the `rangeLimit`.
@@ -49,7 +49,7 @@ declare namespace braces {
          * console.log(braces.expand('{1..100}'));
          * //=> ['1', '2', '3', '4', '5', …, '100']
          */
-        rangeLimit?: number;
+        rangeLimit?: number | undefined;
         /**
          * Customize range expansion.
          *
@@ -62,7 +62,7 @@ declare namespace braces {
          * console.log(range);
          * //=> [ 'xfooay', 'xfooby', 'xfoocy', 'xfoody', 'xfooey' ]
          */
-        transform?: Transform;
+        transform?: Transform | undefined;
         /**
          * In regular expressions, quanitifiers can be used to specify how many times a token can be repeated.
          * For example, `a{1,3}` will match the letter `a` one to three times.
@@ -82,13 +82,13 @@ declare namespace braces {
          * console.log(braces('a/b{1,3}/{x,y,z}', {quantifiers: true, expand: true}));
          * //=> [ 'a/b{1,3}/x', 'a/b{1,3}/y', 'a/b{1,3}/z' ]
          */
-        quantifiers?: boolean;
+        quantifiers?: boolean | undefined;
         /**
          * Strip backslashes that were used for escaping from the result.
          *
          * @default undefined
          */
-        unescape?: boolean;
+        unescape?: boolean | undefined;
     }
 }
 interface Braces {

--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -198,7 +198,7 @@ export interface ApplePay {
      * });
      */
     performValidation(
-        options: { validationURL: string; displayName?: string; merchantIdentifier?: string },
+        options: { validationURL: string; displayName?: string | undefined; merchantIdentifier?: string | undefined },
         callback: callback,
     ): void;
 

--- a/types/braintree-web/modules/client.d.ts
+++ b/types/braintree-web/modules/client.d.ts
@@ -20,7 +20,7 @@ export interface CreditCardInfo {
     cvv: string;
     expirationDate: string;
     billingAddress: {
-        postalCode?: string;
+        postalCode?: string | undefined;
     };
 }
 
@@ -95,7 +95,7 @@ export interface Client {
      *   });
      * });
      */
-    request(options: { method: string; endpoint: string; data: any; timeout?: number }, callback: callback): void;
+    request(options: { method: string; endpoint: string; data: any; timeout?: number | undefined }, callback: callback): void;
 
     /**
      * Cleanly tear down anything set up by {@link Client#getConfiguration|create}.

--- a/types/braintree-web/modules/data-collector.d.ts
+++ b/types/braintree-web/modules/data-collector.d.ts
@@ -2,8 +2,8 @@ import { callback } from './core';
 import { Client } from './client';
 
 export interface DataCollector {
-    create(options: { client: Client; kount?: boolean; paypal?: boolean }): Promise<DataCollector>;
-    create(options: { client: Client; kount?: boolean; paypal?: boolean }, callback: callback): void;
+    create(options: { client: Client; kount?: boolean | undefined; paypal?: boolean | undefined }): Promise<DataCollector>;
+    create(options: { client: Client; kount?: boolean | undefined; paypal?: boolean | undefined }, callback: callback): void;
 
     VERSION: string;
 

--- a/types/braintree-web/modules/google-payment.d.ts
+++ b/types/braintree-web/modules/google-payment.d.ts
@@ -135,19 +135,19 @@ export interface GooglePayment {
      *
      */
     create(options: {
-        client?: Client;
-        authorization?: string;
-        useDeferredClient?: boolean;
-        googlePayVersion?: number;
-        googleMerchantId?: string;
+        client?: Client | undefined;
+        authorization?: string | undefined;
+        useDeferredClient?: boolean | undefined;
+        googlePayVersion?: number | undefined;
+        googleMerchantId?: string | undefined;
     }): Promise<GooglePayment>;
     create(
         options: {
-            client?: Client;
-            authorization?: string;
-            useDeferredClient?: boolean;
-            googlePayVersion?: number;
-            googleMerchantId?: string;
+            client?: Client | undefined;
+            authorization?: string | undefined;
+            useDeferredClient?: boolean | undefined;
+            googlePayVersion?: number | undefined;
+            googleMerchantId?: string | undefined;
         },
         callback?: callback,
     ): void;
@@ -226,10 +226,10 @@ export interface GooglePayment {
      * });
      */
     createPaymentDataRequest(overrides?: {
-        emailRequired?: boolean;
+        emailRequired?: boolean | undefined;
         merchantInfo?: {
             merchantId: string;
-        };
+        } | undefined;
         transactionInfo: {
             currencyCode: string;
             totalPriceStatus: string;

--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -6,11 +6,11 @@ export interface HostedFieldsFieldMaskInput {
      * The character to use when masking the input.
      * @default '•'
      */
-    character?: string;
+    character?: string | undefined;
     /**
      * Only applicable for the credit card field. Whether or not to show the last 4 digits of the card when masking.
      */
-    showLastFour?: boolean;
+    showLastFour?: boolean | undefined;
 }
 
 /**
@@ -20,31 +20,31 @@ export interface HostedFieldsField {
     /**
      * @deprecated Now an alias for `container`.
      */
-    selector?: string;
-    container?: string | HTMLElement;
-    placeholder?: string;
-    type?: string;
-    formatInput?: boolean;
-    maskInput?: boolean | HostedFieldsFieldMaskInput;
-    select?: boolean | { options: string[] };
-    maxCardLength?: number;
-    maxlength?: number;
-    minlength?: number;
-    prefill?: string;
-    rejectUnsupportedCards?: boolean;
+    selector?: string | undefined;
+    container?: string | HTMLElement | undefined;
+    placeholder?: string | undefined;
+    type?: string | undefined;
+    formatInput?: boolean | undefined;
+    maskInput?: boolean | HostedFieldsFieldMaskInput | undefined;
+    select?: boolean | { options: string[] } | undefined;
+    maxCardLength?: number | undefined;
+    maxlength?: number | undefined;
+    minlength?: number | undefined;
+    prefill?: string | undefined;
+    rejectUnsupportedCards?: boolean | undefined;
 }
 
 /**
  * An object that has {@link module:braintree-web/hosted-fields~field field objects} for each field. Used in {@link module:braintree-web/hosted-fields~create create}.
  */
 export interface HostedFieldFieldOptions {
-    cardholderName?: HostedFieldsField;
-    cvv?: HostedFieldsField;
-    expirationDate?: HostedFieldsField;
-    expirationMonth?: HostedFieldsField;
-    expirationYear?: HostedFieldsField;
+    cardholderName?: HostedFieldsField | undefined;
+    cvv?: HostedFieldsField | undefined;
+    expirationDate?: HostedFieldsField | undefined;
+    expirationMonth?: HostedFieldsField | undefined;
+    expirationYear?: HostedFieldsField | undefined;
     number: HostedFieldsField;
-    postalCode?: HostedFieldsField;
+    postalCode?: HostedFieldsField | undefined;
 }
 
 /**
@@ -180,13 +180,13 @@ export interface HostedFields {
      * }, callback);
      */
     create(options: {
-        client?: Client;
-        authorization?: string;
+        client?: Client | undefined;
+        authorization?: string | undefined;
         fields: HostedFieldFieldOptions;
         styles?: any;
     }): Promise<HostedFields>;
     create(
-        options: { client?: Client; authorization?: string; fields: HostedFieldFieldOptions; styles?: any },
+        options: { client?: Client | undefined; authorization?: string | undefined; fields: HostedFieldFieldOptions; styles?: any },
         callback: callback,
     ): void;
 
@@ -275,11 +275,11 @@ export interface HostedFields {
      * });
      */
     tokenize(options?: {
-        vault?: boolean;
-        cardholderName?: string;
+        vault?: boolean | undefined;
+        cardholderName?: string | undefined;
         billingAddress?: any;
     }): Promise<HostedFieldsTokenizePayload>;
-    tokenize(options: { vault?: boolean; cardholderName?: string; billingAddress?: any }, callback: callback): void;
+    tokenize(options: { vault?: boolean | undefined; cardholderName?: string | undefined; billingAddress?: any }, callback: callback): void;
     tokenize(callback: callback): void;
 
     /**

--- a/types/braintree-web/modules/paypal-checkout.d.ts
+++ b/types/braintree-web/modules/paypal-checkout.d.ts
@@ -5,27 +5,27 @@ import { Client } from './client';
 
 export interface PayPalCheckoutCreatePaymentOptions {
     flow: paypal.FlowType;
-    intent?: paypal.Intent;
-    offerCredit?: boolean;
-    amount?: string | number;
-    currency?: string;
-    displayName?: string;
-    locale?: string;
-    vaultInitiatedCheckoutPaymentMethodToken?: string;
-    shippingOptions?: paypal.ShippingOption[];
-    enableShippingAddress?: boolean;
-    shippingAddressOverride?: paypal.Address;
-    shippingAddressEditable?: boolean;
-    billingAgreementDescription?: string;
-    landingPageType?: string;
-    lineItems?: paypal.LineItem[];
+    intent?: paypal.Intent | undefined;
+    offerCredit?: boolean | undefined;
+    amount?: string | number | undefined;
+    currency?: string | undefined;
+    displayName?: string | undefined;
+    locale?: string | undefined;
+    vaultInitiatedCheckoutPaymentMethodToken?: string | undefined;
+    shippingOptions?: paypal.ShippingOption[] | undefined;
+    enableShippingAddress?: boolean | undefined;
+    shippingAddressOverride?: paypal.Address | undefined;
+    shippingAddressEditable?: boolean | undefined;
+    billingAgreementDescription?: string | undefined;
+    landingPageType?: string | undefined;
+    lineItems?: paypal.LineItem[] | undefined;
 }
 
 export interface PayPalCheckoutTokenizationOptions {
     payerId: string;
-    paymentId?: string;
-    billingToken?: string;
-    vault?: boolean;
+    paymentId?: string | undefined;
+    billingToken?: string | undefined;
+    vault?: boolean | undefined;
 }
 
 export interface PayPalCheckoutLoadPayPalSDKOptions {
@@ -34,7 +34,7 @@ export interface PayPalCheckoutLoadPayPalSDKOptions {
      * Braintree component. When used in conjunction with passing authorization when creating the
      * PayPal Checkout component, you can speed up the loading of the PayPal SDK.
      */
-    'client-id'?: string;
+    'client-id'?: string | undefined;
 
     /**
      * By default, the PayPal SDK defaults to an intent of capture. Since the default intent when
@@ -45,19 +45,19 @@ export interface PayPalCheckoutLoadPayPalSDKOptions {
      *
      * @default 'authorize'
      */
-    intent?: 'authorize' | 'capture' | 'sale' | 'tokenize';
+    intent?: 'authorize' | 'capture' | 'sale' | 'tokenize' | undefined;
 
     /**
      * If a currency is passed in createPayment, it must match the currency passed here.
      *
      * @default 'USD'
      */
-    currency?: string;
+    currency?: string | undefined;
 
     /**
      * Must be true when using flow: vault in createPayment.
      */
-    vault?: boolean;
+    vault?: boolean | undefined;
 
     /**
      * By default, the Braintree SDK will only load the PayPal smart buttons component. If you would
@@ -66,7 +66,7 @@ export interface PayPalCheckoutLoadPayPalSDKOptions {
      *
      * @default 'buttons'
      */
-    components?: 'buttons' | 'messages' | 'buttons,messages';
+    components?: 'buttons' | 'messages' | 'buttons,messages' | undefined;
 
     /**
      * The data attributes to apply to the script. Any data attribute can be passed. A subset of the
@@ -76,28 +76,28 @@ export interface PayPalCheckoutLoadPayPalSDKOptions {
         /**
          * CSP nonce used for rendering the button.
          */
-        'csp-nonce'?: string;
+        'csp-nonce'?: string | undefined;
 
         /**
          * Client token used for identifying your buyers.
          */
-        'data-client-token'?: string;
+        'data-client-token'?: string | undefined;
 
         /**
          * Order ID used for optimizing the funding that displays.
          */
-        'data-order-id'?: string;
+        'data-order-id'?: string | undefined;
 
         /**
          * Log page type and interactions for the JavaScript SDK.
          */
-        'data-page-type'?: string;
+        'data-page-type'?: string | undefined;
 
         /**
          * Partner attribution ID used for revenue attribution.
          */
-        'data-partner-attribution-id'?: string;
-    };
+        'data-partner-attribution-id'?: string | undefined;
+    } | undefined;
 }
 
 export interface PayPalCheckout {
@@ -117,8 +117,8 @@ export interface PayPalCheckout {
      *   console.error('Error!', err);
      * });
      */
-    create(options: { client?: Client; authorization?: string; merchantAccountId?: string }): Promise<PayPalCheckout>;
-    create(options: { client?: Client; authorization?: string; merchantAccountId?: string }, callback?: callback): void;
+    create(options: { client?: Client | undefined; authorization?: string | undefined; merchantAccountId?: string | undefined }): Promise<PayPalCheckout>;
+    create(options: { client?: Client | undefined; authorization?: string | undefined; merchantAccountId?: string | undefined }, callback?: callback): void;
 
     /**
      * Resolves when the PayPal SDK has been succesfully loaded onto the page.

--- a/types/braintree-web/modules/paypal.d.ts
+++ b/types/braintree-web/modules/paypal.d.ts
@@ -139,32 +139,32 @@ export interface PayPal {
      */
     tokenize(options: {
         flow: string;
-        intent?: string;
-        offerCredit?: boolean;
-        useraction?: string;
-        amount?: string | number;
-        currency?: string;
-        displayName?: string;
-        locale?: string;
-        enableShippingAddress?: boolean;
-        shippingAddressOverride?: PayPalShippingAddress;
-        shippingAddressEditable?: boolean;
-        billingAgreementDescription?: string;
+        intent?: string | undefined;
+        offerCredit?: boolean | undefined;
+        useraction?: string | undefined;
+        amount?: string | number | undefined;
+        currency?: string | undefined;
+        displayName?: string | undefined;
+        locale?: string | undefined;
+        enableShippingAddress?: boolean | undefined;
+        shippingAddressOverride?: PayPalShippingAddress | undefined;
+        shippingAddressEditable?: boolean | undefined;
+        billingAgreementDescription?: string | undefined;
     }): Promise<PayPalTokenizePayload>;
     tokenize(
         options: {
             flow: string;
-            intent?: string;
-            offerCredit?: boolean;
-            useraction?: string;
-            amount?: string | number;
-            currency?: string;
-            displayName?: string;
-            locale?: string;
-            enableShippingAddress?: boolean;
-            shippingAddressOverride?: PayPalShippingAddress;
-            shippingAddressEditable?: boolean;
-            billingAgreementDescription?: string;
+            intent?: string | undefined;
+            offerCredit?: boolean | undefined;
+            useraction?: string | undefined;
+            amount?: string | number | undefined;
+            currency?: string | undefined;
+            displayName?: string | undefined;
+            locale?: string | undefined;
+            enableShippingAddress?: boolean | undefined;
+            shippingAddressOverride?: PayPalShippingAddress | undefined;
+            shippingAddressEditable?: boolean | undefined;
+            billingAgreementDescription?: string | undefined;
         },
         callback: callback<PayPalTokenizePayload>,
     ): PayPalTokenizeReturn;

--- a/types/braintree-web/modules/three-d-secure.d.ts
+++ b/types/braintree-web/modules/three-d-secure.d.ts
@@ -15,16 +15,16 @@ export interface ThreeDSecureVerifyPayload {
 }
 
 export interface ThreeDSecureBillingAddress {
-    givenName?: string;
-    surname?: string;
-    phoneNumber?: string;
-    streetAddress?: string;
-    extendedAddress?: string;
-    line3?: string;
-    locality?: string;
-    region?: string;
-    postalCode?: string;
-    countryCodeAlpha2?: string;
+    givenName?: string | undefined;
+    surname?: string | undefined;
+    phoneNumber?: string | undefined;
+    streetAddress?: string | undefined;
+    extendedAddress?: string | undefined;
+    line3?: string | undefined;
+    locality?: string | undefined;
+    region?: string | undefined;
+    postalCode?: string | undefined;
+    countryCodeAlpha2?: string | undefined;
 }
 
 export interface ThreeDSecureShippingAddress {
@@ -38,72 +38,72 @@ export interface ThreeDSecureShippingAddress {
 }
 
 export interface ThreeDSecureAdditionalInformation {
-    workPhoneNumber?: string;
-    shippingGivenName?: string;
-    shippingSurname?: string;
-    shippingAddress?: ThreeDSecureShippingAddress;
-    streetAddress?: string;
-    extendedAddress?: string;
-    line3?: string;
-    locality?: string;
-    region?: string;
-    postalCode?: string;
-    countryCodeAlpha2?: string;
-    shippingPhone?: string;
-    shippingMethod?: string;
-    shippingMethodIndicator?: string;
-    productCode?: string;
-    deliveryTimeframe?: string;
-    deliveryEmail?: string;
-    reorderindicator?: string;
-    preorderIndicator?: string;
-    preorderDate?: string;
-    giftCardAmount?: string;
-    giftCardCurrencyCode?: string;
-    giftCardCount?: string;
-    accountAgeIndicator?: string;
-    accountCreateDate?: string;
-    accountChangeIndicator?: string;
-    accountChangeDate?: string;
-    accountPwdChangeIndicator?: string;
-    accountPwdChangeDate?: string;
-    shippingAddressUsageIndicator?: string;
-    shippingAddressUsageDate?: string;
-    transactionCountDay?: string;
-    transactionCountYear?: string;
-    addCardAttempts?: string;
-    accountPurchases?: string;
-    fraudActivity?: string;
-    shippingNameIndicator?: string;
-    paymentAccountIndicator?: string;
-    paymentAccountAge?: string;
-    acsWindowSize?: string;
-    sdkMaxTimeout?: string;
-    addressMatch?: string;
-    accountId?: string;
-    ipAddress?: string;
-    orderDescription?: string;
-    taxAmount?: string;
-    userAgent?: string;
-    authenticationIndicator?: string;
-    installment?: string;
-    purchaseDate?: string;
-    recurringEnd?: string;
-    recurringFrequency?: string;
+    workPhoneNumber?: string | undefined;
+    shippingGivenName?: string | undefined;
+    shippingSurname?: string | undefined;
+    shippingAddress?: ThreeDSecureShippingAddress | undefined;
+    streetAddress?: string | undefined;
+    extendedAddress?: string | undefined;
+    line3?: string | undefined;
+    locality?: string | undefined;
+    region?: string | undefined;
+    postalCode?: string | undefined;
+    countryCodeAlpha2?: string | undefined;
+    shippingPhone?: string | undefined;
+    shippingMethod?: string | undefined;
+    shippingMethodIndicator?: string | undefined;
+    productCode?: string | undefined;
+    deliveryTimeframe?: string | undefined;
+    deliveryEmail?: string | undefined;
+    reorderindicator?: string | undefined;
+    preorderIndicator?: string | undefined;
+    preorderDate?: string | undefined;
+    giftCardAmount?: string | undefined;
+    giftCardCurrencyCode?: string | undefined;
+    giftCardCount?: string | undefined;
+    accountAgeIndicator?: string | undefined;
+    accountCreateDate?: string | undefined;
+    accountChangeIndicator?: string | undefined;
+    accountChangeDate?: string | undefined;
+    accountPwdChangeIndicator?: string | undefined;
+    accountPwdChangeDate?: string | undefined;
+    shippingAddressUsageIndicator?: string | undefined;
+    shippingAddressUsageDate?: string | undefined;
+    transactionCountDay?: string | undefined;
+    transactionCountYear?: string | undefined;
+    addCardAttempts?: string | undefined;
+    accountPurchases?: string | undefined;
+    fraudActivity?: string | undefined;
+    shippingNameIndicator?: string | undefined;
+    paymentAccountIndicator?: string | undefined;
+    paymentAccountAge?: string | undefined;
+    acsWindowSize?: string | undefined;
+    sdkMaxTimeout?: string | undefined;
+    addressMatch?: string | undefined;
+    accountId?: string | undefined;
+    ipAddress?: string | undefined;
+    orderDescription?: string | undefined;
+    taxAmount?: string | undefined;
+    userAgent?: string | undefined;
+    authenticationIndicator?: string | undefined;
+    installment?: string | undefined;
+    purchaseDate?: string | undefined;
+    recurringEnd?: string | undefined;
+    recurringFrequency?: string | undefined;
 }
 
 export interface ThreeDSecureVerifyOptions {
     nonce: string;
     amount: number;
     bin: string;
-    challengeRequested?: boolean;
-    exemptionRequested?: boolean;
-    email?: string;
-    mobilePhoneNumber?: string;
-    billingAddress?: ThreeDSecureBillingAddress;
-    additionalInformation?: ThreeDSecureAdditionalInformation;
-    addFrame?: (err?: BraintreeError, iframe?: HTMLIFrameElement) => void;
-    removeFrame?: () => void;
+    challengeRequested?: boolean | undefined;
+    exemptionRequested?: boolean | undefined;
+    email?: string | undefined;
+    mobilePhoneNumber?: string | undefined;
+    billingAddress?: ThreeDSecureBillingAddress | undefined;
+    additionalInformation?: ThreeDSecureAdditionalInformation | undefined;
+    addFrame?: ((err?: BraintreeError, iframe?: HTMLIFrameElement) => void) | undefined;
+    removeFrame?: (() => void) | undefined;
 }
 
 export interface ThreeDSecure {
@@ -113,15 +113,15 @@ export interface ThreeDSecure {
      * }, callback);
      */
     create(options: {
-        authorization?: string;
-        version?: 1 | '1' | 2 | '2' | '2-bootstrap3-modal' | '2-inline-iframe';
-        client?: Client;
+        authorization?: string | undefined;
+        version?: 1 | '1' | 2 | '2' | '2-bootstrap3-modal' | '2-inline-iframe' | undefined;
+        client?: Client | undefined;
     }): Promise<ThreeDSecure>;
     create(
         options: {
-            authorization?: string;
-            version?: 1 | '1' | 2 | '2' | '2-bootstrap3-modal' | '2-inline-iframe';
-            client?: Client;
+            authorization?: string | undefined;
+            version?: 1 | '1' | 2 | '2' | '2-bootstrap3-modal' | '2-inline-iframe' | undefined;
+            client?: Client | undefined;
         },
         callback: callback,
     ): void;

--- a/types/braintree-web/modules/vault-manager.d.ts
+++ b/types/braintree-web/modules/vault-manager.d.ts
@@ -12,8 +12,8 @@ import { VenmoAccountDetails } from './venmo';
  * @see https://braintree.github.io/braintree-web/3.75.0/module-braintree-web_vault-manager.html
  */
 export class VaultManager {
-    static create(options: { client?: Client; authorization?: string; }): Promise<VaultManager>;
-    static create(options: { client?: Client; authorization?: string; }, callback: callback<VaultManager>): void;
+    static create(options: { client?: Client | undefined; authorization?: string | undefined; }): Promise<VaultManager>;
+    static create(options: { client?: Client | undefined; authorization?: string | undefined; }, callback: callback<VaultManager>): void;
 
     /**
      * Fetches payment methods owned by the customer whose id was used to generate the client token used to create the client.
@@ -38,8 +38,8 @@ export class VaultManager {
 export interface FetchPaymentMethodsPayload {
     nonce: string;
     default: boolean;
-    details?: HostedFieldsAccountDetails | ThreeDSecureAccountDetails | GooglePaymentDetails | PayPalAccountDetails | UnionPayAccountDetails | VenmoAccountDetails | Record<string, any>;
+    details?: HostedFieldsAccountDetails | ThreeDSecureAccountDetails | GooglePaymentDetails | PayPalAccountDetails | UnionPayAccountDetails | VenmoAccountDetails | Record<string, any> | undefined;
     type: string;
     description: string | null;
-    binData?: Record<string, any>;
+    binData?: Record<string, any> | undefined;
 }

--- a/types/braintree-web/modules/venmo.d.ts
+++ b/types/braintree-web/modules/venmo.d.ts
@@ -22,21 +22,21 @@ export interface Venmo {
      * });
      */
     create(options: {
-        client?: Client;
-        authorization?: string;
-        allowNewBrowserTab?: boolean;
-        ignoreHistoryChanges?: boolean;
-        profileId?: string;
-        deepLinkReturnUrl?: string;
+        client?: Client | undefined;
+        authorization?: string | undefined;
+        allowNewBrowserTab?: boolean | undefined;
+        ignoreHistoryChanges?: boolean | undefined;
+        profileId?: string | undefined;
+        deepLinkReturnUrl?: string | undefined;
     }): Promise<Venmo>;
     create(
         options: {
-            client?: Client;
-            authorization?: string;
-            allowNewBrowserTab?: boolean;
-            ignoreHistoryChanges?: boolean;
-            profileId?: string;
-            deepLinkReturnUrl?: string;
+            client?: Client | undefined;
+            authorization?: string | undefined;
+            allowNewBrowserTab?: boolean | undefined;
+            ignoreHistoryChanges?: boolean | undefined;
+            profileId?: string | undefined;
+            deepLinkReturnUrl?: string | undefined;
         },
         callback?: callback,
     ): void;
@@ -95,9 +95,9 @@ export interface Venmo {
      *   });
      * });
      */
-    tokenize(options?: { processResultsDelay?: number }): Promise<VenmoTokenizePayload>;
+    tokenize(options?: { processResultsDelay?: number | undefined }): Promise<VenmoTokenizePayload>;
     tokenize(
-        options?: { processResultsDelay?: number },
+        options?: { processResultsDelay?: number | undefined },
         callback?: (error?: BraintreeError, payload?: VenmoTokenizePayload) => void,
     ): void;
 

--- a/types/browser-resolve/index.d.ts
+++ b/types/browser-resolve/index.d.ts
@@ -28,29 +28,29 @@ declare namespace resolve {
         /**
          * directory to begin resolving from
          */
-        basedir?: string;
+        basedir?: string | undefined;
         /**
          * the 'browser' property to use from package.json
          * @default 'browser'
          */
-        browser?: string;
+        browser?: string | undefined;
         /**
          * the calling filename where the require() call originated (in the source)
          */
-        filename?: string;
+        filename?: string | undefined;
         /**
          * modules object with id to path mappings to consult before doing manual resolution
          * (use to provide core modules)
          */
-        modules?: { [id: string]: string };
+        modules?: { [id: string]: string } | undefined;
         /**
          * transform the parsed package.json contents before looking at the main field
          */
-        packageFilter?: (info: any, pkgdir: string) => any;
+        packageFilter?: ((info: any, pkgdir: string) => any) | undefined;
         /**
          * require.paths array to use if nothing is found on the normal node_modules recursive walk
          */
-        paths?: string[];
+        paths?: string[] | undefined;
     }
 
     type AsyncOpts = resv.AsyncOpts & Opts;

--- a/types/browser-sync/index.d.ts
+++ b/types/browser-sync/index.d.ts
@@ -27,44 +27,44 @@ declare namespace browserSync {
          * weinre.port - Default: 8080
          * Note: Requires at least version 2.0.0.
          */
-        ui?: UIOptions | boolean;
+        ui?: UIOptions | boolean | undefined;
         /**
          * Browsersync can watch your files as you work. Changes you make will either be injected into the page (CSS
          * & images) or will cause all browsers to do a full-page refresh. See anymatch for more information on glob
          * patterns.
          * Default: false
          */
-        files?: string | (string | FileCallback | object)[];
+        files?: string | (string | FileCallback | object)[] | undefined;
         /**
          * Specify which file events to respond to.
          * Available events: `add`, `change`, `unlink`, `addDir`, `unlinkDir`
          */
-        watchEvents?: WatchEvents | string[];
+        watchEvents?: WatchEvents | string[] | undefined;
         /**
          * Watch files automatically.
          */
-        watch?: boolean;
+        watch?: boolean | undefined;
         /**
          * Patterns for any watchers to ignore.
          * Anything provided here will end up inside 'watchOptions.ignored'.
          */
-        ignore?: string[];
+        ignore?: string[] | undefined;
         /**
          * Serve an index.html file for all non-asset routes.
          * Useful when using client-routers.
          */
-        single?: boolean;
+        single?: boolean | undefined;
         /**
          * File watching options that get passed along to Chokidar. Check their docs for available options
          * Default: undefined
          * Note: Requires at least version 2.6.0.
          */
-        watchOptions?: chokidar.WatchOptions;
+        watchOptions?: chokidar.WatchOptions | undefined;
         /**
          * Use the built-in static server for basic HTML/JS/CSS websites.
          * Default: false
          */
-        server?: string | boolean | string[] | ServerOptions;
+        server?: string | boolean | string[] | ServerOptions | undefined;
         /**
          * Proxy an EXISTING vhost. Browsersync will wrap your vhost with a proxy URL to view your site.
          * Passing only a URL as a string equates to passing only target property of ProxyOptions type.
@@ -75,151 +75,151 @@ declare namespace browserSync {
          * proxyRes - Default: undefined (http.ServerResponse if expecting single parameter)
          * proxyReq - Default: undefined
          */
-        proxy?: string | ProxyOptions;
+        proxy?: string | ProxyOptions | undefined;
         /**
          * Use a specific port (instead of the one auto-detected by Browsersync)
          * Default: 3000
          */
-        port?: number;
+        port?: number | undefined;
         /**
          * Functions or actual plugins used as middleware.
          */
-        middleware?: MiddlewareHandler | PerRouteMiddleware | (MiddlewareHandler | PerRouteMiddleware)[];
+        middleware?: MiddlewareHandler | PerRouteMiddleware | (MiddlewareHandler | PerRouteMiddleware)[] | undefined;
         /**
          * Add additional directories from which static files should be served.
          * Should only be used in proxy or snippet mode.
          * Default: []
          * Note: Requires at least version 2.8.0.
          */
-        serveStatic?: StaticOptions[] | string[];
+        serveStatic?: StaticOptions[] | string[] | undefined;
         /**
          * Options that are passed to the serve-static middleware when you use the
          * string[] syntax: eg: `serveStatic: ['./app']`.
          * Please see [serve-static](https://github.com/expressjs/serve-static) for details.
          */
-        serveStaticOptions?: ServeStaticOptions;
+        serveStaticOptions?: ServeStaticOptions | undefined;
         /**
          * Enable https for localhost development.
          * Note: This may not be needed for proxy option as it will try to infer from your target url.
          * Note: If privacy error is encountered please see HttpsOptions below, setting those will resolve.
          * Note: Requires at least version 1.3.0.
          */
-        https?: boolean | HttpsOptions;
+        https?: boolean | HttpsOptions | undefined;
         /**
          * Override http module to allow using 3rd party server modules (such as http2).
          */
-        httpModule?: string;
+        httpModule?: string | undefined;
         /**
          * Clicks, Scrolls & Form inputs on any device will be mirrored to all others.
          * clicks - Default: true
          * scroll - Default: true
          * forms - Default: true
          */
-        ghostMode?: GhostOptions | boolean;
+        ghostMode?: GhostOptions | boolean | undefined;
         /**
          * Can be either "info", "debug", "warn", or "silent"
          * Default: info
          */
-        logLevel?: LogLevel;
+        logLevel?: LogLevel | undefined;
         /**
          * Change the console logging prefix. Useful if you're creating your own project based on Browsersync
          * Default: BS
          * Note: Requires at least version 1.5.1.
          */
-        logPrefix?: string;
+        logPrefix?: string | undefined;
         /**
          * Whether or not to log connections
          * Default: false
          */
-        logConnections?: boolean;
+        logConnections?: boolean | undefined;
         /**
          * Whether or not to log information about changed files
          * Default: false
          */
-        logFileChanges?: boolean;
+        logFileChanges?: boolean | undefined;
         /**
          * Log the snippet to the console when you're in snippet mode (no proxy/server)
          * Default: true
          * Note: Requires at least version 1.5.2.
          */
-        logSnippet?: boolean;
+        logSnippet?: boolean | undefined;
         /**
          * You can control how the snippet is injected onto each page via a custom regex + function.
          * You can also provide patterns for certain urls that should be ignored from the snippet injection.
          * Note: Requires at least version 2.0.0.
          */
-        snippetOptions?: SnippetOptions;
+        snippetOptions?: SnippetOptions | undefined;
         /**
          * Add additional HTML rewriting rules.
          * Default: false
          * Note: Requires at least version 2.4.0.
          */
-        rewriteRules?: boolean | RewriteRules[];
+        rewriteRules?: boolean | RewriteRules[] | undefined;
         /**
          * Tunnel the Browsersync server through a random Public URL
          * Default: null
          */
-        tunnel?: string | boolean;
+        tunnel?: string | boolean | undefined;
         /**
          * Some features of Browsersync (such as xip & tunnel) require an internet connection, but if you're
          * working offline, you can reduce start-up time by setting this option to false
          */
-        online?: boolean;
+        online?: boolean | undefined;
         /**
          * Default: true
          * Decide which URL to open automatically when Browsersync starts. Defaults to "local" if none set.
          * Can be true, local, external, ui, ui-external, tunnel or false
          */
-        open?: OpenOptions | boolean;
+        open?: OpenOptions | boolean | undefined;
         /**
          * The browser(s) to open
          * Default: default
          */
-        browser?: string | string[];
+        browser?: string | string[] | undefined;
         /**
          * Add HTTP access control (CORS) headers to assets served by Browsersync.
          * Default: false
          * Note: Requires at least version 2.16.0.
          */
-        cors?: boolean;
+        cors?: boolean | undefined;
         /**
          * Requires an internet connection - useful for services such as Typekit as it allows you to configure
          * domains such as *.xip.io in your kit settings
          * Default: false
          */
-        xip?: boolean;
+        xip?: boolean | undefined;
         /**
          * Reload each browser when Browsersync is restarted.
          * Default: false
          */
-        reloadOnRestart?: boolean;
+        reloadOnRestart?: boolean | undefined;
         /**
          * The small pop-over notifications in the browser are not always needed/wanted.
          * Default: true
          */
-        notify?: boolean;
+        notify?: boolean | undefined;
         /**
          * scrollProportionally: false // Sync viewports to TOP position
          * Default: true
          */
-        scrollProportionally?: boolean;
+        scrollProportionally?: boolean | undefined;
         /**
          * How often to send scroll events
          * Default: 0
          */
-        scrollThrottle?: number;
+        scrollThrottle?: number | undefined;
         /**
          * Decide which technique should be used to restore scroll position following a reload.
          * Can be window.name or cookie
          * Default: 'window.name'
          */
-        scrollRestoreTechnique?: string;
+        scrollRestoreTechnique?: string | undefined;
         /**
          * Sync the scroll position of any element on the page. Add any amount of CSS selectors
          * Default: []
          * Note: Requires at least version 2.9.0.
          */
-        scrollElements?: string[];
+        scrollElements?: string[] | undefined;
         /**
          * Default: []
          * Note: Requires at least version 2.9.0.
@@ -227,74 +227,74 @@ declare namespace browserSync {
          * all others to match scroll position. This is helpful when a breakpoint alters which element
          * is actually scrolling
          */
-        scrollElementMapping?: string[];
+        scrollElementMapping?: string[] | undefined;
         /**
          * Time, in milliseconds, to wait before instructing the browser to reload/inject following a file
          * change event
          * Default: 0
          */
-        reloadDelay?: number;
+        reloadDelay?: number | undefined;
         /**
          * Restrict the frequency in which browser:reload events can be emitted to connected clients
          * Default: 0
          * Note: Requires at least version 2.6.0.
          */
-        reloadDebounce?: number;
+        reloadDebounce?: number | undefined;
         /**
          * Emit only the first event during sequential time windows of a specified duration.
          * Note: Requires at least version 2.13.0.
          */
-        reloadThrottle?: number;
+        reloadThrottle?: number | undefined;
         /**
          * User provided plugins
          * Default: []
          * Note: Requires at least version 2.6.0.
          */
-        plugins?: any[];
+        plugins?: any[] | undefined;
         /**
          * Whether to inject changes (rather than a page refresh)
          * Default: true
          */
-        injectChanges?: boolean;
+        injectChanges?: boolean | undefined;
         /**
          * The initial path to load
          */
-        startPath?: string;
+        startPath?: string | undefined;
         /**
          * Whether to minify the client script
          * Default: true
          */
-        minify?: boolean;
+        minify?: boolean | undefined;
         /**
          * Override host detection if you know the correct IP to use
          */
-        host?: string;
+        host?: string | undefined;
         /**
          * Support environments where dynamic hostnames are not required (ie: electron).
          */
-        localOnly?: boolean;
+        localOnly?: boolean | undefined;
         /**
          * Send file-change events to the browser
          * Default: true
          */
-        codeSync?: boolean;
+        codeSync?: boolean | undefined;
         /**
          * Append timestamps to injected files
          * Default: true
          */
-        timestamps?: boolean;
+        timestamps?: boolean | undefined;
         /**
          * ¯\_(ツ)_/¯
          * Best guess, when ghostMode (or SocketIO?) is setup the events
          * listed here will be emitted and able to hook into.
          */
-        clientEvents?: string[];
+        clientEvents?: string[] | undefined;
         /**
          * Alter the script path for complete control over where the Browsersync Javascript is served
          * from. Whatever you return from this function will be used as the script path.
          * Note: Requires at least version 1.5.0.
          */
-        scriptPath?: (path: string) => string;
+        scriptPath?: ((path: string) => string) | undefined;
         /**
          * Configure the Socket.IO path and namespace & domain to avoid collisions.
          * path - Default: "/browser-sync/socket.io"
@@ -305,19 +305,19 @@ declare namespace browserSync {
          * clients.heartbeatTimeout - Default: 5000
          * Note: Requires at least version 1.6.2.
          */
-        socket?: SocketOptions;
+        socket?: SocketOptions | undefined;
         /**
          * ¯\_(ツ)_/¯
          */
-        tagNames?: TagNamesOptions;
+        tagNames?: TagNamesOptions | undefined;
         /**
          * ¯\_(ツ)_/¯
          */
-        injectFileTypes?: string[];
+        injectFileTypes?: string[] | undefined;
         /**
          * ¯\_(ツ)_/¯
          */
-        excludeFileTypes?: string[];
+        excludeFileTypes?: string[] | undefined;
     }
 
     type WatchEvents = "add" | "change" | "unlink" | "addDir" | "unlinkDir";
@@ -332,44 +332,44 @@ declare namespace browserSync {
 
     interface UIOptions {
         /** set the default port */
-        port?: number;
+        port?: number | undefined;
         /** set the default weinre port */
         weinre?: {
-            port?: number;
-        };
+            port?: number | undefined;
+        } | undefined;
     }
 
     interface FileCallback {
-        match?: string | string[];
+        match?: string | string[] | undefined;
         fn: (event: string, file: string) => any;
-        options?: chokidar.WatchOptions;
+        options?: chokidar.WatchOptions | undefined;
     }
 
     interface ServerOptions {
         /** set base directory */
-        baseDir?: string | string[];
+        baseDir?: string | string[] | undefined;
         /** enable directory listing */
-        directory?: boolean;
+        directory?: boolean | undefined;
         /** set index filename */
-        index?: string;
+        index?: string | undefined;
         /**
          * key-value object hash, where the key is the url to match,
          * and the value is the folder to serve (relative to your working directory)
          */
-        routes?: Hash<string>;
+        routes?: Hash<string> | undefined;
         /** configure custom middleware */
-        middleware?: (MiddlewareHandler | PerRouteMiddleware)[];
-        serveStaticOptions?: ServeStaticOptions;
+        middleware?: (MiddlewareHandler | PerRouteMiddleware)[] | undefined;
+        serveStaticOptions?: ServeStaticOptions | undefined;
     }
 
     interface ProxyOptions {
-        target?: string;
-        middleware?: MiddlewareHandler;
-        ws?: boolean;
-        reqHeaders?: (config: object) => Hash<object>;
-        proxyRes?: ProxyResponseMiddleware | ProxyResponseMiddleware[];
-        proxyReq?: ((res: http.IncomingMessage) => void)[] | ((res: http.IncomingMessage) => void);
-        error?: (err: NodeJS.ErrnoException, req: http.IncomingMessage, res: http.ServerResponse) => void;
+        target?: string | undefined;
+        middleware?: MiddlewareHandler | undefined;
+        ws?: boolean | undefined;
+        reqHeaders?: ((config: object) => Hash<object>) | undefined;
+        proxyRes?: ProxyResponseMiddleware | ProxyResponseMiddleware[] | undefined;
+        proxyReq?: ((res: http.IncomingMessage) => void)[] | ((res: http.IncomingMessage) => void) | undefined;
+        error?: ((err: NodeJS.ErrnoException, req: http.IncomingMessage, res: http.ServerResponse) => void) | undefined;
     }
 
     interface ProxyResponseMiddleware {
@@ -377,8 +377,8 @@ declare namespace browserSync {
     }
 
     interface HttpsOptions {
-        key?: string;
-        cert?: string;
+        key?: string | undefined;
+        cert?: string | undefined;
     }
 
     interface StaticOptions {
@@ -391,15 +391,15 @@ declare namespace browserSync {
     }
 
     interface PerRouteMiddleware {
-        id?: string;
+        id?: string | undefined;
         route: string;
         handle: MiddlewareHandler;
     }
 
     interface GhostOptions {
-        clicks?: boolean;
-        scroll?: boolean;
-        forms?: FormsOptions | boolean;
+        clicks?: boolean | undefined;
+        scroll?: boolean | undefined;
+        forms?: FormsOptions | boolean | undefined;
     }
 
     interface FormsOptions {
@@ -409,45 +409,45 @@ declare namespace browserSync {
     }
 
     interface SnippetOptions {
-        async?: boolean;
-        whitelist?: string[],
-        blacklist?: string[],
+        async?: boolean | undefined;
+        whitelist?: string[] | undefined,
+        blacklist?: string[] | undefined,
         rule?: {
-            match?: RegExp;
-            fn?: (snippet: string, match: string) => any
-        };
+            match?: RegExp | undefined;
+            fn?: ((snippet: string, match: string) => any) | undefined
+        } | undefined;
     }
 
     interface SocketOptions {
-        path?: string;
-        clientPath?: string;
-        namespace?: string;
-        domain?: string;
-        port?: number;
-        clients?: { heartbeatTimeout?: number; };
+        path?: string | undefined;
+        clientPath?: string | undefined;
+        namespace?: string | undefined;
+        domain?: string | undefined;
+        port?: number | undefined;
+        clients?: { heartbeatTimeout?: number | undefined; } | undefined;
     }
 
     interface TagNamesOptions {
-        less?: string;
-        scss?: string;
-        css?: string;
-        jpg?: string;
-        jpeg?: string;
-        png?: string;
-        svg?: string;
-        gif?: string;
-        js?: string;
+        less?: string | undefined;
+        scss?: string | undefined;
+        css?: string | undefined;
+        jpg?: string | undefined;
+        jpeg?: string | undefined;
+        png?: string | undefined;
+        svg?: string | undefined;
+        gif?: string | undefined;
+        js?: string | undefined;
     }
 
     interface RewriteRules {
         match: RegExp;
-        replace?: string;
-        fn?: (req: http.IncomingMessage, res: http.ServerResponse, match: string) => string;
+        replace?: string | undefined;
+        fn?: ((req: http.IncomingMessage, res: http.ServerResponse, match: string) => string) | undefined;
     }
 
     interface StreamOptions {
-        once?: boolean;
-        match?: mm.Pattern | mm.Pattern[];
+        once?: boolean | undefined;
+        match?: mm.Pattern | mm.Pattern[] | undefined;
     }
 
     interface BrowserSyncStatic extends BrowserSyncInstance {
@@ -550,7 +550,7 @@ declare namespace browserSync {
          * @param {object} options The
          * @param {any} cb A callback function that will return any errors.
          */
-        use(module: { "plugin:name"?: string, plugin: (opts: object, bs: BrowserSyncInstance) => any }, options?: object, cb?: any): void;
+        use(module: { "plugin:name"?: string | undefined, plugin: (opts: object, bs: BrowserSyncInstance) => any }, options?: object, cb?: any): void;
         /**
          * Callback helper to examine what options have been set.
          * @param {string} name The key to search options map for.

--- a/types/bser/index.d.ts
+++ b/types/bser/index.d.ts
@@ -62,7 +62,7 @@ export class BunserBuf extends EventEmitter {
     buf: Accumulator;
     state: 0 | 1;
     // replace "IntWrapper" with "number"?
-    pduLen?: false | IntWrapper;
+    pduLen?: false | IntWrapper | undefined;
 
     constructor();
 

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -10,49 +10,49 @@
 
 interface CommonSerializeOptions {
     /** {default:false}, the serializer will check if keys are valid. */
-    checkKeys?: boolean;
+    checkKeys?: boolean | undefined;
     /** {default:false}, serialize the javascript functions. */
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     /** {default:true}, ignore undefined fields. */
-    ignoreUndefined?: boolean;
+    ignoreUndefined?: boolean | undefined;
 }
 
 export interface SerializeOptions extends CommonSerializeOptions {
     /** {default:1024*1024*17}, minimum size of the internal temporary serialization buffer. */
-    minInternalBufferSize?: number;
+    minInternalBufferSize?: number | undefined;
 }
 
 export interface SerializeWithBufferAndIndexOptions extends CommonSerializeOptions {
     /** {default:0}, the index in the buffer where we wish to start serializing into. */
-    index?: number;
+    index?: number | undefined;
 }
 
 export interface DeserializeOptions {
     /** {default:false}, evaluate functions in the BSON document scoped to the object deserialized. */
-    evalFunctions?: boolean;
+    evalFunctions?: boolean | undefined;
     /** {default:false}, cache evaluated functions for reuse. */
-    cacheFunctions?: boolean;
+    cacheFunctions?: boolean | undefined;
     /** {default:false}, use a crc32 code for caching, otherwise use the string of the function. */
-    cacheFunctionsCrc32?: boolean;
+    cacheFunctionsCrc32?: boolean | undefined;
     /** {default:true}, when deserializing a Long will fit it into a Number if it's smaller than 53 bits. */
-    promoteLongs?: boolean;
+    promoteLongs?: boolean | undefined;
     /** {default:false}, deserialize Binary data directly into node.js Buffer object. */
-    promoteBuffers?: boolean;
+    promoteBuffers?: boolean | undefined;
     /** {default:false}, when deserializing will promote BSON values to their Node.js closest equivalent types. */
-    promoteValues?: boolean;
+    promoteValues?: boolean | undefined;
     /** {default:null}, allow to specify if there what fields we wish to return as unserialized raw buffer. */
-    fieldsAsRaw?: { readonly [fieldName: string]: boolean };
+    fieldsAsRaw?: { readonly [fieldName: string]: boolean } | undefined;
     /** {default:false}, return BSON regular expressions as BSONRegExp instances. */
-    bsonRegExp?: boolean;
+    bsonRegExp?: boolean | undefined;
     /** {default:false}, allows the buffer to be larger than the parsed BSON object. */
-    allowObjectSmallerThanBufferSize?: boolean;
+    allowObjectSmallerThanBufferSize?: boolean | undefined;
 }
 
 export interface CalculateObjectSizeOptions {
     /** {default:false}, serialize the javascript functions */
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     /** {default:true}, ignore undefined fields. */
-    ignoreUndefined?: boolean;
+    ignoreUndefined?: boolean | undefined;
 }
 
 
@@ -133,7 +133,7 @@ export class Binary {
     /** The underlying Buffer which stores the binary data. */
     readonly buffer: Buffer;
     /** Binary data subtype */
-    readonly sub_type?: number;
+    readonly sub_type?: number | undefined;
 
     /** The length of the binary. */
     length(): number;
@@ -173,7 +173,7 @@ export class DBRef {
     constructor(namespace: string, oid: ObjectId, db?: string);
     namespace: string;
     oid: ObjectId;
-    db?: string;
+    db?: string | undefined;
 }
 
 /** A class representation of the BSON Double type. */
@@ -364,7 +364,7 @@ export class ObjectId {
     /** The generation time of this ObjectId instance */
     generationTime: number;
     /** If true cache the hex string representation of ObjectId */
-    static cacheHexString?: boolean;
+    static cacheHexString?: boolean | undefined;
     /**
      * Creates an ObjectId from a hex string representation of an ObjectId.
      * @param {string} hexString create a ObjectId from a passed in 24 byte hexstring.
@@ -489,7 +489,7 @@ export namespace EJSON {
      * // prints { int32: 10 }
      * console.log(EJSON.parse(text));
      */
-    export function parse(text: string, options?: {relaxed?: boolean;}): {};
+    export function parse(text: string, options?: {relaxed?: boolean | undefined;}): {};
 
     /**
      * Deserializes an Extended JSON object into a plain JavaScript object with native/BSON types
@@ -499,7 +499,7 @@ export namespace EJSON {
      * @param {object} [options] Optional settings passed to the parse method
      * @return {object}
      */
-    export function deserialize(ejson: {}, options?: {relaxed?: boolean;}): {};
+    export function deserialize(ejson: {}, options?: {relaxed?: boolean | undefined;}): {};
 
     /**
      * Serializes an object to an Extended JSON string, and reparse it as a JavaScript object.
@@ -509,7 +509,7 @@ export namespace EJSON {
      * @param {object} [options] Optional settings passed to the `stringify` function
      * @return {object}
      */
-    export function serialize(bson: {}, options?: {relaxed?: boolean;}): {};
+    export function serialize(bson: {}, options?: {relaxed?: boolean | undefined;}): {};
 
     /**
      * Converts a BSON document to an Extended JSON string, optionally replacing values if a replacer
@@ -536,7 +536,7 @@ export namespace EJSON {
      */
     export function stringify(
         value: {},
-        options?: {relaxed?: boolean;}
+        options?: {relaxed?: boolean | undefined;}
     ): string;
 
     /**
@@ -566,7 +566,7 @@ export namespace EJSON {
     export function stringify(
         value: {},
         replacer: ((key: string, value: any) => any) | Array<string|number> | null | undefined,
-        options?: {relaxed?: boolean;}
+        options?: {relaxed?: boolean | undefined;}
     ): string;
     /**
      * Converts a BSON document to an Extended JSON string, optionally replacing values if a replacer
@@ -595,6 +595,6 @@ export namespace EJSON {
         value: {},
         replacer: ((key: string, value: any) => any) | Array<string | number> | null | undefined,
         indents?: string | number,
-        options?: {relaxed?: boolean;}
+        options?: {relaxed?: boolean | undefined;}
         ): string;
 }

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -45,16 +45,16 @@ declare namespace Bull {
     /** Per duration in milliseconds */
     duration: number;
     /** When jobs get rate limited, they stay in the waiting queue and are not moved to the delayed queue */
-    bounceBack?: boolean;
+    bounceBack?: boolean | undefined;
     /** Groups jobs with the specified key from the data object passed to the Queue#add ex. "network.handle" */
-    groupKey?: string;
+    groupKey?: string | undefined;
   }
 
   interface QueueOptions {
     /**
      * Options passed directly to the `ioredis` constructor
      */
-    redis?: Redis.RedisOptions | string;
+    redis?: Redis.RedisOptions | string | undefined;
 
     /**
      * When specified, the `Queue` will use this function to create new `ioredis` client connections.
@@ -65,58 +65,58 @@ declare namespace Bull {
     /**
      * Prefix to use for all redis keys
      */
-    prefix?: string;
+    prefix?: string | undefined;
 
-    settings?: AdvancedSettings;
+    settings?: AdvancedSettings | undefined;
 
-    limiter?: RateLimiter;
+    limiter?: RateLimiter | undefined;
 
-    defaultJobOptions?: JobOptions;
+    defaultJobOptions?: JobOptions | undefined;
   }
 
   interface AdvancedSettings {
     /**
      * Key expiration time for job locks
      */
-    lockDuration?: number;
+    lockDuration?: number | undefined;
 
     /**
      * Interval in milliseconds on which to acquire the job lock.
      */
-    lockRenewTime?: number;
+    lockRenewTime?: number | undefined;
 
     /**
      * How often check for stalled jobs (use 0 for never checking)
      */
-    stalledInterval?: number;
+    stalledInterval?: number | undefined;
 
     /**
      * Max amount of times a stalled job will be re-processed
      */
-    maxStalledCount?: number;
+    maxStalledCount?: number | undefined;
 
     /**
      * Poll interval for delayed jobs and added jobs
      */
-    guardInterval?: number;
+    guardInterval?: number | undefined;
 
     /**
      * Delay before processing next job in case of internal error
      */
-    retryProcessDelay?: number;
+    retryProcessDelay?: number | undefined;
 
     /**
      * Define a custom backoff strategy
      */
     backoffStrategies?: {
       [key: string]: (attemptsMade: number, err: Error) => number;
-    };
+    } | undefined;
 
     /**
      * A timeout for when the queue is in `drained` state (empty waiting for jobs).
      * It is used when calling `queue.getNextJob()`, which will pass it to `.brpoplpush` on the Redis client.
      */
-    drainDelay?: number;
+    drainDelay?: number | undefined;
   }
 
   type DoneCallback = (error?: Error | null, value?: any) => void;
@@ -147,12 +147,12 @@ declare namespace Bull {
     /**
      * When this job was started (unix milliseconds)
      */
-    processedOn?: number;
+    processedOn?: number | undefined;
 
     /**
      * When this job was completed (unix milliseconds)
      */
-    finishedOn?: number;
+    finishedOn?: number | undefined;
 
     /**
      * Which queue this job was part of
@@ -173,7 +173,7 @@ declare namespace Bull {
 
     returnvalue: any;
 
-    failedReason?: string;
+    failedReason?: string | undefined;
 
     /**
      * Get progress on a job
@@ -328,24 +328,24 @@ declare namespace Bull {
     /**
      * Backoff delay, in milliseconds
      */
-    delay?: number;
+    delay?: number | undefined;
   }
 
   interface RepeatOptions {
     /**
      * Timezone
      */
-    tz?: string;
+    tz?: string | undefined;
 
     /**
      * End date when the repeat job should stop repeating
      */
-    endDate?: Date | string | number;
+    endDate?: Date | string | number | undefined;
 
     /**
      * Number of times the job should repeat at max.
      */
-    limit?: number;
+    limit?: number | undefined;
   }
 
   interface CronRepeatOptions extends RepeatOptions {
@@ -357,7 +357,7 @@ declare namespace Bull {
     /**
      * Start date when the repeat job should start repeating (only with cron).
      */
-    startDate?: Date | string | number;
+    startDate?: Date | string | number | undefined;
   }
 
   interface EveryRepeatOptions extends RepeatOptions {
@@ -372,39 +372,39 @@ declare namespace Bull {
      * Optional priority value. ranges from 1 (highest priority) to MAX_INT  (lowest priority).
      * Note that using priorities has a slight impact on performance, so do not use it if not required
      */
-    priority?: number;
+    priority?: number | undefined;
 
     /**
      * An amount of miliseconds to wait until this job can be processed.
      * Note that for accurate delays, both server and clients should have their clocks synchronized. [optional]
      */
-    delay?: number;
+    delay?: number | undefined;
 
     /**
      * The total number of attempts to try the job until it completes
      */
-    attempts?: number;
+    attempts?: number | undefined;
 
     /**
      * Repeat job according to a cron specification
      */
-    repeat?: CronRepeatOptions | EveryRepeatOptions;
+    repeat?: CronRepeatOptions | EveryRepeatOptions | undefined;
 
     /**
      * Backoff setting for automatic retries if the job fails
      */
-    backoff?: number | BackoffOptions;
+    backoff?: number | BackoffOptions | undefined;
 
     /**
      * A boolean which, if true, adds the job to the right
      * of the queue instead of the left (default false)
      */
-    lifo?: boolean;
+    lifo?: boolean | undefined;
 
     /**
      *  The number of milliseconds after which the job should be fail with a timeout error
      */
-    timeout?: number;
+    timeout?: number | undefined;
 
     /**
      * Override the job ID - by default, the job ID is a unique
@@ -413,31 +413,31 @@ declare namespace Bull {
      * jobId is unique. If you attempt to add a job with an id that
      * already exists, it will not be added.
      */
-    jobId?: JobId;
+    jobId?: JobId | undefined;
 
     /**
      * A boolean which, if true, removes the job when it successfully completes.
      * When a number, it specifies the amount of jobs to keep.
      * Default behavior is to keep the job in the failed set.
      */
-    removeOnComplete?: boolean | number;
+    removeOnComplete?: boolean | number | undefined;
 
     /**
      * A boolean which, if true, removes the job when it fails after all attempts.
      * When a number, it specifies the amount of jobs to keep.
      * Default behavior is to keep the job in the completed set.
      */
-    removeOnFail?: boolean | number;
+    removeOnFail?: boolean | number | undefined;
 
     /**
      * Limits the amount of stack trace lines that will be recorded in the stacktrace.
      */
-    stackTraceLimit?: number;
+    stackTraceLimit?: number | undefined;
 
     /**
      * Prevents JSON data from being parsed.
      */
-    preventParsingData?: boolean;
+    preventParsingData?: boolean | undefined;
   }
 
   interface JobCounts {
@@ -451,9 +451,9 @@ declare namespace Bull {
   interface JobInformation {
     key: string;
     name: string;
-    id?: string;
-    endDate?: number;
-    tz?: string;
+    id?: string | undefined;
+    endDate?: number | undefined;
+    tz?: string | undefined;
     cron: string;
     every: number;
     next: number;
@@ -590,7 +590,7 @@ declare namespace Bull {
      * If the queue is empty the jobs will be executed directly,
      * otherwise they will be placed in the queue and executed as soon as possible.
      */
-    addBulk(jobs: Array<{name?: string, data: T, opts?: JobOptions}>): Promise<Array<Job<T>>>;
+    addBulk(jobs: Array<{name?: string | undefined, data: T, opts?: JobOptions | undefined}>): Promise<Array<Job<T>>>;
 
     /**
      * Returns a promise that resolves when the queue is paused.
@@ -689,7 +689,7 @@ declare namespace Bull {
      * Removes a given repeatable job. The RepeatOptions and JobId needs to be the same as the ones
      * used for the job when it was added.
      */
-    removeRepeatable(repeat: (CronRepeatOptions | EveryRepeatOptions) & { jobId?: JobId }): Promise<void>;
+    removeRepeatable(repeat: (CronRepeatOptions | EveryRepeatOptions) & { jobId?: JobId | undefined }): Promise<void>;
 
     /**
      * Removes a given repeatable job. The RepeatOptions and JobId needs to be the same as the ones
@@ -697,7 +697,7 @@ declare namespace Bull {
      *
      * name: The name of the to be removed job
      */
-    removeRepeatable(name: string, repeat: (CronRepeatOptions | EveryRepeatOptions) & { jobId?: JobId }): Promise<void>;
+    removeRepeatable(name: string, repeat: (CronRepeatOptions | EveryRepeatOptions) & { jobId?: JobId | undefined }): Promise<void>;
 
     /**
      * Removes a given repeatable job by key.

--- a/types/bull/v2/index.d.ts
+++ b/types/bull/v2/index.d.ts
@@ -92,28 +92,28 @@ declare module "bull" {
              * An amount of miliseconds to wait until this job can be processed.
              * Note that for accurate delays, both server and clients should have their clocks synchronized
              */
-            delay?: number;
+            delay?: number | undefined;
 
             /**
              * A number of attempts to retry if the job fails [optional]
              */
-            attempts?: number;
+            attempts?: number | undefined;
 
             /**
              * Backoff setting for automatic retries if the job fails
              */
-            backoff?: number | Backoff
+            backoff?: number | Backoff | undefined
 
             /**
              * A boolean which, if true, adds the job to the right
              * of the queue instead of the left (default false)
              */
-            lifo?: boolean;
+            lifo?: boolean | undefined;
 
             /**
              *  The number of milliseconds after which the job should be fail with a timeout error
              */
-            timeout?: number;
+            timeout?: number | undefined;
         }
 
         export interface Queue {
@@ -326,7 +326,7 @@ declare module "bull/lib/priority-queue" {
             /**
              * "low", "normal", "medium", "high", "critical"
              */
-            priority?: string;
+            priority?: string | undefined;
         }
 
 

--- a/types/bunyan/index.d.ts
+++ b/types/bunyan/index.d.ts
@@ -222,24 +222,24 @@ declare namespace Logger {
     function resolveLevel(value: LogLevel): number;
 
     interface Stream {
-        type?: string;
-        level?: LogLevel;
-        path?: string;
-        stream?: NodeJS.WritableStream | Stream;
-        closeOnExit?: boolean;
-        period?: string;
-        count?: number;
-        name?: string;
-        reemitErrorEvents?: boolean;
+        type?: string | undefined;
+        level?: LogLevel | undefined;
+        path?: string | undefined;
+        stream?: NodeJS.WritableStream | Stream | undefined;
+        closeOnExit?: boolean | undefined;
+        period?: string | undefined;
+        count?: number | undefined;
+        name?: string | undefined;
+        reemitErrorEvents?: boolean | undefined;
     }
 
     interface LoggerOptions {
         name: string;
-        streams?: Stream[];
-        level?: LogLevel;
-        stream?: NodeJS.WritableStream;
-        serializers?: Serializers;
-        src?: boolean;
+        streams?: Stream[] | undefined;
+        level?: LogLevel | undefined;
+        stream?: NodeJS.WritableStream | undefined;
+        serializers?: Serializers | undefined;
+        src?: boolean | undefined;
         [custom: string]: any;
     }
 
@@ -256,7 +256,7 @@ declare namespace Logger {
     }
 
     interface RingBufferOptions {
-        limit?: number;
+        limit?: number | undefined;
     }
 
     class RingBuffer extends EventEmitter {
@@ -273,8 +273,8 @@ declare namespace Logger {
 
     interface RotatingFileStreamOptions {
         path: string;
-        count?: number;
-        period?: string;
+        count?: number | undefined;
+        period?: string | undefined;
     }
 
     class RotatingFileStream extends EventEmitter {

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -11,19 +11,19 @@ declare namespace busboy {
 
     interface BusboyConfig {
         headers?: any;
-        highWaterMark?: number;
-        fileHwm?: number;
-        defCharset?: string;
-        preservePath?: boolean;
+        highWaterMark?: number | undefined;
+        fileHwm?: number | undefined;
+        defCharset?: string | undefined;
+        preservePath?: boolean | undefined;
         limits?: {
-            fieldNameSize?: number;
-            fieldSize?: number;
-            fields?: number;
-            fileSize?: number;
-            files?: number;
-            parts?: number;
-            headerPairs?: number;
-        };
+            fieldNameSize?: number | undefined;
+            fieldSize?: number | undefined;
+            fields?: number | undefined;
+            fileSize?: number | undefined;
+            files?: number | undefined;
+            parts?: number | undefined;
+            headerPairs?: number | undefined;
+        } | undefined;
     }
 
     interface Busboy extends NodeJS.WritableStream {

--- a/types/byline/index.d.ts
+++ b/types/byline/index.d.ts
@@ -13,7 +13,7 @@ declare function bl(stream: NodeJS.ReadableStream, options?: bl.LineStreamOption
 declare namespace bl {
 
     export interface LineStreamOptions extends stream.TransformOptions {
-        keepEmptyLines?: boolean;
+        keepEmptyLines?: boolean | undefined;
     }
 
     export interface LineStream extends stream.Transform {

--- a/types/bytes/index.d.ts
+++ b/types/bytes/index.d.ts
@@ -19,11 +19,11 @@ declare namespace bytes {
     type Unit = 'b' | 'gb' | 'kb' | 'mb' | 'pb' | 'tb' | 'B' | 'GB' | 'KB' | 'MB' | 'PB' | 'TB';
 
     interface BytesOptions {
-        decimalPlaces?: number;
-        fixedDecimals?: boolean;
-        thousandsSeparator?: string;
-        unit?: Unit;
-        unitSeparator?: string;
+        decimalPlaces?: number | undefined;
+        fixedDecimals?: boolean | undefined;
+        thousandsSeparator?: string | undefined;
+        unit?: Unit | undefined;
+        unitSeparator?: string | undefined;
     }
 
     /**

--- a/types/c3/index.d.ts
+++ b/types/c3/index.d.ts
@@ -45,15 +45,15 @@ export type YAxisType = "linear" | "time" | "timeseries" | "log";
 
 export interface SidePadding {
     /** Right padding. */
-    right?: number;
+    right?: number | undefined;
     /** Left padding. */
-    left?: number;
+    left?: number | undefined;
 }
 export interface Padding extends SidePadding {
     /** Top padding. */
-    top?: number;
+    top?: number | undefined;
     /** Bottom padding. */
-    bottom?: number;
+    bottom?: number | undefined;
 }
 
 export interface ChartConfiguration {
@@ -64,12 +64,12 @@ export interface ChartConfiguration {
      * Note: When chart is not binded, c3 starts observing if chart.element is binded by MutationObserver. In this case, polyfill is required in IE9 and IE10 becuase they do not support
      * MutationObserver. On the other hand, if chart always will be binded, polyfill will not be required because MutationObserver will never be called.
      */
-    bindto?: string | HTMLElement | d3.Selection<any, any, any, any> | null;
+    bindto?: string | HTMLElement | d3.Selection<any, any, any, any> | null | undefined;
 
     svg?: {
         /** Class to assign to the chart's container SVG element. */
-        classname?: string;
-    };
+        classname?: string | undefined;
+    } | undefined;
 
     size?: {
         /**
@@ -77,55 +77,55 @@ export interface ChartConfiguration {
          * If this option is not specified, the width of the chart will be calculated by the size of the parent element it's appended to.
          * Note: This option should be specified if possible because it can improve its performance because some size calculations will be skipped by an explicit value.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * The desired height of the chart element.
          * If this option is not specified, the height of the chart will be calculated by the size of the parent element it's appended to.
          */
-        height?: number;
-    };
+        height?: number | undefined;
+    } | undefined;
 
-    padding?: Padding;
+    padding?: Padding | undefined;
 
     resize?: {
         /**
          * Indicate if the chart should automatically get resized when the window gets resized.
          */
-        auto?: boolean;
-    };
+        auto?: boolean | undefined;
+    } | undefined;
 
     color?: {
         /**
          * Set custom color pattern. Order matches the order of the data.
          */
-        pattern?: string[];
+        pattern?: string[] | undefined;
         /**
          * **Experimental.**
          */
         threshold?: {
-            unit?: string;
-            values?: unknown[];
+            unit?: string | undefined;
+            values?: unknown[] | undefined;
             /** Defaults to `100`. */
-            max?: number;
-        };
-    };
+            max?: number | undefined;
+        } | undefined;
+    } | undefined;
 
     interaction?: {
         /**
          * Indicate if the chart should have interactions.
          * If `false` is set, all of interactions (showing/hiding tooltip, selection, mouse events, etc) will be disabled.
          */
-        enabled?: boolean;
-        brighten?: boolean;
-    };
+        enabled?: boolean | undefined;
+        brighten?: boolean | undefined;
+    } | undefined;
 
     transition?: {
         /**
          * Set duration of transition (in milliseconds) for chart animation.
          * Note: If `0` or `null` set, transition will be skipped. So, this makes initial rendering faster especially in case you have a lot of data.
          */
-        duration?: number | null;
-    };
+        duration?: number | null | undefined;
+    } | undefined;
 
     /**
      * Set a callback to execute when the chart is initialized.
@@ -159,9 +159,9 @@ export interface ChartConfiguration {
 
     data: Data;
 
-    axis?: AxesOptions;
+    axis?: AxesOptions | undefined;
 
-    grid?: GridOptions;
+    grid?: GridOptions | undefined;
 
     /**
      * Show rectangles inside the chart.
@@ -169,26 +169,26 @@ export interface ChartConfiguration {
      * axis must be x, y or y2. start and end should be the value where regions start and end. If not specified, the edge values will be used. If timeseries x axis, date string, Date object and
      * unixtime integer can be used. If class is set, the region element will have it as class.
      */
-    regions?: RegionOptions[];
+    regions?: RegionOptions[] | undefined;
 
-    legend?: LegendOptions;
+    legend?: LegendOptions | undefined;
 
-    tooltip?: TooltipOptions;
+    tooltip?: TooltipOptions | undefined;
 
-    subchart?: SubchartOptions;
+    subchart?: SubchartOptions | undefined;
 
-    zoom?: ZoomOptions;
+    zoom?: ZoomOptions | undefined;
 
-    point?: PointOptions;
+    point?: PointOptions | undefined;
 
-    line?: LineOptions;
+    line?: LineOptions | undefined;
 
     area?: {
         /**
          * Set if min or max value will be 0 on area chart.
          */
-        zerobased?: boolean;
-    };
+        zerobased?: boolean | undefined;
+    } | undefined;
 
     bar?: {
         /**
@@ -205,91 +205,91 @@ export interface ChartConfiguration {
                   /**
                    * Set max width of each bar
                    */
-                  max?: number;
-              };
+                  max?: number | undefined;
+              } | undefined;
         /**
          * Set if min or max value will be 0 on bar chart.
          */
-        zerobased?: boolean;
+        zerobased?: boolean | undefined;
         /**
          * Set space between bars in bar charts
          */
-        space?: number;
-    };
+        space?: number | undefined;
+    } | undefined;
 
     pie?: {
-        label?: LabelOptionsWithThreshold;
+        label?: LabelOptionsWithThreshold | undefined;
         /**
          * Enable or disable expanding pie pieces.
          */
-        expand?: ExpandOptions;
+        expand?: ExpandOptions | undefined;
         /**
          * Sets the angular separation between each adjacent arc.
          */
-        padAngle?: number;
-    };
+        padAngle?: number | undefined;
+    } | undefined;
 
     donut?: {
-        label?: LabelOptionsWithThreshold;
+        label?: LabelOptionsWithThreshold | undefined;
         /**
          * Enable or disable expanding pie pieces.
          */
-        expand?: ExpandOptions;
+        expand?: ExpandOptions | undefined;
         /**
          * Sets the angular separation between each adjacent arc.
          */
-        padAngle?: number;
+        padAngle?: number | undefined;
         /**
          * Set width of donut chart.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * Set title of donut chart.
          */
-        title?: string;
-    };
+        title?: string | undefined;
+    } | undefined;
 
     gauge?: {
-        label?: LabelOptions;
+        label?: LabelOptions | undefined;
         labelLine?: {
-            show?: boolean;
-        }
+            show?: boolean | undefined;
+        } | undefined
         /**
          * Enable or disable expanding gauge.
          */
-        expand?: ExpandOptions;
+        expand?: ExpandOptions | undefined;
         /**
          * Set min value of the gauge.
          * Defaults to `0`.
          */
-        min?: number;
+        min?: number | undefined;
         /**
          * Set max value of the gauge.
          * Defaults to `100`.
          */
-        max?: number;
+        max?: number | undefined;
         /**
          * Set units of the gauge.
          */
-        units?: string;
+        units?: string | undefined;
         /**
          * Set width of gauge chart.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * Whether this should be displayed
          * as a full circle instead of a
          * half circle.
          * Defaults to `false`.
          */
-        fullCircle?: boolean;
+        fullCircle?: boolean | undefined;
         arcs?: {
             /**
              * Defaults to `5`.
              */
-            minWidth?: number;
-        }
-    };
+            minWidth?: number | undefined;
+        } | undefined
+    } | undefined;
 
     spline?: {
         interpolation?: {
@@ -298,20 +298,20 @@ export interface ChartConfiguration {
              */
             type?: 'linear' | 'linear-closed' | 'basis' | 'basis-open' | 'basis-closed' |
                    'bundle' | 'cardinal' | 'cardinal-open' | 'cardinal-closed' | 'monotone' |
-                   'step' | 'step-before' | 'step-after';
-        };
-    };
+                   'step' | 'step-before' | 'step-after' | undefined;
+        } | undefined;
+    } | undefined;
 
     stanford?: {
         /** Show lines anywhere in the chart. */
         lines?: Array<{
-            value_x1?: number;
-            value_y1?: number;
-            value_x2?: number;
-            value_y2?: number;
+            value_x1?: number | undefined;
+            value_y1?: number | undefined;
+            value_x2?: number | undefined;
+            value_y2?: number | undefined;
             /** Class to apply to the line. */
-            class?: string;
-        }>;
+            class?: string | undefined;
+        }> | undefined;
         /** Add regions to the chart. */
         regions?: Array<{
             /** Points should be added in counter-clockwise direction  to close the polygon. */
@@ -319,74 +319,74 @@ export interface ChartConfiguration {
                 x: number;
                 y: number;
             }>;
-            text?: (value: number, percentage: number) => string;
-            opacity?: number;
+            text?: ((value: number, percentage: number) => string) | undefined;
+            opacity?: number | undefined;
             /** Class to apply to the region. */
-            class?: string;
-        }>;
+            class?: string | undefined;
+        }> | undefined;
         /** Show text anywhere inside the chart. */
         texts?: Array<{
             /** x-position. */
-            x?: number;
+            x?: number | undefined;
             /** y-position. */
-            y?: number;
+            y?: number | undefined;
             /** Text content to show. */
-            content?: string;
+            content?: string | undefined;
             /** Class to apply to the text. */
-            class?: string;
-        }>;
+            class?: string | undefined;
+        }> | undefined;
         /** Change the minimum value of the stanford color scale. */
-        scaleMin?: number;
+        scaleMin?: number | undefined;
         /** Change the maximum value of the stanford color scale. */
-        scaleMax?: number;
+        scaleMax?: number | undefined;
         /**
          * Change the width of the stanford color scale.
          * Defaults to `20`.
          */
-        scaleWidth?: number;
+        scaleWidth?: number | undefined;
         /**
          * Set formatter for stanford color scale axis tick text.
          * This option accepts the string 'pow10', a d3.format object and any function you define.
          * Defauls to `d3.format("d")`.
          */
-        scaleFormat?: 'pow10' | ((arg0: number) => string);
+        scaleFormat?: 'pow10' | ((arg0: number) => string) | undefined;
         /**
          * Set the values for stanford color scale axis tick text. This option accepts a function that returns an array of numbers.
          */
-        scaleValues?: (minValue: number, maxValue: number) => number[];
+        scaleValues?: ((minValue: number, maxValue: number) => number[]) | undefined;
         /**
          * Set the color interpolator for stanford color scale. This option is a
          * `d3.interpolate*` object or any function you definethat receives a
          * value between `0` and `1`, and returns a color as string.
          */
-        colors?: (value: number) => string;
+        colors?: ((value: number) => string) | undefined;
         /**
          * Set the padding for the Stanford color scale.
          */
-        padding?: Padding;
-    };
+        padding?: Padding | undefined;
+    } | undefined;
 
     title?: {
         /**
          * Chart title text.
          */
-        text?: string;
+        text?: string | undefined;
         /**
          * Spacing around the title.
          */
-        padding?: Padding;
+        padding?: Padding | undefined;
         /**
          * Position the title relative to the chart.
          */
-        title_position?: "right" | "center" | "left";
-    };
+        title_position?: "right" | "center" | "left" | undefined;
+    } | undefined;
 }
 
 export interface LabelOptions {
     /**
      * Show or hide label on each pie piece.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     /**
      * Set formatter for the label on each pie piece.
      */
@@ -395,7 +395,7 @@ export interface LabelOptions {
 
 export type ExpandOptions = boolean | {
     /** Transition duration for expanding. */
-    duration?: number;
+    duration?: number | undefined;
 };
 
 export interface LabelOptionsWithThreshold extends LabelOptions {
@@ -403,98 +403,98 @@ export interface LabelOptionsWithThreshold extends LabelOptions {
      * Set threshold to show/hide labels.
      * Defaults to `0.05`.
      */
-    threshold?: number;
-    ratio?: unknown;
+    threshold?: number | undefined;
+    ratio?: unknown | undefined;
 }
 
 export interface Data {
     /**
      * Load a CSV or JSON file from a URL. Note that this will not work if loading via the `"file://"` protocol as most browsers with block `XMLHTTPRequests`.
      */
-    url?: string;
+    url?: string | undefined;
     /**
      * Specify headers for the data request if `data.url` is provided.
      */
-    headers?: unknown;
+    headers?: unknown | undefined;
     /**
      * Parse a JSON object for data. Can be in the column form `{key1: [val1, val2, ...]; ...}` or in the row form `[{key1: val1; key2: val2}, ...]`. If `url` is provided this will be ignored.
      */
-    json?: Record<string, PrimitiveArray> | Array<Record<string, Primitive>>;
+    json?: Record<string, PrimitiveArray> | Array<Record<string, Primitive>> | undefined;
     /**
      * A list of rows, where the first row is the column names and the remaining rows are data.  If `url` or `json` are provided this will be ignored.
      */
-    rows?: PrimitiveArray[];
+    rows?: PrimitiveArray[] | undefined;
     /**
      * A list of columns, where the first element in each column is the ID and the remaining elements are data. If `url`, `json`, or `rows` are provided, this will be ignored.
      */
-    columns?: Array<[string, ...PrimitiveArray]>;
+    columns?: Array<[string, ...PrimitiveArray]> | undefined;
     /**
      * Used if loading JSON via `data.url`.
      */
-    mimeType?: string;
+    mimeType?: string | undefined;
     /**
      * If `data.json` is provided and is in row form, these keys are used to pull the data from each row.
      */
     keys?: {
         /** This is the key for the x-value in each row. */
-        x?: string;
+        x?: string | undefined;
         /** List of remaining keys (besides the x key) to pull data for. */
         value: string[];
-    };
+    } | undefined;
     /**
      * Specify the key of x values in the data.
      * We can show the data with non-index x values by this option. This option is required when the type of x axis is timeseries. If this option is set on category axis, the values of the data
      * on the key will be used for category names.
      */
-    x?: string;
+    x?: string | undefined;
     /**
      * Specify the keys of the x values for each data.
      * This option can be used if we want to show the data that has different x values.
      */
-    xs?: { [key: string]: string };
+    xs?: { [key: string]: string } | undefined;
     /**
      * Set a format to parse string specifed as x.
      * Default is `"%Y-%m-%d"`.
      * @see https://github.com/d3/d3-time-format#locale_format For a list of valid format specifiers.
      */
-    xFormat?: string;
+    xFormat?: string | undefined;
     /**
      * Set to `true` to parse dates and times as local time.
      * **Experimental.**
      */
-    xLocaltime?: boolean;
+    xLocaltime?: boolean | undefined;
     /**
      * Set to `true` to sort x values.
      * **Experimental.**
      */
-    xSort?: boolean;
+    xSort?: boolean | undefined;
     /**
      * Set custom data display names.
      */
-    names?: { [key: string]: string };
+    names?: { [key: string]: string } | undefined;
     /**
      * Set custom data classes for styling.
      * If this option is specified, the element g for the data has an additional class that has the prefix `c3-target-` (e.g. `c3-target-additional-data1-class`).
      */
-    classes?: { [key: string]: string };
+    classes?: { [key: string]: string } | undefined;
     /**
      * Set groups for the data for stacking.
      */
-    groups?: string[][];
+    groups?: string[][] | undefined;
     /**
      * Set y axis the data related to.
      */
-    axes?: { [key: string]: AxisName };
+    axes?: { [key: string]: AxisName } | undefined;
     /**
      * Set chart type at once.
      * If this option is specified, the type will be applied to every data. This setting can be overwritten for individual data by `data.types`.
      */
-    type?: ChartType;
+    type?: ChartType | undefined;
     /**
      * Set chart type for each data.
      * This setting overwrites the chart-wide `data.type` setting.
      */
-    types?: { [key: string]: ChartType };
+    types?: { [key: string]: ChartType } | undefined;
     /**
      * Show labels on each data points or set formatter function for data labels.
      * Control all labels with a boolean value or `format` function, or control behavior for individual data with a `format` object.
@@ -502,25 +502,25 @@ export interface Data {
     labels?:
         | boolean
         | { format: FormatFunction }
-        | { format: { [key: string]: boolean | FormatFunction } };
+        | { format: { [key: string]: boolean | FormatFunction } } | undefined;
     /**
      * Define the order of the data.
      * This option changes the order of stacking the data and pieces of pie/donut. If null specified, it will be the order the data loaded. If function specified, it will be used to sort the data
      * and it will recieve the data as argument.
      */
-    order?: "asc" | "desc" | ((...data: DataSeries[]) => number) | null;
+    order?: "asc" | "desc" | ((...data: DataSeries[]) => number) | null | undefined;
     /**
      * Define regions for each data.
      * The values must be an array for each data and it should include an object that has start, end, style. If start is not set, the start will be the first data point. If end is not set, the
      * end will be the last data point.
      * Currently this option supports only line chart and dashed style. If this option specified, the line will be dashed only in the regions.
      */
-    regions?: { [key: string]: RegionOptions[] };
+    regions?: { [key: string]: RegionOptions[] } | undefined;
     /**
      * Set color converter function.
      * The function is called for each data ID, for each data series, and for each individual point.
      */
-    color?: (color: string, d: string | DataSeries | DataPoint) => string | d3.RGBColor | d3.HSLColor;
+    color?: ((color: string, d: string | DataSeries | DataPoint) => string | d3.RGBColor | d3.HSLColor) | undefined;
     /**
      * Set color for each data.
      * If a function is specified, it is called once each with the data ID, the data series, and each point.
@@ -531,12 +531,12 @@ export interface Data {
             | d3.RGBColor
             | d3.HSLColor
             | ((d: string | DataSeries | DataPoint) => string | d3.RGBColor | d3.HSLColor);
-    };
+    } | undefined;
     /**
      * Hide each data when the chart appears.
      * If true specified, all of data will be hidden. If multiple ids specified as an array, those will be hidden.
      */
-    hide?: boolean | string[];
+    hide?: boolean | string[] | undefined;
     /**
      * Specify a filter function to selectively load data.
      * @param series The data series for which to decide whether to show or not.
@@ -544,12 +544,12 @@ export interface Data {
      * @param allSeries Array of all data series, whether filtered or not.
      * @returns `true` if the series should be shown, `false` if it should be hidden.
      */
-    filter?: (series: DataSeries, index: number, allSeries: DataSeries[]) => boolean;
+    filter?: ((series: DataSeries, index: number, allSeries: DataSeries[]) => boolean) | undefined;
     /**
      * Set text displayed when empty data.
      * Defaults to `""`.
      */
-    empty?: { label: { text: string } };
+    empty?: { label: { text: string } } | undefined;
 
     selection?: {
         /**
@@ -557,42 +557,42 @@ export interface Data {
          * If this option is set `true`, we can select the data points and get/set its state of selection by API (e.g. `select`, `unselect`, `selected`).
          * Defaults to `false`.
          */
-        enabled?: boolean;
+        enabled?: boolean | undefined;
         /**
          * Set grouped selection enabled.
          * If this option set `true`, multiple data points that have same x value will be selected by one selection.
          * Defaults to `false`.
          */
-        grouped?: boolean;
+        grouped?: boolean | undefined;
         /**
          * Set multiple data points selection enabled.
          * If this option set `true`, multiple data points can have the selected
          * state at the same time. If `false` set, only one data point can have
          * the selected state and the others will be unselected when the new data point is selected.
          */
-        multiple?: boolean;
+        multiple?: boolean | undefined;
         /**
          * Enable to select data points by dragging.
          * If this option set `true`, data points can be selected by dragging.
          *
          * **Note**: If this option set `true`, scrolling on the chart will be disabled because dragging event will handle the event.
          */
-        draggable?: boolean;
+        draggable?: boolean | undefined;
         /**
          * Prevent specific data from being selected. Only called if `selection.enabled` is `true`.
          * @param d The data series to decide for.
          * @returns `false` if selection should be disabled for this data.
          */
         isselectable?(this: Record<string, any>, d: DataSeries): boolean;
-    };
+    } | undefined;
     stack?: {
         /**
          * Set the stacking to be normalized. Default is false.
          *
          * **Note**: For stacking, the `data.groups` option should be set and have positive values. The yAxis will be set in percentage value (0 ~ 100%).
          */
-        normalize?: boolean
-    };
+        normalize?: boolean | undefined
+    } | undefined;
     /**
      * Set a callback for click event on each data point.
      * @param d The data point that was clicked.
@@ -627,7 +627,7 @@ export interface Data {
      * For Stanford charts, specify the key of the epochs data, which maps values to their color.
      * Defaults to `"epochs"`.
      */
-    epochs?: string;
+    epochs?: string | undefined;
 
     /**
      * Convert data IDs with this function before creating chart.
@@ -641,38 +641,38 @@ export interface AxesOptions {
     /**
      * Switch x and y axis position.
      */
-    rotated?: boolean;
+    rotated?: boolean | undefined;
     /** x axis configuration. */
-    x?: XAxisConfiguration;
+    x?: XAxisConfiguration | undefined;
     /** y axis configuration. */
-    y?: YAxisConfigurationWithTime;
+    y?: YAxisConfigurationWithTime | undefined;
     /** y2 axis configuration. */
-    y2?: YAxisConfiguration;
+    y2?: YAxisConfiguration | undefined;
 }
 
 export interface AxisConfiguration {
     /**
      * Show or hide the axis.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     /**
      * Set padding for axis.
      * If this option is set, the range of axis will increase/decrease according to the values. If no padding is needed in the range of axis, `0` should be set. On category axis, this option
      * will be ignored.
      */
-    padding?: Padding;
+    padding?: Padding | undefined;
     /**
      * Set max value of the axis.
      */
-    max?: string | number | Date;
+    max?: string | number | Date | undefined;
     /**
      * Set min value of the axis.
      */
-    min?: string | number | Date;
+    min?: string | number | Date | undefined;
     /**
      * Show the axis inside of the chart.
      */
-    inner?: boolean;
+    inner?: boolean | undefined;
 }
 
 export interface XAxisConfiguration extends AxisConfiguration {
@@ -680,19 +680,19 @@ export interface XAxisConfiguration extends AxisConfiguration {
      * Set type of x axis.
      * Defaults to `"indexed"`.
      */
-    type?: XAxisType;
+    type?: XAxisType | undefined;
     /**
      * Set how to treat the timezone of x values.
      * If `true` (default), treat x value as localtime. If `false`, convert to UTC internally.
      */
-    localtime?: boolean;
+    localtime?: boolean | undefined;
     /**
      * Set category names on category axis.
      * This must be an array that includes category names in string. If category names are included in the date by `data.x` option, this is not required.
      */
-    categories?: string[];
+    categories?: string[] | undefined;
 
-    tick?: XTickConfiguration;
+    tick?: XTickConfiguration | undefined;
 
     /**
      * Set label on X axis.
@@ -710,18 +710,18 @@ export interface XAxisConfiguration extends AxisConfiguration {
                   | 'outer-right'
                   | 'outer-center'
                   | 'outer-left';
-          };
+          } | undefined;
 
     /**
      * Set height of x axis.
      * The height of x axis can be set manually by this option. If you need more space for x axis, please use this option for that. The unit is pixel.
      */
-    height?: number;
+    height?: number | undefined;
     /**
      * Set default extent for subchart and zoom. This can be an array or function that returns an array.
      */
-    extent?: number[] | (() => number[]);
-    selection?: unknown;
+    extent?: number[] | (() => number[]) | undefined;
+    selection?: unknown | undefined;
 }
 
 export interface YAxisConfiguration extends AxisConfiguration {
@@ -729,15 +729,15 @@ export interface YAxisConfiguration extends AxisConfiguration {
      * Change the direction of y axis.
      * If true set, the direction will be from the top to the bottom.
      */
-    inverted?: boolean;
+    inverted?: boolean | undefined;
     /**
      * Set center value of y axis.
      */
-    center?: number;
+    center?: number | undefined;
 
-    tick?: YTickConfiguration;
+    tick?: YTickConfiguration | undefined;
 
-    type?: YAxisType;
+    type?: YAxisType | undefined;
 
     /**
      * Set label on Y axis.
@@ -755,54 +755,54 @@ export interface YAxisConfiguration extends AxisConfiguration {
                   | 'outer-top'
                   | 'outer-middle'
                   | 'outer-bottom';
-          };
+          } | undefined;
 
     /**
      * Set default range of y axis. This option set the default value for y axis when there is no data on init.
      */
-    default?: [number, number];
+    default?: [number, number] | undefined;
 
-    max?: number;
-    min?: number;
+    max?: number | undefined;
+    min?: number | undefined;
 }
 
 export interface YAxisConfigurationWithTime extends YAxisConfiguration {
-    tick?: YTickConfigurationWithTime;
+    tick?: YTickConfigurationWithTime | undefined;
 }
 
 export interface TickConfiguration {
     /**
      * Show x axis outer tick.
      */
-    outer?: boolean;
+    outer?: boolean | undefined;
     /**
      * Set the x values of ticks manually.
      * If this option is provided, the position of the ticks will be determined based on those values. This option works with timeseries data and the x values will be parsed accoding to the type
      * of the value and data.xFormat option.
      */
-    values?: number[] | string[];
+    values?: number[] | string[] | undefined;
     /**
      * Rotate x axis tick text. If you set negative value, it will rotate to opposite direction.
      */
-    rotate?: number;
+    rotate?: number | undefined;
     /**
      * The number of x axis ticks to show.
      * This option hides tick lines together with tick text. If this option is used on timeseries axis, the ticks position will be determined precisely and not nicely positioned (e.g. it will
      * have rough second value).
      */
-    count?: number;
+    count?: number | undefined;
 }
 
 export interface XTickConfiguration extends TickConfiguration {
     /**
      * A function to format x-axis tick values. A format string is also supported for timeseries data.
      */
-    format?: string | ((x: number | Date) => string | number);
+    format?: string | ((x: number | Date) => string | number) | undefined;
 
     /**
      * Centerise ticks on category axis
      */
-    centered?: boolean;
+    centered?: boolean | undefined;
     /**
      * Setting for culling ticks.
      * If `true` is set, the ticks will be culled, then only limitted tick text will be shown.
@@ -815,117 +815,117 @@ export interface XTickConfiguration extends TickConfiguration {
            * The number of tick texts will be adjusted to less than this value.
            */
           max: number;
-        };
+        } | undefined;
     /**
      * Fit x axis ticks.
      * If `true` set, the ticks will be positioned nicely. If `false` set, the ticks will be positioned
      * according to x value of the data points.
      */
-    fit?: boolean;
+    fit?: boolean | undefined;
     /**
      * Set width of x axis tick.
      */
-    width?: number;
-    multiline?: boolean;
-    multilineMax?: number;
+    width?: number | undefined;
+    multiline?: boolean | undefined;
+    multilineMax?: number | undefined;
 }
 
 export interface YTickConfiguration extends TickConfiguration {
     /**
      * A function to format y-axis tick values.
      */
-    format?: (x: number) => string | number;
+    format?: ((x: number) => string | number) | undefined;
 }
 
 export interface YTickConfigurationWithTime extends YTickConfiguration {
     time?: {
-        type?: unknown;
-        interval?: unknown;
-    };
+        type?: unknown | undefined;
+        interval?: unknown | undefined;
+    } | undefined;
 }
 
 export interface GridOptions {
-    x?: AxisGridOptions;
-    y?: AxisGridOptions;
+    x?: AxisGridOptions | undefined;
+    y?: AxisGridOptions | undefined;
     focus?: {
-        show?: boolean;
-    };
+        show?: boolean | undefined;
+    } | undefined;
     lines?: {
-        front?: boolean;
-    };
+        front?: boolean | undefined;
+    } | undefined;
 }
 
 export interface AxisGridOptions {
     /**
      * Show grids along an axis.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     /**
      * Show additional grid lines along x axis.
      * If x axis is `category` axis, value can be category name. If x axis is `timeseries` axis, value can be date string, `Date` object and unixtime integer.
      */
-    lines?: GridLineOptions[];
+    lines?: GridLineOptions[] | undefined;
     /** Not used. */
-    type?: string;
+    type?: string | undefined;
 }
 
 export interface GridLineOptions {
     /** Value to place the grid line at. */
     value: string | number | Date;
-    text?: string;
-    position?: "start" | "end" | "middle";
+    text?: string | undefined;
+    position?: "start" | "end" | "middle" | undefined;
     /** Class to give the grid line for styling. */
-    class?: string;
+    class?: string | undefined;
 }
 
 export interface GridLineOptionsWithAxis extends GridLineOptions {
-    axis?: AxisName;
+    axis?: AxisName | undefined;
 }
 
 export interface RegionOptions {
     /**
      * The axis on which `start` and `end` values lie.
      */
-    axis?: AxisName;
+    axis?: AxisName | undefined;
     /**
      * The point on the axis at which to start the region. If not provided, will
      * use the start edge of the axis.
      */
-    start?: string | number | Date;
+    start?: string | number | Date | undefined;
     /**
      * The point on the axis at which to end the region. If not provided, will
      * use the end edge of the axis.
      */
-    end?: string | number | Date;
+    end?: string | number | Date | undefined;
     /**
      * An optional class to apply to the region, which can be used for styling
      * or targeting.
      */
-    class?: string;
+    class?: string | undefined;
     /**
      * Control the opacity of the region area.
      */
-    opacity?: number;
+    opacity?: number | undefined;
     /**
      * If `'dashed'`, renders the line as dashed in this range instead of showing a region block.
      */
-    style?: "dashed";
+    style?: "dashed" | undefined;
     /**
      * An optional label property can be provided to display a label for the region.
      */
-    label?: string;
+    label?: string | undefined;
     /**
      * Control the position of the label vertically.
      */
-    paddingY?: number;
+    paddingY?: number | undefined;
     /**
      * Control the position of the label horizontally.
      */
-    paddingX?: number;
+    paddingX?: number | undefined;
     /**
      * Used to identify whether or not the label text should be rotated 90 degrees
      */
-    vertical?: boolean;
+    vertical?: boolean | undefined;
 }
 
 export interface LegendOptions {
@@ -933,17 +933,17 @@ export interface LegendOptions {
      * Show or hide legend.
      * Defaults to `true`.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     /**
      * Hide legend
      * If true given, all legend will be hidden. If string or array given, only the legend that has the id will be hidden.
      * Defaults to `false`.
      */
-    hide?: boolean | ArrayOrString;
+    hide?: boolean | ArrayOrString | undefined;
     /**
      * Change the position of legend.
      */
-    position?: "bottom" | "right" | "inset";
+    position?: "bottom" | "right" | "inset" | undefined;
     /**
      * Change inset legend attributes. Ignored unless `legend.position` is `"inset"`.
      */
@@ -952,27 +952,27 @@ export interface LegendOptions {
          * Decides the position of the legend.
          * Defaults to `"top-left"`.
          */
-        anchor?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+        anchor?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | undefined;
         /**
          * Set the horizontal position of the legend based on the anchor.
          * Defaults to `10`.
          */
-        x?: number;
+        x?: number | undefined;
         /**
          * Set the vertical position of the legend based on the anchor.
          * Defaults to `0`.
          */
-        y?: number;
+        y?: number | undefined;
         /**
          * Defines the max step the legend has (e.g. If `step=2` and legend has 3 items, the legend has 2 columns).
          */
-        step?: number;
-    };
+        step?: number | undefined;
+    } | undefined;
     /**
      * Padding between legend elements.
      * Defaults to `0`.
      */
-    padding?: number;
+    padding?: number | undefined;
 
     item?: {
         /**
@@ -998,19 +998,19 @@ export interface LegendOptions {
              * Tile width.
              * Defaults to `10`.
              */
-            width?: number;
+            width?: number | undefined;
             /**
              * Tile height.
              * Defaults to `10`.
              */
-            height?: number;
-        };
-    };
+            height?: number | undefined;
+        } | undefined;
+    } | undefined;
 
     /**
      * Defaults to `false`.
      */
-    equally?: boolean;
+    equally?: boolean | undefined;
 }
 
 export interface TooltipOptions {
@@ -1018,12 +1018,12 @@ export interface TooltipOptions {
      * Show or hide tooltip.
      * Defaults to `true`.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     /**
      * Set if tooltip is grouped or not for the data points.
      * Defaults to `true`.
      */
-    grouped?: boolean;
+    grouped?: boolean | undefined;
     format?: {
         /**
          * Set format for the title of tooltip.
@@ -1042,9 +1042,9 @@ export interface TooltipOptions {
          * @returns If `undefined` returned, the row of that value will be skipped.
          */
         value?(value: Primitive, ratio: number | undefined, id: string, index: number): string | undefined;
-    };
+    } | undefined;
     /** Show the tooltips based on the horizontal position of the mouse. */
-    horizontal?: boolean;
+    horizontal?: boolean | undefined;
     /**
      * Set custom position for the tooltip. This option can be used to modify the tooltip position by returning object that has top and left.
      */
@@ -1069,17 +1069,17 @@ export interface TooltipOptions {
     /**
      * Set tooltip values order.
      */
-    order?: "desc" | "asc" | unknown[] | ((data1: unknown, data2: unknown) => number) | null;
+    order?: "desc" | "asc" | unknown[] | ((data1: unknown, data2: unknown) => number) | null | undefined;
     init?: {
-        show?: boolean;
-        x?: number;
+        show?: boolean | undefined;
+        x?: number | undefined;
         position?: {
             /** Defaults to `"0px"`. */
-            top?: string;
+            top?: string | undefined;
             /** Defaults to `"50px"`. */
-            left?: string;
-        };
-    };
+            left?: string | undefined;
+        } | undefined;
+    } | undefined;
     // onshow?: () => void; // Not used
     // onhide?: () => void; // Not used
 }
@@ -1089,18 +1089,18 @@ export interface SubchartOptions {
      * Show sub chart on the bottom of the chart.
      * Defaults to `false`.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     size?: {
         /**
          * Change the height of the subchart.
          */
         height: number;
-    };
+    } | undefined;
     axis?: {
         x?: {
             show: boolean;
-        }
-    };
+        } | undefined
+    } | undefined;
     /**
      * Set callback for brush event.
      * Specified function receives the current zoomed x domain.
@@ -1112,15 +1112,15 @@ export interface ZoomOptions {
     /**
      * Enable zooming.
      */
-    enabled?: boolean;
+    enabled?: boolean | undefined;
     /**
      * Set interaction type for zooming
      */
-    type?: 'scroll' | 'drag';
+    type?: 'scroll' | 'drag' | undefined;
     /**
      * Enable to rescale after zooming. If true set, y domain will be updated according to the zoomed region.
      */
-    rescale?: boolean;
+    rescale?: boolean | undefined;
     /**
      * Set callback that is called when the chart is zooming. Specified function receives the zoomed domain.
      */
@@ -1136,23 +1136,23 @@ export interface ZoomOptions {
     /**
      * Set the initial minimum and maximum x-axis zoom values.
      */
-    initialRange?: Domain;
+    initialRange?: Domain | undefined;
     /**
      * Disable the default animation of zoom. This option is useful when you want to get the zoomed domain by `onzoom` or `onzoomend` handlers and override the default animation behavior.
      * @see https://github.com/c3js/c3/pull/2439 for details.
      */
-    disableDefaultBehavior?: boolean;
+    disableDefaultBehavior?: boolean | undefined;
 
-    priveleged?: boolean;
+    priveleged?: boolean | undefined;
     x?: {
-        min?: number;
-        max?: number;
-    };
+        min?: number | undefined;
+        max?: number | undefined;
+    } | undefined;
     /**
      * Change zoom extent.
      * **Experimental.**
      */
-    extent?: [number, number];
+    extent?: [number, number] | undefined;
 }
 
 export interface PointOptions {
@@ -1160,38 +1160,38 @@ export interface PointOptions {
      * Whether to show each point in line.
      * Defaults to `true`.
      */
-    show?: boolean;
+    show?: boolean | undefined;
     /**
      * The radius size of each point.
      * Defaults to `2.5`. If it's a function, will call for each point.
      */
-    r?: number | ((this: ChartInternal, d: DataPoint) => number);
+    r?: number | ((this: ChartInternal, d: DataPoint) => number) | undefined;
 
     /**
      * How sensitive is each point to mouse cursor hover.
      * Defaults to `10`.
      */
-    sensitivity?: number;
+    sensitivity?: number | undefined;
 
     focus?: {
         expand: {
             /**
              * Whether to expand each point on focus.
              */
-            enabled?: boolean;
+            enabled?: boolean | undefined;
             /**
              * The radius size of each point on focus.
              */
-            r?: number;
+            r?: number | undefined;
         };
-    };
+    } | undefined;
 
     select?: {
         /**
          * The radius size of each point on selected.
          */
-        r?: number;
-    };
+        r?: number | undefined;
+    } | undefined;
 }
 
 export interface LineOptions {
@@ -1200,19 +1200,19 @@ export interface LineOptions {
      * If `true` set, the region of null data will be connected without any data point.
      * If `false` set, the region of null data will not be connected and get empty.
      */
-    connectNull?: boolean;
+    connectNull?: boolean | undefined;
     step?: {
         /**
          * Change step type for step chart.
          * Defaults to `"step"`.
          */
         type: "step" | "step-before" | "step-after";
-    };
+    } | undefined;
 }
 
 export interface ShowHideOptions {
     /** Controls whether the legend will be shown or hidden along with the data. */
-    withLegend?: boolean;
+    withLegend?: boolean | undefined;
 }
 
 export interface ChartAPI {
@@ -1258,46 +1258,46 @@ export interface ChartAPI {
      */
     load(args: {
         /** Data to load. */
-        data?: Data;
+        data?: Data | undefined;
         /** API url to load data from. If `data` is provided this will be ignored. */
-        url?: string;
+        url?: string | undefined;
         /**
          * An object to convert to data to load. Can be in the column form
          * (`{key1: [val1, val2, ...]; ...}`) or in the row form (`[{key1: val1; key2: val2}, ...]`).
          * If `data` or `url` are provided this will be ignored.
          */
-        json?: Record<string, PrimitiveArray> | Array<Record<string, Primitive>>;
+        json?: Record<string, PrimitiveArray> | Array<Record<string, Primitive>> | undefined;
         /** If json is provided and is in row form, these keys are used to pull the data from each row. */
         keys?: {
             /** This is the key for the x-value in each row. */
-            x?: string;
+            x?: string | undefined;
             /** List of remaining keys (besides the x key) to pull data for. */
             value: string[];
-        };
+        } | undefined;
         /** A list of rows, where the first row is the column names and the remaining rows are data.  If `data`, `url`, or `json` are provided this will be ignored.  */
-        rows?: PrimitiveArray[];
+        rows?: PrimitiveArray[] | undefined;
         /** A list of columns, where the first element in each column is the ID and the remaining elements are data. If `data`, `url`, `json`, or 'rows' are provided, this will be ignored. */
-        columns?: Array<[string, ...PrimitiveArray]>;
+        columns?: Array<[string, ...PrimitiveArray]> | undefined;
         /** Match x columns to the corresponding data columns. */
-        xs?: Record<string, string>;
+        xs?: Record<string, string> | undefined;
         /** Match loaded data IDs with display names. */
-        names?: Record<string, string>;
+        names?: Record<string, string> | undefined;
         /** If classes given, the classes specifed by `data.classes` will be updated. Keys should be data IDs and values should be classes to assign. */
-        classes?: Record<string, string>;
+        classes?: Record<string, string> | undefined;
         /** Array of arrays of data IDs. IDs that share a sub-array will be categorized together. */
-        categories?: string[][];
+        categories?: string[][] | undefined;
         /** Match data IDs to their axes. */
-        axes?: Record<string, AxisName>;
+        axes?: Record<string, AxisName> | undefined;
         /** Match data IDs to the colors to render that data as. */
-        colors?: Record<string, string | d3.RGBColor | d3.HSLColor>;
+        colors?: Record<string, string | d3.RGBColor | d3.HSLColor> | undefined;
         /** Select the plot type for the loaded data. */
-        type?: ChartType;
+        type?: ChartType | undefined;
         /** Select the plot types for each individual data by ID. */
-        types?: Record<string, ChartType>;
+        types?: Record<string, ChartType> | undefined;
         /** ID of data to remove, or list of IDs of data to remove, or `true` to remove all data. */
-        unload?: true | ArrayOrString;
+        unload?: true | ArrayOrString | undefined;
         /** Called when loading completes. */
-        done?: () => void;
+        done?: (() => void) | undefined;
     }): void;
     /**
      * Unload data from the chart.
@@ -1305,9 +1305,9 @@ export interface ChartAPI {
      * NOTE: If you call load API soon after/before unload, unload param of load should be used. Otherwise chart will not be rendered properly because of cancel of animation.
      */
     unload(args?: ArrayOrString | {
-        ids?: ArrayOrString;
+        ids?: ArrayOrString | undefined;
         /** Called after data is loaded, but not after rendering. This is because rendering will finish after some transition and there is some time lag between loading and rendering. */
-        done?: () => void;
+        done?: (() => void) | undefined;
     }): void;
     /**
      * Flow data to the chart. By this API, you can append new data points to the chart.
@@ -1316,24 +1316,24 @@ export interface ChartAPI {
      */
     flow(args: {
         /** An object to convert to data to load. Can be in the column form `{key1: [val1, val2, ...]; ...}` or in the row form `[{key1: val1; key2: val2}, ...]`. */
-        json?: Record<string, PrimitiveArray> | Array<Record<string, Primitive>>;
+        json?: Record<string, PrimitiveArray> | Array<Record<string, Primitive>> | undefined;
         /** If json is provided and is in row form, these keys are used to pull the data from each row. */
         keys?: {
             /** This is the key for the x-value in each row. */
-            x?: string;
+            x?: string | undefined;
             /** List of remaining keys (besides the x key) to pull data for. */
             value: string[];
-        };
+        } | undefined;
         /** A list of rows, where the first row is the column names and the remaining rows are data. If this is provided and `json` is provided, this is ignored. */
-        rows?: [string[], ...PrimitiveArray[]];
+        rows?: [string[], ...PrimitiveArray[]] | undefined;
         /** A list of columns, where the first element in each column is the ID and the remaining elements are data. If `json` or `rows` are provided, this will be ignored. */
-        columns?: Array<[string, ...PrimitiveArray]>;
+        columns?: Array<[string, ...PrimitiveArray]> | undefined;
         /** If given, the lower x edge will move to that point. If not given, the lower x edge will move by the number of given data points. */
-        to?: string | number;
+        to?: string | number | undefined;
         /** If given, the lower x edge will move by the number of this argument. */
-        length?: number;
+        length?: number | undefined;
         /** If given, the duration of the transition will be specified value. If not given, `transition.duration` will be used as default. */
-        duration?: number;
+        duration?: number | undefined;
         /** Will be called when the flow ends. */
         done?(): void;
     }): void;
@@ -1393,9 +1393,9 @@ export interface ChartAPI {
          */
         remove(args?: {
             /** If provided, removes the regions that have all of the specified classes. Otherwise removes all regions. */
-            classes?: string[];
+            classes?: string[] | undefined;
             /** Transition duration for fade out. */
-            duration?: number;
+            duration?: number | undefined;
         }): RegionOptions[];
     };
 
@@ -1515,8 +1515,8 @@ export interface ChartAPI {
             max: { [key in AxisName]: number; };
         };
         range(range: {
-            min?: number | { [key in AxisName]?: number };
-            max?: number | { [key in AxisName]?: number };
+            min?: number | { [key in AxisName]?: number } | undefined;
+            max?: number | { [key in AxisName]?: number } | undefined;
         }): void;
 
         types(types: { [key in AxisName]?: XAxisType | YAxisType }): void;
@@ -1595,8 +1595,8 @@ export interface ChartAPI {
             min: number;
         }
         range(range: {
-            max?: number;
-            min?: number;
+            max?: number | undefined;
+            min?: number | undefined;
         }): void;
     };
 
@@ -1609,7 +1609,7 @@ export interface ChartAPI {
      * Resize the chart. If no size is specified it will resize to fit.
      * @param size This argument should include width and height in pixels.
      */
-    resize(size?: { width?: number; height?: number }): void;
+    resize(size?: { width?: number | undefined; height?: number | undefined }): void;
 
     /**
      * Force to redraw.
@@ -1628,9 +1628,9 @@ export interface ChartAPI {
             mouse: unknown;
             data?: {
                 targets: DataSeries[];
-            };
-            id?: string;
-            x?: number;
+            } | undefined;
+            id?: string | undefined;
+            x?: number | undefined;
         }): void;
         hide(): void;
     };
@@ -1645,8 +1645,8 @@ export interface ChartInternal {
 }
 
 export interface DataSeries {
-    id?: string;
-    id_org?: string;
+    id?: string | undefined;
+    id_org?: string | undefined;
     values: DataPoint[];
 }
 
@@ -1683,8 +1683,8 @@ export interface GridOperations {
      */
     remove(params?: {
         /** If provided, will remove all gridlines with this class. */
-        class?: string;
+        class?: string | undefined;
         /** If provided, will remove all gridlines at this value. */
-        value?: number | string;
+        value?: number | string | undefined;
     }): void;
 }

--- a/types/cacache/index.d.ts
+++ b/types/cacache/index.d.ts
@@ -45,7 +45,7 @@ export namespace get {
          *
          * `algorithms` has no effect if this option is present.
          */
-        integrity?: string;
+        integrity?: string | undefined;
 
         /**
          * Default: `null`
@@ -63,14 +63,14 @@ export namespace get {
          * `memoize: false` to the reader functions, but their default will be
          * to read from memory.
          */
-        memoize?: null | boolean;
+        memoize?: null | boolean | undefined;
 
         /**
          * If provided, the data stream will be verified to check that enough
          * data was passed through. If there's more or less data than expected,
          * insertion will fail with an `EBADSIZE` error.
          */
-        size?: number;
+        size?: number | undefined;
     }
 
     namespace copy {
@@ -146,7 +146,7 @@ export namespace put {
          * Currently only supports one algorithm at a time (i.e., an array
          * length of exactly `1`). Has no effect if `opts.integrity` is present.
          */
-        algorithms?: string[];
+        algorithms?: string[] | undefined;
 
         /**
          * If present, the pre-calculated digest for the inserted content. If
@@ -155,7 +155,7 @@ export namespace put {
          *
          * `algorithms` has no effect if this option is present.
          */
-        integrity?: string;
+        integrity?: string | undefined;
 
         /** Arbitrary metadata to be attached to the inserted key. */
         metadata?: any;
@@ -176,21 +176,21 @@ export namespace put {
          * `memoize: false` to the reader functions, but their default will be
          * to read from memory.
          */
-        memoize?: null | boolean;
+        memoize?: null | boolean | undefined;
 
         /**
          * If provided, the data stream will be verified to check that enough
          * data was passed through. If there's more or less data than expected,
          * insertion will fail with an `EBADSIZE` error.
          */
-        size?: number;
+        size?: number | undefined;
 
         /**
          * Default: `null`
          *
          * Prefix to append on the temporary directory name inside the cache's tmp dir.
          */
-        tmpPrefix?: null | string;
+        tmpPrefix?: null | string | undefined;
     }
 
     /**
@@ -235,14 +235,14 @@ export namespace tmp {
          *
          * Number of concurrently read files in the filesystem while doing clean up.
          */
-        concurrency?: number;
+        concurrency?: number | undefined;
 
         /**
          * Receives a formatted entry. Return `false` to remove it.
          *
          * Note: might be called more than once on the same entry.
          */
-        filter?: string | false;
+        filter?: string | false | undefined;
 
         /**
          * Custom logger function:
@@ -251,14 +251,14 @@ export namespace tmp {
          *   log.silly('verify', 'verifying cache at', cache)
          * ```
          */
-        log?: Record<string, (...args: any[]) => any>;
+        log?: Record<string, (...args: any[]) => any> | undefined;
 
         /**
          * Default: `null`
          *
          * Prefix to append on the temporary directory name inside the cache's tmp dir.
          */
-        tmpPrefix?: null | string;
+        tmpPrefix?: null | string | undefined;
     }
 
     /**
@@ -302,14 +302,14 @@ export namespace verify {
          *
          * Number of concurrently read files in the filesystem while doing clean up.
          */
-        concurrency?: number;
+        concurrency?: number | undefined;
 
         /**
          * Receives a formatted entry. Return `false` to remove it.
          *
          * Note: might be called more than once on the same entry.
          */
-        filter?: string | false;
+        filter?: string | false | undefined;
 
         /**
          * Custom logger function:
@@ -318,7 +318,7 @@ export namespace verify {
          *   log.silly('verify', 'verifying cache at', cache)
          * ```
          */
-        log?: Record<string, (...args: any[]) => any>;
+        log?: Record<string, (...args: any[]) => any> | undefined;
     }
 
     /**

--- a/types/cache-manager/index.d.ts
+++ b/types/cache-manager/index.d.ts
@@ -32,7 +32,7 @@ export interface StoreConfig extends CachingConfig {
     store: 'memory' | 'none' | Store | {
         create(...args: any[]): Store;
     };
-    max?: number;
+    max?: number | undefined;
 
     /**
      * You may pass in any other arguments these will be passed on to the `create` method of your store,

--- a/types/cacheable-request/index.d.ts
+++ b/types/cacheable-request/index.d.ts
@@ -38,7 +38,7 @@ declare namespace CacheableRequest {
          * If the cache should be used. Setting this to `false` will completely bypass the cache for the current request.
          * @default true
          */
-        cache?: boolean;
+        cache?: boolean | undefined;
 
         /**
          * If set to `true` once a cached resource has expired it is deleted and will have to be re-requested.
@@ -47,27 +47,27 @@ declare namespace CacheableRequest {
          * on the next request with `If-None-Match`/`If-Modified-Since` headers.
          * @default false
          */
-        strictTtl?: boolean;
+        strictTtl?: boolean | undefined;
 
         /**
          * Limits TTL. The `number` represents milliseconds.
          * @default undefined
          */
-        maxTtl?: number;
+        maxTtl?: number | undefined;
 
         /**
          * When set to `true`, if the DB connection fails we will automatically fallback to a network request.
          * DB errors will still be emitted to notify you of the problem even though the request callback may succeed.
          * @default false
          */
-        automaticFailover?: boolean;
+        automaticFailover?: boolean | undefined;
 
         /**
          * Forces refreshing the cache. If the response could be retrieved from the cache, it will perform a
          * new request and override the cache instead.
          * @default false
          */
-        forceRefresh?: boolean;
+        forceRefresh?: boolean | undefined;
     }
 
     interface Emitter extends EventEmitter {

--- a/types/caniuse-api/index.d.ts
+++ b/types/caniuse-api/index.d.ts
@@ -8,11 +8,11 @@ export const features: string[];
 
 export interface BrowserSupport {
     [browser: string]: {
-        y?: number;
-        n?: number;
-        a?: number;
-        x?: number;
-        p?: number;
+        y?: number | undefined;
+        n?: number | undefined;
+        a?: number | undefined;
+        x?: number | undefined;
+        p?: number | undefined;
     };
 }
 

--- a/types/caniuse-lite/index.d.ts
+++ b/types/caniuse-lite/index.d.ts
@@ -121,7 +121,7 @@ export interface Agent {
     /**
      * Exceptions to vendor prefix use.
      */
-    prefix_exceptions?: { [version: string]: string | undefined };
+    prefix_exceptions?: { [version: string]: string | undefined } | undefined;
 }
 
 /**

--- a/types/canvas-confetti/index.d.ts
+++ b/types/canvas-confetti/index.d.ts
@@ -32,71 +32,71 @@ declare namespace confetti {
          * The number of confetti to launch. More is always fun... but be cool, there's a lot of math involved.
          * @default 50
          */
-        particleCount?: number;
+        particleCount?: number | undefined;
         /**
          * The angle in which to launch the confetti, in degrees. 90 is straight up.
          * @default 90
          */
-        angle?: number;
+        angle?: number | undefined;
         /**
          * How far off center the confetti can go, in degrees. 45 means the confetti will launch at the defined angle plus or minus 22.5 degrees.
          * @default 45
          */
-        spread?: number;
+        spread?: number | undefined;
         /**
          * How fast the confetti will start going, in pixels.
          * @default 45
          */
-        startVelocity?: number;
+        startVelocity?: number | undefined;
         /**
          * How quickly the confetti will lose speed. Keep this number between 0 and 1, otherwise the confetti will gain speed. Better yet, just never change it.
          * @default 0.9
          */
-        decay?: number;
+        decay?: number | undefined;
         /**
          * How many times the confetti will move. This is abstract... but play with it if the confetti disappear too quickly for you.
          * @default 200
          */
-        ticks?: number;
+        ticks?: number | undefined;
         /**
          * Where to start firing confetti from. Feel free to launch off-screen if you'd like.
          */
-        origin?: Origin;
+        origin?: Origin | undefined;
         /**
          * An array of color strings, in the HEX format... you know, like #bada55.
          */
-        colors?: string[];
+        colors?: string[] | undefined;
         /**
          * The possible values are square and circle. The default is to use both shapes in an even mix.
          * @default ['square','circle']
          */
-        shapes?: shape[];
+        shapes?: shape[] | undefined;
         /**
          * The confetti should be on top, after all. But if you have a crazy high page, you can set it even higher.
          * @default 100
          */
-        zIndex?: number;
+        zIndex?: number | undefined;
         /**
          * Scale factor for each confetti particle. Use decimals to make the confetti smaller.
          * @default 1
          */
-        scalar?: number;
+        scalar?: number | undefined;
         /**
          * How quickly the particles are pulled down. 1 is full gravity, 0.5 is half gravity, etc., but there are no limits.
          * @default 1
          */
-        gravity?: number;
+        gravity?: number | undefined;
         /**
          * How much to the side the confetti will drift. The default is 0, meaning that they will fall straight down.
          * Use a negative number for left and positive number for right
          * @default 0
          */
-        drift?: number;
+        drift?: number | undefined;
         /**
          * Disables confetti entirely for users that prefer reduced motion. The confetti() promise will resolve immediately in this case.
          * @default false
          */
-        disableForReducedMotion?: boolean;
+        disableForReducedMotion?: boolean | undefined;
     }
 
     interface Origin {
@@ -104,12 +104,12 @@ declare namespace confetti {
          * The x position on the page, with 0 being the left edge and 1 being the right edge.
          * @default 0.5
          */
-        x?: number;
+        x?: number | undefined;
         /**
          * The y position on the page, with 0 being the left edge and 1 being the right edge.
          * @default 0.5
          */
-        y?: number;
+        y?: number | undefined;
     }
 
     interface GlobalOptions {
@@ -117,17 +117,17 @@ declare namespace confetti {
          * Whether to allow setting the canvas image size, as well as keep it correctly sized if the window changes size
          * @default false
          */
-        resize?: boolean;
+        resize?: boolean | undefined;
         /**
          * Whether to use an asynchronous web worker to render the confetti animation, whenever possible
          * @default false
          */
-        useWorker?: boolean;
+        useWorker?: boolean | undefined;
         /**
          * Disables confetti entirely for users that prefer reduced motion. When set to true, use of this
          * confetti instance will always respect a user's request for reduced motion and disable confetti for them.
          */
-        disableForReducedMotion?: boolean;
+        disableForReducedMotion?: boolean | undefined;
     }
 
     /**

--- a/types/case-sensitive-paths-webpack-plugin/index.d.ts
+++ b/types/case-sensitive-paths-webpack-plugin/index.d.ts
@@ -19,10 +19,10 @@ declare namespace CaseSensitivePathsWebpackPlugin {
         /**
          * Show more information
          */
-        debug?: boolean;
+        debug?: boolean | undefined;
         /**
          * Run before emit instead of after resolve for individual files
          */
-        useBeforeEmitHook?: boolean;
+        useBeforeEmitHook?: boolean | undefined;
     }
 }

--- a/types/catbox/index.d.ts
+++ b/types/catbox/index.d.ts
@@ -194,37 +194,37 @@ export interface PolicyGetCachedOptions<T> {
  */
 export interface PolicyOptions<T> {
     /** expiresIn - relative expiration expressed in the number of milliseconds since the item was saved in the cache. Cannot be used together with expiresAt. */
-    expiresIn?: number;
+    expiresIn?: number | undefined;
     /** expiresAt - time of day expressed in 24h notation using the 'HH:MM' format, at which point all cache records for the route expire. Uses local time. Cannot be used together with expiresIn. */
-    expiresAt?: string;
+    expiresAt?: string | undefined;
     /** generateFunc - a function used to generate a new cache item if one is not found in the cache when calling get(). The method's signature is function(id, next) where: */
-    generateFunc?: GenerateFunc<T>;
+    generateFunc?: GenerateFunc<T> | undefined;
     /**
      * staleIn - number of milliseconds to mark an item stored in cache as stale and attempt to regenerate it when generateFunc is provided.
      * Must be less than expiresIn. Alternatively function that returns staleIn value in milliseconds. The function signature is function(stored, ttl) where:
      *  * stored - the timestamp when the item was stored in the cache (in milliseconds).
      *  * ttl - the remaining time-to-live (not the original value used when storing the object).
      */
-    staleIn?: number | ((stored: number, ttl: number) => number);
+    staleIn?: number | ((stored: number, ttl: number) => number) | undefined;
     /** staleTimeout - number of milliseconds to wait before returning a stale value while generateFunc is generating a fresh value. */
-    staleTimeout?: number;
+    staleTimeout?: number | undefined;
     /**
      * generateTimeout - number of milliseconds to wait before returning a timeout error when the generateFunc function takes too long to return a value.
      * When the value is eventually returned, it is stored in the cache for future requests. Required if generateFunc is present.
      * Set to false to disable timeouts which may cause all get() requests to get stuck forever.
      */
-    generateTimeout?: number | false;
+    generateTimeout?: number | false | undefined;
     /** dropOnError - if true, an error or timeout in the generateFunc causes the stale value to be evicted from the cache. Defaults to true. */
-    dropOnError?: boolean;
+    dropOnError?: boolean | undefined;
     /** generateOnReadError - if false, an upstream cache read error will stop the get() method from calling the generate function and will instead pass back the cache error. Defaults to true. */
-    generateOnReadError?: boolean;
+    generateOnReadError?: boolean | undefined;
     /** generateIgnoreWriteError - if false, an upstream cache write error will be passed back with the generated value when calling the get() method. Defaults to true. */
-    generateIgnoreWriteError?: boolean;
+    generateIgnoreWriteError?: boolean | undefined;
     /**
      * pendingGenerateTimeout - number of milliseconds while generateFunc call is in progress for a given id, before a subsequent generateFunc call is allowed.
      * @default 0, no blocking of concurrent generateFunc calls beyond staleTimeout.
      */
-    pendingGenerateTimeout?: number;
+    pendingGenerateTimeout?: number | undefined;
 }
 
 export interface DecoratedPolicyOptions<T> extends PolicyOptions<T> {
@@ -264,7 +264,7 @@ export interface PolicyGetReportLog {
     /** ttl - the cache ttl value for the record. */
     ttl: number;
     /** error - lookup error. */
-    error?: Error;
+    error?: Error | undefined;
 }
 
 /**

--- a/types/catbox/v7/index.d.ts
+++ b/types/catbox/v7/index.d.ts
@@ -229,37 +229,37 @@ export interface PolicyGetCallbackCachedOptions {
  */
 export interface PolicyOptions {
     /** expiresIn - relative expiration expressed in the number of milliseconds since the item was saved in the cache. Cannot be used together with expiresAt. */
-    expiresIn?: number;
+    expiresIn?: number | undefined;
     /** expiresAt - time of day expressed in 24h notation using the 'HH:MM' format, at which point all cache records for the route expire. Uses local time. Cannot be used together with expiresIn. */
-    expiresAt?: string;
+    expiresAt?: string | undefined;
     /** generateFunc - a function used to generate a new cache item if one is not found in the cache when calling get(). The method's signature is function(id, next) where: */
-    generateFunc?: GenerateFunc;
+    generateFunc?: GenerateFunc | undefined;
     /**
      * staleIn - number of milliseconds to mark an item stored in cache as stale and attempt to regenerate it when generateFunc is provided.
      * Must be less than expiresIn. Alternatively function that returns staleIn value in milliseconds. The function signature is function(stored, ttl) where:
      *  * stored - the timestamp when the item was stored in the cache (in milliseconds).
      *  * ttl - the remaining time-to-live (not the original value used when storing the object).
      */
-    staleIn?: number | ((stored: number, ttl: number) => number);
+    staleIn?: number | ((stored: number, ttl: number) => number) | undefined;
     /** staleTimeout - number of milliseconds to wait before returning a stale value while generateFunc is generating a fresh value. */
-    staleTimeout?: number;
+    staleTimeout?: number | undefined;
     /**
      * generateTimeout - number of milliseconds to wait before returning a timeout error when the generateFunc function takes too long to return a value.
      * When the value is eventually returned, it is stored in the cache for future requests. Required if generateFunc is present.
      * Set to false to disable timeouts which may cause all get() requests to get stuck forever.
      */
-    generateTimeout?: number | false;
+    generateTimeout?: number | false | undefined;
     /** dropOnError - if true, an error or timeout in the generateFunc causes the stale value to be evicted from the cache. Defaults to true. */
-    dropOnError?: boolean;
+    dropOnError?: boolean | undefined;
     /** generateOnReadError - if false, an upstream cache read error will stop the get() method from calling the generate function and will instead pass back the cache error. Defaults to true. */
-    generateOnReadError?: boolean;
+    generateOnReadError?: boolean | undefined;
     /** generateIgnoreWriteError - if false, an upstream cache write error will be passed back with the generated value when calling the get() method. Defaults to true. */
-    generateIgnoreWriteError?: boolean;
+    generateIgnoreWriteError?: boolean | undefined;
     /**
      * pendingGenerateTimeout - number of milliseconds while generateFunc call is in progress for a given id, before a subsequent generateFunc call is allowed.
      * Defaults to 0, no blocking of concurrent generateFunc calls beyond staleTimeout.
      */
-    pendingGenerateTimeout?: number;
+    pendingGenerateTimeout?: number | undefined;
 }
 
 /**
@@ -288,7 +288,7 @@ export interface PolicyGetCallbackReportLog {
     /** ttl - the cache ttl value for the record. */
     ttl: number;
     /** error - lookup error. */
-    error?: Boom.BoomError;
+    error?: Boom.BoomError | undefined;
 }
 
 /**

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1195,7 +1195,7 @@ declare namespace Chai {
          * @param length   Potential expected length of object.
          * @param message   Message to display on error.
          */
-        lengthOf<T extends { readonly length?: number }>(object: T, length: number, message?: string): void;
+        lengthOf<T extends { readonly length?: number | undefined }>(object: T, length: number, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -273,16 +273,16 @@ declare namespace Chance {
     }
 
     interface DateOptions {
-        string?: boolean;
-        american?: boolean;
-        year?: number;
-        month?: number;
-        day?: number;
-        min?: Date;
-        max?: Date;
+        string?: boolean | undefined;
+        american?: boolean | undefined;
+        year?: number | undefined;
+        month?: number | undefined;
+        day?: number | undefined;
+        min?: Date | undefined;
+        max?: Date | undefined;
     }
 
-    type UniqueOptions<T> = { comparator?: (array: T[], value: T) => boolean } & Options;
+    type UniqueOptions<T> = { comparator?: ((array: T[], value: T) => boolean) | undefined } & Options;
 
     interface Month {
         name: string;

--- a/types/chardet/index.d.ts
+++ b/types/chardet/index.d.ts
@@ -9,12 +9,12 @@
 export interface Confidence {
     name: string;
     confidence: number;
-    lang?: string;
+    lang?: string | undefined;
 }
 
 export interface Options {
-    returnAllMatches?: boolean;
-    sampleSize?: number;
+    returnAllMatches?: boolean | undefined;
+    sampleSize?: number | undefined;
 }
 
 // As of v0.6, these fns return the highest-confidence result

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -117,13 +117,13 @@ declare class PluginServiceStatic {
 interface Meta {
     type: Chart.ChartType;
     data: MetaData[];
-    dataset?: Chart.ChartDataSets;
+    dataset?: Chart.ChartDataSets | undefined;
     controller: { [key: string]: any; };
-    hidden?: boolean;
-    total?: string;
-    xAxisID?: string;
-    yAxisID?: string;
-    "$filler"?: { [key: string]: any; };
+    hidden?: boolean | undefined;
+    total?: string | undefined;
+    xAxisID?: string | undefined;
+    yAxisID?: string | undefined;
+    "$filler"?: { [key: string]: any; } | undefined;
 }
 
 interface MetaData {
@@ -135,7 +135,7 @@ interface MetaData {
     _view: Model;
     _xScale: Chart.ChartScales;
     _yScale: Chart.ChartScales;
-    hidden?: boolean;
+    hidden?: boolean | undefined;
 }
 
 // NOTE: This model is generic with a bunch of optional properties to represent all types of chart models.
@@ -143,22 +143,22 @@ interface MetaData {
 // might always have values depending on the chart type.
 interface Model {
     backgroundColor: string;
-    borderAlign?: Chart.BorderAlignment;
+    borderAlign?: Chart.BorderAlignment | undefined;
     borderColor: string;
-    borderWidth?: number;
-    circumference?: number;
+    borderWidth?: number | undefined;
+    circumference?: number | undefined;
     controlPointNextX: number;
     controlPointNextY: number;
     controlPointPreviousX: number;
     controlPointPreviousY: number;
-    endAngle?: number;
+    endAngle?: number | undefined;
     hitRadius: number;
-    innerRadius?: number;
-    outerRadius?: number;
+    innerRadius?: number | undefined;
+    outerRadius?: number | undefined;
     pointStyle: string;
     radius: string;
-    skip?: boolean;
-    startAngle?: number;
+    skip?: boolean | undefined;
+    startAngle?: number | undefined;
     steppedLine?: undefined;
     tension: number;
     x: number;
@@ -212,32 +212,32 @@ declare namespace Chart {
     }
 
     interface ChartLegendItem {
-        text?: string;
-        fillStyle?: string;
-        hidden?: boolean;
-        index?: number;
-        lineCap?: 'butt' | 'round' | 'square';
-        lineDash?: number[];
-        lineDashOffset?: number;
-        lineJoin?: 'bevel' | 'round' | 'miter';
-        lineWidth?: number;
-        strokeStyle?: string;
-        pointStyle?: PointStyle;
+        text?: string | undefined;
+        fillStyle?: string | undefined;
+        hidden?: boolean | undefined;
+        index?: number | undefined;
+        lineCap?: 'butt' | 'round' | 'square' | undefined;
+        lineDash?: number[] | undefined;
+        lineDashOffset?: number | undefined;
+        lineJoin?: 'bevel' | 'round' | 'miter' | undefined;
+        lineWidth?: number | undefined;
+        strokeStyle?: string | undefined;
+        pointStyle?: PointStyle | undefined;
     }
 
     interface ChartLegendLabelItem extends ChartLegendItem {
-        datasetIndex?: number;
+        datasetIndex?: number | undefined;
     }
 
     interface ChartTooltipItem {
-        label?: string;
-        value?: string;
-        xLabel?: string | number;
-        yLabel?: string | number;
-        datasetIndex?: number;
-        index?: number;
-        x?: number;
-        y?: number;
+        label?: string | undefined;
+        value?: string | undefined;
+        xLabel?: string | number | undefined;
+        yLabel?: string | number | undefined;
+        datasetIndex?: number | undefined;
+        index?: number | undefined;
+        x?: number | undefined;
+        y?: number | undefined;
     }
 
     interface ChartTooltipLabelColor {
@@ -267,26 +267,26 @@ declare namespace Chart {
     }
 
     interface ChartPoint {
-        x?: number | string | Date | Moment;
-        y?: number | string | Date | Moment;
-        r?: number;
-        t?: number | string | Date | Moment;
+        x?: number | string | Date | Moment | undefined;
+        y?: number | string | Date | Moment | undefined;
+        r?: number | undefined;
+        t?: number | string | Date | Moment | undefined;
     }
 
     interface ChartConfiguration {
-        type?: ChartType | string;
-        data?: ChartData;
-        options?: ChartOptions;
-        plugins?: PluginServiceRegistrationOptions[];
+        type?: ChartType | string | undefined;
+        data?: ChartData | undefined;
+        options?: ChartOptions | undefined;
+        plugins?: PluginServiceRegistrationOptions[] | undefined;
     }
 
     interface ChartData {
-        labels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
-        datasets?: ChartDataSets[];
+        labels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]> | undefined;
+        datasets?: ChartDataSets[] | undefined;
     }
 
     interface RadialChartOptions extends ChartOptions {
-        scale?: RadialLinearScale;
+        scale?: RadialLinearScale | undefined;
     }
 
     interface ChartSize {
@@ -295,122 +295,122 @@ declare namespace Chart {
     }
 
     interface ChartOptions {
-        responsive?: boolean;
-        responsiveAnimationDuration?: number;
-        aspectRatio?: number;
-        maintainAspectRatio?: boolean;
-        events?: string[];
+        responsive?: boolean | undefined;
+        responsiveAnimationDuration?: number | undefined;
+        aspectRatio?: number | undefined;
+        maintainAspectRatio?: boolean | undefined;
+        events?: string[] | undefined;
         legendCallback?(chart: Chart): string;
         onHover?(this: Chart, event: MouseEvent, activeElements: Array<{}>): any;
         onClick?(event?: MouseEvent, activeElements?: Array<{}>): any;
         onResize?(this: Chart, newSize: ChartSize): void;
-        title?: ChartTitleOptions;
-        legend?: ChartLegendOptions;
-        tooltips?: ChartTooltipOptions;
-        hover?: ChartHoverOptions;
-        animation?: ChartAnimationOptions;
-        elements?: ChartElementsOptions;
-        layout?: ChartLayoutOptions;
-        scale?: RadialLinearScale;
-        scales?: ChartScales | LinearScale | LogarithmicScale | TimeScale;
-        showLines?: boolean;
-        spanGaps?: boolean;
-        cutoutPercentage?: number;
-        circumference?: number;
-        rotation?: number;
-        devicePixelRatio?: number;
-        plugins?: ChartPluginsOptions;
-        defaultColor?: ChartColor;
+        title?: ChartTitleOptions | undefined;
+        legend?: ChartLegendOptions | undefined;
+        tooltips?: ChartTooltipOptions | undefined;
+        hover?: ChartHoverOptions | undefined;
+        animation?: ChartAnimationOptions | undefined;
+        elements?: ChartElementsOptions | undefined;
+        layout?: ChartLayoutOptions | undefined;
+        scale?: RadialLinearScale | undefined;
+        scales?: ChartScales | LinearScale | LogarithmicScale | TimeScale | undefined;
+        showLines?: boolean | undefined;
+        spanGaps?: boolean | undefined;
+        cutoutPercentage?: number | undefined;
+        circumference?: number | undefined;
+        rotation?: number | undefined;
+        devicePixelRatio?: number | undefined;
+        plugins?: ChartPluginsOptions | undefined;
+        defaultColor?: ChartColor | undefined;
     }
 
     interface ChartFontOptions {
-        defaultFontColor?: ChartColor;
-        defaultFontFamily?: string;
-        defaultFontSize?: number;
-        defaultFontStyle?: string;
+        defaultFontColor?: ChartColor | undefined;
+        defaultFontFamily?: string | undefined;
+        defaultFontSize?: number | undefined;
+        defaultFontStyle?: string | undefined;
     }
 
     interface ChartTitleOptions {
-        display?: boolean;
-        position?: PositionType;
-        fullWidth?: boolean;
-        fontSize?: number;
-        fontFamily?: string;
-        fontColor?: ChartColor;
-        fontStyle?: string;
-        padding?: number;
-        lineHeight?: number | string;
-        text?: string | string[];
+        display?: boolean | undefined;
+        position?: PositionType | undefined;
+        fullWidth?: boolean | undefined;
+        fontSize?: number | undefined;
+        fontFamily?: string | undefined;
+        fontColor?: ChartColor | undefined;
+        fontStyle?: string | undefined;
+        padding?: number | undefined;
+        lineHeight?: number | string | undefined;
+        text?: string | string[] | undefined;
     }
 
     interface ChartLegendOptions {
-        align?: 'center' | 'end' | 'start';
-        display?: boolean;
-        position?: PositionType;
-        fullWidth?: boolean;
+        align?: 'center' | 'end' | 'start' | undefined;
+        display?: boolean | undefined;
+        position?: PositionType | undefined;
+        fullWidth?: boolean | undefined;
         onClick?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
         onHover?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
         onLeave?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
-        labels?: ChartLegendLabelOptions;
-        reverse?: boolean;
-        rtl?: boolean;
-        textDirection?: string;
+        labels?: ChartLegendLabelOptions | undefined;
+        reverse?: boolean | undefined;
+        rtl?: boolean | undefined;
+        textDirection?: string | undefined;
     }
 
     interface ChartLegendLabelOptions {
-        boxWidth?: number;
-        fontSize?: number;
-        fontStyle?: string;
-        fontColor?: ChartColor;
-        fontFamily?: string;
-        padding?: number;
+        boxWidth?: number | undefined;
+        fontSize?: number | undefined;
+        fontStyle?: string | undefined;
+        fontColor?: ChartColor | undefined;
+        fontFamily?: string | undefined;
+        padding?: number | undefined;
         generateLabels?(chart: Chart): ChartLegendLabelItem[];
         filter?(legendItem: ChartLegendLabelItem, data: ChartData): any;
-        usePointStyle?: boolean;
+        usePointStyle?: boolean | undefined;
     }
 
     interface ChartTooltipOptions {
-        axis?: 'x'|'y'|'xy';
-        enabled?: boolean;
-        custom?: (tooltipModel: ChartTooltipModel) => void;
-        mode?: InteractionMode;
-        intersect?: boolean;
-        backgroundColor?: ChartColor;
-        titleAlign?: TextAlignment;
-        titleFontFamily?: string;
-        titleFontSize?: number;
-        titleFontStyle?: string;
-        titleFontColor?: ChartColor;
-        titleSpacing?: number;
-        titleMarginBottom?: number;
-        bodyAlign?: TextAlignment;
-        bodyFontFamily?: string;
-        bodyFontSize?: number;
-        bodyFontStyle?: string;
-        bodyFontColor?: ChartColor;
-        bodySpacing?: number;
-        footerAlign?: TextAlignment;
-        footerFontFamily?: string;
-        footerFontSize?: number;
-        footerFontStyle?: string;
-        footerFontColor?: ChartColor;
-        footerSpacing?: number;
-        footerMarginTop?: number;
-        xPadding?: number;
-        yPadding?: number;
-        caretSize?: number;
-        cornerRadius?: number;
-        multiKeyBackground?: string;
-        callbacks?: ChartTooltipCallback;
+        axis?: 'x'|'y'|'xy' | undefined;
+        enabled?: boolean | undefined;
+        custom?: ((tooltipModel: ChartTooltipModel) => void) | undefined;
+        mode?: InteractionMode | undefined;
+        intersect?: boolean | undefined;
+        backgroundColor?: ChartColor | undefined;
+        titleAlign?: TextAlignment | undefined;
+        titleFontFamily?: string | undefined;
+        titleFontSize?: number | undefined;
+        titleFontStyle?: string | undefined;
+        titleFontColor?: ChartColor | undefined;
+        titleSpacing?: number | undefined;
+        titleMarginBottom?: number | undefined;
+        bodyAlign?: TextAlignment | undefined;
+        bodyFontFamily?: string | undefined;
+        bodyFontSize?: number | undefined;
+        bodyFontStyle?: string | undefined;
+        bodyFontColor?: ChartColor | undefined;
+        bodySpacing?: number | undefined;
+        footerAlign?: TextAlignment | undefined;
+        footerFontFamily?: string | undefined;
+        footerFontSize?: number | undefined;
+        footerFontStyle?: string | undefined;
+        footerFontColor?: ChartColor | undefined;
+        footerSpacing?: number | undefined;
+        footerMarginTop?: number | undefined;
+        xPadding?: number | undefined;
+        yPadding?: number | undefined;
+        caretSize?: number | undefined;
+        cornerRadius?: number | undefined;
+        multiKeyBackground?: string | undefined;
+        callbacks?: ChartTooltipCallback | undefined;
         filter?(item: ChartTooltipItem, data: ChartData): boolean;
         itemSort?(itemA: ChartTooltipItem, itemB: ChartTooltipItem, data?: ChartData): number;
-        position?: string;
-        caretPadding?: number;
-        displayColors?: boolean;
-        borderColor?: ChartColor;
-        borderWidth?: number;
-        rtl?: boolean;
-        textDirection?: string;
+        position?: string | undefined;
+        caretPadding?: number | undefined;
+        displayColors?: boolean | undefined;
+        borderColor?: ChartColor | undefined;
+        borderWidth?: number | undefined;
+        rtl?: boolean | undefined;
+        textDirection?: string | undefined;
     }
 
     interface ChartTooltipModel {
@@ -482,197 +482,197 @@ declare namespace Chart {
     type ChartTooltipPositioner = (elements: any[], eventPosition: Point) => Point;
 
     interface ChartHoverOptions {
-        mode?: InteractionMode;
-        animationDuration?: number;
-        intersect?: boolean;
-        axis?: 'x' | 'y' | 'xy';
+        mode?: InteractionMode | undefined;
+        animationDuration?: number | undefined;
+        intersect?: boolean | undefined;
+        axis?: 'x' | 'y' | 'xy' | undefined;
         onHover?(this: Chart, event: MouseEvent, activeElements: Array<{}>): any;
     }
 
     interface ChartAnimationObject {
-        currentStep?: number;
-        numSteps?: number;
-        easing?: Easing;
+        currentStep?: number | undefined;
+        numSteps?: number | undefined;
+        easing?: Easing | undefined;
         render?(arg: any): void;
         onAnimationProgress?(arg: any): void;
         onAnimationComplete?(arg: any): void;
     }
 
     interface ChartAnimationOptions {
-        duration?: number;
-        easing?: Easing;
+        duration?: number | undefined;
+        easing?: Easing | undefined;
         onProgress?(chart: any): void;
         onComplete?(chart: any): void;
-        animateRotate?: boolean;
-        animateScale?: boolean;
+        animateRotate?: boolean | undefined;
+        animateScale?: boolean | undefined;
     }
 
     interface ChartElementsOptions {
-        point?: ChartPointOptions;
-        line?: ChartLineOptions;
-        arc?: ChartArcOptions;
-        rectangle?: ChartRectangleOptions;
+        point?: ChartPointOptions | undefined;
+        line?: ChartLineOptions | undefined;
+        arc?: ChartArcOptions | undefined;
+        rectangle?: ChartRectangleOptions | undefined;
     }
 
     interface ChartArcOptions {
-        angle?: number | Scriptable<number>;
-        backgroundColor?: ChartDataSets["backgroundColor"];
-        borderAlign?: BorderAlignment | Scriptable<BorderAlignment>;
-        borderColor?: ChartColor | Scriptable<ChartColor>;
-        borderWidth?: number | Scriptable<number>;
+        angle?: number | Scriptable<number> | undefined;
+        backgroundColor?: ChartDataSets["backgroundColor"] | undefined;
+        borderAlign?: BorderAlignment | Scriptable<BorderAlignment> | undefined;
+        borderColor?: ChartColor | Scriptable<ChartColor> | undefined;
+        borderWidth?: number | Scriptable<number> | undefined;
     }
 
     type CubicInterpolationMode = 'default' | 'monotone';
     type FillMode = 'zero' | 'top' | 'bottom' | boolean;
 
     interface ChartLineOptions {
-        cubicInterpolationMode?: CubicInterpolationMode | Scriptable<CubicInterpolationMode>;
-        tension?: number | Scriptable<number>;
-        backgroundColor?: ChartDataSets["backgroundColor"];
-        borderWidth?: number | Scriptable<number>;
-        borderColor?: ChartColor | Scriptable<ChartColor>;
-        borderCapStyle?: string | Scriptable<string>;
-        borderDash?: any[] | Scriptable<any[]>;
-        borderDashOffset?: number | Scriptable<number>;
-        borderJoinStyle?: string | Scriptable<string>;
-        capBezierPoints?: boolean | Scriptable<boolean>;
-        fill?: FillMode | Scriptable<FillMode>;
-        stepped?: boolean | Scriptable<boolean>;
+        cubicInterpolationMode?: CubicInterpolationMode | Scriptable<CubicInterpolationMode> | undefined;
+        tension?: number | Scriptable<number> | undefined;
+        backgroundColor?: ChartDataSets["backgroundColor"] | undefined;
+        borderWidth?: number | Scriptable<number> | undefined;
+        borderColor?: ChartColor | Scriptable<ChartColor> | undefined;
+        borderCapStyle?: string | Scriptable<string> | undefined;
+        borderDash?: any[] | Scriptable<any[]> | undefined;
+        borderDashOffset?: number | Scriptable<number> | undefined;
+        borderJoinStyle?: string | Scriptable<string> | undefined;
+        capBezierPoints?: boolean | Scriptable<boolean> | undefined;
+        fill?: FillMode | Scriptable<FillMode> | undefined;
+        stepped?: boolean | Scriptable<boolean> | undefined;
     }
 
     interface ChartPointOptions {
-        radius?: number | Scriptable<number>;
-        pointStyle?: PointStyle | Scriptable<PointStyle>;
-        rotation?: number | Scriptable<number>;
-        backgroundColor?: ChartDataSets["backgroundColor"];
-        borderWidth?: number | Scriptable<number>;
-        borderColor?: ChartColor | Scriptable<ChartColor>;
-        hitRadius?: number | Scriptable<number>;
-        hoverRadius?: number | Scriptable<number>;
-        hoverBorderWidth?: number | Scriptable<number>;
+        radius?: number | Scriptable<number> | undefined;
+        pointStyle?: PointStyle | Scriptable<PointStyle> | undefined;
+        rotation?: number | Scriptable<number> | undefined;
+        backgroundColor?: ChartDataSets["backgroundColor"] | undefined;
+        borderWidth?: number | Scriptable<number> | undefined;
+        borderColor?: ChartColor | Scriptable<ChartColor> | undefined;
+        hitRadius?: number | Scriptable<number> | undefined;
+        hoverRadius?: number | Scriptable<number> | undefined;
+        hoverBorderWidth?: number | Scriptable<number> | undefined;
     }
 
     interface ChartRectangleOptions {
-        backgroundColor?: ChartDataSets["backgroundColor"];
-        borderWidth?: number | Scriptable<number>;
-        borderColor?: ChartColor | Scriptable<ChartColor>;
-        borderSkipped?: string | Scriptable<string>;
+        backgroundColor?: ChartDataSets["backgroundColor"] | undefined;
+        borderWidth?: number | Scriptable<number> | undefined;
+        borderColor?: ChartColor | Scriptable<ChartColor> | undefined;
+        borderSkipped?: string | Scriptable<string> | undefined;
     }
 
     interface ChartLayoutOptions {
-        padding?: ChartLayoutPaddingObject | number;
+        padding?: ChartLayoutPaddingObject | number | undefined;
     }
 
     interface ChartLayoutPaddingObject {
-        top?: number;
-        right?: number;
-        bottom?: number;
-        left?: number;
+        top?: number | undefined;
+        right?: number | undefined;
+        bottom?: number | undefined;
+        left?: number | undefined;
     }
 
     interface GridLineOptions {
-        display?: boolean;
-        circular?: boolean;
-        color?: ChartColor;
-        borderDash?: number[];
-        borderDashOffset?: number;
-        lineWidth?: number | number[];
-        drawBorder?: boolean;
-        drawOnChartArea?: boolean;
-        drawTicks?: boolean;
-        tickMarkLength?: number;
-        zeroLineWidth?: number;
-        zeroLineColor?: ChartColor;
-        zeroLineBorderDash?: number[];
-        zeroLineBorderDashOffset?: number;
-        offsetGridLines?: boolean;
-        z?: number;
+        display?: boolean | undefined;
+        circular?: boolean | undefined;
+        color?: ChartColor | undefined;
+        borderDash?: number[] | undefined;
+        borderDashOffset?: number | undefined;
+        lineWidth?: number | number[] | undefined;
+        drawBorder?: boolean | undefined;
+        drawOnChartArea?: boolean | undefined;
+        drawTicks?: boolean | undefined;
+        tickMarkLength?: number | undefined;
+        zeroLineWidth?: number | undefined;
+        zeroLineColor?: ChartColor | undefined;
+        zeroLineBorderDash?: number[] | undefined;
+        zeroLineBorderDashOffset?: number | undefined;
+        offsetGridLines?: boolean | undefined;
+        z?: number | undefined;
     }
 
     interface ScaleTitleOptions {
-        display?: boolean;
-        labelString?: string;
-        lineHeight?: number | string;
-        fontColor?: ChartColor;
-        fontFamily?: string;
-        fontSize?: number;
-        fontStyle?: string;
-        padding?: ChartLayoutPaddingObject | number;
+        display?: boolean | undefined;
+        labelString?: string | undefined;
+        lineHeight?: number | string | undefined;
+        fontColor?: ChartColor | undefined;
+        fontFamily?: string | undefined;
+        fontSize?: number | undefined;
+        fontStyle?: string | undefined;
+        padding?: ChartLayoutPaddingObject | number | undefined;
     }
 
     interface TickOptions extends NestedTickOptions {
-        minor?: NestedTickOptions | false;
-        major?: MajorTickOptions | false;
+        minor?: NestedTickOptions | false | undefined;
+        major?: MajorTickOptions | false | undefined;
     }
 
     interface NestedTickOptions {
-        autoSkip?: boolean;
-        autoSkipPadding?: number;
-        backdropColor?: ChartColor;
-        backdropPaddingX?: number;
-        backdropPaddingY?: number;
-        beginAtZero?: boolean;
+        autoSkip?: boolean | undefined;
+        autoSkipPadding?: number | undefined;
+        backdropColor?: ChartColor | undefined;
+        backdropPaddingX?: number | undefined;
+        backdropPaddingY?: number | undefined;
+        beginAtZero?: boolean | undefined;
         /**
          * If the callback returns null or undefined the associated grid line will be hidden.
          */
         callback?(value: number | string, index: number, values: number[] | string[]): string | number | null | undefined;
-        display?: boolean;
-        fontColor?: ChartColor;
-        fontFamily?: string;
-        fontSize?: number;
-        fontStyle?: string;
-        labelOffset?: number;
-        lineHeight?: number;
+        display?: boolean | undefined;
+        fontColor?: ChartColor | undefined;
+        fontFamily?: string | undefined;
+        fontSize?: number | undefined;
+        fontStyle?: string | undefined;
+        labelOffset?: number | undefined;
+        lineHeight?: number | undefined;
         max?: any;
-        maxRotation?: number;
-        maxTicksLimit?: number;
+        maxRotation?: number | undefined;
+        maxTicksLimit?: number | undefined;
         min?: any;
-        minRotation?: number;
-        mirror?: boolean;
-        padding?: number;
-        precision?: number;
-        reverse?: boolean;
+        minRotation?: number | undefined;
+        mirror?: boolean | undefined;
+        padding?: number | undefined;
+        precision?: number | undefined;
+        reverse?: boolean | undefined;
         /**
          * The number of ticks to examine when deciding how many labels will fit.
          * Setting a smaller value will be faster, but may be less accurate
          * when there is large variability in label length.
          * Deault: `ticks.length`
          */
-        sampleSize?: number;
-        showLabelBackdrop?: boolean;
-        source?: 'auto' | 'data' | 'labels';
-        stepSize?: number;
-        suggestedMax?: number;
-        suggestedMin?: number;
+        sampleSize?: number | undefined;
+        showLabelBackdrop?: boolean | undefined;
+        source?: 'auto' | 'data' | 'labels' | undefined;
+        stepSize?: number | undefined;
+        suggestedMax?: number | undefined;
+        suggestedMin?: number | undefined;
     }
 
     interface MajorTickOptions extends NestedTickOptions {
-        enabled?: boolean;
+        enabled?: boolean | undefined;
     }
 
     interface AngleLineOptions {
-        display?: boolean;
-        color?: ChartColor;
-        lineWidth?: number;
-        borderDash?: number[];
-        borderDashOffset?: number;
+        display?: boolean | undefined;
+        color?: ChartColor | undefined;
+        lineWidth?: number | undefined;
+        borderDash?: number[] | undefined;
+        borderDashOffset?: number | undefined;
     }
 
     interface PointLabelOptions {
         callback?(arg: any): any;
-        fontColor?: ChartColor;
-        fontFamily?: string;
-        fontSize?: number;
-        fontStyle?: string;
-        lineHeight?: number|string;
+        fontColor?: ChartColor | undefined;
+        fontFamily?: string | undefined;
+        fontSize?: number | undefined;
+        fontStyle?: string | undefined;
+        lineHeight?: number|string | undefined;
     }
 
     interface LinearTickOptions extends TickOptions {
-        maxTicksLimit?: number;
-        stepSize?: number;
-        precision?: number;
-        suggestedMin?: number;
-        suggestedMax?: number;
+        maxTicksLimit?: number | undefined;
+        stepSize?: number | undefined;
+        precision?: number | undefined;
+        suggestedMin?: number | undefined;
+        suggestedMax?: number | undefined;
     }
 
     // tslint:disable-next-line no-empty-interface
@@ -682,87 +682,96 @@ declare namespace Chart {
     type ChartColor = string | CanvasGradient | CanvasPattern | string[];
 
     type Scriptable<T> = (ctx: {
-        chart?: Chart;
-        dataIndex?: number;
-        dataset?: ChartDataSets
-        datasetIndex?: number;
+        chart?: Chart | undefined;
+        dataIndex?: number | undefined;
+        dataset?: ChartDataSets | undefined
+        datasetIndex?: number | undefined;
     }) => T;
 
     interface ChartDataSets {
-        cubicInterpolationMode?: CubicInterpolationMode | Scriptable<CubicInterpolationMode>;
-        backgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        barPercentage?: number;
-        barThickness?: number | "flex";
-        borderAlign?: BorderAlignment | BorderAlignment[] | Scriptable<BorderAlignment>;
-        borderWidth?: BorderWidth | BorderWidth[] | Scriptable<BorderWidth>;
-        borderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        borderCapStyle?: 'butt' | 'round' | 'square';
-        borderDash?: number[];
-        borderDashOffset?: number;
-        borderJoinStyle?: 'bevel' | 'round' | 'miter';
-        borderSkipped?: PositionType | PositionType[] | Scriptable<PositionType>;
-        categoryPercentage?: number;
-        data?: Array<number | null | undefined | number[]> | ChartPoint[];
-        fill?: boolean | number | string;
-        hitRadius?: number | number[] | Scriptable<number>;
-        hoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        hoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        hoverBorderWidth?: number | number[] | Scriptable<number>;
-        hoverRadius?: number;
-        label?: string;
-        lineTension?: number;
-        maxBarThickness?: number;
-        minBarLength?: number;
-        steppedLine?: 'before' | 'after' | 'middle' | boolean;
-        order?: number;
-        pointBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        pointBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        pointBorderWidth?: number | number[] | Scriptable<number>;
-        pointRadius?: number | number[] | Scriptable<number>;
-        pointRotation?: number | number[] | Scriptable<number>;
-        pointHoverRadius?: number | number[] | Scriptable<number>;
-        pointHitRadius?: number | number[] | Scriptable<number>;
-        pointHoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        pointHoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        pointHoverBorderWidth?: number | number[] | Scriptable<number>;
-        pointStyle?: PointStyle | HTMLImageElement | HTMLCanvasElement | Array<PointStyle | HTMLImageElement | HTMLCanvasElement> | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
-        radius?: number | number[] | Scriptable<number>;
-        rotation?: number | number[] | Scriptable<number>;
-        xAxisID?: string;
-        yAxisID?: string;
-        type?: ChartType | string;
-        hidden?: boolean;
-        hideInLegendAndTooltip?: boolean;
-        showLine?: boolean;
-        stack?: string;
-        spanGaps?: boolean;
-        weight?: number;
+        cubicInterpolationMode?: CubicInterpolationMode | Scriptable<CubicInterpolationMode> | undefined;
+        backgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        barPercentage?: number | undefined;
+        barThickness?: number | "flex" | undefined;
+        borderAlign?: BorderAlignment | BorderAlignment[] | Scriptable<BorderAlignment> | undefined;
+        borderWidth?: BorderWidth | BorderWidth[] | Scriptable<BorderWidth> | undefined;
+        borderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        borderCapStyle?: 'butt' | 'round' | 'square' | undefined;
+        borderDash?: number[] | undefined;
+        borderDashOffset?: number | undefined;
+        borderJoinStyle?: 'bevel' | 'round' | 'miter' | undefined;
+        borderSkipped?: PositionType | PositionType[] | Scriptable<PositionType> | undefined;
+        categoryPercentage?: number | undefined;
+        data?: Array<number | null | undefined | number[]> | ChartPoint[] | undefined;
+        fill?: boolean | number | string | undefined;
+        hitRadius?: number | number[] | Scriptable<number> | undefined;
+        hoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        hoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        hoverBorderWidth?: number | number[] | Scriptable<number> | undefined;
+        hoverRadius?: number | undefined;
+        label?: string | undefined;
+        lineTension?: number | undefined;
+        maxBarThickness?: number | undefined;
+        minBarLength?: number | undefined;
+        steppedLine?: 'before' | 'after' | 'middle' | boolean | undefined;
+        order?: number | undefined;
+        pointBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        pointBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        pointBorderWidth?: number | number[] | Scriptable<number> | undefined;
+        pointRadius?: number | number[] | Scriptable<number> | undefined;
+        pointRotation?: number | number[] | Scriptable<number> | undefined;
+        pointHoverRadius?: number | number[] | Scriptable<number> | undefined;
+        pointHitRadius?: number | number[] | Scriptable<number> | undefined;
+        pointHoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        pointHoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor> | undefined;
+        pointHoverBorderWidth?: number | number[] | Scriptable<number> | undefined;
+        pointStyle?: PointStyle
+            | HTMLImageElement
+            | HTMLCanvasElement
+            | Array<PointStyle
+            | HTMLImageElement
+            | HTMLCanvasElement>
+            | Scriptable<PointStyle
+            | HTMLImageElement
+            | HTMLCanvasElement>
+            | undefined;
+        radius?: number | number[] | Scriptable<number> | undefined;
+        rotation?: number | number[] | Scriptable<number> | undefined;
+        xAxisID?: string | undefined;
+        yAxisID?: string | undefined;
+        type?: ChartType | string | undefined;
+        hidden?: boolean | undefined;
+        hideInLegendAndTooltip?: boolean | undefined;
+        showLine?: boolean | undefined;
+        stack?: string | undefined;
+        spanGaps?: boolean | undefined;
+        weight?: number | undefined;
     }
 
     interface ChartScales {
-        type?: ScaleType | string;
-        display?: boolean;
-        position?: PositionType | string;
-        gridLines?: GridLineOptions;
-        scaleLabel?: ScaleTitleOptions;
-        ticks?: TickOptions;
-        xAxes?: ChartXAxe[];
-        yAxes?: ChartYAxe[];
+        type?: ScaleType | string | undefined;
+        display?: boolean | undefined;
+        position?: PositionType | string | undefined;
+        gridLines?: GridLineOptions | undefined;
+        scaleLabel?: ScaleTitleOptions | undefined;
+        ticks?: TickOptions | undefined;
+        xAxes?: ChartXAxe[] | undefined;
+        yAxes?: ChartYAxe[] | undefined;
     }
 
     interface CommonAxe {
-        bounds?: string;
-        type?: ScaleType | string;
-        display?: boolean | string;
-        id?: string;
-        labels?: string[];
-        stacked?: boolean;
-        position?: string;
-        ticks?: TickOptions;
-        gridLines?: GridLineOptions;
-        scaleLabel?: ScaleTitleOptions;
-        time?: TimeScale;
-        offset?: boolean;
+        bounds?: string | undefined;
+        type?: ScaleType | string | undefined;
+        display?: boolean | string | undefined;
+        id?: string | undefined;
+        labels?: string[] | undefined;
+        stacked?: boolean | undefined;
+        position?: string | undefined;
+        ticks?: TickOptions | undefined;
+        gridLines?: GridLineOptions | undefined;
+        scaleLabel?: ScaleTitleOptions | undefined;
+        time?: TimeScale | undefined;
+        offset?: boolean | undefined;
         beforeUpdate?(scale?: any): void;
         beforeSetDimension?(scale?: any): void;
         beforeDataLimits?(scale?: any): void;
@@ -780,7 +789,7 @@ declare namespace Chart {
     }
 
     interface ChartXAxe extends CommonAxe {
-        distribution?: 'linear' | 'series';
+        distribution?: 'linear' | 'series' | undefined;
     }
 
     // tslint:disable-next-line no-empty-interface
@@ -788,52 +797,52 @@ declare namespace Chart {
     }
 
     interface LinearScale extends ChartScales {
-        ticks?: LinearTickOptions;
+        ticks?: LinearTickOptions | undefined;
     }
 
     interface LogarithmicScale extends ChartScales {
-        ticks?: LogarithmicTickOptions;
+        ticks?: LogarithmicTickOptions | undefined;
     }
 
     interface TimeDisplayFormat {
-        millisecond?: string;
-        second?: string;
-        minute?: string;
-        hour?: string;
-        day?: string;
-        week?: string;
-        month?: string;
-        quarter?: string;
-        year?: string;
+        millisecond?: string | undefined;
+        second?: string | undefined;
+        minute?: string | undefined;
+        hour?: string | undefined;
+        day?: string | undefined;
+        week?: string | undefined;
+        month?: string | undefined;
+        quarter?: string | undefined;
+        year?: string | undefined;
     }
 
     interface DateAdapterOptions {
-        date?: object;
+        date?: object | undefined;
     }
 
     interface TimeScale extends ChartScales {
-        adapters?: DateAdapterOptions;
-        displayFormats?: TimeDisplayFormat;
-        isoWeekday?: boolean;
-        max?: string;
-        min?: string;
-        parser?: string | ((arg: any) => any);
-        round?: TimeUnit;
-        tooltipFormat?: string;
-        unit?: TimeUnit;
-        unitStepSize?: number;
-        stepSize?: number;
-        minUnit?: TimeUnit;
+        adapters?: DateAdapterOptions | undefined;
+        displayFormats?: TimeDisplayFormat | undefined;
+        isoWeekday?: boolean | undefined;
+        max?: string | undefined;
+        min?: string | undefined;
+        parser?: string | ((arg: any) => any) | undefined;
+        round?: TimeUnit | undefined;
+        tooltipFormat?: string | undefined;
+        unit?: TimeUnit | undefined;
+        unitStepSize?: number | undefined;
+        stepSize?: number | undefined;
+        minUnit?: TimeUnit | undefined;
     }
 
     interface RadialLinearScale {
-        animate?: boolean;
-        position?: PositionType;
-        angleLines?: AngleLineOptions;
-        pointLabels?: PointLabelOptions;
-        ticks?: LinearTickOptions;
-        display?: boolean;
-        gridLines?: GridLineOptions;
+        animate?: boolean | undefined;
+        position?: PositionType | undefined;
+        angleLines?: AngleLineOptions | undefined;
+        pointLabels?: PointLabelOptions | undefined;
+        ticks?: LinearTickOptions | undefined;
+        display?: boolean | undefined;
+        gridLines?: GridLineOptions | undefined;
     }
 
     interface Point {
@@ -842,7 +851,7 @@ declare namespace Chart {
     }
 
     interface PluginServiceGlobalRegistration {
-        id?: string;
+        id?: string | undefined;
     }
 
     interface PluginServiceRegistrationOptions {
@@ -896,15 +905,15 @@ declare namespace Chart {
     }
 
     interface ChartUpdateProps {
-        duration?: number;
-        lazy?: boolean;
-        easing?: Easing;
+        duration?: number | undefined;
+        lazy?: boolean | undefined;
+        easing?: Easing | undefined;
     }
 
     interface ChartRenderProps {
-        duration?: number;
-        lazy?: boolean;
-        easing?: Easing;
+        duration?: number | undefined;
+        lazy?: boolean | undefined;
+        easing?: Easing | undefined;
     }
 
     // Model used with the doughnut chart

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -92,15 +92,15 @@ declare namespace Chartist {
     // this definition gives some intellisense, but does not protect the user from misuse
     // TODO: come in and tidy this up and make it fit better
     interface IChartistData {
-        labels?: Array<string> | Array<number> | Array<Date>;
+        labels?: Array<string> | Array<number> | Array<Date> | undefined;
         series: Array<IChartistSeriesData> | Array<Array<IChartistSeriesData>> | Array<Array<IChartistData>> | Array<number> | Array<Array<number>>;
     }
 
     interface IChartistSeriesData {
-        name?: string;
-        value?: number;
-        data?: Array<number> | Array<{ x: number | Date, y: number }>;
-        className?: string;
+        name?: string | undefined;
+        value?: number | undefined;
+        data?: Array<number> | Array<{ x: number | Date, y: number }> | undefined;
+        className?: string | undefined;
         meta?: any;
     }
 
@@ -118,7 +118,7 @@ declare namespace Chartist {
         supportsAnimations: boolean;
         resizeListener: any;
 
-        plugins?: Array<any>; // all of these plugins seem to be functions with options, but keeping type any for now
+        plugins?: Array<any> | undefined; // all of these plugins seem to be functions with options, but keeping type any for now
 
         update(data: Object, options?: T, override?: boolean): void;
 
@@ -163,99 +163,99 @@ declare namespace Chartist {
         /**
          * If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
          */
-        reverseData?: boolean;
+        reverseData?: boolean | undefined;
 
-        plugins?: Array<any>;
+        plugins?: Array<any> | undefined;
     }
 
     interface IPieChartOptions extends IChartOptions {
         /**
          * Specify a fixed width for the chart as a string (i.e. '100px' or '50%')
          */
-        width?: number | string;
+        width?: number | string | undefined;
 
         /**
          * Specify a fixed height for the chart as a string (i.e. '100px' or '50%')
          */
-        height?: number | string;
+        height?: number | string | undefined;
 
         /**
          * Padding of the chart drawing area to the container element and labels as a number or padding object {top: 5, right: 5, bottom: 5, left: 5}
          */
-        chartPadding?: IChartPadding | number;
+        chartPadding?: IChartPadding | number | undefined;
 
         /**
          * Override the class names that are used to generate the SVG structure of the chart
          */
-        classNames?: IPieChartClasses;
+        classNames?: IPieChartClasses | undefined;
 
         /**
          * The start angle of the pie chart in degrees where 0 points north. A higher value offsets the start angle clockwise.
          */
-        startAngle?: number;
+        startAngle?: number | undefined;
 
         /**
          * An optional total you can specify. By specifying a total value, the sum of the values in the series must be this total in order to draw a full pie. You can use this parameter to draw only parts of a pie or gauge charts.
          */
-        total?: number;
+        total?: number | undefined;
 
         /**
          * If specified the donut CSS classes will be used and strokes will be drawn instead of pie slices.
          */
-        donut?: boolean;
+        donut?: boolean | undefined;
 
         /**
          * If specified the donut segments will be drawn as shapes instead of strokes.
          */
-        donutSolid?: boolean;
+        donutSolid?: boolean | undefined;
 
         /**
          * Specify the donut stroke width, currently done in javascript for convenience. May move to CSS styles in the future.
          * This option can be set as number or string to specify a relative width (i.e. 100 or '30%').
          */
-        donutWidth?: number | string;
+        donutWidth?: number | string | undefined;
 
         /**
          * Specify if a label should be shown or not
          */
-        showLabel?: boolean;
+        showLabel?: boolean | undefined;
 
         /**
          * Label position offset from the standard position which is half distance of the radius. This value can be either positive or negative. Positive values will position the label away from the center.
          */
-        labelOffset?: number;
+        labelOffset?: number | undefined;
 
         /**
          * This option can be set to 'inside', 'outside' or 'center'. Positioned with 'inside' the labels will be placed on half the distance of the radius to the border of the Pie by respecting the 'labelOffset'. The 'outside' option will place the labels at the border of the pie and 'center' will place the labels in the absolute center point of the chart. The 'center' option only makes sense in conjunction with the 'labelOffset' option.
          */
-        labelPosition?: string;
+        labelPosition?: string | undefined;
 
         /**
          * An interpolation function for the label value
          */
-        labelInterpolationFnc?: Function;
+        labelInterpolationFnc?: Function | undefined;
 
         /**
          * Label direction can be 'neutral', 'explode' or 'implode'.  Default is 'neutral'.  The labels anchor will be positioned based on those settings as well as the fact if the labels are on the right or left side of the center of the chart. Usually explode is useful when labels are positioned far away from the center.
          */
-        labelDirection?: string;
+        labelDirection?: string | undefined;
 
         /**
          * If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
          */
-        reverseData?: boolean;
+        reverseData?: boolean | undefined;
 
         /**
          * If true empty values will be ignored to avoid drawing unncessary slices and labels
          */
-        ignoreEmptyValues?: boolean;
+        ignoreEmptyValues?: boolean | undefined;
     }
 
     interface IChartPadding {
-        top?: number;
-        right?: number;
-        bottom?: number;
-        left?: number;
+        top?: number | undefined;
+        right?: number | undefined;
+        bottom?: number | undefined;
+        left?: number | undefined;
     }
 
     interface IChartRect {
@@ -330,8 +330,8 @@ declare namespace Chartist {
         series: number[];
         seriesIndex: number;
         value: {
-          x?: number;
-          y?: number;
+          x?: number | undefined;
+          y?: number | undefined;
         };
         x1: number;
         x2: number;
@@ -345,148 +345,148 @@ declare namespace Chartist {
         | IChartDrawBarData;
 
     interface IPieChartClasses {
-        chartPie?: string;
-        chartDonut?: string;
-        series?: string;
-        slicePie?: string;
-        sliceDonut?: string;
-        label?: string;
+        chartPie?: string | undefined;
+        chartDonut?: string | undefined;
+        series?: string | undefined;
+        slicePie?: string | undefined;
+        sliceDonut?: string | undefined;
+        label?: string | undefined;
     }
 
     interface IBarChartOptions extends IChartOptions {
-        axisX?: IBarChartAxis;
-        axisY?: IBarChartAxis;
-        width?: number | string;
-        height?: number | string;
-        high?: number;
-        low?: number;
-        ticks?: Array<string | number>;
-        onlyInteger?: boolean;
-        chartPadding?: IChartPadding;
-        seriesBarDistance?: number;
+        axisX?: IBarChartAxis | undefined;
+        axisY?: IBarChartAxis | undefined;
+        width?: number | string | undefined;
+        height?: number | string | undefined;
+        high?: number | undefined;
+        low?: number | undefined;
+        ticks?: Array<string | number> | undefined;
+        onlyInteger?: boolean | undefined;
+        chartPadding?: IChartPadding | undefined;
+        seriesBarDistance?: number | undefined;
         /**
          * Override the class names that are used to generate the SVG structure of the chart
          */
-        classNames?: IBarChartClasses;
+        classNames?: IBarChartClasses | undefined;
         /**
          * If set to true this property will cause the series bars to be stacked and form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
          */
-        stackBars?: boolean;
-        stackMode?: 'overlap' | 'accumulate';
+        stackBars?: boolean | undefined;
+        stackMode?: 'overlap' | 'accumulate' | undefined;
 
-        horizontalBars?: boolean;
-        distributeSeries?: boolean;
+        horizontalBars?: boolean | undefined;
+        distributeSeries?: boolean | undefined;
     }
 
     interface IBarChartAxis {
-        offset?: number;
-        position?: string;
+        offset?: number | undefined;
+        position?: string | undefined;
         labelOffset?: {
-            x?: number;
-            y?: number;
-        };
-        showLabel?: boolean;
-        showGrid?: boolean;
-        labelInterpolationFnc?: Function;
-        scaleMinSpace?: number;
-        onlyInteger?: boolean;
+            x?: number | undefined;
+            y?: number | undefined;
+        } | undefined;
+        showLabel?: boolean | undefined;
+        showGrid?: boolean | undefined;
+        labelInterpolationFnc?: Function | undefined;
+        scaleMinSpace?: number | undefined;
+        onlyInteger?: boolean | undefined;
     }
 
     interface IBarChartClasses {
-        chart?: string;
-        horizontalBars?: string;
-        label?: string;
-        labelGroup?: string;
-        series?: string;
-        bar?: string;
-        grid?: string;
-        gridGroup?: string;
-        vertical?: string;
-        horizontal?: string;
-        start?: string;
-        end?: string;
+        chart?: string | undefined;
+        horizontalBars?: string | undefined;
+        label?: string | undefined;
+        labelGroup?: string | undefined;
+        series?: string | undefined;
+        bar?: string | undefined;
+        grid?: string | undefined;
+        gridGroup?: string | undefined;
+        vertical?: string | undefined;
+        horizontal?: string | undefined;
+        start?: string | undefined;
+        end?: string | undefined;
     }
 
     interface ILineChartOptions extends IChartOptions {
-        axisX?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis;
-        axisY?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis;
-        width?: number | string;
-        height?: number | string;
-        showLine?: boolean;
-        showPoint?: boolean;
-        showArea?: boolean;
-        areaBase?: number;
-        lineSmooth?: Function | boolean;
-        low?: number;
-        high?: number;
-        ticks?: Array<string | number>;
-        chartPadding?: IChartPadding;
-        fullWidth?: boolean;
-        classNames?: ILineChartClasses;
+        axisX?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis | undefined;
+        axisY?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis | undefined;
+        width?: number | string | undefined;
+        height?: number | string | undefined;
+        showLine?: boolean | undefined;
+        showPoint?: boolean | undefined;
+        showArea?: boolean | undefined;
+        areaBase?: number | undefined;
+        lineSmooth?: Function | boolean | undefined;
+        low?: number | undefined;
+        high?: number | undefined;
+        ticks?: Array<string | number> | undefined;
+        chartPadding?: IChartPadding | undefined;
+        fullWidth?: boolean | undefined;
+        classNames?: ILineChartClasses | undefined;
         series?: {
             [key: string]: {
-                lineSmooth?: Function | boolean;
-                showLine?: boolean;
-                showPoint?: boolean;
-                showArea?: boolean;
-                areaBase?: number;
+                lineSmooth?: Function | boolean | undefined;
+                showLine?: boolean | undefined;
+                showPoint?: boolean | undefined;
+                showArea?: boolean | undefined;
+                areaBase?: number | undefined;
             }
-        }
+        } | undefined
     }
 
     interface ILineChartAxis {
-        offset?: number;
-        position?: string;
+        offset?: number | undefined;
+        position?: string | undefined;
         labelOffset?: {
-            x?: number;
-            y?: number;
-        };
-        showLabel?: boolean;
-        showGrid?: boolean;
-        labelInterpolationFnc?: Function;
+            x?: number | undefined;
+            y?: number | undefined;
+        } | undefined;
+        showLabel?: boolean | undefined;
+        showGrid?: boolean | undefined;
+        labelInterpolationFnc?: Function | undefined;
     }
 
     interface IChartistStepAxis extends ILineChartAxis {
-        type?: IStepAxisStatic;
-        ticks?: Array<string> | Array<number>;
-        stretch?: boolean;
+        type?: IStepAxisStatic | undefined;
+        ticks?: Array<string> | Array<number> | undefined;
+        stretch?: boolean | undefined;
     }
 
     interface IChartistFixedScaleAxis extends ILineChartAxis {
-        type?: IFixedScaleAxisStatic;
-        high?: number;
-        low?: number;
-        divisor?: number;
-        ticks?: Array<string> | Array<number>;
+        type?: IFixedScaleAxisStatic | undefined;
+        high?: number | undefined;
+        low?: number | undefined;
+        divisor?: number | undefined;
+        ticks?: Array<string> | Array<number> | undefined;
     }
 
     interface IChartistAutoScaleAxis extends ILineChartAxis {
-        high?: number;
-        low?: number;
-        scaleMinSpace?: number;
-        onlyInteger?: boolean;
-        referenceValue?: number;
-        type?: IAutoScaleAxisStatic;
+        high?: number | undefined;
+        low?: number | undefined;
+        scaleMinSpace?: number | undefined;
+        onlyInteger?: boolean | undefined;
+        referenceValue?: number | undefined;
+        type?: IAutoScaleAxisStatic | undefined;
     }
 
     interface ILineChartClasses {
         /**
          * Default is 'ct-chart-line'
          */
-        chart?: string;
-        label?: string;
-        labelGroup?: string;
-        series?: string;
-        line?: string;
-        point?: string;
-        area?: string;
-        grid?: string;
-        gridGroup?: string;
-        gridBackground?: string;
-        vertical?: string;
-        horizontal?: string;
-        start?: string;
-        end?: string;
+        chart?: string | undefined;
+        label?: string | undefined;
+        labelGroup?: string | undefined;
+        series?: string | undefined;
+        line?: string | undefined;
+        point?: string | undefined;
+        area?: string | undefined;
+        grid?: string | undefined;
+        gridGroup?: string | undefined;
+        gridBackground?: string | undefined;
+        vertical?: string | undefined;
+        horizontal?: string | undefined;
+        start?: string | undefined;
+        end?: string | undefined;
     }
 
     interface ICandleChartOptions extends IChartOptions {
@@ -494,97 +494,97 @@ declare namespace Chartist {
         /**
          * Options for X-Axis
          */
-        axisX?: ICandleChartAxis;
+        axisX?: ICandleChartAxis | undefined;
 
         /**
          * Options for Y-Axis
          */
-        axisY?: ICandleChartAxis;
+        axisY?: ICandleChartAxis | undefined;
 
         /**
          * Specify a fixed width for the chart as a string (i.e. '100px' or '50%')
          */
-        width?: number | string;
+        width?: number | string | undefined;
 
         /**
          * Specify a fixed height for the chart as a string (i.e. '100px' or '50%')
          */
-        height?: number | string;
+        height?: number | string | undefined;
 
         /**
          * Overriding the natural high of the chart allows you to zoom in or limit the charts highest displayed value
          */
-        hight?: number | string;
+        hight?: number | string | undefined;
 
         /**
          * Overriding the natural low of the chart allows you to zoom in or limit the charts lowest displayed value
          */
-        low?: number | string;
+        low?: number | string | undefined;
 
         /**
          * Width of candle body in pixel (IMO is 2 px best minimum value)
          */
-        candleWidth?: number | string;
+        candleWidth?: number | string | undefined;
 
         /**
          * Width of candle wick in pixel (IMO is 1 px best minimum value)
          */
-        candleWickWidth?: number | string;
+        candleWickWidth?: number | string | undefined;
 
         /**
          * Use calculated x-axis step length, depending on the number of quotes to display, as candle width. Otherwise the candleWidth is being used.
          */
-        useStepLengthAsCandleWidth?: boolean | string;
+        useStepLengthAsCandleWidth?: boolean | string | undefined;
 
         /**
          * Use 1/3 of candle body width as width for the candle wick, otherwise the candleWickWidth is being used.
          */
-        useOneThirdAsCandleWickWidth?: boolean | string;
+        useOneThirdAsCandleWickWidth?: boolean | string | undefined;
 
         /**
          * Padding of the chart drawing area to the container element and labels as a number or padding object {top: 5, right: 5, bottom: 5, left: 5}
          */
-        chartPadding?: IChartPadding | number;
+        chartPadding?: IChartPadding | number | undefined;
 
         /**
          * When set to true, the last grid line on the x-axis is not drawn and the chart elements will expand to the full available width of the chart. For the last label to be drawncorrectly you might need to add chart padding or offset the last label with a draw event handler.
          */
-        fullWidth?: boolean | string;
+        fullWidth?: boolean | string | undefined;
 
         /**
          * Override the class names that get used to generate the SVG structure of the chart
          */
-        classNames?: ICandleChartClasses;
+        classNames?: ICandleChartClasses | undefined;
     }
 
     interface ICandleChartAxis {
         /**
          * The offset of the chart drawing area to the border of the container
          */
-        offset?: number;
+        offset?: number | undefined;
         /**
          * Position where labels are placed. Can be set to `start` or `end` where `start` is equivalent to left or top on vertical axis and `end` is equivalent to right or bottom on horizontal axis.
          */
-        position?: string;
+        position?: string | undefined;
         /**
          * Allows you to correct label positioning on this axis by positive or negative x and y offset.
          */
         labelOffset?: {
-            x?: number;
-            y?: number;
-        };
+            x?: number | undefined;
+            y?: number | undefined;
+        } | undefined;
         /**
          * If labels should be shown or not
          */
-        showLabel?: boolean;
+        showLabel?: boolean | undefined;
         /**
          * If the axis grid should be drawn or not
          */
-        showGrid?: boolean;
+        showGrid?: boolean | undefined;
         /**
          * Interpolation function that allows you to intercept the value from the axis label
          */
-        labelInterpolationFnc?: Function;
+        labelInterpolationFnc?: Function | undefined;
         /**
          * Set the axis type to be used to project values on this axis. If not defined, Chartist.StepAxis will be used for the X-Axis, where the ticks option will be set to the labels in the data and the stretch option will be set to the global fullWidth option. This type can be changed to any axis constructor available (e.g. Chartist.FixedScaleAxis), where all axis options should be present here.
          */
@@ -592,19 +592,19 @@ declare namespace Chartist {
     }
 
     interface ICandleChartClasses {
-        chart?: string;
-        label?: string;
-        labelGroup?: string;
-        series?: string;
-        candlePositive?: string;
-        candleNegative?: string,
-        grid?: string,
-        gridGroup?: string,
-        gridBackground?: string,
-        vertical?: string,
-        horizontal?: string,
-        start?: string,
-        end?: string,
+        chart?: string | undefined;
+        label?: string | undefined;
+        labelGroup?: string | undefined;
+        series?: string | undefined;
+        candlePositive?: string | undefined;
+        candleNegative?: string | undefined,
+        grid?: string | undefined,
+        gridGroup?: string | undefined,
+        gridBackground?: string | undefined,
+        vertical?: string | undefined,
+        horizontal?: string | undefined,
+        start?: string | undefined,
+        end?: string | undefined,
     }
 
 
@@ -733,13 +733,13 @@ declare namespace Chartist {
     }
 
     interface IChartistAnimationOptions {
-        id?: string;
+        id?: string | undefined;
         dur: string | number;
         from: string | number;
         to: string | number;
-        easing?: IChartistEasingDefinition | string;
-        fill?: string;
-        begin?: string;
+        easing?: IChartistEasingDefinition | string | undefined;
+        fill?: string | undefined;
+        begin?: string | undefined;
     }
 
     interface IChartistEasingDefinition {
@@ -800,19 +800,19 @@ declare namespace Chartist {
     }
 
     interface IChartistInterpolationOptions {
-        fillHoles?: boolean;
+        fillHoles?: boolean | undefined;
     }
 
     interface IChartistSimpleInterpolationOptions extends IChartistInterpolationOptions {
-        divisor?: number;
+        divisor?: number | undefined;
     }
 
     interface IChartistCardinalInterpolationOptions extends IChartistInterpolationOptions {
-        tension?: number;
+        tension?: number | undefined;
     }
 
     interface IChartistStepInterpolationOptions extends IChartistInterpolationOptions {
-        postpone?: boolean;
+        postpone?: boolean | undefined;
     }
 }
 

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -24,9 +24,9 @@ declare namespace cheerio {
         next: Element | null;
         prev: Element | null;
         parent: Element;
-        data?: string;
-        startIndex?: number;
-        endIndex?: number;
+        data?: string | undefined;
+        startIndex?: number | undefined;
+        endIndex?: number | undefined;
     }
 
     interface TagElement {
@@ -47,9 +47,9 @@ declare namespace cheerio {
         parent: Element;
         parentNode: Element;
         nodeValue: string;
-        data?: string;
-        startIndex?: number;
-        endIndex?: number;
+        data?: string | undefined;
+        startIndex?: number | undefined;
+        endIndex?: number | undefined;
     }
 
     interface CommentElement {
@@ -57,9 +57,9 @@ declare namespace cheerio {
         next: Element | null;
         prev: Element | null;
         parent: Element;
-        data?: string;
-        startIndex?: number;
-        endIndex?: number;
+        data?: string | undefined;
+        startIndex?: number | undefined;
+        endIndex?: number | undefined;
     }
 
     type AttrFunction = (el: Element, i: number, currentValue: string) => any;
@@ -279,17 +279,17 @@ declare namespace cheerio {
         // HTMLParser2 https://github.com/fb55/htmlparser2/wiki/Parser-options
         // DomHandler https://github.com/fb55/DomHandler
 
-        xmlMode?: boolean;
-        decodeEntities?: boolean;
-        lowerCaseTags?: boolean;
-        lowerCaseAttributeNames?: boolean;
-        recognizeCDATA?: boolean;
-        recognizeSelfClosing?: boolean;
-        normalizeWhitespace?: boolean;
-        withStartIndices?: boolean;
-        withEndIndices?: boolean;
-        ignoreWhitespace?: boolean;
-        _useHtmlParser2?: boolean;
+        xmlMode?: boolean | undefined;
+        decodeEntities?: boolean | undefined;
+        lowerCaseTags?: boolean | undefined;
+        lowerCaseAttributeNames?: boolean | undefined;
+        recognizeCDATA?: boolean | undefined;
+        recognizeSelfClosing?: boolean | undefined;
+        normalizeWhitespace?: boolean | undefined;
+        withStartIndices?: boolean | undefined;
+        withEndIndices?: boolean | undefined;
+        ignoreWhitespace?: boolean | undefined;
+        _useHtmlParser2?: boolean | undefined;
     }
 
     interface Selector {

--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -921,7 +921,7 @@ declare namespace chrome.cast.media {
         customData: Object;
         idleReason: chrome.cast.media.IdleReason | null;
         items: Array<chrome.cast.media.QueueItem>;
-        liveSeekableRange?: chrome.cast.media.LiveSeekableRange;
+        liveSeekableRange?: chrome.cast.media.LiveSeekableRange | undefined;
         loadingItemId: number;
         media: chrome.cast.media.MediaInfo;
         mediaSessionId: number;
@@ -1185,10 +1185,10 @@ declare namespace chrome.cast.media {
          */
         constructor(start?: number, end?: number, isMovingWindow?: boolean, isLiveDone?: boolean);
 
-        start?: number;
-        end?: number;
-        isMovingWindow?: boolean;
-        isLiveDone?: boolean;
+        start?: number | undefined;
+        end?: number | undefined;
+        isMovingWindow?: boolean | undefined;
+        isLiveDone?: boolean | undefined;
     }
 }
 

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -101,14 +101,14 @@ declare namespace chrome.action {
         /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is [255, 0, 0, 255]. Can also be a string with a CSS value, with opaque red being #FF0000 or #F00. */
         color: string | ColorArray;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export interface BadgeTextDetails {
         /** Any number of characters can be passed, but only about four can fit in the space. */
         text: string;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export type ColorArray = [number, number, number, number];
@@ -117,12 +117,12 @@ declare namespace chrome.action {
         /** The string the action should display when moused over. */
         title: string;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export interface PopupDetails {
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
         /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
         popup: string;
     }
@@ -131,16 +131,16 @@ declare namespace chrome.action {
 
     export interface TabIconDetails {
         /** Optional. Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'  */
-        path?: string | { [index: number]: string };
+        path?: string | { [index: number]: string } | undefined;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
         /** Optional. Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'  */
-        imageData?: ImageData | { [index: number]: ImageData };
+        imageData?: ImageData | { [index: number]: ImageData } | undefined;
     }
 
     export interface TabDetails {
         /** Optional. The ID of the tab to query state for. If no tab is specified, the non-tab-specific state is returned.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     /**
@@ -322,16 +322,16 @@ declare namespace chrome.action {
 declare namespace chrome.alarms {
     export interface AlarmCreateInfo {
         /** Optional. Length of time in minutes after which the onAlarm event should fire.  */
-        delayInMinutes?: number;
+        delayInMinutes?: number | undefined;
         /** Optional. If set, the onAlarm event should fire every periodInMinutes minutes after the initial event specified by when or delayInMinutes. If not set, the alarm will only fire once.  */
-        periodInMinutes?: number;
+        periodInMinutes?: number | undefined;
         /** Optional. Time at which the alarm should fire, in milliseconds past the epoch (e.g. Date.now() + n).  */
-        when?: number;
+        when?: number | undefined;
     }
 
     export interface Alarm {
         /** Optional. If not null, the alarm is a repeating alarm and will fire again in periodInMinutes minutes.  */
-        periodInMinutes?: number;
+        periodInMinutes?: number | undefined;
         /** Time at which this alarm was scheduled to fire, in milliseconds past the epoch (e.g. Date.now() + n). For performance reasons, the alarm may have been delayed an arbitrary amount beyond this. */
         scheduledTime: number;
         /** Name of this alarm. */
@@ -475,21 +475,21 @@ declare namespace chrome.bookmarks {
     /** A node (either a bookmark or a folder) in the bookmark tree. Child nodes are ordered within their parent folder. */
     export interface BookmarkTreeNode {
         /** Optional. The 0-based position of this node within its parent folder.  */
-        index?: number;
+        index?: number | undefined;
         /** Optional. When this node was created, in milliseconds since the epoch (new Date(dateAdded)).  */
-        dateAdded?: number;
+        dateAdded?: number | undefined;
         /** The text displayed for the node. */
         title: string;
         /** Optional. The URL navigated to when a user clicks the bookmark. Omitted for folders.   */
-        url?: string;
+        url?: string | undefined;
         /** Optional. When the contents of this folder last changed, in milliseconds since the epoch.   */
-        dateGroupModified?: number;
+        dateGroupModified?: number | undefined;
         /** The unique identifier for the node. IDs are unique within the current profile, and they remain valid even after the browser is restarted.  */
         id: string;
         /** Optional. The id of the parent folder. Omitted for the root node.   */
-        parentId?: string;
+        parentId?: string | undefined;
         /** Optional. An ordered list of children of this node.  */
-        children?: BookmarkTreeNode[];
+        children?: BookmarkTreeNode[] | undefined;
         /**
          * Optional.
          * Since Chrome 37.
@@ -512,7 +512,7 @@ declare namespace chrome.bookmarks {
     }
 
     export interface BookmarkChangeInfo {
-        url?: string;
+        url?: string | undefined;
         title: string;
     }
 
@@ -539,27 +539,27 @@ declare namespace chrome.bookmarks {
         extends chrome.events.Event<(id: string, reorderInfo: BookmarkReorderInfo) => void> { }
 
     export interface BookmarkSearchQuery {
-        query?: string;
-        url?: string;
-        title?: string;
+        query?: string | undefined;
+        url?: string | undefined;
+        title?: string | undefined;
     }
 
     export interface BookmarkCreateArg {
         /** Optional. Defaults to the Other Bookmarks folder.  */
-        parentId?: string;
-        index?: number;
-        title?: string;
-        url?: string;
+        parentId?: string | undefined;
+        index?: number | undefined;
+        title?: string | undefined;
+        url?: string | undefined;
     }
 
     export interface BookmarkDestinationArg {
-        parentId?: string;
-        index?: number;
+        parentId?: string | undefined;
+        index?: number | undefined;
     }
 
     export interface BookmarkChangesArg {
-        title?: string;
-        url?: string;
+        title?: string | undefined;
+        url?: string | undefined;
     }
 
     /** @deprecated since Chrome 38. Bookmark write operations are no longer limited by Chrome. */
@@ -768,14 +768,14 @@ declare namespace chrome.browserAction {
         /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is [255, 0, 0, 255]. Can also be a string with a CSS value, with opaque red being #FF0000 or #F00. */
         color: string | ColorArray;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export interface BadgeTextDetails {
         /** Any number of characters can be passed, but only about four can fit in the space. */
-        text?: string;
+        text?: string | undefined;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export type ColorArray = [number, number, number, number];
@@ -784,26 +784,26 @@ declare namespace chrome.browserAction {
         /** The string the browser action should display when moused over. */
         title: string;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export interface TabDetails {
         /** Optional. Specify the tab to get the information. If no tab is specified, the non-tab-specific information is returned.  */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export interface TabIconDetails {
         /** Optional. Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'  */
         path?: any;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
         /** Optional. Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'  */
-        imageData?: ImageData | { [index: number]: ImageData };
+        imageData?: ImageData | { [index: number]: ImageData } | undefined;
     }
 
     export interface PopupDetails {
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number;
+        tabId?: number | undefined;
         /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
         popup: string;
     }
@@ -951,11 +951,11 @@ declare namespace chrome.browserAction {
 declare namespace chrome.browsingData {
     export interface OriginTypes {
         /** Optional. Websites that have been installed as hosted applications (be careful!).  */
-        protectedWeb?: boolean;
+        protectedWeb?: boolean | undefined;
         /** Optional. Extensions and packaged applications a user has installed (be _really_ careful!).  */
-        extension?: boolean;
+        extension?: boolean | undefined;
         /** Optional. Normal websites.  */
-        unprotectedWeb?: boolean;
+        unprotectedWeb?: boolean | undefined;
     }
 
     /** Options that determine exactly what data will be removed. */
@@ -965,9 +965,9 @@ declare namespace chrome.browsingData {
          * Since Chrome 21.
          * An object whose properties specify which origin types ought to be cleared. If this object isn't specified, it defaults to clearing only "unprotected" origins. Please ensure that you really want to remove application data before adding 'protectedWeb' or 'extensions'.
          */
-        originTypes?: OriginTypes;
+        originTypes?: OriginTypes | undefined;
         /** Optional. Remove data accumulated on or after this date, represented in milliseconds since the epoch (accessible via the getTime method of the JavaScript Date object). If absent, defaults to 0 (which would remove all browsing data).  */
-        since?: number;
+        since?: number | undefined;
     }
 
     /**
@@ -976,37 +976,37 @@ declare namespace chrome.browsingData {
      */
     export interface DataTypeSet {
         /** Optional. Websites' WebSQL data.  */
-        webSQL?: boolean;
+        webSQL?: boolean | undefined;
         /** Optional. Websites' IndexedDB data.  */
-        indexedDB?: boolean;
+        indexedDB?: boolean | undefined;
         /** Optional. The browser's cookies.  */
-        cookies?: boolean;
+        cookies?: boolean | undefined;
         /** Optional. Stored passwords.  */
-        passwords?: boolean;
+        passwords?: boolean | undefined;
         /** Optional. Server-bound certificates.  */
-        serverBoundCertificates?: boolean;
+        serverBoundCertificates?: boolean | undefined;
         /** Optional. The browser's download list.  */
-        downloads?: boolean;
+        downloads?: boolean | undefined;
         /** Optional. The browser's cache. Note: when removing data, this clears the entire cache: it is not limited to the range you specify.  */
-        cache?: boolean;
+        cache?: boolean | undefined;
         /** Optional. Websites' appcaches.  */
-        appcache?: boolean;
+        appcache?: boolean | undefined;
         /** Optional. Websites' file systems.  */
-        fileSystems?: boolean;
+        fileSystems?: boolean | undefined;
         /** Optional. Plugins' data.  */
-        pluginData?: boolean;
+        pluginData?: boolean | undefined;
         /** Optional. Websites' local storage data.  */
-        localStorage?: boolean;
+        localStorage?: boolean | undefined;
         /** Optional. The browser's stored form data.  */
-        formData?: boolean;
+        formData?: boolean | undefined;
         /** Optional. The browser's history.  */
-        history?: boolean;
+        history?: boolean | undefined;
         /**
          * Optional.
          * Since Chrome 39.
          * Service Workers.
          */
-        serviceWorkers?: boolean;
+        serviceWorkers?: boolean | undefined;
     }
 
     export interface SettingsCallback {
@@ -1129,11 +1129,11 @@ declare namespace chrome.browsingData {
 declare namespace chrome.commands {
     export interface Command {
         /** Optional. The name of the Extension Command  */
-        name?: string;
+        name?: string | undefined;
         /** Optional. The Extension Command description  */
-        description?: string;
+        description?: string | undefined;
         /** Optional. The shortcut active for this command, or blank if not active.  */
-        shortcut?: string;
+        shortcut?: string | undefined;
     }
 
     export interface CommandEvent extends chrome.events.Event<(command: string, tab: chrome.tabs.Tab) => void> { }
@@ -1169,18 +1169,18 @@ declare namespace chrome.contentSettings {
          * * regular: setting for regular profile (which is inherited by the incognito profile if not overridden elsewhere),
          * * incognito_session_only: setting for incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular settings).
          */
-        scope?: ScopeEnum;
+        scope?: ScopeEnum | undefined;
     }
 
     export interface SetDetails {
         /** Optional. The resource identifier for the content type.  */
-        resourceIdentifier?: ResourceIdentifier;
+        resourceIdentifier?: ResourceIdentifier | undefined;
         /** The setting applied by this rule. See the description of the individual ContentSetting objects for the possible values. */
         setting: any;
         /** Optional. The pattern for the secondary URL. Defaults to matching all URLs. For details on the format of a pattern, see Content Setting Patterns.  */
-        secondaryPattern?: string;
+        secondaryPattern?: string | undefined;
         /** Optional. Where to set the setting (default: regular).  */
-        scope?: ScopeEnum;
+        scope?: ScopeEnum | undefined;
         /** The pattern for the primary URL. For details on the format of a pattern, see Content Setting Patterns. */
         primaryPattern: string;
     }
@@ -1239,11 +1239,11 @@ declare namespace chrome.contentSettings {
 
     export interface GetDetails {
         /** Optional. The secondary URL for which the content setting should be retrieved. Defaults to the primary URL. Note that the meaning of a secondary URL depends on the content type, and not all content types use secondary URLs.  */
-        secondaryUrl?: string;
+        secondaryUrl?: string | undefined;
         /** Optional. A more specific identifier of the type of content for which the settings should be retrieved.  */
-        resourceIdentifier?: ResourceIdentifier;
+        resourceIdentifier?: ResourceIdentifier | undefined;
         /** Optional. Whether to check the content settings for an incognito session. (default false)  */
-        incognito?: boolean;
+        incognito?: boolean | undefined;
         /** The primary URL for which the content setting should be retrieved. Note that the meaning of a primary URL depends on the content type. */
         primaryUrl: string;
     }
@@ -1337,7 +1337,7 @@ declare namespace chrome.contentSettings {
         /** The resource identifier for the given content type. */
         id: string;
         /** Optional. A human readable description of the resource.  */
-        description?: string;
+        description?: string | undefined;
     }
 
     /**
@@ -1479,13 +1479,13 @@ declare namespace chrome.contextMenus {
          * Since Chrome 35.
          * The text for the context selection, if any.
          */
-        selectionText?: string;
+        selectionText?: string | undefined;
         /**
          * Optional.
          * Since Chrome 35.
          * A flag indicating the state of a checkbox or radio item after it is clicked.
          */
-        checked?: boolean;
+        checked?: boolean | undefined;
         /**
          * Since Chrome 35.
          * The ID of the menu item that was clicked.
@@ -1497,13 +1497,13 @@ declare namespace chrome.contextMenus {
          * The ID of the frame of the element where the context menu was
          * clicked, if it was in a frame.
          */
-        frameId?: number;
+        frameId?: number | undefined;
         /**
          * Optional.
          * Since Chrome 35.
          * The URL of the frame of the element where the context menu was clicked, if it was in a frame.
          */
-        frameUrl?: string;
+        frameUrl?: string | undefined;
         /**
          * Since Chrome 35.
          * A flag indicating whether the element is editable (text input, textarea, etc.).
@@ -1514,13 +1514,13 @@ declare namespace chrome.contextMenus {
          * Since Chrome 35.
          * One of 'image', 'video', or 'audio' if the context menu was activated on one of these types of elements.
          */
-        mediaType?: string;
+        mediaType?: string | undefined;
         /**
          * Optional.
          * Since Chrome 35.
          * A flag indicating the state of a checkbox or radio item before it was clicked.
          */
-        wasChecked?: boolean;
+        wasChecked?: boolean | undefined;
         /**
          * Since Chrome 35.
          * The URL of the page where the menu item was clicked. This property is not set if the click occured in a context where there is no current page, such as in a launcher context menu.
@@ -1531,7 +1531,7 @@ declare namespace chrome.contextMenus {
          * Since Chrome 35.
          * If the element is a link, the URL it points to.
          */
-        linkUrl?: string;
+        linkUrl?: string | undefined;
         /**
          * Optional.
          * Since Chrome 35.
@@ -1543,69 +1543,69 @@ declare namespace chrome.contextMenus {
          * Since Chrome 35.
          * Will be present for elements with a 'src' URL.
          */
-        srcUrl?: string;
+        srcUrl?: string | undefined;
     }
 
     export interface CreateProperties {
         /** Optional. Lets you restrict the item to apply only to documents whose URL matches one of the given patterns. (This applies to frames as well.) For details on the format of a pattern, see Match Patterns.  */
-        documentUrlPatterns?: string[];
+        documentUrlPatterns?: string[] | undefined;
         /** Optional. The initial state of a checkbox or radio item: true for selected and false for unselected. Only one radio item can be selected at a time in a given group of radio items.  */
-        checked?: boolean;
+        checked?: boolean | undefined;
         /** Optional. The text to be displayed in the item; this is required unless type is 'separator'. When the context is 'selection', you can use %s within the string to show the selected text. For example, if this parameter's value is "Translate '%s' to Pig Latin" and the user selects the word "cool", the context menu item for the selection is "Translate 'cool' to Pig Latin".  */
-        title?: string;
+        title?: string | undefined;
         /** Optional. List of contexts this menu item will appear in. Defaults to ['page'] if not specified.  */
-        contexts?: string[];
+        contexts?: string[] | undefined;
         /**
          * Optional.
          * Since Chrome 20.
          * Whether this context menu item is enabled or disabled. Defaults to true.
          */
-        enabled?: boolean;
+        enabled?: boolean | undefined;
         /** Optional. Similar to documentUrlPatterns, but lets you filter based on the src attribute of img/audio/video tags and the href of anchor tags.  */
-        targetUrlPatterns?: string[];
+        targetUrlPatterns?: string[] | undefined;
         /**
          * Optional.
          * A function that will be called back when the menu item is clicked. Event pages cannot use this; instead, they should register a listener for chrome.contextMenus.onClicked.
          * @param info Information sent when a context menu item is clicked.
          * @param tab The details of the tab where the click took place. Note: this parameter only present for extensions.
          */
-        onclick?: (info: OnClickData, tab: chrome.tabs.Tab) => void;
+        onclick?: ((info: OnClickData, tab: chrome.tabs.Tab) => void) | undefined;
         /** Optional. The ID of a parent menu item; this makes the item a child of a previously added item.  */
         parentId?: any;
         /** Optional. The type of menu item. Defaults to 'normal' if not specified.  */
-        type?: string;
+        type?: string | undefined;
         /**
          * Optional.
          * Since Chrome 21.
          * The unique ID to assign to this item. Mandatory for event pages. Cannot be the same as another ID for this extension.
          */
-        id?: string;
+        id?: string | undefined;
         /**
          * Optional.
          * Since Chrome 62.
          * Whether the item is visible in the menu.
          */
-        visible?: boolean;
+        visible?: boolean | undefined;
     }
 
     export interface UpdateProperties {
-        documentUrlPatterns?: string[];
-        checked?: boolean;
-        title?: string;
-        contexts?: string[];
+        documentUrlPatterns?: string[] | undefined;
+        checked?: boolean | undefined;
+        title?: string | undefined;
+        contexts?: string[] | undefined;
         /** Optional. Since Chrome 20.  */
-        enabled?: boolean;
-        targetUrlPatterns?: string[];
-        onclick?: Function;
+        enabled?: boolean | undefined;
+        targetUrlPatterns?: string[] | undefined;
+        onclick?: Function | undefined;
         /** Optional. Note: You cannot change an item to be a child of one of its own descendants.  */
         parentId?: any;
-        type?: string;
+        type?: string | undefined;
         /**
          * Optional.
          * @since Chrome 62.
          * Whether the item is visible in the menu.
          */
-        visible?: boolean;
+        visible?: boolean | undefined;
     }
 
     export interface MenuClickedEvent extends chrome.events.Event<(info: OnClickData, tab?: chrome.tabs.Tab) => void> { }
@@ -1699,7 +1699,7 @@ declare namespace chrome.cookies {
         /** True if the cookie is a host-only cookie (i.e. a request's host must exactly match the domain of the cookie). */
         hostOnly: boolean;
         /** Optional. The expiration date of the cookie as the number of seconds since the UNIX epoch. Not provided for session cookies.  */
-        expirationDate?: number;
+        expirationDate?: number | undefined;
         /** The path of the cookie. */
         path: string;
         /** True if the cookie is marked as HttpOnly (i.e. the cookie is inaccessible to client-side scripts). */
@@ -1723,51 +1723,51 @@ declare namespace chrome.cookies {
 
     export interface GetAllDetails {
         /** Optional. Restricts the retrieved cookies to those whose domains match or are subdomains of this one.  */
-        domain?: string;
+        domain?: string | undefined;
         /** Optional. Filters the cookies by name.  */
-        name?: string;
+        name?: string | undefined;
         /** Optional. Restricts the retrieved cookies to those that would match the given URL.  */
-        url?: string;
+        url?: string | undefined;
         /** Optional. The cookie store to retrieve cookies from. If omitted, the current execution context's cookie store will be used.  */
-        storeId?: string;
+        storeId?: string | undefined;
         /** Optional. Filters out session vs. persistent cookies.  */
-        session?: boolean;
+        session?: boolean | undefined;
         /** Optional. Restricts the retrieved cookies to those whose path exactly matches this string.  */
-        path?: string;
+        path?: string | undefined;
         /** Optional. Filters the cookies by their Secure property.  */
-        secure?: boolean;
+        secure?: boolean | undefined;
     }
 
     export interface SetDetails {
         /** Optional. The domain of the cookie. If omitted, the cookie becomes a host-only cookie.  */
-        domain?: string;
+        domain?: string | undefined;
         /** Optional. The name of the cookie. Empty by default if omitted.  */
-        name?: string;
+        name?: string | undefined;
         /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail. */
         url: string;
         /** Optional. The ID of the cookie store in which to set the cookie. By default, the cookie is set in the current execution context's cookie store.  */
-        storeId?: string;
+        storeId?: string | undefined;
         /** Optional. The value of the cookie. Empty by default if omitted.  */
-        value?: string;
+        value?: string | undefined;
         /** Optional. The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.  */
-        expirationDate?: number;
+        expirationDate?: number | undefined;
         /** Optional. The path of the cookie. Defaults to the path portion of the url parameter.  */
-        path?: string;
+        path?: string | undefined;
         /** Optional. Whether the cookie should be marked as HttpOnly. Defaults to false.  */
-        httpOnly?: boolean;
+        httpOnly?: boolean | undefined;
         /** Optional. Whether the cookie should be marked as Secure. Defaults to false.  */
-        secure?: boolean;
+        secure?: boolean | undefined;
         /**
          * Optional. The cookie's same-site status. Defaults to "unspecified", i.e., if omitted, the cookie is set without specifying a SameSite attribute.
          * @since Chrome 51.
          */
-        sameSite?: SameSiteStatus;
+        sameSite?: SameSiteStatus | undefined;
     }
 
     export interface Details {
         name: string;
         url: string;
-        storeId?: string;
+        storeId?: string | undefined;
     }
 
     export interface CookieChangeInfo {
@@ -1869,19 +1869,19 @@ declare module chrome {
         /** Debuggee identifier. Either tabId or extensionId must be specified */
         export interface Debuggee {
             /** Optional. The id of the tab which you intend to debug.  */
-            tabId?: number;
+            tabId?: number | undefined;
             /**
              * Optional.
              * Since Chrome 27.
              * The id of the extension which you intend to debug. Attaching to an extension background page is only possible when 'silent-debugger-extension-api' flag is enabled on the target browser.
              */
-            extensionId?: string;
+            extensionId?: string | undefined;
             /**
              * Optional.
              * Since Chrome 28.
              * The opaque id of the debug target.
              */
-            targetId?: string;
+            targetId?: string | undefined;
         }
 
         /**
@@ -1898,13 +1898,13 @@ declare module chrome {
              * Since Chrome 30.
              * The tab id, defined if type == 'page'.
              */
-            tabId?: number;
+            tabId?: number | undefined;
             /**
              * Optional.
              * Since Chrome 30.
              * The extension id, defined if type = 'background_page'.
              */
-            extensionId?: string;
+            extensionId?: string | undefined;
             /** True if debugger is already attached. */
             attached: boolean;
             /** Target page title. */
@@ -1912,7 +1912,7 @@ declare module chrome {
             /** Target URL. */
             url: string;
             /** Optional. Target favicon URL.  */
-            faviconUrl?: string;
+            faviconUrl?: string | undefined;
         }
 
         export interface DebuggerDetachedEvent
@@ -1982,58 +1982,58 @@ declare module chrome {
 declare namespace chrome.declarativeContent {
     export interface PageStateUrlDetails {
         /** Optional. Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name.  */
-        hostContains?: string;
+        hostContains?: string | undefined;
         /** Optional. Matches if the host name of the URL is equal to a specified string.  */
-        hostEquals?: string;
+        hostEquals?: string | undefined;
         /** Optional. Matches if the host name of the URL starts with a specified string.  */
-        hostPrefix?: string;
+        hostPrefix?: string | undefined;
         /** Optional. Matches if the host name of the URL ends with a specified string.  */
-        hostSuffix?: string;
+        hostSuffix?: string | undefined;
         /** Optional. Matches if the path segment of the URL contains a specified string.  */
-        pathContains?: string;
+        pathContains?: string | undefined;
         /** Optional. Matches if the path segment of the URL is equal to a specified string.  */
-        pathEquals?: string;
+        pathEquals?: string | undefined;
         /** Optional. Matches if the path segment of the URL starts with a specified string.  */
-        pathPrefix?: string;
+        pathPrefix?: string | undefined;
         /** Optional. Matches if the path segment of the URL ends with a specified string.  */
-        pathSuffix?: string;
+        pathSuffix?: string | undefined;
         /** Optional. Matches if the query segment of the URL contains a specified string.  */
-        queryContains?: string;
+        queryContains?: string | undefined;
         /** Optional. Matches if the query segment of the URL is equal to a specified string.  */
-        queryEquals?: string;
+        queryEquals?: string | undefined;
         /** Optional. Matches if the query segment of the URL starts with a specified string.  */
-        queryPrefix?: string;
+        queryPrefix?: string | undefined;
         /** Optional. Matches if the query segment of the URL ends with a specified string.  */
-        querySuffix?: string;
+        querySuffix?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlContains?: string;
+        urlContains?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlEquals?: string;
+        urlEquals?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.  */
-        urlMatches?: string;
+        urlMatches?: string | undefined;
         /** Optional. Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.  */
-        originAndPathMatches?: string;
+        originAndPathMatches?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlPrefix?: string;
+        urlPrefix?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlSuffix?: string;
+        urlSuffix?: string | undefined;
         /** Optional. Matches if the scheme of the URL is equal to any of the schemes specified in the array.  */
-        schemes?: string[];
+        schemes?: string[] | undefined;
         /** Optional. Matches if the port of the URL is contained in any of the specified port lists. For example [80, 443, [1000, 1200]] matches all requests on port 80, 443 and in the range 1000-1200.  */
-        ports?: (number | number[])[];
+        ports?: (number | number[])[] | undefined;
     }
 
     export class PageStateMatcherProperties {
         /** Optional. Filters URLs for various criteria. See event filtering. All criteria are case sensitive.  */
-        pageUrl?: PageStateUrlDetails;
+        pageUrl?: PageStateUrlDetails | undefined;
         /** Optional. Matches if all of the CSS selectors in the array match displayed elements in a frame with the same origin as the page's main frame. All selectors in this array must be compound selectors to speed up matching. Note that listing hundreds of CSS selectors or CSS selectors that match hundreds of times per page can still slow down web sites.  */
-        css?: string[];
+        css?: string[] | undefined;
         /**
          * Optional.
          * Since Chrome 45. Warning: this is the current Beta channel. More information available on the API documentation pages.
          * Matches if the bookmarked state of the page is equal to the specified value. Requres the bookmarks permission.
          */
-        isBookmarked?: boolean;
+        isBookmarked?: boolean | undefined;
     }
 
     /** Matches the state of a web page by various criteria. */
@@ -2046,7 +2046,7 @@ declare namespace chrome.declarativeContent {
 
     /** Declarative event action that changes the icon of the page action while the corresponding conditions are met. */
     export class SetIcon {
-        constructor(options?: { imageData?: ImageData | { [size: string]: ImageData } });
+        constructor(options?: { imageData?: ImageData | { [size: string]: ImageData } | undefined });
     }
 
     /** Provides the Declarative Event API consisting of addRules, removeRules, and getRules. */
@@ -2060,14 +2060,14 @@ declare namespace chrome.declarativeContent {
 ////////////////////
 declare namespace chrome.declarativeWebRequest {
     export interface HeaderFilter {
-        nameEquals?: string;
+        nameEquals?: string | undefined;
         valueContains?: any;
-        nameSuffix?: string;
-        valueSuffix?: string;
-        valuePrefix?: string;
+        nameSuffix?: string | undefined;
+        valueSuffix?: string | undefined;
+        valuePrefix?: string | undefined;
         nameContains?: any;
-        valueEquals?: string;
-        namePrefix?: string;
+        valueEquals?: string | undefined;
+        namePrefix?: string | undefined;
     }
 
     export interface AddResponseHeader {
@@ -2081,16 +2081,16 @@ declare namespace chrome.declarativeWebRequest {
 
     export interface RemoveResponseHeader {
         name: string;
-        value?: string;
+        value?: string | undefined;
     }
 
     export interface RequestMatcher {
-        contentType?: string[];
-        url?: chrome.events.UrlFilter;
-        excludeContentType?: string[];
-        excludeResponseHeader?: HeaderFilter[];
-        resourceType?: string;
-        responseHeaders?: HeaderFilter[];
+        contentType?: string[] | undefined;
+        url?: chrome.events.UrlFilter | undefined;
+        excludeContentType?: string[] | undefined;
+        excludeResponseHeader?: HeaderFilter[] | undefined;
+        resourceType?: string | undefined;
+        responseHeaders?: HeaderFilter[] | undefined;
     }
 
     export interface IgnoreRules {
@@ -2104,14 +2104,14 @@ declare namespace chrome.declarativeWebRequest {
     }
 
     export interface ResponseCookie {
-        domain?: string;
-        name?: string;
-        expires?: string;
-        maxAge?: number;
-        value?: string;
-        path?: string;
-        httpOnly?: string;
-        secure?: string;
+        domain?: string | undefined;
+        name?: string | undefined;
+        expires?: string | undefined;
+        maxAge?: number | undefined;
+        value?: string | undefined;
+        path?: string | undefined;
+        httpOnly?: string | undefined;
+        secure?: string | undefined;
     }
 
     export interface AddResponseCookie {
@@ -2140,8 +2140,8 @@ declare namespace chrome.declarativeWebRequest {
     }
 
     export interface RequestCookie {
-        name?: string;
-        value?: string;
+        name?: string | undefined;
+        value?: string | undefined;
     }
 
     export interface RedirectByRegEx {
@@ -2236,17 +2236,17 @@ declare namespace chrome.devtools.inspectedWindow {
 
     export interface ReloadOptions {
         /** Optional. If specified, the string will override the value of the User-Agent HTTP header that's sent while loading the resources of the inspected page. The string will also override the value of the navigator.userAgent property that's returned to any scripts that are running within the inspected page.  */
-        userAgent?: string;
+        userAgent?: string | undefined;
         /** Optional. When true, the loader will ignore the cache for all inspected page resources loaded before the load event is fired. The effect is similar to pressing Ctrl+Shift+R in the inspected window or within the Developer Tools window.  */
-        ignoreCache?: boolean;
+        ignoreCache?: boolean | undefined;
         /** Optional. If specified, the script will be injected into every frame of the inspected page immediately upon load, before any of the frame's scripts. The script will not be injected after subsequent reloads—for example, if the user presses Ctrl+R.  */
-        injectedScript?: string;
+        injectedScript?: string | undefined;
         /**
          * Optional.
          * If specified, this script evaluates into a function that accepts three string arguments: the source to preprocess, the URL of the source, and a function name if the source is an DOM event handler. The preprocessorerScript function should return a string to be compiled by Chrome in place of the input source. In the case that the source is a DOM event handler, the returned source must compile to a single JS function.
          * @deprecated Deprecated since Chrome 41. Please avoid using this parameter, it will be removed soon.
          */
-        preprocessorScript?: string;
+        preprocessorScript?: string | undefined;
     }
 
     export interface EvaluationExceptionInfo {
@@ -2317,11 +2317,11 @@ declare namespace chrome.devtools.inspectedWindow {
 
     export interface EvalOptions {
         /** If specified, the expression is evaluated on the iframe whose URL matches the one specified. By default, the expression is evaluated in the top frame of the inspected page. */
-        frameURL?: string;
+        frameURL?: string | undefined;
         /** Evaluate the expression in the context of the content script of the calling extension, provided that the content script is already injected into the inspected page. If not, the expression is not evaluated and the callback is invoked with the exception parameter set to an object that has the isError field set to true and the code field set to E_NOTFOUND. */
-        useContentScriptContext?: boolean;
+        useContentScriptContext?: boolean | undefined;
         /** Evaluate the expression in the context of a content script of an extension that matches the specified origin. If given, contextSecurityOrigin overrides the 'true' setting on userContentScriptContext. */
-        contextSecurityOrigin?: string;
+        contextSecurityOrigin?: string | undefined;
     }
 }
 
@@ -2571,9 +2571,9 @@ declare namespace chrome.devtools.panels {
 declare namespace chrome.documentScan {
     export interface DocumentScanOptions {
         /** Optional. The MIME types that are accepted by the caller.  */
-        mimeTypes?: string[];
+        mimeTypes?: string[] | undefined;
         /** Optional. The number of scanned images allowed (defaults to 1).  */
-        maxImages?: number;
+        maxImages?: number | undefined;
     }
 
     export interface DocumentScanCallbackArg {
@@ -2611,71 +2611,71 @@ declare namespace chrome.downloads {
 
     export interface DownloadOptions {
         /** Optional. Post body.  */
-        body?: string;
+        body?: string | undefined;
         /** Optional. Use a file-chooser to allow the user to select a filename regardless of whether filename is set or already exists.  */
-        saveAs?: boolean;
+        saveAs?: boolean | undefined;
         /** The URL to download. */
         url: string;
         /** Optional. A file path relative to the Downloads directory to contain the downloaded file, possibly containing subdirectories. Absolute paths, empty paths, and paths containing back-references ".." will cause an error. onDeterminingFilename allows suggesting a filename after the file's MIME type and a tentative filename have been determined.  */
-        filename?: string;
+        filename?: string | undefined;
         /** Optional. Extra HTTP headers to send with the request if the URL uses the HTTP[s] protocol. Each header is represented as a dictionary containing the keys name and either value or binaryValue, restricted to those allowed by XMLHttpRequest.  */
-        headers?: HeaderNameValuePair[];
+        headers?: HeaderNameValuePair[] | undefined;
         /** Optional. The HTTP method to use if the URL uses the HTTP[S] protocol.  */
-        method?: string;
+        method?: string | undefined;
         /** Optional. The action to take if filename already exists.  */
-        conflictAction?: string;
+        conflictAction?: string | undefined;
     }
 
     export interface DownloadDelta {
         /** The id of the DownloadItem that changed. */
         id: number;
         /** Optional. The change in danger, if any.  */
-        danger?: StringDelta;
+        danger?: StringDelta | undefined;
         /** Optional. The change in url, if any.  */
-        url?: StringDelta;
+        url?: StringDelta | undefined;
         /**
          * Optional. The change in finalUrl, if any.
          * @since Since Chrome 54.
          */
         finalUrl: StringDelta;
         /** Optional. The change in totalBytes, if any.  */
-        totalBytes?: DoubleDelta;
+        totalBytes?: DoubleDelta | undefined;
         /** Optional. The change in filename, if any.  */
-        filename?: StringDelta;
+        filename?: StringDelta | undefined;
         /** Optional. The change in paused, if any.  */
-        paused?: BooleanDelta;
+        paused?: BooleanDelta | undefined;
         /** Optional. The change in state, if any.  */
-        state?: StringDelta;
+        state?: StringDelta | undefined;
         /** Optional. The change in mime, if any.  */
-        mime?: StringDelta;
+        mime?: StringDelta | undefined;
         /** Optional. The change in fileSize, if any.  */
-        fileSize?: DoubleDelta;
+        fileSize?: DoubleDelta | undefined;
         /** Optional. The change in startTime, if any.  */
-        startTime?: StringDelta;
+        startTime?: StringDelta | undefined;
         /** Optional. The change in error, if any.  */
-        error?: StringDelta;
+        error?: StringDelta | undefined;
         /** Optional. The change in endTime, if any.  */
-        endTime?: StringDelta;
+        endTime?: StringDelta | undefined;
         /** Optional. The change in canResume, if any.  */
-        canResume?: BooleanDelta;
+        canResume?: BooleanDelta | undefined;
         /** Optional. The change in exists, if any.  */
-        exists?: BooleanDelta;
+        exists?: BooleanDelta | undefined;
     }
 
     export interface BooleanDelta {
-        current?: boolean;
-        previous?: boolean;
+        current?: boolean | undefined;
+        previous?: boolean | undefined;
     }
 
     /** Since Chrome 34. */
     export interface DoubleDelta {
-        current?: number;
-        previous?: number;
+        current?: number | undefined;
+        previous?: number | undefined;
     }
 
     export interface StringDelta {
-        current?: string;
-        previous?: string;
+        current?: string | undefined;
+        previous?: string | undefined;
     }
 
     export interface DownloadItem {
@@ -2705,9 +2705,9 @@ declare namespace chrome.downloads {
         /** The time when the download began in ISO 8601 format. May be passed directly to the Date constructor: chrome.downloads.search({}, function(items){items.forEach(function(item){console.log(new Date(item.startTime))})}) */
         startTime: string;
         /** Optional. Why the download was interrupted. Several kinds of HTTP errors may be grouped under one of the errors beginning with SERVER_. Errors relating to the network begin with NETWORK_, errors relating to the process of writing the file to the file system begin with FILE_, and interruptions initiated by the user begin with USER_.  */
-        error?: string;
+        error?: string | undefined;
         /** Optional. The time when the download ended in ISO 8601 format. May be passed directly to the Date constructor: chrome.downloads.search({}, function(items){items.forEach(function(item){if (item.endTime) console.log(new Date(item.endTime))})})  */
-        endTime?: string;
+        endTime?: string | undefined;
         /** An identifier that is persistent across browser sessions. */
         id: number;
         /** False if this download is recorded in the history, true if it is not recorded. */
@@ -2715,81 +2715,81 @@ declare namespace chrome.downloads {
         /** Absolute URL. */
         referrer: string;
         /** Optional. Estimated time when the download will complete in ISO 8601 format. May be passed directly to the Date constructor: chrome.downloads.search({}, function(items){items.forEach(function(item){if (item.estimatedEndTime) console.log(new Date(item.estimatedEndTime))})})  */
-        estimatedEndTime?: string;
+        estimatedEndTime?: string | undefined;
         /** True if the download is in progress and paused, or else if it is interrupted and can be resumed starting from where it was interrupted. */
         canResume: boolean;
         /** Whether the downloaded file still exists. This information may be out of date because Chrome does not automatically watch for file removal. Call search() in order to trigger the check for file existence. When the existence check completes, if the file has been deleted, then an onChanged event will fire. Note that search() does not wait for the existence check to finish before returning, so results from search() may not accurately reflect the file system. Also, search() may be called as often as necessary, but will not check for file existence any more frequently than once every 10 seconds. */
         exists: boolean;
         /** Optional. The identifier for the extension that initiated this download if this download was initiated by an extension. Does not change once it is set.  */
-        byExtensionId?: string;
+        byExtensionId?: string | undefined;
         /** Optional. The localized name of the extension that initiated this download if this download was initiated by an extension. May change if the extension changes its name or if the user changes their locale.  */
-        byExtensionName?: string;
+        byExtensionName?: string | undefined;
     }
 
     export interface GetFileIconOptions {
         /** Optional. * The size of the returned icon. The icon will be square with dimensions size * size pixels. The default and largest size for the icon is 32x32 pixels. The only supported sizes are 16 and 32. It is an error to specify any other size.
          */
-        size?: number;
+        size?: number | undefined;
     }
 
     export interface DownloadQuery {
         /** Optional. Set elements of this array to DownloadItem properties in order to sort search results. For example, setting orderBy=['startTime'] sorts the DownloadItem by their start time in ascending order. To specify descending order, prefix with a hyphen: '-startTime'.  */
-        orderBy?: string[];
+        orderBy?: string[] | undefined;
         /** Optional. Limits results to DownloadItem whose url matches the given regular expression.  */
-        urlRegex?: string;
+        urlRegex?: string | undefined;
         /** Optional. Limits results to DownloadItem that ended before the time in ISO 8601 format.  */
-        endedBefore?: string;
+        endedBefore?: string | undefined;
         /** Optional. Limits results to DownloadItem whose totalBytes is greater than the given integer.  */
-        totalBytesGreater?: number;
+        totalBytesGreater?: number | undefined;
         /** Optional. Indication of whether this download is thought to be safe or known to be suspicious.  */
-        danger?: string;
+        danger?: string | undefined;
         /** Optional. Number of bytes in the whole file, without considering file compression, or -1 if unknown.  */
-        totalBytes?: number;
+        totalBytes?: number | undefined;
         /** Optional. True if the download has stopped reading data from the host, but kept the connection open.  */
-        paused?: boolean;
+        paused?: boolean | undefined;
         /** Optional. Limits results to DownloadItem whose filename matches the given regular expression.  */
-        filenameRegex?: string;
+        filenameRegex?: string | undefined;
         /** Optional. This array of search terms limits results to DownloadItem whose filename or url contain all of the search terms that do not begin with a dash '-' and none of the search terms that do begin with a dash.  */
-        query?: string[];
+        query?: string[] | undefined;
         /** Optional. Limits results to DownloadItem whose totalBytes is less than the given integer.  */
-        totalBytesLess?: number;
+        totalBytesLess?: number | undefined;
         /** Optional. The id of the DownloadItem to query.  */
-        id?: number;
+        id?: number | undefined;
         /** Optional. Number of bytes received so far from the host, without considering file compression.  */
-        bytesReceived?: number;
+        bytesReceived?: number | undefined;
         /** Optional. Limits results to DownloadItem that ended after the time in ISO 8601 format.  */
-        endedAfter?: string;
+        endedAfter?: string | undefined;
         /** Optional. Absolute local path.  */
-        filename?: string;
+        filename?: string | undefined;
         /** Optional. Indicates whether the download is progressing, interrupted, or complete.  */
-        state?: string;
+        state?: string | undefined;
         /** Optional. Limits results to DownloadItem that started after the time in ISO 8601 format.  */
-        startedAfter?: string;
+        startedAfter?: string | undefined;
         /** Optional. The file's MIME type.  */
-        mime?: string;
+        mime?: string | undefined;
         /** Optional. Number of bytes in the whole file post-decompression, or -1 if unknown.  */
-        fileSize?: number;
+        fileSize?: number | undefined;
         /** Optional. The time when the download began in ISO 8601 format.  */
-        startTime?: string;
+        startTime?: string | undefined;
         /** Optional. Absolute URL.  */
-        url?: string;
+        url?: string | undefined;
         /** Optional. Limits results to DownloadItem that started before the time in ISO 8601 format.  */
-        startedBefore?: string;
+        startedBefore?: string | undefined;
         /** Optional. The maximum number of matching DownloadItem returned. Defaults to 1000. Set to 0 in order to return all matching DownloadItem. See search for how to page through results.  */
-        limit?: number;
+        limit?: number | undefined;
         /** Optional. Why a download was interrupted.  */
-        error?: number;
+        error?: number | undefined;
         /** Optional. The time when the download ended in ISO 8601 format.  */
-        endTime?: string;
+        endTime?: string | undefined;
         /** Optional. Whether the downloaded file exists;  */
-        exists?: boolean;
+        exists?: boolean | undefined;
     }
 
     export interface DownloadFilenameSuggestion {
         /** The DownloadItem's new target DownloadItem.filename, as a path relative to the user's default Downloads directory, possibly containing subdirectories. Absolute paths, empty paths, and paths containing back-references ".." will be ignored. */
         filename: string;
         /** Optional. The action to take if filename already exists.  */
-        conflictAction?: string;
+        conflictAction?: string | undefined;
     }
 
     export interface DownloadChangedEvent extends chrome.events.Event<(downloadDelta: DownloadDelta) => void> { }
@@ -3075,9 +3075,9 @@ declare namespace chrome.enterprise.networkingAttributes {
         /** The device's MAC address. */
         macAddress: string;
         /** Optional. The device's local IPv4 address (undefined if not configured). */
-        ipv4?: string;
+        ipv4?: string | undefined;
         /** Optional. The device's local IPv6 address (undefined if not configured). */
-        ipv6?: string;
+        ipv6?: string | undefined;
     }
 
     /**
@@ -3100,53 +3100,53 @@ declare namespace chrome.events {
     /** Filters URLs for various criteria. See event filtering. All criteria are case sensitive. */
     export interface UrlFilter {
         /** Optional. Matches if the scheme of the URL is equal to any of the schemes specified in the array.  */
-        schemes?: string[];
+        schemes?: string[] | undefined;
         /**
          * Optional.
          * Since Chrome 23.
          * Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.
          */
-        urlMatches?: string;
+        urlMatches?: string | undefined;
         /** Optional. Matches if the path segment of the URL contains a specified string.  */
-        pathContains?: string;
+        pathContains?: string | undefined;
         /** Optional. Matches if the host name of the URL ends with a specified string.  */
-        hostSuffix?: string;
+        hostSuffix?: string | undefined;
         /** Optional. Matches if the host name of the URL starts with a specified string.  */
-        hostPrefix?: string;
+        hostPrefix?: string | undefined;
         /** Optional. Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name.  */
-        hostContains?: string;
+        hostContains?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlContains?: string;
+        urlContains?: string | undefined;
         /** Optional. Matches if the query segment of the URL ends with a specified string.  */
-        querySuffix?: string;
+        querySuffix?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlPrefix?: string;
+        urlPrefix?: string | undefined;
         /** Optional. Matches if the host name of the URL is equal to a specified string.  */
-        hostEquals?: string;
+        hostEquals?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlEquals?: string;
+        urlEquals?: string | undefined;
         /** Optional. Matches if the query segment of the URL contains a specified string.  */
-        queryContains?: string;
+        queryContains?: string | undefined;
         /** Optional. Matches if the path segment of the URL starts with a specified string.  */
-        pathPrefix?: string;
+        pathPrefix?: string | undefined;
         /** Optional. Matches if the path segment of the URL is equal to a specified string.  */
-        pathEquals?: string;
+        pathEquals?: string | undefined;
         /** Optional. Matches if the path segment of the URL ends with a specified string.  */
-        pathSuffix?: string;
+        pathSuffix?: string | undefined;
         /** Optional. Matches if the query segment of the URL is equal to a specified string.  */
-        queryEquals?: string;
+        queryEquals?: string | undefined;
         /** Optional. Matches if the query segment of the URL starts with a specified string.  */
-        queryPrefix?: string;
+        queryPrefix?: string | undefined;
         /** Optional. Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-        urlSuffix?: string;
+        urlSuffix?: string | undefined;
         /** Optional. Matches if the port of the URL is contained in any of the specified port lists. For example [80, 443, [1000, 1200]] matches all requests on port 80, 443 and in the range 1000-1200.  */
-        ports?: any[];
+        ports?: any[] | undefined;
         /**
          * Optional.
          * Since Chrome 28.
          * Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.
          */
-        originAndPathMatches?: string;
+        originAndPathMatches?: string | undefined;
     }
 
     /** An object which allows the addition and removal of listeners for a Chrome event. */
@@ -3216,11 +3216,11 @@ declare namespace chrome.events {
     /** Description of a declarative rule for handling events. */
     export interface Rule {
         /** Optional. Optional priority of this rule. Defaults to 100.  */
-        priority?: number;
+        priority?: number | undefined;
         /** List of conditions that can trigger the actions. */
         conditions: any[];
         /** Optional. Optional identifier that allows referencing this rule.  */
-        id?: string;
+        id?: string | undefined;
         /** List of actions that are triggered if one of the condtions is fulfilled. */
         actions: any[];
         /**
@@ -3228,7 +3228,7 @@ declare namespace chrome.events {
          * Since Chrome 28.
          * Tags can be used to annotate rules and perform operations on sets of rules.
          */
-        tags?: string[];
+        tags?: string[] | undefined;
     }
 }
 
@@ -3246,11 +3246,11 @@ declare namespace chrome.extension {
          * Chrome 54+
          * Find a view according to a tab id. If this field is omitted, returns all views.
          */
-        tabId?: number;
+        tabId?: number | undefined;
         /** Optional. The window to restrict the search to. If omitted, returns all views.  */
-        windowId?: number;
+        windowId?: number | undefined;
         /** Optional. The type of view to get. If omitted, returns all views (including background pages and tabs). Valid values: 'tab', 'notification', 'popup'.  */
-        type?: string;
+        type?: string | undefined;
     }
 
     export interface LastError {
@@ -3353,14 +3353,14 @@ declare namespace chrome.fileBrowserHandler {
          * List of file extensions that the selected file can have. The list is also used to specify what files to be shown in the select file dialog. Files with the listed extensions are only shown in the dialog. Extensions should not include the leading '.'. Example: ['jpg', 'png']
          * Since Chrome 23.
          */
-        allowedFileExtensions?: string[];
+        allowedFileExtensions?: string[] | undefined;
         /** Suggested name for the file. */
         suggestedName: string;
     }
 
     export interface SelectionResult {
         /** Optional. Selected file entry. It will be null if a file hasn't been selected.  */
-        entry?: Object | null;
+        entry?: Object | null | undefined;
         /** Whether the file has been selected. */
         success: boolean;
     }
@@ -3368,7 +3368,7 @@ declare namespace chrome.fileBrowserHandler {
     /** Event details payload for fileBrowserHandler.onExecute event. */
     export interface FileHandlerExecuteEventDetails {
         /** Optional. The ID of the tab that raised this event. Tab IDs are unique within a browser session.  */
-        tab_id?: number;
+        tab_id?: number | undefined;
         /** Array of Entry instances representing files that are targets of this action (selected in ChromeOS file browser). */
         entries: any[];
     }
@@ -3416,7 +3416,7 @@ declare namespace chrome.fileSystemProvider {
         /** Whether watching should include all child entries recursively. It can be true for directories only. */
         recursive: boolean;
         /** Optional. Tag used by the last notification for the watcher.  */
-        lastTag?: string;
+        lastTag?: string | undefined;
     }
 
     export interface EntryMetadata {
@@ -3429,9 +3429,9 @@ declare namespace chrome.fileSystemProvider {
         /** The last modified time of this entry. */
         modificationTime: Date;
         /** Optional. Mime type for the entry.  */
-        mimeType?: string;
+        mimeType?: string | undefined;
         /** Optional. Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the onGetMetadataRequested event.  */
-        thumbnail?: string;
+        thumbnail?: string | undefined;
     }
 
     export interface FileSystemInfo {
@@ -3456,7 +3456,7 @@ declare namespace chrome.fileSystemProvider {
          * Whether the file system supports the tag field for observing directories.
          * @since Since Chrome 45. Warning: this is the current Beta channel.
          */
-        supportsNotifyTag?: boolean;
+        supportsNotifyTag?: boolean | undefined;
         /**
          * List of watchers.
          * @since Since Chrome 45. Warning: this is the current Beta channel.
@@ -3479,7 +3479,7 @@ declare namespace chrome.fileSystemProvider {
         /** The identifier of the action. Any string or CommonActionId for common actions. */
         id: string;
         /** Optional. The title of the action. It may be ignored for common actions.  */
-        title?: string;
+        title?: string | undefined;
     }
 
     /** @since Since Chrome 45. Warning: this is the current Beta channel. */
@@ -3500,19 +3500,19 @@ declare namespace chrome.fileSystemProvider {
         /** A human-readable name for the file system. */
         displayName: string;
         /** Optional. Whether the file system supports operations which may change contents of the file system (such as creating, deleting or writing to files).  */
-        writable?: boolean;
+        writable?: boolean | undefined;
         /**
          * Optional.
          * The maximum number of files that can be opened at once. If not specified, or 0, then not limited.
          * @since Since Chrome 41.
          */
-        openedFilesLimit?: number;
+        openedFilesLimit?: number | undefined;
         /**
          * Optional.
          * Whether the file system supports the tag field for observed directories.
          * @since Since Chrome 45. Warning: this is the current Beta channel.
          */
-        supportsNotifyTag?: boolean;
+        supportsNotifyTag?: boolean | undefined;
     }
 
     export interface UnmountOptions {
@@ -3537,9 +3537,9 @@ declare namespace chrome.fileSystemProvider {
         /** The type of the change which happened to the observed entry. If it is DELETED, then the observed entry will be automatically removed from the list of observed entries. */
         changeType: string;
         /** Optional. List of changes to entries within the observed directory (including the entry itself)  */
-        changes?: NotificationChange[];
+        changes?: NotificationChange[] | undefined;
         /** Optional. Tag for the notification. Required if the file system was mounted with the supportsNotifyTag option. Note, that this flag is necessary to provide notifications about changes which changed even when the system was shutdown.  */
-        tag?: string;
+        tag?: string | undefined;
     }
 
     export interface RequestedEventOptions {
@@ -3857,7 +3857,7 @@ declare namespace chrome.fontSettings {
         /** The generic font family for the font. */
         genericFamily: string;
         /** Optional. The script for the font. If omitted, the global script font setting is affected.  */
-        script?: string;
+        script?: string | undefined;
     }
 
     export interface FullFontDetails {
@@ -3866,7 +3866,7 @@ declare namespace chrome.fontSettings {
         /** The level of control this extension has over the setting. */
         levelOfControl: string;
         /** Optional. The script code for which the font setting has changed.  */
-        script?: string;
+        script?: string | undefined;
         /** The font ID. See the description in getFont. */
         fontId: string;
     }
@@ -4013,7 +4013,7 @@ declare namespace chrome.gcm {
         /** The ID of the message. It must be unique for each message in scope of the applications. See the Cloud Messaging documentation for advice for picking and handling an ID. */
         messageId: string;
         /** Optional. Time-to-live of the message in seconds. If it is not possible to send the message within that time, an onSendError event will be raised. A time-to-live of 0 indicates that the message should be sent immediately or fail if it's not possible. The maximum and a default value of time-to-live is 86400 seconds (1 day). */
-        timeToLive?: number;
+        timeToLive?: number | undefined;
         /** Message data to send to the server. Case-insensitive goog. and google, as well as case-sensitive collapse_key are disallowed as key prefixes. Sum of all key/value pairs should not exceed gcm.MAX_MESSAGE_SIZE. */
         data: Object;
     }
@@ -4026,19 +4026,19 @@ declare namespace chrome.gcm {
          * The sender who issued the message.
          * @since Since Chrome 41.
          */
-        from?: string;
+        from?: string | undefined;
         /**
          * Optional.
          * The collapse key of a message. See Collapsible Messages section of Cloud Messaging documentation for details.
          */
-        collapseKey?: string;
+        collapseKey?: string | undefined;
     }
 
     export interface GcmError {
         /** The error message describing the problem. */
         errorMessage: string;
         /** Optional. The ID of the message with this error, if error is related to a specific message. */
-        messageId?: string;
+        messageId?: string | undefined;
         /** Additional details related to the error, when available. */
         detail: Object;
     }
@@ -4100,7 +4100,7 @@ declare namespace chrome.history {
         /** The transition type for this visit from its referrer. */
         transition: string;
         /** Optional. When this visit occurred, represented in milliseconds since the epoch. */
-        visitTime?: number;
+        visitTime?: number | undefined;
         /** The unique identifier for this visit. */
         visitId: string;
         /** The visit ID of the referrer. */
@@ -4112,15 +4112,15 @@ declare namespace chrome.history {
     /** An object encapsulating one result of a history query. */
     export interface HistoryItem {
         /** Optional. The number of times the user has navigated to this page by typing in the address. */
-        typedCount?: number;
+        typedCount?: number | undefined;
         /** Optional. The title of the page when it was last loaded. */
-        title?: string;
+        title?: string | undefined;
         /** Optional. The URL navigated to by a user. */
-        url?: string;
+        url?: string | undefined;
         /** Optional. When this page was last loaded, represented in milliseconds since the epoch. */
-        lastVisitTime?: number;
+        lastVisitTime?: number | undefined;
         /** Optional. The number of times the user has navigated to this page. */
-        visitCount?: number;
+        visitCount?: number | undefined;
         /** The unique identifier for the item. */
         id: string;
     }
@@ -4129,11 +4129,11 @@ declare namespace chrome.history {
         /** A free-text query to the history service. Leave empty to retrieve all pages. */
         text: string;
         /** Optional. The maximum number of results to retrieve. Defaults to 100. */
-        maxResults?: number;
+        maxResults?: number | undefined;
         /** Optional. Limit results to those visited after this date, represented in milliseconds since the epoch. */
-        startTime?: number;
+        startTime?: number | undefined;
         /** Optional. Limit results to those visited before this date, represented in milliseconds since the epoch. */
-        endTime?: number;
+        endTime?: number | undefined;
     }
 
     export interface Url {
@@ -4152,7 +4152,7 @@ declare namespace chrome.history {
         /** True if all history was removed. If true, then urls will be empty. */
         allHistory: boolean;
         /** Optional. */
-        urls?: string[];
+        urls?: string[] | undefined;
     }
 
     export interface HistoryVisitedEvent extends chrome.events.Event<(result: HistoryItem) => void> { }
@@ -4282,7 +4282,7 @@ declare namespace chrome.identity {
          * Optional.
          * A status of the primary account signed into a profile whose ProfileUserInfo should be returned. Defaults to SYNC account status.
          */
-        accountStatus?: AccountStatus;
+        accountStatus?: AccountStatus | undefined;
     }
 
     export interface TokenDetails {
@@ -4290,21 +4290,21 @@ declare namespace chrome.identity {
          * Optional.
          * Fetching a token may require the user to sign-in to Chrome, or approve the application's requested scopes. If the interactive flag is true, getAuthToken will prompt the user as necessary. When the flag is false or omitted, getAuthToken will return failure any time a prompt would be required.
          */
-        interactive?: boolean;
+        interactive?: boolean | undefined;
         /**
          * Optional.
          * The account ID whose token should be returned. If not specified, the primary account for the profile will be used.
          * account is only supported when the "enable-new-profile-management" flag is set.
          * @since Chrome 37.
          */
-        account?: AccountInfo;
+        account?: AccountInfo | undefined;
         /**
          * Optional.
          * A list of OAuth2 scopes to request.
          * When the scopes field is present, it overrides the list of scopes specified in manifest.json.
          * @since Chrome 37.
          */
-        scopes?: string[];
+        scopes?: string[] | undefined;
     }
 
     export interface UserInfo {
@@ -4328,7 +4328,7 @@ declare namespace chrome.identity {
          * Since some auth flows may immediately redirect to a result URL, launchWebAuthFlow hides its web view until the first navigation either redirects to the final URL, or finishes loading a page meant to be displayed.
          * If the interactive flag is true, the window will be displayed when a page load completes. If the flag is false or omitted, launchWebAuthFlow will return with an error if the initial navigation does not complete the flow.
          */
-        interactive?: boolean;
+        interactive?: boolean | undefined;
     }
 
     export interface SignInChangeEvent extends chrome.events.Event<(account: AccountInfo, signedIn: boolean) => void> { }
@@ -4463,31 +4463,31 @@ declare namespace chrome.input.ime {
          * Optional.
          * Whether or not the SHIFT key is pressed.
          */
-        shiftKey?: boolean;
+        shiftKey?: boolean | undefined;
         /**
          * Optional.
          * Whether or not the ALT key is pressed.
          */
-        altKey?: boolean;
+        altKey?: boolean | undefined;
         /**
          * Optional.
          * Whether or not the ALTGR key is pressed.
          * @since Chrome 79.
          */
-        altgrKey?: boolean;
+        altgrKey?: boolean | undefined;
         /**
          * Optional.
          * The ID of the request.
          * @deprecated since Chrome 79.
          */
-        requestId?: string;
+        requestId?: string | undefined;
         /** Value of the key being pressed */
         key: string;
         /**
          * Optional.
          * Whether or not the CTRL key is pressed.
          */
-        ctrlKey?: boolean;
+        ctrlKey?: boolean | undefined;
         /** One of keyup or keydown. */
         type: string;
         /**
@@ -4495,7 +4495,7 @@ declare namespace chrome.input.ime {
          * The extension ID of the sender of this keyevent.
          * @since Chrome 34.
          */
-        extensionId?: string;
+        extensionId?: string | undefined;
         /**
          * Optional.
          * Value of the physical key being pressed. The value is not affected by current keyboard layout or modifier state.
@@ -4507,13 +4507,13 @@ declare namespace chrome.input.ime {
          * The deprecated HTML keyCode, which is system- and implementation-dependent numerical code signifying the unmodified identifier associated with the key pressed.
          * @since Chrome 37.
          */
-        keyCode?: number;
+        keyCode?: number | undefined;
         /**
          * Optional.
          * Whether or not the CAPS_LOCK is enabled.
          * @since Chrome 29.
          */
-        capsLock?: boolean;
+        capsLock?: boolean | undefined;
     }
 
     /** Describes an input Context */
@@ -4547,15 +4547,15 @@ declare namespace chrome.input.ime {
         /** String that will be passed to callbacks referencing this MenuItem. */
         id: string;
         /** Optional. Text displayed in the menu for this item. */
-        label?: string;
+        label?: string | undefined;
         /** Optional. The type of menu item. */
-        style?: string;
+        style?: string | undefined;
         /** Optional. Indicates this item is visible. */
-        visible?: boolean;
+        visible?: boolean | undefined;
         /** Indicates this item should be drawn with a check. */
-        checked?: boolean;
+        checked?: boolean | undefined;
         /** Indicates this item is enabled. */
-        enabled?: boolean;
+        enabled?: boolean | undefined;
     }
 
     export interface ImeParameters {
@@ -4588,22 +4588,22 @@ declare namespace chrome.input.ime {
          * Optional.
          * The id to add these candidates under
          */
-        parentId?: number;
+        parentId?: number | undefined;
         /**
          * Optional.
          * Short string displayed to next to the candidate, often the shortcut key or index
          */
-        label?: string;
+        label?: string | undefined;
         /**
          * Optional.
          * Additional text describing the candidate
          */
-        annotation?: string;
+        annotation?: string | undefined;
         /**
          * Optional.
          * The usage or detail description of word.
          */
-        usage?: CandidateUsage;
+        usage?: CandidateUsage | undefined;
     }
 
     export interface CandidatesParameters {
@@ -4628,13 +4628,13 @@ declare namespace chrome.input.ime {
         /** Text to set */
         text: string;
         /** Optional. List of segments and their associated types. */
-        segments?: CompositionParameterSegment[];
+        segments?: CompositionParameterSegment[] | undefined;
         /** Position in the text of the cursor. */
         cursor: number;
         /** Optional. Position in the text that the selection starts at. */
-        selectionStart?: number;
+        selectionStart?: number | undefined;
         /** Optional. Position in the text that the selection ends at. */
-        selectionEnd?: number;
+        selectionEnd?: number | undefined;
     }
 
     export interface MenuItemParameters {
@@ -4652,7 +4652,7 @@ declare namespace chrome.input.ime {
     export interface AssistiveWindowProperties {
         type: AssistiveWindowType;
         visible: boolean;
-        announceString?: string;
+        announceString?: string | undefined;
     }
 
     export interface CandidateWindowParameterProperties {
@@ -4660,38 +4660,38 @@ declare namespace chrome.input.ime {
          * Optional.
          * True to show the cursor, false to hide it.
          */
-        cursorVisible?: boolean;
+        cursorVisible?: boolean | undefined;
         /**
          * Optional.
          * True if the candidate window should be rendered vertical, false to make it horizontal.
          */
-        vertical?: boolean;
+        vertical?: boolean | undefined;
         /**
          * Optional.
          * The number of candidates to display per page.
          */
-        pageSize?: number;
+        pageSize?: number | undefined;
         /**
          * Optional.
          * True to display the auxiliary text, false to hide it.
          */
-        auxiliaryTextVisible?: boolean;
+        auxiliaryTextVisible?: boolean | undefined;
         /**
          * Optional.
          * Text that is shown at the bottom of the candidate window.
          */
-        auxiliaryText?: string;
+        auxiliaryText?: string | undefined;
         /**
          * Optional.
          * True to show the Candidate window, false to hide it.
          */
-        visible?: boolean;
+        visible?: boolean | undefined;
         /**
          * Optional.
          * Where to display the candidate window.
          * @since Chrome 28.
          */
-        windowPosition?: string;
+        windowPosition?: string | undefined;
     }
 
     export interface CandidateWindowParameter {
@@ -4831,7 +4831,7 @@ declare namespace chrome.input.ime {
             contextID: number;
             buttonID: chrome.input.ime.AssistiveWindowButton;
             windowType: chrome.input.ime.AssistiveWindowType;
-            announceString?: string;
+            announceString?: string | undefined;
             highlighted: boolean;
         },
         callback?: () => void,
@@ -4966,9 +4966,9 @@ declare namespace chrome.management {
          * A reason the item is disabled.
          * @since Chrome 17.
          */
-        disabledReason?: string;
+        disabledReason?: string | undefined;
         /** Optional. The launch url (only present for apps). */
-        appLaunchUrl?: string;
+        appLaunchUrl?: string | undefined;
         /**
          * The description of this extension, app, or theme.
          * @since Chrome 9.
@@ -4983,7 +4983,7 @@ declare namespace chrome.management {
          * Optional.
          * A list of icon information. Note that this just reflects what was declared in the manifest, and the actual image at that url may be larger or smaller than what was declared, so you might consider using explicit width and height attributes on img tags referencing these images. See the manifest documentation on icons for more details.
          */
-        icons?: IconInfo[];
+        icons?: IconInfo[] | undefined;
         /**
          * Returns a list of host based permissions.
          * @since Chrome 9.
@@ -4996,7 +4996,7 @@ declare namespace chrome.management {
          * The URL of the homepage of this extension, app, or theme.
          * @since Chrome 11.
          */
-        homepageUrl?: string;
+        homepageUrl?: string | undefined;
         /**
          * Whether this extension can be disabled or uninstalled by the user.
          * @since Chrome 12.
@@ -5021,7 +5021,7 @@ declare namespace chrome.management {
          * The update URL of this extension, app, or theme.
          * @since Chrome 16.
          */
-        updateUrl?: string;
+        updateUrl?: string | undefined;
         /**
          * The type of this extension, app, or theme.
          * @since Chrome 23.
@@ -5046,13 +5046,13 @@ declare namespace chrome.management {
          * The app launch type (only present for apps).
          * @since Chrome 37.
          */
-        launchType?: string;
+        launchType?: string | undefined;
         /**
          * Optional.
          * The currently available launch types (only present for apps).
          * @since Chrome 37.
          */
-        availableLaunchTypes?: string[];
+        availableLaunchTypes?: string[] | undefined;
     }
 
     /** Information about an icon belonging to an extension, app, or theme. */
@@ -5068,7 +5068,7 @@ declare namespace chrome.management {
          * Optional.
          * Whether or not a confirm-uninstall dialog should prompt the user. Defaults to false for self uninstalls. If an extension uninstalls another extension, this parameter is ignored and the dialog is always shown.
          */
-        showConfirmDialog?: boolean;
+        showConfirmDialog?: boolean | undefined;
     }
 
     export interface ManagementDisabledEvent extends chrome.events.Event<(info: ExtensionInfo) => void> { }
@@ -5313,15 +5313,15 @@ declare namespace chrome.networking.config {
         /** Currently only WiFi supported. */
         Type: string;
         /** Optional. A unique identifier of the network. */
-        GUID?: string;
+        GUID?: string | undefined;
         /** Optional. A hex-encoded byte sequence. */
-        HexSSID?: string;
+        HexSSID?: string | undefined;
         /** Optional. The decoded SSID of the network (default encoding is UTF-8). To filter for non-UTF-8 SSIDs, use HexSSID instead. */
-        SSID?: string;
+        SSID?: string | undefined;
         /** Optional. The basic service set identification (BSSID) uniquely identifying the basic service set. BSSID is represented as a human readable, hex-encoded string with bytes separated by colons, e.g. 45:67:89:ab:cd:ef. */
-        BSSID?: string;
+        BSSID?: string | undefined;
         /** Optional. Identifier indicating the security type of the network. Valid values are None, WEP-PSK, WPA-PSK and WPA-EAP. */
-        Security?: string;
+        Security?: string | undefined;
     }
 
     export interface CaptivePorttalDetectedEvent extends chrome.events.Event<(networkInfo: NetworkInfo) => void> { }
@@ -5364,7 +5364,7 @@ declare namespace chrome.networking.config {
 declare namespace chrome.notifications {
     export interface ButtonOptions {
         title: string;
-        iconUrl?: string;
+        iconUrl?: string | undefined;
     }
 
     export interface ItemOptions {
@@ -5376,63 +5376,63 @@ declare namespace chrome.notifications {
 
     export interface NotificationOptions {
         /** Optional. Which type of notification to display. Required for notifications.create method. */
-        type?: string;
+        type?: string | undefined;
         /**
          * Optional.
          * A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
          * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file Required for notifications.create method.
          */
-        iconUrl?: string;
+        iconUrl?: string | undefined;
         /** Optional. Title of the notification (e.g. sender name for email). Required for notifications.create method. */
-        title?: string;
+        title?: string | undefined;
         /** Optional. Main notification content. Required for notifications.create method. */
-        message?: string;
+        message?: string | undefined;
         /**
          * Optional.
          * Alternate notification content with a lower-weight font.
          * @since Chrome 31.
          */
-        contextMessage?: string;
+        contextMessage?: string | undefined;
         /** Optional. Priority ranges from -2 to 2. -2 is lowest priority. 2 is highest. Zero is default. */
-        priority?: number;
+        priority?: number | undefined;
         /** Optional. A timestamp associated with the notification, in milliseconds past the epoch (e.g. Date.now() + n). */
-        eventTime?: number;
+        eventTime?: number | undefined;
         /** Optional. Text and icons for up to two notification action buttons. */
-        buttons?: ButtonOptions[];
+        buttons?: ButtonOptions[] | undefined;
         /** Optional. Items for multi-item notifications. */
-        items?: ItemOptions[];
+        items?: ItemOptions[] | undefined;
         /**
          * Optional.
          * Current progress ranges from 0 to 100.
          * @since Chrome 30.
          */
-        progress?: number;
+        progress?: number | undefined;
         /**
          * Optional.
          * Whether to show UI indicating that the app will visibly respond to clicks on the body of a notification.
          * @since Chrome 32.
          */
-        isClickable?: boolean;
+        isClickable?: boolean | undefined;
         /**
          * Optional.
          * A URL to the app icon mask. URLs have the same restrictions as iconUrl. The app icon mask should be in alpha channel, as only the alpha channel of the image will be considered.
          * @since Chrome 38.
          */
-        appIconMaskUrl?: string;
+        appIconMaskUrl?: string | undefined;
         /** Optional. A URL to the image thumbnail for image-type notifications. URLs have the same restrictions as iconUrl. */
-        imageUrl?: string;
+        imageUrl?: string | undefined;
         /**
          * Indicates that the notification should remain visible on screen until the user activates or dismisses the notification.
          * This defaults to false.
          * @since Chrome 50
          */
-        requireInteraction?: boolean;
+        requireInteraction?: boolean | undefined;
         /**
          * Optional.
          * Indicates that no sounds or vibrations should be made when the notification is being shown. This defaults to false.
          * @since Chrome 70
          */
-        silent?: boolean;
+        silent?: boolean | undefined;
     }
 
     export interface NotificationClosedEvent
@@ -5550,7 +5550,7 @@ declare namespace chrome.omnibox {
          * Whether the suggest result can be deleted by the user.
          * @since Chrome 63.
          */
-        deletable?: boolean;
+        deletable?: boolean | undefined;
     }
 
     export interface Suggestion {
@@ -5631,12 +5631,12 @@ declare namespace chrome.pageAction {
          * Optional.
          * @deprecated This argument is ignored.
          */
-        iconIndex?: number;
+        iconIndex?: number | undefined;
         /**
          * Optional.
          * Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'
          */
-        imageData?: ImageData | { [index: number]: ImageData };
+        imageData?: ImageData | { [index: number]: ImageData } | undefined;
         /**
          * Optional.
          * Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'
@@ -5728,12 +5728,12 @@ declare namespace chrome.permissions {
          * Optional.
          * List of named permissions (does not include hosts or origins). Anything listed here must appear in the optional_permissions list in the manifest.
          */
-        permissions?: string[];
+        permissions?: string[] | undefined;
         /**
          * Optional.
          * List of origin permissions. Anything listed here must be a subset of a host that appears in the optional_permissions list in the manifest. For example, if http://*.example.com/ or http://* appears in optional_permissions, you can request an origin of http://help.example.com/. Any path is ignored.
          */
-        origins?: string[];
+        origins?: string[] | undefined;
     }
 
     export interface PermissionsRemovedEvent {
@@ -5820,7 +5820,7 @@ declare namespace chrome.platformKeys {
          * Optional.
          * If given, the selectClientCertificates operates on this list. Otherwise, obtains the list of all certificates from the platform's certificate stores that are available to this extensions. Entries that the extension doesn't have permission for or which doesn't match the request, are removed.
          */
-        clientCerts?: ArrayBuffer[];
+        clientCerts?: ArrayBuffer[] | undefined;
         /** If true, the filtered list is presented to the user to manually select a certificate and thereby granting the extension access to the certificate(s) and key(s). Only the selected certificate(s) will be returned. If is false, the list is reduced to all certificates that the extension has been granted access to (automatically or manually). */
         interactive: boolean;
     }
@@ -5925,7 +5925,7 @@ declare namespace chrome.printerProvider {
         /** Printer's human readable name. */
         name: string;
         /** Optional. Printer's human readable description. */
-        description?: string;
+        description?: string | undefined;
     }
 
     export interface PrinterCapabilities {
@@ -6046,19 +6046,19 @@ declare namespace chrome.proxy {
     /** An object holding proxy auto-config information. Exactly one of the fields should be non-empty. */
     export interface PacScript {
         /** Optional. URL of the PAC file to be used. */
-        url?: string;
+        url?: string | undefined;
         /** Optional. If true, an invalid PAC script will prevent the network stack from falling back to direct connections. Defaults to false. */
-        mandatory?: boolean;
+        mandatory?: boolean | undefined;
         /** Optional. A PAC script. */
-        data?: string;
+        data?: string | undefined;
     }
 
     /** An object encapsulating a complete proxy configuration. */
     export interface ProxyConfig {
         /** Optional. The proxy rules describing this configuration. Use this for 'fixed_servers' mode. */
-        rules?: ProxyRules;
+        rules?: ProxyRules | undefined;
         /** Optional. The proxy auto-config (PAC) script for this configuration. Use this for 'pac_script' mode. */
-        pacScript?: PacScript;
+        pacScript?: PacScript | undefined;
         /**
          * 'direct' = Never use a proxy
          * 'auto_detect' = Auto detect proxy settings
@@ -6074,25 +6074,25 @@ declare namespace chrome.proxy {
         /** The URI of the proxy server. This must be an ASCII hostname (in Punycode format). IDNA is not supported, yet. */
         host: string;
         /** Optional. The scheme (protocol) of the proxy server itself. Defaults to 'http'. */
-        scheme?: string;
+        scheme?: string | undefined;
         /** Optional. The port of the proxy server. Defaults to a port that depends on the scheme. */
-        port?: number;
+        port?: number | undefined;
     }
 
     /** An object encapsulating the set of proxy rules for all protocols. Use either 'singleProxy' or (a subset of) 'proxyForHttp', 'proxyForHttps', 'proxyForFtp' and 'fallbackProxy'. */
     export interface ProxyRules {
         /** Optional. The proxy server to be used for FTP requests. */
-        proxyForFtp?: ProxyServer;
+        proxyForFtp?: ProxyServer | undefined;
         /** Optional. The proxy server to be used for HTTP requests. */
-        proxyForHttp?: ProxyServer;
+        proxyForHttp?: ProxyServer | undefined;
         /** Optional. The proxy server to be used for everthing else or if any of the specific proxyFor... is not specified. */
-        fallbackProxy?: ProxyServer;
+        fallbackProxy?: ProxyServer | undefined;
         /** Optional. The proxy server to be used for all per-URL requests (that is http, https, and ftp). */
-        singleProxy?: ProxyServer;
+        singleProxy?: ProxyServer | undefined;
         /** Optional. The proxy server to be used for HTTPS requests. */
-        proxyForHttps?: ProxyServer;
+        proxyForHttps?: ProxyServer | undefined;
         /** Optional. List of servers to connect to without a proxy server. */
-        bypassList?: string[];
+        bypassList?: string[] | undefined;
     }
 
     export interface ErrorDetails {
@@ -6124,11 +6124,11 @@ declare namespace chrome.search {
 
     export interface QueryInfo {
         /** Location where search results should be displayed. CURRENT_TAB is the default.  */
-        disposition?: Disposition;
+        disposition?: Disposition | undefined;
         /** Location where search results should be displayed. tabIdcannot be used with disposition. */
-        tabId?: number;
+        tabId?: number | undefined;
         /** String to query with the default search provider. */
-        text?: string;
+        text?: string | undefined;
     }
 
     /**
@@ -6168,16 +6168,16 @@ declare namespace chrome.serial {
         /** The device's system path. This should be passed as the path argument to chrome.serial.connect in order to connect to this device. */
         path: string;
         /** Optional. A PCI or USB vendor ID if one can be determined for the underlying device. */
-        vendorId?: number;
+        vendorId?: number | undefined;
         /** Optional. A USB product ID if one can be determined for the underlying device. */
-        productId?: number;
+        productId?: number | undefined;
         /** Optional. A human-readable display name for the underlying device if one can be queried from the host driver. */
-        displayName?: number;
+        displayName?: number | undefined;
     }
 
     export interface ConnectionInfo {
         /** The id of the serial port connection. */
-        connectionId?: number;
+        connectionId?: number | undefined;
         /** Flag indicating whether the connection is blocked from firing onReceive events. */
         paused: boolean;
         /** See ConnectionOptions.persistent */
@@ -6187,52 +6187,52 @@ declare namespace chrome.serial {
         /** See ConnectionOptions.bufferSize */
         bufferSize: number;
         /** See ConnectionOptions.receiveTimeout */
-        receiveTimeout?: number;
+        receiveTimeout?: number | undefined;
         /** See ConnectionOptions.sendTimeout */
-        sendTimeout?: number;
+        sendTimeout?: number | undefined;
         /** Optional. See ConnectionOptions.bitrate.
          * This field may be omitted or inaccurate if a non-standard bitrate is in use, or if an error occurred while querying the underlying device. */
-        bitrate?: number;
+        bitrate?: number | undefined;
         /** Optional. See ConnectionOptions.dataBits. This field may be omitted if an error occurred while querying the underlying device. */
-        dataBits?: typeof DataBits[keyof typeof DataBits];
+        dataBits?: typeof DataBits[keyof typeof DataBits] | undefined;
         /** Optional. See ConnectionOptions.parityBit. This field may be omitted if an error occurred while querying the underlying device. */
-        parityBit?: typeof ParityBit[keyof typeof ParityBit];
+        parityBit?: typeof ParityBit[keyof typeof ParityBit] | undefined;
         /** Optional. See ConnectionOptions.stopBits. This field may be omitted if an error occurred while querying the underlying device. */
-        stopBits?: typeof StopBits[keyof typeof StopBits];
+        stopBits?: typeof StopBits[keyof typeof StopBits] | undefined;
         /** Optional. Flag indicating whether or not to enable RTS/CTS hardware flow control. Defaults to false. */
-        ctsFlowControl?: boolean;
+        ctsFlowControl?: boolean | undefined;
     }
 
     export interface ConnectionOptions {
         /** Optional. Flag indicating whether or not the connection should be left open when the application is suspended (see Manage App Lifecycle: https://developer.chrome.com/apps/app_lifecycle).
          *  The default value is "false." When the application is loaded, any serial connections previously opened with persistent=true can be fetched with getConnections. */
-        peristent?: boolean;
+        peristent?: boolean | undefined;
         /** Optional. An application-defined string to associate with the connection. */
-        name?: string;
+        name?: string | undefined;
         /** Optional. The size of the buffer used to receive data. The default value is 4096. */
-        bufferSize?: number;
+        bufferSize?: number | undefined;
         /** Optional. The requested bitrate of the connection to be opened.
          * For compatibility with the widest range of hardware, this number should match one of commonly-available bitrates,
          * such as 110, 300, 1200, 2400, 4800, 9600, 14400, 19200, 38400, 57600, 115200.
          * There is no guarantee, of course, that the device connected to the serial port will support the requested bitrate, even if the port itself supports that bitrate.
          * 9600 will be passed by default. */
-        bitrate?: number;
+        bitrate?: number | undefined;
         /** Optional. "eight" will be passed by default. */
-        dataBits?: typeof DataBits[keyof typeof DataBits];
+        dataBits?: typeof DataBits[keyof typeof DataBits] | undefined;
         /** Optional. "no" will be passed by default. */
-        parityBit?: typeof ParityBit[keyof typeof ParityBit];
+        parityBit?: typeof ParityBit[keyof typeof ParityBit] | undefined;
         /** Optional. "one" will be passed by default. */
-        stopBits?: typeof StopBits[keyof typeof StopBits];
+        stopBits?: typeof StopBits[keyof typeof StopBits] | undefined;
         /** Optional. Flag indicating whether or not to enable RTS/CTS hardware flow control. Defaults to false. */
-        ctsFlowControl?: boolean;
+        ctsFlowControl?: boolean | undefined;
         /** Optional. The maximum amount of time (in milliseconds) to wait for new data before raising an onReceiveError event with a "timeout" error.
          * If zero, receive timeout errors will not be raised for the connection.
          * Defaults to 0. */
-        receiveTimeout?: number;
+        receiveTimeout?: number | undefined;
         /** Optional. The maximum amount of time (in milliseconds) to wait for a send operation to complete before calling the callback with a "timeout" error.
          * If zero, send timeout errors will not be triggered.
          * Defaults to 0. */
-        sendTimeout?: number;
+        sendTimeout?: number | undefined;
     }
 
     /**
@@ -6444,12 +6444,12 @@ declare namespace chrome.runtime {
 
     export interface LastError {
         /** Optional. Details about the error which occurred.  */
-        message?: string;
+        message?: string | undefined;
     }
 
     export interface ConnectInfo {
-        name?: string;
-        includeTlsChannelId?: boolean;
+        name?: string | undefined;
+        includeTlsChannelId?: boolean | undefined;
     }
 
     export interface InstalledDetails {
@@ -6462,18 +6462,18 @@ declare namespace chrome.runtime {
          * Optional.
          * Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'.
          */
-        previousVersion?: string;
+        previousVersion?: string | undefined;
         /**
          * Optional.
          * Indicates the ID of the imported shared module extension which updated. This is present only if 'reason' is 'shared_module_update'.
          * @since Chrome 29.
          */
-        id?: string;
+        id?: string | undefined;
     }
 
     export interface MessageOptions {
         /** Whether the TLS channel ID will be passed into onMessageExternal for processes that are listening for the connection event. */
-        includeTlsChannelId?: boolean;
+        includeTlsChannelId?: boolean | undefined;
     }
 
     /**
@@ -6482,33 +6482,33 @@ declare namespace chrome.runtime {
      */
     export interface MessageSender {
         /** The ID of the extension or app that opened the connection, if any. */
-        id?: string;
+        id?: string | undefined;
         /** The tabs.Tab which opened the connection, if any. This property will only be present when the connection was opened from a tab (including content scripts), and only if the receiver is an extension, not an app. */
-        tab?: chrome.tabs.Tab;
+        tab?: chrome.tabs.Tab | undefined;
         /** The name of the native application that opened the connection, if any.
          * @since Chrome 74
          */
-        nativeApplication?: string;
+        nativeApplication?: string | undefined;
         /**
          * The frame that opened the connection. 0 for top-level frames, positive for child frames. This will only be set when tab is set.
          * @since Chrome 41.
          */
-        frameId?: number;
+        frameId?: number | undefined;
         /**
          * The URL of the page or frame that opened the connection. If the sender is in an iframe, it will be iframe's URL not the URL of the page which hosts it.
          * @since Chrome 28.
          */
-        url?: string;
+        url?: string | undefined;
         /**
          * The TLS channel ID of the page or frame that opened the connection, if requested by the extension or app, and if available.
          * @since Chrome 32.
          */
-        tlsChannelId?: string;
+        tlsChannelId?: string | undefined;
         /**
          * The origin of the page or frame that opened the connection. It can vary from the url property (e.g., about:blank) or can be opaque (e.g., sandboxed iframes). This is useful for identifying if the origin can be trusted if we can't immediately tell from the URL.
          * @since Chrome 80.
          */
-        origin?: string;
+        origin?: string | undefined;
     }
 
     /**
@@ -6544,7 +6544,7 @@ declare namespace chrome.runtime {
          * Optional.
          * This property will only be present on ports passed to onConnect/onConnectExternal listeners.
          */
-        sender?: MessageSender;
+        sender?: MessageSender | undefined;
         /** An object which allows the addition and removal of listeners for a Chrome event. */
         onDisconnect: PortDisconnectEvent;
         /** An object which allows the addition and removal of listeners for a Chrome event. */
@@ -6590,27 +6590,27 @@ declare namespace chrome.runtime {
     }
 
     export interface ManifestAction {
-        default_icon?: ManifestIcons;
-        default_title?: string;
-        default_popup?: string;
+        default_icon?: ManifestIcons | undefined;
+        default_title?: string | undefined;
+        default_popup?: string | undefined;
     }
 
     export interface SearchProvider {
-        name?: string;
-        keyword?: string;
-        favicon_url?: string;
+        name?: string | undefined;
+        keyword?: string | undefined;
+        favicon_url?: string | undefined;
         search_url: string;
-        encoding?: string;
-        suggest_url?: string;
-        instant_url?: string;
-        image_url?: string;
-        search_url_post_params?: string;
-        suggest_url_post_params?: string;
-        instant_url_post_params?: string;
-        image_url_post_params?: string;
-        alternate_urls?: string[];
-        prepopulated_id?: number;
-        is_default?: boolean;
+        encoding?: string | undefined;
+        suggest_url?: string | undefined;
+        instant_url?: string | undefined;
+        image_url?: string | undefined;
+        search_url_post_params?: string | undefined;
+        suggest_url_post_params?: string | undefined;
+        instant_url_post_params?: string | undefined;
+        image_url_post_params?: string | undefined;
+        alternate_urls?: string[] | undefined;
+        prepopulated_id?: number | undefined;
+        is_default?: boolean | undefined;
     }
 
     export interface Manifest {
@@ -6620,176 +6620,176 @@ declare namespace chrome.runtime {
         version: string;
 
         // Recommended
-        default_locale?: string;
-        description?: string;
-        icons?: ManifestIcons;
+        default_locale?: string | undefined;
+        description?: string | undefined;
+        icons?: ManifestIcons | undefined;
 
         // Pick one (or none)
-        browser_action?: ManifestAction;
-        page_action?: ManifestAction;
+        browser_action?: ManifestAction | undefined;
+        page_action?: ManifestAction | undefined;
 
         // Optional
         author?: any;
         automation?: any;
         background?: {
-            scripts?: string[];
-            page?: string;
-            persistent?: boolean;
-        };
-        background_page?: string;
+            scripts?: string[] | undefined;
+            page?: string | undefined;
+            persistent?: boolean | undefined;
+        } | undefined;
+        background_page?: string | undefined;
         chrome_settings_overrides?: {
-            homepage?: string;
-            search_provider?: SearchProvider;
-            startup_pages?: string[];
-        };
+            homepage?: string | undefined;
+            search_provider?: SearchProvider | undefined;
+            startup_pages?: string[] | undefined;
+        } | undefined;
         chrome_ui_overrides?: {
             bookmarks_ui?: {
-                remove_bookmark_shortcut?: boolean;
-                remove_button?: boolean;
-            };
-        };
+                remove_bookmark_shortcut?: boolean | undefined;
+                remove_button?: boolean | undefined;
+            } | undefined;
+        } | undefined;
         chrome_url_overrides?: {
-            bookmarks?: string;
-            history?: string;
-            newtab?: string;
-        };
+            bookmarks?: string | undefined;
+            history?: string | undefined;
+            newtab?: string | undefined;
+        } | undefined;
         commands?: {
             [name: string]: {
                 suggested_key?: {
-                    default?: string;
-                    windows?: string;
-                    mac?: string;
-                    chromeos?: string;
-                    linux?: string;
-                };
-                description?: string;
-                global?: boolean;
+                    default?: string | undefined;
+                    windows?: string | undefined;
+                    mac?: string | undefined;
+                    chromeos?: string | undefined;
+                    linux?: string | undefined;
+                } | undefined;
+                description?: string | undefined;
+                global?: boolean | undefined;
             };
-        };
+        } | undefined;
         content_capabilities?: {
-            matches?: string[];
-            permissions?: string[];
-        };
+            matches?: string[] | undefined;
+            permissions?: string[] | undefined;
+        } | undefined;
         content_scripts?: {
-            matches?: string[];
-            exclude_matches?: string[];
-            css?: string[];
-            js?: string[];
-            run_at?: string;
-            all_frames?: boolean;
-            match_about_blank?: boolean;
-            include_globs?: string[];
-            exclude_globs?: string[];
-        }[];
-        content_security_policy?: string;
-        converted_from_user_script?: boolean;
+            matches?: string[] | undefined;
+            exclude_matches?: string[] | undefined;
+            css?: string[] | undefined;
+            js?: string[] | undefined;
+            run_at?: string | undefined;
+            all_frames?: boolean | undefined;
+            match_about_blank?: boolean | undefined;
+            include_globs?: string[] | undefined;
+            exclude_globs?: string[] | undefined;
+        }[] | undefined;
+        content_security_policy?: string | undefined;
+        converted_from_user_script?: boolean | undefined;
         copresence?: any;
-        current_locale?: string;
-        devtools_page?: string;
+        current_locale?: string | undefined;
+        devtools_page?: string | undefined;
         event_rules?: {
-            event?: string;
+            event?: string | undefined;
             actions?: {
                 type: string;
-            }[];
-            conditions?: chrome.declarativeContent.PageStateMatcherProperties[];
-        }[];
+            }[] | undefined;
+            conditions?: chrome.declarativeContent.PageStateMatcherProperties[] | undefined;
+        }[] | undefined;
         externally_connectable?: {
-            ids?: string[];
-            matches?: string[];
-            accepts_tls_channel_id?: boolean;
-        };
+            ids?: string[] | undefined;
+            matches?: string[] | undefined;
+            accepts_tls_channel_id?: boolean | undefined;
+        } | undefined;
         file_browser_handlers?: {
-            id?: string;
-            default_title?: string;
-            file_filters?: string[];
-        }[];
+            id?: string | undefined;
+            default_title?: string | undefined;
+            file_filters?: string[] | undefined;
+        }[] | undefined;
         file_system_provider_capabilities?: {
-            configurable?: boolean;
-            watchable?: boolean;
-            multiple_mounts?: boolean;
-            source?: string;
-        };
-        homepage_url?: string;
+            configurable?: boolean | undefined;
+            watchable?: boolean | undefined;
+            multiple_mounts?: boolean | undefined;
+            source?: string | undefined;
+        } | undefined;
+        homepage_url?: string | undefined;
         import?: {
             id: string;
-            minimum_version?: string;
-        }[];
+            minimum_version?: string | undefined;
+        }[] | undefined;
         export?: {
-            whitelist?: string[];
-        };
-        incognito?: string;
+            whitelist?: string[] | undefined;
+        } | undefined;
+        incognito?: string | undefined;
         input_components?: {
-            name?: string;
-            type?: string;
-            id?: string;
-            description?: string;
-            language?: string;
-            layouts?: any[];
-        }[];
-        key?: string;
-        minimum_chrome_version?: string;
+            name?: string | undefined;
+            type?: string | undefined;
+            id?: string | undefined;
+            description?: string | undefined;
+            language?: string | undefined;
+            layouts?: any[] | undefined;
+        }[] | undefined;
+        key?: string | undefined;
+        minimum_chrome_version?: string | undefined;
         nacl_modules?: {
             path: string;
             mime_type: string;
-        }[];
+        }[] | undefined;
         oauth2?: {
             client_id: string;
-            scopes?: string[];
-        };
-        offline_enabled?: boolean;
+            scopes?: string[] | undefined;
+        } | undefined;
+        offline_enabled?: boolean | undefined;
         omnibox?: {
             keyword: string;
-        };
-        optional_permissions?: string[];
-        options_page?: string;
+        } | undefined;
+        optional_permissions?: string[] | undefined;
+        options_page?: string | undefined;
         options_ui?: {
-            page?: string;
-            chrome_style?: boolean;
-            open_in_tab?: boolean;
-        };
-        permissions?: string[];
+            page?: string | undefined;
+            chrome_style?: boolean | undefined;
+            open_in_tab?: boolean | undefined;
+        } | undefined;
+        permissions?: string[] | undefined;
         platforms?: {
-            nacl_arch?: string;
+            nacl_arch?: string | undefined;
             sub_package_path: string;
-        }[];
+        }[] | undefined;
         plugins?: {
             path: string;
-        }[];
+        }[] | undefined;
         requirements?: {
             '3D'?: {
-                features?: string[];
-            };
+                features?: string[] | undefined;
+            } | undefined;
             plugins?: {
-                npapi?: boolean;
-            };
-        };
+                npapi?: boolean | undefined;
+            } | undefined;
+        } | undefined;
         sandbox?: {
             pages: string[];
-            content_security_policy?: string;
-        };
-        short_name?: string;
+            content_security_policy?: string | undefined;
+        } | undefined;
+        short_name?: string | undefined;
         signature?: any;
         spellcheck?: {
-            dictionary_language?: string;
-            dictionary_locale?: string;
-            dictionary_format?: string;
-            dictionary_path?: string;
-        };
+            dictionary_language?: string | undefined;
+            dictionary_locale?: string | undefined;
+            dictionary_format?: string | undefined;
+            dictionary_path?: string | undefined;
+        } | undefined;
         storage?: {
             managed_schema: string;
-        };
+        } | undefined;
         system_indicator?: any;
         tts_engine?: {
             voices: {
                 voice_name: string;
-                lang?: string;
-                gender?: string;
-                event_types?: string[];
+                lang?: string | undefined;
+                gender?: string | undefined;
+                event_types?: string[] | undefined;
             }[];
-        };
-        update_url?: string;
-        version_name?: string;
-        web_accessible_resources?: string[];
+        } | undefined;
+        update_url?: string | undefined;
+        version_name?: string | undefined;
+        web_accessible_resources?: string[] | undefined;
         [key: string]: any;
     }
 
@@ -6992,29 +6992,29 @@ declare namespace chrome.scripting {
 
     export interface InjectionTarget {
         /* Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if frameIds is specified. */
-        allFrames?: boolean;
+        allFrames?: boolean | undefined;
         /* The IDs of specific frames to inject into. */
-        frameIds?: number[];
+        frameIds?: number[] | undefined;
         /* The ID of the tab into which to inject. */
         tabId: number;
     }
 
     export interface CSSInjection {
         /* A string containing the CSS to inject. Exactly one of files and css must be specified. */
-        css?: string;
+        css?: string | undefined;
         /* The path of the CSS files to inject, relative to the extension's root directory. NOTE: Currently a maximum of one file is supported. Exactly one of files and css must be specified. */
-        files?: string[];
+        files?: string[] | undefined;
         /* The style origin for the injection. Defaults to 'AUTHOR'. */
-        origin?: StyleOrigin;
+        origin?: StyleOrigin | undefined;
         /* Details specifying the target into which to insert the CSS. */
         target: InjectionTarget;
     }
 
     export interface ScriptInjection {
         /* The path of the JS files to inject, relative to the extension's root directory. NOTE: Currently a maximum of one file is supported. Exactly one of files and function must be specified. */
-        files?: string[];
+        files?: string[] | undefined;
         /* A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of files and function must be specified. */
-        function?: () => void;
+        function?: (() => void) | undefined;
         /* Details specifying the target into which to inject the script. */
         target: InjectionTarget;
     }
@@ -7094,7 +7094,7 @@ declare namespace chrome.sessions {
          * Optional.
          * The maximum number of entries to be fetched in the requested list. Omit this parameter to fetch the maximum number of entries (sessions.MAX_SESSION_RESULTS).
          */
-        maxResults?: number;
+        maxResults?: number | undefined;
     }
 
     export interface Session {
@@ -7104,12 +7104,12 @@ declare namespace chrome.sessions {
          * Optional.
          * The tabs.Tab, if this entry describes a tab. Either this or sessions.Session.window will be set.
          */
-        tab?: tabs.Tab;
+        tab?: tabs.Tab | undefined;
         /**
          * Optional.
          * The windows.Window, if this entry describes a window. Either this or sessions.Session.tab will be set.
          */
-        window?: windows.Window;
+        window?: windows.Window | undefined;
     }
 
     export interface Device {
@@ -7284,7 +7284,7 @@ declare namespace chrome.socket {
 
     export interface AcceptInfo {
         resultCode: number;
-        socketId?: number;
+        socketId?: number | undefined;
     }
 
     export interface ReadInfo {
@@ -7305,10 +7305,10 @@ declare namespace chrome.socket {
 
     export interface SocketInfo {
         socketType: string;
-        localPort?: number;
-        peerAddress?: string;
-        peerPort?: number;
-        localAddress?: string;
+        localPort?: number | undefined;
+        peerAddress?: string | undefined;
+        peerPort?: number | undefined;
+        localAddress?: string | undefined;
         connected: boolean;
     }
 
@@ -7653,7 +7653,7 @@ declare namespace chrome.system.display {
          * @see(See `enableUnifiedDesktop` for details).
          * @since Chrome 59
          * */
-        isUnified?: boolean;
+        isUnified?: boolean | undefined;
 
         /**
          * requires(CrOS) Chrome OS only.
@@ -7666,20 +7666,20 @@ declare namespace chrome.system.display {
          * which must not be the same as the id passed to setDisplayProperties.
          * If set, no other property may be set.
          */
-        mirroringSourceId?: string;
+        mirroringSourceId?: string | undefined;
 
         /**
          * If set to true, makes the display primary.
          * No-op if set to false.
          */
-        isPrimary?: boolean;
+        isPrimary?: boolean | undefined;
 
         /**
          * If set, sets the display's overscan insets to the provided values.
          * Note that overscan values may not be negative or larger than a half of the screen's size.
          * Overscan cannot be changed on the internal monitor. It's applied after isPrimary parameter.
          */
-        overscan?: Insets;
+        overscan?: Insets | undefined;
 
         /**
          * If set, updates the display's rotation.
@@ -7687,7 +7687,7 @@ declare namespace chrome.system.display {
          * The rotation is set clockwise, relative to the display's vertical position.
          * It's applied after overscan parameter.
          */
-        rotation?: 0 | 90 | 180 | 270;
+        rotation?: 0 | 90 | 180 | 270 | undefined;
 
         /**
          * If set, updates the display's logical bounds origin along x-axis.
@@ -7699,19 +7699,19 @@ declare namespace chrome.system.display {
          * Note that is also invalid to set bounds origin values if isPrimary is also set
          * (as isPrimary parameter is applied first).
          */
-        boundsOriginX?: number;
+        boundsOriginX?: number | undefined;
 
         /**
          * If set, updates the display's logical bounds origin along y-axis.
          * @see[See documentation for boundsOriginX parameter.]
          */
-        boundsOriginY?: number;
+        boundsOriginY?: number | undefined;
 
         /**
          * If set, updates the display mode to the mode matching this value.
          * @since Chrome 52
          */
-        displayMode?: DisplayMode;
+        displayMode?: DisplayMode | undefined;
 
         /**
          * @since Chrome 65.
@@ -7721,7 +7721,7 @@ declare namespace chrome.system.display {
          * in a better quality zoom than just performing
          * a pixel by pixel stretch enlargement.
          */
-        displayZoomFactor?: number;
+        displayZoomFactor?: number | undefined;
     }
 
     /**
@@ -7734,7 +7734,7 @@ declare namespace chrome.system.display {
          * @see[enableUnifiedDesktop]
          * @default false
          */
-        singleUnified?: boolean;
+        singleUnified?: boolean | undefined;
     }
 
     /** Information about display properties. */
@@ -7758,8 +7758,8 @@ declare namespace chrome.system.display {
             /**
              * Year of manufacturer.
              */
-            yearOfManufacture?: string;
-        };
+            yearOfManufacture?: string | undefined;
+        } | undefined;
         /**
          * requires(CrOS) Only working properly on Chrome OS.
          * Identifier of the display that is being mirrored on the display unit.
@@ -7823,13 +7823,13 @@ declare namespace chrome.system.display {
          * **mixed**
          * The specified source display will be mirrored to the provided destination displays. All other connected displays will be extended.
          */
-        mode?: 'off' | 'normal' | 'mixed';
+        mode?: 'off' | 'normal' | 'mixed' | undefined;
     }
     export interface MirrorModeInfoMixed extends MirrorModeInfo {
         mode: 'mixed';
-        mirroringSourceId?: string;
+        mirroringSourceId?: string | undefined;
         /** The ids of the mirroring destination displays. */
-        mirroringDestinationIds?: string[];
+        mirroringDestinationIds?: string[] | undefined;
     }
 
     /**
@@ -8068,25 +8068,25 @@ declare namespace chrome.tabCapture {
 
     export interface MediaStreamConstraint {
         mandatory: object;
-        optional?: object;
+        optional?: object | undefined;
     }
 
     export interface CaptureOptions {
         /** Optional. */
-        audio?: boolean;
+        audio?: boolean | undefined;
         /** Optional. */
-        video?: boolean;
+        video?: boolean | undefined;
         /** Optional. */
-        audioConstraints?: MediaStreamConstraint;
+        audioConstraints?: MediaStreamConstraint | undefined;
         /** Optional. */
-        videoConstraints?: MediaStreamConstraint;
+        videoConstraints?: MediaStreamConstraint | undefined;
     }
 
     export interface GetMediaStreamOptions {
         /** Optional tab id of the tab which will later invoke getUserMedia() to consume the stream. If not specified then the resulting stream can be used only by the calling extension. The stream can only be used by frames in the given tab whose security origin matches the consumber tab's origin. The tab's origin must be a secure origin, e.g. HTTPS. */
-        consumerTabId?: number;
+        consumerTabId?: number | undefined;
         /** Optional tab id of the tab which will be captured. If not specified then the current active tab will be selected. Only tabs for which the extension has been granted the activeTab permission can be used as the target tab. */
-        targetTabId?: number;
+        targetTabId?: number | undefined;
     }
 
     export interface CaptureStatusChangedEvent extends chrome.events.Event<(info: CaptureInfo) => void> { }
@@ -8137,12 +8137,12 @@ declare namespace chrome.tabs {
          * "capture": Tab capture started, forcing a muted state change.
          * "extension": An extension, identified by the extensionId field, set the muted state.
          */
-        reason?: string;
+        reason?: string | undefined;
         /**
          * Optional.
          * The ID of the extension that changed the muted state. Not set if an extension was not the reason the muted state last changed.
          */
-        extensionId?: string;
+        extensionId?: string | undefined;
     }
 
     export interface Tab {
@@ -8150,7 +8150,7 @@ declare namespace chrome.tabs {
          * Optional.
          * Either loading or complete.
          */
-        status?: string;
+        status?: string | undefined;
         /** The zero-based index of the tab within its window. */
         index: number;
         /**
@@ -8158,23 +8158,23 @@ declare namespace chrome.tabs {
          * The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists.
          * @since Chrome 18.
          */
-        openerTabId?: number;
+        openerTabId?: number | undefined;
         /**
          * Optional.
          * The title of the tab. This property is only present if the extension's manifest includes the "tabs" permission.
          */
-        title?: string;
+        title?: string | undefined;
         /**
          * Optional.
          * The URL the tab is displaying. This property is only present if the extension's manifest includes the "tabs" permission.
          */
-        url?: string;
+        url?: string | undefined;
         /**
          * The URL the tab is navigating to, before it has committed.
          * This property is only present if the extension's manifest includes the "tabs" permission and there is a pending navigation.
          * @since Chrome 79.
          */
-        pendingUrl?: string;
+        pendingUrl?: string | undefined;
         /**
          * Whether the tab is pinned.
          * @since Chrome 9.
@@ -8196,12 +8196,12 @@ declare namespace chrome.tabs {
          * Optional.
          * The URL of the tab's favicon. This property is only present if the extension's manifest includes the "tabs" permission. It may also be an empty string if the tab is loading.
          */
-        favIconUrl?: string;
+        favIconUrl?: string | undefined;
         /**
          * Optional.
          * The ID of the tab. Tab IDs are unique within a browser session. Under some circumstances a Tab may not be assigned an ID, for example when querying foreign tabs using the sessions API, in which case a session ID may be present. Tab ID can also be set to chrome.tabs.TAB_ID_NONE for apps and devtools windows.
          */
-        id?: number;
+        id?: number | undefined;
         /** Whether the tab is in an incognito window. */
         incognito: boolean;
         /**
@@ -8214,7 +8214,7 @@ declare namespace chrome.tabs {
          * Whether the tab has produced sound over the past couple of seconds (but it might not be heard if also muted). Equivalent to whether the speaker audio indicator is showing.
          * @since Chrome 45.
          */
-        audible?: boolean;
+        audible?: boolean | undefined;
         /**
          * Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
          * @since Chrome 54.
@@ -8230,22 +8230,22 @@ declare namespace chrome.tabs {
          * Current tab muted state and the reason for the last state change.
          * @since Chrome 46. Warning: this is the current Beta channel.
          */
-        mutedInfo?: MutedInfo;
+        mutedInfo?: MutedInfo | undefined;
         /**
          * Optional. The width of the tab in pixels.
          * @since Chrome 31.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * Optional. The height of the tab in pixels.
          * @since Chrome 31.
          */
-        height?: number;
+        height?: number | undefined;
         /**
          * Optional. The session ID used to uniquely identify a Tab obtained from the sessions API.
          * @since Chrome 31.
          */
-        sessionId?: string;
+        sessionId?: string | undefined;
         /**
          * The ID of the group that the tab belongs to.
          * @since Chrome 88
@@ -8265,20 +8265,20 @@ declare namespace chrome.tabs {
          * "manual": Overrides the automatic handling of zoom changes. The onZoomChange event will still be dispatched, and it is the responsibility of the extension to listen for this event and manually scale the page. This mode does not support per-origin zooming, and will thus ignore the scope zoom setting and assume per-tab.
          * "disabled": Disables all zooming in the tab. The tab will revert to the default zoom level, and all attempted zoom changes will be ignored.
          */
-        mode?: string;
+        mode?: string | undefined;
         /**
          * Optional.
          * Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to per-origin when in automatic mode, and per-tab otherwise.
          * "per-origin": Zoom changes will persist in the zoomed page's origin, i.e. all other tabs navigated to that same origin will be zoomed as well. Moreover, per-origin zoom changes are saved with the origin, meaning that when navigating to other pages in the same origin, they will all be zoomed to the same zoom factor. The per-origin scope is only available in the automatic mode.
          * "per-tab": Zoom changes only take effect in this tab, and zoom changes in other tabs will not affect the zooming of this tab. Also, per-tab zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.
          */
-        scope?: string;
+        scope?: string | undefined;
         /**
          * Optional.
          * Used to return the default zoom level for the current tab in calls to tabs.getZoomSettings.
          * @since Chrome 43.
          */
-        defaultZoomFactor?: number;
+        defaultZoomFactor?: number | undefined;
     }
 
     export interface InjectDetails {
@@ -8286,79 +8286,79 @@ declare namespace chrome.tabs {
          * Optional.
          * If allFrames is true, implies that the JavaScript or CSS should be injected into all frames of current page. By default, it's false and is only injected into the top frame.
          */
-        allFrames?: boolean;
+        allFrames?: boolean | undefined;
         /**
          * Optional. JavaScript or CSS code to inject.
          * Warning: Be careful using the code parameter. Incorrect use of it may open your extension to cross site scripting attacks.
          */
-        code?: string;
+        code?: string | undefined;
         /**
          * Optional. The soonest that the JavaScript or CSS will be injected into the tab.
          * One of: "document_start", "document_end", or "document_idle"
          * @since Chrome 20.
          */
-        runAt?: string;
+        runAt?: string | undefined;
         /** Optional. JavaScript or CSS file to inject. */
-        file?: string;
+        file?: string | undefined;
         /**
          * Optional.
          * The frame where the script or CSS should be injected. Defaults to 0 (the top-level frame).
          * @since Chrome 39.
          */
-        frameId?: number;
+        frameId?: number | undefined;
         /**
          * Optional.
          * If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is false.
          * @since Chrome 39.
          */
-        matchAboutBlank?: boolean;
+        matchAboutBlank?: boolean | undefined;
         /**
          * Optional. The origin of the CSS to inject. This may only be specified for CSS, not JavaScript. Defaults to "author".
          * One of: "author", or "user"
          * @since Chrome 66.
          */
-        cssOrigin?: string;
+        cssOrigin?: string | undefined;
     }
 
     export interface CreateProperties {
         /** Optional. The position the tab should take in the window. The provided value will be clamped to between zero and the number of tabs in the window. */
-        index?: number;
+        index?: number | undefined;
         /**
          * Optional.
          * The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab.
          * @since Chrome 18.
          */
-        openerTabId?: number;
+        openerTabId?: number | undefined;
         /**
          * Optional.
          * The URL to navigate the tab to initially. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.
          */
-        url?: string;
+        url?: string | undefined;
         /**
          * Optional. Whether the tab should be pinned. Defaults to false
          * @since Chrome 9.
          */
-        pinned?: boolean;
+        pinned?: boolean | undefined;
         /** Optional. The window to create the new tab in. Defaults to the current window. */
-        windowId?: number;
+        windowId?: number | undefined;
         /**
          * Optional.
          * Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see windows.update). Defaults to true.
          * @since Chrome 16.
          */
-        active?: boolean;
+        active?: boolean | undefined;
         /**
          * Optional. Whether the tab should become the selected tab in the window. Defaults to true
          * @deprecated since Chrome 33. Please use active.
          */
-        selected?: boolean;
+        selected?: boolean | undefined;
     }
 
     export interface MoveProperties {
         /** The position to move the window to. -1 will place the tab at the end of the window. */
         index: number;
         /** Optional. Defaults to the window the tab is currently in. */
-        windowId?: number;
+        windowId?: number | undefined;
     }
 
     export interface UpdateProperties {
@@ -8366,39 +8366,39 @@ declare namespace chrome.tabs {
          * Optional. Whether the tab should be pinned.
          * @since Chrome 9.
          */
-        pinned?: boolean;
+        pinned?: boolean | undefined;
         /**
          * Optional. The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.
          * @since Chrome 18.
          */
-        openerTabId?: number;
+        openerTabId?: number | undefined;
         /** Optional. A URL to navigate the tab to. */
-        url?: string;
+        url?: string | undefined;
         /**
          * Optional. Adds or removes the tab from the current selection.
          * @since Chrome 16.
          */
-        highlighted?: boolean;
+        highlighted?: boolean | undefined;
         /**
          * Optional. Whether the tab should be active. Does not affect whether the window is focused (see windows.update).
          * @since Chrome 16.
          */
-        active?: boolean;
+        active?: boolean | undefined;
         /**
          * Optional. Whether the tab should be selected.
          * @deprecated since Chrome 33. Please use highlighted.
          */
-        selected?: boolean;
+        selected?: boolean | undefined;
         /**
          * Optional. Whether the tab should be muted.
          * @since Chrome 45.
          */
-        muted?: boolean;
+        muted?: boolean | undefined;
         /**
          * Optional. Whether the tab should be discarded automatically by the browser when resources are low.
          * @since Chrome 54.
          */
-        autoDiscardable?: boolean;
+        autoDiscardable?: boolean | undefined;
     }
 
     export interface CaptureVisibleTabOptions {
@@ -8406,51 +8406,51 @@ declare namespace chrome.tabs {
          * Optional.
          * When format is "jpeg", controls the quality of the resulting image. This value is ignored for PNG images. As quality is decreased, the resulting image will have more visual artifacts, and the number of bytes needed to store it will decrease.
          */
-        quality?: number;
+        quality?: number | undefined;
         /**
          * Optional. The format of an image.
          * One of: "jpeg", or "png"
          */
-        format?: string;
+        format?: string | undefined;
     }
 
     export interface ReloadProperties {
         /** Optional. Whether using any local cache. Default is false. */
-        bypassCache?: boolean;
+        bypassCache?: boolean | undefined;
     }
 
     export interface ConnectInfo {
         /** Optional. Will be passed into onConnect for content scripts that are listening for the connection event. */
-        name?: string;
+        name?: string | undefined;
         /**
          * Open a port to a specific frame identified by frameId instead of all frames in the tab.
          * @since Chrome 41.
          */
-        frameId?: number;
+        frameId?: number | undefined;
     }
 
     export interface MessageSendOptions {
         /** Optional. Send a message to a specific frame identified by frameId instead of all frames in the tab. */
-        frameId?: number;
+        frameId?: number | undefined;
     }
 
     export interface GroupOptions {
         /** Optional. Configurations for creating a group. Cannot be used if groupId is already specified. */
         createProperties?: {
             /** Optional. The window of the new group. Defaults to the current window. */
-            windowId?: number
-        },
+            windowId?: number | undefined
+        } | undefined,
         /** Optional. The ID of the group to add the tabs to. If not specified, a new group will be created. */
-        groupId?: number;
+        groupId?: number | undefined;
         /** TOptional. he tab ID or list of tab IDs to add to the specified group. */
-        tabIds?: number | number[];
+        tabIds?: number | number[] | undefined;
     }
 
     export interface HighlightInfo {
         /** One or more tab indices to highlight. */
         tabs: number | number[];
         /** Optional. The window that contains the tabs. */
-        windowId?: number;
+        windowId?: number | undefined;
     }
 
     export interface QueryInfo {
@@ -8458,66 +8458,66 @@ declare namespace chrome.tabs {
          * Optional. Whether the tabs have completed loading.
          * One of: "loading", or "complete"
          */
-        status?: 'loading' | 'complete';
+        status?: 'loading' | 'complete' | undefined;
         /**
          * Optional. Whether the tabs are in the last focused window.
          * @since Chrome 19.
          */
-        lastFocusedWindow?: boolean;
+        lastFocusedWindow?: boolean | undefined;
         /** Optional. The ID of the parent window, or windows.WINDOW_ID_CURRENT for the current window. */
-        windowId?: number;
+        windowId?: number | undefined;
         /**
          * Optional. The type of window the tabs are in.
          * One of: "normal", "popup", "panel", "app", or "devtools"
          */
-        windowType?: 'normal' | 'popup' | 'panel' | 'app' | 'devtools';
+        windowType?: 'normal' | 'popup' | 'panel' | 'app' | 'devtools' | undefined;
         /** Optional. Whether the tabs are active in their windows. */
-        active?: boolean;
+        active?: boolean | undefined;
         /**
          * Optional. The position of the tabs within their windows.
          * @since Chrome 18.
          */
-        index?: number;
+        index?: number | undefined;
         /** Optional. Match page titles against a pattern. */
-        title?: string;
+        title?: string | undefined;
         /** Optional. Match tabs against one or more URL patterns. Note that fragment identifiers are not matched. */
-        url?: string | string[];
+        url?: string | string[] | undefined;
         /**
          * Optional. Whether the tabs are in the current window.
          * @since Chrome 19.
          */
-        currentWindow?: boolean;
+        currentWindow?: boolean | undefined;
         /** Optional. Whether the tabs are highlighted. */
-        highlighted?: boolean;
+        highlighted?: boolean | undefined;
         /**
          * Optional.
          * Whether the tabs are discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
          * @since Chrome 54.
          */
-        discarded?: boolean;
+        discarded?: boolean | undefined;
         /**
          * Optional.
          * Whether the tabs can be discarded automatically by the browser when resources are low.
          * @since Chrome 54.
          */
-        autoDiscardable?: boolean;
+        autoDiscardable?: boolean | undefined;
         /** Optional. Whether the tabs are pinned. */
-        pinned?: boolean;
+        pinned?: boolean | undefined;
         /**
          * Optional. Whether the tabs are audible.
          * @since Chrome 45.
          */
-        audible?: boolean;
+        audible?: boolean | undefined;
         /**
          * Optional. Whether the tabs are muted.
          * @since Chrome 45.
          */
-        muted?: boolean;
+        muted?: boolean | undefined;
         /**
          * Optional. The ID of the group that the tabs are in, or chrome.tabGroups.TAB_GROUP_ID_NONE for ungrouped tabs.
          * @since Chrome 88
          */
-        groupId?: number;
+        groupId?: number | undefined;
     }
 
     export interface TabHighlightInfo {
@@ -8542,49 +8542,49 @@ declare namespace chrome.tabs {
 
     export interface TabChangeInfo {
         /** Optional. The status of the tab. Can be either loading or complete. */
-        status?: string;
+        status?: string | undefined;
         /**
          * The tab's new pinned state.
          * @since Chrome 9.
          */
-        pinned?: boolean;
+        pinned?: boolean | undefined;
         /** Optional. The tab's URL if it has changed. */
-        url?: string;
+        url?: string | undefined;
         /**
          * The tab's new audible state.
          * @since Chrome 45.
          */
-        audible?: boolean;
+        audible?: boolean | undefined;
         /**
          * The tab's new discarded state.
          * @since Chrome 54.
          */
-        discarded?: boolean;
+        discarded?: boolean | undefined;
         /**
          * The tab's new auto-discardable
          * @since Chrome 54.
          */
-        autoDiscardable?: boolean;
+        autoDiscardable?: boolean | undefined;
         /**
          * The tab's new group.
          * @since Chrome 88
          */
-        groupId?: number;
+        groupId?: number | undefined;
         /**
          * The tab's new muted state and the reason for the change.
          * @since Chrome 46. Warning: this is the current Beta channel.
          */
-        mutedInfo?: MutedInfo;
+        mutedInfo?: MutedInfo | undefined;
         /**
          * The tab's new favicon URL.
          * @since Chrome 27.
          */
-        favIconUrl?: string;
+        favIconUrl?: string | undefined;
         /**
          * The tab's new title.
          * @since Chrome 48.
          */
-        title?: string;
+        title?: string | undefined;
     }
 
     export interface TabMoveInfo {
@@ -9312,7 +9312,7 @@ declare namespace chrome.tabs {
         /** The ID of the group. Group IDs are unique within a browser session. */
         id: number;
         /** Optional. The title of the group. */
-        title?: string;
+        title?: string | undefined;
         /** The ID of the window that contains the group. */
         windowId: number;
     }
@@ -9321,27 +9321,27 @@ declare namespace chrome.tabs {
         /** The position to move the group to. Use -1 to place the group at the end of the window. */
         index: number;
         /** Optional. The window to move the group to. Defaults to the window the group is currently in. Note that groups can only be moved to and from windows with chrome.windows.WindowType type "normal". */
-        windowId?: number;
+        windowId?: number | undefined;
     }
 
     export interface QueryInfo {
         /** Optional. Whether the groups are collapsed. */
-        collapsed?: boolean;
+        collapsed?: boolean | undefined;
         /** Optional. The color of the groups. */
-        color?: ColorEnum;
+        color?: ColorEnum | undefined;
         /** Optional. Match group titles against a pattern. */
-        title?: string;
+        title?: string | undefined;
         /** Optional. The ID of the window that contains the group. */
-        windowId?: number;
+        windowId?: number | undefined;
     }
 
     export interface UpdateProperties {
         /** Optional. Whether the group should be collapsed. */
-        collapsed?: boolean;
+        collapsed?: boolean | undefined;
         /** Optional. The color of the group. */
-        color?: ColorEnum;
+        color?: ColorEnum | undefined;
         /** Optional. The title of the group. */
-        title?: string;
+        title?: string | undefined;
     }
 
     /**
@@ -9452,9 +9452,9 @@ declare namespace chrome.tts {
     /** An event from the TTS engine to communicate the status of an utterance. */
     export interface TtsEvent {
         /** Optional. The index of the current character in the utterance. */
-        charIndex?: number;
+        charIndex?: number | undefined;
         /** Optional. The error description, if the event type is 'error'. */
-        errorMessage?: string;
+        errorMessage?: string | undefined;
         /**
          * The type can be 'start' as soon as speech has started, 'word' when a word boundary is reached, 'sentence' when a sentence boundary is reached, 'marker' when an SSML mark element is reached, 'end' when the end of the utterance is reached, 'interrupted' when the utterance is stopped or interrupted before reaching the end, 'cancelled' when it's removed from the queue before ever being synthesized, or 'error' when any other error occurs. When pausing speech, a 'pause' event is fired if a particular utterance is paused in the middle, and 'resume' if an utterance resumes speech. Note that pause and resume events may not fire if speech is paused in-between utterances.
          * One of: "start", "end", "word", "sentence", "marker", "interrupted", "cancelled", "error", "pause", or "resume"
@@ -9465,64 +9465,64 @@ declare namespace chrome.tts {
     /** A description of a voice available for speech synthesis. */
     export interface TtsVoice {
         /** Optional. The language that this voice supports, in the form language-region. Examples: 'en', 'en-US', 'en-GB', 'zh-CN'. */
-        lang?: string;
+        lang?: string | undefined;
         /**
          * Optional. This voice's gender.
          * One of: "male", or "female"
          * @deprecated since Chrome 70. Gender is deprecated and will be ignored.
          */
-        gender?: string;
+        gender?: string | undefined;
         /** Optional. The name of the voice. */
-        voiceName?: string;
+        voiceName?: string | undefined;
         /** Optional. The ID of the extension providing this voice. */
-        extensionId?: string;
+        extensionId?: string | undefined;
         /** Optional. All of the callback event types that this voice is capable of sending. */
-        eventTypes?: string[];
+        eventTypes?: string[] | undefined;
         /**
          * Optional. If true, the synthesis engine is a remote network resource. It may be higher latency and may incur bandwidth costs.
          * @since Chrome 33.
          */
-        remote?: boolean;
+        remote?: boolean | undefined;
     }
 
     export interface SpeakOptions {
         /** Optional. Speaking volume between 0 and 1 inclusive, with 0 being lowest and 1 being highest, with a default of 1.0. */
-        volume?: number;
+        volume?: number | undefined;
         /**
          * Optional.
          * If true, enqueues this utterance if TTS is already in progress. If false (the default), interrupts any current speech and flushes the speech queue before speaking this new utterance.
          */
-        enqueue?: boolean;
+        enqueue?: boolean | undefined;
         /**
          * Optional.
          * Speaking rate relative to the default rate for this voice. 1.0 is the default rate, normally around 180 to 220 words per minute. 2.0 is twice as fast, and 0.5 is half as fast. Values below 0.1 or above 10.0 are strictly disallowed, but many voices will constrain the minimum and maximum rates further—for example a particular voice may not actually speak faster than 3 times normal even if you specify a value larger than 3.0.
          */
-        rate?: number;
+        rate?: number | undefined;
         /**
          * Optional. This function is called with events that occur in the process of speaking the utterance.
          * @param event The update event from the text-to-speech engine indicating the status of this utterance.
          */
-        onEvent?: (event: TtsEvent) => void;
+        onEvent?: ((event: TtsEvent) => void) | undefined;
         /**
          * Optional.
          * Speaking pitch between 0 and 2 inclusive, with 0 being lowest and 2 being highest. 1.0 corresponds to a voice's default pitch.
          */
-        pitch?: number;
+        pitch?: number | undefined;
         /** Optional. The language to be used for synthesis, in the form language-region. Examples: 'en', 'en-US', 'en-GB', 'zh-CN'. */
-        lang?: string;
+        lang?: string | undefined;
         /** Optional. The name of the voice to use for synthesis. If empty, uses any available voice. */
-        voiceName?: string;
+        voiceName?: string | undefined;
         /** Optional. The extension ID of the speech engine to use, if known. */
-        extensionId?: string;
+        extensionId?: string | undefined;
         /**
          * Optional. Gender of voice for synthesized speech.
          * One of: "male", or "female"
          */
-        gender?: string;
+        gender?: string | undefined;
         /** Optional. The TTS event types the voice must support. */
-        requiredEventTypes?: string[];
+        requiredEventTypes?: string[] | undefined;
         /** Optional. The TTS event types that you are interested in listening to. If missing, all event types may be sent. */
-        desiredEventTypes?: string[];
+        desiredEventTypes?: string[] | undefined;
     }
 
     /** Checks whether the engine is currently speaking. On Mac OS X, the result is true whenever the system speech engine is speaking, even if the speech wasn't initiated by Chrome. */
@@ -9567,23 +9567,23 @@ declare namespace chrome.tts {
 declare namespace chrome.ttsEngine {
     export interface SpeakOptions {
         /** Optional. The language to be used for synthesis, in the form language-region. Examples: 'en', 'en-US', 'en-GB', 'zh-CN'. */
-        lang?: string;
+        lang?: string | undefined;
         /** Optional. The name of the voice to use for synthesis. */
-        voiceName?: string;
+        voiceName?: string | undefined;
         /**
          * Optional. Gender of voice for synthesized speech.
          * One of: "male", or "female"
          */
-        gender?: string;
+        gender?: string | undefined;
         /** Optional. Speaking volume between 0 and 1 inclusive, with 0 being lowest and 1 being highest, with a default of 1.0. */
-        volume?: number;
+        volume?: number | undefined;
         /**
          * Optional.
          * Speaking rate relative to the default rate for this voice. 1.0 is the default rate, normally around 180 to 220 words per minute. 2.0 is twice as fast, and 0.5 is half as fast. This value is guaranteed to be between 0.1 and 10.0, inclusive. When a voice does not support this full range of rates, don't return an error. Instead, clip the rate to the range the voice supports.
          */
-        rate?: number;
+        rate?: number | undefined;
         /** Optional. Speaking pitch between 0 and 2 inclusive, with 0 being lowest and 2 being highest. 1.0 corresponds to this voice's default pitch. */
-        pitch?: number;
+        pitch?: number | undefined;
     }
 
     export interface TtsEngineSpeakEvent
@@ -9624,7 +9624,7 @@ declare namespace chrome.types {
          * • incognito_persistent: setting for the incognito profile that survives browser restarts (overrides regular preferences),
          * • incognito_session_only: setting for the incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular and incognito_persistent preferences).
          */
-        scope?: string;
+        scope?: string | undefined;
     }
 
     export interface ChromeSettingSetDetails extends ChromeSettingClearDetails {
@@ -9641,12 +9641,12 @@ declare namespace chrome.types {
          * • incognito_persistent: setting for the incognito profile that survives browser restarts (overrides regular preferences),
          * • incognito_session_only: setting for the incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular and incognito_persistent preferences).
          */
-        scope?: string;
+        scope?: string | undefined;
     }
 
     export interface ChromeSettingGetDetails {
         /** Optional. Whether to return the value that applies to the incognito session (default false). */
-        incognito?: boolean;
+        incognito?: boolean | undefined;
     }
 
     /**
@@ -9670,7 +9670,7 @@ declare namespace chrome.types {
          * Whether the effective value is specific to the incognito session.
          * This property will only be present if the incognito property in the details parameter of get() was true.
          */
-        incognitoSpecific?: boolean;
+        incognitoSpecific?: boolean | undefined;
     }
 
     export interface ChromeSettingChangedEvent extends chrome.events.Event<DetailsCallback> { }
@@ -9713,9 +9713,9 @@ declare namespace chrome.vpnProvider {
         /** IP address for the VPN interface in CIDR notation. IPv4 is currently the only supported mode. */
         address: string;
         /** Optional. Broadcast address for the VPN interface. (default: deduced from IP address and mask) */
-        broadcastAddress?: string;
+        broadcastAddress?: string | undefined;
         /** Optional. MTU setting for the VPN interface. (default: 1500 bytes) */
-        mtu?: string;
+        mtu?: string | undefined;
         /**
          * Exclude network traffic to the list of IP blocks in CIDR notation from the tunnel. This can be used to bypass traffic to and from the VPN server. When many rules match a destination, the rule with the longest matching prefix wins. Entries that correspond to the same CIDR block are treated as duplicates. Such duplicates in the collated (exclusionList + inclusionList) list are eliminated and the exact duplicate entry that will be eliminated is undefined.
          */
@@ -9725,7 +9725,7 @@ declare namespace chrome.vpnProvider {
          */
         inclusionList: string[];
         /** Optional. A list of search domains. (default: no search domain) */
-        domainSearch?: string[];
+        domainSearch?: string[] | undefined;
         /** A list of IPs for the DNS servers. */
         dnsServer: string[];
     }
@@ -9802,7 +9802,7 @@ declare namespace chrome.wallpaper {
         /** Optional. The jpeg or png encoded wallpaper image. */
         data?: any;
         /** Optional. The URL of the wallpaper to be set. */
-        url?: string;
+        url?: string | undefined;
         /**
          * The supported wallpaper layouts.
          * One of: "STRETCH", "CENTER", or "CENTER_CROPPED"
@@ -9811,7 +9811,7 @@ declare namespace chrome.wallpaper {
         /** The file name of the saved wallpaper. */
         filename: string;
         /** Optional. True if a 128x60 thumbnail should be generated. */
-        thumbnail?: boolean;
+        thumbnail?: boolean | undefined;
     }
 
     /**
@@ -9837,7 +9837,7 @@ declare namespace chrome.webNavigation {
          * @since Chrome 22.
          * @deprecated since Chrome 49. Frames are now uniquely identified by their tab ID and frame ID; the process ID is no longer needed and therefore ignored.
          */
-        processId?: number;
+        processId?: number | undefined;
         /** The ID of the tab in which the frame is. */
         tabId: number;
         /** The ID of the frame in the given tab. */
@@ -10031,46 +10031,46 @@ declare namespace chrome.webRequest {
     /** An HTTP Header, represented as an object containing a key and either a value or a binaryValue. */
     export interface HttpHeader {
         name: string;
-        value?: string;
-        binaryValue?: ArrayBuffer;
+        value?: string | undefined;
+        binaryValue?: ArrayBuffer | undefined;
     }
 
     /** Returns value for event handlers that have the 'blocking' extraInfoSpec applied. Allows the event handler to modify network requests. */
     export interface BlockingResponse {
         /** Optional. If true, the request is cancelled. Used in onBeforeRequest, this prevents the request from being sent. */
-        cancel?: boolean;
+        cancel?: boolean | undefined;
         /**
          * Optional.
          * Only used as a response to the onBeforeRequest and onHeadersReceived events. If set, the original request is prevented from being sent/completed and is instead redirected to the given URL. Redirections to non-HTTP schemes such as data: are allowed. Redirects initiated by a redirect action use the original request method for the redirect, with one exception: If the redirect is initiated at the onHeadersReceived stage, then the redirect will be issued using the GET method.
          */
-        redirectUrl?: string;
+        redirectUrl?: string | undefined;
         /**
          * Optional.
          * Only used as a response to the onHeadersReceived event. If set, the server is assumed to have responded with these response headers instead. Only return responseHeaders if you really want to modify the headers in order to limit the number of conflicts (only one extension may modify responseHeaders for each request).
          */
-        responseHeaders?: HttpHeader[];
+        responseHeaders?: HttpHeader[] | undefined;
         /** Optional. Only used as a response to the onAuthRequired event. If set, the request is made using the supplied credentials. */
-        authCredentials?: AuthCredentials;
+        authCredentials?: AuthCredentials | undefined;
         /**
          * Optional.
          * Only used as a response to the onBeforeSendHeaders event. If set, the request is made with these request headers instead.
          */
-        requestHeaders?: HttpHeader[];
+        requestHeaders?: HttpHeader[] | undefined;
     }
 
     /** An object describing filters to apply to webRequest events. */
     export interface RequestFilter {
         /** Optional. */
-        tabId?: number;
+        tabId?: number | undefined;
         /**
          * A list of request types. Requests that cannot match any of the types will be filtered out.
          */
-        types?: ResourceType[];
+        types?: ResourceType[] | undefined;
         /** A list of URLs or URL patterns. Requests that cannot match any of the URLs will be filtered out. */
         urls: string[];
 
         /** Optional. */
-        windowId?: number;
+        windowId?: number | undefined;
     }
 
     /**
@@ -10079,24 +10079,24 @@ declare namespace chrome.webRequest {
      */
     export interface UploadData {
         /** Optional. An ArrayBuffer with a copy of the data. */
-        bytes?: ArrayBuffer;
+        bytes?: ArrayBuffer | undefined;
         /** Optional. A string with the file's path and name. */
-        file?: string;
+        file?: string | undefined;
     }
 
     export interface WebRequestBody {
         /** Optional. Errors when obtaining request body data. */
-        error?: string;
+        error?: string | undefined;
         /**
          * Optional.
          * If the request method is POST and the body is a sequence of key-value pairs encoded in UTF8, encoded as either multipart/form-data, or application/x-www-form-urlencoded, this dictionary is present and for each key contains the list of all values for that key. If the data is of another media type, or if it is malformed, the dictionary is not present. An example value of this dictionary is {'key': ['value1', 'value2']}.
          */
-        formData?: { [key: string]: string[] };
+        formData?: { [key: string]: string[] } | undefined;
         /**
          * Optional.
          * If the request method is PUT or POST, and the body is not already parsed in formData, then the unparsed request body elements are contained in this array.
          */
-        raw?: UploadData[];
+        raw?: UploadData[] | undefined;
     }
 
     export interface WebAuthChallenger {
@@ -10123,7 +10123,7 @@ declare namespace chrome.webRequest {
         /** The origin where the request was initiated. This does not change through redirects. If this is an opaque origin, the string 'null' will be used.
          * @since Since Chrome 63.
          */
-        initiator?: string;
+        initiator?: string | undefined;
     }
 
     export interface WebRequestDetails extends ResourceRequest {
@@ -10133,7 +10133,7 @@ declare namespace chrome.webRequest {
 
     export interface WebRequestHeadersDetails extends WebRequestDetails {
         /** Optional. The HTTP request headers that are going to be sent out with this request. */
-        requestHeaders?: HttpHeader[];
+        requestHeaders?: HttpHeader[] | undefined;
     }
 
     export interface WebRequestBodyDetails extends WebRequestDetails {
@@ -10158,7 +10158,7 @@ declare namespace chrome.webRequest {
 
     export interface WebResponseHeadersDetails extends WebResponseDetails {
         /** Optional. The HTTP response headers that have been received with this response. */
-        responseHeaders?: HttpHeader[];
+        responseHeaders?: HttpHeader[] | undefined;
         method: string /** standard HTTP method i.e. GET, POST, PUT, etc. */;
     }
 
@@ -10167,7 +10167,7 @@ declare namespace chrome.webRequest {
          * Optional.
          * The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.
          */
-        ip?: string;
+        ip?: string | undefined;
         /** Indicates if this response was fetched from disk cache. */
         fromCache: boolean;
     }
@@ -10181,7 +10181,7 @@ declare namespace chrome.webRequest {
         /** The authentication scheme, e.g. Basic or Digest. */
         scheme: string;
         /** The authentication realm provided by the server, if there is one. */
-        realm?: string;
+        realm?: string | undefined;
         /** The server requesting authentication. */
         challenger: WebAuthChallenger;
         /** True for Proxy-Authenticate, false for WWW-Authenticate. */
@@ -10400,18 +10400,18 @@ declare namespace chrome.webstore {
 declare namespace chrome.windows {
     export interface Window {
         /** Optional. Array of tabs.Tab objects representing the current tabs in the window. */
-        tabs?: chrome.tabs.Tab[];
+        tabs?: chrome.tabs.Tab[] | undefined;
         /** Optional. The offset of the window from the top edge of the screen in pixels. Under some circumstances a Window may not be assigned top property, for example when querying closed windows from the sessions API. */
-        top?: number;
+        top?: number | undefined;
         /** Optional. The height of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned height property, for example when querying closed windows from the sessions API. */
-        height?: number;
+        height?: number | undefined;
         /** Optional. The width of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned width property, for example when querying closed windows from the sessions API. */
-        width?: number;
+        width?: number | undefined;
         /**
          * The state of this browser window.
          * @since Chrome 17.
          */
-        state?: windowStateEnum;
+        state?: windowStateEnum | undefined;
         /** Whether the window is currently the focused window. */
         focused: boolean;
         /**
@@ -10424,16 +10424,16 @@ declare namespace chrome.windows {
         /**
          * The type of browser window this is.
          */
-        type?: windowTypeEnum;
+        type?: windowTypeEnum | undefined;
         /** Optional. The ID of the window. Window IDs are unique within a browser session. Under some circumstances a Window may not be assigned an ID, for example when querying windows using the sessions API, in which case a session ID may be present. */
-        id?: number;
+        id?: number | undefined;
         /** Optional. The offset of the window from the left edge of the screen in pixels. Under some circumstances a Window may not be assigned left property, for example when querying closed windows from the sessions API. */
-        left?: number;
+        left?: number | undefined;
         /**
          * Optional. The session ID used to uniquely identify a Window obtained from the sessions API.
          * @since Chrome 31.
          */
-        sessionId?: string;
+        sessionId?: string | undefined;
     }
 
     export interface QueryOptions {
@@ -10442,11 +10442,11 @@ declare namespace chrome.windows {
          * If true, the windows.Window object will have a tabs property that contains a list of the tabs.Tab objects.
          * The Tab objects only contain the url, pendingUrl, title and favIconUrl properties if the extension's manifest file includes the "tabs" permission.
          */
-        populate?: boolean;
+        populate?: boolean | undefined;
         /**
          * If set, the Window returned is filtered based on its type. If unset, the default filter is set to ['normal', 'popup'].
          */
-        windowTypes?: windowTypeEnum[];
+        windowTypes?: windowTypeEnum[] | undefined;
     }
 
     export interface CreateData {
@@ -10454,77 +10454,77 @@ declare namespace chrome.windows {
          * Optional. The id of the tab for which you want to adopt to the new window.
          * @since Chrome 10.
          */
-        tabId?: number;
+        tabId?: number | undefined;
         /**
          * Optional.
          * A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.
          */
-        url?: string | string[];
+        url?: string | string[] | undefined;
         /**
          * Optional.
          * The number of pixels to position the new window from the top edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.
          */
-        top?: number;
+        top?: number | undefined;
         /**
          * Optional.
          * The height in pixels of the new window, including the frame. If not specified defaults to a natural height.
          */
-        height?: number;
+        height?: number | undefined;
         /**
          * Optional.
          * The width in pixels of the new window, including the frame. If not specified defaults to a natural width.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * Optional. If true, opens an active window. If false, opens an inactive window.
          * @since Chrome 12.
          */
-        focused?: boolean;
+        focused?: boolean | undefined;
         /** Optional. Whether the new window should be an incognito window. */
-        incognito?: boolean;
+        incognito?: boolean | undefined;
         /** Optional. Specifies what type of browser window to create. */
-        type?: createTypeEnum;
+        type?: createTypeEnum | undefined;
         /**
          * Optional.
          * The number of pixels to position the new window from the left edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.
          */
-        left?: number;
+        left?: number | undefined;
         /**
          * Optional. The initial state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.
          * @since Chrome 44.
          */
-        state?: windowStateEnum;
+        state?: windowStateEnum | undefined;
         /**
          * If true, the newly-created window's 'window.opener' is set to the caller and is in the same [unit of related browsing contexts](https://www.w3.org/TR/html51/browsers.html#unit-of-related-browsing-contexts) as the caller.
          * @since Chrome 64.
          */
-        setSelfAsOpener?: boolean;
+        setSelfAsOpener?: boolean | undefined;
     }
 
     export interface UpdateInfo {
         /** Optional. The offset from the top edge of the screen to move the window to in pixels. This value is ignored for panels. */
-        top?: number;
+        top?: number | undefined;
         /**
          * Optional. If true, causes the window to be displayed in a manner that draws the user's attention to the window, without changing the focused window. The effect lasts until the user changes focus to the window. This option has no effect if the window already has focus. Set to false to cancel a previous draw attention request.
          * @since Chrome 14.
          */
-        drawAttention?: boolean;
+        drawAttention?: boolean | undefined;
         /** Optional. The height to resize the window to in pixels. This value is ignored for panels. */
-        height?: number;
+        height?: number | undefined;
         /** Optional. The width to resize the window to in pixels. This value is ignored for panels. */
-        width?: number;
+        width?: number | undefined;
         /**
          * Optional. The new state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.
          * @since Chrome 17.
          */
-        state?: windowStateEnum;
+        state?: windowStateEnum | undefined;
         /**
          * Optional. If true, brings the window to the front. If false, brings the next window in the z-order to the front.
          * @since Chrome 8.
          */
-        focused?: boolean;
+        focused?: boolean | undefined;
         /** Optional. The offset from the left edge of the screen to move the window to in pixels. This value is ignored for panels. */
-        left?: number;
+        left?: number | undefined;
     }
 
     export interface WindowEventFilter {
@@ -10804,7 +10804,7 @@ declare namespace chrome.declarativeNetRequest {
          * This does not change through redirects.
          * If this is an opaque origin, the string 'null' will be used.
          */
-        initiator?: string;
+        initiator?: string | undefined;
 
         /** Standard HTTP method. */
         method: string;
@@ -10854,17 +10854,17 @@ declare namespace chrome.declarativeNetRequest {
         /** Describes how the redirect should be performed.
          * Only valid for redirect rules.
          */
-        redirect?: Redirect;
+        redirect?: Redirect | undefined;
 
         /** The request headers to modify for the request.
          * Only valid if RuleActionType is "modifyHeaders".
          */
-        requestHeaders?: ModifyHeaderInfo[];
+        requestHeaders?: ModifyHeaderInfo[] | undefined;
 
         /** The response headers to modify for the request.
          * Only valid if RuleActionType is "modifyHeaders".
          */
-        responseHeaders?: ModifyHeaderInfo[];
+        responseHeaders?: ModifyHeaderInfo[] | undefined;
 
         /** The type of action to perform. */
         type: RuleActionType;
@@ -10874,7 +10874,7 @@ declare namespace chrome.declarativeNetRequest {
         /** Specifies whether the network request is first-party or third-party to the domain from which it originated.
          * If omitted, all requests are accepted.
          */
-        domainType?: DomainType;
+        domainType?: DomainType | undefined;
 
         /** The rule will only match network requests originating from the list of domains.
          * If the list is omitted, the rule is applied to requests from all domains.
@@ -10886,7 +10886,7 @@ declare namespace chrome.declarativeNetRequest {
          * Use punycode encoding for internationalized domains.
          * This matches against the request initiator and not the request url.
          */
-        domains?: string[];
+        domains?: string[] | undefined;
 
         /** The rule will not match network requests originating from the list of excludedDomains.
          * If the list is empty or omitted, no domains are excluded.
@@ -10898,19 +10898,19 @@ declare namespace chrome.declarativeNetRequest {
          * Use punycode encoding for internationalized domains.
          * This matches against the request initiator and not the request url.
          */
-        excludedDomains?: string[];
+        excludedDomains?: string[] | undefined;
 
         /** List of resource types which the rule won't match.
          * Only one of resourceTypes and excludedResourceTypes should be specified.
          * If neither of them is specified, all resource types except "main_frame" are blocked.
          */
-        excludedResourceTypes?: ResourceType[];
+        excludedResourceTypes?: ResourceType[] | undefined;
 
         /**
          * Whether the urlFilter or regexFilter (whichever is specified) is case sensitive.
          * Default is true.
          */
-        isUrlFilterCaseSensitive?: boolean;
+        isUrlFilterCaseSensitive?: boolean | undefined;
 
         /** Regular expression to match against the network request url.
          * This follows the RE2 syntax.
@@ -10920,14 +10920,14 @@ declare namespace chrome.declarativeNetRequest {
          * Note: The regexFilter must be composed of only ASCII characters.
          * This is matched against a url where the host is encoded in the punycode format (in case of internationalized domains) and any other non-ascii characters are url encoded in utf-8.
          */
-        regexFilter?: string;
+        regexFilter?: string | undefined;
 
         /** List of resource types which the rule can match.
          * An empty list is not allowed.
          *
          * Note: this must be specified for allowAllRequests rules and may only include the sub_frame and main_frame resource types.
          */
-        resourceTypes?: ResourceType[];
+        resourceTypes?: ResourceType[] | undefined;
 
         /** The pattern which is matched against the network request url.
          * Supported constructs:
@@ -10953,7 +10953,7 @@ declare namespace chrome.declarativeNetRequest {
          * This is matched against a url where the host is encoded in the punycode format (in case of internationalized domains) and any other non-ascii characters are url encoded in utf-8.
          * For example, when the request url is http://abc.рф?q=ф, the urlFilter will be matched against the url http://abc.xn--p1ai/?q=%D1%84.
          */
-        urlFilter?: string;
+        urlFilter?: string | undefined;
     }
 
     export interface MatchedRule {
@@ -10980,12 +10980,12 @@ declare namespace chrome.declarativeNetRequest {
 
     export interface MatchedRulesFilter {
         /** If specified, only matches rules after the given timestamp. */
-        minTimeStamp?: number;
+        minTimeStamp?: number | undefined;
 
         /** If specified, only matches rules for the given tab.
          * Matches rules not associated with any active tab if set to -1.
          */
-        tabId?: number;
+        tabId?: number | undefined;
     }
 
     export interface ModifyHeaderInfo {
@@ -10998,7 +10998,7 @@ declare namespace chrome.declarativeNetRequest {
         /** The new value for the header.
          * Must be specified for append and set operations.
          */
-        value?: string;
+        value?: string | undefined;
     }
 
     export interface QueryKeyValue {
@@ -11008,56 +11008,56 @@ declare namespace chrome.declarativeNetRequest {
 
     export interface QueryTransform {
         /** The list of query key-value pairs to be added or replaced. */
-        addOrReplaceParams?: QueryKeyValue[];
+        addOrReplaceParams?: QueryKeyValue[] | undefined;
 
         /** The list of query keys to be removed. */
-        removeParams?: string[];
+        removeParams?: string[] | undefined;
     }
 
     export interface URLTransform {
         /** The new fragment for the request.
          * Should be either empty, in which case the existing fragment is cleared; or should begin with '#'.
          */
-        fragment?: string;
+        fragment?: string | undefined;
 
         /** The new host for the request. */
-        host?: string;
+        host?: string | undefined;
 
         /** The new password for the request. */
-        password?: string;
+        password?: string | undefined;
 
         /** The new path for the request.
          * If empty, the existing path is cleared.
          */
-        path?: string;
+        path?: string | undefined;
 
         /** The new port for the request.
          * If empty, the existing port is cleared.
          */
-        port?: string;
+        port?: string | undefined;
 
         /** The new query for the request.
          * Should be either empty, in which case the existing query is cleared; or should begin with '?'.
          */
-        query?: string;
+        query?: string | undefined;
 
         /** Add, remove or replace query key-value pairs. */
-        queryTransform?: QueryTransform;
+        queryTransform?: QueryTransform | undefined;
 
         /** The new scheme for the request.
          * Allowed values are "http", "https", "ftp" and "chrome-extension".
          */
-        scheme?: string;
+        scheme?: string | undefined;
 
         /** The new username for the request. */
-        username?: string;
+        username?: string | undefined;
     }
 
     export interface RegexOptions {
         /** Whether the regex specified is case sensitive.
          * Default is true.
          */
-        isCaseSensitive?: boolean;
+        isCaseSensitive?: boolean | undefined;
 
         /** The regular expresson to check. */
         regex: string;
@@ -11066,7 +11066,7 @@ declare namespace chrome.declarativeNetRequest {
          * Capturing is only required for redirect rules which specify a regexSubstition action.
          * The default is false.
          */
-        requireCapturing?: boolean;
+        requireCapturing?: boolean | undefined;
     }
 
     export interface IsRegexSupportedResult {
@@ -11075,7 +11075,7 @@ declare namespace chrome.declarativeNetRequest {
         /** Specifies the reason why the regular expression is not supported.
          * Only provided if isSupported is false.
          */
-        reason?: UnsupportedRegexReason;
+        reason?: UnsupportedRegexReason | undefined;
     }
 
     export interface TabActionCountUpdate {
@@ -11092,50 +11092,50 @@ declare namespace chrome.declarativeNetRequest {
         /** Whether to automatically display the action count for a page as the extension's badge text.
          * This preference is persisted across sessions.
          */
-        displayActionCountAsBadgeText?: boolean;
+        displayActionCountAsBadgeText?: boolean | undefined;
 
         /** Details of how the tab's action count should be adjusted. */
-        tabUpdate?: TabActionCountUpdate;
+        tabUpdate?: TabActionCountUpdate | undefined;
     }
 
     export interface Redirect {
         /** Path relative to the extension directory.
          * Should start with '/'.
          */
-        extensionPath?: string;
+        extensionPath?: string | undefined;
 
         /** Substitution pattern for rules which specify a regexFilter.
          * The first match of regexFilter within the url will be replaced with this pattern.
          * Within regexSubstitution, backslash-escaped digits (\1 to \9) can be used to insert the corresponding capture groups.
          * \0 refers to the entire matching text.
          */
-        regexSubstitution?: string;
+        regexSubstitution?: string | undefined;
 
         /** Url transformations to perform. */
-        transform?: URLTransform;
+        transform?: URLTransform | undefined;
 
         /** The redirect url.
          * Redirects to JavaScript urls are not allowed.
          */
-        url?: string;
+        url?: string | undefined;
     }
 
     export interface UpdateRuleOptions {
         /** Rules to add. */
-        addRules?: Rule[];
+        addRules?: Rule[] | undefined;
 
         /** IDs of the rules to remove.
          * Any invalid IDs will be ignored.
          */
-        removeRuleIds?: number[];
+        removeRuleIds?: number[] | undefined;
     }
 
     export interface UpdateRulesetOptions {
         /** The set of ids corresponding to a static Ruleset that should be disabled. */
-        disableRulesetIds?: string[];
+        disableRulesetIds?: string[] | undefined;
 
         /** The set of ids corresponding to a static Ruleset that should be enabled. */
-        enableRulesetIds?: string[];
+        enableRulesetIds?: string[] | undefined;
     }
 
     export interface MatchedRuleInfoDebug {

--- a/types/circular-dependency-plugin/index.d.ts
+++ b/types/circular-dependency-plugin/index.d.ts
@@ -21,23 +21,23 @@ declare namespace CircularDependencyPlugin {
     /**
      * @default false
      */
-    allowAsyncCycles?: boolean;
+    allowAsyncCycles?: boolean | undefined;
     /**
      * @default process.cwd()
      */
-    cwd?: string;
+    cwd?: string | undefined;
     /**
      * @default /$^/
      */
-    exclude?: RegExp;
+    exclude?: RegExp | undefined;
     /**
      * @default /.*\/
      */
-    include?: RegExp;
+    include?: RegExp | undefined;
     /**
      * @default false
      */
-    failOnError?: boolean;
+    failOnError?: boolean | undefined;
     /**
      * @default false
      */
@@ -45,8 +45,8 @@ declare namespace CircularDependencyPlugin {
       module: Module;
       paths: string[];
       compilation: compilation.Compilation;
-    }) => void);
-    onEnd?: (x: { compilation: compilation.Compilation }) => void;
-    onStart?: (x: { compilation: compilation.Compilation }) => void;
+    }) => void) | undefined;
+    onEnd?: ((x: { compilation: compilation.Compilation }) => void) | undefined;
+    onStart?: ((x: { compilation: compilation.Compilation }) => void) | undefined;
   }
 }

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -18,18 +18,18 @@ interface OptionsBase {
      * Controls compatibility mode used; defaults to ie10+ using `'*'`.
      *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`
      */
-    compatibility?: "*" | "ie9" | "ie8" | "ie7" | CleanCSS.CompatibilityOptions;
+    compatibility?: "*" | "ie9" | "ie8" | "ie7" | CleanCSS.CompatibilityOptions | undefined;
 
     /**
      * Controls a function for handling remote requests; Defaults to the build in `loadRemoteResource` function
      */
-    fetch?: (uri: string, inlineRequest: HttpRequestOptions | HttpsRequestOptions, inlineTimeout: number, done: (message: string | number, body: string) => void) => void;
+    fetch?: ((uri: string, inlineRequest: HttpRequestOptions | HttpsRequestOptions, inlineTimeout: number, done: (message: string | number, body: string) => void) => void) | undefined;
 
     /**
      * Controls output CSS formatting; defaults to `false`.
      *  Format hash exposes the following properties: `breaks`, `breakWith`, `indentBy`, `indentWith`, `spaces`, and `wrapAt`.
      */
-    format?: "beautify" | "keep-breaks" | CleanCSS.FormatOptions | false;
+    format?: "beautify" | "keep-breaks" | CleanCSS.FormatOptions | false | undefined;
 
     /**
      * inline option whitelists which @import rules will be processed.  Defaults to `'local'`
@@ -41,44 +41,44 @@ interface OptionsBase {
      *  '[uri]': enables remote inlining from the specified uri;
      *  '![url]': disables remote inlining from the specified uri;
      */
-    inline?: ReadonlyArray<string> | false;
+    inline?: ReadonlyArray<string> | false | undefined;
 
     /**
      * Controls extra options for inlining remote @import rules
      */
-    inlineRequest?: HttpRequestOptions | HttpsRequestOptions;
+    inlineRequest?: HttpRequestOptions | HttpsRequestOptions | undefined;
 
     /**
      * Controls number of milliseconds after which inlining a remote @import fails; defaults to `5000`;
      */
-    inlineTimeout?: number;
+    inlineTimeout?: number | undefined;
 
     /**
      * Controls optimization level used; defaults to `1`.
      * Level hash exposes `1`, and `2`.
      */
-    level?: 0 | 1 | 2 | CleanCSS.OptimizationsOptions;
+    level?: 0 | 1 | 2 | CleanCSS.OptimizationsOptions | undefined;
 
     /**
      * Controls URL rebasing; defaults to `true`;
      */
-    rebase?: boolean;
+    rebase?: boolean | undefined;
 
     /**
      * controls a directory to which all URLs are rebased, most likely the directory under which the output file
      * will live; defaults to the current directory;
      */
-    rebaseTo?: string;
+    rebaseTo?: string | undefined;
 
     /**
      *  Controls whether an output source map is built; defaults to `false`
      */
-    sourceMap?: boolean;
+    sourceMap?: boolean | undefined;
 
     /**
      *  Controls embedding sources inside a source map's `sourcesContent` field; defaults to `false`
      */
-    sourceMapInlineSources?: boolean;
+    sourceMapInlineSources?: boolean | undefined;
 }
 
 declare namespace CleanCSS {
@@ -143,8 +143,8 @@ declare namespace CleanCSS {
             /**
              * Controls `rgba()` / `hsla()` color support; defaults to `true`
              */
-            opacity?: boolean;
-        };
+            opacity?: boolean | undefined;
+        } | undefined;
         /**
          * A hash of properties that can be set with compatibility
          */
@@ -152,68 +152,68 @@ declare namespace CleanCSS {
             /**
              * Controls background-clip merging into shorthand; defaults to `true`
              */
-            backgroundClipMerging?: boolean;
+            backgroundClipMerging?: boolean | undefined;
 
             /**
              * Controls background-origin merging into shorthand; defaults to `true`
              */
-            backgroundOriginMerging?: boolean;
+            backgroundOriginMerging?: boolean | undefined;
 
             /**
              * Controls background-size merging into shorthand; defaults to `true`
              */
-            backgroundSizeMerging?: boolean;
+            backgroundSizeMerging?: boolean | undefined;
 
             /**
              * controls color optimizations; defaults to `true`
              */
-            colors?: boolean,
+            colors?: boolean | undefined,
 
             /**
              * Controls keeping IE bang hack; defaults to `false`
              */
-            ieBangHack?: boolean;
+            ieBangHack?: boolean | undefined;
 
             /**
              * Controls keeping IE `filter` / `-ms-filter`; defaults to `false`
              */
-            ieFilters?: boolean;
+            ieFilters?: boolean | undefined;
 
             /**
              * Controls keeping IE prefix hack; defaults to `false`
              */
-            iePrefixHack?: boolean;
+            iePrefixHack?: boolean | undefined;
 
             /**
              * Controls keeping IE suffix hack; defaults to `false`
              */
-            ieSuffixHack?: boolean;
+            ieSuffixHack?: boolean | undefined;
 
             /**
              * Controls property merging based on understandably; defaults to `true`
              */
-            merging?: boolean;
+            merging?: boolean | undefined;
 
             /**
              * Controls shortening pixel units into `pc`, `pt`, or `in` units; defaults to `false`
              */
-            shorterLengthUnits?: false;
+            shorterLengthUnits?: false | undefined;
 
             /**
              * Controls keeping space after closing brace - `url() no-repeat` into `url()no-repeat`; defaults to `true`
              */
-            spaceAfterClosingBrace?: true;
+            spaceAfterClosingBrace?: true | undefined;
 
             /**
              * Controls keeping quoting inside `url()`; defaults to `false`
              */
-            urlQuotes?: boolean;
+            urlQuotes?: boolean | undefined;
 
             /**
              * Controls removal of units `0` value; defaults to `true`
              */
-            zeroUnits?: boolean;
-        };
+            zeroUnits?: boolean | undefined;
+        } | undefined;
         /**
          * A hash of options related to compatibility of selectors
          */
@@ -221,17 +221,17 @@ declare namespace CleanCSS {
             /**
              * Controls extra space before `nav` element; defaults to `false`
              */
-            adjacentSpace?: boolean;
+            adjacentSpace?: boolean | undefined;
 
             /**
              * Controls removal of IE7 selector hacks, e.g. `*+html...`; defaults to `true`
              */
-            ie7Hack?: boolean;
+            ie7Hack?: boolean | undefined;
 
             /**
              * Controls a whitelist of mergeable pseudo classes; defaults to `[':active', ...]`
              */
-            mergeablePseudoClasses?: ReadonlyArray<string>;
+            mergeablePseudoClasses?: ReadonlyArray<string> | undefined;
 
             /**
              * Controls a whitelist of mergeable pseudo elements; defaults to `['::after', ...]`
@@ -247,7 +247,7 @@ declare namespace CleanCSS {
              * Controls merging of rules with multiple pseudo classes / elements (since 4.1.0); defaults to `true`
              */
             multiplePseudoMerging: boolean;
-        };
+        } | undefined;
         /**
          * A hash of options related to comparability of supported units
          */
@@ -255,48 +255,48 @@ declare namespace CleanCSS {
             /**
              * Controls treating `ch` as a supported unit; defaults to `true`
              */
-            ch?: boolean;
+            ch?: boolean | undefined;
 
             /**
              * Controls treating `in` as a supported unit; defaults to `true`
              */
-            in?: boolean;
+            in?: boolean | undefined;
 
             /**
              * Controls treating `pc` as a supported unit; defaults to `true`
              */
-            pc?: boolean;
+            pc?: boolean | undefined;
 
             /**
              * Controls treating `pt` as a supported unit; defaults to `true`
              */
-            pt?: boolean;
+            pt?: boolean | undefined;
 
             /**
              * Controls treating `rem` as a supported unit; defaults to `true`
              */
-            rem?: boolean;
+            rem?: boolean | undefined;
 
             /**
              * Controls treating `vh` as a supported unit; defaults to `true`
              */
-            vh?: boolean;
+            vh?: boolean | undefined;
 
             /**
              * Controls treating `vm` as a supported unit; defaults to `true`
              */
-            vm?: boolean;
+            vm?: boolean | undefined;
 
             /**
              * Controls treating `vmax` as a supported unit; defaults to `true`
              */
-            vmax?: boolean;
+            vmax?: boolean | undefined;
 
             /**
              * Controls treating `vmin` as a supported unit; defaults to `true`
              */
-            vmin?: boolean;
-        };
+            vmin?: boolean | undefined;
+        } | undefined;
     }
 
     /**
@@ -310,63 +310,63 @@ declare namespace CleanCSS {
             /**
              * Controls if a line break comes after an at-rule; e.g. `@charset`; defaults to `false`
              */
-            afterAtRule?: boolean;
+            afterAtRule?: boolean | undefined;
 
             /**
              * Controls if a line break comes after a block begins; e.g. `@media`; defaults to `false`
              */
-            afterBlockBegins?: boolean;
+            afterBlockBegins?: boolean | undefined;
 
             /**
              * Controls if a line break comes after a block ends, defaults to `false`
              */
-            afterBlockEnds?: boolean;
+            afterBlockEnds?: boolean | undefined;
 
             /**
              * Controls if a line break comes after a comment; defaults to `false`
              */
-            afterComment?: boolean;
+            afterComment?: boolean | undefined;
 
             /**
              * Controls if a line break comes after a property; defaults to `false`
              */
-            afterProperty?: boolean;
+            afterProperty?: boolean | undefined;
 
             /**
              * Controls if a line break comes after a rule begins; defaults to `false`
              */
-            afterRuleBegins?: boolean;
+            afterRuleBegins?: boolean | undefined;
 
             /**
              * Controls if a line break comes after a rule ends; defaults to `false`
              */
-            afterRuleEnds?: boolean;
+            afterRuleEnds?: boolean | undefined;
 
             /**
              * Controls if a line break comes before a block ends; defaults to `false`
              */
-            beforeBlockEnds?: boolean;
+            beforeBlockEnds?: boolean | undefined;
 
             /**
              * Controls if a line break comes between selectors; defaults to `false`
              */
-            betweenSelectors?: boolean;
-        };
+            betweenSelectors?: boolean | undefined;
+        } | undefined;
         /**
          * Controls the new line character, can be `'\r\n'` or `'\n'`(aliased as `'windows'` and `'unix'`
          * or `'crlf'` and `'lf'`); defaults to system one, so former on Windows and latter on Unix
          */
-        breakWith?: string;
+        breakWith?: string | undefined;
 
         /**
          * Controls number of characters to indent with; defaults to `0`
          */
-        indentBy?: number;
+        indentBy?: number | undefined;
 
         /**
          * Controls a character to indent with, can be `'space'` or `'tab'`; defaults to `'space'`
          */
-        indentWith?: "space" | "tab";
+        indentWith?: "space" | "tab" | undefined;
 
         /**
          * Controls where to insert spaces
@@ -375,27 +375,27 @@ declare namespace CleanCSS {
             /**
              * Controls if spaces come around selector relations; e.g. `div > a`; defaults to `false`
              */
-            aroundSelectorRelation?: boolean;
+            aroundSelectorRelation?: boolean | undefined;
 
             /**
              * Controls if a space comes before a block begins; e.g. `.block {`; defaults to `false`
              */
-            beforeBlockBegins?: boolean;
+            beforeBlockBegins?: boolean | undefined;
 
             /**
              * Controls if a space comes before a value; e.g. `width: 1rem`; defaults to `false`
              */
-            beforeValue?: boolean;
-        };
+            beforeValue?: boolean | undefined;
+        } | undefined;
         /**
          * Controls maximum line length; defaults to `false`
          */
-        wrapAt?: false | number;
+        wrapAt?: false | number | undefined;
 
         /**
          * Controls removing trailing semicolons in rule; defaults to `false` - means remove
          */
-        semicolonAfterLastProperty?: boolean;
+        semicolonAfterLastProperty?: boolean | undefined;
     }
 
     /**
@@ -406,195 +406,195 @@ declare namespace CleanCSS {
             /**
              * Sets all optimizations at this level unless otherwise specified
              */
-            all?: boolean;
+            all?: boolean | undefined;
 
             /**
              * Controls `@charset` moving to the front of a stylesheet; defaults to `true`
              */
-            cleanupCharsets?: boolean;
+            cleanupCharsets?: boolean | undefined;
 
             /**
              * Controls URL normalization; defaults to `true`
              */
-            normalizeUrls?: boolean;
+            normalizeUrls?: boolean | undefined;
 
             /**
              * Controls `background` property optimizations; defaults to `true`
              */
-            optimizeBackground?: boolean;
+            optimizeBackground?: boolean | undefined;
 
             /**
              * Controls `border-radius` property optimizations; defaults to `true`
              */
-            optimizeBorderRadius?: boolean;
+            optimizeBorderRadius?: boolean | undefined;
 
             /**
              * Controls `filter` property optimizations; defaults to `true`
              */
-            optimizeFilter?: boolean;
+            optimizeFilter?: boolean | undefined;
 
             /**
              * Controls `font` property optimizations; defaults to `true`
              */
-            optimizeFont?: boolean;
+            optimizeFont?: boolean | undefined;
 
             /**
              * Controls `font-weight` property optimizations; defaults to `true`
              */
-            optimizeFontWeight?: boolean;
+            optimizeFontWeight?: boolean | undefined;
 
             /**
              * Controls `outline` property optimizations; defaults to `true`
              */
-            optimizeOutline?: boolean;
+            optimizeOutline?: boolean | undefined;
 
             /**
              * Controls removing empty rules and nested blocks; defaults to `true`
              */
-            removeEmpty?: boolean;
+            removeEmpty?: boolean | undefined;
 
             /**
              * Controls removing negative paddings; defaults to `true`
              */
-            removeNegativePaddings?: boolean;
+            removeNegativePaddings?: boolean | undefined;
 
             /**
              * Controls removing quotes when unnecessary; defaults to `true`
              */
-            removeQuotes?: boolean;
+            removeQuotes?: boolean | undefined;
 
             /**
              * Controls removing unused whitespace; defaults to `true`
              */
-            removeWhitespace?: boolean;
+            removeWhitespace?: boolean | undefined;
 
             /**
              * Contols removing redundant zeros; defaults to `true`
              */
-            replaceMultipleZeros?: boolean;
+            replaceMultipleZeros?: boolean | undefined;
 
             /**
              * Controls replacing time units with shorter values; defaults to `true`
              */
-            replaceTimeUnits?: boolean;
+            replaceTimeUnits?: boolean | undefined;
 
             /**
              * Controls replacing zero values with units; defaults to `true`
              */
-            replaceZeroUnits?: boolean;
+            replaceZeroUnits?: boolean | undefined;
 
             /**
              * Rounds pixel values to `N` decimal places; `false` disables rounding; defaults to `false`
              */
-            roundingPrecision?: boolean;
+            roundingPrecision?: boolean | undefined;
 
             /**
              * denotes selector sorting method; can be `'natural'` or `'standard'`, `'none'`, or false (the last two
              * since 4.1.0); defaults to `'standard'`
              */
-            selectorsSortingMethod?: "standard" | "natural" | "none";
+            selectorsSortingMethod?: "standard" | "natural" | "none" | undefined;
 
             /**
              * denotes a number of /*! ... * / comments preserved; defaults to `all`
              */
-            specialComments?: string;
+            specialComments?: string | undefined;
 
             /**
              * Controls at-rules (e.g. `@charset`, `@import`) optimizing; defaults to `true`
              */
-            tidyAtRules?: boolean;
+            tidyAtRules?: boolean | undefined;
 
             /**
              * Controls block scopes (e.g. `@media`) optimizing; defaults to `true`
              */
-            tidyBlockScopes?: boolean;
+            tidyBlockScopes?: boolean | undefined;
 
             /**
              * Controls selectors optimizing; defaults to `true`
              */
-            tidySelectors?: boolean;
+            tidySelectors?: boolean | undefined;
 
             /**
              * Defines a callback for fine-grained property optimization; defaults to no-op
              */
-            transform?: (propertyName: string, propertyValue: string, selector?: string) => string;
-        };
+            transform?: ((propertyName: string, propertyValue: string, selector?: string) => string) | undefined;
+        } | undefined;
         2?: {
             /**
              * Sets all optimizations at this level unless otherwise specified
              */
-            all?: boolean;
+            all?: boolean | undefined;
 
             /**
              * Controls adjacent rules merging; defaults to true
              */
-            mergeAdjacentRules?: boolean;
+            mergeAdjacentRules?: boolean | undefined;
 
             /**
              * Controls merging properties into shorthands; defaults to true
              */
-            mergeIntoShorthands?: boolean;
+            mergeIntoShorthands?: boolean | undefined;
 
             /**
              * Controls `@media` merging; defaults to true
              */
-            mergeMedia?: boolean;
+            mergeMedia?: boolean | undefined;
 
             /**
              * Controls non-adjacent rule merging; defaults to true
              */
-            mergeNonAdjacentRules?: boolean;
+            mergeNonAdjacentRules?: boolean | undefined;
 
             /**
              * Controls semantic merging; defaults to false
              */
-            mergeSemantically?: boolean;
+            mergeSemantically?: boolean | undefined;
 
             /**
              * Controls property overriding based on understandably; defaults to true
              */
-            overrideProperties?: boolean;
+            overrideProperties?: boolean | undefined;
 
             /**
              * Controls removing empty rules and nested blocks; defaults to `true`
              */
-            removeEmpty?: boolean;
+            removeEmpty?: boolean | undefined;
 
             /**
              * Controls non-adjacent rule reducing; defaults to true
              */
-            reduceNonAdjacentRules?: boolean;
+            reduceNonAdjacentRules?: boolean | undefined;
 
             /**
              * Controls duplicate `@font-face` removing; defaults to true
              */
-            removeDuplicateFontRules?: boolean;
+            removeDuplicateFontRules?: boolean | undefined;
 
             /**
              * Controls duplicate `@media` removing; defaults to true
              */
-            removeDuplicateMediaBlocks?: boolean;
+            removeDuplicateMediaBlocks?: boolean | undefined;
 
             /**
              * Controls duplicate rules removing; defaults to true
              */
-            removeDuplicateRules?: boolean;
+            removeDuplicateRules?: boolean | undefined;
 
             /**
              * Controls unused at rule removing; defaults to false (available since 4.1.0)
              */
-            removeUnusedAtRules?: boolean;
+            removeUnusedAtRules?: boolean | undefined;
 
             /**
              * Controls rule restructuring; defaults to false
              */
-            restructureRules?: boolean;
+            restructureRules?: boolean | undefined;
 
             /**
              * Controls which properties won't be optimized, defaults to `[]` which means all will be optimized (since 4.1.0)
              */
-            skipProperties?: ReadonlyArray<string>;
-        };
+            skipProperties?: ReadonlyArray<string> | undefined;
+        } | undefined;
     }
 
     /**
@@ -614,7 +614,7 @@ declare namespace CleanCSS {
             /**
              * The source map of the file, if needed
              */
-            sourceMap?: RawSourceMap | string;
+            sourceMap?: RawSourceMap | string | undefined;
         };
     }
 
@@ -664,7 +664,7 @@ declare namespace CleanCSS {
         /**
          * If you prefer clean-css to return a Promise object then you need to explicitly ask for it; defaults to `false`
          */
-        returnPromise?: false
+        returnPromise?: false | undefined
     };
 
     /**

--- a/types/clean-css/v3/index.d.ts
+++ b/types/clean-css/v3/index.d.ts
@@ -7,67 +7,67 @@
 declare namespace CleanCSS {
     interface Options {
         // Set to false to disable advanced optimizations - selector & property merging, reduction, etc.
-        advanced?: boolean;
+        advanced?: boolean | undefined;
 
         // Set to false to disable aggressive merging of properties.
-        aggressiveMerging?: boolean;
+        aggressiveMerging?: boolean | undefined;
 
         // Turns on benchmarking mode measuring time spent on cleaning up (run npm run bench to see example)
-        benchmark?: boolean;
+        benchmark?: boolean | undefined;
 
         // Enables compatibility mode
-        compatibility?: Object;
+        compatibility?: Object | undefined;
 
         // Set to true to get minification statistics under stats property (see test/custom-test.js for examples)
-        debug?: boolean;
+        debug?: boolean | undefined;
 
         // A hash of options for @import inliner, see test/protocol-imports-test.js for examples, or this comment for a proxy use case.
-        inliner?: Object;
+        inliner?: Object | undefined;
 
         // Whether to keep line breaks (default is false)
-        keepBreaks?: boolean;
+        keepBreaks?: boolean | undefined;
 
         // * for keeping all (default), 1 for keeping first one only, 0 for removing all
-        keepSpecialComments?: string | number;
+        keepSpecialComments?: string | number | undefined;
 
         // Whether to merge @media at-rules (default is true)
-        mediaMerging?: boolean;
+        mediaMerging?: boolean | undefined;
 
         // Whether to process @import rules
-        processImport?: boolean;
+        processImport?: boolean | undefined;
 
         // A list of @import rules, can be ['all'] (default), ['local'], ['remote'], or a blacklisted path e.g. ['!fonts.googleapis.com']
-        processImportFrom?: Array<string>;
+        processImportFrom?: Array<string> | undefined;
 
         // Set to false to skip URL rebasing
-        rebase?: boolean;
+        rebase?: boolean | undefined;
 
         // Path to resolve relative @import rules and URLs
-        relativeTo?: string;
+        relativeTo?: string | undefined;
 
         // Set to false to disable restructuring in advanced optimizations
-        restructuring?: boolean;
+        restructuring?: boolean | undefined;
 
         // Path to resolve absolute @import rules and rebase relative URLs
-        root?: string;
+        root?: string | undefined;
 
         // Rounding precision; defaults to 2; -1 disables rounding
-        roundingPrecision?: number;
+        roundingPrecision?: number | undefined;
 
         // Set to true to enable semantic merging mode which assumes BEM-like content (default is false as it's highly likely this will break your stylesheets - use with caution!)
-        semanticMerging?: boolean;
+        semanticMerging?: boolean | undefined;
 
         // Set to false to skip shorthand compacting (default is true unless sourceMap is set when it's false)
-        shorthandCompacting?: boolean;
+        shorthandCompacting?: boolean | undefined;
 
         // Exposes source map under sourceMap property, e.g. new CleanCSS().minify(source).sourceMap (default is false) If input styles are a product of CSS preprocessor (Less, Sass) an input source map can be passed as a string.
-        sourceMap?: boolean | string;
+        sourceMap?: boolean | string | undefined;
 
         // Set to true to inline sources inside a source map's sourcesContent field (defaults to false) It is also required to process inlined sources from input source maps.
-        sourceMapInlineSources?: boolean;
+        sourceMapInlineSources?: boolean | undefined;
 
         // Path to a folder or an output file to which rebase all URLs
-        target?: string;
+        target?: string | undefined;
     }
 
     interface Output {

--- a/types/cleave.js/options/index.d.ts
+++ b/types/cleave.js/options/index.d.ts
@@ -1,59 +1,59 @@
 import { CreditCardTypeChangeHandler } from "./creditCard";
 
 export interface CleaveOptions {
-    creditCard?: boolean;
-    creditCardStrictMode?: boolean;
-    creditCardType?: string;
-    onCreditCardTypeChanged?: CreditCardTypeChangeHandler;
+    creditCard?: boolean | undefined;
+    creditCardStrictMode?: boolean | undefined;
+    creditCardType?: string | undefined;
+    onCreditCardTypeChanged?: CreditCardTypeChangeHandler | undefined;
 }
 
 // Phone Options
 export interface CleaveOptions {
-    phone?: boolean;
-    phoneRegionCode?: string;
+    phone?: boolean | undefined;
+    phoneRegionCode?: string | undefined;
 }
 
 // Date Options
 export interface CleaveOptions {
-    date?: boolean;
-    dateMin?: string;
-    dateMax?: string;
-    datePattern?: ReadonlyArray<string>;
+    date?: boolean | undefined;
+    dateMin?: string | undefined;
+    dateMax?: string | undefined;
+    datePattern?: ReadonlyArray<string> | undefined;
 }
 
 // Time Options
 export interface CleaveOptions {
-    time?: boolean;
-    timePattern?: ReadonlyArray<string>;
-    timeFormat?: string;
+    time?: boolean | undefined;
+    timePattern?: ReadonlyArray<string> | undefined;
+    timeFormat?: string | undefined;
 }
 
 // Numeral Options
 export type NumeralThousandsGroupStyleType = "lakh" | "thousand" | "wan" | "none";
 
 export interface CleaveOptions {
-    numeral?: boolean;
-    numeralDecimalMark?: string;
-    numeralDecimalScale?: number;
-    numeralIntegerScale?: number;
-    numeralPositiveOnly?: boolean;
-    numeralThousandsGroupStyle?: NumeralThousandsGroupStyleType;
-    stripLeadingZeroes?: boolean;
+    numeral?: boolean | undefined;
+    numeralDecimalMark?: string | undefined;
+    numeralDecimalScale?: number | undefined;
+    numeralIntegerScale?: number | undefined;
+    numeralPositiveOnly?: boolean | undefined;
+    numeralThousandsGroupStyle?: NumeralThousandsGroupStyleType | undefined;
+    stripLeadingZeroes?: boolean | undefined;
 }
 
 // Extra Options
 export interface CleaveOptions {
-    blocks?: ReadonlyArray<number>;
-    copyDelimiter?: boolean;
-    delimiter?: string;
-    delimiters?: ReadonlyArray<string>;
-    delimiterLazyShow?: boolean;
+    blocks?: ReadonlyArray<number> | undefined;
+    copyDelimiter?: boolean | undefined;
+    delimiter?: string | undefined;
+    delimiters?: ReadonlyArray<string> | undefined;
+    delimiterLazyShow?: boolean | undefined;
     initValue?: any;
-    lowercase?: boolean;
-    numericOnly?: boolean;
-    prefix?: string;
-    noImmediatePrefix?: boolean;
-    rawValueTrimPrefix?: boolean;
-    uppercase?: boolean;
+    lowercase?: boolean | undefined;
+    numericOnly?: boolean | undefined;
+    prefix?: string | undefined;
+    noImmediatePrefix?: boolean | undefined;
+    rawValueTrimPrefix?: boolean | undefined;
+    uppercase?: boolean | undefined;
     onValueChanged?(event: any): void;
 }

--- a/types/cleave.js/react/props.d.ts
+++ b/types/cleave.js/react/props.d.ts
@@ -10,8 +10,8 @@ export interface ChangeEvent<T> extends React.ChangeEvent<T> {
 export type ChangeEventHandler<T = Element> = React.EventHandler<ChangeEvent<T>>;
 
 export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
-    onInit?: InitHandler;
+    onInit?: InitHandler | undefined;
     options: CleaveOptions;
-    htmlRef?: (i: any) => void;
-    onChange?: ChangeEventHandler<HTMLInputElement>;
+    htmlRef?: ((i: any) => void) | undefined;
+    onChange?: ChangeEventHandler<HTMLInputElement> | undefined;
 }

--- a/types/cli-color/columns.d.ts
+++ b/types/cli-color/columns.d.ts
@@ -3,18 +3,18 @@ declare namespace columns {
         /**
          * align: Possible options: `'left'`, `'right'` (defaults to `'left'`)
          */
-        align?: 'left' | 'right';
+        align?: 'left' | 'right' | undefined;
     }
 
     export interface ColumnsOptions {
         /**
          *  Custom colums separator (defaults to `|`)
          */
-        sep?: string;
+        sep?: string | undefined;
         /**
          * columns: Per column customizations, as e.g. `[{ align: 'right' }, null, { align: 'left' }]`
          */
-        columns?: Array<ColumnOptions | null>;
+        columns?: Array<ColumnOptions | null> | undefined;
     }
 
     export type Row = Iterable<any> | ArrayLike<any>;

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -35,86 +35,86 @@ export interface Options {
      *    is rendered as
      *      progress [========================================] 100% | ETA: 0s | 200/200
      */
-    format?: string | GenericFormatter;
+    format?: string | GenericFormatter | undefined;
 
     /** a custom bar formatter function which renders the bar-element (default: format-bar.js) */
-    formatBar?: BarFormatter;
+    formatBar?: BarFormatter | undefined;
 
     /** a custom timer formatter function which renders the formatted time elements like eta_formatted and duration-formatted (default: format-time.js) */
-    formatTime?: TimeFormatter;
+    formatTime?: TimeFormatter | undefined;
 
     /** a custom value formatter function which renders all other values (default: format-value.js) */
-    formatValue?: ValueFormatter;
+    formatValue?: ValueFormatter | undefined;
 
     /** the maximum update rate (default: 10) */
-    fps?: number;
+    fps?: number | undefined;
 
     /** output stream to use (default: process.stderr) */
-    stream?: NodeJS.WritableStream;
+    stream?: NodeJS.WritableStream | undefined;
 
     /**  automatically call stop() when the value reaches the total (default: false) */
-    stopOnComplete?: boolean;
+    stopOnComplete?: boolean | undefined;
 
     /** clear the progress bar on complete / stop() call (default: false) */
-    clearOnComplete?: boolean;
+    clearOnComplete?: boolean | undefined;
 
     /** the length of the progress bar in chars (default: 40) */
-    barsize?: number;
+    barsize?: number | undefined;
 
     /**  position of the progress bar - 'left' (default), 'right' or 'center  */
-    align?: 'left' | 'right' | 'center';
+    align?: 'left' | 'right' | 'center' | undefined;
 
     /** character to use as "complete" indicator in the bar (default: "=") */
-    barCompleteString?: string;
+    barCompleteString?: string | undefined;
 
     /** character to use as "incomplete" indicator in the bar (default: "-") */
-    barIncompleteString?: string;
+    barIncompleteString?: string | undefined;
 
     /** character to use as "complete" indicator in the bar (default: "=") */
-    barCompleteChar?: string;
+    barCompleteChar?: string | undefined;
 
     /** character to use as "incomplete" indicator in the bar (default: "-") */
-    barIncompleteChar?: string;
+    barIncompleteChar?: string | undefined;
 
     /**
      * hide the cursor during progress operation; restored on complete (default: false)
      * - pass `null` to keep terminal settings
      */
-    hideCursor?: boolean | null;
+    hideCursor?: boolean | null | undefined;
 
     /** number of updates with which to calculate the eta; higher numbers give a more stable eta (default: 10) */
-    etaBuffer?: number;
+    etaBuffer?: number | undefined;
 
     /**
      *  trigger an eta calculation update during asynchronous rendering trigger using the current value
      * - should only be used for long running processes in conjunction with lof `fps` values and large `etaBuffer`
      * @default false
      */
-    etaAsynchronousUpdate?: boolean;
+    etaAsynchronousUpdate?: boolean | undefined;
 
     /** disable line wrapping (default: false) - pass null to keep terminal settings; pass true to trim the output to terminal width */
-    linewrap?: boolean | null;
+    linewrap?: boolean | null | undefined;
 
     /** trigger redraw during update() in case threshold time x2 is exceeded (default: true) - limited to single bar usage */
-    synchronousUpdate?: boolean;
+    synchronousUpdate?: boolean | undefined;
 
     /** enable scheduled output to notty streams - e.g. redirect to files (default: false) */
-    noTTYOutput?: boolean;
+    noTTYOutput?: boolean | undefined;
 
     /** set the output schedule/interval for notty output in ms (default: 2000ms) */
-    notTTYSchedule?: number;
+    notTTYSchedule?: number | undefined;
 
     /** display progress bars with 'total' of zero(0) as empty, not full (default: false) */
-    emptyOnZero?: boolean;
+    emptyOnZero?: boolean | undefined;
 
     /** trigger redraw on every frame even if progress remains the same; can be useful if progress bar gets overwritten by other concurrent writes to the terminal (default: false) */
-    forceRedraw?: boolean;
+    forceRedraw?: boolean | undefined;
 
     /** add padding chars to formatted time and percentage to force fixed width (default: false) */
-    autopadding?: boolean;
+    autopadding?: boolean | undefined;
 
     /** the character sequence used for autopadding (default: " ") */
-    autopaddingChar?: string;
+    autopaddingChar?: string | undefined;
 }
 
 export interface Preset {

--- a/types/clone/index.d.ts
+++ b/types/clone/index.d.ts
@@ -28,10 +28,10 @@ declare function clone<T>(val: T, circular?: boolean, depth?: number, prototype?
 declare function clone<T>(val: T, opts: CloneOpts): T;
 
 interface CloneOpts {
-    circular?: boolean,
-    depth?: number,
+    circular?: boolean | undefined,
+    depth?: number | undefined,
     prototype?: any,
-    includeNonEnumerable?: boolean
+    includeNonEnumerable?: boolean | undefined
 }
 
 declare namespace clone {

--- a/types/co-body/index.d.ts
+++ b/types/co-body/index.d.ts
@@ -21,15 +21,15 @@ declare namespace CoBody {
     }
 
     export interface Options {
-        limit?: number | string;
-        strict?: boolean;
-        queryString?: qs.IParseOptions;
-        jsonTypes?: string[];
-        returnRawBody?: boolean;
-        formTypes?: string[];
-        textTypes?: string[];
-        encoding?: string;
-        length?: number;
+        limit?: number | string | undefined;
+        strict?: boolean | undefined;
+        queryString?: qs.IParseOptions | undefined;
+        jsonTypes?: string[] | undefined;
+        returnRawBody?: boolean | undefined;
+        formTypes?: string[] | undefined;
+        textTypes?: string[] | undefined;
+        encoding?: string | undefined;
+        length?: number | undefined;
     }
 }
 

--- a/types/codemirror/addon/comment/comment.d.ts
+++ b/types/codemirror/addon/comment/comment.d.ts
@@ -14,21 +14,21 @@ declare module '../../' {
 
     interface CommentOptions {
         /** Override the [comment string properties](https://codemirror.net/doc/manual.html#mode_comment) of the mode with custom comment strings. */
-        blockCommentStart?: string;
+        blockCommentStart?: string | undefined;
         /** Override the [comment string properties](https://codemirror.net/doc/manual.html#mode_comment) of the mode with custom comment strings. */
-        blockCommentEnd?: string;
+        blockCommentEnd?: string | undefined;
         /** Override the [comment string properties](https://codemirror.net/doc/manual.html#mode_comment) of the mode with custom comment strings. */
-        blockCommentLead?: string;
+        blockCommentLead?: string | undefined;
         /** Override the [comment string properties](https://codemirror.net/doc/manual.html#mode_comment) of the mode with custom comment strings. */
-        lineComment?: string;
+        lineComment?: string | undefined;
         /** A string that will be inserted after opening and leading markers, and before closing comment markers. Defaults to a single space. */
-        padding?: string | null;
+        padding?: string | null | undefined;
         /** Whether, when adding line comments, to also comment lines that contain only whitespace. */
-        commentBlankLines?: boolean;
+        commentBlankLines?: boolean | undefined;
         /** When adding line comments and this is turned on, it will align the comment block to the current indentation of the first line of the block. */
-        indent?: boolean;
+        indent?: boolean | undefined;
         /** When block commenting, this controls whether the whole lines are indented, or only the precise range that is given. Defaults to `true`. */
-        fullLines?: boolean;
+        fullLines?: boolean | undefined;
     }
 
     interface CommandActions {

--- a/types/codemirror/addon/comment/continuecomment.d.ts
+++ b/types/codemirror/addon/comment/continuecomment.d.ts
@@ -7,6 +7,6 @@ declare module '../../' {
          * pressing the Enter key. If set to a string, it will continue comments
          * using a custom shortcut.
          */
-        continueComments?: boolean | string | { key: string, continueLineComment?: boolean };
+        continueComments?: boolean | string | { key: string, continueLineComment?: boolean | undefined } | undefined;
     }
 }

--- a/types/codemirror/addon/dialog/dialog.d.ts
+++ b/types/codemirror/addon/dialog/dialog.d.ts
@@ -3,14 +3,14 @@ import '../../';
 export type DialogCloseFunction = () => void;
 
 export interface DialogOptions {
-    bottom?: boolean;
+    bottom?: boolean | undefined;
 }
 
 export interface OpenDialogOptions extends DialogOptions {
     /** If true, the dialog will be closed when the user presses enter in the input. Defaults to true. */
-    closeOnEnter?: boolean;
+    closeOnEnter?: boolean | undefined;
     /** Determines whether the dialog is closed when it loses focus. Defaults to true. */
-    closeOnBlur?: boolean;
+    closeOnBlur?: boolean | undefined;
     /** An event handler that will be called whenever keydown fires in the dialog's input. If the callback returns true, the dialog will not do any further processing of the event. */
     onKeyDown?(event: KeyboardEvent, value: string, close: DialogCloseFunction): boolean | undefined;
     /** An event handler that will be called whenever keyup fires in the dialog's input. If the callback returns true, the dialog will not do any further processing of the event. */
@@ -22,7 +22,7 @@ export interface OpenDialogOptions extends DialogOptions {
 }
 
 export interface OpenNotificationOptions extends DialogOptions {
-    duration?: number;
+    duration?: number | undefined;
 }
 
 declare module '../../' {

--- a/types/codemirror/addon/display/autorefresh.d.ts
+++ b/types/codemirror/addon/display/autorefresh.d.ts
@@ -4,6 +4,6 @@ declare module '../../' {
     interface EditorConfiguration {
         // if true, it will be refreshed the first time the editor becomes visible.
         // you can pass delay (msec) time as polling duration
-        autoRefresh?: boolean | { delay: number };
+        autoRefresh?: boolean | { delay: number } | undefined;
     }
 }

--- a/types/codemirror/addon/display/fullscreen.d.ts
+++ b/types/codemirror/addon/display/fullscreen.d.ts
@@ -8,6 +8,6 @@ declare module '../../' {
          * @see {@link https://codemirror.net/doc/manual.html#addon_fullscreen}
          * @default false
          */
-        fullScreen?: boolean;
+        fullScreen?: boolean | undefined;
     }
 }

--- a/types/codemirror/addon/display/panel.d.ts
+++ b/types/codemirror/addon/display/panel.d.ts
@@ -16,17 +16,17 @@ declare module '../../' {
          * `bottom`: Adds the panel at the very bottom.
          * `before-bottom`: Adds the panel at the top of the bottom panels.
          */
-        position?: 'top' | 'after-top' | 'bottom' | 'before-bottom';
+        position?: 'top' | 'after-top' | 'bottom' | 'before-bottom' | undefined;
         /** The new panel will be added before the given panel. */
-        before?: Panel;
+        before?: Panel | undefined;
         /** The new panel will be added after the given panel. */
-        after?: Panel;
+        after?: Panel | undefined;
         /** The new panel will replace the given panel. */
-        replace?: Panel;
+        replace?: Panel | undefined;
         /** Whether to scroll the editor to keep the text's vertical position stable, when adding a panel above it. Defaults to false. */
-        stable?: boolean;
+        stable?: boolean | undefined;
         /** The initial height of the panel. Defaults to the offsetHeight of the node. */
-        height?: number;
+        height?: number | undefined;
     }
 
     interface Editor {

--- a/types/codemirror/addon/display/placeholder.d.ts
+++ b/types/codemirror/addon/display/placeholder.d.ts
@@ -6,6 +6,6 @@ declare module '../../' {
          * Adds a placeholder option that can be used to make content appear in the editor when it is empty and not focused.
          * It can hold either a string or a DOM node. Also gives the editor a CodeMirror-empty CSS class whenever it doesn't contain any text.
          */
-        placeholder?: string | Node;
+        placeholder?: string | Node | undefined;
     }
 }

--- a/types/codemirror/addon/display/rulers.d.ts
+++ b/types/codemirror/addon/display/rulers.d.ts
@@ -2,15 +2,15 @@ import '../../';
 
 export interface Ruler {
     column: number;
-    className?: string;
-    color?: string;
-    lineStyle?: string;
-    width?: string;
+    className?: string | undefined;
+    color?: string | undefined;
+    lineStyle?: string | undefined;
+    width?: string | undefined;
 }
 
 declare module '../../' {
     interface EditorConfiguration {
         /** show one or more vertical rulers in the editor. */
-         rulers?: false | ReadonlyArray<number | Ruler>;
+         rulers?: false | ReadonlyArray<number | Ruler> | undefined;
     }
 }

--- a/types/codemirror/addon/edit/closebrackets.d.ts
+++ b/types/codemirror/addon/edit/closebrackets.d.ts
@@ -5,28 +5,28 @@ declare module '../../' {
         /**
          * String containing pairs of matching characters.
          */
-        pairs?: string;
+        pairs?: string | undefined;
 
         /**
          * If the next character is in the string, opening a bracket should be auto-closed.
          */
-        closeBefore?: string;
+        closeBefore?: string | undefined;
 
         /**
          * String containing chars that could do a triple quote.
          */
-        triples?: string;
+        triples?: string | undefined;
 
         /**
          * explode should be a similar string that gives the pairs of characters that, when enter is pressed between them, should have the second character also moved to its own line.
          */
-        explode?: string;
+        explode?: string | undefined;
 
         /**
          * By default, if the active mode has a closeBrackets property, that overrides the configuration given in the option.
          * But you can add an override property with a truthy value to override mode-specific configuration.
          */
-        override?: boolean;
+        override?: boolean | undefined;
     }
 
     interface EditorConfiguration {
@@ -35,6 +35,6 @@ declare module '../../' {
          * By default, it'll auto-close ()[]{}''"", but you can pass it a string similar to that (containing pairs of matching characters),
          * or an object with pairs and optionally explode properties to customize it.
          */
-        autoCloseBrackets?: AutoCloseBrackets | boolean | string;
+        autoCloseBrackets?: AutoCloseBrackets | boolean | string | undefined;
     }
 }

--- a/types/codemirror/addon/edit/closetag.d.ts
+++ b/types/codemirror/addon/edit/closetag.d.ts
@@ -9,24 +9,24 @@ declare module '../../' {
         /**
          * Whether to autoclose when the '/' of a closing tag is typed. (default true)
          */
-        whenClosing?: boolean;
+        whenClosing?: boolean | undefined;
 
         /**
          * Whether to autoclose the tag when the final '>' of an opening tag is typed. (default true)
          */
-        whenOpening?: boolean;
+        whenOpening?: boolean | undefined;
 
         /**
          * An array of tag names that should not be autoclosed. (default is empty tags for HTML, none for XML)
          */
-        dontCloseTags?: ReadonlyArray<string>;
+        dontCloseTags?: ReadonlyArray<string> | undefined;
 
         /**
          * An array of tag names that should, when opened, cause a
          * blank line to be added inside the tag, and the blank line and
          * closing line to be indented. (default is block tags for HTML, none for XML)
          */
-        indentTags?: ReadonlyArray<string>;
+        indentTags?: ReadonlyArray<string> | undefined;
 
         /**
          * An array of XML tag names that should be autoclosed with '/>'. (default is none)
@@ -39,6 +39,6 @@ declare module '../../' {
          * Will auto-close XML tags when '>' or '/' is typed.
          * Depends on the fold/xml-fold.js addon.
          */
-        autoCloseTags?: AutoCloseTags | boolean;
+        autoCloseTags?: AutoCloseTags | boolean | undefined;
     }
 }

--- a/types/codemirror/addon/edit/matchbrackets.d.ts
+++ b/types/codemirror/addon/edit/matchbrackets.d.ts
@@ -5,31 +5,31 @@ declare module '../../' {
         /**
          * Only use the character after the start position, never the one before it.
          */
-        afterCursor?: boolean;
+        afterCursor?: boolean | undefined;
 
         /**
          * Causes only matches where both brackets are at the same side of the start position to be considered.
          */
-        strict?: boolean;
+        strict?: boolean | undefined;
 
         /**
          * Stop after scanning this amount of lines without a successful match. Defaults to 1000.
          */
-        maxScanLines?: number;
+        maxScanLines?: number | undefined;
 
         /**
          * Ignore lines longer than this. Defaults to 10000.
          */
-        maxScanLineLength?: number;
+        maxScanLineLength?: number | undefined;
 
         /**
          * Don't highlight a bracket in a line longer than this. Defaults to 1000.
          */
-        maxHighlightLineLength?: number;
+        maxHighlightLineLength?: number | undefined;
     }
 
     interface EditorConfiguration {
         //  When set to true or an options object, causes matching brackets to be highlighted whenever the cursor is next to them.
-        matchBrackets?: MatchBrackets | boolean;
+        matchBrackets?: MatchBrackets | boolean | undefined;
     }
 }

--- a/types/codemirror/addon/edit/matchtags.d.ts
+++ b/types/codemirror/addon/edit/matchtags.d.ts
@@ -12,7 +12,7 @@ declare module '../../' {
         /**
          * Highlight both matching tags.
          */
-        bothTags?: boolean;
+        bothTags?: boolean | undefined;
     }
 
     interface EditorConfiguration {
@@ -20,6 +20,6 @@ declare module '../../' {
          * When enabled will cause the tags around the cursor to be highlighted (using the CodeMirror-matchingtag class).
          * Depends on the addon/fold/xml-fold.js addon.
          */
-        matchTags?: MatchTags | boolean;
+        matchTags?: MatchTags | boolean | undefined;
     }
 }

--- a/types/codemirror/addon/edit/trailingspace.d.ts
+++ b/types/codemirror/addon/edit/trailingspace.d.ts
@@ -3,6 +3,6 @@ import '../../';
 declare module '../../' {
     interface EditorConfiguration {
         /** when enabled, adds the CSS class cm-trailingspace to stretches of whitespace at the end of lines. */
-         showTrailingSpace?: boolean;
+         showTrailingSpace?: boolean | undefined;
     }
 }

--- a/types/codemirror/addon/fold/foldcode.d.ts
+++ b/types/codemirror/addon/fold/foldcode.d.ts
@@ -27,7 +27,7 @@ declare module '../../' {
     }
 
     interface EditorConfiguration {
-        foldOptions?: FoldOptions;
+        foldOptions?: FoldOptions | undefined;
     }
 
     interface FoldOptions {
@@ -38,26 +38,26 @@ declare module '../../' {
          * CodeMirror.fold.indent, for languages where indentation determines block structure (Python, Haskell), and CodeMirror.fold.xml, for XML-style languages,
          * and CodeMirror.fold.comment, for folding comment blocks.
          */
-        rangeFinder?: FoldRangeFinder;
+        rangeFinder?: FoldRangeFinder | undefined;
 
         /**
          * The widget to show for folded ranges. Can be either a string, in which case it'll become a span with class CodeMirror-foldmarker, or a DOM node.
          * To dynamically generate the widget, this can be a function that returns a string or DOM node, which will then render as described.
          * The function will be invoked with parameters identifying the range to be folded.
          */
-        widget?: string | Element | ((from: Position, to: Position) => string | Element);
+        widget?: string | Element | ((from: Position, to: Position) => string | Element) | undefined;
 
         /**
          * When true (default is false), the addon will try to find foldable ranges on the lines above the current one if there isn't an eligible one on the given line.
          */
-        scanUp?: boolean;
+        scanUp?: boolean | undefined;
 
         /**
          * The minimum amount of lines that a fold should span to be accepted. Defaults to 0, which also allows single-line folds.
          */
-        minFoldSize?: number;
+        minFoldSize?: number | undefined;
 
-        clearOnEnter?: boolean;
+        clearOnEnter?: boolean | undefined;
     }
 
     interface FoldRange {

--- a/types/codemirror/addon/fold/foldgutter.d.ts
+++ b/types/codemirror/addon/fold/foldgutter.d.ts
@@ -7,23 +7,23 @@ declare module '../../' {
         /**
          * Provides an option foldGutter, which can be used to create a gutter with markers indicating the blocks that can be folded.
          */
-        foldGutter?: boolean | FoldGutterOptions;
+        foldGutter?: boolean | FoldGutterOptions | undefined;
     }
 
     interface FoldGutterOptions {
         /**
          * The CSS class of the gutter. Defaults to "CodeMirror-foldgutter". You will have to style this yourself to give it a width (and possibly a background).
          */
-        gutter?: string;
+        gutter?: string | undefined;
 
         /**
          * A CSS class or DOM element to be used as the marker for open, foldable blocks. Defaults to "CodeMirror-foldgutter-open".
          */
-        indicatorOpen?: string | Element;
+        indicatorOpen?: string | Element | undefined;
 
         /**
          * A CSS class or DOM element to be used as the marker for folded blocks. Defaults to "CodeMirror-foldgutter-folded".
          */
-        indicatorFolded?: string | Element;
+        indicatorFolded?: string | Element | undefined;
     }
 }

--- a/types/codemirror/addon/hint/anyword-hint.d.ts
+++ b/types/codemirror/addon/hint/anyword-hint.d.ts
@@ -6,7 +6,7 @@ declare module '../../' {
     }
 
     interface ShowHintOptions {
-        word?: RegExp;
-        range?: number;
+        word?: RegExp | undefined;
+        range?: number | undefined;
     }
 }

--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -34,13 +34,13 @@ declare module '../../' {
      */
     interface Hint {
         text: string;
-        className?: string;
-        displayText?: string;
-        from?: Position;
+        className?: string | undefined;
+        displayText?: string | undefined;
+        from?: Position | undefined;
         /** Called if a completion is picked. If provided *you* are responsible for applying the completion */
-        hint?: (cm: Editor, data: Hints, cur: Hint) => void;
-        render?: (element: HTMLLIElement, data: Hints, cur: Hint) => void;
-        to?: Position;
+        hint?: ((cm: Editor, data: Hints, cur: Hint) => void) | undefined;
+        render?: ((element: HTMLLIElement, data: Hints, cur: Hint) => void) | undefined;
+        to?: Position | undefined;
     }
 
     interface EditorEventMap {
@@ -72,20 +72,20 @@ declare module '../../' {
     }
 
     interface ShowHintOptions {
-        completeSingle?: boolean;
-        hint?: HintFunction | AsyncHintFunction | HintFunctionResolver;
-        alignWithWord?: boolean;
-        closeCharacters?: RegExp;
-        closeOnPick?: boolean;
-        closeOnUnfocus?: boolean;
-        updateOnCursorActivity?: boolean;
-        completeOnSingleClick?: boolean;
-        container?: HTMLElement | null;
-        customKeys?: { [key: string]: ((editor: Editor, handle: CompletionHandle) => void) | string } | null;
-        extraKeys?: { [key: string]: ((editor: Editor, handle: CompletionHandle) => void) | string } | null;
-        paddingForScrollbar?: boolean;
-        moveOnOverlap?: boolean;
-        words?: ReadonlyArray<string>; // used by fromList
+        completeSingle?: boolean | undefined;
+        hint?: HintFunction | AsyncHintFunction | HintFunctionResolver | undefined;
+        alignWithWord?: boolean | undefined;
+        closeCharacters?: RegExp | undefined;
+        closeOnPick?: boolean | undefined;
+        closeOnUnfocus?: boolean | undefined;
+        updateOnCursorActivity?: boolean | undefined;
+        completeOnSingleClick?: boolean | undefined;
+        container?: HTMLElement | null | undefined;
+        customKeys?: { [key: string]: ((editor: Editor, handle: CompletionHandle) => void) | string } | null | undefined;
+        extraKeys?: { [key: string]: ((editor: Editor, handle: CompletionHandle) => void) | string } | null | undefined;
+        paddingForScrollbar?: boolean | undefined;
+        moveOnOverlap?: boolean | undefined;
+        words?: ReadonlyArray<string> | undefined; // used by fromList
     }
 
     /** The Handle used to interact with the autocomplete dialog box. */
@@ -100,8 +100,8 @@ declare module '../../' {
     }
 
     interface EditorConfiguration {
-        showHint?: boolean;
-        hintOptions?: ShowHintOptions;
+        showHint?: boolean | undefined;
+        hintOptions?: ShowHintOptions | undefined;
     }
 
     interface HintHelpers {

--- a/types/codemirror/addon/hint/sql-hint.d.ts
+++ b/types/codemirror/addon/hint/sql-hint.d.ts
@@ -10,8 +10,8 @@ declare module '../../' {
     }
 
     interface ShowHintOptions {
-        tables?: ReadonlyArray<string | { text: string, columns: string[] }> | Record<string, string[] | { columns: string[] }>;
-        defaultTable?: string;
-        disableKeywords?: boolean;
+        tables?: ReadonlyArray<string | { text: string, columns: string[] }> | Record<string, string[] | { columns: string[] }> | undefined;
+        defaultTable?: string | undefined;
+        disableKeywords?: boolean | undefined;
     }
 }

--- a/types/codemirror/addon/hint/xml-hint.d.ts
+++ b/types/codemirror/addon/hint/xml-hint.d.ts
@@ -7,7 +7,7 @@ declare module '../../' {
 
     interface ShowHintOptions {
         schemaInfo?: any;
-        quoteChar?: string;
-        matchInMiddle?: boolean;
+        quoteChar?: string | undefined;
+        matchInMiddle?: boolean | undefined;
     }
 }

--- a/types/codemirror/addon/lint/lint.d.ts
+++ b/types/codemirror/addon/lint/lint.d.ts
@@ -2,15 +2,15 @@ import * as CodeMirror from '../../';
 
 export interface BaseLintStateOptions<T> {
     /** debounce delay before linting onChange */
-    delay?: number;
+    delay?: number | undefined;
 
     /** callback to modify an annotation before display */
-    formatAnnotation?: (annotation: Annotation) => Annotation;
+    formatAnnotation?: ((annotation: Annotation) => Annotation) | undefined;
 
     /** whether to lint onChange event */
-    lintOnChange?: boolean;
+    lintOnChange?: boolean | undefined;
 
-    selfContain?: boolean;
+    selfContain?: boolean | undefined;
 
     /** callback after linter completes */
     onUpdateLinting?(annotationsNotSorted: Annotation[], annotations: Annotation[], codeMirror: CodeMirror.Editor): void;
@@ -19,21 +19,21 @@ export interface BaseLintStateOptions<T> {
      * Passing rules in `options` property prevents JSHint (and other linters) from complaining
      * about unrecognized rules like `onUpdateLinting`, `delay`, `lintOnChange`, etc.
      */
-    options?: T;
+    options?: T | undefined;
 
     /** controls display of lint tooltips */
-    tooltips?: boolean | 'gutter';
+    tooltips?: boolean | 'gutter' | undefined;
 }
 
 export interface SyncLintStateOptions<T> extends BaseLintStateOptions<T> {
-    async?: false;
-    getAnnotations?: Linter<T>;
+    async?: false | undefined;
+    getAnnotations?: Linter<T> | undefined;
 }
 
 export interface AsyncLintStateOptions<T> extends BaseLintStateOptions<T> {
     /** specifies that the lint process runs asynchronously */
     async: true;
-    getAnnotations?: AsyncLinter<T>;
+    getAnnotations?: AsyncLinter<T> | undefined;
 }
 
 export type LintStateOptions<T> = SyncLintStateOptions<T> | AsyncLintStateOptions<T>;
@@ -73,9 +73,9 @@ export interface UpdateLintingCallback {
  */
 export interface Annotation {
     from: CodeMirror.Position;
-    message?: string;
-    severity?: string;
-    to?: CodeMirror.Position;
+    message?: string | undefined;
+    severity?: string | undefined;
+    to?: CodeMirror.Position | undefined;
 }
 
 declare module '../../' {
@@ -85,7 +85,7 @@ declare module '../../' {
 
     interface EditorConfiguration {
         /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. */
-        lint?: boolean | LintStateOptions<any> | Linter<any>;
+        lint?: boolean | LintStateOptions<any> | Linter<any> | undefined;
     }
 
     namespace lint {}

--- a/types/codemirror/addon/merge/merge.d.ts
+++ b/types/codemirror/addon/merge/merge.d.ts
@@ -31,14 +31,14 @@ export interface MergeView {
     /**
      * Left side of the merge view.
      */
-    left?: DiffView;
+    left?: DiffView | undefined;
     leftChunks(): MergeViewDiffChunk[] | undefined;
     leftOriginal(): CodeMirror.Editor | undefined;
 
     /**
      * Right side of the merge view.
      */
-    right?: DiffView;
+    right?: DiffView | undefined;
     rightChunks(): MergeViewDiffChunk[] | undefined;
     rightOriginal(): CodeMirror.Editor | undefined;
 
@@ -60,19 +60,19 @@ export interface MergeViewConfiguration extends CodeMirror.EditorConfiguration {
     /**
      * Determines whether the original editor allows editing. Defaults to false.
      */
-    allowEditingOriginals?: boolean;
+    allowEditingOriginals?: boolean | undefined;
 
     /**
      * When true stretches of unchanged text will be collapsed. When a number is given, this indicates the amount
      * of lines to leave visible around such stretches (which defaults to 2). Defaults to false.
      */
-    collapseIdentical?: boolean | number;
+    collapseIdentical?: boolean | number | undefined;
 
     /**
      * Sets the style used to connect changed chunks of code. By default, connectors are drawn. When this is set to "align",
      * the smaller chunk is padded to align with the bigger chunk instead.
      */
-    connect?: string;
+    connect?: string | undefined;
 
     /**
      * Callback for when stretches of unchanged text are collapsed.
@@ -82,26 +82,26 @@ export interface MergeViewConfiguration extends CodeMirror.EditorConfiguration {
     /**
      * Provides original version of the document to be shown on the right of the editor.
      */
-    orig?: string;
+    orig?: string | undefined;
 
     /**
      * Provides original version of the document to be shown on the left of the editor.
      * To create a 2-way (as opposed to 3-way) merge view, provide only one of origLeft and origRight.
      */
-    origLeft?: string;
+    origLeft?: string | undefined;
 
     /**
      * Provides original version of document to be shown on the right of the editor.
      * To create a 2-way (as opposed to 3-way) merge view, provide only one of origLeft and origRight.
      */
-    origRight?: string;
+    origRight?: string | undefined;
 
     /**
      * Determines whether buttons that allow the user to revert changes are shown. Defaults to true.
      */
-    revertButtons?: boolean;
+    revertButtons?: boolean | undefined;
 
-    revertChunk?: (
+    revertChunk?: ((
         mv: MergeView,
         from: CodeMirror.Editor,
         fromStart: CodeMirror.Position,
@@ -109,12 +109,12 @@ export interface MergeViewConfiguration extends CodeMirror.EditorConfiguration {
         to: CodeMirror.Editor,
         toStart: CodeMirror.Position,
         toEnd: CodeMirror.Position
-    ) => void;
+    ) => void) | undefined;
 
     /**
      * When true, changed pieces of text are highlighted. Defaults to true.
      */
-    showDifferences?: boolean;
+    showDifferences?: boolean | undefined;
 }
 
 declare module '../../' {

--- a/types/codemirror/addon/mode/multiplex.d.ts
+++ b/types/codemirror/addon/mode/multiplex.d.ts
@@ -4,9 +4,9 @@ export interface MultiplexedInnerMode {
     open: string;
     close: string;
     mode: CodeMirror.Mode<any>;
-    parseDelimiters?: boolean;
-    delimStyle?: string;
-    innerStyle?: string;
+    parseDelimiters?: boolean | undefined;
+    delimStyle?: string | undefined;
+    innerStyle?: string | undefined;
 }
 
 declare module '../../' {

--- a/types/codemirror/addon/mode/simple.d.ts
+++ b/types/codemirror/addon/mode/simple.d.ts
@@ -3,20 +3,20 @@ import '../../';
 declare module '../../' {
     // Based on https://codemirror.net/demo/simplemode.html
     interface Rule {
-        regex?: string | RegExp;
-        token?: string | string[] | null;
-        sol?: boolean;
-        next?: string;
-        push?: string;
-        pop?: boolean;
+        regex?: string | RegExp | undefined;
+        token?: string | string[] | null | undefined;
+        sol?: boolean | undefined;
+        next?: string | undefined;
+        push?: string | undefined;
+        pop?: boolean | undefined;
         mode?: {
             spec: string | ModeSpec<any>;
-            end?: RegExp;
-            persistent?: boolean;
-        };
-        indent?: boolean;
-        dedent?: boolean;
-        dedentIfLineStart?: boolean;
+            end?: RegExp | undefined;
+            persistent?: boolean | undefined;
+        } | undefined;
+        indent?: boolean | undefined;
+        dedent?: boolean | undefined;
+        dedentIfLineStart?: boolean | undefined;
     }
 
     function defineSimpleMode<K extends string>(

--- a/types/codemirror/addon/runmode/runmode.d.ts
+++ b/types/codemirror/addon/runmode/runmode.d.ts
@@ -18,6 +18,6 @@ declare module '../../' {
         callback:
             | HTMLElement
             | ((text: string, style?: string | null, row?: number, column?: number, state?: any) => void),
-        options?: { tabSize?: number; state?: any },
+        options?: { tabSize?: number | undefined; state?: any },
     ): void;
 }

--- a/types/codemirror/addon/scroll/annotatescrollbar.d.ts
+++ b/types/codemirror/addon/scroll/annotatescrollbar.d.ts
@@ -11,8 +11,8 @@ export interface Annotation {
 
 export interface AnnotateScrollbarOptions {
     className: string;
-    scrollButtonHeight?: number;
-    listenForChanges?: boolean;
+    scrollButtonHeight?: number | undefined;
+    listenForChanges?: boolean | undefined;
 }
 
 declare module '../../' {
@@ -21,6 +21,6 @@ declare module '../../' {
     }
 
     interface EditorConfiguration {
-        scrollButtonHeight?: number;
+        scrollButtonHeight?: number | undefined;
     }
 }

--- a/types/codemirror/addon/scroll/scrollpastend.d.ts
+++ b/types/codemirror/addon/scroll/scrollpastend.d.ts
@@ -5,6 +5,6 @@ declare module '../../' {
         /**
          * When the end of the file is reached it allows you to keep scrolling so that your last few lines of code are not stuck at the bottom of the editor.
          */
-        scrollPastEnd?: boolean;
+        scrollPastEnd?: boolean | undefined;
     }
 }

--- a/types/codemirror/addon/search/jump-to-line.d.ts
+++ b/types/codemirror/addon/search/jump-to-line.d.ts
@@ -9,6 +9,6 @@ declare module '../../' {
     interface EditorConfiguration {
         search?: {
             bottom: boolean;
-        };
+        } | undefined;
     }
 }

--- a/types/codemirror/addon/search/match-highlighter.d.ts
+++ b/types/codemirror/addon/search/match-highlighter.d.ts
@@ -7,37 +7,37 @@ declare module '../../' {
         /**
          * Minimum amount of selected characters that triggers a highlight (default 2).
          */
-        minChars?: number;
+        minChars?: number | undefined;
 
         /**
          * The style to be used to highlight the matches (default "matchhighlight", which will correspond to CSS class cm-matchhighlight).
          */
-        style?: string;
+        style?: string | undefined;
 
         /**
          * Controls whether whitespace is trimmed from the selection.
          */
-        trim?: boolean;
+        trim?: boolean | undefined;
 
         /**
          * Can be set to true or to a regexp matching the characters that make up a word.
          */
-        showToken?: boolean | RegExp;
+        showToken?: boolean | RegExp | undefined;
 
         /**
          * Used to specify how much time to wait, in milliseconds, before highlighting the matches (default is 100).
          */
-        delay?: number;
+        delay?: number | undefined;
 
         /**
          * If wordsOnly is enabled, the matches will be highlighted only if the selected text is a word.
          */
-        wordsOnly?: boolean;
+        wordsOnly?: boolean | undefined;
 
         /**
          * If annotateScrollbar is enabled, the occurences will be highlighted on the scrollbar via the matchesonscrollbar addon.
          */
-        annotateScrollbar?: boolean;
+        annotateScrollbar?: boolean | undefined;
     }
 
     interface EditorConfiguration {
@@ -45,6 +45,6 @@ declare module '../../' {
          * Adds a highlightSelectionMatches option that can be enabled to highlight all instances of a currently selected word.
          * When enabled, it causes the current word to be highlighted when nothing is selected (defaults to off).
          */
-        highlightSelectionMatches?: HighlightSelectionMatches | boolean;
+        highlightSelectionMatches?: HighlightSelectionMatches | boolean | undefined;
     }
 }

--- a/types/codemirror/addon/search/search.d.ts
+++ b/types/codemirror/addon/search/search.d.ts
@@ -18,6 +18,6 @@ declare module '../../' {
     interface EditorConfiguration {
         search?: {
             bottom: boolean;
-        };
+        } | undefined;
     }
 }

--- a/types/codemirror/addon/selection/active-line.d.ts
+++ b/types/codemirror/addon/selection/active-line.d.ts
@@ -13,6 +13,6 @@ declare module '../../' {
          * When enabled gives the wrapper of the line that contains the cursor the class CodeMirror-activeline,
          * adds a background with the class CodeMirror-activeline-background, and adds the class CodeMirror-activeline-gutter to the line's gutter space is enabled.
          */
-        styleActiveLine?: StyleActiveLine | boolean;
+        styleActiveLine?: StyleActiveLine | boolean | undefined;
     }
 }

--- a/types/codemirror/addon/selection/mark-selection.d.ts
+++ b/types/codemirror/addon/selection/mark-selection.d.ts
@@ -6,6 +6,6 @@ declare module '../../' {
          * Causes the selected text to be marked with the CSS class CodeMirror-selectedtext or a custom class when the styleSelectedText option is enabled.
          * Useful to change the colour of the selection (in addition to the background).
          */
-         styleSelectedText?: boolean | string;
+         styleSelectedText?: boolean | string | undefined;
     }
 }

--- a/types/codemirror/addon/selection/selection-pointer.d.ts
+++ b/types/codemirror/addon/selection/selection-pointer.d.ts
@@ -6,6 +6,6 @@ declare module '../../' {
          * Controls the mouse cursor appearance when hovering over the selection. It can be set to a string, like "pointer", or to true,
          * in which case the "default" (arrow) cursor will be used.
          */
-         selectionPointer?: boolean | string;
+         selectionPointer?: boolean | string | undefined;
     }
 }

--- a/types/codemirror/addon/tern/tern.d.ts
+++ b/types/codemirror/addon/tern/tern.d.ts
@@ -51,9 +51,9 @@ declare module '../../' {
 
     interface TernOptions {
         /** An object mapping plugin names to configuration options. */
-        plugins?: Tern.ConstructorOptions['plugins'];
+        plugins?: Tern.ConstructorOptions['plugins'] | undefined;
         /** An array of JSON definition data structures. */
-        defs?: Tern.Def[];
+        defs?: Tern.Def[] | undefined;
         /**
          * Can be used to access files in
          * the project that haven't been loaded yet. Simply do callback(null) to
@@ -91,15 +91,15 @@ declare module '../../' {
          * want to feature detect the actual value you use here, for example
          * !!window.Worker.
          */
-        useWorker?: boolean;
+        useWorker?: boolean | undefined;
         /** The main script of the worker. Point this to wherever you are hosting worker.js from this directory. */
-        workerScript?: string;
+        workerScript?: string | undefined;
         /**
          * An array of paths pointing (relative to workerScript)
          * to the Acorn and Tern libraries and any Tern plugins you want to
          * load. Or, if you minified those into a single script and included
          * them in the workerScript, simply leave this undefined.
          */
-        workerDeps?: string[];
+        workerDeps?: string[] | undefined;
     }
 }

--- a/types/codemirror/addon/wrap/hardwrap.d.ts
+++ b/types/codemirror/addon/wrap/hardwrap.d.ts
@@ -1,12 +1,12 @@
 import '../../';
 
 export interface HardwrapOptions {
-    column?: number;
-    paragraphStart?: RegExp;
-    paragraphEnd?: RegExp;
-    wrapOn?: RegExp;
-    killTrailingSpace?: boolean;
-    forceBreak?: boolean;
+    column?: number | undefined;
+    paragraphStart?: RegExp | undefined;
+    paragraphEnd?: RegExp | undefined;
+    wrapOn?: RegExp | undefined;
+    killTrailingSpace?: boolean | undefined;
+    forceBreak?: boolean | undefined;
 }
 
 declare module '../../' {

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -234,7 +234,7 @@ declare namespace CodeMirror {
             amount: number,
             unit: string,
             visually: boolean,
-        ): { line: number; ch: number; hitSide?: boolean };
+        ): { line: number; ch: number; hitSide?: boolean | undefined };
 
         /**
          * Similar to findPosH , but used for vertical motion.unit may be "line" or "page".
@@ -244,7 +244,7 @@ declare namespace CodeMirror {
             start: Position,
             amount: number,
             unit: string,
-        ): { line: number; ch: number; hitSide?: boolean };
+        ): { line: number; ch: number; hitSide?: boolean | undefined };
 
         /** Returns the start and end of the 'word' (the stretch of letters, whitespace, or punctuation) at the given position. */
         findWordAt(pos: Position): Range;
@@ -277,7 +277,7 @@ declare namespace CodeMirror {
          * Currently, only the opaque option is recognized. This defaults to off, but can be given to allow the overlay styling, when not null,
          * to override the styling of the base mode entirely, instead of the two being applied together.
          */
-        addOverlay(mode: any, options?: {opaque?: boolean, priority?: number}): void;
+        addOverlay(mode: any, options?: {opaque?: boolean | undefined, priority?: number | undefined}): void;
 
         /** Pass this the exact argument passed for the mode parameter to addOverlay to remove an overlay again. */
         removeOverlay(mode: any): void;
@@ -309,7 +309,7 @@ declare namespace CodeMirror {
         setCursor(
             pos: Position | number,
             ch?: number,
-            options?: { bias?: number; origin?: string; scroll?: boolean },
+            options?: { bias?: number | undefined; origin?: string | undefined; scroll?: boolean | undefined },
         ): void;
 
         /**
@@ -579,124 +579,124 @@ declare namespace CodeMirror {
         /** Below options are supported in CSS mode */
 
         /** Whether to highlight non-standard CSS property keywords such as margin-inline or zoom (default: true). */
-        highlightNonStandardPropertyKeywords?: boolean;
+        highlightNonStandardPropertyKeywords?: boolean | undefined;
 
         /** Below options are supported in Cython/Python modes */
 
         /**  The version of Python to recognize. Default is 3. */
-        version?: 2 | 3;
+        version?: 2 | 3 | undefined;
         /**
          * If you have a single-line string that is not terminated at the end of the line, this will show subsequent
          * lines as errors if true, otherwise it will consider the newline as the end of the string. Default is false.
          */
-        singleLineStringErrors?: boolean;
+        singleLineStringErrors?: boolean | undefined;
         /**
          * If you want to write long arguments to a function starting on a new line, how much that line should be
          * indented. Defaults to one normal indentation unit.
          */
-        hangingIndent?: number;
+        hangingIndent?: number | undefined;
         /** Regular Expression for single operator matching */
-        singleOperators?: unknown;
+        singleOperators?: unknown | undefined;
         /**  Regular Expression for single delimiter matching default :^[\\(\\)\\[\\]\\{\\}@,:`=;\\.] */
-        singleDelimiters?: unknown;
+        singleDelimiters?: unknown | undefined;
         /** Regular Expression for double operators matching, default :^((==)|(!=)|(<=)|(>=)|(<>)|(<<)|(>>)|(//)|(\\*\\*)) */
-        doubleOperators?: unknown;
+        doubleOperators?: unknown | undefined;
         /** Regular Expression for double delimiters matching default :^((\\+=)|(\\-=)|(\\*=)|(%=)|(/=)|(&=)|(\\|=)|(\\^=)) */
-        doubleDelimiters?: unknown;
+        doubleDelimiters?: unknown | undefined;
         /** Regular Expression for triple delimiters matching default :^((//=)|(>>=)|(<<=)|(\\*\\*=)) */
-        tripleDelimiters?: unknown;
+        tripleDelimiters?: unknown | undefined;
         /** RegEx - Regular Expression for identifier, default :^[_A-Za-z][_A-Za-z0-9]* */
-        identifiers?: unknown;
+        identifiers?: unknown | undefined;
         /** List of extra words ton consider as keywords */
-        extra_keywords?: string[];
+        extra_keywords?: string[] | undefined;
         /** List of extra words ton consider as builtins */
-        extra_builtins?: string[];
+        extra_builtins?: string[] | undefined;
 
         /** useCPP, which determines whether C preprocessor directives are recognized. */
-        useCPP?: boolean;
+        useCPP?: boolean | undefined;
 
         /** Below options are supported in Handlebars/Haskell/YAML front matter  mode */
-        base?: string;
+        base?: string | undefined;
 
         /** Below options are supported in HTML mixed  mode */
-        tags?: {[key: string]: unknown};
+        tags?: {[key: string]: unknown} | undefined;
 
         /** Below options are supported in JavaScript mixed  mode */
 
         /** json which will set the mode to expect JSON data rather than a JavaScript program. */
-        json?: boolean;
+        json?: boolean | undefined;
         /** jsonld which will set the mode to expect JSON-LD linked data rather than a JavaScript program */
-        jsonld?: boolean;
+        jsonld?: boolean | undefined;
         /** typescript which will activate additional syntax highlighting and some other things for TypeScript code */
-        typescript?: boolean;
+        typescript?: boolean | undefined;
         /**
          * trackScope can be set to false to turn off tracking of local variables. This will prevent locals from getting
          * the "variable-2" token type, and will break completion of locals with javascript-hint.
          */
-        trackScope?: boolean;
+        trackScope?: boolean | undefined;
         /**
          * statementIndent which (given a number) will determine the amount of indentation to use for statements
          * continued on a new line.
          */
-        statementIndent?: boolean;
+        statementIndent?: boolean | undefined;
         /**
          * wordCharacters, a regexp that indicates which characters should be considered part of an identifier.
          *  Defaults to /[\w$]/, which does not handle non-ASCII identifiers. Can be set to something more elaborate to
          *  improve Unicode support.
          */
-        wordCharacters?: unknown;
+        wordCharacters?: unknown | undefined;
 
         /** Below options are supported in Markdown mixed  mode */
 
         /** Whether to separately highlight markdown meta characters (*[]()etc.) (default: false). */
-        highlightFormatting?: boolean;
+        highlightFormatting?: boolean | undefined;
         /** Maximum allowed blockquote nesting (default: 0 - infinite nesting). */
-        maxBlockquoteDepth?: boolean;
+        maxBlockquoteDepth?: boolean | undefined;
         /** Whether to highlight inline XML (default: true). */
-        xml?: boolean;
+        xml?: boolean | undefined;
         /**
          * Whether to syntax-highlight fenced code blocks, if given mode is included, or fencedCodeBlockDefaultMode
          * is set (default: true).
          */
-        fencedCodeBlockHighlighting?: boolean;
+        fencedCodeBlockHighlighting?: boolean | undefined;
         /** Mode to use for fencedCodeBlockHighlighting, if given mode is not included. */
-        fencedCodeBlockDefaultMode?: string;
+        fencedCodeBlockDefaultMode?: string | undefined;
         /** When you want to override default token type names (e.g. {code: "code"}). */
-        tokenTypeOverrides?: unknown;
+        tokenTypeOverrides?: unknown | undefined;
         /** Allow lazy headers without whitespace between hashtag and text (default: false). */
-        allowAtxHeaderWithoutSpace?: boolean;
+        allowAtxHeaderWithoutSpace?: boolean | undefined;
 
         /** Below options are supported in GFM mode mode */
-        gitHubSpice?: boolean;
-        taskLists?: boolean;
-        strikethrough?: boolean;
-        emoji?: boolean;
+        gitHubSpice?: boolean | undefined;
+        taskLists?: boolean | undefined;
+        strikethrough?: boolean | undefined;
+        emoji?: boolean | undefined;
 
         /** Below options are supported in Smarty mode */
 
         /** leftDelimiter and rightDelimiter, which should be strings that determine where the Smarty syntax starts and ends. */
-        leftDelimiter?: string;
-        rightDelimiter?: string;
-        baseMode?: string;
+        leftDelimiter?: string | undefined;
+        rightDelimiter?: string | undefined;
+        baseMode?: string | undefined;
 
         /** Below options are supported in sTeX mode */
 
         /** Whether to start parsing in math mode (default: false) */
-        inMathMode?: boolean;
+        inMathMode?: boolean | undefined;
 
         /** Below options are supported in SystemVerilog mode */
 
         /** List of keywords which should not cause indentation to increase. */
-        noIndentKeywords?: unknown;
+        noIndentKeywords?: unknown | undefined;
 
         /** Below options are supported in VHDL mode */
 
         /** List of atom words. Default: "null" */
-        atoms?: unknown;
+        atoms?: unknown | undefined;
         /** List of meta hooks. Default: ["`", "$"] */
-        hooks?: unknown;
+        hooks?: unknown | undefined;
         /** Whether multi-line strings are accepted. Default: false */
-        multiLineStrings?: boolean;
+        multiLineStrings?: boolean | undefined;
 
         /** Below options are supported in XML mode */
 
@@ -704,14 +704,14 @@ declare namespace CodeMirror {
          * This switches the mode to parse HTML instead of XML. This means attributes do not have to be quoted,
          * and some elements (such as br) do not require a closing tag.
          */
-        htmlMode?: boolean;
+        htmlMode?: boolean | undefined;
         /**
          * Controls whether the mode checks that close tags match the corresponding opening tag,
          * and highlights mismatches as errors. Defaults to true.
          */
-        matchClosing?: boolean;
+        matchClosing?: boolean | undefined;
         /** Setting this to true will force the opening tag of CDATA blocks to not be indented. */
-        alignCDATA?: boolean;
+        alignCDATA?: boolean | undefined;
     }
 
     type ModeSpec<T> = {
@@ -854,14 +854,14 @@ declare namespace CodeMirror {
         setCursor(
             pos: Position | number,
             ch?: number,
-            options?: { bias?: number; origin?: string; scroll?: boolean },
+            options?: { bias?: number | undefined; origin?: string | undefined; scroll?: boolean | undefined },
         ): void;
 
         /** Set a single selection range. anchor and head should be {line, ch} objects. head defaults to anchor when not given. */
         setSelection(
             anchor: Position,
             head?: Position,
-            options?: { bias?: number; origin?: string; scroll?: boolean },
+            options?: { bias?: number | undefined; origin?: string | undefined; scroll?: boolean | undefined },
         ): void;
 
         /**
@@ -873,7 +873,7 @@ declare namespace CodeMirror {
         setSelections(
             ranges: Array<{ anchor: Position; head: Position }>,
             primary?: number,
-            options?: { bias?: number; origin?: string; scroll?: boolean },
+            options?: { bias?: number | undefined; origin?: string | undefined; scroll?: boolean | undefined },
         ): void;
 
         /**
@@ -896,16 +896,16 @@ declare namespace CodeMirror {
              * When turned on, the linked copy will share an undo history with the original.
              * Thus, something done in one of the two can be undone in the other, and vice versa.
              */
-            sharedHist?: boolean;
-            from?: number;
+            sharedHist?: boolean | undefined;
+            from?: number | undefined;
             /**
              * Can be given to make the new document a subview of the original. Subviews only show a given range of lines.
              * Note that line coordinates inside the subview will be consistent with those of the parent,
              * so that for example a subview starting at line 10 will refer to its first line as line 10, not 0.
              */
-            to?: number;
+            to?: number | undefined;
             /** By default, the new document inherits the mode of the parent. This option can be set to a mode spec to give it a different mode. */
-            mode?: string | ModeSpec<ModeSpecOptions>;
+            mode?: string | ModeSpec<ModeSpecOptions> | undefined;
         }): Doc;
 
         /**
@@ -957,22 +957,22 @@ declare namespace CodeMirror {
             pos: Position,
             options?: {
                 /** Can be used to display a DOM node at the current location of the bookmark (analogous to the replacedWith option to markText). */
-                widget?: HTMLElement;
+                widget?: HTMLElement | undefined;
 
                 /**
                  * By default, text typed when the cursor is on top of the bookmark will end up to the right of the bookmark.
                  * Set this option to true to make it go to the left instead.
                  */
-                insertLeft?: boolean;
+                insertLeft?: boolean | undefined;
 
                 /**
                  * When the target document is linked to other documents, you can set shared to true to make the marker appear in all documents.
                  * By default, a marker appears only in its target document.
                  */
-                shared?: boolean;
+                shared?: boolean | undefined;
 
                 /** As with markText, this determines whether mouse events on the widget inserted for this bookmark are handled by CodeMirror. The default is false. */
-                handleMouseEvents?: boolean;
+                handleMouseEvents?: boolean | undefined;
             },
         ): TextMarker<Position>;
 
@@ -1082,26 +1082,26 @@ declare namespace CodeMirror {
 
     interface LineWidgetOptions {
         /** Whether the widget should cover the gutter. */
-        coverGutter?: boolean;
+        coverGutter?: boolean | undefined;
         /** Whether the widget should stay fixed in the face of horizontal scrolling. */
-        noHScroll?: boolean;
+        noHScroll?: boolean | undefined;
         /** Causes the widget to be placed above instead of below the text of the line. */
-        above?: boolean;
+        above?: boolean | undefined;
         /** When true, will cause the widget to be rendered even if the line it is associated with is hidden. */
-        showIfHidden?: boolean;
+        showIfHidden?: boolean | undefined;
         /**
          * Determines whether the editor will capture mouse and drag events occurring in this widget.
          * Default is false—the events will be left alone for the default browser handler, or specific handlers on the widget, to capture.
          */
-        handleMouseEvents?: boolean;
+        handleMouseEvents?: boolean | undefined;
         /**
          * By default, the widget is added below other widgets for the line.
          * This option can be used to place it at a different position (zero for the top, N to put it after the Nth other widget).
          * Note that this only has effect once, when the widget is created.
          */
-        insertAt?: number;
+        insertAt?: number | undefined;
         /** Add an extra CSS class name to the wrapper element created for the widget. */
-        className?: string;
+        className?: string | undefined;
     }
 
     interface EditorChange {
@@ -1112,9 +1112,9 @@ declare namespace CodeMirror {
         /** Array of strings representing the text that replaced the changed range (split by line). */
         text: string[];
         /**  Text that used to be between from and to, which is overwritten by this change. */
-        removed?: string[];
+        removed?: string[] | undefined;
         /**  String representing the origin of the change event and whether it can be merged with history */
-        origin?: string;
+        origin?: string | undefined;
     }
 
     interface EditorChangeCancellable extends EditorChange {
@@ -1135,7 +1135,7 @@ declare namespace CodeMirror {
     interface EditorSelectionChange {
         ranges: Range[];
         update(ranges: Range[]): void;
-        origin?: string;
+        origin?: string | undefined;
     }
 
     interface Range {
@@ -1149,7 +1149,7 @@ declare namespace CodeMirror {
     interface Position {
         ch: number;
         line: number;
-        sticky?: string;
+        sticky?: string | undefined;
     }
 
     interface ScrollbarMeasure {
@@ -1186,7 +1186,7 @@ declare namespace CodeMirror {
 
     interface EditorConfiguration {
         /** The starting value of the editor. Can be a string, or a document object. */
-        value?: string | Doc;
+        value?: string | Doc | undefined;
 
         /**
          * string|object. The mode to use. When not given, this will default to the first mode that was loaded.
@@ -1194,50 +1194,50 @@ declare namespace CodeMirror {
          * Alternatively, it may be an object containing configuration options for the mode,
          * with a name property that names the mode (for example {name: "javascript", json: true}).
          */
-        mode?: string | ModeSpec<ModeSpecOptions>;
+        mode?: string | ModeSpec<ModeSpecOptions> | undefined;
 
         /**
          * Explicitly set the line separator for the editor. By default (value null), the document will be split on CRLFs as well
          * as lone CRs and LFs, and a single LF will be used as line separator in all output (such as getValue). When a specific
          * string is given, lines will only be split on that string, and output will, by default, use that same separator.
          */
-        lineSeparator?: string | null;
+        lineSeparator?: string | null | undefined;
 
         /**
          * The theme to style the editor with. You must make sure the CSS file defining the corresponding .cm-s-[name] styles is loaded.
          * The default is "default".
          */
-        theme?: string;
+        theme?: string | undefined;
 
         /** How many spaces a block (whatever that means in the edited language) should be indented. The default is 2. */
-        indentUnit?: number;
+        indentUnit?: number | undefined;
 
         /** Whether to use the context-sensitive indentation that the mode provides (or just indent the same as the line before). Defaults to true. */
-        smartIndent?: boolean;
+        smartIndent?: boolean | undefined;
 
         /** The width of a tab character. Defaults to 4. */
-        tabSize?: number;
+        tabSize?: number | undefined;
 
         /** Whether, when indenting, the first N*tabSize spaces should be replaced by N tabs. Default is false. */
-        indentWithTabs?: boolean;
+        indentWithTabs?: boolean | undefined;
 
         /**
          * Configures whether the editor should re-indent the current line when a character is typed
          * that might change its proper indentation (only works if the mode supports indentation). Default is true.
          */
-        electricChars?: boolean;
+        electricChars?: boolean | undefined;
 
         /**
          * A regular expression used to determine which characters should be replaced by a special placeholder. Mostly useful for non-printing
          * special characters. The default is /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200f\u2028\u2029\ufeff\ufff9-\ufffc]/.
          */
-        specialChars?: RegExp;
+        specialChars?: RegExp | undefined;
 
         /**
          * A function that, given a special character identified by the specialChars option, produces a DOM node that is used to
          * represent the character. By default, a red dot (•) is shown, with a title tooltip to indicate the character code.
          */
-        specialCharPlaceholder?: (char: string) => HTMLElement;
+        specialCharPlaceholder?: ((char: string) => HTMLElement) | undefined;
 
         /**
          * Flips overall layout and selects base paragraph direction to be left-to-right or right-to-left. Default is "ltr". CodeMirror
@@ -1246,7 +1246,7 @@ declare namespace CodeMirror {
          * leading and trailing punctuation jumps to the wrong side of the line). Therefore, it's helpful for multilingual input to let
          * users toggle this option.
          */
-        direction?: "ltr" | "rtl";
+        direction?: "ltr" | "rtl" | undefined;
 
         /**
          * Determines whether horizontal cursor movement through right-to-left (Arabic, Hebrew) text
@@ -1254,35 +1254,35 @@ declare namespace CodeMirror {
          * or logical (pressing the left arrow moves to the next lower index in the string, which is visually right in right-to-left text).
          * The default is false on Windows, and true on other platforms.
          */
-        rtlMoveVisually?: boolean;
+        rtlMoveVisually?: boolean | undefined;
 
         /**
          * Configures the keymap to use. The default is "default", which is the only keymap defined in codemirror.js itself.
          * Extra keymaps are found in the keymap directory. See the section on keymaps for more information.
          */
-        keyMap?: string;
+        keyMap?: string | undefined;
 
         /** Can be used to specify extra keybindings for the editor, alongside the ones defined by keyMap. Should be either null, or a valid keymap value. */
-        extraKeys?: string | KeyMap;
+        extraKeys?: string | KeyMap | undefined;
 
         /** Allows you to configure the behavior of mouse selection and dragging. The function is called when the left mouse button is pressed. */
-        configureMouse?: (
+        configureMouse?: ((
             cm: Editor,
             repeat: 'single' | 'double' | 'triple',
             event: Event,
-        ) => MouseSelectionConfiguration;
+        ) => MouseSelectionConfiguration) | undefined;
 
         /** Whether CodeMirror should scroll or wrap for long lines. Defaults to false (scroll). */
-        lineWrapping?: boolean;
+        lineWrapping?: boolean | undefined;
 
         /** Whether to show line numbers to the left of the editor. */
-        lineNumbers?: boolean;
+        lineNumbers?: boolean | undefined;
 
         /** At which number to start counting lines. Default is 1. */
-        firstLineNumber?: number;
+        firstLineNumber?: number | undefined;
 
         /** A function used to format line numbers. The function is passed the line number, and should return a string that will be shown in the gutter. */
-        lineNumberFormatter?: (line: number) => string;
+        lineNumberFormatter?: ((line: number) => string) | undefined;
 
         /**
          * Can be used to add extra gutters (beyond or instead of the line number gutter).
@@ -1291,25 +1291,25 @@ declare namespace CodeMirror {
          * May include the CodeMirror-linenumbers class, in order to explicitly set the position of the line number gutter
          * (it will default to be to the right of all other gutters). These class names are the keys passed to setGutterMarker.
          */
-        gutters?: Array<string | { className: string; style?: string }>;
+        gutters?: Array<string | { className: string; style?: string | undefined }> | undefined;
 
         /**
          * Determines whether the gutter scrolls along with the content horizontally (false)
          * or whether it stays fixed during horizontal scrolling (true, the default).
          */
-        fixedGutter?: boolean;
+        fixedGutter?: boolean | undefined;
 
         /**
          * Chooses a scrollbar implementation. The default is "native", showing native scrollbars. The core library also
          * provides the "null" style, which completely hides the scrollbars. Addons can implement additional scrollbar models.
          */
-        scrollbarStyle?: keyof ScrollbarModels;
+        scrollbarStyle?: keyof ScrollbarModels | undefined;
 
         /**
          * When fixedGutter is on, and there is a horizontal scrollbar, by default the gutter will be visible to the left of this scrollbar.
          * If this option is set to true, it will be covered by an element with class CodeMirror-gutter-filler.
          */
-        coverGutterNextToScrollbar?: boolean;
+        coverGutterNextToScrollbar?: boolean | undefined;
 
         /**
          * Selects the way CodeMirror handles input and focus.
@@ -1317,60 +1317,60 @@ declare namespace CodeMirror {
          * On mobile browsers, the default is "contenteditable". On desktop browsers, the default is "textarea".
          * Support for IME and screen readers is better in the "contenteditable" model.
          */
-        inputStyle?: InputStyle;
+        inputStyle?: InputStyle | undefined;
 
         /** boolean|string. This disables editing of the editor content by the user. If the special value "nocursor" is given (instead of simply true), focusing of the editor is also disallowed. */
-        readOnly?: boolean | 'nocursor';
+        readOnly?: boolean | 'nocursor' | undefined;
 
         /** This label is read by the screenreaders when CodeMirror text area is focused. This is helpful for accessibility. */
-        screenReaderLabel?: string;
+        screenReaderLabel?: string | undefined;
 
         /** Whether the cursor should be drawn when a selection is active. Defaults to false. */
-        showCursorWhenSelecting?: boolean;
+        showCursorWhenSelecting?: boolean | undefined;
 
         /** When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them. */
-        lineWiseCopyCut?: boolean;
+        lineWiseCopyCut?: boolean | undefined;
 
         /**
          * When pasting something from an external source (not from the editor itself), if the number of lines matches the number of selection,
          * CodeMirror will by default insert one line per selection. You can set this to false to disable that behavior.
          */
-        pasteLinesPerSelection?: boolean;
+        pasteLinesPerSelection?: boolean | undefined;
 
         /** Determines whether multiple selections are joined as soon as they touch (the default) or only when they overlap (true). */
-        selectionsMayTouch?: boolean;
+        selectionsMayTouch?: boolean | undefined;
 
         /** The maximum number of undo levels that the editor stores. Defaults to 40. */
-        undoDepth?: number;
+        undoDepth?: number | undefined;
 
         /** The period of inactivity (in milliseconds) that will cause a new history event to be started when typing or deleting. Defaults to 500. */
-        historyEventDelay?: number;
+        historyEventDelay?: number | undefined;
 
         /** The tab index to assign to the editor. If not given, no tab index will be assigned. */
-        tabindex?: number;
+        tabindex?: number | undefined;
 
         /**
          * Can be used to make CodeMirror focus itself on initialization. Defaults to off.
          * When fromTextArea is used, and no explicit value is given for this option, it will be set to true when either the source textarea is focused,
          * or it has an autofocus attribute and no other element is focused.
          */
-        autofocus?: boolean;
+        autofocus?: boolean | undefined;
 
         /** Controls whether drag-and - drop is enabled. On by default. */
-        dragDrop?: boolean;
+        dragDrop?: boolean | undefined;
 
         /**
          * When set (default is null) only files whose type is in the array can be dropped into the editor.
          * The strings should be MIME types, and will be checked against the type of the File object as reported by the browser.
          */
-        allowDropFileTypes?: string[] | null;
+        allowDropFileTypes?: string[] | null | undefined;
 
         /**
          * When given , this will be called when the editor is handling a dragenter , dragover , or drop event.
          * It will be passed the editor instance and the event object as arguments.
          * The callback can choose to handle the event itself , in which case it should return true to indicate that CodeMirror should not do anything further.
          */
-        onDragEvent?: (instance: Editor, event: DragEvent) => boolean;
+        onDragEvent?: ((instance: Editor, event: DragEvent) => boolean) | undefined;
 
         /**
          * This provides a rather low-level hook into CodeMirror's key handling.
@@ -1384,66 +1384,66 @@ declare namespace CodeMirror {
          * If you respond to an event, you should probably inspect its type property and only do something when it is keydown
          * (or keypress for actions that need character data).
          */
-        onKeyEvent?: (instance: Editor, event: KeyboardEvent) => boolean;
+        onKeyEvent?: ((instance: Editor, event: KeyboardEvent) => boolean) | undefined;
 
         /** Half - period in milliseconds used for cursor blinking. The default blink rate is 530ms. */
-        cursorBlinkRate?: number;
+        cursorBlinkRate?: number | undefined;
 
         /**
          * How much extra space to always keep above and below the cursor when
          * approaching the top or bottom of the visible view in a scrollable document. Default is 0.
          */
-        cursorScrollMargin?: number;
+        cursorScrollMargin?: number | undefined;
 
         /**
          * Determines the height of the cursor. Default is 1 , meaning it spans the whole height of the line.
          * For some fonts (and by some tastes) a smaller height (for example 0.85),
          * which causes the cursor to not reach all the way to the bottom of the line, looks better
          */
-        cursorHeight?: number;
+        cursorHeight?: number | undefined;
 
         /**
          * Controls whether, when the context menu is opened with a click outside of the current selection,
          * the cursor is moved to the point of the click. Defaults to true.
          */
-        resetSelectionOnContextMenu?: boolean;
+        resetSelectionOnContextMenu?: boolean | undefined;
 
         /**
          * Highlighting is done by a pseudo background thread that will work for workTime milliseconds,
          * and then use timeout to sleep for workDelay milliseconds.
          * The defaults are 200 and 300, you can change these options to make the highlighting more or less aggressive.
          */
-        workTime?: number;
+        workTime?: number | undefined;
 
         /** See workTime. */
-        workDelay?: number;
+        workDelay?: number | undefined;
 
         /**
          * Indicates how quickly CodeMirror should poll its input textarea for changes(when focused).
          * Most input is captured by events, but some things, like IME input on some browsers, don't generate events that allow CodeMirror to properly detect it.
          * Thus, it polls. Default is 100 milliseconds.
          */
-        pollInterval?: number;
+        pollInterval?: number | undefined;
 
         /**
          * By default, CodeMirror will combine adjacent tokens into a single span if they have the same class.
          * This will result in a simpler DOM tree, and thus perform better. With some kinds of styling(such as rounded corners),
          * this will change the way the document looks. You can set this option to false to disable this behavior.
          */
-        flattenSpans?: boolean;
+        flattenSpans?: boolean | undefined;
 
         /**
          * When enabled (off by default), an extra CSS class will be added to each token, indicating the (inner) mode that produced it, prefixed with "cm-m-".
          * For example, tokens from the XML mode will get the cm-m-xml class.
          */
-        addModeClass?: boolean;
+        addModeClass?: boolean | undefined;
 
         /**
          * When highlighting long lines, in order to stay responsive, the editor will give up and simply style
          * the rest of the line as plain text when it reaches a certain position. The default is 10000.
          * You can set this to Infinity to turn off this behavior.
          */
-        maxHighlightLength?: number;
+        maxHighlightLength?: number | undefined;
 
         /**
          * Specifies the amount of lines that are rendered above and below the part of the document that's currently scrolled into view.
@@ -1451,59 +1451,59 @@ declare namespace CodeMirror {
          * You should usually leave it at its default, 10. Can be set to Infinity to make sure the whole document is always rendered,
          * and thus the browser's text search works on it. This will have bad effects on performance of big documents.
          */
-        viewportMargin?: number;
+        viewportMargin?: number | undefined;
 
         /** Specifies whether or not spellcheck will be enabled on the input. */
-        spellcheck?: boolean;
+        spellcheck?: boolean | undefined;
 
         /** Specifies whether or not autocorrect will be enabled on the input. */
-        autocorrect?: boolean;
+        autocorrect?: boolean | undefined;
 
         /** Specifies whether or not autocapitalization will be enabled on the input. */
-        autocapitalize?: boolean;
+        autocapitalize?: boolean | undefined;
     }
 
     interface TextMarkerOptions {
         /** Assigns a CSS class to the marked stretch of text. */
-        className?: string;
+        className?: string | undefined;
 
         /** Determines whether text inserted on the left of the marker will end up inside or outside of it. */
-        inclusiveLeft?: boolean;
+        inclusiveLeft?: boolean | undefined;
 
         /** Like inclusiveLeft, but for the right side. */
-        inclusiveRight?: boolean;
+        inclusiveRight?: boolean | undefined;
 
         /** For atomic ranges, determines whether the cursor is allowed to be placed directly to the left of the range. Has no effect on non-atomic ranges. */
-        selectLeft?: boolean;
+        selectLeft?: boolean | undefined;
 
         /** Like selectLeft, but for the right side. */
-        selectRight?: boolean;
+        selectRight?: boolean | undefined;
 
         /**
          * Atomic ranges act as a single unit when cursor movement is concerned — i.e. it is impossible to place the cursor inside of them.
          * You can control whether the cursor is allowed to be placed directly before or after them using selectLeft or selectRight.
          * If selectLeft (or right) is not provided, then inclusiveLeft (or right) will control this behavior.
          */
-        atomic?: boolean;
+        atomic?: boolean | undefined;
 
         /** Collapsed ranges do not show up in the display. Setting a range to be collapsed will automatically make it atomic. */
-        collapsed?: boolean;
+        collapsed?: boolean | undefined;
 
         /**
          * When enabled, will cause the mark to clear itself whenever the cursor enters its range.
          * This is mostly useful for text - replacement widgets that need to 'snap open' when the user tries to edit them.
          * The "clear" event fired on the range handle can be used to be notified when this happens.
          */
-        clearOnEnter?: boolean;
+        clearOnEnter?: boolean | undefined;
 
         /** Determines whether the mark is automatically cleared when it becomes empty. Default is true. */
-        clearWhenEmpty?: boolean;
+        clearWhenEmpty?: boolean | undefined;
 
         /**
          * Use a given node to display this range. Implies both collapsed and atomic.
          * The given DOM node must be an inline element (as opposed to a block element).
          */
-        replacedWith?: HTMLElement;
+        replacedWith?: HTMLElement | undefined;
 
         /**
          * When replacedWith is given, this determines whether the editor will
@@ -1511,38 +1511,38 @@ declare namespace CodeMirror {
          * false—the events will be left alone for the default browser handler,
          * or specific handlers on the widget, to capture.
          */
-        handleMouseEvents?: boolean;
+        handleMouseEvents?: boolean | undefined;
 
         /**
          * A read-only span can, as long as it is not cleared, not be modified except by calling setValue to reset the whole document.
          * Note: adding a read-only span currently clears the undo history of the editor,
          * because existing undo events being partially nullified by read - only spans would corrupt the history (in the current implementation).
          */
-        readOnly?: boolean;
+        readOnly?: boolean | undefined;
 
         /** When set to true (default is false), adding this marker will create an event in the undo history that can be individually undone (clearing the marker). */
-        addToHistory?: boolean;
+        addToHistory?: boolean | undefined;
 
         /** Can be used to specify an extra CSS class to be applied to the leftmost span that is part of the marker. */
-        startStyle?: string;
+        startStyle?: string | undefined;
 
         /** Equivalent to startStyle, but for the rightmost span. */
-        endStyle?: string;
+        endStyle?: string | undefined;
 
         /** A string of CSS to be applied to the covered text. For example "color: #fe3". */
-        css?: string;
+        css?: string | undefined;
 
         /** When given, will give the nodes created for this span a HTML title attribute with the given value. */
-        title?: string;
+        title?: string | undefined;
 
         /** When given, add the attributes in the given object to the elements created for the marked text. Adding class or style attributes this way is not supported. */
-        attributes?: { [name: string]: string };
+        attributes?: { [name: string]: string } | undefined;
 
         /**
          * When the target document is linked to other documents, you can set shared to true to make the marker appear in all documents.
          * By default, a marker appears only in its target document.
          */
-        shared?: boolean;
+        shared?: boolean | undefined;
     }
 
     class StringStream {
@@ -1657,7 +1657,7 @@ declare namespace CodeMirror {
      * advances it past a token, and returns a style for that token. More advanced modes can also handle indentation for the language.
      */
     interface Mode<T> {
-        name?: string;
+        name?: string | undefined;
 
         /**
          * This function should read one token from the stream it is given as an argument, optionally update its state,
@@ -1668,50 +1668,50 @@ declare namespace CodeMirror {
         /**
          * A function that produces a state object to be used at the start of a document.
          */
-        startState?: () => T;
+        startState?: (() => T) | undefined;
         /**
          * For languages that have significant blank lines, you can define a blankLine(state) method on your mode that will get called
          * whenever a blank line is passed over, so that it can update the parser state.
          */
-        blankLine?: (state: T) => void;
+        blankLine?: ((state: T) => void) | undefined;
         /**
          * Given a state returns a safe copy of that state.
          */
-        copyState?: (state: T) => T;
+        copyState?: ((state: T) => T) | undefined;
 
         /**
          * Returns the number of spaces of indentation that should be used if a newline were added after the given state. Optionally
          * this can use the textAfter string (which is the text after the current position) or the line string, which is the whole
          * text of the line.
          */
-        indent?: (state: T, textAfter: string, line: string) => number;
+        indent?: ((state: T, textAfter: string, line: string) => number) | undefined;
 
         /** The four below strings are used for working with the commenting addon. */
         /**
          * String that starts a line comment.
          */
-        lineComment?: string;
+        lineComment?: string | undefined;
         /**
          * String that starts a block comment.
          */
-        blockCommentStart?: string;
+        blockCommentStart?: string | undefined;
         /**
          * String that ends a block comment.
          */
-        blockCommentEnd?: string;
+        blockCommentEnd?: string | undefined;
         /**
          * String to put at the start of continued lines in a block comment.
          */
-        blockCommentLead?: string;
+        blockCommentLead?: string | undefined;
 
         /**
          * Trigger a reindent whenever one of the characters in the string is typed.
          */
-        electricChars?: string;
+        electricChars?: string | undefined;
         /**
          * Trigger a reindent whenever the regex matches the part of the line before the cursor.
          */
-        electricinput?: RegExp;
+        electricinput?: RegExp | undefined;
     }
 
     /**
@@ -1927,26 +1927,26 @@ declare namespace CodeMirror {
             | 'word'
             | 'line'
             | 'rectangle'
-            | ((cm: Editor, pos: Position) => { from: Position; to: Position });
+            | ((cm: Editor, pos: Position) => { from: Position; to: Position }) | undefined;
 
         /**
          * Whether to extend the existing selection range or start
          * a new one. By default, this is enabled when shift clicking.
          */
-        extend?: boolean;
+        extend?: boolean | undefined;
 
         /**
          * When enabled, this adds a new range to the existing selection,
          * rather than replacing it. The default behavior is to enable this
          * for command-click on Mac OS, and control-click on other platforms.
          */
-        addNew?: boolean;
+        addNew?: boolean | undefined;
 
         /**
          * When the mouse even drags content around inside the editor, this
          * controls whether it is copied (false) or moved (true). By default, this
          * is enabled by alt-clicking on Mac OS, and ctrl-clicking elsewhere.
          */
-        moveOnDrag?: boolean;
+        moveOnDrag?: boolean | undefined;
     }
 }

--- a/types/codemirror/mode/meta.d.ts
+++ b/types/codemirror/mode/meta.d.ts
@@ -2,12 +2,12 @@ import '../';
 
 export interface ModeInfo {
     name: string;
-    mime?: string;
-    mimes?: string[];
+    mime?: string | undefined;
+    mimes?: string[] | undefined;
     mode: string;
-    file?: RegExp;
-    ext?: string[];
-    alias?: string[];
+    file?: RegExp | undefined;
+    ext?: string[] | undefined;
+    alias?: string[] | undefined;
 }
 
 declare module '../' {

--- a/types/color-support/index.d.ts
+++ b/types/color-support/index.d.ts
@@ -9,14 +9,14 @@
 type ColorSupportLevel = 0 | 1 | 2 | 3;
 
 interface ColorSupportOptions {
-    alwaysReturn?: boolean;
-    env?: NodeJS.ProcessEnv;
-    ignoreCI?: boolean;
-    ignoreDumb?: boolean;
-    ignoreTTY?: boolean;
-    level?: ColorSupportLevel;
-    stream?: NodeJS.WriteStream;
-    term?: string;
+    alwaysReturn?: boolean | undefined;
+    env?: NodeJS.ProcessEnv | undefined;
+    ignoreCI?: boolean | undefined;
+    ignoreDumb?: boolean | undefined;
+    ignoreTTY?: boolean | undefined;
+    level?: ColorSupportLevel | undefined;
+    stream?: NodeJS.WriteStream | undefined;
+    term?: string | undefined;
 }
 
 interface ColorSupportResult {

--- a/types/color/index.d.ts
+++ b/types/color/index.d.ts
@@ -16,9 +16,9 @@ interface Color<T extends ColorParam = ColorParam> {
     string(places?: number): string;
     percentString(places?: number): string;
     array(): number[];
-    object(): { alpha?: number } & { [key: string]: number };
+    object(): { alpha?: number | undefined } & { [key: string]: number };
     unitArray(): number[];
-    unitObject(): { r: number, g: number, b: number, alpha?: number };
+    unitObject(): { r: number, g: number, b: number, alpha?: number | undefined };
     round(places?: number): Color;
     alpha(): number;
     alpha(val: number): Color;

--- a/types/color/v0/index.d.ts
+++ b/types/color/v0/index.d.ts
@@ -9,28 +9,28 @@ declare namespace Color {
         r: number
         g: number
         b: number
-        a?: number
+        a?: number | undefined
     }
 
     interface FullRGBColor {
         red: number
         green: number
         blue: number
-        alpha?: number
+        alpha?: number | undefined
     }
 
     interface HSLColor {
         h: number
         s: number
         l: number
-        a?: number
+        a?: number | undefined
     }
 
     interface FullHSLColor {
         hue: number
         saturation: number
         lightness: number
-        alpha?: number
+        alpha?: number | undefined
     }
 
     interface HSVColor {

--- a/types/color/v2/index.d.ts
+++ b/types/color/v2/index.d.ts
@@ -14,9 +14,9 @@ interface Color {
     string(places?: number): string;
     percentString(places?: number): string;
     array(): number[];
-    object(): { alpha?: number } & { [key: string]: number };
+    object(): { alpha?: number | undefined } & { [key: string]: number };
     unitArray(): number[];
-    unitObject(): { r: number, g: number, b: number, alpha?: number };
+    unitObject(): { r: number, g: number, b: number, alpha?: number | undefined };
     round(places?: number): Color;
     alpha(): number;
     alpha(val: number): Color;

--- a/types/combined-stream/index.d.ts
+++ b/types/combined-stream/index.d.ts
@@ -11,8 +11,8 @@ type Appendable = NodeJS.ReadableStream | NodeJS.WritableStream | Buffer | strin
 type NextFunction = (next: (stream: Appendable) => any) => any;
 
 interface Options {
-    maxDataSize?: number;
-    pauseStreams?: boolean;
+    maxDataSize?: number | undefined;
+    pauseStreams?: boolean | undefined;
 }
 
 declare class CombinedStream extends Stream implements Options {

--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -15,7 +15,7 @@ declare namespace commandLineArgs {
         /**
          * Command-line arguments not parsed by `commandLineArgs`.
          */
-        _unknown?: string[];
+        _unknown?: string[] | undefined;
         [propName: string]: any;
     }
 
@@ -23,23 +23,23 @@ declare namespace commandLineArgs {
         /**
          * An array of strings which if present will be parsed instead of `process.argv`.
          */
-        argv?: string[];
+        argv?: string[] | undefined;
 
         /**
          * If `true`, `commandLineArgs` will not throw on unknown options or values, instead returning them in the `_unknown` property of the output.
          */
-        partial?: boolean;
+        partial?: boolean | undefined;
 
         /**
          * If `true`, `commandLineArgs` will not throw on unknown options or values. Instead, parsing will stop at the first unknown argument
          * and the remaining arguments returned in the `_unknown` property of the output. If set, `partial: true` is implied.
          */
-        stopAtFirstUnknown?: boolean;
+        stopAtFirstUnknown?: boolean | undefined;
 
         /**
          * If `true`, options with hypenated names (e.g. `move-to`) will be returned in camel-case (e.g. `moveTo`).
          */
-        camelCase?: boolean;
+        camelCase?: boolean | undefined;
     }
 
     interface OptionDefinition {
@@ -52,28 +52,28 @@ declare namespace commandLineArgs {
          * A setter function (you receive the output from this) enabling you to be specific about the type and value received. Typical values
          * are `String` (the default), `Number` and `Boolean` but you can use a custom function. If no option value was set you will receive `null`.
          */
-        type?: (input: string) => any;
+        type?: ((input: string) => any) | undefined;
 
         /**
          * A getopt-style short option name. Can be any single character except a digit or hyphen.
          */
-        alias?: string;
+        alias?: string | undefined;
 
         /**
          * Set this flag if the option accepts multiple values. In the output, you will receive an array of values each passed through the `type` function.
          */
-        multiple?: boolean;
+        multiple?: boolean | undefined;
 
         /**
          * Identical to `multiple` but with greedy parsing disabled.
          */
-        lazyMultiple?: boolean;
+        lazyMultiple?: boolean | undefined;
 
         /**
          * Any values unaccounted for by an option definition will be set on the `defaultOption`. This flag is typically set
          * on the most commonly-used option to enable more concise usage.
          */
-        defaultOption?: boolean;
+        defaultOption?: boolean | undefined;
 
         /**
          * An initial value for the option.
@@ -83,7 +83,7 @@ declare namespace commandLineArgs {
         /**
          * One or more group names the option belongs to.
          */
-        group?: string | string[];
+        group?: string | string[] | undefined;
     }
 }
 

--- a/types/command-line-args/v4/index.d.ts
+++ b/types/command-line-args/v4/index.d.ts
@@ -14,7 +14,7 @@ declare namespace commandLineArgs {
         /**
          * Command-line arguments not parsed by `commandLineArgs`.
          */
-        _unknown?: string[];
+        _unknown?: string[] | undefined;
         [propName: string]: any;
     }
 
@@ -22,12 +22,12 @@ declare namespace commandLineArgs {
         /**
          * An array of strings which if present will be parsed instead of `process.argv`.
          */
-        argv?: string[];
+        argv?: string[] | undefined;
 
         /**
          * If `true`, `commandLineArgs` will not throw on unknown options or values, instead returning them in the `_unknown` property of the output.
          */
-        partial?: boolean;
+        partial?: boolean | undefined;
     }
 
     interface OptionDefinition {
@@ -40,23 +40,23 @@ declare namespace commandLineArgs {
          * A setter function (you receive the output from this) enabling you to be specific about the type and value received. Typical values
          * are `String` (the default), `Number` and `Boolean` but you can use a custom function. If no option value was set you will receive `null`.
          */
-        type?: (input: string) => any;
+        type?: ((input: string) => any) | undefined;
 
         /**
          * A getopt-style short option name. Can be any single character except a digit or hyphen.
          */
-        alias?: string;
+        alias?: string | undefined;
 
         /**
          * Set this flag if the option accepts multiple values. In the output, you will receive an array of values each passed through the `type` function.
          */
-        multiple?: boolean;
+        multiple?: boolean | undefined;
 
         /**
          * Any values unaccounted for by an option definition will be set on the `defaultOption`. This flag is typically set
          * on the most commonly-used option to enable more concise usage.
          */
-        defaultOption?: boolean;
+        defaultOption?: boolean | undefined;
 
         /**
          * An initial value for the option.
@@ -66,7 +66,7 @@ declare namespace commandLineArgs {
         /**
          * One or more group names the option belongs to.
          */
-        group?: string | string[];
+        group?: string | string[] | undefined;
     }
 }
 

--- a/types/command-line-usage/index.d.ts
+++ b/types/command-line-usage/index.d.ts
@@ -20,7 +20,7 @@ declare namespace commandLineUsage {
     /** A Content section comprises a header and one or more lines of content. */
     interface Content {
         /** The section header, always bold and underlined. */
-        header?: string;
+        header?: string | undefined;
         /**
          * Overloaded property, accepting data in one of four formats.
          *  1. A single string (one line of text).
@@ -29,9 +29,9 @@ declare namespace commandLineUsage {
          *     consistent throughout the array.
          *  4. An object with two properties - data and options. In this case, the data and options will be passed directly to the underlying table layout module for rendering.
          */
-        content?: string | string[] | any[] | { data: any; options: any };
+        content?: string | string[] | any[] | { data: any; options: any } | undefined;
         /** Set to true to avoid indentation and wrapping. Useful for banners. */
-        raw?: boolean;
+        raw?: boolean | undefined;
     }
 
     /** Describes a command-line option. Additionally, if generating a usage guide with command-line-usage you could optionally add description and typeLabel properties to each definition. */
@@ -44,13 +44,13 @@ declare namespace commandLineUsage {
          */
         type?: any;
         /** getopt-style short option names. Can be any single character (unicode included) except a digit or hyphen. */
-        alias?: string;
+        alias?: string | undefined;
         /** Set this flag if the option takes a list of values. You will receive an array of values, each passed through the type function (if specified). */
-        multiple?: boolean;
+        multiple?: boolean | undefined;
         /** Identical to multiple but with greedy parsing disabled. */
-        lazyMultiple?: boolean;
+        lazyMultiple?: boolean | undefined;
         /** Any values unaccounted for by an option definition will be set on the defaultOption. This flag is typically set on the most commonly-used option to make for more concise usage. */
-        defaultOption?: boolean;
+        defaultOption?: boolean | undefined;
         /** An initial value for the option. */
         defaultValue?: any;
         /**
@@ -58,24 +58,24 @@ declare namespace commandLineUsage {
          *
          * There are two automatic groups: _all (contains all options) and _none (contains options without a group specified in their definition).
          */
-        group?: string | string[];
+        group?: string | string[] | undefined;
         /** A string describing the option. */
-        description?: string;
+        description?: string | undefined;
         /** A string to replace the default type string (e.g. <string>). It's often more useful to set a more descriptive type label, like <ms>, <files>, <command>, etc.. */
-        typeLabel?: string;
+        typeLabel?: string | undefined;
     }
 
     /** A OptionList section adds a table displaying details of the available options. */
     interface OptionList {
-        header?: string;
+        header?: string | undefined;
         /** An array of option definition objects. */
-        optionList?: OptionDefinition[];
+        optionList?: OptionDefinition[] | undefined;
         /** If specified, only options from this particular group will be printed.  */
-        group?: string | string[];
+        group?: string | string[] | undefined;
         /** The names of one of more option definitions to hide from the option list.  */
-        hide?: string | string[];
+        hide?: string | string[] | undefined;
         /** If true, the option alias will be displayed after the name, i.e. --verbose, -v instead of -v, --verbose). */
-        reverseNameOrder?: boolean;
+        reverseNameOrder?: boolean | undefined;
         /** An options object suitable for passing into table-layout. */
         tableOptions?: any;
     }

--- a/types/common-tags/index.d.ts
+++ b/types/common-tags/index.d.ts
@@ -116,25 +116,25 @@ export interface TemplateTransformer<TCtx = { [key: string]: any }> {
      * The result of this hook will be passed to other hooks as `context`.
      * If omitted, `context` will be an empty object.
      */
-    getInitialContext?: () => TCtx;
+    getInitialContext?: (() => TCtx) | undefined;
     /**
      * Called when the tag encounters a string.
      * (a string is whatever's not inside "${}" in your template literal)
      * `str` is the value of the current string
      */
-    onString?: (str: string, context: TCtx) => string;
+    onString?: ((str: string, context: TCtx) => string) | undefined;
     /**
      * Called when the tag encounters a substitution.
      * (a substitution is whatever's inside "${}" in your template literal)
      * `substitution` is the value of the current substitution
      * `resultSoFar` is the end result up to the point of this substitution
      */
-    onSubstitution?: (substitution: string, resultSoFar: string, context: TCtx) => string;
+    onSubstitution?: ((substitution: string, resultSoFar: string, context: TCtx) => string) | undefined;
     /**
      * Called when all substitutions have been parsed
      * `endResult` is the final value.
      */
-    onEndResult?: (endResult: string, context: TCtx) => string;
+    onEndResult?: ((endResult: string, context: TCtx) => string) | undefined;
 }
 
 export type PluginFunction = (oldValue: string, newValue: string) => TemplateTransformer<any>;
@@ -209,9 +209,9 @@ export function replaceStringTransformer(
  * @return a TemplateTag transformer
  */
 export function inlineArrayTransformer(opts?: {
-    separator?: string;
-    conjunction?: string;
-    serial?: boolean;
+    separator?: string | undefined;
+    conjunction?: string | undefined;
+    serial?: boolean | undefined;
 }): TemplateTransformer;
 
 /**

--- a/types/compression-webpack-plugin/index.d.ts
+++ b/types/compression-webpack-plugin/index.d.ts
@@ -50,39 +50,39 @@ declare namespace CompressionPlugin {
          * ⚠ Ignored in webpack 5! Please use webpack.js.org/configuration/other-options/#cache.
          * @default true
          */
-        cache?: boolean | string;
+        cache?: boolean | string | undefined;
         /**
          * Whether to delete the original assets or not
          * @default false
          */
-        deleteOriginalAssets?: boolean | 'keep-source-map';
+        deleteOriginalAssets?: boolean | 'keep-source-map' | undefined;
         /**
          * Exclude all assets matching any of these conditions
          */
-        exclude?: Rules;
+        exclude?: Rules | undefined;
         /**
          * The target asset filename.
          * @default '[path][base].gz'
          */
-        filename?: string | FilenameFunction;
+        filename?: string | FilenameFunction | undefined;
         /**
          * Include all assets matching any of these conditions
          */
-        include?: Rules;
+        include?: Rules | undefined;
         /**
          * Only assets that compress better than this ratio are processed (minRatio = Compressed Size / Original Size)
          * @default 0.8
          */
-        minRatio?: number;
+        minRatio?: number | undefined;
         /**
          * Include all assets that pass test assertion
          */
-        test?: Rules;
+        test?: Rules | undefined;
         /**
          * Only assets bigger than this size are processed (in bytes)
          * @default 0
          */
-        threshold?: number;
+        threshold?: number | undefined;
     }
 
     interface ZlibOptions extends BaseOptions {
@@ -90,17 +90,17 @@ declare namespace CompressionPlugin {
          * The compression algorithm/function
          * @default 'gzip'
          */
-        algorithm?: ZlibAlgorithm;
+        algorithm?: ZlibAlgorithm | undefined;
         /**
          * Compression options for algorithm
          * @default { level: 9 }
          */
-        compressionOptions?: ZlibCompressionOptions;
+        compressionOptions?: ZlibCompressionOptions | undefined;
     }
 
     interface CustomOptions<O> extends BaseOptions {
         algorithm: Algorithm<O>;
-        compressionOptions?: O;
+        compressionOptions?: O | undefined;
     }
 
     type Options<O> = ZlibOptions | CustomOptions<O>;

--- a/types/compression-webpack-plugin/v2/index.d.ts
+++ b/types/compression-webpack-plugin/v2/index.d.ts
@@ -22,24 +22,24 @@ declare namespace CompressionPlugin {
     type Pattern = string | RegExp | ReadonlyArray<RegExp> | ReadonlyArray<string>;
 
     interface BaseOptions {
-        cache?: boolean | string;
-        deleteOriginalAssets?: boolean;
-        exclude?: Pattern;
-        filename?: string;
-        include?: Pattern;
-        minRatio?: number;
-        test?: Pattern;
-        threshold?: number;
+        cache?: boolean | string | undefined;
+        deleteOriginalAssets?: boolean | undefined;
+        exclude?: Pattern | undefined;
+        filename?: string | undefined;
+        include?: Pattern | undefined;
+        minRatio?: number | undefined;
+        test?: Pattern | undefined;
+        threshold?: number | undefined;
     }
 
     interface ZlibOptions extends BaseOptions {
-        algorithm?: ZlibAlgorithm;
-        compressionOptions?: ZlibCompressionOptions;
+        algorithm?: ZlibAlgorithm | undefined;
+        compressionOptions?: ZlibCompressionOptions | undefined;
     }
 
     interface CustomOptions<O> extends BaseOptions {
         algorithm: Algorithm<O>;
-        compressionOptions?: O;
+        compressionOptions?: O | undefined;
     }
 
     type Options<O> = ZlibOptions | CustomOptions<O>;

--- a/types/compression/index.d.ts
+++ b/types/compression/index.d.ts
@@ -74,7 +74,7 @@ declare namespace compression {
          * @see {@link http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning| Node.js documentation}
          * @see {@link https://github.com/expressjs/compression#chunksize|chunkSize documentation}
          */
-        chunkSize?: number;
+        chunkSize?: number | undefined;
 
         /**
          * A function to decide if the response should be considered for compression. This function is called as
@@ -87,7 +87,7 @@ declare namespace compression {
          * @see {@link https://github.com/expressjs/compression#filter|`filter` documentation}
          * @see {@link https://www.npmjs.com/package/compressible|compressible module}
          */
-        filter?: CompressionFilter;
+        filter?: CompressionFilter | undefined;
 
         /**
          * The level of zlib compression to apply to responses. A higher level will result in better compression, but
@@ -114,7 +114,7 @@ declare namespace compression {
          * @default zlib.constants.DEFAULT_COMPRESSION or -1
          * @see {@link https://github.com/expressjs/compression#level|`level` documentation}
          */
-        level?: number;
+        level?: number | undefined;
 
         /**
          * This specifies how much memory should be allocated for the internal compression state and is an integer in
@@ -124,7 +124,7 @@ declare namespace compression {
          * @see {@link http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning|Node.js documentation}
          * @see {@link https://github.com/expressjs/compression#memlevel|`memLevel` documentation}
          */
-        memLevel?: number;
+        memLevel?: number | undefined;
 
         /**
          * This is used to tune the compression algorithm. This value only affects the compression ratio, not the
@@ -142,7 +142,7 @@ declare namespace compression {
          *
          * **Note** in the list above, `zlib` is from `zlib = require('zlib')`.
          */
-        strategy?: number;
+        strategy?: number | undefined;
 
         /**
          * The byte threshold for the response body size before compression is considered for the response, defaults to
@@ -155,13 +155,13 @@ declare namespace compression {
          * @see {@link https://www.npmjs.com/package/bytes|`bytes` module}
          * @see {@link https://github.com/expressjs/compression#threshold|`threshold` documentation}
          */
-        threshold?: number | string;
+        threshold?: number | string | undefined;
 
         /**
          * @default zlib.constants.Z_DEFAULT_WINDOWBITS or 15.
          * @see {@link http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning|Node.js documentation}
          */
-        windowBits?: number;
+        windowBits?: number | undefined;
         /**
          * In addition , `zlib` options may be passed in to the options object.
          */

--- a/types/concat-stream/index.d.ts
+++ b/types/concat-stream/index.d.ts
@@ -8,7 +8,7 @@
 import { Writable } from "stream";
 
 interface ConcatOpts {
-  encoding?: string;
+  encoding?: string | undefined;
 }
 
 declare function concat(cb: (buf: Buffer) => void): Writable;

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -14,10 +14,10 @@ declare function concurrently(
 declare namespace concurrently {
     interface CommandObj {
         command: string;
-        cwd?: Options['cwd'];
-        env?: NodeJS.ProcessEnv;
-        name?: string;
-        prefixColor?: string;
+        cwd?: Options['cwd'] | undefined;
+        env?: NodeJS.ProcessEnv | undefined;
+        name?: string | undefined;
+        prefixColor?: string | undefined;
     }
     interface ExitInfos {
         command: CommandObj;
@@ -33,36 +33,36 @@ declare namespace concurrently {
          * The working directory to be used by all commands. Can be overridden per command.
          * @default process.cwd()
          */
-        cwd?: string;
+        cwd?: string | undefined;
         /** the default input target when reading from `inputStream`. Default: `0`. */
-        defaultInputTarget?: number;
+        defaultInputTarget?: number | undefined;
         /** a Readable stream to read the input from, eg `process.stdin` */
-        inputStream?: NodeJS.ReadableStream;
+        inputStream?: NodeJS.ReadableStream | undefined;
         /** an array of exiting conditions that will cause a process to kill others. Can contain any of success or failure. */
-        killOthers?: Array<'success' | 'failure'>;
+        killOthers?: Array<'success' | 'failure'> | undefined;
         /**
          * how many processes should run at once
          * @default 0
          */
-        maxProcesses?: number;
+        maxProcesses?: number | undefined;
         /**  a Writable stream to write logs to. Default: `process.stdout` */
-        outputStream?: NodeJS.WritableStream;
+        outputStream?: NodeJS.WritableStream | undefined;
         /**
          * the prefix type to use when logging processes output.
          */
-        prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string;
+        prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string | undefined;
         /** how many characters to show when prefixing with `command`. Default: `10` */
-        prefixLength?: number;
+        prefixLength?: number | undefined;
         /** whether raw mode should be used, meaning strictly process output will be logged, without any prefixes, colouring or extra stuff. */
-        raw?: boolean;
+        raw?: boolean | undefined;
         /** the condition to consider the run was successful. */
-        successCondition?: 'first' | 'last';
+        successCondition?: 'first' | 'last' | undefined;
         /** how many attempts to restart a process that dies will be made. Default: `0` */
-        restartTries?: number;
+        restartTries?: number | undefined;
         /** how many milliseconds to wait between process restarts. Default: 0 */
-        restartDelay?: number;
+        restartDelay?: number | undefined;
         /** a date-fns format to use when prefixing with time. Default: `yyyy-MM-dd HH:mm:ss.ZZZ` */
-        timestampFormat?: string;
+        timestampFormat?: string | undefined;
     }
 }
 

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -61,7 +61,7 @@ declare namespace c {
 
     interface IConfigSource {
         name: string;
-        original?: string;
+        original?: string | undefined;
         parsed: any;
     }
 }

--- a/types/configstore/index.d.ts
+++ b/types/configstore/index.d.ts
@@ -66,7 +66,7 @@ declare class Configstore {
 
 declare namespace Configstore {
     interface ConfigstoreOptions {
-        globalConfigPath?: boolean;
-        configPath?: string;
+        globalConfigPath?: boolean | undefined;
+        configPath?: string | undefined;
     }
 }

--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -16,12 +16,12 @@ declare function historyApiFallback(options?: historyApiFallback.Options): core.
 
 declare namespace historyApiFallback {
     interface Options {
-        readonly disableDotRule?: true;
-        readonly htmlAcceptHeaders?: ReadonlyArray<string>;
-        readonly index?: string;
-        readonly logger?: typeof console.log;
-        readonly rewrites?: ReadonlyArray<Rewrite>;
-        readonly verbose?: boolean;
+        readonly disableDotRule?: true | undefined;
+        readonly htmlAcceptHeaders?: ReadonlyArray<string> | undefined;
+        readonly index?: string | undefined;
+        readonly logger?: typeof console.log | undefined;
+        readonly rewrites?: ReadonlyArray<Rewrite> | undefined;
+        readonly verbose?: boolean | undefined;
     }
 
     interface Context {

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -25,21 +25,21 @@ declare module 'connect-redis' {
             client: Client;
         }
         interface RedisStoreOptions {
-            client?: Client;
-            host?: string;
-            port?: number;
-            socket?: string;
-            url?: string;
-            ttl?: number | string | ((store: RedisStore, sess: session.SessionData, sid: string) => number);
-            disableTTL?: boolean;
-            disableTouch?: boolean;
-            db?: number;
-            pass?: string;
-            prefix?: string;
-            unref?: boolean;
-            serializer?: Serializer | JSON;
-            logErrors?: boolean | ((error: string) => void);
-            scanCount?: number;
+            client?: Client | undefined;
+            host?: string | undefined;
+            port?: number | undefined;
+            socket?: string | undefined;
+            url?: string | undefined;
+            ttl?: number | string | ((store: RedisStore, sess: session.SessionData, sid: string) => number) | undefined;
+            disableTTL?: boolean | undefined;
+            disableTouch?: boolean | undefined;
+            db?: number | undefined;
+            pass?: string | undefined;
+            prefix?: string | undefined;
+            unref?: boolean | undefined;
+            serializer?: Serializer | JSON | undefined;
+            logErrors?: boolean | ((error: string) => void) | undefined;
+            scanCount?: number | undefined;
         }
         interface Serializer {
             stringify: Function;


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers widely used packages (more than 100,000 downloads per
month) from body-parser -- connect-redis
microsoft/dtslint#335