### PR TITLE
Add undefined to optional properties, Connect to Duplexer

### DIFF
--- a/types/connect/index.d.ts
+++ b/types/connect/index.d.ts
@@ -18,7 +18,7 @@ declare namespace createServer {
     export type ServerHandle = HandleFunction | http.Server;
 
     export class IncomingMessage extends http.IncomingMessage {
-        originalUrl?: http.IncomingMessage["url"];
+        originalUrl?: http.IncomingMessage["url"] | undefined;
     }
 
     type NextFunction = (err?: any) => void;

--- a/types/console-log-level/index.d.ts
+++ b/types/console-log-level/index.d.ts
@@ -12,9 +12,9 @@ declare namespace consoleLogLevel {
 }
 
 interface Options {
-    level?: consoleLogLevel.LogLevelNames;
-    prefix?: string | PrefixFunction;
-    stderr?: boolean;
+    level?: consoleLogLevel.LogLevelNames | undefined;
+    prefix?: string | PrefixFunction | undefined;
+    stderr?: boolean | undefined;
 }
 
 declare function consoleLogLevel(opts?: Options): consoleLogLevel.Logger;

--- a/types/consolidate/index.d.ts
+++ b/types/consolidate/index.d.ts
@@ -89,13 +89,13 @@ interface Consolidate extends ConsolidateType {
 interface RendererInterface {
     render(path: string, fn: (err: Error, html: string) => any): any;
 
-    render(path: string, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: string) => any): any;
+    render(path: string, options: { cache?: boolean | undefined, [otherOptions: string]: any }, fn: (err: Error, html: string) => any): any;
 
-    render(path: string, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<string>;
+    render(path: string, options?: { cache?: boolean | undefined, [otherOptions: string]: any }): Promise<string>;
 
     (path: string, fn: (err: Error, html: string) => any): any;
 
-    (path: string, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: string) => any): any;
+    (path: string, options: { cache?: boolean | undefined, [otherOptions: string]: any }, fn: (err: Error, html: string) => any): any;
 
-    (path: string, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<string>;
+    (path: string, options?: { cache?: boolean | undefined, [otherOptions: string]: any }): Promise<string>;
 }

--- a/types/contains-path/index.d.ts
+++ b/types/contains-path/index.d.ts
@@ -13,7 +13,7 @@ declare function containsPath(
 
 declare namespace containsPath {
     interface Options {
-        nocase?: boolean;
-        partialMatch?: boolean;
+        nocase?: boolean | undefined;
+        partialMatch?: boolean | undefined;
     }
 }

--- a/types/content-disposition/index.d.ts
+++ b/types/content-disposition/index.d.ts
@@ -28,14 +28,14 @@ declare namespace contentDisposition {
          * The `type` is normalized to lower-case.
          * @default 'attachment'
          */
-        type?: 'attachment' | 'inline' | string;
+        type?: 'attachment' | 'inline' | string | undefined;
         /**
          * If the filename option is outside ISO-8859-1,
          * then the file name is actually stored in a supplemental field for clients
          * that support Unicode file names and a ISO-8859-1 version of the file name is automatically generated
          * @default true
          */
-        fallback?: string | boolean;
+        fallback?: string | boolean | undefined;
     }
 
     /**

--- a/types/content-type/index.d.ts
+++ b/types/content-type/index.d.ts
@@ -14,7 +14,7 @@ export interface ParsedMediaType {
 
 export interface MediaType {
     type: string;
-    parameters?: {[key: string]: string};
+    parameters?: {[key: string]: string} | undefined;
 }
 
 export interface RequestLike {

--- a/types/convert-source-map/index.d.ts
+++ b/types/convert-source-map/index.d.ts
@@ -25,7 +25,7 @@ export interface SourceMapConverter {
      * By default, the comment is formatted like: //# sourceMappingURL=..., which you would normally see in a JS source file.
      * When options.multiline == true, the comment is formatted like: /*# sourceMappingURL=... *\/, which you would find in a CSS source file
      */
-    toComment(options?: { multiline?: boolean }): string;
+    toComment(options?: { multiline?: boolean | undefined }): string;
 
     /** Adds given property to the source map. Throws an error if property already exists */
     addProperty(key: string, value: any): SourceMapConverter;
@@ -83,4 +83,4 @@ export const mapFileCommentRegex: RegExp;
  * By default, the comment is formatted like: //# sourceMappingURL=..., which you would normally see in a JS source file.
  * When options.multiline == true, the comment is formatted like: /*# sourceMappingURL=... *\/, which you would find in a CSS source file.
  */
-export function generateMapFileComment(file: string, options?: { multiline?: boolean }): string;
+export function generateMapFileComment(file: string, options?: { multiline?: boolean | undefined }): string;

--- a/types/convict/convict-tests.ts
+++ b/types/convict/convict-tests.ts
@@ -56,7 +56,7 @@ convict({
 
 interface Foo {
     a: string;
-    b?: number;
+    b?: number | undefined;
 }
 // $ExpectType Config<{ foo: Foo; }>
 convict({

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for convict 6.1
+// Type definitions for convict 6.0
 // Project: https://github.com/mozilla/node-convict
 // Definitions by: Wim Looman <https://github.com/Nemo157>
 //                 Vesa Poikajärvi <https://github.com/vesse>
@@ -24,20 +24,14 @@ declare namespace convict {
          * any properties specified in config files that are not declared in the schema will
          * throw errors. This is to ensure that the schema and the config files are in sync.
          */
-        allowed?: ValidationMethod;
+        allowed?: ValidationMethod | undefined;
 
         /** @deprecated use allowed instead */
-        strict?: boolean;
-
-        /**
-         * If specififed, possible warnings will be passed to this function instead of being
-         * outputted to console.log, which would be the default behaviour.
-         */
-        output?(message: string): void;
+        strict?: boolean | undefined;
     }
 
     interface Format {
-        name?: string;
+        name?: string | undefined;
         validate?(val: any, schema: SchemaObj): void;
         coerce?(val: any): any;
     }
@@ -71,7 +65,7 @@ declare namespace convict {
          * Set its default to null and if your format doesn't accept null it will throw an error.
          */
         default: T | null;
-        doc?: string;
+        doc?: string | undefined;
         /**
          * From the implementation:
          *
@@ -84,11 +78,10 @@ declare namespace convict {
          * If omitted, format will be set to the value of Object.prototype.toString.call
          * for the default value
          */
-        format?: PredefinedFormat | any[] | ((val: any) => asserts val is T) | ((val: any) => void);
-        env?: string;
-        arg?: string;
-        sensitive?: boolean;
-        nullable?: boolean;
+        format?: PredefinedFormat | any[] | ((val: any) => asserts val is T) | ((val: any) => void) | undefined;
+        env?: string | undefined;
+        arg?: string | undefined;
+        sensitive?: boolean | undefined;
         [key: string]: any;
     }
 
@@ -103,8 +96,8 @@ declare namespace convict {
     }
 
     interface Options {
-        env?: NodeJS.ProcessEnv;
-        args?: string[];
+        env?: NodeJS.ProcessEnv | undefined;
+        args?: string[] | undefined;
     }
 
     // Taken from https://twitter.com/diegohaz/status/1309489079378219009

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for convict 6.0
+// Type definitions for convict 6.1
 // Project: https://github.com/mozilla/node-convict
 // Definitions by: Wim Looman <https://github.com/Nemo157>
 //                 Vesa Poikajärvi <https://github.com/vesse>
@@ -28,6 +28,12 @@ declare namespace convict {
 
         /** @deprecated use allowed instead */
         strict?: boolean | undefined;
+
+        /**
+         * If specified, possible warnings will be passed to this function instead of being
+         * outputted to console.log, which would be the default behaviour.
+         */
+        output?: ((message: string) => void) | undefined;
     }
 
     interface Format {
@@ -82,6 +88,7 @@ declare namespace convict {
         env?: string | undefined;
         arg?: string | undefined;
         sensitive?: boolean | undefined;
+        nullable?: boolean | undefined;
         [key: string]: any;
     }
 

--- a/types/cookie-parser/cookie-parser-tests.ts
+++ b/types/cookie-parser/cookie-parser-tests.ts
@@ -17,7 +17,7 @@ if (typeof res === 'undefined') {
 }
 
 const res2 = cookieParser.JSONCookies({foo: 'bar'});
-const jsonRes: { foo?: object } = res2;
+const jsonRes: { foo?: object | undefined } = res2;
 
 const res3 = cookieParser.signedCookie('', 'keyboard cat');
 cookieParser.signedCookie('', ['keyboard', 'cat']);
@@ -28,4 +28,4 @@ if (typeof res3 === 'string') {
 }
 
 const res4 = cookieParser.signedCookies({foo: 'bar'}, 'keyboard cat');
-const signedCookieRes: { foo?: string | false } = res4;
+const signedCookieRes: { foo?: string | false | undefined } = res4;

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -16,85 +16,85 @@ declare namespace CookieSessionInterfaces {
         /**
          * The name of the cookie to set, defaults to session.
          */
-        name?: string;
+        name?: string | undefined;
 
         /**
          * The list of keys to use to sign & verify cookie values. Set cookies are always signed with keys[0], while the other keys are valid for verification, allowing for key rotation.
          */
-        keys?: Array<string> | import('keygrip');
+        keys?: Array<string> | import('keygrip') | undefined;
 
         /**
          * A string which will be used as single key if keys is not provided.
          */
-        secret?: string;
+        secret?: string | undefined;
 
         /**
          * a number representing the milliseconds from Date.now() for expiry.
          */
-        maxAge?: number;
+        maxAge?: number | undefined;
 
         /**
          * a Date object indicating the cookie's expiration date (expires at the end of session by default).
          */
-        expires?: Date;
+        expires?: Date | undefined;
 
         /**
          * a string indicating the path of the cookie (/ by default).
          */
-        path?: string;
+        path?: string | undefined;
 
         /**
          * a string indicating the domain of the cookie (no default).
          */
-        domain?: string;
+        domain?: string | undefined;
 
         /**
          * a boolean or string indicating whether the cookie is a "same site" cookie (false by default). This can be set to 'strict', 'lax', 'none', or true (which maps to 'strict').
          */
-        sameSite?: "strict" | "lax" | "none" | boolean;
+        sameSite?: "strict" | "lax" | "none" | boolean | undefined;
 
         /**
          * a boolean indicating whether the cookie is only to be sent over HTTPS (false by default for HTTP, true by default for HTTPS).
          */
-        secure?: boolean;
+        secure?: boolean | undefined;
 
         /**
          * a boolean indicating whether the cookie is only to be sent over HTTPS (use this if you handle SSL not in your node process).
          */
-        secureProxy?: boolean;
+        secureProxy?: boolean | undefined;
 
         /**
          * a boolean indicating whether the cookie is only to be sent over HTTP(S), and not made available to client JavaScript (true by default).
          */
-        httpOnly?: boolean;
+        httpOnly?: boolean | undefined;
 
         /**
          * a boolean indicating whether the cookie is to be signed (true by default). If this is true, another cookie of the same name with the .sig suffix appended will also be sent, with a 27-byte url-safe base64 SHA1 value representing the hash of cookie-name=cookie-value against the
          * first Keygrip key. This signature key is used to detect tampering the next time a cookie is received.
          */
-        signed?: boolean;
+        signed?: boolean | undefined;
 
         /**
          * a boolean indicating whether to overwrite previously set cookies of the same name (true by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
          */
-        overwrite?: boolean;
+        overwrite?: boolean | undefined;
     }
 
     interface CookieSessionObject {
         /**
          * Is true if the session has been changed during the request.
          */
-        isChanged?: boolean;
+        isChanged?: boolean | undefined;
 
         /**
          * Is true if the session is new.
          */
-        isNew?: boolean;
+        isNew?: boolean | undefined;
 
         /**
          * Determine if the session has been populated with data or is empty.
          */
-        isPopulated?: boolean;
+        isPopulated?: boolean | undefined;
 
         [propertyName: string]: any;
     }
@@ -103,7 +103,7 @@ declare namespace CookieSessionInterfaces {
         /**
          * Represents the session for the given request.
          */
-        session?: CookieSessionObject | null;
+        session?: CookieSessionObject | null | undefined;
 
         /**
          * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.

--- a/types/cookie/index.d.ts
+++ b/types/cookie/index.d.ts
@@ -17,7 +17,7 @@ export interface CookieSerializeOptions {
      * domain is set, and most clients will consider the cookie to apply to only
      * the current domain.
      */
-    domain?: string;
+    domain?: string | undefined;
 
     /**
      * Specifies a function that will be used to encode a cookie's value. Since
@@ -41,7 +41,7 @@ export interface CookieSerializeOptions {
      * possible not all clients by obey this, so if both are set, they should
      * point to the same date and time.
      */
-    expires?: Date;
+    expires?: Date | undefined;
     /**
      * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.6|`HttpOnly` `Set-Cookie` attribute}.
      * When truthy, the `HttpOnly` attribute is set, otherwise it is not. By
@@ -50,7 +50,7 @@ export interface CookieSerializeOptions {
      * *Note* be careful when setting this to true, as compliant clients will
      * not allow client-side JavaScript to see the cookie in `document.cookie`.
      */
-    httpOnly?: boolean;
+    httpOnly?: boolean | undefined;
     /**
      * Specifies the number (in seconds) to be the value for the `Max-Age`
      * `Set-Cookie` attribute. The given number will be converted to an integer
@@ -61,12 +61,12 @@ export interface CookieSerializeOptions {
      * possible not all clients by obey this, so if both are set, they should
      * point to the same date and time.
      */
-    maxAge?: number;
+    maxAge?: number | undefined;
     /**
      * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
      * By default, the path is considered the "default path".
      */
-    path?: string;
+    path?: string | undefined;
     /**
      * Specifies the boolean or string to be the value for the {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|`SameSite` `Set-Cookie` attribute}.
      *
@@ -84,7 +84,7 @@ export interface CookieSerializeOptions {
      *
      * *note* This is an attribute that has not yet been fully standardized, and may change in the future. This also means many clients may ignore this attribute until they understand it.
      */
-    sameSite?: true | false | 'lax' | 'strict' | 'none';
+    sameSite?: true | false | 'lax' | 'strict' | 'none' | undefined;
     /**
      * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.5|`Secure` `Set-Cookie` attribute}. When truthy, the
      * `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.
@@ -93,7 +93,7 @@ export interface CookieSerializeOptions {
      * not send the cookie back to the server in the future if the browser does
      * not have an HTTPS connection.
      */
-    secure?: boolean;
+    secure?: boolean | undefined;
 }
 
 /**

--- a/types/cookies/index.d.ts
+++ b/types/cookies/index.d.ts
@@ -43,8 +43,8 @@ declare namespace Cookies {
     type IOptions = SetOption;
 
     interface Option {
-        keys?: string[] | Keygrip;
-        secure?: boolean;
+        keys?: string[] | Keygrip | undefined;
+        secure?: boolean | undefined;
     }
 
     interface GetOption {
@@ -55,39 +55,39 @@ declare namespace Cookies {
         /**
          * a number representing the milliseconds from Date.now() for expiry
          */
-        maxAge?: number;
+        maxAge?: number | undefined;
         /**
          * a Date object indicating the cookie's expiration
          * date (expires at the end of session by default).
          */
-        expires?: Date;
+        expires?: Date | undefined;
         /**
          * a string indicating the path of the cookie (/ by default).
          */
-        path?: string;
+        path?: string | undefined;
         /**
          * a string indicating the domain of the cookie (no default).
          */
-        domain?: string;
+        domain?: string | undefined;
         /**
          * a boolean indicating whether the cookie is only to be sent
          * over HTTPS (false by default for HTTP, true by default for HTTPS).
          */
-        secure?: boolean;
+        secure?: boolean | undefined;
         /**
          * "secureProxy" option is deprecated; use "secure" option, provide "secure" to constructor if needed
          */
-        secureProxy?: boolean;
+        secureProxy?: boolean | undefined;
         /**
          * a boolean indicating whether the cookie is only to be sent over HTTP(S),
          * and not made available to client JavaScript (true by default).
          */
-        httpOnly?: boolean;
+        httpOnly?: boolean | undefined;
         /**
          * a boolean or string indicating whether the cookie is a "same site" cookie (false by default).
          * This can be set to 'strict', 'lax', or true (which maps to 'strict').
          */
-        sameSite?: 'strict' | 'lax' | 'none' | boolean;
+        sameSite?: 'strict' | 'lax' | 'none' | boolean | undefined;
         /**
          * a boolean indicating whether the cookie is to be signed (false by default).
          * If this is true, another cookie of the same name with the .sig suffix
@@ -95,7 +95,7 @@ declare namespace Cookies {
          * representing the hash of cookie-name=cookie-value against the first Keygrip key.
          * This signature key is used to detect tampering the next time a cookie is received.
          */
-        signed?: boolean;
+        signed?: boolean | undefined;
         /**
          * a boolean indicating whether to overwrite previously set
          * cookies of the same name (false by default). If this is true,
@@ -103,7 +103,7 @@ declare namespace Cookies {
          * name (regardless of path or domain) are filtered out of
          * the Set-Cookie header when setting this cookie.
          */
-        overwrite?: boolean;
+        overwrite?: boolean | undefined;
     }
 
     type CookieAttr = SetOption;

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -43,25 +43,25 @@ declare namespace CopyPlugin {
               }: {
                   context: Exclude<ObjectPattern["context"], undefined>;
                   absoluteFilename: string;
-              }) => string);
+              }) => string) | undefined;
 
         /**
          * A path that determines how to interpret the `from` path.
          * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#context}
          * @default options.context | compiler.options.context
          */
-        context?: string;
+        context?: string | undefined;
 
         /**
          * Allows to configure the glob pattern matching library used by the plugin.
          * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#globoptions}
          */
-        globOptions?: object;
+        globOptions?: object | undefined;
 
         /**
          * Allows to filter copied assets.
          */
-        filter?: (resourcePath: string) => boolean;
+        filter?: ((resourcePath: string) => boolean) | undefined;
 
         /**
          * How to interpret `to`. default: undefined
@@ -70,38 +70,38 @@ declare namespace CopyPlugin {
          * `template` - if 'to' contains a template pattern.
          * @default undefined
          */
-        toType?: "file" | "dir" | "template";
+        toType?: "file" | "dir" | "template" | undefined;
 
         /**
          * Overwrites files already in `compilation.assets` (usually added by other plugins.
          * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#force}
          * @default false
          */
-        force?: boolean;
+        force?: boolean | undefined;
 
         /**
          * Allows you to specify the copy priority.
          * @default 0
          */
-        priority?: number;
+        priority?: number | undefined;
 
         /**
          * Function that modifies file contents before writing to webpack. (default: `(content, path) => content`)
          * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#transform}
          * @default undefined
          */
-        transform?: (content: Buffer, absoluteFrom: string) => string | Buffer | Promise<string | Buffer>;
+        transform?: ((content: Buffer, absoluteFrom: string) => string | Buffer | Promise<string | Buffer>) | undefined;
 
         /**
          * Doesn't generate an error on missing file(s);
          * @default false
          */
-        noErrorOnMissing?: boolean;
+        noErrorOnMissing?: boolean | undefined;
 
         /**
          * Allows to add assets info
          */
-        info?: Record<string, unknown> | ((file: string) => Record<string, unknown>);
+        info?: Record<string, unknown> | ((file: string) => Record<string, unknown>) | undefined;
     }
 
     type StringPattern = string;
@@ -111,12 +111,12 @@ declare namespace CopyPlugin {
          * Limits the number of simultaneous requests to fs
          * @default 100
          */
-        concurrency?: number;
+        concurrency?: number | undefined;
     }
 
     interface CopyPluginOptions {
         patterns: ReadonlyArray<StringPattern | ObjectPattern>;
-        options?: Options;
+        options?: Options | undefined;
     }
 }
 

--- a/types/copy-webpack-plugin/v6/index.d.ts
+++ b/types/copy-webpack-plugin/v6/index.d.ts
@@ -30,25 +30,25 @@ interface ObjectPattern {
           }: {
               context: Exclude<ObjectPattern['context'], undefined>;
               absoluteFilename: string;
-          }) => string);
+          }) => string) | undefined;
 
     /**
      * A path that determines how to interpret the `from` path.
      * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#context}
      * @default options.context | compiler.options.context
      */
-    context?: string;
+    context?: string | undefined;
 
     /**
      * Allows to configure the glob pattern matching library used by the plugin.
      * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#globoptions}
      */
-    globOptions?: object;
+    globOptions?: object | undefined;
 
     /**
      * Allows to filter copied assets.
      */
-    filter?: (resourcePath: string) => boolean;
+    filter?: ((resourcePath: string) => boolean) | undefined;
 
     /**
      * How to interpret `to`. default: undefined
@@ -57,14 +57,14 @@ interface ObjectPattern {
      * `template` - if 'to' contains a template pattern.
      * @default undefined
      */
-    toType?: 'file' | 'dir' | 'template';
+    toType?: 'file' | 'dir' | 'template' | undefined;
 
     /**
      * Overwrites files already in `compilation.assets` (usually added by other plugins.
      * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#force}
      * @default false
      */
-    force?: boolean;
+    force?: boolean | undefined;
 
     /**
      * Removes all directory references and only copies file names. (default: `false`)
@@ -72,38 +72,38 @@ interface ObjectPattern {
      * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#flatten}
      * @default false
      */
-    flatten?: boolean;
+    flatten?: boolean | undefined;
 
     /**
      * Function that modifies file contents before writing to webpack. (default: `(content, path) => content`)
      * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#transform}
      * @default undefined
      */
-    transform?: (content: Buffer, absoluteFrom: string) => string | Buffer | Promise<string | Buffer>;
+    transform?: ((content: Buffer, absoluteFrom: string) => string | Buffer | Promise<string | Buffer>) | undefined;
 
     /**
      * Enable/disable and configure caching. Default path to cache directory: node_modules/.cache/copy-webpack-plugin.
      * @default false
      */
-    cacheTransform?: boolean | string | object;
+    cacheTransform?: boolean | string | object | undefined;
 
     /**
      * Allows to modify the writing path.
      * Returns the new path or a promise that resolves into the new path
      * @default undefined
      */
-    transformPath?: (targetPath: string, absolutePath: string) => string | Promise<string>;
+    transformPath?: ((targetPath: string, absolutePath: string) => string | Promise<string>) | undefined;
 
     /**
      * Doesn't generate an error on missing file(s);
      * @default false
      */
-    noErrorOnMissing?: boolean;
+    noErrorOnMissing?: boolean | undefined;
 
     /**
      * Allows to add assets info
      */
-    info?: Record<string, unknown> | ((file: string) => Record<string, unknown>);
+    info?: Record<string, unknown> | ((file: string) => Record<string, unknown>) | undefined;
 }
 
 type StringPattern = string;
@@ -113,12 +113,12 @@ interface Options {
      * Limits the number of simultaneous requests to fs
      * @default 100
      */
-    concurrency?: number;
+    concurrency?: number | undefined;
 }
 
 interface CopyPluginOptions {
     patterns: ReadonlyArray<StringPattern | ObjectPattern>;
-    options?: Options;
+    options?: Options | undefined;
 }
 
 interface CopyPlugin {

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -13,30 +13,30 @@ type CustomOrigin = (requestOrigin: string | undefined, callback: (err: Error | 
 
 declare namespace e {
     interface CorsRequest {
-        method?: string;
+        method?: string | undefined;
         headers: IncomingHttpHeaders;
     }
     interface CorsOptions {
         /**
          * @default '*''
          */
-        origin?: StaticOrigin | CustomOrigin;
+        origin?: StaticOrigin | CustomOrigin | undefined;
         /**
          * @default 'GET,HEAD,PUT,PATCH,POST,DELETE'
          */
-        methods?: string | string[];
-        allowedHeaders?: string | string[];
-        exposedHeaders?: string | string[];
-        credentials?: boolean;
-        maxAge?: number;
+        methods?: string | string[] | undefined;
+        allowedHeaders?: string | string[] | undefined;
+        exposedHeaders?: string | string[] | undefined;
+        credentials?: boolean | undefined;
+        maxAge?: number | undefined;
         /**
          * @default false
          */
-        preflightContinue?: boolean;
+        preflightContinue?: boolean | undefined;
         /**
          * @default 204
          */
-        optionsSuccessStatus?: number;
+        optionsSuccessStatus?: number | undefined;
     }
     type CorsOptionsDelegate<T extends CorsRequest = CorsRequest> = (
         req: T,
@@ -49,7 +49,7 @@ declare function e<T extends e.CorsRequest = e.CorsRequest>(
 ): (
     req: T,
     res: {
-        statusCode?: number;
+        statusCode?: number | undefined;
         setHeader(key: string, value: string): any;
         end(): any;
     },

--- a/types/cron/index.d.ts
+++ b/types/cron/index.d.ts
@@ -10,7 +10,7 @@
 import { Moment } from 'moment';
 import { SpawnOptions } from "child_process";
 
-export declare type CronCommand = (() => void) | string | { command: string, args?: ReadonlyArray<string>, options?: SpawnOptions};
+export declare type CronCommand = (() => void) | string | { command: string, args?: ReadonlyArray<string> | undefined, options?: SpawnOptions | undefined};
 
 export declare class CronTime {
     /**
@@ -49,15 +49,15 @@ export declare interface CronJobParameters {
     /**
      * A function that will fire when the job is stopped with ```job.stop()```, and may also be called by ```onTick``` at the end of each run.
      */
-    onComplete?: CronCommand | null;
+    onComplete?: CronCommand | null | undefined;
     /**
      * Specifies whether to start the job just before exiting the constructor. By default this is set to false. If left at default you will need to call ```job.start()``` in order to start the job (assuming ```job``` is the variable you set the cronjob to). This does not immediately fire your ```onTick``` function, it just gives you more control over the behavior of your jobs.
      */
-    start?: boolean;
+    start?: boolean | undefined;
     /**
      * Specify the timezone for the execution. This will modify the actual time relative to your timezone. If the timezone is invalid, an error is thrown. You can check all timezones available at [Moment Timezone Website](http://momentjs.com/timezone/). Probably don't use both ```timeZone``` and ```utcOffset``` together or weird things may happen.
      */
-    timeZone?: string;
+    timeZone?: string | undefined;
     /**
      * The context within which to execute the onTick method. This defaults to the cronjob itself allowing you to call ```this.stop()```. However, if you change this you'll have access to the functions and values within your context object.
      */
@@ -65,15 +65,15 @@ export declare interface CronJobParameters {
     /**
      * This will immediately fire your ```onTick``` function as soon as the requisit initialization has happened. This option is set to ```false``` by default for backwards compatibility.
      */
-    runOnInit?: boolean;
+    runOnInit?: boolean | undefined;
     /**
      * This allows you to specify the offset of your timezone rather than using the ```timeZone``` param. Probably don't use both ```timeZone``` and ```utcOffset``` together or weird things may happen.
      */
-    utcOffset?: string | number;
+    utcOffset?: string | number | undefined;
     /**
      * If you have code that keeps the event loop running and want to stop the node process when that finishes regardless of the state of your cronjob, you can do so making use of this parameter. This is off by default and cron will run as if it needs to control the event loop. For more information take a look at [timers#timers_timeout_unref](https://nodejs.org/api/timers.html#timers_timeout_unref) from the NodeJS docs.
      */
-    unrefTimeout?: boolean;
+    unrefTimeout?: boolean | undefined;
 }
 
 export declare class CronJob {

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -281,8 +281,8 @@ interface CipherOption {
     /**
      * The IV to use for this operation.
      */
-    iv?: WordArray;
-    format?: Format;
+    iv?: WordArray | undefined;
+    format?: Format | undefined;
     [key: string]: any;
 }
 
@@ -503,15 +503,15 @@ interface KDFOption {
     /**
      * The key size in words to generate.
      */
-    keySize?: number;
+    keySize?: number | undefined;
     /**
      * The hasher to use.
      */
-    hasher?: HasherStatic;
+    hasher?: HasherStatic | undefined;
     /**
      * The number of iterations to perform.
      */
-    iterations?: number;
+    iterations?: number | undefined;
 }
 
 declare global {
@@ -1190,7 +1190,7 @@ declare global {
                  *     var kdf = CryptoJS.algo.EvpKDF.create({ keySize: 8 });
                  *     var kdf = CryptoJS.algo.EvpKDF.create({ keySize: 8, iterations: 1000 });
                  */
-                static create(cfg?: { keySize: number; hasher?: HasherStatic; iterations: number }): EvpKDF;
+                static create(cfg?: { keySize: number; hasher?: HasherStatic | undefined; iterations: number }): EvpKDF;
 
                 /**
                  * Derives a key from a password.
@@ -1723,7 +1723,7 @@ declare global {
             salt: WordArray | string,
             cfg?: {
                 keySize: number;
-                hasher?: HasherStatic;
+                hasher?: HasherStatic | undefined;
                 iterations: number;
             },
         ): WordArray;

--- a/types/css-declaration-sorter/index.d.ts
+++ b/types/css-declaration-sorter/index.d.ts
@@ -52,13 +52,13 @@ declare namespace cssDeclarationSorter {
          * Provide the name of one of the built-in sort orders or a comparison function that is passed to `Array.sort`.
          * @default 'alphabetical'
          */
-        order?: SortOrder | SortFunction;
+        order?: SortOrder | SortFunction | undefined;
         /**
          * To prevent breaking legacy CSS where shorthand declarations override longhand declarations
          * (also taking into account vendor prefixes) this option can enabled.
          * For example `animation-name: some; animation: greeting;` will be kept in this order when `keepOverrides` is `true`.
          */
-        keepOverrides?: boolean;
+        keepOverrides?: boolean | undefined;
     }
 
     type CssDeclarationSorter = PluginCreator<Options>;

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -8,7 +8,7 @@ export type FontFaceSetLoadStatus = 'loading' | 'loaded';
 export type BinaryData = ArrayBuffer | ArrayBufferView;
 
 export interface FontFaceSetLoadEventInit extends EventInit {
-    fontfaces?: FontFace[];
+    fontfaces?: FontFace[] | undefined;
 }
 
 export interface FontFaceSetEventMap {
@@ -47,13 +47,13 @@ export interface FontFaceSet extends Set<FontFace>, EventTarget {
 
 declare global {
     interface FontFaceDescriptors {
-        display?: string;
-        featureSettings?: string;
-        stretch?: string;
-        style?: string;
-        unicodeRange?: string;
-        variant?: string;
-        weight?: string;
+        display?: string | undefined;
+        featureSettings?: string | undefined;
+        stretch?: string | undefined;
+        style?: string | undefined;
+        unicodeRange?: string | undefined;
+        variant?: string | undefined;
+        weight?: string | undefined;
     }
 
     interface FontFace {

--- a/types/css-minimizer-webpack-plugin/index.d.ts
+++ b/types/css-minimizer-webpack-plugin/index.d.ts
@@ -23,60 +23,60 @@ declare class CssMinimizerPlugin {
 
 declare namespace CssMinimizerPlugin {
     interface Options {
-        minimizerOptions?: MinimizerOptions | MinimizerOptions[];
+        minimizerOptions?: MinimizerOptions | MinimizerOptions[] | undefined;
         /**
          * Test to match files against.
          */
-        test?: string | RegExp | Array<string | RegExp>;
+        test?: string | RegExp | Array<string | RegExp> | undefined;
         /**
          * Files to include
          */
-        include?: string | RegExp | Array<string | RegExp>;
+        include?: string | RegExp | Array<string | RegExp> | undefined;
         /**
          * Files to exclude.
          */
-        exclude?: string | RegExp | Array<string | RegExp>;
+        exclude?: string | RegExp | Array<string | RegExp> | undefined;
         /**
          * Enable file caching.
          * @default 'node_modules/.cache/css-minimizer-webpack-plugin'
          */
-        cache?: boolean | string;
+        cache?: boolean | string | undefined;
         /**
          * Allows you to override default cache keys.
          */
-        cacheKeys?: (defaultCacheKeys: CacheKeys, file: string) => CacheKeys;
+        cacheKeys?: ((defaultCacheKeys: CacheKeys, file: string) => CacheKeys) | undefined;
         /**
          * Use multi-process parallel running to improve the build speed.
          * Default number of concurrent runs: os.cpus().length - 1.
          */
-        parallel?: boolean | number;
+        parallel?: boolean | number | undefined;
         /**
          * Enable (and configure) source map support.
          * Use PostCss SourceMap options.
          * Default configuration when enabled: { inline: false }.
          */
-        sourceMap?: boolean | SourceMapOptions;
+        sourceMap?: boolean | SourceMapOptions | undefined;
         /**
          * Allows you to override default minify function.
          * By default plugin uses cssnano package. Useful for using and testing unpublished versions or forks.
          */
-        minify?: MinifyFunc | MinifyFunc[];
+        minify?: MinifyFunc | MinifyFunc[] | undefined;
         /**
          * Allow to filter css-minimizer warnings (By default cssnano).
          * Return true to keep the warning, a falsy value (false/null/undefined) otherwise.
          */
-        warningsFilter?: (warning: string, file: string, source: string) => boolean | undefined | null;
+        warningsFilter?: ((warning: string, file: string, source: string) => boolean | undefined | null) | undefined;
     }
 
     interface MinimizerOptions extends CssNanoOptions {
         processorOptions?: {
-            from?: ProcessOptions["from"];
-            map?: ProcessOptions["map"];
-            parser?: ProcessOptions["parser"] | string;
-            stringifier?: ProcessOptions["stringifier"] | string;
-            syntax?: ProcessOptions["syntax"] | string;
-            to?: ProcessOptions["to"];
-        };
+            from?: ProcessOptions["from"] | undefined;
+            map?: ProcessOptions["map"] | undefined;
+            parser?: ProcessOptions["parser"] | string | undefined;
+            stringifier?: ProcessOptions["stringifier"] | string | undefined;
+            syntax?: ProcessOptions["syntax"] | string | undefined;
+            to?: ProcessOptions["to"] | undefined;
+        } | undefined;
     }
 
     interface MinifyFunc {

--- a/types/css-selector-tokenizer/index.d.ts
+++ b/types/css-selector-tokenizer/index.d.ts
@@ -4,9 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface BaseNode {
-    name?: string;
-    before?: string;
-    after?: string;
+    name?: string | undefined;
+    before?: string | undefined;
+    after?: string | undefined;
 }
 
 /** Any node returned by `parse`. Useful for `walk` implementations. */
@@ -40,7 +40,7 @@ export type SelectorNodeType =
 export interface ElementNode extends BaseNode {
     type: 'element';
     name: string;
-    namespace?: string;
+    namespace?: string | undefined;
 }
 
 export interface PseudoElementNode extends BaseNode {
@@ -56,7 +56,7 @@ export interface ClassNode extends BaseNode {
 export interface PseudoClassNode extends BaseNode {
     type: 'pseudo-class';
     name: string;
-    content?: string;
+    content?: string | undefined;
 }
 
 export interface AttributeNode extends BaseNode {
@@ -87,7 +87,7 @@ export interface SpacingNode extends BaseNode {
 
 export interface UniversalNode extends BaseNode {
     type: 'universal';
-    namespace?: string;
+    namespace?: string | undefined;
 }
 
 export interface OperatorNode extends BaseNode {
@@ -130,9 +130,9 @@ export interface NestedItemNode extends BaseNode {
 export interface UrlNode extends BaseNode {
     type: 'url';
     url: string;
-    stringType?: string;
-    innerSpacingBefore?: string;
-    innerSpacingAfter?: string;
+    stringType?: string | undefined;
+    innerSpacingBefore?: string | undefined;
+    innerSpacingAfter?: string | undefined;
 }
 
 export interface StringNode extends BaseNode {

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -79,7 +79,7 @@ export class List<TData> {
 
 export interface CssNodeCommon {
     type: string;
-    loc?: CssLocation;
+    loc?: CssLocation | undefined;
 }
 
 export interface AnPlusB extends CssNodeCommon {
@@ -486,18 +486,18 @@ export interface SyntaxParseError extends SyntaxError {
 }
 
 export interface ParseOptions {
-    context?: string;
-    atrule?: string;
-    positions?: boolean;
-    onParseError?: (error: SyntaxParseError, fallbackNode: CssNode) => void;
-    filename?: string;
-    offset?: number;
-    line?: number;
-    column?: number;
-    parseAtrulePrelude?: boolean;
-    parseRulePrelude?: boolean;
-    parseValue?: boolean;
-    parseCustomProperty?: boolean;
+    context?: string | undefined;
+    atrule?: string | undefined;
+    positions?: boolean | undefined;
+    onParseError?: ((error: SyntaxParseError, fallbackNode: CssNode) => void) | undefined;
+    filename?: string | undefined;
+    offset?: number | undefined;
+    line?: number | undefined;
+    column?: number | undefined;
+    parseAtrulePrelude?: boolean | undefined;
+    parseRulePrelude?: boolean | undefined;
+    parseValue?: boolean | undefined;
+    parseCustomProperty?: boolean | undefined;
 }
 
 export function parse(text: string, options?: ParseOptions): CssNode;
@@ -510,8 +510,8 @@ export interface GenerateHandlers {
 }
 
 export interface GenerateOptions {
-    sourceMap?: boolean;
-    decorator?: (handlers: GenerateHandlers) => GenerateHandlers;
+    sourceMap?: boolean | undefined;
+    decorator?: ((handlers: GenerateHandlers) => GenerateHandlers) | undefined;
 }
 
 export function generate(ast: CssNode, options?: GenerateOptions): string;
@@ -531,16 +531,16 @@ export interface WalkContext {
 export type EnterOrLeaveFn<NodeType = CssNode> = (this: WalkContext, node: NodeType, item: ListItem<CssNode>, list: List<CssNode>) => void;
 
 export interface WalkOptionsNoVisit {
-    enter?: EnterOrLeaveFn;
-    leave?: EnterOrLeaveFn;
-    reverse?: boolean;
+    enter?: EnterOrLeaveFn | undefined;
+    leave?: EnterOrLeaveFn | undefined;
+    reverse?: boolean | undefined;
 }
 
 export interface WalkOptionsVisit<NodeType extends CssNode = CssNode> {
     visit: NodeType['type'];
-    enter?: EnterOrLeaveFn<NodeType>;
-    leave?: EnterOrLeaveFn<NodeType>;
-    reverse?: boolean;
+    enter?: EnterOrLeaveFn<NodeType> | undefined;
+    leave?: EnterOrLeaveFn<NodeType> | undefined;
+    reverse?: boolean | undefined;
 }
 
 export type WalkOptions =
@@ -747,17 +747,17 @@ export type DSNodeMultiplied =
  * Definition syntax generate options
  */
 export interface DSGenerateOptions {
-    forceBraces?: boolean;
-    compact?: boolean;
-    decorate?: (result: string, node: DSNode) => void;
+    forceBraces?: boolean | undefined;
+    compact?: boolean | undefined;
+    decorate?: ((result: string, node: DSNode) => void) | undefined;
 }
 
 /**
  * Definition syntax walk options
  */
 export interface DSWalkOptions {
-    enter?: DSWalkEnterOrLeaveFn;
-    leave?: DSWalkEnterOrLeaveFn;
+    enter?: DSWalkEnterOrLeaveFn | undefined;
+    leave?: DSWalkEnterOrLeaveFn | undefined;
 }
 
 /**

--- a/types/css/index.d.ts
+++ b/types/css/index.d.ts
@@ -13,9 +13,9 @@
  */
 export interface ParserOptions {
     /** Silently fail on parse errors */
-    silent?: boolean;
+    silent?: boolean | undefined;
     /** The path to the file containing css. Makes errors and source maps more helpful, by letting them know where code comes from. */
-    source?: string;
+    source?: string | undefined;
 }
 
 /**
@@ -23,21 +23,21 @@ export interface ParserOptions {
  */
 export interface StringifyOptions {
     /** The string used to indent the output. Defaults to two spaces. */
-    indent?: string;
+    indent?: string | undefined;
     /** Omit comments and extraneous whitespace. */
-    compress?: boolean;
+    compress?: boolean | undefined;
     /** Return a sourcemap along with the CSS output. 
      * Using the source option of css.parse is strongly recommended 
      * when creating a source map. Specify sourcemap: 'generator' 
      * to return the SourceMapGenerator object instead of serializing the source map. 
      */
-    sourcemap?: string;
+    sourcemap?: string | undefined;
     /** (enabled by default, specify false to disable)
      *  Reads any source maps referenced by the input files 
      * when generating the output source map. When enabled, 
      * file system access may be required for reading the referenced source maps. 
      */
-    inputSourcemaps?: boolean;
+    inputSourcemaps?: boolean | undefined;
 }
 
 /**
@@ -45,15 +45,15 @@ export interface StringifyOptions {
  */
 export interface ParserError {
     /** The full error message with the source position. */
-    message?: string;
+    message?: string | undefined;
     /** The error message without position. */
-    reason?: string;
+    reason?: string | undefined;
     /** The value of options.source if passed to css.parse. Otherwise undefined. */
-    filename?: string;
-    line?: number;
-    column?: number;
+    filename?: string | undefined;
+    line?: number | undefined;
+    column?: number | undefined;
     /** The portion of code that couldn't be parsed. */
-    source?: string;
+    source?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------------
@@ -65,8 +65,8 @@ export interface ParserError {
  * The line and column numbers are 1-based: The first line is 1 and the first column of a line is 1 (not 0).
  */
 export interface Position {
-    line?: number;
-    column?: number;
+    line?: number | undefined;
+    column?: number | undefined;
 }
 
 /**
@@ -74,39 +74,39 @@ export interface Position {
  */
 export interface Node {
     /** The possible values are the ones listed in the Types section on https://github.com/reworkcss/css page. */
-    type?: string;
+    type?: string | undefined;
     /** A reference to the parent node, or null if the node has no parent. */
-    parent?: Node;
+    parent?: Node | undefined;
     /** Information about the position in the source string that corresponds to the node. */
     position?: {
-        start?: Position;
-        end?: Position;
+        start?: Position | undefined;
+        end?: Position | undefined;
         /** The value of options.source if passed to css.parse. Otherwise undefined. */
-        source?: string;
+        source?: string | undefined;
         /** The full source string passed to css.parse. */
-        content?: string;
-    };
+        content?: string | undefined;
+    } | undefined;
 }
 
 export interface Rule extends Node {
     /** The list of selectors of the rule, split on commas. Each selector is trimmed from whitespace and comments. */
-    selectors?: Array<string>;
+    selectors?: Array<string> | undefined;
     /** Array of nodes with the types declaration and comment. */
-    declarations?: Array<Declaration | Comment>;
+    declarations?: Array<Declaration | Comment> | undefined;
 }
 
 export interface Declaration extends Node {
     /** The property name, trimmed from whitespace and comments. May not be empty. */
-    property?: string;
+    property?: string | undefined;
     /** The value of the property, trimmed from whitespace and comments. Empty values are allowed. */
-    value?: string;
+    value?: string | undefined;
 }
 
 /** 
  * A rule-level or declaration-level comment. Comments inside selectors, properties and values etc. are lost.
  */
 export interface Comment extends Node {
-    comment?: string;
+    comment?: string | undefined;
 }
 
 /** 
@@ -114,7 +114,7 @@ export interface Comment extends Node {
  */
 export interface Charset extends Node {
     /** The part following @charset. */
-    charset?: string;
+    charset?: string | undefined;
 }
 
 /**
@@ -122,9 +122,9 @@ export interface Charset extends Node {
  */
 export interface CustomMedia extends Node {
     /** The ---prefixed name. */
-    name?: string;
+    name?: string | undefined;
     /** The part following the name. */
-    media?: string;
+    media?: string | undefined;
 }
 
 /**
@@ -132,11 +132,11 @@ export interface CustomMedia extends Node {
  */
 export interface Document extends Node {
     /** The part following @document. */
-    document?: string;
+    document?: string | undefined;
     /** The vendor prefix in @document, or undefined if there is none. */
-    vendor?: string;
+    vendor?: string | undefined;
     /** Array of nodes with the types rule, comment and any of the at-rule types. */
-    rules?: Array<Rule | Comment | AtRule>;
+    rules?: Array<Rule | Comment | AtRule> | undefined;
 }
 
 /**
@@ -144,7 +144,7 @@ export interface Document extends Node {
  */
 export interface FontFace extends Node {
     /** Array of nodes with the types declaration and comment. */
-    declarations?: Array<Declaration | Comment>;
+    declarations?: Array<Declaration | Comment> | undefined;
 }
 
 /**
@@ -152,7 +152,7 @@ export interface FontFace extends Node {
  */
 export interface Host extends Node {
     /** Array of nodes with the types rule, comment and any of the at-rule types. */
-    rules?: Array<Rule | Comment | AtRule>;
+    rules?: Array<Rule | Comment | AtRule> | undefined;
 }
 
 /**
@@ -160,7 +160,7 @@ export interface Host extends Node {
  */
 export interface Import extends Node {
     /** The part following @import. */
-    import?: string;
+    import?: string | undefined;
 }
 
 /**
@@ -168,18 +168,18 @@ export interface Import extends Node {
  */
 export interface KeyFrames extends Node {
     /** The name of the keyframes rule. */
-    name?: string;
+    name?: string | undefined;
     /** The vendor prefix in @keyframes, or undefined if there is none. */
-    vendor?: string;
+    vendor?: string | undefined;
     /** Array of nodes with the types keyframe and comment. */
-    keyframes?: Array<KeyFrame | Comment>;
+    keyframes?: Array<KeyFrame | Comment> | undefined;
 }
 
 export interface KeyFrame extends Node {
     /** The list of "selectors" of the keyframe rule, split on commas. Each “selector” is trimmed from whitespace. */
-    values?: Array<string>;
+    values?: Array<string> | undefined;
     /** Array of nodes with the types declaration and comment. */
-    declarations?: Array<Declaration | Comment>;
+    declarations?: Array<Declaration | Comment> | undefined;
 }
 
 /**
@@ -187,9 +187,9 @@ export interface KeyFrame extends Node {
  */
 export interface Media extends Node {
     /** The part following @media. */
-    media?: string;
+    media?: string | undefined;
     /** Array of nodes with the types rule, comment and any of the at-rule types. */
-    rules?: Array<Rule | Comment | AtRule>;
+    rules?: Array<Rule | Comment | AtRule> | undefined;
 }
 
 /**
@@ -197,7 +197,7 @@ export interface Media extends Node {
  */
 export interface Namespace extends Node {
     /** The part following @namespace. */
-    namespace?: string;
+    namespace?: string | undefined;
 }
 
 /**
@@ -205,9 +205,9 @@ export interface Namespace extends Node {
  */
 export interface Page extends Node {
     /** The list of selectors of the rule, split on commas. Each selector is trimmed from whitespace and comments. */
-    selectors?: Array<string>;
+    selectors?: Array<string> | undefined;
     /** Array of nodes with the types declaration and comment. */
-    declarations?: Array<Declaration | Comment>;
+    declarations?: Array<Declaration | Comment> | undefined;
 }
 
 /**
@@ -215,9 +215,9 @@ export interface Page extends Node {
  */
 export interface Supports extends Node {
     /** The part following @supports. */
-    supports?: string;
+    supports?: string | undefined;
     /** Array of nodes with the types rule, comment and any of the at-rule types. */
-    rules?: Array<Rule | Comment | AtRule>;
+    rules?: Array<Rule | Comment | AtRule> | undefined;
 }
 
 /** All at-rules. */
@@ -230,14 +230,14 @@ export interface StyleRules {
     /** Array of nodes with the types rule, comment and any of the at-rule types. */
     rules: Array<Rule | Comment | AtRule>;
     /** Array of Errors. Errors collected during parsing when option silent is true. */
-    parsingErrors?: Array<ParserError>
+    parsingErrors?: Array<ParserError> | undefined
 }
 
 /** 
  * The root node returned by css.parse. 
  */
 export interface Stylesheet extends Node {
-    stylesheet?: StyleRules;
+    stylesheet?: StyleRules | undefined;
 }
 
 // ---------------------------------------------------------------------------------

--- a/types/cssnano/index.d.ts
+++ b/types/cssnano/index.d.ts
@@ -8,8 +8,8 @@ import { Plugin } from 'postcss';
 
 declare namespace cssnano {
     interface CssNanoOptions {
-        configFile?: string;
-        preset?: [string, object] | string;
+        configFile?: string | undefined;
+        preset?: [string, object] | string | undefined;
     }
 
     type CssNano = Plugin<CssNanoOptions>;

--- a/types/csso/index.d.ts
+++ b/types/csso/index.d.ts
@@ -20,15 +20,15 @@ declare namespace csso {
     }
 
     interface Usage {
-        tags?: string[];
-        ids?: string[];
-        classes?: string[];
-        scopes?: string[][];
+        tags?: string[] | undefined;
+        ids?: string[] | undefined;
+        classes?: string[] | undefined;
+        scopes?: string[][] | undefined;
         blacklist?: {
-            tags?: string[];
-            ids?: string[];
-            classes?: string[];
-        };
+            tags?: string[] | undefined;
+            ids?: string[] | undefined;
+            classes?: string[] | undefined;
+        } | undefined;
     }
 
     interface CompressOptions {
@@ -36,18 +36,18 @@ declare namespace csso {
          * Disable or enable a structure optimisations.
          * @default true
          */
-        restructure?: boolean;
+        restructure?: boolean | undefined;
         /**
          * Enables merging of @media rules with the same media query by splitted by other rules.
          * The optimisation is unsafe in general, but should work fine in most cases. Use it on your own risk.
          * @default false
          */
-        forceMediaMerge?: boolean;
+        forceMediaMerge?: boolean | undefined;
         /**
          * Transform a copy of input AST if true. Useful in case of AST reuse.
          * @default false
          */
-        clone?: boolean;
+        clone?: boolean | undefined;
         /**
          * Specify what comments to leave:
          * - 'exclamation' or true – leave all exclamation comments
@@ -55,15 +55,15 @@ declare namespace csso {
          * - false – remove all comments
          * @default true
          */
-        comments?: string | boolean;
+        comments?: string | boolean | undefined;
         /**
          * Usage data for advanced optimisations.
          */
-        usage?: Usage;
+        usage?: Usage | undefined;
         /**
          * Function to track every step of transformation.
          */
-        logger?: () => void;
+        logger?: (() => void) | undefined;
     }
 
     interface MinifyOptions {
@@ -71,26 +71,26 @@ declare namespace csso {
          * Generate a source map when true.
          * @default false
          */
-        sourceMap?: boolean;
+        sourceMap?: boolean | undefined;
         /**
          * Filename of input CSS, uses for source map generation.
          * @default '<unknown>'
          */
-        filename?: string;
+        filename?: string | undefined;
         /**
          * Output debug information to stderr.
          * @default false
          */
-        debug?: boolean;
+        debug?: boolean | undefined;
         /**
          * Called right after parse is run.
          */
-        beforeCompress?: BeforeCompressFn | BeforeCompressFn[];
+        beforeCompress?: BeforeCompressFn | BeforeCompressFn[] | undefined;
         /**
          * Called right after compress() is run.
          */
-        afterCompress?: AfterCompressFn | AfterCompressFn[];
-        restructure?: boolean;
+        afterCompress?: AfterCompressFn | AfterCompressFn[] | undefined;
+        restructure?: boolean | undefined;
     }
 
     type BeforeCompressFn = (ast: object, options: CompressOptions) => void;

--- a/types/csurf/index.d.ts
+++ b/types/csurf/index.d.ts
@@ -14,13 +14,13 @@ declare global {
 }
 
 declare function csurf(options?: {
-    value?: (req: express.Request) => string;
+    value?: ((req: express.Request) => string) | undefined;
     /**
      * @default false
      */
-    cookie?: csurf.CookieOptions | boolean;
-    ignoreMethods?: string[];
-    sessionKey?: string;
+    cookie?: csurf.CookieOptions | boolean | undefined;
+    ignoreMethods?: string[] | undefined;
+    sessionKey?: string | undefined;
 }): express.RequestHandler;
 
 declare namespace csurf {
@@ -28,7 +28,7 @@ declare namespace csurf {
         /**
          * @default '_csrf'
          */
-        key?: string;
+        key?: string | undefined;
     }
 }
 

--- a/types/cypress-cucumber-preprocessor/steps/index.d.ts
+++ b/types/cypress-cucumber-preprocessor/steps/index.d.ts
@@ -1,10 +1,10 @@
 export interface Transform {
     regexp: RegExp;
     transformer(...arg: string[]): any;
-    useForSnippets?: boolean;
-    preferForRegexpMatch?: boolean;
-    name?: string;
-    typeName?: string; // deprecated
+    useForSnippets?: boolean | undefined;
+    preferForRegexpMatch?: boolean | undefined;
+    name?: string | undefined;
+    typeName?: string | undefined; // deprecated
 }
 
 export function defineStep(expression: RegExp | string, implementation: (...args: any[]) => void): void;

--- a/types/d/auto-bind.d.ts
+++ b/types/d/auto-bind.d.ts
@@ -7,7 +7,7 @@ declare function autoBind(
 
 declare namespace autoBind {
     interface Options {
-        overwriteDefinition?: boolean;
-        resolveContext?: (context: any) => any;
+        overwriteDefinition?: boolean | undefined;
+        resolveContext?: ((context: any) => any) | undefined;
     }
 }

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -824,7 +824,7 @@ const keysComparator: string[] = d3Array.groupSort(barley, (a, b) => d3Array.asc
 let count: number;
 
 count = d3Array.count([1, 2, NaN]); // 2
-count = d3Array.count<{ n: string, age?: number; }>([{ n: "Alice", age: NaN }, { n: "Bob", age: 18 }, { n: "Other" }], d => d.age); // 1
+count = d3Array.count<{ n: string, age?: number | undefined; }>([{ n: "Alice", age: NaN }, { n: "Bob", age: 18 }, { n: "Other" }], d => d.age); // 1
 
 // cross() ---------------------------------------------------------------------
 

--- a/types/d3-array/v2/d3-array-tests.ts
+++ b/types/d3-array/v2/d3-array-tests.ts
@@ -801,7 +801,7 @@ const keysComparator: string[] = d3Array.groupSort(barley, (a, b) => d3Array.asc
 let count: number;
 
 count = d3Array.count([1, 2, NaN]); // 2
-count = d3Array.count<{ n: string, age?: number; }>([{ n: "Alice", age: NaN }, { n: "Bob", age: 18 }, { n: "Other" }], d => d.age); // 1
+count = d3Array.count<{ n: string, age?: number | undefined; }>([{ n: "Alice", age: NaN }, { n: "Bob", age: 18 }, { n: "Other" }], d => d.age); // 1
 
 // cross() ---------------------------------------------------------------------
 

--- a/types/d3-collection/d3-collection-tests.ts
+++ b/types/d3-collection/d3-collection-tests.ts
@@ -352,7 +352,7 @@ type TestL2NestedArray = Array<{
 
 type TestL1NestedArrayRollup = Array<{
     key: string;
-    value?: number; // conservatively allow for value to be undefined
+    value?: number | undefined; // conservatively allow for value to be undefined
 }>;
 
 let testL2NestedArray: TestL2NestedArray;

--- a/types/d3-color/index.d.ts
+++ b/types/d3-color/index.d.ts
@@ -167,7 +167,7 @@ export interface RGBColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { r?: number; g?: number; b?: number; opacity?: number }): this;
+    copy(values?: { r?: number | undefined; g?: number | undefined; b?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -248,7 +248,7 @@ export interface HSLColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; s?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; s?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -330,7 +330,7 @@ export interface LabColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { l?: number; a?: number; b?: number; opacity?: number }): this;
+    copy(values?: { l?: number | undefined; a?: number | undefined; b?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -425,7 +425,7 @@ export interface HCLColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; c?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; c?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -540,7 +540,7 @@ export interface CubehelixColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; s?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; s?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**

--- a/types/d3-color/v1/index.d.ts
+++ b/types/d3-color/v1/index.d.ts
@@ -167,7 +167,7 @@ export interface RGBColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { r?: number; g?: number; b?: number; opacity?: number }): this;
+    copy(values?: { r?: number | undefined; g?: number | undefined; b?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -247,7 +247,7 @@ export interface HSLColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; s?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; s?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -328,7 +328,7 @@ export interface LabColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { l?: number; a?: number; b?: number; opacity?: number }): this;
+    copy(values?: { l?: number | undefined; a?: number | undefined; b?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -422,7 +422,7 @@ export interface HCLColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; c?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; c?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -535,7 +535,7 @@ export interface CubehelixColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; s?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; s?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**

--- a/types/d3-color/v2/index.d.ts
+++ b/types/d3-color/v2/index.d.ts
@@ -167,7 +167,7 @@ export interface RGBColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { r?: number; g?: number; b?: number; opacity?: number }): this;
+    copy(values?: { r?: number | undefined; g?: number | undefined; b?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -247,7 +247,7 @@ export interface HSLColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; s?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; s?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -328,7 +328,7 @@ export interface LabColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { l?: number; a?: number; b?: number; opacity?: number }): this;
+    copy(values?: { l?: number | undefined; a?: number | undefined; b?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -422,7 +422,7 @@ export interface HCLColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; c?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; c?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**
@@ -535,7 +535,7 @@ export interface CubehelixColor extends Color {
      *
      * @param values If values is specified, any enumerable own properties of values are assigned to the new returned color.
      */
-    copy(values?: { h?: number; s?: number; l?: number; opacity?: number }): this;
+    copy(values?: { h?: number | undefined; s?: number | undefined; l?: number | undefined; opacity?: number | undefined }): this;
 }
 
 /**

--- a/types/d3-force/index.d.ts
+++ b/types/d3-force/index.d.ts
@@ -29,31 +29,31 @@ export interface SimulationNodeDatum {
     /**
      * Node’s zero-based index into nodes array. This property is set during the initialization process of a simulation.
      */
-    index?: number;
+    index?: number | undefined;
     /**
      * Node’s current x-position
      */
-    x?: number;
+    x?: number | undefined;
     /**
      * Node’s current y-position
      */
-    y?: number;
+    y?: number | undefined;
     /**
      * Node’s current x-velocity
      */
-    vx?: number;
+    vx?: number | undefined;
     /**
      * Node’s current y-velocity
      */
-    vy?: number;
+    vy?: number | undefined;
     /**
      * Node’s fixed x-position (if position was fixed)
      */
-    fx?: number | null;
+    fx?: number | null | undefined;
     /**
      * Node’s fixed y-position (if position was fixed)
      */
-    fy?: number | null;
+    fy?: number | null | undefined;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface SimulationLinkDatum<NodeDatum extends SimulationNodeDatum> {
     /**
      * The zero-based index into the links array. Internally generated when calling ForceLink.links(...)
      */
-    index?: number;
+    index?: number | undefined;
 }
 
 /**

--- a/types/d3-force/v1/index.d.ts
+++ b/types/d3-force/v1/index.d.ts
@@ -29,31 +29,31 @@ export interface SimulationNodeDatum {
     /**
      * Node’s zero-based index into nodes array. This property is set during the initialization process of a simulation.
      */
-    index?: number;
+    index?: number | undefined;
     /**
      * Node’s current x-position
      */
-    x?: number;
+    x?: number | undefined;
     /**
      * Node’s current y-position
      */
-    y?: number;
+    y?: number | undefined;
     /**
      * Node’s current x-velocity
      */
-    vx?: number;
+    vx?: number | undefined;
     /**
      * Node’s current y-velocity
      */
-    vy?: number;
+    vy?: number | undefined;
     /**
      * Node’s fixed x-position (if position was fixed)
      */
-    fx?: number | null;
+    fx?: number | null | undefined;
     /**
      * Node’s fixed y-position (if position was fixed)
      */
-    fy?: number | null;
+    fy?: number | null | undefined;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface SimulationLinkDatum<NodeDatum extends SimulationNodeDatum> {
     /**
      * The zero-based index into the links array. Internally generated when calling ForceLink.links(...)
      */
-    index?: number;
+    index?: number | undefined;
 }
 
 /**

--- a/types/d3-force/v2/index.d.ts
+++ b/types/d3-force/v2/index.d.ts
@@ -29,31 +29,31 @@ export interface SimulationNodeDatum {
     /**
      * Node’s zero-based index into nodes array. This property is set during the initialization process of a simulation.
      */
-    index?: number;
+    index?: number | undefined;
     /**
      * Node’s current x-position
      */
-    x?: number;
+    x?: number | undefined;
     /**
      * Node’s current y-position
      */
-    y?: number;
+    y?: number | undefined;
     /**
      * Node’s current x-velocity
      */
-    vx?: number;
+    vx?: number | undefined;
     /**
      * Node’s current y-velocity
      */
-    vy?: number;
+    vy?: number | undefined;
     /**
      * Node’s fixed x-position (if position was fixed)
      */
-    fx?: number | null;
+    fx?: number | null | undefined;
     /**
      * Node’s fixed y-position (if position was fixed)
      */
-    fy?: number | null;
+    fy?: number | null | undefined;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface SimulationLinkDatum<NodeDatum extends SimulationNodeDatum> {
     /**
      * The zero-based index into the links array. Internally generated when calling ForceLink.links(...)
      */
-    index?: number;
+    index?: number | undefined;
 }
 
 /**

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -33,19 +33,19 @@ export interface FormatLocaleDefinition {
     /**
      * An optional array of ten strings to replace the numerals 0-9.
      */
-    numerals?: string[];
+    numerals?: string[] | undefined;
     /**
      * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */
-    percent?: string;
+    percent?: string | undefined;
     /**
      * Optional; the minus sign (defaults to "−").
      */
-    minus?: string;
+    minus?: string | undefined;
     /**
      * Optional; the not-a-number value (defaults "NaN").
      */
-    nan?: string;
+    nan?: string | undefined;
 }
 
 /**
@@ -83,7 +83,7 @@ export interface FormatSpecifierObject {
     /**
      * fill can be any character. The presence of a fill character is signaled by the align character following it.
      */
-    fill?: string;
+    fill?: string | undefined;
     /**
      * Alignment used for format, as set by choosing one of the following:
      *
@@ -92,7 +92,7 @@ export interface FormatSpecifierObject {
      * '^' - Forces the field to be centered within the available space.
      * '=' - Like '>', but with any sign and symbol to the left of any padding.
      */
-    align?: string;
+    align?: string | undefined;
     /**
      * The sign can be:
      *
@@ -102,7 +102,7 @@ export interface FormatSpecifierObject {
      * ' ' (space) - a space for positive and a minus sign for negative.
      *
      */
-    sign?: string;
+    sign?: string | undefined;
     /**
      * The symbol can be:
      *
@@ -110,20 +110,20 @@ export interface FormatSpecifierObject {
      * '#' - for binary, octal, or hexadecimal notation, prefix by 0b, 0o, or 0x, respectively.
      * '' (none) - no symbol. (Default behavior.)
      */
-    symbol?: string;
+    symbol?: string | undefined;
     /**
      * The zero (0) option enables zero-padding; this implicitly sets fill to 0 and align to =.
      */
-    zero?: string;
+    zero?: string | undefined;
     /**
      * The width defines the minimum field width;
      * if not specified, then the width will be determined by the content.
      */
-    width?: string;
+    width?: string | undefined;
     /**
      * The comma (,) option enables the use of a group separator, such as a comma for thousands.
      */
-    comma?: string;
+    comma?: string | undefined;
     /**
      * Depending on the type, the precision either indicates the number of digits that follow the decimal point (types 'f' and '%'),
      * or the number of significant digits (types '' (none), 'e', 'g', 'r', 's' and 'p'). If the precision is not specified,
@@ -132,12 +132,12 @@ export interface FormatSpecifierObject {
      *
      * See precisionFixed and precisionRound for help picking an appropriate precision.
      */
-    precision?: string;
+    precision?: string | undefined;
     /**
      * The '~' option trims insignificant trailing zeros across all format types.
      * This is most commonly used in conjunction with types 'r', 'e', 's' and '%'.
      */
-    trim?: string;
+    trim?: string | undefined;
     /**
      * The available type values are:
      *
@@ -159,7 +159,7 @@ export interface FormatSpecifierObject {
      * the type 'n' is shorthand for ',g'. For the 'g', 'n' and '' (none) types,
      * decimal notation is used if the resulting string would have precision or fewer digits; otherwise, exponent notation is used.
      */
-    type?: string;
+    type?: string | undefined;
 }
 
 /**

--- a/types/d3-format/v1/index.d.ts
+++ b/types/d3-format/v1/index.d.ts
@@ -33,19 +33,19 @@ export interface FormatLocaleDefinition {
     /**
      * An optional array of ten strings to replace the numerals 0-9.
      */
-    numerals?: string[];
+    numerals?: string[] | undefined;
     /**
      * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */
-    percent?: string;
+    percent?: string | undefined;
     /**
      * Optional; the minus sign (defaults to hyphen-minus, "-").
      */
-    minus?: string;
+    minus?: string | undefined;
     /**
      * Optional; the not-a-number value (defaults `"NaN"`).
      */
-    nan?: string;
+    nan?: string | undefined;
 }
 
 /**
@@ -83,7 +83,7 @@ export interface FormatSpecifierObject {
     /**
      * fill can be any character. The presence of a fill character is signaled by the align character following it.
      */
-    fill?: string;
+    fill?: string | undefined;
     /**
      * Alignment used for format, as set by choosing one of the following:
      *
@@ -92,7 +92,7 @@ export interface FormatSpecifierObject {
      * '^' - Forces the field to be centered within the available space.
      * '=' - Like '>', but with any sign and symbol to the left of any padding.
      */
-    align?: string;
+    align?: string | undefined;
     /**
      * The sign can be:
      *
@@ -102,7 +102,7 @@ export interface FormatSpecifierObject {
      * ' ' (space) - a space for positive and a minus sign for negative.
      *
      */
-    sign?: string;
+    sign?: string | undefined;
     /**
      * The symbol can be:
      *
@@ -110,20 +110,20 @@ export interface FormatSpecifierObject {
      * '#' - for binary, octal, or hexadecimal notation, prefix by 0b, 0o, or 0x, respectively.
      * '' (none) - no symbol. (Default behavior.)
      */
-    symbol?: string;
+    symbol?: string | undefined;
     /**
      * The zero (0) option enables zero-padding; this implicitly sets fill to 0 and align to =.
      */
-    zero?: string;
+    zero?: string | undefined;
     /**
      * The width defines the minimum field width;
      * if not specified, then the width will be determined by the content.
      */
-    width?: string;
+    width?: string | undefined;
     /**
      * The comma (,) option enables the use of a group separator, such as a comma for thousands.
      */
-    comma?: string;
+    comma?: string | undefined;
     /**
      * Depending on the type, the precision either indicates the number of digits that follow the decimal point (types 'f' and '%'),
      * or the number of significant digits (types '' (none), 'e', 'g', 'r', 's' and 'p'). If the precision is not specified,
@@ -132,12 +132,12 @@ export interface FormatSpecifierObject {
      *
      * See precisionFixed and precisionRound for help picking an appropriate precision.
      */
-    precision?: string;
+    precision?: string | undefined;
     /**
      * The '~' option trims insignificant trailing zeros across all format types.
      * This is most commonly used in conjunction with types 'r', 'e', 's' and '%'.
      */
-    trim?: string;
+    trim?: string | undefined;
     /**
      * The available type values are:
      *
@@ -159,7 +159,7 @@ export interface FormatSpecifierObject {
      * the type 'n' is shorthand for ',g'. For the 'g', 'n' and '' (none) types,
      * decimal notation is used if the resulting string would have precision or fewer digits; otherwise, exponent notation is used.
      */
-    type?: string;
+    type?: string | undefined;
 }
 
 /**

--- a/types/d3-format/v2/index.d.ts
+++ b/types/d3-format/v2/index.d.ts
@@ -33,19 +33,19 @@ export interface FormatLocaleDefinition {
     /**
      * An optional array of ten strings to replace the numerals 0-9.
      */
-    numerals?: string[];
+    numerals?: string[] | undefined;
     /**
      * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */
-    percent?: string;
+    percent?: string | undefined;
     /**
      * Optional; the minus sign (defaults to "−").
      */
-    minus?: string;
+    minus?: string | undefined;
     /**
      * Optional; the not-a-number value (defaults "NaN").
      */
-    nan?: string;
+    nan?: string | undefined;
 }
 
 /**
@@ -83,7 +83,7 @@ export interface FormatSpecifierObject {
     /**
      * fill can be any character. The presence of a fill character is signaled by the align character following it.
      */
-    fill?: string;
+    fill?: string | undefined;
     /**
      * Alignment used for format, as set by choosing one of the following:
      *
@@ -92,7 +92,7 @@ export interface FormatSpecifierObject {
      * '^' - Forces the field to be centered within the available space.
      * '=' - Like '>', but with any sign and symbol to the left of any padding.
      */
-    align?: string;
+    align?: string | undefined;
     /**
      * The sign can be:
      *
@@ -102,7 +102,7 @@ export interface FormatSpecifierObject {
      * ' ' (space) - a space for positive and a minus sign for negative.
      *
      */
-    sign?: string;
+    sign?: string | undefined;
     /**
      * The symbol can be:
      *
@@ -110,20 +110,20 @@ export interface FormatSpecifierObject {
      * '#' - for binary, octal, or hexadecimal notation, prefix by 0b, 0o, or 0x, respectively.
      * '' (none) - no symbol. (Default behavior.)
      */
-    symbol?: string;
+    symbol?: string | undefined;
     /**
      * The zero (0) option enables zero-padding; this implicitly sets fill to 0 and align to =.
      */
-    zero?: string;
+    zero?: string | undefined;
     /**
      * The width defines the minimum field width;
      * if not specified, then the width will be determined by the content.
      */
-    width?: string;
+    width?: string | undefined;
     /**
      * The comma (,) option enables the use of a group separator, such as a comma for thousands.
      */
-    comma?: string;
+    comma?: string | undefined;
     /**
      * Depending on the type, the precision either indicates the number of digits that follow the decimal point (types 'f' and '%'),
      * or the number of significant digits (types '' (none), 'e', 'g', 'r', 's' and 'p'). If the precision is not specified,
@@ -132,12 +132,12 @@ export interface FormatSpecifierObject {
      *
      * See precisionFixed and precisionRound for help picking an appropriate precision.
      */
-    precision?: string;
+    precision?: string | undefined;
     /**
      * The '~' option trims insignificant trailing zeros across all format types.
      * This is most commonly used in conjunction with types 'r', 'e', 's' and '%'.
      */
-    trim?: string;
+    trim?: string | undefined;
     /**
      * The available type values are:
      *
@@ -159,7 +159,7 @@ export interface FormatSpecifierObject {
      * the type 'n' is shorthand for ',g'. For the 'g', 'n' and '' (none) types,
      * decimal notation is used if the resulting string would have precision or fewer digits; otherwise, exponent notation is used.
      */
-    type?: string;
+    type?: string | undefined;
 }
 
 /**

--- a/types/d3-geo/index.d.ts
+++ b/types/d3-geo/index.d.ts
@@ -40,11 +40,11 @@ export type GeoGeometryObjects = GeoJSON.GeometryObject | GeoSphere;
  */
 export interface ExtendedGeometryCollection<GeometryType extends GeoGeometryObjects = GeoGeometryObjects> {
     type: string;
-    bbox?: number[];
+    bbox?: number[] | undefined;
     crs?: {
         type: string;
         properties: any;
-    };
+    } | undefined;
     geometries: GeometryType[];
 }
 
@@ -64,7 +64,7 @@ export interface ExtendedFeature<
     > extends GeoJSON.GeoJsonObject {
     geometry: GeometryType;
     properties: Properties;
-    id?: string | number;
+    id?: string | number | undefined;
 }
 
 /**

--- a/types/d3-geo/v1/index.d.ts
+++ b/types/d3-geo/v1/index.d.ts
@@ -41,11 +41,11 @@ export type GeoGeometryObjects = GeoJSON.GeometryObject | GeoSphere;
  */
 export interface ExtendedGeometryCollection<GeometryType extends GeoGeometryObjects = GeoGeometryObjects> {
     type: string;
-    bbox?: number[];
+    bbox?: number[] | undefined;
     crs?: {
         type: string;
         properties: any;
-    };
+    } | undefined;
     geometries: GeometryType[];
 }
 
@@ -65,7 +65,7 @@ export interface ExtendedFeature<
     > extends GeoJSON.GeoJsonObject {
     geometry: GeometryType;
     properties: Properties;
-    id?: string | number;
+    id?: string | number | undefined;
 }
 
 /**

--- a/types/d3-geo/v2/index.d.ts
+++ b/types/d3-geo/v2/index.d.ts
@@ -41,11 +41,11 @@ export type GeoGeometryObjects = GeoJSON.GeometryObject | GeoSphere;
  */
 export interface ExtendedGeometryCollection<GeometryType extends GeoGeometryObjects = GeoGeometryObjects> {
     type: string;
-    bbox?: number[];
+    bbox?: number[] | undefined;
     crs?: {
         type: string;
         properties: any;
-    };
+    } | undefined;
     geometries: GeometryType[];
 }
 
@@ -65,7 +65,7 @@ export interface ExtendedFeature<
     > extends GeoJSON.GeoJsonObject {
     geometry: GeometryType;
     properties: Properties;
-    id?: string | number;
+    id?: string | number | undefined;
 }
 
 /**

--- a/types/d3-hierarchy/d3-hierarchy-tests.ts
+++ b/types/d3-hierarchy/d3-hierarchy-tests.ts
@@ -26,7 +26,7 @@ let idString: string | undefined;
 interface HierarchyDatum {
     name: string;
     val: number;
-    children?: Iterable<HierarchyDatum>;
+    children?: Iterable<HierarchyDatum> | undefined;
 }
 
 let hierarchyRootDatum: HierarchyDatum = {

--- a/types/d3-hierarchy/index.d.ts
+++ b/types/d3-hierarchy/index.d.ts
@@ -49,17 +49,17 @@ export interface HierarchyNode<Datum> {
     /**
      * An array of child nodes, if any; undefined for leaf nodes.
      */
-    children?: this[];
+    children?: this[] | undefined;
 
     /**
      * Aggregated numeric value as calculated by `sum(value)` or `count()`, if previously invoked.
      */
-    readonly value?: number;
+    readonly value?: number | undefined;
 
     /**
      * Optional node id string set by `StratifyOperator`, if hierarchical data was created from tabular data using stratify().
      */
-    readonly id?: string;
+    readonly id?: string | undefined;
 
     /**
      * Returns the array of ancestors nodes, starting with this node, then followed by each parent up to the root.
@@ -835,12 +835,12 @@ export interface PackRadius {
     /**
      * The x-coordinate of the circle’s center.
      */
-    x?: number;
+    x?: number | undefined;
 
     /**
      * The y-coordinate of the circle’s center.
      */
-    y?: number;
+    y?: number | undefined;
 }
 
 export interface PackCircle {

--- a/types/d3-hierarchy/v1/d3-hierarchy-tests.ts
+++ b/types/d3-hierarchy/v1/d3-hierarchy-tests.ts
@@ -26,7 +26,7 @@ let idString: string | undefined;
 interface HierarchyDatum {
     name: string;
     val: number;
-    children?: HierarchyDatum[];
+    children?: HierarchyDatum[] | undefined;
 }
 
 let hierarchyRootDatum: HierarchyDatum = {

--- a/types/d3-hierarchy/v1/index.d.ts
+++ b/types/d3-hierarchy/v1/index.d.ts
@@ -49,17 +49,17 @@ export interface HierarchyNode<Datum> {
     /**
      * An array of child nodes, if any; undefined for leaf nodes.
      */
-    children?: this[];
+    children?: this[] | undefined;
 
     /**
      * Aggregated numeric value as calculated by `sum(value)` or `count()`, if previously invoked.
      */
-    readonly value?: number;
+    readonly value?: number | undefined;
 
     /**
      * Optional node id string set by `StratifyOperator`, if hierarchical data was created from tabular data using stratify().
      */
-    readonly id?: string;
+    readonly id?: string | undefined;
 
     /**
      * Returns the array of ancestors nodes, starting with this node, then followed by each parent up to the root.
@@ -812,12 +812,12 @@ export interface PackRadius {
     /**
      * The x-coordinate of the circle’s center.
      */
-    x?: number;
+    x?: number | undefined;
 
     /**
      * The y-coordinate of the circle’s center.
      */
-    y?: number;
+    y?: number | undefined;
 }
 
 export interface PackCircle {

--- a/types/d3-hierarchy/v2/d3-hierarchy-tests.ts
+++ b/types/d3-hierarchy/v2/d3-hierarchy-tests.ts
@@ -26,7 +26,7 @@ let idString: string | undefined;
 interface HierarchyDatum {
     name: string;
     val: number;
-    children?: Iterable<HierarchyDatum>;
+    children?: Iterable<HierarchyDatum> | undefined;
 }
 
 let hierarchyRootDatum: HierarchyDatum = {

--- a/types/d3-hierarchy/v2/index.d.ts
+++ b/types/d3-hierarchy/v2/index.d.ts
@@ -49,17 +49,17 @@ export interface HierarchyNode<Datum> {
     /**
      * An array of child nodes, if any; undefined for leaf nodes.
      */
-    children?: this[];
+    children?: this[] | undefined;
 
     /**
      * Aggregated numeric value as calculated by `sum(value)` or `count()`, if previously invoked.
      */
-    readonly value?: number;
+    readonly value?: number | undefined;
 
     /**
      * Optional node id string set by `StratifyOperator`, if hierarchical data was created from tabular data using stratify().
      */
-    readonly id?: string;
+    readonly id?: string | undefined;
 
     /**
      * Returns the array of ancestors nodes, starting with this node, then followed by each parent up to the root.
@@ -829,12 +829,12 @@ export interface PackRadius {
     /**
      * The x-coordinate of the circle’s center.
      */
-    x?: number;
+    x?: number | undefined;
 
     /**
      * The y-coordinate of the circle’s center.
      */
-    y?: number;
+    y?: number | undefined;
 }
 
 export interface PackCircle {

--- a/types/d3-quadtree/index.d.ts
+++ b/types/d3-quadtree/index.d.ts
@@ -21,7 +21,7 @@ export interface QuadtreeLeaf<T> {
     /**
      * The next datum in this leaf, if any.
      */
-    next?: QuadtreeLeaf<T>;
+    next?: QuadtreeLeaf<T> | undefined;
 
     /**
      * The length property may be used to distinguish leaf nodes from internal nodes: it is undefined for leaf nodes, and 4 for internal nodes.

--- a/types/d3-quadtree/v1/index.d.ts
+++ b/types/d3-quadtree/v1/index.d.ts
@@ -22,7 +22,7 @@ export interface QuadtreeLeaf<T> {
     /**
      * The next datum in this leaf, if any.
      */
-    next?: QuadtreeLeaf<T>;
+    next?: QuadtreeLeaf<T> | undefined;
 
     /**
      * The length property may be used to distinguish leaf nodes from internal nodes: it is undefined for leaf nodes, and 4 for internal nodes.

--- a/types/d3-quadtree/v2/index.d.ts
+++ b/types/d3-quadtree/v2/index.d.ts
@@ -22,7 +22,7 @@ export interface QuadtreeLeaf<T> {
     /**
      * The next datum in this leaf, if any.
      */
-    next?: QuadtreeLeaf<T>;
+    next?: QuadtreeLeaf<T> | undefined;
 
     /**
      * The length property may be used to distinguish leaf nodes from internal nodes: it is undefined for leaf nodes, and 4 for internal nodes.

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -32,45 +32,45 @@ export interface SankeyNodeMinimal<N extends SankeyExtraProperties, L extends Sa
      * Array of outgoing links which have this node as their source.
      * This property is calculated internally by the Sankey layout generator.
      */
-    sourceLinks?: Array<SankeyLink<N, L>>;
+    sourceLinks?: Array<SankeyLink<N, L>> | undefined;
     /**
      * Array of incoming links which have this node as their target.
      * This property is calculated internally by the Sankey layout generator.
      */
-    targetLinks?: Array<SankeyLink<N, L>>;
+    targetLinks?: Array<SankeyLink<N, L>> | undefined;
     /**
      * Node's value calculated by Sankey layout Generator;
      * the sum of link.value for the node’s incoming links.
      */
-    value?: number;
+    value?: number | undefined;
     /**
      * Node’s zero-based index within the array of nodes calculated by Sankey layout generator.
      */
-    index?: number;
+    index?: number | undefined;
     /**
      * Node’s zero-based graph depth, derived from the graph topology calculated by Sankey layout generator.
      */
-    depth?: number;
+    depth?: number | undefined;
     /**
      * Node’s zero-based graph height, derived from the graph topology calculated by Sankey layout generator.
      */
-    height?: number;
+    height?: number | undefined;
     /**
      * Node's minimum horizontal position (derived from the node.depth) calculated by Sankey layout generator.
      */
-    x0?: number;
+    x0?: number | undefined;
     /**
      * Node’s maximum horizontal position (node.x0 + sankey.nodeWidth) calculated by Sankey layout generator.
      */
-    x1?: number;
+    x1?: number | undefined;
     /**
      * Node's minimum vertical position calculated by Sankey layout generator.
      */
-    y0?: number;
+    y0?: number | undefined;
     /**
      * Node's maximum vertical position (node.y1 - node.y0 is proportional to node.value) calculated by Sankey layout generator.
      */
-    y1?: number;
+    y1?: number | undefined;
 }
 
 /**
@@ -127,19 +127,19 @@ export interface SankeyLinkMinimal<N extends SankeyExtraProperties, L extends Sa
     /**
      * Link's vertical starting position (at source node) calculated by Sankey layout generator.
      */
-    y0?: number;
+    y0?: number | undefined;
     /**
      * Link's vertical end position (at target node) calculated by Sankey layout generator.
      */
-    y1?: number;
+    y1?: number | undefined;
     /**
      * Link's width (proportional to its value) calculated by Sankey layout generator.
      */
-    width?: number;
+    width?: number | undefined;
     /**
      * Link's zero-based index within the array of links calculated by Sankey layout generator.
      */
-    index?: number;
+    index?: number | undefined;
 }
 
 /**

--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -29,7 +29,7 @@ interface ArcDatum {
     oRadius: number;
     sAngle: number;
     eAngle: number;
-    pAngle?: number;
+    pAngle?: number | undefined;
 }
 
 const arcDefaultDatum: d3Shape.DefaultArcObject = {

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -63,7 +63,7 @@ export interface DefaultArcObject {
     /**
      * Optional. Pad angle of arc in radians.
      */
-    padAngle?: number;
+    padAngle?: number | undefined;
 }
 
 /**

--- a/types/d3-shape/v1/d3-shape-tests.ts
+++ b/types/d3-shape/v1/d3-shape-tests.ts
@@ -29,7 +29,7 @@ interface ArcDatum {
     oRadius: number;
     sAngle: number;
     eAngle: number;
-    pAngle?: number;
+    pAngle?: number | undefined;
 }
 
 const arcDefaultDatum: d3Shape.DefaultArcObject = {

--- a/types/d3-shape/v1/index.d.ts
+++ b/types/d3-shape/v1/index.d.ts
@@ -64,7 +64,7 @@ export interface DefaultArcObject {
     /**
      * Optional. Pad angle of arc in radians.
      */
-    padAngle?: number;
+    padAngle?: number | undefined;
 }
 
 /**

--- a/types/d3-shape/v2/d3-shape-tests.ts
+++ b/types/d3-shape/v2/d3-shape-tests.ts
@@ -29,7 +29,7 @@ interface ArcDatum {
     oRadius: number;
     sAngle: number;
     eAngle: number;
-    pAngle?: number;
+    pAngle?: number | undefined;
 }
 
 const arcDefaultDatum: d3Shape.DefaultArcObject = {

--- a/types/d3-shape/v2/index.d.ts
+++ b/types/d3-shape/v2/index.d.ts
@@ -64,7 +64,7 @@ export interface DefaultArcObject {
     /**
      * Optional. Pad angle of arc in radians.
      */
-    padAngle?: number;
+    padAngle?: number | undefined;
 }
 
 /**

--- a/types/d3/v3/d3-tests.ts
+++ b/types/d3/v3/d3-tests.ts
@@ -1042,7 +1042,7 @@ namespace forceCollapsable {
     interface Node extends d3.layout.force.Node {
         id: string;
         _children: Node[];
-        children?: Node[];
+        children?: Node[] | undefined;
         size: number;
     }
 
@@ -1430,7 +1430,7 @@ function quadtree() {
         .attr("height", function (d) { return d.height; } );
 
     var point = svg.selectAll(".point")
-        .data(<{ scanned?: boolean; selected?: boolean; 0: number; 1: number }[]> data)
+        .data(<{ scanned?: boolean | undefined; selected?: boolean | undefined; 0: number; 1: number }[]> data)
         .enter().append("circle")
         .attr("class", "point")
         .attr("cx", function (d) { return d[0]; } )
@@ -1461,8 +1461,8 @@ function quadtree() {
     }
 
     // Find the nodes within the specified rectangle.
-    function search(quadtree: d3.geom.quadtree.Quadtree<{ scanned?: boolean; selected?: boolean; 0: number; 1: number }>, x0: number, y0: number, x3: number, y3: number) {
-        quadtree.visit(function (node: d3.geom.quadtree.Node<{ scanned?: boolean; selected?: boolean; 0: number; 1: number }>, x1: number, y1: number, x2:number, y2: number) {
+    function search(quadtree: d3.geom.quadtree.Quadtree<{ scanned?: boolean | undefined; selected?: boolean | undefined; 0: number; 1: number }>, x0: number, y0: number, x3: number, y3: number) {
+        quadtree.visit(function (node: d3.geom.quadtree.Node<{ scanned?: boolean | undefined; selected?: boolean | undefined; 0: number; 1: number }>, x1: number, y1: number, x2:number, y2: number) {
             var p = node.point;
             if (p) {
                 p.scanned = true;
@@ -1705,7 +1705,7 @@ function streamGraph() {
     }
 
     // Inspired by Lee Byron's test data generator.
-    function bumpLayer(n: number): Array<{x: number; y: number;y0?:number;}> {
+    function bumpLayer(n: number): Array<{x: number; y: number;y0?:number | undefined;}> {
 
         function bump(a: number[]) {
             var x = 1 / (.1 + Math.random()),
@@ -2302,7 +2302,7 @@ function nestTest () {
       .map(function(d) { return d.key; })
       .sort(d3.ascending);
 
-    var entries = d3.nest<{foo: number; bar?: number}>()
+    var entries = d3.nest<{foo: number; bar?: number | undefined}>()
       .key(function(d) { return String(d.foo); })
       .entries([{foo: 1, bar: 0}, {foo: 2}, {foo: 1, bar: 1}]);
 
@@ -2311,12 +2311,12 @@ function nestTest () {
         .entries([{foo: 1}, {foo: 1}, {foo: 2}])
         .map(function(d) { return d.key; });
 
-    entries = d3.nest<{ foo: number; bar?: number }>()
+    entries = d3.nest<{ foo: number; bar?: number | undefined }>()
         .key(function(d) { return String(d.foo); })
         .sortValues(function(a, b) { return a.bar - b.bar; })
         .entries([{foo: 1, bar: 2}, {foo: 1, bar: 0}, {foo: 1, bar: 1}, {foo: 2}]);
 
-    entries = d3.nest<{ foo: number; bar?: number }>()
+    entries = d3.nest<{ foo: number; bar?: number | undefined }>()
         .key(function(d) { return String(d.foo); })
         .rollup(function(values) { return d3.sum<any>(values, function(d) { return d.bar; }); })
         .entries([{foo: 1, bar: 2}, {foo: 1, bar: 0}, {foo: 1, bar: 1}, {foo: 2}]);
@@ -2332,13 +2332,13 @@ function nestTest () {
         .rollup(function(values) { return values.length; })
         .entries([[0, 1], [0, 2], [1, 1], [1, 2], [0, 2]]);
 
-    entries = d3.nest<{ 0: number; 1: number; 2?: number }>()
+    entries = d3.nest<{ 0: number; 1: number; 2?: number | undefined }>()
         .key(function(d) { return String(d[0]); }).sortKeys(d3.ascending)
         .key(function(d) { return String(d[1]); }).sortKeys(d3.ascending)
         .sortValues(function(a, b) { return a[2] - b[2]; })
         .entries([[0, 1], [0, 2, 1], [1, 1], [1, 2], [0, 2, 0]]);
 
-    var map = d3.nest<{ 0: number; 1: number; 2?: number }>()
+    var map = d3.nest<{ 0: number; 1: number; 2?: number | undefined }>()
         .key(function(d) { return String(d[0]); }).sortKeys(d3.ascending)
         .key(function(d) { return String(d[1]); }).sortKeys(d3.ascending)
         .sortValues(function(a, b) { return a[2] - b[2]; })
@@ -2756,7 +2756,7 @@ class BrushAxisTest {
     }
 }
 
-interface NodeWithText extends d3.layout.partition.Node { t: string; children?: NodeWithText[]; }
+interface NodeWithText extends d3.layout.partition.Node { t: string; children?: NodeWithText[] | undefined; }
 function testPartition(data: Array<NodeWithText>) {
         var width = 1000;
         var height = 1000;

--- a/types/d3/v3/index.d.ts
+++ b/types/d3/v3/index.d.ts
@@ -937,7 +937,7 @@ declare namespace d3 {
 
     interface BaseEvent {
         type: string;
-        sourceEvent?: Event;
+        sourceEvent?: Event | undefined;
     }
 
     /**
@@ -2843,11 +2843,11 @@ declare namespace d3 {
 
         namespace cluster {
             interface Result {
-                parent?: Result;
-                children?: Result[];
-                depth?: number;
-                x?: number;
-                y?: number;
+                parent?: Result | undefined;
+                children?: Result[] | undefined;
+                depth?: number | undefined;
+                x?: number | undefined;
+                y?: number | undefined;
             }
 
             interface Link<T extends Result> {
@@ -2895,13 +2895,13 @@ declare namespace d3 {
             }
 
             interface Node {
-                index?: number;
-                x?: number;
-                y?: number;
-                px?: number;
-                py?: number;
-                fixed?: boolean;
-                weight?: number;
+                index?: number | undefined;
+                x?: number | undefined;
+                y?: number | undefined;
+                px?: number | undefined;
+                py?: number | undefined;
+                fixed?: boolean | undefined;
+                weight?: number | undefined;
             }
 
             interface Event {
@@ -2968,10 +2968,10 @@ declare namespace d3 {
 
         namespace hierarchy {
             interface Result {
-                parent?: Result;
-                children?: Result[];
-                value?: number;
-                depth?: number;
+                parent?: Result | undefined;
+                children?: Result[] | undefined;
+                value?: number | undefined;
+                depth?: number | undefined;
             }
         }
 
@@ -3025,13 +3025,13 @@ declare namespace d3 {
 
         namespace pack {
             interface Node {
-                parent?: Node;
-                children?: Node[];
-                value?: number;
-                depth?: number;
-                x?: number;
-                y?: number;
-                r?: number;
+                parent?: Node | undefined;
+                children?: Node[] | undefined;
+                value?: number | undefined;
+                depth?: number | undefined;
+                x?: number | undefined;
+                y?: number | undefined;
+                r?: number | undefined;
             }
 
             interface Link<T extends Node> {
@@ -3077,14 +3077,14 @@ declare namespace d3 {
             }
 
             interface Node {
-                parent?: Node;
-                children?: Node[];
-                value?: number;
-                depth?: number;
-                x?: number;
-                y?: number;
-                dx?: number;
-                dy?: number;
+                parent?: Node | undefined;
+                children?: Node[] | undefined;
+                value?: number | undefined;
+                depth?: number | undefined;
+                x?: number | undefined;
+                y?: number | undefined;
+                dx?: number | undefined;
+                dy?: number | undefined;
             }
 
         }
@@ -3151,7 +3151,7 @@ declare namespace d3 {
             interface Value {
                 x: number;
                 y: number;
-                y0?: number;
+                y0?: number | undefined;
             }
         }
 
@@ -3196,11 +3196,11 @@ declare namespace d3 {
             }
 
             interface Node {
-                parent?: Node;
-                children?: Node[];
-                depth?: number;
-                x?: number;
-                y?: number;
+                parent?: Node | undefined;
+                children?: Node[] | undefined;
+                depth?: number | undefined;
+                x?: number | undefined;
+                y?: number | undefined;
             }
         }
 
@@ -3235,14 +3235,14 @@ declare namespace d3 {
 
         namespace treemap {
             interface Node {
-                parent?: Node;
-                children?: Node[];
-                value?: number;
-                depth?: number;
-                x?: number;
-                y?: number;
-                dx?: number;
-                dy?: number;
+                parent?: Node | undefined;
+                children?: Node[] | undefined;
+                value?: number | undefined;
+                depth?: number | undefined;
+                x?: number | undefined;
+                y?: number | undefined;
+                dx?: number | undefined;
+                dy?: number | undefined;
             }
 
             interface Link<T extends Node> {

--- a/types/dagre/index.d.ts
+++ b/types/dagre/index.d.ts
@@ -12,7 +12,7 @@ export as namespace dagre;
 
 export namespace graphlib {
     class Graph<T = {}> {
-        constructor(opt?: { directed?: boolean; multigraph?: boolean; compound?: boolean });
+        constructor(opt?: { directed?: boolean | undefined; multigraph?: boolean | undefined; compound?: boolean | undefined });
 
         graph(): GraphLabel;
         isDirected(): boolean;
@@ -76,32 +76,32 @@ export type WeightFn = (edge: Edge) => number;
 export type EdgeFn = (outNodeName: string) => GraphEdge[];
 
 export interface GraphLabel {
-    width?: number;
-    height?: number;
-    compound?: boolean;
-    rankdir?: string;
-    align?: string;
-    nodesep?: number;
-    edgesep?: number;
-    ranksep?: number;
-    marginx?: number;
-    marginy?: number;
-    acyclicer?: string;
-    ranker?: string;
+    width?: number | undefined;
+    height?: number | undefined;
+    compound?: boolean | undefined;
+    rankdir?: string | undefined;
+    align?: string | undefined;
+    nodesep?: number | undefined;
+    edgesep?: number | undefined;
+    ranksep?: number | undefined;
+    marginx?: number | undefined;
+    marginy?: number | undefined;
+    acyclicer?: string | undefined;
+    ranker?: string | undefined;
 }
 
 export interface NodeConfig {
-    width?: number;
-    height?: number;
+    width?: number | undefined;
+    height?: number | undefined;
 }
 
 export interface EdgeConfig {
-    minlen?: number;
-    weight?: number;
-    width?: number;
-    height?: number;
-    lablepos?: 'l' | 'c' | 'r';
-    labeloffest?: number;
+    minlen?: number | undefined;
+    weight?: number | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
+    lablepos?: 'l' | 'c' | 'r' | undefined;
+    labeloffest?: number | undefined;
 }
 
 export function layout(graph: graphlib.Graph, layout?: GraphLabel & NodeConfig & EdgeConfig): void;
@@ -109,7 +109,7 @@ export function layout(graph: graphlib.Graph, layout?: GraphLabel & NodeConfig &
 export interface Edge {
     v: string;
     w: string;
-    name?: string;
+    name?: string | undefined;
 }
 
 export interface GraphEdge {
@@ -122,12 +122,12 @@ export type Node<T = {}> = T & {
     y: number;
     width: number;
     height: number;
-    class?: string;
-    label?: string;
-    padding?: number;
-    paddingX?: number;
-    paddingY?: number;
-    rx?: number;
-    ry?: number;
-    shape?: string;
+    class?: string | undefined;
+    label?: string | undefined;
+    padding?: number | undefined;
+    paddingX?: number | undefined;
+    paddingY?: number | undefined;
+    rx?: number | undefined;
+    ry?: number | undefined;
+    shape?: string | undefined;
 };

--- a/types/dashdash/index.d.ts
+++ b/types/dashdash/index.d.ts
@@ -81,19 +81,19 @@ export interface ParsingConfiguration {
     /**
      * The argv to parse. Defaults to `process.argv`.
      */
-    argv?: string[];
+    argv?: string[] | undefined;
 
     /**
      * The index into argv at which options/args begin.  Default is 2, as appropriate for `process.argv`.
      */
-    slice?: number;
+    slice?: number | undefined;
 
     /**
      * The env to use for 'env' entries in the option specs. Defaults to `process.env`.
      */
     env?: any; // NodeJS.ProcessEnv;
 
-    options?: Array<Option | Group>;
+    options?: Array<Option | Group> | undefined;
 }
 
 export interface ParserConfiguration {
@@ -107,7 +107,7 @@ export interface ParserConfiguration {
      * If false, then unknown args are included in the _args array.
      * Default: false
      */
-    allowUnknown?: boolean;
+    allowUnknown?: boolean | undefined;
 
     /**
      * Whether to allow interspersed arguments (non-options) and options.
@@ -122,7 +122,7 @@ export interface ParserConfiguration {
      *
      * Default: true
      */
-    interspersed?: boolean;
+    interspersed?: boolean | undefined;
 }
 
 export interface OptionWithoutAliases extends OptionBase {
@@ -158,38 +158,38 @@ export interface OptionBase {
      * This is for custom completions for a given tool.
      * Typically these custom functions are provided in the specExtra argument to dashdash.bashCompletionFromOptions().
      */
-    completionType?: string;
+    completionType?: string | undefined;
 
     /**
      * An environment variable name (or names) that can be used as a fallback for this option.
      * An environment variable is only used as a fallback, i.e. it is ignored if the associated option is given in `argv`.
      */
-    env?: string | string[];
+    env?: string | string[] | undefined;
 
     /**
      * Used for parser.help() output.
      */
-    help?: string;
+    help?: string | undefined;
 
     /**
      * Used in help output as the placeholder for the option argument.
      */
-    helpArg?: string;
+    helpArg?: string | undefined;
 
     /**
      * Set this to false to have that option's help not be text wrapped in <parser>.help() output.
      */
-    helpWrap?: boolean;
+    helpWrap?: boolean | undefined;
 
     /**
      * A default value used for this option, if the option isn't specified in argv.
      */
-    default?: string;
+    default?: string | undefined;
 
     /**
      * If true, help output will not include this option.
      */
-    hidden?: boolean;
+    hidden?: boolean | undefined;
 }
 
 export interface Group {
@@ -207,7 +207,7 @@ export interface OptionType {
     /**
      * Required iff `takesArg === true`. The string to show in generated help for options of this type.
      */
-    helpArg?: string;
+    helpArg?: string | undefined;
     /**
      * parser that takes a string argument and returns an instance of the
      * appropriate type, or throws an error if the arg is invalid.
@@ -217,8 +217,8 @@ export interface OptionType {
      * Set to true if this is an 'arrayOf' type
      * that collects multiple usages of the option in process.argv and puts results in an array.
      */
-    array?: boolean;
-    arrayFlatten?: boolean;
+    array?: boolean | undefined;
+    arrayFlatten?: boolean | undefined;
     /**
      * Default value for options of this type, if no default is specified in the option type usage.
      */
@@ -235,20 +235,20 @@ export interface BashCompletionConfiguration {
     /**
      * The array of dashdash option specs.
      */
-    options?: Array<Option | Group>;
+    options?: Array<Option | Group> | undefined;
 
     /**
      * Extra Bash code content to add
      * to the end of the "spec". Typically this is used to append Bash
      * "complete_TYPE" functions for custom option types.
      */
-    specExtra?: string;
+    specExtra?: string | undefined;
 
     /**
      * Array of completion types for positional args (i.e. non-options).
      * If not given, positional args will use Bash's 'default' completion.
      */
-    argtypes?: string[];
+    argtypes?: string[] | undefined;
 }
 
 export interface BashCompletionSpecConfiguration {
@@ -262,7 +262,7 @@ export interface BashCompletionSpecConfiguration {
      * vars in the spec. By default it is the empty string. When used to
      * scope for completion on a *sub-command*.
      */
-    context?: string;
+    context?: string | undefined;
 
     /**
      * By default
@@ -271,13 +271,13 @@ export interface BashCompletionSpecConfiguration {
      * will be completed. "Hidden" options and subcmds are ones with the
      * `hidden: true` attribute to exclude them from default help output.
      */
-    includeHidden?: boolean;
+    includeHidden?: boolean | undefined;
 
     /**
      * Array of completion types for positional args (i.e. non-options).
      * If not given, positional args will use Bash's 'default' completion.
      */
-    argtypes?: string[];
+    argtypes?: string[] | undefined;
 }
 
 export interface HelpConfiguration {
@@ -285,58 +285,58 @@ export interface HelpConfiguration {
      * Set to a number (for that many spaces) or a string for the literal indent.
      * Default: 4
      */
-    indent?: number | string;
+    indent?: number | string | undefined;
 
     /**
      * Set to a number (for that many spaces) or a string for the literal indent.
      * This indent applies to group heading lines, between normal option lines.
      * Default: half length of `indent`
      */
-    headingIndent?: number | string;
+    headingIndent?: number | string | undefined;
 
     /**
      * By default the names are sorted to put the short opts first (i.e. '-h, --help' preferred to '--help, -h').
      * Set to 'none' to not do this sorting.
      * Default: 'length'
      */
-    nameSort?: string;
+    nameSort?: string | undefined;
 
     /**
      * Note that reflow is just done on whitespace so a long token in the option help can overflow maxCol.
      * Default: 80
      */
-    maxCol?: number;
+    maxCol?: number | undefined;
 
     /**
      * If not set a reasonable value will be determined between minHelpCol and maxHelpCol.
      */
-    helpCol?: number;
+    helpCol?: number | undefined;
 
     /**
      * Default: 20
      */
-    minHelpCol?: number;
+    minHelpCol?: number | undefined;
 
     /**
      * Default: 40
      */
-    maxHelpCol?: number;
+    maxHelpCol?: number | undefined;
 
     /**
      * Set to `false` to have option `help` strings not be textwrapped to the helpCol..maxCol range.
      * Default: true
      */
-    helpWrap?: boolean;
+    helpWrap?: boolean | undefined;
 
     /**
      * If the option has associated environment variables (via the env option spec attribute), then append mentioned of those envvars to the help string.
      * Default: false
      */
-    includeEnv?: boolean;
+    includeEnv?: boolean | undefined;
 
     /**
      * If the option has a default value (via the default option spec attribute, or a default on the option's type), then a "Default: VALUE" string will be appended to the help string.
      * Default: false
      */
-    includeDefault?: boolean;
+    includeDefault?: boolean | undefined;
 }

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -149,24 +149,24 @@ declare namespace DataTables {
          * The order modifier provides the ability to control which order the rows are processed in.
          * Values: 'current', 'applied', 'index',  'original'
          */
-        order?: string;
+        order?: string | undefined;
 
         /**
          * The search modifier provides the ability to govern which rows are used by the selector using the search options that are applied to the table.
          * Values: 'none', 'applied', 'removed'
          */
-        search?: string;
+        search?: string | undefined;
 
         /**
          * The searchPlaceholder modifier provides the ability to provide informational text for an input control when it has no value.
          */
-        searchPlaceholder?: string;
+        searchPlaceholder?: string | undefined;
 
         /**
          * The page modifier allows you to control if the selector should consider all data in the table, regardless of paging, or if only the rows in the currently disabled page should be used.
          * Values: 'all', 'current'
          */
-        page?: string;
+        page?: string | undefined;
     }
 
     //#region "Namespaces"
@@ -1156,13 +1156,13 @@ declare namespace DataTables {
          * 0: Column index to order upon.
          * 1: Direction so order to apply ("asc" for ascending order or "desc" for descending order).
          */
-        pre?: any[];
+        pre?: any[] | undefined;
         /**
          * Two-element array:
          * 0: Column index to order upon.
          * 1: Direction so order to apply ("asc" for ascending order or "desc" for descending order).
          */
-        post?: any[];
+        post?: any[] | undefined;
     }
 
     interface StaticRenderFunctions {
@@ -1223,67 +1223,67 @@ declare namespace DataTables {
         /**
          * Feature control DataTables' smart column width handling. Since: 1.10
          */
-        autoWidth?: boolean;
+        autoWidth?: boolean | undefined;
 
         /**
          * Feature control deferred rendering for additional speed of initialisation. Since: 1.10
          */
-        deferRender?: boolean;
+        deferRender?: boolean | undefined;
 
         /**
          * Feature control table information display field. Since: 1.10
          */
-        info?: boolean;
+        info?: boolean | undefined;
 
         /**
          * Use markup and classes for the table to be themed by jQuery UI ThemeRoller. Since: 1.10
          */
-        jQueryUI?: boolean;
+        jQueryUI?: boolean | undefined;
 
         /**
          * Feature control the end user's ability to change the paging display length of the table. Since: 1.10
          */
-        lengthChange?: boolean;
+        lengthChange?: boolean | undefined;
 
         /**
          * Feature control ordering (sorting) abilities in DataTables. Since: 1.10
          */
-        ordering?: boolean;
+        ordering?: boolean | undefined;
 
         /**
          * Enable or disable table pagination. Since: 1.10
          */
-        paging?: boolean;
+        paging?: boolean | undefined;
 
         /**
          * Feature control the processing indicator. Since: 1.10
          */
-        processing?: boolean;
+        processing?: boolean | undefined;
 
         /**
          * Horizontal scrolling. Since: 1.10
          */
-        scrollX?: boolean;
+        scrollX?: boolean | undefined;
 
         /**
          * Vertical scrolling. Since: 1.10 Exp: "200px"
          */
-        scrollY?: string;
+        scrollY?: string | undefined;
 
         /**
          * Feature control search (filtering) abilities Since: 1.10
          */
-        searching?: boolean;
+        searching?: boolean | undefined;
 
         /**
          * Feature control DataTables' server-side processing mode. Since: 1.10
          */
-        serverSide?: boolean;
+        serverSide?: boolean | undefined;
 
         /**
          * State saving - restore table state on page reload. Since: 1.10
          */
-        stateSave?: boolean;
+        stateSave?: boolean | undefined;
 
         //#endregion "Features"
 
@@ -1292,12 +1292,12 @@ declare namespace DataTables {
         /**
          * Load data for the table's content from an Ajax source. Since: 1.10
          */
-        ajax?: string | AjaxSettings | FunctionAjax;
+        ajax?: string | AjaxSettings | FunctionAjax | undefined;
 
         /**
          * Data to use as the display data for the table. Since: 1.10
          */
-        data?: any[];
+        data?: any[] | undefined;
 
         //#endregion "Data"
 
@@ -1306,132 +1306,132 @@ declare namespace DataTables {
         /**
          * Data to use as the display data for the table. Since: 1.10
          */
-        columns?: ColumnSettings[];
+        columns?: ColumnSettings[] | undefined;
 
         /**
          * Assign a column definition to one or more columns.. Since: 1.10
          */
-        columnDefs?: ColumnDefsSettings[];
+        columnDefs?: ColumnDefsSettings[] | undefined;
 
         /**
          * Delay the loading of server-side data until second draw
          */
-        deferLoading?: number | number[];
+        deferLoading?: number | number[] | undefined;
 
         /**
          * Destroy any existing table matching the selector and replace with the new options. Since: 1.10
          */
-        destroy?: boolean;
+        destroy?: boolean | undefined;
 
         /**
          * Initial paging start point. Since: 1.10
          */
-        displayStart?: number;
+        displayStart?: number | undefined;
 
         /**
          * Define the table control elements to appear on the page and in what order. Since: 1.10
          */
-        dom?: string;
+        dom?: string | undefined;
 
         /**
          * Change the options in the page length select list. Since: 1.10
          */
-        lengthMenu?: Array<(number | string)> | Array<Array<(number | string)>>;
+        lengthMenu?: Array<(number | string)> | Array<Array<(number | string)>> | undefined;
 
         /**
          * Control which cell the order event handler will be applied to in a column. Since: 1.10
          */
-        orderCellsTop?: boolean;
+        orderCellsTop?: boolean | undefined;
 
         /**
          * Highlight the columns being ordered in the table's body. Since: 1.10
          */
-        orderClasses?: boolean;
+        orderClasses?: boolean | undefined;
 
         /**
          * Initial order (sort) to apply to the table. Since: 1.10
          */
-        order?: Array<(number | string)> | Array<Array<(number | string)>>;
+        order?: Array<(number | string)> | Array<Array<(number | string)>> | undefined;
 
         /**
          * Ordering to always be applied to the table. Since: 1.10
          */
-        orderFixed?: Array<(number | string)> | Array<Array<(number | string)>> | object;
+        orderFixed?: Array<(number | string)> | Array<Array<(number | string)>> | object | undefined;
 
         /**
          * Multiple column ordering ability control. Since: 1.10
          */
-        orderMulti?: boolean;
+        orderMulti?: boolean | undefined;
 
         /**
          * Change the initial page length (number of rows per page). Since: 1.10
          */
-        pageLength?: number;
+        pageLength?: number | undefined;
 
         /**
          * Pagination button display options. Basic Types: numbers (1.10.8) simple, simple_numbers, full, full_numbers
          */
-        pagingType?: string;
+        pagingType?: string | undefined;
 
         /**
          * Retrieve an existing DataTables instance. Since: 1.10
          */
-        retrieve?: boolean;
+        retrieve?: boolean | undefined;
 
         /**
          * Display component renderer types. Since: 1.10
          */
-        renderer?: string | RendererSettings;
+        renderer?: string | RendererSettings | undefined;
 
         /**
          * Data property name that DataTables will use to set <tr> element DOM IDs. Since: 1.10.8
          */
-        rowId?: string;
+        rowId?: string | undefined;
 
         /**
          * Allow the table to reduce in height when a limited number of rows are shown. Since: 1.10
          */
-        scrollCollapse?: boolean;
+        scrollCollapse?: boolean | undefined;
 
         /**
          * Set an initial filter in DataTables and / or filtering options. Since: 1.10
          */
-        search?: SearchSettings | boolean;
+        search?: SearchSettings | boolean | undefined;
 
         /**
          * Set placeholder attribute for input type="text" tag elements. Since: 1.10
          */
-        searchPlaceholder?: SearchSettings;
+        searchPlaceholder?: SearchSettings | undefined;
 
         /**
          * Define an initial search for individual columns. Since: 1.10
          */
-        searchCols?: SearchSettings[];
+        searchCols?: SearchSettings[] | undefined;
 
         /**
          * Set a throttle frequency for searching. Since: 1.10
          */
-        searchDelay?: number;
+        searchDelay?: number | undefined;
 
         /**
          * Saved state validity duration. Since: 1.10
          */
-        stateDuration?: number;
+        stateDuration?: number | undefined;
 
         /**
          * Set the zebra stripe class names for the rows in the table. Since: 1.10
          */
-        stripeClasses?: string[];
+        stripeClasses?: string[] | undefined;
 
         /**
          * Tab index control for keyboard navigation. Since: 1.10
          */
-        tabIndex?: number;
+        tabIndex?: number | undefined;
 
         /**
          * Enable or disable datatables responsive. Since: 1.10
          */
-        responsive?: boolean | object;
+        responsive?: boolean | object | undefined;
 
         //#endregion "Options"
 
@@ -1440,78 +1440,78 @@ declare namespace DataTables {
         /**
          * Callback for whenever a TR element is created for the table's body. Since: 1.10
          */
-        createdRow?: FunctionCreateRow;
+        createdRow?: FunctionCreateRow | undefined;
 
         /**
          * Function that is called every time DataTables performs a draw. Since: 1.10
          */
-        drawCallback?: FunctionDrawCallback;
+        drawCallback?: FunctionDrawCallback | undefined;
 
         /**
          * Footer display callback function. Since: 1.10
          */
-        footerCallback?: FunctionFooterCallback;
+        footerCallback?: FunctionFooterCallback | undefined;
 
         /**
          * Number formatting callback function. Since: 1.10
          */
-        formatNumber?: FunctionFormatNumber;
+        formatNumber?: FunctionFormatNumber | undefined;
 
         /**
          * Header display callback function. Since: 1.10
          */
-        headerCallback?: FunctionHeaderCallback;
+        headerCallback?: FunctionHeaderCallback | undefined;
 
         /**
          * Table summary information display callback. Since: 1.10
          */
-        infoCallback?: FunctionInfoCallback;
+        infoCallback?: FunctionInfoCallback | undefined;
 
         /**
          * Initialisation complete callback. Since: 1.10
          */
-        initComplete?: FunctionInitComplete;
+        initComplete?: FunctionInitComplete | undefined;
 
         /**
          * Pre-draw callback. Since: 1.10
          */
-        preDrawCallback?: FunctionPreDrawCallback;
+        preDrawCallback?: FunctionPreDrawCallback | undefined;
 
         /**
          * Row draw callback.. Since: 1.10
          */
-        rowCallback?: FunctionRowCallback;
+        rowCallback?: FunctionRowCallback | undefined;
 
         /**
          * Callback that defines where and how a saved state should be loaded. Since: 1.10
          */
-        stateLoadCallback?: FunctionStateLoadCallback;
+        stateLoadCallback?: FunctionStateLoadCallback | undefined;
 
         /**
          * State loaded callback. Since: 1.10
          */
-        stateLoaded?: FunctionStateLoaded;
+        stateLoaded?: FunctionStateLoaded | undefined;
 
         /**
          * State loaded - data manipulation callback. Since: 1.10
          */
-        stateLoadParams?: FunctionStateLoadParams;
+        stateLoadParams?: FunctionStateLoadParams | undefined;
 
         /**
          * Callback that defines how the table state is stored and where. Since: 1.10
          */
-        stateSaveCallback?: FunctionStateSaveCallback;
+        stateSaveCallback?: FunctionStateSaveCallback | undefined;
 
         /**
          * State save - data manipulation callback. Since: 1.10
          */
-        stateSaveParams?: FunctionStateSaveParams;
+        stateSaveParams?: FunctionStateSaveParams | undefined;
 
         //#endregion "Callbacks"
 
         //#region "Language"
 
-        language?: LanguageSettings;
+        language?: LanguageSettings | undefined;
 
         //#endregion "Language"
     }
@@ -1547,23 +1547,23 @@ declare namespace DataTables {
     }
 
     interface AjaxData {
-        draw?: number;
-        recordsTotal?: number;
-        recordsFiltered?: number;
+        draw?: number | undefined;
+        recordsTotal?: number | undefined;
+        recordsFiltered?: number | undefined;
         data: any;
-        error?: string;
+        error?: string | undefined;
     }
 
     interface AjaxSettings extends JQueryAjaxSettings {
         /**
          * Add or modify data submitted to the server upon an Ajax request. Since: 1.10
          */
-        data?: object | FunctionAjaxData;
+        data?: object | FunctionAjaxData | undefined;
 
         /**
          * Data property or manipulation method for table data. Since: 1.10
          */
-        dataSrc?: string | ((data: any) => any[]);
+        dataSrc?: string | ((data: any) => any[]) | undefined;
     }
 
     type FunctionAjax = (data: object, callback: ((data: any) => void), settings: SettingsLegacy) => void;
@@ -1578,52 +1578,52 @@ declare namespace DataTables {
         /**
          * Cell type to be created for a column. th/td Since: 1.10
          */
-        cellType?: string;
+        cellType?: string | undefined;
 
         /**
          * Class to assign to each cell in the column. Since: 1.10
          */
-        className?: string;
+        className?: string | undefined;
 
         /**
          * Add padding to the text content used when calculating the optimal with for a table. Since: 1.10
          */
-        contentPadding?: string;
+        contentPadding?: string | undefined;
 
         /**
          * Cell created callback to allow DOM manipulation. Since: 1.10
          */
-        createdCell?: FunctionColumnCreatedCell;
+        createdCell?: FunctionColumnCreatedCell | undefined;
 
         /**
          * Class to assign to each cell in the column. Since: 1.10
          */
-        data?: number | string | ObjectColumnData | FunctionColumnData | null;
+        data?: number | string | ObjectColumnData | FunctionColumnData | null | undefined;
 
         /**
          * Set default, static, content for a column. Since: 1.10
          */
-        defaultContent?: string;
+        defaultContent?: string | undefined;
 
         /**
          * Set a descriptive name for a column. Since: 1.10
          */
-        name?: string;
+        name?: string | undefined;
 
         /**
          * Enable or disable ordering on this column. Since: 1.10
          */
-        orderable?: boolean;
+        orderable?: boolean | undefined;
 
         /**
          * Define multiple column ordering as the default order for a column. Since: 1.10
          */
-        orderData?: number | number[];
+        orderData?: number | number[] | undefined;
 
         /**
          * Live DOM sorting type assignment. Since: 1.10
          */
-        orderDataType?: string;
+        orderDataType?: string | undefined;
 
         /**
          * Ordering to always be applied to the table. Since 1.10
@@ -1632,42 +1632,42 @@ declare namespace DataTables {
          * 0: Column index to order upon.
          * 1: Direction so order to apply ("asc" for ascending order or "desc" for descending order).
          */
-        orderFixed?: any[] | ObjectOrderFixed;
+        orderFixed?: any[] | ObjectOrderFixed | undefined;
 
         /**
          * Order direction application sequence. Since: 1.10
          */
-        orderSequence?: string[];
+        orderSequence?: string[] | undefined;
 
         /**
          * Render (process) the data for use in the table. Since: 1.10
          */
-        render?: number | string | ObjectColumnData | FunctionColumnRender | ObjectColumnRender;
+        render?: number | string | ObjectColumnData | FunctionColumnRender | ObjectColumnRender | undefined;
 
         /**
          * Enable or disable filtering on the data in this column. Since: 1.10
          */
-        searchable?: boolean;
+        searchable?: boolean | undefined;
 
         /**
          * Set the column title. Since: 1.10
          */
-        title?: string;
+        title?: string | undefined;
 
         /**
          * Set the column type - used for filtering and sorting string processing. Since: 1.10
          */
-        type?: string;
+        type?: string | undefined;
 
         /**
          * Enable or disable the display of this column. Since: 1.10
          */
-        visible?: boolean;
+        visible?: boolean | undefined;
 
         /**
          * Column width assignment. Since: 1.10
          */
-        width?: string;
+        width?: string | undefined;
     }
 
     interface ColumnDefsSettings extends ColumnSettings {
@@ -1683,20 +1683,20 @@ declare namespace DataTables {
 
     interface ObjectColumnData {
         _: string | number | FunctionColumnData;
-        filter?: string | number | FunctionColumnData;
-        display?: string | number | FunctionColumnData;
-        type?: string | number | FunctionColumnData;
-        sort?: string | number | FunctionColumnData;
+        filter?: string | number | FunctionColumnData | undefined;
+        display?: string | number | FunctionColumnData | undefined;
+        type?: string | number | FunctionColumnData | undefined;
+        sort?: string | number | FunctionColumnData | undefined;
     }
 
     type FunctionColumnRender = (data: any, type: any, row: any, meta: CellMetaSettings) => any;
 
     interface ObjectColumnRender {
-        _?: string | number | FunctionColumnRender;
-        filter?: string | number | FunctionColumnRender;
-        display?: string | number | FunctionColumnRender;
-        type?: string | number | FunctionColumnRender;
-        sort?: string | number | FunctionColumnRender;
+        _?: string | number | FunctionColumnRender | undefined;
+        filter?: string | number | FunctionColumnRender | undefined;
+        display?: string | number | FunctionColumnRender | undefined;
+        type?: string | number | FunctionColumnRender | undefined;
+        sort?: string | number | FunctionColumnRender | undefined;
     }
 
     interface CellMetaSettings {
@@ -1710,35 +1710,35 @@ declare namespace DataTables {
     //#region "other-settings"
 
     interface RendererSettings {
-        header?: string;
-        pageButton?: string;
+        header?: string | undefined;
+        pageButton?: string | undefined;
     }
 
     interface SearchSettings {
         /**
          * Control case-sensitive filtering option. Since: 1.10
          */
-        caseInsensitive?: boolean;
+        caseInsensitive?: boolean | undefined;
 
         /**
          * Enable / disable escaping of regular expression characters in the search term. Since: 1.10
          */
-        regex?: boolean;
+        regex?: boolean | undefined;
 
         /**
          * Enable / disable DataTables' smart filtering. Since: 1.10
          */
-        smart?: boolean;
+        smart?: boolean | undefined;
 
         /**
          * Set an initial filtering condition on the table. Since: 1.10
          */
-        search?: string;
+        search?: string | undefined;
 
         /**
          * Set a placeholder attribute for input type="text" tag elements. Since: 1.10.1
          */
-        searchPlaceholder?: string;
+        searchPlaceholder?: string | undefined;
     }
 
     //#endregion "other-settings"
@@ -1779,22 +1779,22 @@ declare namespace DataTables {
 
     // these are all optional
     interface LanguageSettings {
-        emptyTable?: string;
-        info?: string;
-        infoEmpty?: string;
-        infoFiltered?: string;
-        infoPostFix?: string;
-        decimal?: string;
-        thousands?: string;
-        lengthMenu?: string;
-        loadingRecords?: string;
-        processing?: string;
-        search?: string;
-        searchPlaceholder?: string;
-        zeroRecords?: string;
-        paginate?: LanguagePaginateSettings;
-        aria?: LanguageAriaSettings;
-        url?: string;
+        emptyTable?: string | undefined;
+        info?: string | undefined;
+        infoEmpty?: string | undefined;
+        infoFiltered?: string | undefined;
+        infoPostFix?: string | undefined;
+        decimal?: string | undefined;
+        thousands?: string | undefined;
+        lengthMenu?: string | undefined;
+        loadingRecords?: string | undefined;
+        processing?: string | undefined;
+        search?: string | undefined;
+        searchPlaceholder?: string | undefined;
+        zeroRecords?: string | undefined;
+        paginate?: LanguagePaginateSettings | undefined;
+        aria?: LanguageAriaSettings | undefined;
+        url?: string | undefined;
     }
 
     interface LanguagePaginateSettings {
@@ -1807,7 +1807,7 @@ declare namespace DataTables {
     interface LanguageAriaSettings {
         sortAscending: string;
         sortDescending: string;
-        paginate?: LanguagePaginateSettings;
+        paginate?: LanguagePaginateSettings | undefined;
     }
 
     //#endregion "language-settings"
@@ -1975,32 +1975,32 @@ declare namespace DataTables {
     type CookieCallbackLegacy = (name: string, data: any, expires: string, path: string, cookie: string) => void;
 
     interface LanguageLegacy {
-        oAria?: LanguageAriaLegacy;
-        oPaginate?: LanguagePaginateLegacy;
-        sEmptyTable?: string;
-        sInfo?: string;
-        sInfoEmpty?: string;
-        sInfoFiltered?: string;
-        sInfoPostFix?: string;
-        sInfoThousands?: string;
-        sLengthMenu?: string;
-        sLoadingRecords?: string;
-        sProcessing?: string;
-        sSearch?: string;
-        sUrl?: string;
-        sZeroRecords?: string;
+        oAria?: LanguageAriaLegacy | undefined;
+        oPaginate?: LanguagePaginateLegacy | undefined;
+        sEmptyTable?: string | undefined;
+        sInfo?: string | undefined;
+        sInfoEmpty?: string | undefined;
+        sInfoFiltered?: string | undefined;
+        sInfoPostFix?: string | undefined;
+        sInfoThousands?: string | undefined;
+        sLengthMenu?: string | undefined;
+        sLoadingRecords?: string | undefined;
+        sProcessing?: string | undefined;
+        sSearch?: string | undefined;
+        sUrl?: string | undefined;
+        sZeroRecords?: string | undefined;
     }
 
     interface LanguageAriaLegacy {
-        sSortAscending?: string;
-        sSortDescending?: string;
+        sSortAscending?: string | undefined;
+        sSortDescending?: string | undefined;
     }
 
     interface LanguagePaginateLegacy {
-        sFirst?: string;
-        sLast?: string;
-        sNext?: string;
-        sPrevious?: string;
+        sFirst?: string | undefined;
+        sLast?: string | undefined;
+        sNext?: string | undefined;
+        sPrevious?: string | undefined;
     }
     //#endregion "SettingsLegacy"
 
@@ -2042,178 +2042,178 @@ declare namespace DataTables {
          * Default Value:
          * dataTable
          */
-        sTable?: string;
+        sTable?: string | undefined;
 
         /**
          * Default Value:
          * no-footer
          */
-        sNoFooter?: string;
+        sNoFooter?: string | undefined;
 
         /**
          * Default Value:
          * paginate_button
          */
-        sPageButton?: string;
+        sPageButton?: string | undefined;
 
         /**
          * Default Value:
          * current
          */
-        sPageButtonActive?: string;
+        sPageButtonActive?: string | undefined;
 
         /**
          * Default Value:
          * disabled
          */
-        sPageButtonDisabled?: string;
+        sPageButtonDisabled?: string | undefined;
 
         /**
          * Default Value:
          * odd
          */
-        sStripeOdd?: string;
+        sStripeOdd?: string | undefined;
 
         /**
          * Default Value:
          * even
          */
-        sStripeEven?: string;
+        sStripeEven?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_empty
          */
-        sRowEmpty?: string;
+        sRowEmpty?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_wrapper
          */
-        sWrapper?: string;
+        sWrapper?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_filter
          */
-        sFilter?: string;
+        sFilter?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_info
          */
-        sInfo?: string;
+        sInfo?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_paginate paging_
          */
-        sPaging?: string;
+        sPaging?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_length
          */
-        sLength?: string;
+        sLength?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_processing
          */
-        sProcessing?: string;
+        sProcessing?: string | undefined;
 
         /**
          * Default Value:
          * sorting_asc
          */
-        sSortAsc?: string;
+        sSortAsc?: string | undefined;
 
         /**
          * Default Value:
          * sorting_desc
          */
-        sSortDesc?: string;
+        sSortDesc?: string | undefined;
 
         /**
          * Default Value:
          * sorting
          */
-        sSortable?: string;
+        sSortable?: string | undefined;
 
         /**
          * Default Value:
          * sorting_asc_disabled
          */
-        sSortableAsc?: string;
+        sSortableAsc?: string | undefined;
 
         /**
          * Default Value:
          * sorting_desc_disabled
          */
-        sSortableDesc?: string;
+        sSortableDesc?: string | undefined;
 
         /**
          * Default Value:
          * sorting_disabled
          */
-        sSortableNone?: string;
+        sSortableNone?: string | undefined;
 
         /**
          * Default Value:
          * sorting_
          */
-        sSortColumn?: string;
+        sSortColumn?: string | undefined;
 
-        sFilterInput?: string;
-        sLengthSelect?: string;
+        sFilterInput?: string | undefined;
+        sLengthSelect?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_scroll
          */
-        sScrollWrapper?: string;
+        sScrollWrapper?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_scrollHead
          */
-        sScrollHead?: string;
+        sScrollHead?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_scrollHeadInner
          */
-        sScrollHeadInner?: string;
+        sScrollHeadInner?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_scrollBody
          */
-        sScrollBody?: string;
+        sScrollBody?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_scrollFoot
          */
-        sScrollFoot?: string;
+        sScrollFoot?: string | undefined;
 
         /**
          * Default Value:
          * dataTables_scrollFootInner
          */
-        sScrollFootInner?: string;
+        sScrollFootInner?: string | undefined;
 
-        sHeaderTH?: string;
-        sFooterTH?: string;
-        sSortJUIAsc?: string;
-        sSortJUIDesc?: string;
-        sSortJUI?: string;
-        sSortJUIAscAllowed?: string;
-        sSortJUIDescAllowed?: string;
-        sSortJUIWrapper?: string;
-        sSortIcon?: string;
-        sJUIHeader?: string;
-        sJUIFooter?: string;
+        sHeaderTH?: string | undefined;
+        sFooterTH?: string | undefined;
+        sSortJUIAsc?: string | undefined;
+        sSortJUIDesc?: string | undefined;
+        sSortJUI?: string | undefined;
+        sSortJUIAscAllowed?: string | undefined;
+        sSortJUIDescAllowed?: string | undefined;
+        sSortJUIWrapper?: string | undefined;
+        sSortIcon?: string | undefined;
+        sJUIHeader?: string | undefined;
+        sJUIFooter?: string | undefined;
     }
     //#endregion "ext internal"
 

--- a/types/debounce-promise/index.d.ts
+++ b/types/debounce-promise/index.d.ts
@@ -5,8 +5,8 @@
 
 declare namespace debounce {
     interface DebounceOptions {
-        leading?: boolean;
-        accumulate?: boolean;
+        leading?: boolean | undefined;
+        accumulate?: boolean | undefined;
     }
 }
 

--- a/types/decompress/index.d.ts
+++ b/types/decompress/index.d.ts
@@ -32,11 +32,11 @@ declare namespace decompress {
          * Array of plugins to use.
          * Default: [decompressTar(), decompressTarbz2(), decompressTargz(), decompressUnzip()]
          */
-        plugins?: any[];
+        plugins?: any[] | undefined;
         /**
          * Remove leading directory components from extracted files.
          * Default: 0
          */
-        strip?: number;
+        strip?: number | undefined;
     }
 }

--- a/types/deep-diff/index.d.ts
+++ b/types/deep-diff/index.d.ts
@@ -6,26 +6,26 @@
 
 export interface DiffNew<RHS> {
     kind: 'N';
-    path?: any[];
+    path?: any[] | undefined;
     rhs: RHS;
 }
 
 export interface DiffDeleted<LHS> {
     kind: 'D';
-    path?: any[];
+    path?: any[] | undefined;
     lhs: LHS;
 }
 
 export interface DiffEdit<LHS, RHS = LHS> {
     kind: 'E';
-    path?: any[];
+    path?: any[] | undefined;
     lhs: LHS;
     rhs: RHS;
 }
 
 export interface DiffArray<LHS, RHS = LHS> {
     kind: 'A';
-    path?: any[];
+    path?: any[] | undefined;
     index: number;
     item: Diff<LHS, RHS>;
 }

--- a/types/detect-port/index.d.ts
+++ b/types/detect-port/index.d.ts
@@ -8,8 +8,8 @@ type DetectPortCallback = (err: Error, _port: number) => void;
 
 interface PortConfig {
     port: number;
-    hostname?: string;
-    callback?: DetectPortCallback;
+    hostname?: string | undefined;
+    callback?: DetectPortCallback | undefined;
 }
 
 interface DetectPort {

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -170,7 +170,7 @@ declare global {
              * Mock opening the app from URL. sourceApp is an optional parameter to specify source application bundle id.
              * @param url
              */
-            openURL(url: { url: string; sourceApp?: string }): Promise<void>;
+            openURL(url: { url: string; sourceApp?: string | undefined }): Promise<void>;
             /**
              * Mock handling of received user notification when app is in foreground.
              * @param params
@@ -638,44 +638,44 @@ declare global {
         type Orientation = 'portrait' | 'landscape';
         type Speed = 'fast' | 'slow';
         interface LanguageAndLocale {
-            language?: string;
-            locale?: string;
+            language?: string | undefined;
+            locale?: string | undefined;
         }
         interface DetoxInitOptions {
             /**
              * Detox exports device, expect, element, by and waitFor as globals by default, if you want to control their initialization manually, set init detox with initGlobals set to false.
              * This is useful when during E2E tests you also need to run regular expectations in node. jest Expect for instance, will not be overriden by Detox when this option is used.
              */
-            initGlobals?: boolean;
+            initGlobals?: boolean | undefined;
             /**
              * By default await detox.init(config); will launch the installed app. If you wish to control when your app is launched, add {launchApp: false} param to your init.
              */
-            launchApp?: boolean;
+            launchApp?: boolean | undefined;
             /**
              * By default await detox.init(config); will uninstall and install the app. If you wish to reuse the existing app for a faster run, add {reuse: true} param to your init.
              */
-            reuse?: boolean;
+            reuse?: boolean | undefined;
         }
 
         /**
          *  Source for string definitions is https://github.com/wix/AppleSimulatorUtils
          */
         interface DevicePermissions {
-            location?: LocationPermission;
-            notifications?: NotificationsPermission;
-            calendar?: CalendarPermission;
-            camera?: CameraPermission;
-            contacts?: ContactsPermission;
-            health?: HealthPermission;
-            homekit?: HomekitPermission;
-            medialibrary?: MediaLibraryPermission;
-            microphone?: MicrophonePermission;
-            motion?: MotionPermission;
-            photos?: PhotosPermission;
-            reminders?: RemindersPermission;
-            siri?: SiriPermission;
-            speech?: SpeechPermission;
-            faceid?: FaceIDPermission;
+            location?: LocationPermission | undefined;
+            notifications?: NotificationsPermission | undefined;
+            calendar?: CalendarPermission | undefined;
+            camera?: CameraPermission | undefined;
+            contacts?: ContactsPermission | undefined;
+            health?: HealthPermission | undefined;
+            homekit?: HomekitPermission | undefined;
+            medialibrary?: MediaLibraryPermission | undefined;
+            microphone?: MicrophonePermission | undefined;
+            motion?: MotionPermission | undefined;
+            photos?: PhotosPermission | undefined;
+            reminders?: RemindersPermission | undefined;
+            siri?: SiriPermission | undefined;
+            speech?: SpeechPermission | undefined;
+            faceid?: FaceIDPermission | undefined;
         }
 
         type LocationPermission = 'always' | 'inuse' | 'never' | 'unset';
@@ -700,12 +700,12 @@ declare global {
              * Restart the app
              * Terminate the app and launch it again. If set to false, the simulator will try to bring app from background, if the app isn't running, it will launch a new instance. default is false
              */
-            newInstance?: boolean;
+            newInstance?: boolean | undefined;
             /**
              * Set runtime permissions
              * Grant or deny runtime permissions for your application.
              */
-            permissions?: DevicePermissions;
+            permissions?: DevicePermissions | undefined;
             /**
              * Launch from URL
              * Mock opening the app from URL to test your app's deep link handling mechanism.
@@ -723,7 +723,7 @@ declare global {
              * Launch into a fresh installation
              * A flag that enables relaunching into a fresh installation of the app (it will uninstall and install the binary again), default is false.
              */
-            delete?: boolean;
+            delete?: boolean | undefined;
             /**
              * Detox can start the app with additional launch arguments
              * The added launchArgs will be passed through the launch command to the device and be accessible via [[NSProcessInfo processInfo] arguments]
@@ -732,24 +732,24 @@ declare global {
             /**
              * Disables touch indicators on iOS. Default is false.
              */
-            disableTouchIndicators?: boolean;
+            disableTouchIndicators?: boolean | undefined;
             /**
              * Launch the app with a specific system language.
              * @see https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
              */
-            languageAndLocale?: LanguageAndLocale;
+            languageAndLocale?: LanguageAndLocale | undefined;
             /**
              * Launches the app with the synchronization mechanism enabled or disabled. Synchronization can later be enabled using `device.enableSynchronization()`.
              */
-            detoxEnableSynchronization?: number;
+            detoxEnableSynchronization?: number | undefined;
             /**
              * Launches the app with a URL blacklist to disable network synchronization on certain endpoints. Useful if the app makes frequent network calls to blacklisted endpoints upon startup.
              */
-            detoxURLBlacklistRegex?: number;
+            detoxURLBlacklistRegex?: number | undefined;
             /**
              * Mock opening the app from URL. sourceApp is an optional iOS-only parameter to specify source application bundle id. (iOS only)
              */
-            sourceApp?: string;
+            sourceApp?: string | undefined;
         }
 
         interface StatusBarOptionsOfIOS {
@@ -757,35 +757,35 @@ declare global {
              * Set the date or time to a fixed value.
              * If the string is a valid ISO date string it will also set the date on relevant devices.
              */
-            time?: string;
+            time?: string | undefined;
             /**
              * If specified must be one of `wifi`, `3g`, `4g`, `lte`, `lte-a`, or `lte+`.
              */
-            dataNetwork?: DataNetwork;
+            dataNetwork?: DataNetwork | undefined;
             /**
              * If specified must be one of `searching`, `failed`, or `active`.
              */
-            wifiMode?: WifiMode;
+            wifiMode?: WifiMode | undefined;
             /**
              * If specified must be 0-3.
              */
-            wifiBars?: 0 | 1 | 2 | 3;
+            wifiBars?: 0 | 1 | 2 | 3 | undefined;
             /**
              * If specified must be one of `notSupported`, `searching`, `failed`, or `active`.
              */
-            cellularMode?: CellularMode;
+            cellularMode?: CellularMode | undefined;
             /**
              * If specified must be 0-3.
              */
-            cellularBars?: 0 | 1 | 2 | 3;
+            cellularBars?: 0 | 1 | 2 | 3 | undefined;
             /**
              * If specified must be one of `charging`, `charged`, or `discharging`.
              */
-            batteryState?: BatteryState;
+            batteryState?: BatteryState | undefined;
             /**
              * If specified must be 0-100.
              */
-            batteryLevel?: number;
+            batteryLevel?: number | undefined;
         }
 
         interface AttributeIOSFrame {

--- a/types/dicer/index.d.ts
+++ b/types/dicer/index.d.ts
@@ -103,15 +103,15 @@ declare namespace Dicer {
         /**
          * This is the boundary used to detect the beginning of a new part.
          */
-        boundary?: string;
+        boundary?: string | undefined;
         /**
          * If true, preamble header parsing will be performed first.
          */
-        headerFirst?: boolean;
+        headerFirst?: boolean | undefined;
         /**
          * The maximum number of header key=>value pairs to parse Default: 2000 (same as node's http).
          */
-        maxHeaderPairs?: number;
+        maxHeaderPairs?: number | undefined;
     }
 
     /**

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -23,21 +23,21 @@ export interface BaseOptions {
      * `true` to ignore casing difference.
      * @default false
      */
-    ignoreCase?: boolean;
+    ignoreCase?: boolean | undefined;
 }
 
 export interface WordsOptions extends BaseOptions {
     /**
      * `true` to ignore leading and trailing whitespace. This is the same as `diffWords()`.
      */
-    ignoreWhitespace?: boolean;
+    ignoreWhitespace?: boolean | undefined;
 }
 
 export interface LinesOptions extends BaseOptions {
     /**
      * `true` to ignore leading and trailing whitespace. This is the same as `diffTrimmedLines()`.
      */
-    ignoreWhitespace?: boolean;
+    ignoreWhitespace?: boolean | undefined;
 
     /**
      * `true` to treat newline characters as separate tokens. This allows for changes to the newline structure
@@ -45,14 +45,14 @@ export interface LinesOptions extends BaseOptions {
      * human friendly form of `diffLines()` and `diffLines()` is better suited for patches and other computer
      * friendly output.
      */
-    newlineIsToken?: boolean;
+    newlineIsToken?: boolean | undefined;
 }
 
 export interface JsonOptions extends LinesOptions {
     /**
      * Replacer used to stringify the properties of the passed objects.
      */
-    stringifyReplacer?: (key: string, value: any) => any;
+    stringifyReplacer?: ((key: string, value: any) => any) | undefined;
 
     /**
      * The value to use when `undefined` values in the passed objects are encountered during stringification.
@@ -66,7 +66,7 @@ export interface ArrayOptions<TLeft, TRight> extends BaseOptions {
     /**
      * Comparator for custom equality checks.
      */
-    comparator?: (left: TLeft, right: TRight) => boolean;
+    comparator?: ((left: TLeft, right: TRight) => boolean) | undefined;
 }
 
 export interface PatchOptions extends LinesOptions {
@@ -74,7 +74,7 @@ export interface PatchOptions extends LinesOptions {
      * Describes how many lines of context should be included.
      * @default 4
      */
-    context?: number;
+    context?: number | undefined;
 }
 
 export interface ApplyPatchOptions {
@@ -82,7 +82,7 @@ export interface ApplyPatchOptions {
      * Number of lines that are allowed to differ before rejecting a patch.
      * @default 0
      */
-    fuzzFactor?: number;
+    fuzzFactor?: number | undefined;
 
     /**
      * Callback used to compare to given lines to determine if they should be considered equal when patching.
@@ -90,12 +90,12 @@ export interface ApplyPatchOptions {
      *
      * @default strict equality
      */
-    compareLine?: (
+    compareLine?: ((
         lineNumber: number,
         line: string,
         operation: '-' | ' ',
         patchContent: string
-    ) => boolean;
+    ) => boolean) | undefined;
 }
 
 export interface ApplyPatchesOptions extends ApplyPatchOptions {
@@ -105,7 +105,7 @@ export interface ApplyPatchesOptions extends ApplyPatchOptions {
 }
 
 export interface Change {
-    count?: number;
+    count?: number | undefined;
     /**
      * Text content.
      */
@@ -113,26 +113,26 @@ export interface Change {
     /**
      * `true` if the value was inserted into the new string.
      */
-    added?: boolean;
+    added?: boolean | undefined;
     /**
      * `true` if the value was removed from the old string.
      */
-    removed?: boolean;
+    removed?: boolean | undefined;
 }
 
 export interface ArrayChange<T> {
     value: T[];
-    count?: number;
-    added?: boolean;
-    removed?: boolean;
+    count?: number | undefined;
+    added?: boolean | undefined;
+    removed?: boolean | undefined;
 }
 
 export interface ParsedDiff {
-    index?: string;
-    oldFileName?: string;
-    newFileName?: string;
-    oldHeader?: string;
-    newHeader?: string;
+    index?: string | undefined;
+    oldFileName?: string | undefined;
+    newFileName?: string | undefined;
+    oldHeader?: string | undefined;
+    newHeader?: string | undefined;
     hunks: Hunk[];
 }
 
@@ -386,7 +386,7 @@ export function applyPatches(patch: string | ParsedDiff[], options: ApplyPatches
  *
  * @returns A JSON object representation of the a patch, suitable for use with the `applyPatch()` method.
  */
-export function parsePatch(diffStr: string, options?: { strict?: boolean }): ParsedDiff[];
+export function parsePatch(diffStr: string, options?: { strict?: boolean | undefined }): ParsedDiff[];
 
 /**
  * Converts a list of changes to a serialized XML format.

--- a/types/diff/v3/index.d.ts
+++ b/types/diff/v3/index.d.ts
@@ -15,26 +15,26 @@ declare namespace JsDiff {
     }
 
     interface ILinesOptions extends IOptions {
-        ignoreWhitespace?: boolean;
-        newlineIsToken?: boolean;
+        ignoreWhitespace?: boolean | undefined;
+        newlineIsToken?: boolean | undefined;
     }
 
     interface IArrayOptions {
-        comparator?: (left: any, right: any) => boolean;
+        comparator?: ((left: any, right: any) => boolean) | undefined;
     }
 
     interface IDiffResult {
         value: string;
-        count?: number;
-        added?: boolean;
-        removed?: boolean;
+        count?: number | undefined;
+        added?: boolean | undefined;
+        removed?: boolean | undefined;
     }
 
     interface IDiffArraysResult<T> {
         value: T[];
-        count?: number;
-        added?: boolean;
-        removed?: boolean;
+        count?: number | undefined;
+        added?: boolean | undefined;
+        removed?: boolean | undefined;
     }
 
     interface IBestPath {

--- a/types/dinero.js/index.d.ts
+++ b/types/dinero.js/index.d.ts
@@ -25,9 +25,9 @@ declare namespace DineroFactory {
     function maximum(objects: ReadonlyArray<Dinero>): Dinero;
 
     interface Options {
-        amount?: number;
-        currency?: Currency;
-        precision?: number;
+        amount?: number | undefined;
+        currency?: Currency | undefined;
+        precision?: number | undefined;
     }
 
     interface Dinero {
@@ -77,9 +77,9 @@ declare namespace DineroFactory {
 
     interface ExchangeRatesApiOptions {
         endpoint: string | Promise<{[key: string]: any}>;
-        propertyPath?: string;
-        headers?: { [header: string]: string };
-        roundingMode?: RoundingMode;
+        propertyPath?: string | undefined;
+        headers?: { [header: string]: string } | undefined;
+        roundingMode?: RoundingMode | undefined;
     }
 
     interface DineroObject {

--- a/types/dir-glob/index.d.ts
+++ b/types/dir-glob/index.d.ts
@@ -11,8 +11,8 @@ declare namespace dirGlob {
     function sync(input: string | string[], options?: Options): string[];
 
     interface Options {
-        extensions?: string[];
-        files?: string[];
-        cwd?: string;
+        extensions?: string[] | undefined;
+        files?: string[] | undefined;
+        cwd?: string | undefined;
     }
 }

--- a/types/dns-packet/index.d.ts
+++ b/types/dns-packet/index.d.ts
@@ -61,8 +61,8 @@ export interface Question {
 export interface SrvData {
     port: number;
     target: string;
-    priority?: number;
-    weight?: number;
+    priority?: number | undefined;
+    weight?: number | undefined;
 }
 
 export interface HInfoData {
@@ -73,7 +73,7 @@ export interface HInfoData {
 export interface BaseAnswer<T, D> {
     type: T;
     name: string;
-    ttl?: number;
+    ttl?: number | undefined;
     data: D;
 }
 
@@ -137,9 +137,9 @@ export interface Packet {
      * omitted if it is clear from the context of usage what type of packet
      * it is.
      */
-    type?: "query" | "response";
+    type?: "query" | "response" | undefined;
 
-    id?: number;
+    id?: number | undefined;
 
     /**
      * A bit-mask combination of zero or more of:
@@ -150,11 +150,11 @@ export interface Packet {
      * {@link AUTHENTIC_DATA},
      * {@link CHECKING_DISABLED}.
      */
-    flags?: number;
-    questions?: Question[];
-    answers?: Answer[];
-    additionals?: Answer[];
-    authorities?: Answer[];
+    flags?: number | undefined;
+    questions?: Question[] | undefined;
+    answers?: Answer[] | undefined;
+    additionals?: Answer[] | undefined;
+    authorities?: Answer[] | undefined;
 }
 
 export const AUTHORITATIVE_ANSWER: number;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -335,7 +335,7 @@ declare namespace Dockerode {
         Id: string;
         ParentId: string;
         RepoTags: string[];
-        RepoDigests?: string[];
+        RepoDigests?: string[] | undefined;
         Created: number;
         Size: number;
         VirtualSize: number;
@@ -360,11 +360,11 @@ declare namespace Dockerode {
             Networks: { [networkType: string]: NetworkInfo };
         };
         Mounts: Array<{
-            Name?: string;
+            Name?: string | undefined;
             Type: string;
             Source: string;
             Destination: string;
-            Driver?: string;
+            Driver?: string | undefined;
             Mode: string;
             RW: boolean;
             Propagation: string;
@@ -401,28 +401,28 @@ declare namespace Dockerode {
         Scope: string;
         Driver: string;
         EnableIPv6: boolean;
-        IPAM?: IPAM;
+        IPAM?: IPAM | undefined;
         Internal: boolean;
         Attachable: boolean;
         Ingress: boolean;
-        ConfigFrom?: { Network: string; };
+        ConfigFrom?: { Network: string; } | undefined;
         ConfigOnly: boolean;
-        Containers?: { [id: string]: NetworkContainer };
-        Options?: { [key: string]: string };
-        Labels?: { [key: string]: string };
+        Containers?: { [id: string]: NetworkContainer } | undefined;
+        Options?: { [key: string]: string } | undefined;
+        Labels?: { [key: string]: string } | undefined;
     }
 
     interface NetworkCreateOptions {
         Name: string;
-        CheckDuplicate?: boolean;
-        Driver?: string;
-        Internal?: boolean;
-        Attachable?: boolean;
-        Ingress?: boolean;
-        IPAM?: IPAM;
-        EnableIPv6?: boolean;
-        Options?: { [option: string]: string };
-        Labels?: { [label: string]: string };
+        CheckDuplicate?: boolean | undefined;
+        Driver?: string | undefined;
+        Internal?: boolean | undefined;
+        Attachable?: boolean | undefined;
+        Ingress?: boolean | undefined;
+        IPAM?: IPAM | undefined;
+        EnableIPv6?: boolean | undefined;
+        Options?: { [option: string]: string } | undefined;
+        Labels?: { [label: string]: string } | undefined;
     }
 
     interface NetworkContainer {
@@ -436,8 +436,8 @@ declare namespace Dockerode {
     /* tslint:disable:interface-name */
     interface IPAM {
         Driver: string;
-        Config?: Array<{ [key: string]: string }>;
-        Options?: { [key: string]: string };
+        Config?: Array<{ [key: string]: string }> | undefined;
+        Options?: { [key: string]: string } | undefined;
     }
     /* tslint:enable:interface-name */
 
@@ -445,7 +445,7 @@ declare namespace Dockerode {
         Name: string;
         Driver: string;
         Mountpoint: string;
-        Status?: { [key: string]: string };
+        Status?: { [key: string]: string } | undefined;
         Labels: { [key: string]: string };
         Scope: 'local' | 'global';
         // Field is always present, but sometimes is null
@@ -454,7 +454,7 @@ declare namespace Dockerode {
         UsageData?: {
             Size: number;
             RefCount: number;
-        } | null;
+        } | null | undefined;
     }
 
     interface ContainerInspectInfo {
@@ -483,7 +483,7 @@ declare namespace Dockerode {
                     ExitCode: number;
                     Output: string;
                 }>;
-            };
+            } | undefined;
         };
         Image: string;
         ResolvConfPath: string;
@@ -497,7 +497,7 @@ declare namespace Dockerode {
         MountLabel: string;
         ProcessLabel: string;
         AppArmorProfile: string;
-        ExecIDs?: string[];
+        ExecIDs?: string[] | undefined;
         HostConfig: HostConfig;
         GraphDriver: {
             Name: string;
@@ -508,7 +508,7 @@ declare namespace Dockerode {
             };
         };
         Mounts: Array<{
-            Name?: string;
+            Name?: string | undefined;
             Source: string;
             Destination: string;
             Mode: string;
@@ -531,7 +531,7 @@ declare namespace Dockerode {
             Image: string;
             Volumes: { [volume: string]: {} };
             WorkingDir: string;
-            Entrypoint?: string | string[];
+            Entrypoint?: string | string[] | undefined;
             OnBuild?: any;
             Labels: { [label: string]: string };
         };
@@ -582,7 +582,7 @@ declare namespace Dockerode {
                 Cpus: number;
                 Memory: number;
                 Labels: any;
-            };
+            } | undefined;
         };
     }
 
@@ -666,69 +666,69 @@ declare namespace Dockerode {
     }
 
     interface HostConfig {
-        AutoRemove?: boolean;
-        Binds?: string[];
-        ContainerIDFile?: string;
+        AutoRemove?: boolean | undefined;
+        Binds?: string[] | undefined;
+        ContainerIDFile?: string | undefined;
         LogConfig?: {
             Type: string;
             Config: any;
-        };
-        NetworkMode?: string;
+        } | undefined;
+        NetworkMode?: string | undefined;
         PortBindings?: any;
-        RestartPolicy?: RestartPolicy;
-        VolumeDriver?: string;
+        RestartPolicy?: RestartPolicy | undefined;
+        VolumeDriver?: string | undefined;
         VolumesFrom?: any;
-        Mounts?: MountConfig;
+        Mounts?: MountConfig | undefined;
         CapAdd?: any;
         CapDrop?: any;
-        Dns?: any[];
-        DnsOptions?: any[];
-        DnsSearch?: any[];
+        Dns?: any[] | undefined;
+        DnsOptions?: any[] | undefined;
+        DnsSearch?: any[] | undefined;
         ExtraHosts?: any;
-        GroupAdd?: string[];
-        IpcMode?: string;
-        Cgroup?: string;
+        GroupAdd?: string[] | undefined;
+        IpcMode?: string | undefined;
+        Cgroup?: string | undefined;
         Links?: any;
-        OomScoreAdj?: number;
-        PidMode?: string;
-        Privileged?: boolean;
-        PublishAllPorts?: boolean;
-        ReadonlyRootfs?: boolean;
+        OomScoreAdj?: number | undefined;
+        PidMode?: string | undefined;
+        Privileged?: boolean | undefined;
+        PublishAllPorts?: boolean | undefined;
+        ReadonlyRootfs?: boolean | undefined;
         SecurityOpt?: any;
-        StorageOpt?: { [option: string]: string };
-        Tmpfs?: { [dir: string]: string };
-        UTSMode?: string;
-        UsernsMode?: string;
-        ShmSize?: number;
-        Sysctls?: { [index: string]: string };
-        Runtime?: string;
-        ConsoleSize?: number[];
-        Isolation?: string;
-        MaskedPaths?: string[];
-        ReadonlyPaths?: string[];
-        CpuShares?: number;
-        CgroupParent?: string;
-        BlkioWeight?: number;
+        StorageOpt?: { [option: string]: string } | undefined;
+        Tmpfs?: { [dir: string]: string } | undefined;
+        UTSMode?: string | undefined;
+        UsernsMode?: string | undefined;
+        ShmSize?: number | undefined;
+        Sysctls?: { [index: string]: string } | undefined;
+        Runtime?: string | undefined;
+        ConsoleSize?: number[] | undefined;
+        Isolation?: string | undefined;
+        MaskedPaths?: string[] | undefined;
+        ReadonlyPaths?: string[] | undefined;
+        CpuShares?: number | undefined;
+        CgroupParent?: string | undefined;
+        BlkioWeight?: number | undefined;
         BlkioWeightDevice?: any;
         BlkioDeviceReadBps?: any;
         BlkioDeviceWriteBps?: any;
         BlkioDeviceReadIOps?: any;
         BlkioDeviceWriteIOps?: any;
-        CpuPeriod?: number;
-        CpuQuota?: number;
-        CpusetCpus?: string;
-        CpusetMems?: string;
+        CpuPeriod?: number | undefined;
+        CpuQuota?: number | undefined;
+        CpusetCpus?: string | undefined;
+        CpusetMems?: string | undefined;
         Devices?: any;
-        DeviceCgroupRules?: string[];
-        DeviceRequests?: DeviceRequest[];
-        DiskQuota?: number;
-        KernelMemory?: number;
-        Memory?: number;
-        MemoryReservation?: number;
-        MemorySwap?: number;
-        MemorySwappiness?: number;
-        OomKillDisable?: boolean;
-        PidsLimit?: number;
+        DeviceCgroupRules?: string[] | undefined;
+        DeviceRequests?: DeviceRequest[] | undefined;
+        DiskQuota?: number | undefined;
+        KernelMemory?: number | undefined;
+        Memory?: number | undefined;
+        MemoryReservation?: number | undefined;
+        MemorySwap?: number | undefined;
+        MemorySwappiness?: number | undefined;
+        OomKillDisable?: boolean | undefined;
+        PidsLimit?: number | undefined;
         Ulimits?: any;
     }
 
@@ -757,8 +757,8 @@ declare namespace Dockerode {
             Image: string;
             Volumes: { [path: string]: {} };
             WorkingDir: string;
-            Entrypoint?: string | string[];
-            OnBuild?: any[];
+            Entrypoint?: string | string[] | undefined;
+            OnBuild?: any[] | undefined;
             Labels: { [label: string]: string };
         };
         DockerVersion: string;
@@ -780,7 +780,7 @@ declare namespace Dockerode {
             Image: string;
             Volumes: { [path: string]: {} };
             WorkingDir: string;
-            Entrypoint?: string | string[];
+            Entrypoint?: string | string[] | undefined;
             OnBuild: any[];
             Labels: { [label: string]: string };
         };
@@ -798,53 +798,53 @@ declare namespace Dockerode {
         };
         RootFS: {
             Type: string;
-            Layers?: string[];
-            BaseLayer?: string;
+            Layers?: string[] | undefined;
+            BaseLayer?: string | undefined;
         };
     }
 
     interface ImageBuildOptions {
-        authconfig?: AuthConfig;
-        dockerfile?: string;
-        t?: string;
-        extrahosts?: string;
-        remote?: string;
-        q?: boolean;
-        cachefrom?: string;
-        pull?: string;
-        rm?: boolean;
-        forcerm?: boolean;
-        memory?: number;
-        memswap?: number;
-        cpushares?: number;
-        cpusetcpus?: number;
-        cpuperiod?: number;
-        cpuquota?: number;
-        buildargs?: {[key: string]: string};
-        shmsize?: number;
-        squash?: boolean;
-        labels?: {[key: string]: string};
-        networkmode?: string;
-        platform?: string;
-        target?: string;
-        outputs?: string;
+        authconfig?: AuthConfig | undefined;
+        dockerfile?: string | undefined;
+        t?: string | undefined;
+        extrahosts?: string | undefined;
+        remote?: string | undefined;
+        q?: boolean | undefined;
+        cachefrom?: string | undefined;
+        pull?: string | undefined;
+        rm?: boolean | undefined;
+        forcerm?: boolean | undefined;
+        memory?: number | undefined;
+        memswap?: number | undefined;
+        cpushares?: number | undefined;
+        cpusetcpus?: number | undefined;
+        cpuperiod?: number | undefined;
+        cpuquota?: number | undefined;
+        buildargs?: {[key: string]: string} | undefined;
+        shmsize?: number | undefined;
+        squash?: boolean | undefined;
+        labels?: {[key: string]: string} | undefined;
+        networkmode?: string | undefined;
+        platform?: string | undefined;
+        target?: string | undefined;
+        outputs?: string | undefined;
     }
 
     interface ImagePushOptions {
-        tag?: string;
-        authconfig?: AuthConfig;
+        tag?: string | undefined;
+        authconfig?: AuthConfig | undefined;
     }
 
     interface AuthConfig {
         username: string;
         password: string;
         serveraddress: string;
-        email?: string;
+        email?: string | undefined;
     }
 
     interface PortBinding {
-        HostIp?: string;
-        HostPort?: string;
+        HostIp?: string | undefined;
+        HostPort?: string | undefined;
     }
 
     interface PortMap {
@@ -853,7 +853,7 @@ declare namespace Dockerode {
 
     interface RestartPolicy {
         Name: string;
-        MaximumRetryCount?: number;
+        MaximumRetryCount?: number | undefined;
     }
 
     type LoggingDriverType =
@@ -869,7 +869,7 @@ declare namespace Dockerode {
 
     interface LogConfig {
         Type: LoggingDriverType;
-        Config?: { [key: string]: string };
+        Config?: { [key: string]: string } | undefined;
     }
 
     interface DeviceMapping {
@@ -879,35 +879,35 @@ declare namespace Dockerode {
     }
 
     interface DeviceRequest {
-        Driver?: string;
-        Count?: number;
-        DeviceIDs?: string[];
-        Capabilities?: string[][];
-        Options?: { [key: string]: string };
+        Driver?: string | undefined;
+        Count?: number | undefined;
+        DeviceIDs?: string[] | undefined;
+        Capabilities?: string[][] | undefined;
+        Options?: { [key: string]: string } | undefined;
     }
 
     /* tslint:disable:interface-name */
     interface IPAMConfig {
-        IPv4Address?: string;
-        IPv6Address?: string;
-        LinkLocalIPs?: string[];
+        IPv4Address?: string | undefined;
+        IPv6Address?: string | undefined;
+        LinkLocalIPs?: string[] | undefined;
     }
     /* tslint:enable:interface-name */
 
     interface EndpointSettings {
-        IPAMConfig?: IPAMConfig;
-        Links?: string[];
-        Aliases?: string[];
-        NetworkID?: string;
-        EndpointID?: string;
-        Gateway?: string;
-        IPAddress?: string;
-        IPPrefixLen?: number;
-        IPv6Gateway?: string;
-        GlobalIPv6Address?: string;
-        GlobalIPV6PrefixLen?: number;
-        MacAddress?: string;
-        DriverOpts?: { [key: string]: string };
+        IPAMConfig?: IPAMConfig | undefined;
+        Links?: string[] | undefined;
+        Aliases?: string[] | undefined;
+        NetworkID?: string | undefined;
+        EndpointID?: string | undefined;
+        Gateway?: string | undefined;
+        IPAddress?: string | undefined;
+        IPPrefixLen?: number | undefined;
+        IPv6Gateway?: string | undefined;
+        GlobalIPv6Address?: string | undefined;
+        GlobalIPV6PrefixLen?: number | undefined;
+        MacAddress?: string | undefined;
+        DriverOpts?: { [key: string]: string } | undefined;
     }
 
     interface EndpointsConfig {
@@ -915,16 +915,16 @@ declare namespace Dockerode {
     }
 
     interface ExecCreateOptions {
-        AttachStdin?: boolean;
-        AttachStdout?: boolean;
-        AttachStderr?: boolean;
-        DetachKeys?: string;
-        Tty?: boolean;
-        Env?: string[];
-        Cmd?: string[];
-        Privileged?: boolean;
-        User?: string;
-        WorkingDir?: string;
+        AttachStdin?: boolean | undefined;
+        AttachStdout?: boolean | undefined;
+        AttachStderr?: boolean | undefined;
+        DetachKeys?: string | undefined;
+        Tty?: boolean | undefined;
+        Env?: string[] | undefined;
+        Cmd?: string[] | undefined;
+        Privileged?: boolean | undefined;
+        User?: string | undefined;
+        WorkingDir?: string | undefined;
     }
 
     interface ExecInspectInfo {
@@ -949,11 +949,11 @@ declare namespace Dockerode {
 
     interface ExecStartOptions {
         // hijack and stdin are used by docker-modem
-        hijack?: boolean;
-        stdin?: boolean;
+        hijack?: boolean | undefined;
+        stdin?: boolean | undefined;
         // Detach and Tty are used by Docker's API
-        Detach?: boolean;
-        Tty?: boolean;
+        Detach?: boolean | undefined;
+        Tty?: boolean | undefined;
     }
 
     type MountType = 'bind' | 'volume' | 'tmpfs';
@@ -966,11 +966,11 @@ declare namespace Dockerode {
         Target: string;
         Source: string;
         Type: MountType;
-        ReadOnly?: boolean;
-        Consistency?: MountConsistency;
+        ReadOnly?: boolean | undefined;
+        Consistency?: MountConsistency | undefined;
         BindOptions?: {
             Propagation: MountPropagation;
-        };
+        } | undefined;
         VolumeOptions?: {
             NoCopy: boolean;
             Labels: { [label: string]: string };
@@ -978,82 +978,82 @@ declare namespace Dockerode {
                 Name: string;
                 Options: { [option: string]: string };
             };
-        };
+        } | undefined;
         TmpfsOptions?: {
             SizeBytes: number;
             Mode: number;
-        };
+        } | undefined;
     }
 
     type MountConfig = MountSettings[];
 
     interface ContainerCreateOptions {
-        name?: string;
-        Hostname?: string;
-        Domainname?: string;
-        User?: string;
-        AttachStdin?: boolean;
-        AttachStdout?: boolean;
-        AttachStderr?: boolean;
-        Tty?: boolean;
-        OpenStdin?: boolean;
-        StdinOnce?: boolean;
-        Env?: string[];
-        Cmd?: string[];
-        Entrypoint?: string | string[];
-        Image?: string;
-        Labels?: { [label: string]: string };
-        Volumes?: { [volume: string]: {} };
-        WorkingDir?: string;
-        NetworkDisabled?: boolean;
-        MacAddress?: boolean;
-        ExposedPorts?: { [port: string]: {} };
-        StopSignal?: string;
-        StopTimeout?: number;
-        HostConfig?: HostConfig;
+        name?: string | undefined;
+        Hostname?: string | undefined;
+        Domainname?: string | undefined;
+        User?: string | undefined;
+        AttachStdin?: boolean | undefined;
+        AttachStdout?: boolean | undefined;
+        AttachStderr?: boolean | undefined;
+        Tty?: boolean | undefined;
+        OpenStdin?: boolean | undefined;
+        StdinOnce?: boolean | undefined;
+        Env?: string[] | undefined;
+        Cmd?: string[] | undefined;
+        Entrypoint?: string | string[] | undefined;
+        Image?: string | undefined;
+        Labels?: { [label: string]: string } | undefined;
+        Volumes?: { [volume: string]: {} } | undefined;
+        WorkingDir?: string | undefined;
+        NetworkDisabled?: boolean | undefined;
+        MacAddress?: boolean | undefined;
+        ExposedPorts?: { [port: string]: {} } | undefined;
+        StopSignal?: string | undefined;
+        StopTimeout?: number | undefined;
+        HostConfig?: HostConfig | undefined;
         NetworkingConfig?: {
-            EndpointsConfig?: EndpointsConfig;
-        };
+            EndpointsConfig?: EndpointsConfig | undefined;
+        } | undefined;
     }
 
     interface KeyObject {
         pem: string | Buffer;
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface DockerOptions {
-        socketPath?: string;
-        host?: string;
-        port?: number | string;
-        username?: string;
-        ca?: string | string[] | Buffer | Buffer[];
-        cert?: string | string[] | Buffer | Buffer[];
-        key?: string | string[] | Buffer | Buffer[] | KeyObject[];
-        protocol?: 'https' | 'http' | 'ssh';
-        timeout?: number;
-        version?: string;
-        sshAuthAgent?: string;
-        Promise?: typeof Promise;
+        socketPath?: string | undefined;
+        host?: string | undefined;
+        port?: number | string | undefined;
+        username?: string | undefined;
+        ca?: string | string[] | Buffer | Buffer[] | undefined;
+        cert?: string | string[] | Buffer | Buffer[] | undefined;
+        key?: string | string[] | Buffer | Buffer[] | KeyObject[] | undefined;
+        protocol?: 'https' | 'http' | 'ssh' | undefined;
+        timeout?: number | undefined;
+        version?: string | undefined;
+        sshAuthAgent?: string | undefined;
+        Promise?: typeof Promise | undefined;
     }
 
     interface GetEventsOptions {
-        since?: number;
-        until?: number;
+        since?: number | undefined;
+        until?: number | undefined;
         filters?:
         | string
         | {
-            config?: string;
-            container?: string[];
-            daemon?: string[];
-            event?: string[];
-            image?: string[];
-            label?: string[];
-            network?: string[];
-            node?: string[];
-            plugin?: string[];
-            scope?: Array<'local' | 'swarm'>;
-            secret?: string[];
-            service?: string[];
+            config?: string | undefined;
+            container?: string[] | undefined;
+            daemon?: string[] | undefined;
+            event?: string[] | undefined;
+            image?: string[] | undefined;
+            label?: string[] | undefined;
+            network?: string[] | undefined;
+            node?: string[] | undefined;
+            plugin?: string[] | undefined;
+            scope?: Array<'local' | 'swarm'> | undefined;
+            secret?: string[] | undefined;
+            service?: string[] | undefined;
             type?: Array<
                 | 'container'
                 | 'image'
@@ -1065,9 +1065,9 @@ declare namespace Dockerode {
                 | 'node'
                 | 'secret'
                 | 'config'
-            >;
-            volume?: string[];
-        };
+            > | undefined;
+            volume?: string[] | undefined;
+        } | undefined;
     }
 
     interface SecretVersion {
@@ -1075,164 +1075,164 @@ declare namespace Dockerode {
     }
 
     interface Annotations {
-        Name?: string;
-        Labels?: { [name: string]: string };
+        Name?: string | undefined;
+        Labels?: { [name: string]: string } | undefined;
     }
 
     interface ResourceLimits {
-        NanoCPUs?: number;
-        MemoryBytes?: number;
-        Pids?: number;
+        NanoCPUs?: number | undefined;
+        MemoryBytes?: number | undefined;
+        Pids?: number | undefined;
     }
 
     interface NamedGenericResource {
-        Kind?: string;
-        Value?: string;
+        Kind?: string | undefined;
+        Value?: string | undefined;
     }
 
     interface DiscreteGenericResource {
-        Kind?: string;
-        Value?: number;
+        Kind?: string | undefined;
+        Value?: number | undefined;
     }
 
     type GenericResource = NamedGenericResource | DiscreteGenericResource;
 
     interface RestartPolicy {
-        Condition?: string;
-        Delay?: number;
-        MaxAttempts?: number;
-        Window?: number;
+        Condition?: string | undefined;
+        Delay?: number | undefined;
+        MaxAttempts?: number | undefined;
+        Window?: number | undefined;
     }
 
     interface Resources {
-        NanoCPUs?: number;
-        MemoryBytes?: number;
-        GenericResources?: GenericResource[];
+        NanoCPUs?: number | undefined;
+        MemoryBytes?: number | undefined;
+        GenericResources?: GenericResource[] | undefined;
     }
 
     interface ResourceRequirements {
-        Limits?: ResourceLimits;
-        Reservations?: Resources;
+        Limits?: ResourceLimits | undefined;
+        Reservations?: Resources | undefined;
     }
 
     interface Placement {
-        Constraints?: string[];
-        Preferences?: Array<{ Spread: { SpreadDescriptor: string } }>;
-        MaxReplicas?: number;
+        Constraints?: string[] | undefined;
+        Preferences?: Array<{ Spread: { SpreadDescriptor: string } }> | undefined;
+        MaxReplicas?: number | undefined;
         Platforms?: Array<{
             Architecture: string;
             OS: string;
-        }>;
+        }> | undefined;
     }
 
     interface NetworkAttachmentConfig {
-        Target?: string;
-        Aliases?: string[];
-        DriverOpts?: { [key: string]: string };
+        Target?: string | undefined;
+        Aliases?: string[] | undefined;
+        DriverOpts?: { [key: string]: string } | undefined;
     }
 
     interface Privileges {
         CredentialSpec?: {
-            Config?: string;
-            File?: string;
-            Registry?: string;
-        };
+            Config?: string | undefined;
+            File?: string | undefined;
+            Registry?: string | undefined;
+        } | undefined;
         SELinuxContext?: {
-            Disable?: boolean;
-            User?: string;
-            Role?: string;
-            Type?: string;
-            Level?: string;
-        };
+            Disable?: boolean | undefined;
+            User?: string | undefined;
+            Role?: string | undefined;
+            Type?: string | undefined;
+            Level?: string | undefined;
+        } | undefined;
     }
 
     interface HealthConfig {
-        Test?: string[];
-        Interval?: number;
-        Timeout?: number;
-        StartPeriod?: number;
-        Retries?: number;
+        Test?: string[] | undefined;
+        Interval?: number | undefined;
+        Timeout?: number | undefined;
+        StartPeriod?: number | undefined;
+        Retries?: number | undefined;
     }
 
     interface DNSConfig {
-        Nameservers?: string[];
-        Search?: string[];
-        Options?: string[];
+        Nameservers?: string[] | undefined;
+        Search?: string[] | undefined;
+        Options?: string[] | undefined;
     }
 
     interface SecretReference {
         File?: {
-            Name?: string;
-            UID?: string;
-            GID?: string;
-            Mode?: number;
-        };
-        SecretID?: string;
-        SecretName?: string;
+            Name?: string | undefined;
+            UID?: string | undefined;
+            GID?: string | undefined;
+            Mode?: number | undefined;
+        } | undefined;
+        SecretID?: string | undefined;
+        SecretName?: string | undefined;
     }
 
     interface Ulimit {
-        Name?: string;
-        Hard?: number;
-        Soft?: number;
+        Name?: string | undefined;
+        Hard?: number | undefined;
+        Soft?: number | undefined;
     }
 
     interface ContainerSpec {
-        Image?: string;
-        Labels?: { [label: string]: string };
-        Command?: string[];
-        Args?: string[];
-        Hostname?: string;
-        Env?: string[];
-        Dir?: string;
-        User?: string;
-        Groups?: string[];
-        Privileges?: Privileges;
-        Init?: boolean;
-        TTY?: boolean;
-        OpenStdin?: boolean;
-        ReadOnly?: boolean;
-        Mounts?: MountSettings[];
-        StopSignal?: string;
-        StopGracePeriod?: number;
-        HealthCheck?: HealthConfig;
-        Hosts?: string[];
-        DNSConfig?: DNSConfig;
-        Secrets?: SecretReference[];
-        Isolation?: string;
-        Sysctls?: { [key: string]: string };
-        CapabilityAdd?: string[];
-        CapabilityDrop?: string[];
-        Ulimits?: Ulimit[];
+        Image?: string | undefined;
+        Labels?: { [label: string]: string } | undefined;
+        Command?: string[] | undefined;
+        Args?: string[] | undefined;
+        Hostname?: string | undefined;
+        Env?: string[] | undefined;
+        Dir?: string | undefined;
+        User?: string | undefined;
+        Groups?: string[] | undefined;
+        Privileges?: Privileges | undefined;
+        Init?: boolean | undefined;
+        TTY?: boolean | undefined;
+        OpenStdin?: boolean | undefined;
+        ReadOnly?: boolean | undefined;
+        Mounts?: MountSettings[] | undefined;
+        StopSignal?: string | undefined;
+        StopGracePeriod?: number | undefined;
+        HealthCheck?: HealthConfig | undefined;
+        Hosts?: string[] | undefined;
+        DNSConfig?: DNSConfig | undefined;
+        Secrets?: SecretReference[] | undefined;
+        Isolation?: string | undefined;
+        Sysctls?: { [key: string]: string } | undefined;
+        CapabilityAdd?: string[] | undefined;
+        CapabilityDrop?: string[] | undefined;
+        Ulimits?: Ulimit[] | undefined;
     }
 
     interface PluginSpec {
-        Name?: string;
-        Remote?: string;
+        Name?: string | undefined;
+        Remote?: string | undefined;
         Privileges?: {
-            Name?: string;
-            Description?: string;
-            Value?: string[];
-        };
-        Disabled?: boolean;
-        Env?: string[];
+            Name?: string | undefined;
+            Description?: string | undefined;
+            Value?: string[] | undefined;
+        } | undefined;
+        Disabled?: boolean | undefined;
+        Env?: string[] | undefined;
     }
 
     interface TaskSpecBase {
-        Resources?: ResourceRequirements;
-        RestartPolicy?: RestartPolicy;
-        Placement?: Placement;
-        Networks?: NetworkAttachmentConfig[];
+        Resources?: ResourceRequirements | undefined;
+        RestartPolicy?: RestartPolicy | undefined;
+        Placement?: Placement | undefined;
+        Networks?: NetworkAttachmentConfig[] | undefined;
         LogDriver?: {
-            Name?: string;
-            Options?: { [key: string]: string };
-        };
-        ForceUpdate?: number;
-        Runtime?: string;
+            Name?: string | undefined;
+            Options?: { [key: string]: string } | undefined;
+        } | undefined;
+        ForceUpdate?: number | undefined;
+        Runtime?: string | undefined;
     }
 
     interface ContainerTaskSpec extends TaskSpecBase {
-        ContainerSpec?: ContainerSpec;
+        ContainerSpec?: ContainerSpec | undefined;
     }
 
     interface PluginTaskSpec extends TaskSpecBase {
@@ -1250,92 +1250,92 @@ declare namespace Dockerode {
     type TaskSpec = ContainerTaskSpec | PluginTaskSpec | NetworkAttachmentTaskSpec;
 
     interface ServiceMode {
-        Replicated?: { Replicas?: number };
-        Global?: {};
+        Replicated?: { Replicas?: number | undefined } | undefined;
+        Global?: {} | undefined;
         ReplicatedJob?: {
-            MaxConcurrent?: number;
-            TotalCompletions?: number;
-        };
-        GlobalJob?: {};
+            MaxConcurrent?: number | undefined;
+            TotalCompletions?: number | undefined;
+        } | undefined;
+        GlobalJob?: {} | undefined;
     }
 
     interface UpdateConfig {
         Parallelism: number;
-        Delay?: number;
-        FailureAction?: string;
-        Monitor?: number;
-        MaxFailureRatio?: number;
+        Delay?: number | undefined;
+        FailureAction?: string | undefined;
+        Monitor?: number | undefined;
+        MaxFailureRatio?: number | undefined;
         Order: string;
     }
 
     interface PortConfig {
-        Name?: string;
-        Protocol?: 'tcp' | 'udp' | 'sctp';
-        TargetPort?: number;
-        PublishedPort?: number;
-        PublishMode?: 'ingress' | 'host';
+        Name?: string | undefined;
+        Protocol?: 'tcp' | 'udp' | 'sctp' | undefined;
+        TargetPort?: number | undefined;
+        PublishedPort?: number | undefined;
+        PublishMode?: 'ingress' | 'host' | undefined;
     }
 
     interface EndpointSpec {
-        Mode?: string;
-        Ports?: PortConfig[];
+        Mode?: string | undefined;
+        Ports?: PortConfig[] | undefined;
     }
 
     interface EndpointVirtualIP {
-        NetworkID?: string;
-        Addr?: string;
+        NetworkID?: string | undefined;
+        Addr?: string | undefined;
     }
 
     interface Endpoint {
-        Spec?: EndpointSpec;
-        Ports?: PortConfig[];
-        VirtualIPs?: EndpointVirtualIP[];
+        Spec?: EndpointSpec | undefined;
+        Ports?: PortConfig[] | undefined;
+        VirtualIPs?: EndpointVirtualIP[] | undefined;
     }
 
     interface ServiceSpec extends Annotations {
-        TaskTemplate?: TaskSpec;
-        Mode?: ServiceMode;
-        UpdateConfig?: UpdateConfig;
-        RollbackConfig?: UpdateConfig;
-        Networks?: NetworkAttachmentConfig[];
-        EndpointSpec?: EndpointSpec;
+        TaskTemplate?: TaskSpec | undefined;
+        Mode?: ServiceMode | undefined;
+        UpdateConfig?: UpdateConfig | undefined;
+        RollbackConfig?: UpdateConfig | undefined;
+        Networks?: NetworkAttachmentConfig[] | undefined;
+        EndpointSpec?: EndpointSpec | undefined;
     }
 
     interface CreateServiceOptions extends ServiceSpec {
-        authconfig?: AuthConfig;
+        authconfig?: AuthConfig | undefined;
     }
 
     interface ServiceCreateResponse {
         ID: string;
-        Warnings?: string[];
+        Warnings?: string[] | undefined;
     }
 
     interface ServiceListOptions {
         Filters: {
-            id?: string[];
-            label?: string[];
-            mode?: Array<'replicated' | 'global'>;
-            name?: string[];
+            id?: string[] | undefined;
+            label?: string[] | undefined;
+            mode?: Array<'replicated' | 'global'> | undefined;
+            name?: string[] | undefined;
         };
     }
 
     interface Version {
-        Index?: number;
+        Index?: number | undefined;
     }
 
     interface Meta {
-        Version?: Version;
-        CreatedAt?: string;
-        UpdatedAt?: string;
+        Version?: Version | undefined;
+        CreatedAt?: string | undefined;
+        UpdatedAt?: string | undefined;
     }
 
     type UpdateState = 'updating' | 'paused' | 'completed' | 'rollback_started' | 'rollback_paused' | 'rollback_completed';
 
     interface UpdateStatus {
-        State?: UpdateState;
-        StartedAt?: string;
-        CompletedAt?: string;
-        Message?: string;
+        State?: UpdateState | undefined;
+        StartedAt?: string | undefined;
+        CompletedAt?: string | undefined;
+        Message?: string | undefined;
     }
 
     interface ServiceStatus {
@@ -1346,33 +1346,33 @@ declare namespace Dockerode {
 
     interface JobStatus {
         JobIteration: Version;
-        LastExecution?: string;
+        LastExecution?: string | undefined;
     }
 
     interface Service extends Meta {
         ID: string;
-        Spec?: ServiceSpec;
-        PreviousSpec?: ServiceSpec;
-        Endpoint?: Endpoint;
-        UpdateStatus?: UpdateStatus;
-        ServiceStatus?: ServiceStatus;
-        JobStatus?: JobStatus;
+        Spec?: ServiceSpec | undefined;
+        PreviousSpec?: ServiceSpec | undefined;
+        Endpoint?: Endpoint | undefined;
+        UpdateStatus?: UpdateStatus | undefined;
+        ServiceStatus?: ServiceStatus | undefined;
+        JobStatus?: JobStatus | undefined;
     }
 
     interface OrchestrationConfig {
-        TaskHistoryRetentionLimit?: number;
+        TaskHistoryRetentionLimit?: number | undefined;
     }
 
     interface RaftConfig {
-        SnapshotInterval?: number;
-        KeepOldSnapshots?: number;
-        LogEntriesForSlowFollowers?: number;
-        ElectionTick?: number;
-        HeartbeatTick?: number;
+        SnapshotInterval?: number | undefined;
+        KeepOldSnapshots?: number | undefined;
+        LogEntriesForSlowFollowers?: number | undefined;
+        ElectionTick?: number | undefined;
+        HeartbeatTick?: number | undefined;
     }
 
     interface DispatcherConfig {
-        HeartbeatPeriod?: Duration;
+        HeartbeatPeriod?: Duration | undefined;
     }
 
     type ExternalCAProtocol = 'cfssl' | string;
@@ -1380,20 +1380,20 @@ declare namespace Dockerode {
     interface ExternalCA {
         Protocol: ExternalCAProtocol;
         URL: string;
-        Options?: { [key: string]: string };
+        Options?: { [key: string]: string } | undefined;
         CACert: string;
     }
 
     interface CAConfig {
-        NodeCertExpiry?: Duration;
-        ExternalCAs?: ExternalCA[];
-        SigningCACert?: string;
-        SigningCAKey?: string;
-        ForceRotate?: number;
+        NodeCertExpiry?: Duration | undefined;
+        ExternalCAs?: ExternalCA[] | undefined;
+        SigningCACert?: string | undefined;
+        SigningCAKey?: string | undefined;
+        ForceRotate?: number | undefined;
     }
 
     interface TaskDefaults {
-        LogDriver?: Driver;
+        LogDriver?: Driver | undefined;
     }
 
     interface EncryptionConfig {
@@ -1401,18 +1401,18 @@ declare namespace Dockerode {
     }
 
     interface Spec extends Annotations {
-        Orchestration?: OrchestrationConfig;
+        Orchestration?: OrchestrationConfig | undefined;
         Raft: RaftConfig;
-        Dispatcher?: DispatcherConfig;
-        CAConfig?: CAConfig;
-        TaskDefaults?: TaskDefaults;
-        EncryptionConfig?: EncryptionConfig;
+        Dispatcher?: DispatcherConfig | undefined;
+        CAConfig?: CAConfig | undefined;
+        TaskDefaults?: TaskDefaults | undefined;
+        EncryptionConfig?: EncryptionConfig | undefined;
     }
 
     interface TLSInfo {
-        TrustRoot?: string;
-        CertIssuerSubject?: string;
-        CertIssuerPublicKey?: string;
+        TrustRoot?: string | undefined;
+        CertIssuerSubject?: string | undefined;
+        CertIssuerPublicKey?: string | undefined;
     }
 
     interface ClusterInfo extends Meta {
@@ -1436,26 +1436,26 @@ declare namespace Dockerode {
 
     interface Driver {
         Name: string;
-        Options?: { [key: string]: string };
+        Options?: { [key: string]: string } | undefined;
     }
 
     interface SecretSpec extends Annotations {
-        Data?: string;
-        Driver?: Driver;
-        Templating?: Driver;
+        Data?: string | undefined;
+        Driver?: Driver | undefined;
+        Templating?: Driver | undefined;
     }
 
     interface Secret extends Meta {
         ID: string;
-        Spec?: SecretSpec;
+        Spec?: SecretSpec | undefined;
     }
 
     interface ConfigInfo {
         ID: string;
         Version: SecretVersion;
         CreatedAt: string;
-        UpdatedAt?: string;
-        Spec?: ConfigSpec;
+        UpdatedAt?: string | undefined;
+        Spec?: ConfigSpec | undefined;
     }
 
     interface ConfigSpec {
@@ -1469,11 +1469,11 @@ declare namespace Dockerode {
     }
 
     interface PluginInfo {
-        Id?: string;
+        Id?: string | undefined;
         Name: string;
         Enabled: boolean;
         Settings: PluginSettings;
-        PluginReference?: string;
+        PluginReference?: string | undefined;
         Config: PluginConfig;
     }
 
@@ -1492,7 +1492,7 @@ declare namespace Dockerode {
         Interface: any;
         Entrypoint: string[];
         WorkDir: string;
-        User?: User;
+        User?: User | undefined;
         Network: Network;
         Linux: Linux;
         PropagatedMount: string;
@@ -1585,17 +1585,17 @@ declare namespace Dockerode {
 
     interface ContainerWaitOptions {
         /** Since v1.30 */
-        condition?: 'not-running' | 'next-exit' | 'removed';
+        condition?: 'not-running' | 'next-exit' | 'removed' | undefined;
     }
 
     interface ContainerLogsOptions {
-        stdout?: boolean;
-        stderr?: boolean;
-        follow?: boolean;
-        since?: number;
-        details?: boolean;
-        tail?: number;
-        timestamps?: boolean;
+        stdout?: boolean | undefined;
+        stderr?: boolean | undefined;
+        follow?: boolean | undefined;
+        since?: number | undefined;
+        details?: boolean | undefined;
+        tail?: number | undefined;
+        timestamps?: boolean | undefined;
     }
 
     interface ImageBuildContext {

--- a/types/doctrine/index.d.ts
+++ b/types/doctrine/index.d.ts
@@ -22,38 +22,38 @@ interface Options {
    * Set to `true` to delete the leading `/**`, any `*` that begins a line,
    * and the trailing `* /` from the source text. Default: `false`.
    */
-  unwrap?: boolean;
+  unwrap?: boolean | undefined;
   /**
    * An array of tags to return. When specified, Doctrine returns
    * only tags in this array. For example, if `tags` is `["param"]`, then only
    * `@param` tags will be returned. Default: `null`.
    */
-  tags?: string[];
+  tags?: string[] | undefined;
   /**
    * set to `true` to keep parsing even when syntax errors occur. Default:
    * `false`.
    */
-  recoverable?: boolean;
+  recoverable?: boolean | undefined;
   /**
    * Set to `true` to allow optional parameters to be specified in brackets
    * (`@param {string} [foo]`). Default: `false`.
    */
-  sloppy?: boolean;
+  sloppy?: boolean | undefined;
   /**
    * Set to `true` to throw an error when syntax errors occur. If false then
    * errors will be added to `tag.errors` instead.
    */
-  strict?: boolean;
+  strict?: boolean | undefined;
   /**
    * Set to `true` to preserve leading and trailing whitespace when extracting
    * comment text.
    */
-  preserveWhitespace?: boolean;
+  preserveWhitespace?: boolean | undefined;
   /**
    * Set to `true` to add `lineNumber` to each node, specifying the line on
    * which the node is found in the source. Default: `false`.
    */
-  lineNumbers?: boolean;
+  lineNumbers?: boolean | undefined;
 }
 
 /**
@@ -85,14 +85,14 @@ export interface Tag {
   /** The title of the jsdoc tag. e.g. `@foo` will have a title of 'foo'. */
   title: string;
   /** The name of the thing this tag is documenting, if any. */
-  name?: string;
+  name?: string | undefined;
   /** The description of the thing this tag is documenting. */
   description: string|null;
   /** The type of the thing this tag is documenting. */
-  type?: Type|null;
-  kind?: string;
+  type?: Type|null | undefined;
+  kind?: string | undefined;
   /** Any errors that were encountered in parsing the tag. */
-  errors?: string[];
+  errors?: string[] | undefined;
 }
 
 export type Type =
@@ -106,7 +106,7 @@ export type Type =
 export module type {
   export interface AllLiteral { type: 'AllLiteral' }
   export interface ArrayType { type: 'ArrayType', elements: Type[] }
-  export interface FieldType { type: 'FieldType', key: string, value?: Type }
+  export interface FieldType { type: 'FieldType', key: string, value?: Type | undefined }
   export interface FunctionType {
     type: 'FunctionType';
     'this': Type;
@@ -129,7 +129,7 @@ export module type {
   export interface RecordType { type: 'RecordType', fields: Type[] }
   export interface RestType {
     type: 'RestType';
-    expression?: Type;
+    expression?: Type | undefined;
   }
   export interface TypeApplication {
     type: 'TypeApplication', expression: Type, applications: Type[]

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -20,7 +20,7 @@ declare var MediaRecorderErrorEvent: {
 
 interface BlobEventInit extends EventInit {
     data: Blob;
-    timecode?: number;
+    timecode?: number | undefined;
 }
 
 interface BlobEvent extends Event {
@@ -36,11 +36,11 @@ declare var BlobEvent: {
 type BitrateMode = 'vbr' | 'cbr';
 
 interface MediaRecorderOptions {
-    mimeType?: string;
-    audioBitsPerSecond?: number;
-    videoBitsPerSecond?: number;
-    bitsPerSecond?: number;
-    audioBitrateMode?: BitrateMode;
+    mimeType?: string | undefined;
+    audioBitsPerSecond?: number | undefined;
+    videoBitsPerSecond?: number | undefined;
+    bitsPerSecond?: number | undefined;
+    audioBitrateMode?: BitrateMode | undefined;
 }
 
 interface MediaRecorderEventMap {

--- a/types/domhandler/index.d.ts
+++ b/types/domhandler/index.d.ts
@@ -8,12 +8,12 @@ export interface DomHandlerOptions {
      * Indicates whether the whitespace in text nodes should be normalized
      * (= all whitespace should be replaced with single spaces). The default value is "false".
      */
-    normalizeWhitespace?: boolean;
+    normalizeWhitespace?: boolean | undefined;
 
     /***
      * Adds DOM level 1 properties to all elements.
      */
-    withDomLvl1?: boolean;
+    withDomLvl1?: boolean | undefined;
 
     /***
      * Indicates whether a startIndex property will be added to nodes.
@@ -21,7 +21,7 @@ export interface DomHandlerOptions {
      * indicating the position of the start of the node in the document.
      * The default value is "false".
      */
-    withStartIndices?: boolean;
+    withStartIndices?: boolean | undefined;
 
     /***
      * Indicates whether a endIndex property will be added to nodes.
@@ -29,18 +29,18 @@ export interface DomHandlerOptions {
      * indicating the position of the end of the node in the document.
      * The default value is "false".
      */
-    withEndIndices?: boolean;
+    withEndIndices?: boolean | undefined;
 }
 
 export interface DomElement {
-    attribs?: {[s: string]: string};
-    children?: DomElement[];
+    attribs?: {[s: string]: string} | undefined;
+    children?: DomElement[] | undefined;
     data?: any;
-    name?: string;
-    next?: DomElement;
-    parent?: DomElement;
-    prev?: DomElement;
-    type?: string;
+    name?: string | undefined;
+    next?: DomElement | undefined;
+    parent?: DomElement | undefined;
+    prev?: DomElement | undefined;
+    type?: string | undefined;
 }
 
 export interface Element extends DomElement {

--- a/types/dompurify/index.d.ts
+++ b/types/dompurify/index.d.ts
@@ -22,7 +22,7 @@ declare namespace DOMPurify {
     interface DOMPurifyI {
         sanitize(source: string | Node): string;
         sanitize(source: string | Node, config: Config & { RETURN_TRUSTED_TYPE: true }): TrustedHTML;
-        sanitize(source: string | Node, config: Config & { RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false }): string;
+        sanitize(source: string | Node, config: Config & { RETURN_DOM_FRAGMENT?: false | undefined; RETURN_DOM?: false | undefined }): string;
         sanitize(source: string | Node, config: Config & { RETURN_DOM_FRAGMENT: true }): DocumentFragment;
         sanitize(source: string | Node, config: Config & { RETURN_DOM: true }): HTMLElement;
         sanitize(source: string | Node, config: Config): string | HTMLElement | DocumentFragment;
@@ -45,36 +45,36 @@ declare namespace DOMPurify {
     }
 
     interface Config {
-        ADD_ATTR?: string[];
-        ADD_DATA_URI_TAGS?: string[];
-        ADD_TAGS?: string[];
-        ALLOW_DATA_ATTR?: boolean;
-        ALLOWED_ATTR?: string[];
-        ALLOWED_TAGS?: string[];
-        FORBID_ATTR?: string[];
-        FORBID_TAGS?: string[];
-        FORCE_BODY?: boolean;
-        KEEP_CONTENT?: boolean;
+        ADD_ATTR?: string[] | undefined;
+        ADD_DATA_URI_TAGS?: string[] | undefined;
+        ADD_TAGS?: string[] | undefined;
+        ALLOW_DATA_ATTR?: boolean | undefined;
+        ALLOWED_ATTR?: string[] | undefined;
+        ALLOWED_TAGS?: string[] | undefined;
+        FORBID_ATTR?: string[] | undefined;
+        FORBID_TAGS?: string[] | undefined;
+        FORCE_BODY?: boolean | undefined;
+        KEEP_CONTENT?: boolean | undefined;
         /**
          * change the default namespace from HTML to something different
          */
-        NAMESPACE?: string;
-        RETURN_DOM?: boolean;
-        RETURN_DOM_FRAGMENT?: boolean;
+        NAMESPACE?: string | undefined;
+        RETURN_DOM?: boolean | undefined;
+        RETURN_DOM_FRAGMENT?: boolean | undefined;
         /**
          * This defaults to `true` starting DOMPurify 2.2.0. Note that setting it to `false`
          * might cause XSS from attacks hidden in closed shadowroots in case the browser
          * supports Declarative Shadow: DOM https://web.dev/declarative-shadow-dom/
          */
-        RETURN_DOM_IMPORT?: boolean;
-        RETURN_TRUSTED_TYPE?: boolean;
-        SANITIZE_DOM?: boolean;
-        WHOLE_DOCUMENT?: boolean;
-        ALLOWED_URI_REGEXP?: RegExp;
-        SAFE_FOR_TEMPLATES?: boolean;
-        ALLOW_UNKNOWN_PROTOCOLS?: boolean;
-        USE_PROFILES?: false | { mathMl?: boolean; svg?: boolean; svgFilters?: boolean; html?: boolean };
-        IN_PLACE?: boolean;
+        RETURN_DOM_IMPORT?: boolean | undefined;
+        RETURN_TRUSTED_TYPE?: boolean | undefined;
+        SANITIZE_DOM?: boolean | undefined;
+        WHOLE_DOCUMENT?: boolean | undefined;
+        ALLOWED_URI_REGEXP?: RegExp | undefined;
+        SAFE_FOR_TEMPLATES?: boolean | undefined;
+        ALLOW_UNKNOWN_PROTOCOLS?: boolean | undefined;
+        USE_PROFILES?: false | { mathMl?: boolean | undefined; svg?: boolean | undefined; svgFilters?: boolean | undefined; html?: boolean | undefined } | undefined;
+        IN_PLACE?: boolean | undefined;
     }
 
     type HookName =
@@ -100,6 +100,6 @@ declare namespace DOMPurify {
         attrValue: string;
         keepAttr: boolean;
         allowedAttributes: { [key: string]: boolean };
-        forceKeepAttr?: boolean;
+        forceKeepAttr?: boolean | undefined;
     }
 }

--- a/types/domutils/index.d.ts
+++ b/types/domutils/index.d.ts
@@ -81,7 +81,7 @@ export function getName(elem: DomElement): string;
  * @argument dom An array of DomElement that should be stringified
  * @argument [opts] Optional options object
  */
-export function getOuterHTML(dom: DomElement[], opts?: { decodeEntities?: boolean, xmlMode?: boolean}): string;
+export function getOuterHTML(dom: DomElement[], opts?: { decodeEntities?: boolean | undefined, xmlMode?: boolean | undefined}): string;
 export function getParent(elem: DomElement): DomElement;
 export function getSiblings(elem: DomElement): DomElement[];
 export function getText(elem: DomElement): string;

--- a/types/dotenv-flow/index.d.ts
+++ b/types/dotenv-flow/index.d.ts
@@ -9,7 +9,7 @@ export interface DotenvListFilesOptions {
     /**
      * Node environment (development/test/production/etc,.).
      */
-    node_env?: string;
+    node_env?: string | undefined;
 }
 
 /**
@@ -25,7 +25,7 @@ export interface DotenvReadFileOptions {
     /**
      * Encoding for reading the `.env*` files.
      */
-    encoding?: string;
+    encoding?: string | undefined;
 }
 
 export interface DotenvParseOutput {
@@ -43,8 +43,8 @@ export interface DotenvParseOutput {
 export function parse(filenames: string | string[], options?: DotenvReadFileOptions): DotenvParseOutput;
 
 export interface DotenvLoadOutput {
-    error?: Error;
-    parsed?: DotenvParseOutput;
+    error?: Error | undefined;
+    parsed?: DotenvParseOutput | undefined;
 }
 
 /**
@@ -68,22 +68,22 @@ export interface DotenvConfigOptions {
     /**
      * Node environment (development/test/production/etc,.).
      */
-    node_env?: string;
+    node_env?: string | undefined;
 
     /**
      * Default node environment to use if `process.env.NODE_ENV` is not present.
      */
-    default_node_env?: string;
+    default_node_env?: string | undefined;
 
     /**
      * Path to `.env*` files directory.
      */
-    path?: string;
+    path?: string | undefined;
 
     /**
      * Encoding for reading the `.env*` files.
      */
-    encoding?: string;
+    encoding?: string | undefined;
 
     /**
      * In some cases the original "dotenv" library can be used by one of the dependent npm modules.
@@ -93,12 +93,12 @@ export interface DotenvConfigOptions {
      *
      * Setting the `purge_dotenv` option to `true` can gracefully fix this issue.
      */
-    purge_dotenv?: boolean;
+    purge_dotenv?: boolean | undefined;
 
     /**
      * Suppress all console outputs except errors and deprecation warnings.
      */
-    silent?: boolean;
+    silent?: boolean | undefined;
 }
 
 /**

--- a/types/dotenv-flow/v2/index.d.ts
+++ b/types/dotenv-flow/v2/index.d.ts
@@ -10,7 +10,7 @@ export interface DotenvParseOptions {
     /**
      * You may turn on logging to help debug why certain keys or values are not being set as you expect.
      */
-    debug?: boolean;
+    debug?: boolean | undefined;
 }
 
 export interface DotenvParseOutput {
@@ -33,22 +33,22 @@ export interface DotenvConfigOptions {
     /**
      * Node environment (development/test/production/etc,.).
      */
-    node_env?: string;
+    node_env?: string | undefined;
 
     /**
      * Default node environment to use if `process.env.NODE_ENV` is not present.
      */
-    default_node_env?: string;
+    default_node_env?: string | undefined;
 
     /**
      * Path to `.env*` files directory.
      */
-    path?: string;
+    path?: string | undefined;
 
     /**
      * Encoding for reading the `.env*` files.
      */
-    encoding?: string;
+    encoding?: string | undefined;
 
     /**
      * In some cases the original "dotenv" library can be used by one of the dependent npm modules.
@@ -58,12 +58,12 @@ export interface DotenvConfigOptions {
      *
      * Setting the `purge_dotenv` option to `true` can gracefully fix this issue.
      */
-    purge_dotenv?: boolean;
+    purge_dotenv?: boolean | undefined;
 }
 
 export interface DotenvConfigOutput {
-    error?: Error;
-    parsed?: DotenvParseOutput;
+    error?: Error | undefined;
+    parsed?: DotenvParseOutput | undefined;
 }
 
 /**

--- a/types/dotenv-webpack/index.d.ts
+++ b/types/dotenv-webpack/index.d.ts
@@ -24,51 +24,51 @@ declare namespace DotenvWebpackPlugin {
          * The path to your environment variables.
          * @default './.env'.
          */
-        path?: string;
+        path?: string | undefined;
 
         /**
          * If `false` ignore safe-mode, if `true` load `'./.env.example'`, if a `string` load that file as the sample.
          * @default false
          */
-        safe?: boolean | string;
+        safe?: boolean | string | undefined;
 
         /**
          * Whether to allow empty strings in safe mode.
          * If false, will throw an error if any env variables are empty (but only if safe mode is enabled).
          * @default false
          */
-        allowEmptyValues?: boolean;
+        allowEmptyValues?: boolean | undefined;
 
         /**
          * Set to `true` if you would rather load all system variables as well (useful for CI purposes).
          * @default false
          */
-        systemvars?: boolean;
+        systemvars?: boolean | undefined;
 
         /**
          * If `true`, all warnings will be surpressed.
          * @default false
          */
-        silent?: boolean;
+        silent?: boolean | undefined;
 
         /**
          * Allows your variables to be "expanded" for reusability within your .env file.
          * @default false
          */
-        expand?: boolean;
+        expand?: boolean | undefined;
 
         /**
          * Adds support for dotenv-defaults. If set to `true`, uses `./.env.defaults`. If a `string`, uses that location for a defaults file.
          * Read more at {@link https://www.npmjs.com/package/dotenv-defaults}.
          * @default false
          */
-        defaults?: boolean | string;
+        defaults?: boolean | string | undefined;
 
         /**
          * Override the automatic check whether to stub `process.env`.
          * @dfault false
          */
-        ignoreStub?: boolean;
+        ignoreStub?: boolean | undefined;
     }
 }
 

--- a/types/download/index.d.ts
+++ b/types/download/index.d.ts
@@ -17,12 +17,12 @@ declare namespace download {
          *
          * @default false
          */
-        extract?: boolean;
+        extract?: boolean | undefined;
 
         /**
          * Name of the saved file.
          */
-        filename?: string;
+        filename?: string | undefined;
     }
 }
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -73,19 +73,19 @@ declare namespace Draft {
                 editorState: EditorState;
                 onChange(editorState: EditorState): void;
 
-                placeholder?: string;
+                placeholder?: string | undefined;
 
                 /**
                  * Specify whether text alignment should be forced in a direction
                  * regardless of input characters.
                  */
-                textAlignment?: DraftTextAlignment;
+                textAlignment?: DraftTextAlignment | undefined;
 
                 /**
                  * Specify whether text directionality should be forced in a direction
                  * regardless of input characters.
                  */
-                textDirectionality?: DraftTextDirectionality;
+                textDirectionality?: DraftTextDirectionality | undefined;
 
                 /**
                  * For a given `ContentBlock` object, return an object that specifies
@@ -99,7 +99,7 @@ declare namespace Draft {
                  * an element tag and an optional react element wrapper. This configuration
                  * is used for both rendering and paste processing.
                  */
-                blockRenderMap?: DraftBlockRenderMap;
+                blockRenderMap?: DraftBlockRenderMap | undefined;
 
                 /**
                  * Function that allows to define class names to apply to the given block when it is rendered.
@@ -110,13 +110,13 @@ declare namespace Draft {
                  * Provide a map of inline style names corresponding to CSS style objects
                  * that will be rendered for matching ranges.
                  */
-                customStyleMap?: DraftStyleMap;
+                customStyleMap?: DraftStyleMap | undefined;
 
                 /**
                  * Define a function to transform inline styles to CSS objects
                  * that are applied to spans of text.
                  */
-                customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => React.CSSProperties;
+                customStyleFn?: ((style: DraftInlineStyle, block: ContentBlock) => React.CSSProperties) | undefined;
 
                 /**
                  * A function that accepts a synthetic key event and returns
@@ -130,58 +130,58 @@ declare namespace Draft {
                  * temporarily disabling edit behavior or allowing `DraftEditor` rendering
                  * to be used for consumption purposes.
                  */
-                readOnly?: boolean;
+                readOnly?: boolean | undefined;
 
                 /**
                  * Note: spellcheck is always disabled for IE. If enabled in Safari, OSX
                  * autocorrect is enabled as well.
                  */
-                spellCheck?: boolean;
+                spellCheck?: boolean | undefined;
 
                 /**
                  * When the Editor loses focus (blurs) text selections are cleared
                  * by default to mimic <textarea> behaviour, however in some situations
                  * users may wish to preserve native behaviour.
                  */
-                preserveSelectionOnBlur?: boolean;
+                preserveSelectionOnBlur?: boolean | undefined;
 
                 /**
                  * Set whether to remove all style information from pasted content. If your
                  * use case should not have any block or inline styles, it is recommended
                  * that you set this to `true`.
                  */
-                stripPastedStyles?: boolean;
-                formatPastedText?: (
+                stripPastedStyles?: boolean | undefined;
+                formatPastedText?: ((
                     text: string,
                     html?: string,
-                ) => { text: string, html: string | undefined },
+                ) => { text: string, html: string | undefined }) | undefined,
 
-                tabIndex?: number;
+                tabIndex?: number | undefined;
 
                 // exposed especially to help improve mobile web behaviors
-                autoCapitalize?: string;
-                autoComplete?: string;
-                autoCorrect?: string;
+                autoCapitalize?: string | undefined;
+                autoComplete?: string | undefined;
+                autoCorrect?: string | undefined;
 
-                ariaActiveDescendantID?: string;
-                ariaAutoComplete?: string;
-                ariaControls?: string;
-                ariaDescribedBy?: string;
-                ariaExpanded?: boolean;
-                ariaLabel?: string;
-                ariaLabelledBy?: string;
-                ariaMultiline?: boolean;
-                ariaOwneeID?: string;
+                ariaActiveDescendantID?: string | undefined;
+                ariaAutoComplete?: string | undefined;
+                ariaControls?: string | undefined;
+                ariaDescribedBy?: string | undefined;
+                ariaExpanded?: boolean | undefined;
+                ariaLabel?: string | undefined;
+                ariaLabelledBy?: string | undefined;
+                ariaMultiline?: boolean | undefined;
+                ariaOwneeID?: string | undefined;
 
-                role?: string;
+                role?: string | undefined;
 
-                webDriverTestID?: string;
+                webDriverTestID?: string | undefined;
 
                 /**
                  * If using server-side rendering, this prop is required to be set to
                  * avoid client/server mismatches.
                  */
-                editorKey?: string;
+                editorKey?: string | undefined;
 
                 // Cancelable event handlers, handled from the top level down. A handler
                 // that returns `handled` will be the last handler to execute for that event.
@@ -505,7 +505,7 @@ declare namespace Draft {
                     contentState: ContentState,
                 ) => void;
                 component: Function;
-                props?: object;
+                props?: object | undefined;
             }
 
             /**
@@ -588,7 +588,7 @@ declare namespace Draft {
                 depth: number;
                 inlineStyleRanges: Array<RawDraftInlineStyleRange>;
                 entityRanges: Array<RawDraftEntityRange>;
-                data?: { [key: string]: any };
+                data?: { [key: string]: any } | undefined;
             }
 
             /**
@@ -698,7 +698,7 @@ declare namespace Draft {
 
             interface DraftBlockRenderConfig {
                 element: string;
-                wrapper?: React.ReactNode;
+                wrapper?: React.ReactNode | undefined;
             }
 
             class EditorState extends Record {
@@ -920,8 +920,8 @@ declare namespace Draft {
             }
 
             interface CharacterMetadataConfig {
-                style?: DraftInlineStyle;
-                entity?: string;
+                style?: DraftInlineStyle | undefined;
+                entity?: string | undefined;
             }
 
             type EditorChangeType =

--- a/types/draftjs-to-html/index.d.ts
+++ b/types/draftjs-to-html/index.d.ts
@@ -7,8 +7,8 @@
 import { RawDraftContentState } from 'draft-js';
 
 interface HashtagConfig {
-    trigger?: string;
-    separator?: string;
+    trigger?: string | undefined;
+    separator?: string | undefined;
 }
 
 declare function draftToHtml(

--- a/types/dragula/index.d.ts
+++ b/types/dragula/index.d.ts
@@ -12,19 +12,19 @@ export as namespace dragula;
 
 declare namespace dragula {
     interface DragulaOptions {
-        containers?: Element[];
-        isContainer?: (el?: Element) => boolean;
-        moves?: (el?: Element, container?: Element, handle?: Element, sibling?: Element) => boolean;
-        accepts?: (el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean;
-        invalid?: (el?: Element, target?: Element) => boolean;
-        direction?: string;
-        copy?: ((el: Element, source: Element) => boolean) | boolean;
-        copySortSource?: boolean;
-        revertOnSpill?: boolean;
-        removeOnSpill?: boolean;
-        delay?: boolean | number;
-        mirrorContainer?: Element;
-        ignoreInputTextSelection?: boolean;
+        containers?: Element[] | undefined;
+        isContainer?: ((el?: Element) => boolean) | undefined;
+        moves?: ((el?: Element, container?: Element, handle?: Element, sibling?: Element) => boolean) | undefined;
+        accepts?: ((el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean) | undefined;
+        invalid?: ((el?: Element, target?: Element) => boolean) | undefined;
+        direction?: string | undefined;
+        copy?: ((el: Element, source: Element) => boolean) | boolean | undefined;
+        copySortSource?: boolean | undefined;
+        revertOnSpill?: boolean | undefined;
+        removeOnSpill?: boolean | undefined;
+        delay?: boolean | number | undefined;
+        mirrorContainer?: Element | undefined;
+        ignoreInputTextSelection?: boolean | undefined;
     }
 
     interface Drake {

--- a/types/dragula/v2/index.d.ts
+++ b/types/dragula/v2/index.d.ts
@@ -11,18 +11,18 @@ export as namespace dragula;
 
 declare namespace dragula {
     interface DragulaOptions {
-        containers?: Element[];
-        isContainer?: (el?: Element) => boolean;
-        moves?: (el?: Element, container?: Element, handle?: Element, sibling?: Element) => boolean;
-        accepts?: (el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean;
-        invalid?: (el?: Element, target?: Element) => boolean;
-        direction?: string;
-        copy?: ((el: Element, source: Element) => boolean) | boolean;
-        revertOnSpill?: boolean;
-        removeOnSpill?: boolean;
-        delay?: boolean | number;
-        mirrorContainer?: Element;
-        ignoreInputTextSelection?: boolean;
+        containers?: Element[] | undefined;
+        isContainer?: ((el?: Element) => boolean) | undefined;
+        moves?: ((el?: Element, container?: Element, handle?: Element, sibling?: Element) => boolean) | undefined;
+        accepts?: ((el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean) | undefined;
+        invalid?: ((el?: Element, target?: Element) => boolean) | undefined;
+        direction?: string | undefined;
+        copy?: ((el: Element, source: Element) => boolean) | boolean | undefined;
+        revertOnSpill?: boolean | undefined;
+        removeOnSpill?: boolean | undefined;
+        delay?: boolean | number | undefined;
+        mirrorContainer?: Element | undefined;
+        ignoreInputTextSelection?: boolean | undefined;
     }
 
     interface Drake {

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -18,14 +18,14 @@
 
 declare namespace Dropzone {
     export interface DropzoneResizeInfo {
-        srcX?: number;
-        srcY?: number;
-        trgX?: number;
-        trgY?: number;
-        srcWidth?: number;
-        srcHeight?: number;
-        trgWidth?: number;
-        trgHeight?: number;
+        srcX?: number | undefined;
+        srcY?: number | undefined;
+        trgX?: number | undefined;
+        trgY?: number | undefined;
+        srcWidth?: number | undefined;
+        srcHeight?: number | undefined;
+        trgWidth?: number | undefined;
+        trgHeight?: number | undefined;
     }
 
     export interface DropzoneFileUpload {
@@ -33,18 +33,18 @@ declare namespace Dropzone {
         total: number;
         bytesSent: number;
         uuid: string;
-        totalChunkCount?: number;
+        totalChunkCount?: number | undefined;
     }
 
     export interface DropzoneFile extends File {
-        dataURL?: string;
+        dataURL?: string | undefined;
         previewElement: HTMLElement;
         previewTemplate: HTMLElement;
         previewsContainer: HTMLElement;
         status: string;
         accepted: boolean;
-        xhr?: XMLHttpRequest;
-        upload?: DropzoneFileUpload;
+        xhr?: XMLHttpRequest | undefined;
+        upload?: DropzoneFileUpload | undefined;
     }
 
     export interface DropzoneMockFile {
@@ -54,71 +54,71 @@ declare namespace Dropzone {
     }
 
     export interface DropzoneDictFileSizeUnits {
-        tb?: string;
-        gb?: string;
-        mb?: string;
-        kb?: string;
-        b?: string;
+        tb?: string | undefined;
+        gb?: string | undefined;
+        mb?: string | undefined;
+        kb?: string | undefined;
+        b?: string | undefined;
     }
 
     export interface DropzoneOptions {
-        url?: ((files: ReadonlyArray<DropzoneFile>) => string) | string;
-        method?: ((files: ReadonlyArray<DropzoneFile>) => string) | string;
-        withCredentials?: boolean;
-        timeout?: number;
-        parallelUploads?: number;
-        uploadMultiple?: boolean;
-        chunking?: boolean;
-        forceChunking?: boolean;
-        chunkSize?: number;
-        parallelChunkUploads?: boolean;
-        retryChunks?: boolean;
-        retryChunksLimit?: number;
-        maxFilesize?: number;
-        paramName?: string;
-        createImageThumbnails?: boolean;
-        maxThumbnailFilesize?: number;
-        thumbnailWidth?: number;
-        thumbnailHeight?: number;
-        thumbnailMethod?: 'contain' | 'crop';
-        resizeWidth?: number;
-        resizeHeight?: number;
-        resizeMimeType?: string;
-        resizeQuality?: number;
-        resizeMethod?: 'contain' | 'crop';
-        filesizeBase?: number;
-        maxFiles?: number;
-        params?: {};
-        headers?: { [key: string]: string };
-        clickable?: boolean | string | HTMLElement | (string | HTMLElement)[];
-        ignoreHiddenFiles?: boolean;
-        acceptedFiles?: string;
+        url?: ((files: ReadonlyArray<DropzoneFile>) => string) | string | undefined;
+        method?: ((files: ReadonlyArray<DropzoneFile>) => string) | string | undefined;
+        withCredentials?: boolean | undefined;
+        timeout?: number | undefined;
+        parallelUploads?: number | undefined;
+        uploadMultiple?: boolean | undefined;
+        chunking?: boolean | undefined;
+        forceChunking?: boolean | undefined;
+        chunkSize?: number | undefined;
+        parallelChunkUploads?: boolean | undefined;
+        retryChunks?: boolean | undefined;
+        retryChunksLimit?: number | undefined;
+        maxFilesize?: number | undefined;
+        paramName?: string | undefined;
+        createImageThumbnails?: boolean | undefined;
+        maxThumbnailFilesize?: number | undefined;
+        thumbnailWidth?: number | undefined;
+        thumbnailHeight?: number | undefined;
+        thumbnailMethod?: 'contain' | 'crop' | undefined;
+        resizeWidth?: number | undefined;
+        resizeHeight?: number | undefined;
+        resizeMimeType?: string | undefined;
+        resizeQuality?: number | undefined;
+        resizeMethod?: 'contain' | 'crop' | undefined;
+        filesizeBase?: number | undefined;
+        maxFiles?: number | undefined;
+        params?: {} | undefined;
+        headers?: { [key: string]: string } | undefined;
+        clickable?: boolean | string | HTMLElement | (string | HTMLElement)[] | undefined;
+        ignoreHiddenFiles?: boolean | undefined;
+        acceptedFiles?: string | undefined;
         renameFilename?(name: string): string;
-        autoProcessQueue?: boolean;
-        autoQueue?: boolean;
-        addRemoveLinks?: boolean;
-        previewsContainer?: boolean | string | HTMLElement;
-        hiddenInputContainer?: HTMLElement;
-        capture?: string;
+        autoProcessQueue?: boolean | undefined;
+        autoQueue?: boolean | undefined;
+        addRemoveLinks?: boolean | undefined;
+        previewsContainer?: boolean | string | HTMLElement | undefined;
+        hiddenInputContainer?: HTMLElement | undefined;
+        capture?: string | undefined;
 
-        dictDefaultMessage?: string;
-        dictFallbackMessage?: string;
-        dictFallbackText?: string;
-        dictFileTooBig?: string;
-        dictInvalidFileType?: string;
-        dictResponseError?: string;
-        dictCancelUpload?: string;
-        dictCancelUploadConfirmation?: string;
-        dictRemoveFile?: string;
-        dictRemoveFileConfirmation?: string;
-        dictMaxFilesExceeded?: string;
-        dictFileSizeUnits?: DropzoneDictFileSizeUnits;
-        dictUploadCanceled?: string;
+        dictDefaultMessage?: string | undefined;
+        dictFallbackMessage?: string | undefined;
+        dictFallbackText?: string | undefined;
+        dictFileTooBig?: string | undefined;
+        dictInvalidFileType?: string | undefined;
+        dictResponseError?: string | undefined;
+        dictCancelUpload?: string | undefined;
+        dictCancelUploadConfirmation?: string | undefined;
+        dictRemoveFile?: string | undefined;
+        dictRemoveFileConfirmation?: string | undefined;
+        dictMaxFilesExceeded?: string | undefined;
+        dictFileSizeUnits?: DropzoneDictFileSizeUnits | undefined;
+        dictUploadCanceled?: string | undefined;
 
         accept?(file: DropzoneFile, done: (error?: string | Error) => void): void;
         chunksUploaded?(file: DropzoneFile, done: (error?: string | Error) => void): void;
         init?(this: Dropzone): void;
-        forceFallback?: boolean;
+        forceFallback?: boolean | undefined;
         fallback?(): void;
         resize?(file: DropzoneFile, width?: number, height?: number, resizeMethod?: string): DropzoneResizeInfo;
 
@@ -164,7 +164,7 @@ declare namespace Dropzone {
 
         transformFile?(file: DropzoneFile, done: (file: string | Blob) => void): void;
 
-        previewTemplate?: string;
+        previewTemplate?: string | undefined;
     }
 
     export interface DropzoneListener {
@@ -206,7 +206,7 @@ declare class Dropzone {
 
     element: HTMLElement;
     files: Dropzone.DropzoneFile[];
-    hiddenFileInput?: HTMLInputElement;
+    hiddenFileInput?: HTMLInputElement | undefined;
     listeners: Dropzone.DropzoneListener[];
     defaultOptions: Dropzone.DropzoneOptions;
     options: Dropzone.DropzoneOptions;

--- a/types/dropzone/v4/index.d.ts
+++ b/types/dropzone/v4/index.d.ts
@@ -10,16 +10,16 @@ import * as $ from "jquery";
 
 declare namespace Dropzone {
     export interface DropzoneResizeInfo {
-        srcX?:number;
-        srcY?:number;
-        trgX?:number;
-        trgY?:number;
-        srcWidth?:number;
-        srcHeight?:number;
-        trgWidth?:number;
-        trgHeight?:number;
-        optWidth?:number;
-        optHeight?:number;
+        srcX?:number | undefined;
+        srcY?:number | undefined;
+        trgX?:number | undefined;
+        trgY?:number | undefined;
+        srcWidth?:number | undefined;
+        srcHeight?:number | undefined;
+        trgWidth?:number | undefined;
+        trgHeight?:number | undefined;
+        optWidth?:number | undefined;
+        optHeight?:number | undefined;
     }
 
     export interface DropzoneFile extends File {
@@ -28,51 +28,51 @@ declare namespace Dropzone {
         previewsContainer: HTMLElement;
         status: string;
         accepted: boolean;
-        xhr?: XMLHttpRequest;
+        xhr?: XMLHttpRequest | undefined;
     }
 
     export interface DropzoneOptions {
-        url?: string;
-        method?: string;
-        withCredentials?: boolean;
-        parallelUploads?: number;
-        uploadMultiple?: boolean;
-        maxFilesize?: number;
-        paramName?: string;
-        createImageThumbnails?: boolean;
-        maxThumbnailFilesize?: number;
-        thumbnailWidth?: number;
-        thumbnailHeight?: number;
-        filesizeBase?: number;
-        maxFiles?: number;
-        params?: {};
-        headers?: {};
-        clickable?: boolean|string|HTMLElement|(string|HTMLElement)[];
-        ignoreHiddenFiles?: boolean;
-        acceptedFiles?: string;
+        url?: string | undefined;
+        method?: string | undefined;
+        withCredentials?: boolean | undefined;
+        parallelUploads?: number | undefined;
+        uploadMultiple?: boolean | undefined;
+        maxFilesize?: number | undefined;
+        paramName?: string | undefined;
+        createImageThumbnails?: boolean | undefined;
+        maxThumbnailFilesize?: number | undefined;
+        thumbnailWidth?: number | undefined;
+        thumbnailHeight?: number | undefined;
+        filesizeBase?: number | undefined;
+        maxFiles?: number | undefined;
+        params?: {} | undefined;
+        headers?: {} | undefined;
+        clickable?: boolean|string|HTMLElement|(string|HTMLElement)[] | undefined;
+        ignoreHiddenFiles?: boolean | undefined;
+        acceptedFiles?: string | undefined;
         renameFilename?(name:string): string;
-        autoProcessQueue?: boolean;
-        autoQueue?: boolean;
-        addRemoveLinks?: boolean;
-        previewsContainer?: boolean|string|HTMLElement;
-        hiddenInputContainer?: HTMLElement;
-        capture?: string;
+        autoProcessQueue?: boolean | undefined;
+        autoQueue?: boolean | undefined;
+        addRemoveLinks?: boolean | undefined;
+        previewsContainer?: boolean|string|HTMLElement | undefined;
+        hiddenInputContainer?: HTMLElement | undefined;
+        capture?: string | undefined;
 
-        dictDefaultMessage?: string;
-        dictFallbackMessage?: string;
-        dictFallbackText?: string;
-        dictFileTooBig?: string;
-        dictInvalidFileType?: string;
-        dictResponseError?: string;
-        dictCancelUpload?: string;
-        dictCancelUploadConfirmation?: string;
-        dictRemoveFile?: string;
-        dictRemoveFileConfirmation?: string;
-        dictMaxFilesExceeded?: string;
+        dictDefaultMessage?: string | undefined;
+        dictFallbackMessage?: string | undefined;
+        dictFallbackText?: string | undefined;
+        dictFileTooBig?: string | undefined;
+        dictInvalidFileType?: string | undefined;
+        dictResponseError?: string | undefined;
+        dictCancelUpload?: string | undefined;
+        dictCancelUploadConfirmation?: string | undefined;
+        dictRemoveFile?: string | undefined;
+        dictRemoveFileConfirmation?: string | undefined;
+        dictMaxFilesExceeded?: string | undefined;
 
         accept?(file:DropzoneFile, done:(error?:string|Error) => void):void;
         init?():void;
-        forceFallback?: boolean;
+        forceFallback?: boolean | undefined;
         fallback?():void;
         resize?(file:DropzoneFile):DropzoneResizeInfo;
 
@@ -116,7 +116,7 @@ declare namespace Dropzone {
         maxfilesreached?(files:DropzoneFile[]):void;
         queuecomplete?():void;
 
-        previewTemplate?: string;
+        previewTemplate?: string | undefined;
     }
 }
 

--- a/types/duplexer2/index.d.ts
+++ b/types/duplexer2/index.d.ts
@@ -11,7 +11,7 @@
 import { DuplexOptions } from 'stream';
 
 interface Duplexer2Options extends DuplexOptions {
-  bubbleErrors?: boolean;
+  bubbleErrors?: boolean | undefined;
 }
 
 declare function duplexer2(options: Duplexer2Options, writable: NodeJS.WritableStream, readable: NodeJS.ReadableStream): NodeJS.ReadWriteStream;

--- a/types/duplexer3/index.d.ts
+++ b/types/duplexer3/index.d.ts
@@ -13,6 +13,6 @@ declare function duplexer3(options: duplexer3.Options, writableStream: NodeJS.Wr
 
 declare namespace duplexer3 {
     interface Options extends stream.DuplexOptions {
-        bubbleErrors?: boolean;
+        bubbleErrors?: boolean | undefined;
     }
 }


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers widely used packages (more than 100,000 downloads per
month) from connect -- duplexer3.
microsoft/dtslint#335