### PR TITLE
[braintree] Fix type of authorizationExpiresAt

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1317,7 +1317,7 @@ declare namespace braintree {
             token: string;
         };
         authorizationAdjustments?: AuthorizationAdjustment[];
-        authorizationExpiresAt?: Date;
+        authorizationExpiresAt?: string;
         avsErrorResponseCode: string;
         avsPostalCodeResponseCode: string;
         avsStreetAddressResponseCode: string;


### PR DESCRIPTION
This updates `Transaction.authorizationExpiresAt` to be a `string` rather than a `Date`. The [documentation for this field](https://developer.paypal.com/braintree/docs/reference/response/transaction/node#authorization_expires_at) shows this as `String` and I am indeed seeing (ISO 8601-formatted) strings in API responses from Braintree.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.paypal.com/braintree/docs/reference/response/transaction/node#authorization_expires_at
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
