### PR TITLE
Add undefined to optional properties, Mini to Node

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mini-css-extract-plugin 2.0
+// Type definitions for mini-css-extract-plugin 1.4
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
@@ -38,17 +38,17 @@ declare namespace MiniCssExtractPlugin {
         /**
          * Works like [`output.filename`](https://webpack.js.org/configuration/output/#outputfilename).
          */
-        filename?: Required<Configuration>['output']['filename'];
+        filename?: Required<Configuration>['output']['filename'] | undefined;
         /**
          * Works like [`output.chunkFilename`](https://webpack.js.org/configuration/output/#outputchunkfilename).
          */
-        chunkFilename?: Required<Configuration>['output']['chunkFilename'];
+        chunkFilename?: Required<Configuration>['output']['chunkFilename'] | undefined;
         /**
          * For projects where CSS ordering has been mitigated through consistent
          * use of scoping or naming conventions, the CSS order warnings can be
          * disabled by setting this flag to true for the plugin.
          */
-        ignoreOrder?: boolean;
+        ignoreOrder?: boolean | undefined;
         /**
          * Specify where to insert the link tag.
          *
@@ -61,14 +61,14 @@ declare namespace MiniCssExtractPlugin {
          *
          * @default function() { document.head.appendChild(linkTag); }
          */
-        insert?: string | ((linkTag: any) => void);
+        insert?: string | ((linkTag: any) => void) | undefined;
         /**
          * Specify additional html attributes to add to the link tag.
          *
          * Note: These are only applied to dynamically loaded css chunks. To modify link
          * attributes for entry CSS chunks, please use html-webpack-plugin.
          */
-        attributes?: Record<string, string>;
+        attributes?: Record<string, string> | undefined;
         /**
          * This option allows loading asynchronous chunks with a custom link type, such as
          * `<link type="text/css" ...>`.
@@ -77,37 +77,51 @@ declare namespace MiniCssExtractPlugin {
          *
          * @default 'text/css'
          */
-        linkType?: string | false | 'text/css';
+        linkType?: string | false | 'text/css' | undefined;
 
         /**
          * Use an experimental webpack API to execute modules instead of child compilers
          * @default false
          */
-        experimentalUseImportModule?: boolean;
+        experimentalUseImportModule?: boolean | undefined;
     }
     interface LoaderOptions {
         /**
          * Overrides [`output.publicPath`](https://webpack.js.org/configuration/output/#outputpublicpath).
          * @default output.publicPath
          */
-        publicPath?: string | ((resourcePath: string, context: string) => string);
+        publicPath?: string | ((resourcePath: string, context: string) => string) | undefined;
         /**
          * If false, the plugin will extract the CSS but **will not** emit the file
          * @default true
          */
-        emit?: boolean;
+        emit?: boolean | undefined;
         /**
          * By default, `mini-css-extract-plugin` generates JS modules that use the ES modules syntax.
          * There are some cases in which using ES modules is beneficial,
          * like in the case of module concatenation and tree shaking.
          * @default true
          */
-        esModule?: boolean;
+        esModule?: boolean | undefined;
 
         /**
          * Layer of the css execution
          */
-        layer?: string;
+        layer?: string | undefined;
+
+        modules?: {
+            /**
+             * Enables/disables ES modules named export for locals.
+             *
+             * Names of locals are converted to camelCase. It is not allowed to use
+             * JavaScript reserved words in CSS class names. Options `esModule` and
+             * `modules.namedExport` in css-loader and MiniCssExtractPlugin.loader
+             * must be enabled.
+             *
+             * @default false
+             */
+            namedExport?: boolean | undefined;
+        } | undefined;
     }
 }
 

--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mini-css-extract-plugin 1.4
+// Type definitions for mini-css-extract-plugin 2.0
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
@@ -108,20 +108,6 @@ declare namespace MiniCssExtractPlugin {
          * Layer of the css execution
          */
         layer?: string | undefined;
-
-        modules?: {
-            /**
-             * Enables/disables ES modules named export for locals.
-             *
-             * Names of locals are converted to camelCase. It is not allowed to use
-             * JavaScript reserved words in CSS class names. Options `esModule` and
-             * `modules.namedExport` in css-loader and MiniCssExtractPlugin.loader
-             * must be enabled.
-             *
-             * @default false
-             */
-            namedExport?: boolean | undefined;
-        } | undefined;
     }
 }
 

--- a/types/minimatch/index.d.ts
+++ b/types/minimatch/index.d.ts
@@ -35,21 +35,21 @@ declare namespace M {
          *
          * @default false
          */
-        debug?: boolean;
+        debug?: boolean | undefined;
 
         /**
          * Do not expand {a,b} and {1..3} brace sets.
          *
          * @default false
          */
-        nobrace?: boolean;
+        nobrace?: boolean | undefined;
 
         /**
          * Disable ** matching against multiple folder names.
          *
          * @default false
          */
-        noglobstar?: boolean;
+        noglobstar?: boolean | undefined;
 
         /**
          * Allow patterns to match filenames starting with a period,
@@ -57,21 +57,21 @@ declare namespace M {
          *
          * @default false
          */
-        dot?: boolean;
+        dot?: boolean | undefined;
 
         /**
          * Disable "extglob" style patterns like +(a|b).
          *
          * @default false
          */
-        noext?: boolean;
+        noext?: boolean | undefined;
 
         /**
          * Perform a case-insensitive match.
          *
          * @default false
          */
-        nocase?: boolean;
+        nocase?: boolean | undefined;
 
         /**
          * When a match is not found by minimatch.match,
@@ -80,7 +80,7 @@ declare namespace M {
          *
          * @default false
          */
-        nonull?: boolean;
+        nonull?: boolean | undefined;
 
         /**
          * If set, then patterns without slashes will be matched against
@@ -88,7 +88,7 @@ declare namespace M {
          *
          * @default false
          */
-        matchBase?: boolean;
+        matchBase?: boolean | undefined;
 
         /**
          * Suppress the behavior of treating #
@@ -96,14 +96,14 @@ declare namespace M {
          *
          * @default false
          */
-        nocomment?: boolean;
+        nocomment?: boolean | undefined;
 
         /**
          * Suppress the behavior of treating a leading ! character as negation.
          *
          * @default false
          */
-        nonegate?: boolean;
+        nonegate?: boolean | undefined;
 
         /**
          * Returns from negate expressions the same as if they were not negated.
@@ -111,7 +111,7 @@ declare namespace M {
          *
          * @default false
          */
-        flipNegate?: boolean;
+        flipNegate?: boolean | undefined;
     }
 
     interface IMinimatchStatic {

--- a/types/minimist/index.d.ts
+++ b/types/minimist/index.d.ts
@@ -41,40 +41,40 @@ declare namespace minimist {
         /**
          * A string or array of strings argument names to always treat as strings
          */
-        string?: string | string[];
+        string?: string | string[] | undefined;
 
         /**
          * A boolean, string or array of strings to always treat as booleans. If true will treat
          * all double hyphenated arguments without equals signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
          */
-        boolean?: boolean | string | string[];
+        boolean?: boolean | string | string[] | undefined;
 
         /**
          * An object mapping string names to strings or arrays of string argument names to use as aliases
          */
-        alias?: { [key: string]: string | string[] };
+        alias?: { [key: string]: string | string[] } | undefined;
 
         /**
          * An object mapping string argument names to default values
          */
-        default?: { [key: string]: any };
+        default?: { [key: string]: any } | undefined;
 
         /**
          * When true, populate argv._ with everything after the first non-option
          */
-        stopEarly?: boolean;
+        stopEarly?: boolean | undefined;
 
         /**
          * A function which is invoked with a command line parameter not defined in the opts
          * configuration object. If the function returns false, the unknown option is not added to argv
          */
-        unknown?: (arg: string) => boolean;
+        unknown?: ((arg: string) => boolean) | undefined;
 
         /**
          * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --.
          * Note that with -- set, parsing for arguments still stops after the `--`.
          */
-        '--'?: boolean;
+        '--'?: boolean | undefined;
     }
 
     interface ParsedArgs {
@@ -83,7 +83,7 @@ declare namespace minimist {
         /**
          * If opts['--'] is true, populated with everything after the --
          */
-        '--'?: string[];
+        '--'?: string[] | undefined;
 
         /**
          * Contains all the arguments that didn't have an option associated with them

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -22,13 +22,13 @@ export interface ClientOptions {
     endPoint: string;
     accessKey: string;
     secretKey: string;
-    useSSL?: boolean;
-    port?: number;
-    region?: Region;
+    useSSL?: boolean | undefined;
+    port?: number | undefined;
+    region?: Region | undefined;
     transport?: any;
-    sessionToken?: string;
-    partSize?: number;
-    pathStyle?: boolean;
+    sessionToken?: string | undefined;
+    partSize?: number | undefined;
+    pathStyle?: boolean | undefined;
 }
 
 export interface BucketItemFromList {

--- a/types/minipass/index.d.ts
+++ b/types/minipass/index.d.ts
@@ -29,7 +29,7 @@ declare class MiniPass extends EventEmitter implements NodeJS.WritableStream {
     end(chunk: any, encoding?: string | null, cb?: () => void): void;
     resume(): void;
     pause(): void;
-    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
 
     addEventHandler(event: string, listener: (...args: any[]) => void): this;
     addEventHandler(event: 'data', listener: (chunk: any) => void): this;
@@ -62,7 +62,7 @@ declare class MiniPass extends EventEmitter implements NodeJS.WritableStream {
 
 declare namespace MiniPass {
     interface Options {
-        objectMode?: boolean;
-        encoding?: string | null;
+        objectMode?: boolean | undefined;
+        encoding?: string | null | undefined;
     }
 }

--- a/types/minizlib/index.d.ts
+++ b/types/minizlib/index.d.ts
@@ -15,8 +15,8 @@ type BrotliMode = "BrotliCompress" | "BrotliDecompress";
 type ZlibMode = "Gzip" | "Gunzip" | "Deflate" | "Inflate" | "DeflateRaw" | "InflateRaw" | "Unzip";
 
 interface ZlibBaseOptions extends MiniPass.Options {
-    flush?: number;
-    finishFlush?: number;
+    flush?: number | undefined;
+    finishFlush?: number | undefined;
 }
 
 declare class ZlibBase extends MiniPass {
@@ -36,8 +36,8 @@ declare class ZlibBase extends MiniPass {
 }
 
 interface ZlibOptions extends ZlibBaseOptions {
-    level?: number;
-    strategy?: number;
+    level?: number | undefined;
+    strategy?: number | undefined;
 }
 
 declare class Zlib extends ZlibBase {

--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -19,7 +19,7 @@ export interface Dict {
 }
 
 export interface RequestOptions {
-    transport?: 'xhr' | 'sendBeacon';
+    transport?: 'xhr' | 'sendBeacon' | undefined;
 }
 
 export interface XhrHeadersDef {

--- a/types/mkdirp/index.d.ts
+++ b/types/mkdirp/index.d.ts
@@ -44,13 +44,13 @@ declare namespace mkdirp {
     }
 
     interface Options {
-        mode?: Mode;
-        fs?: FsImplementation;
+        mode?: Mode | undefined;
+        fs?: FsImplementation | undefined;
     }
 
     interface OptionsSync {
-        mode?: Mode;
-        fs?: FsImplementationSync;
+        mode?: Mode | undefined;
+        fs?: FsImplementationSync | undefined;
     }
 
     /**

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -1046,12 +1046,12 @@ declare namespace Mocha {
 
         namespace XUnit {
             interface MochaOptions extends Mocha.MochaOptions {
-                reporterOptions?: ReporterOptions;
+                reporterOptions?: ReporterOptions | undefined;
             }
 
             interface ReporterOptions {
-                output?: string;
-                suiteName?: string;
+                output?: string | undefined;
+                suiteName?: string | undefined;
             }
         }
 
@@ -1074,15 +1074,15 @@ declare namespace Mocha {
 
         namespace Progress {
             interface MochaOptions extends Mocha.MochaOptions {
-                reporterOptions?: ReporterOptions;
+                reporterOptions?: ReporterOptions | undefined;
             }
 
             interface ReporterOptions {
-                open?: string;
-                complete?: string;
-                incomplete?: string;
-                close?: string;
-                verbose?: boolean;
+                open?: string | undefined;
+                complete?: string | undefined;
+                incomplete?: string | undefined;
+                close?: string | undefined;
+                verbose?: boolean | undefined;
             }
         }
 
@@ -1141,14 +1141,14 @@ declare namespace Mocha {
         sync: boolean;
         timedOut: boolean;
         pending: boolean;
-        duration?: number;
-        parent?: Suite;
-        state?: "failed" | "passed";
+        duration?: number | undefined;
+        parent?: Suite | undefined;
+        state?: "failed" | "passed" | undefined;
         timer?: any;
-        ctx?: Context;
-        callback?: Done;
-        allowUncaught?: boolean;
-        file?: string;
+        ctx?: Context | undefined;
+        callback?: Done | undefined;
+        allowUncaught?: boolean | undefined;
+        file?: string | undefined;
 
         /**
          * Get test timeout.
@@ -1312,8 +1312,8 @@ declare namespace Mocha {
     class Context {
         private _runnable;
 
-        test?: Runnable;
-        currentTest?: Test;
+        test?: Runnable | undefined;
+        currentTest?: Test | undefined;
 
         /**
          * Get the context `Runnable`.
@@ -1406,15 +1406,15 @@ declare namespace Mocha {
         started: boolean;
         total: number;
         failures: number;
-        asyncOnly?: boolean;
-        allowUncaught?: boolean;
-        fullStackTrace?: boolean;
-        forbidOnly?: boolean;
-        forbidPending?: boolean;
-        checkLeaks?: boolean;
-        test?: Test;
-        currentRunnable?: Runnable;
-        stats?: Stats; // added by reporters
+        asyncOnly?: boolean | undefined;
+        allowUncaught?: boolean | undefined;
+        fullStackTrace?: boolean | undefined;
+        forbidOnly?: boolean | undefined;
+        forbidPending?: boolean | undefined;
+        checkLeaks?: boolean | undefined;
+        test?: Test | undefined;
+        currentRunnable?: Runnable | undefined;
+        stats?: Stats | undefined; // added by reporters
 
         /**
          * Removes all event handlers set during a run on this instance.
@@ -1767,7 +1767,7 @@ declare namespace Mocha {
         suites: Suite[];
         tests: Test[];
         pending: boolean;
-        file?: string;
+        file?: string | undefined;
         root: boolean;
         delayed: boolean;
         parent: Suite | undefined;
@@ -2160,7 +2160,7 @@ declare namespace Mocha {
         private _error;
 
         type: "hook";
-        originalTitle?: string; // added by Runner
+        originalTitle?: string | undefined; // added by Runner
 
         /**
          * Get the test `err`.
@@ -2192,20 +2192,20 @@ declare namespace Mocha {
        * In serial mode, run after all tests end, once only.
        * In parallel mode, run after all tests end, for each file.
        */
-      afterAll?: Func | AsyncFunc | Func[] | AsyncFunc[];
+      afterAll?: Func | AsyncFunc | Func[] | AsyncFunc[] | undefined;
       /**
        * In serial mode (Mocha's default), before all tests begin, once only.
        * In parallel mode, run before all tests begin, for each file.
        */
-      beforeAll?: Func | AsyncFunc | Func[] | AsyncFunc[];
+      beforeAll?: Func | AsyncFunc | Func[] | AsyncFunc[] | undefined;
       /**
        * In both modes, run after every test.
        */
-      afterEach?: Func | AsyncFunc | Func[] | AsyncFunc[];
+      afterEach?: Func | AsyncFunc | Func[] | AsyncFunc[] | undefined;
       /**
        * In both modes, run before each test.
        */
-      beforeEach?: Func | AsyncFunc | Func[] | AsyncFunc[];
+      beforeEach?: Func | AsyncFunc | Func[] | AsyncFunc[] | undefined;
     }
 
     /**
@@ -2215,8 +2215,8 @@ declare namespace Mocha {
      */
     class Test extends Runnable {
         type: "test";
-        speed?: "slow" | "medium" | "fast"; // added by reporters
-        err?: Error; // added by reporters
+        speed?: "slow" | "medium" | "fast" | undefined; // added by reporters
+        err?: Error | undefined; // added by reporters
         clone(): Test;
     }
 
@@ -2229,9 +2229,9 @@ declare namespace Mocha {
         passes: number;
         pending: number;
         failures: number;
-        start?: Date;
-        end?: Date;
-        duration?: number;
+        start?: Date | undefined;
+        end?: Date | undefined;
+        duration?: number | undefined;
     }
 
     type TestInterface = (suite: Suite) => void;
@@ -2257,73 +2257,73 @@ declare namespace Mocha {
      */
     interface MochaOptions {
         /** Test interfaces ("bdd", "tdd", "exports", etc.). */
-        ui?: Interface;
+        ui?: Interface | undefined;
 
         /**
          * Reporter constructor, built-in reporter name, or reporter module path. Defaults to
          * `"spec"`.
          */
-        reporter?: string | ReporterConstructor;
+        reporter?: string | ReporterConstructor | undefined;
 
         /** Options to pass to the reporter. */
         reporterOptions?: any;
 
         /** Array of accepted globals. */
-        globals?: string[];
+        globals?: string[] | undefined;
 
         /** timeout in milliseconds or time string like '1s'. */
-        timeout?: number | string;
+        timeout?: number | string | undefined;
 
         /** number of times to retry failed tests. */
-        retries?: number;
+        retries?: number | undefined;
 
         /** bail on the first test failure. */
-        bail?: boolean;
+        bail?: boolean | undefined;
 
         /** milliseconds to wait before considering a test slow. */
-        slow?: number;
+        slow?: number | undefined;
 
         /** check for global variable leaks. */
-        checkLeaks?: boolean;
+        checkLeaks?: boolean | undefined;
 
         /** display the full stack trace on failure. */
-        fullStackTrace?: boolean;
+        fullStackTrace?: boolean | undefined;
 
         /** string or regexp to filter tests with. */
-        grep?: string | RegExp;
+        grep?: string | RegExp | undefined;
 
         /** Enable growl support. */
-        growl?: boolean;
+        growl?: boolean | undefined;
 
         /** Color TTY output from reporter */
-        color?: boolean;
+        color?: boolean | undefined;
 
         /** Use inline diffs rather than +/-. */
-        inlineDiffs?: boolean;
+        inlineDiffs?: boolean | undefined;
 
         /** Do not show diffs at all. */
-        hideDiff?: boolean;
+        hideDiff?: boolean | undefined;
 
         /** Run job in parallel */
-        parallel?: boolean;
+        parallel?: boolean | undefined;
 
         /** Max number of worker processes for parallel runs */
-        jobs?: number;
+        jobs?: number | undefined;
 
         /** Assigns hooks to the root suite */
-        rootHooks?: RootHookObject;
+        rootHooks?: RootHookObject | undefined;
 
-        asyncOnly?: boolean;
-        delay?: boolean;
-        forbidOnly?: boolean;
-        forbidPending?: boolean;
-        noHighlighting?: boolean;
-        allowUncaught?: boolean;
-        fullTrace?: boolean;
+        asyncOnly?: boolean | undefined;
+        delay?: boolean | undefined;
+        forbidOnly?: boolean | undefined;
+        forbidPending?: boolean | undefined;
+        noHighlighting?: boolean | undefined;
+        allowUncaught?: boolean | undefined;
+        fullTrace?: boolean | undefined;
     }
 
     interface MochaInstanceOptions extends MochaOptions {
-        files?: string[];
+        files?: string[] | undefined;
     }
 
     /**
@@ -2812,16 +2812,16 @@ declare module "mocha/lib/interfaces/common" {
             title: string;
 
             /** Suite function */
-            fn?: (this: Mocha.Suite) => void;
+            fn?: ((this: Mocha.Suite) => void) | undefined;
 
             /** Is suite pending? */
-            pending?: boolean;
+            pending?: boolean | undefined;
 
             /** Filepath where this Suite resides */
-            file?: string;
+            file?: string | undefined;
 
             /** Is suite exclusive? */
-            isOnly?: boolean;
+            isOnly?: boolean | undefined;
         }
 
         interface SuiteFunctions {

--- a/types/mock-fs/lib/filesystem.d.ts
+++ b/types/mock-fs/lib/filesystem.d.ts
@@ -83,99 +83,99 @@ declare namespace FileSystem {
         /**
          * Create a directory for `process.cwd()`. This is `true` by default.
          */
-        createCwd?: boolean;
+        createCwd?: boolean | undefined;
         /**
          * Create a directory for `os.tmpdir()`. This is `true` by default.
          */
-        createTmp?: boolean;
+        createTmp?: boolean | undefined;
     }
 
     interface FileOptions {
         /** File contents */
-        content?: string | Buffer;
+        content?: string | Buffer | undefined;
         /** File mode (permission and sticky bits). Defaults to `0666`. */
-        mode?: number;
+        mode?: number | undefined;
         /** The user id. Defaults to `process.getuid()`. */
-        uid?: number;
+        uid?: number | undefined;
         /** The group id. Defaults to `process.getgid()`. */
-        gid?: number;
+        gid?: number | undefined;
         /**
          * The last file access time. Defaults to `new Date()`. Updated when
          * file contents are accessed.
          */
-        atime?: Date;
+        atime?: Date | undefined;
         /**
          * The last file change time. Defaults to `new Date()`. Updated when
          * file owner or permissions change.
          */
-        ctime?: Date;
+        ctime?: Date | undefined;
         /**
          * The last file modification time. Defaults to `new Date()`. Updated
          * when file contents change.
          */
-        mtime?: Date;
+        mtime?: Date | undefined;
         /**
          * The time of file creation. Defaults to `new Date()`.
          */
-        birthtime?: Date;
+        birthtime?: Date | undefined;
     }
 
     interface DirectoryOptions {
         /** Directory mode (permission and sticky bits). Defaults to `0777`. */
-        mode?: number;
+        mode?: number | undefined;
         /** The user id. Defaults to `process.getuid()`. */
-        uid?: number;
+        uid?: number | undefined;
         /** The group id. Defaults to `process.getgid()`. */
-        gid?: number;
+        gid?: number | undefined;
         /**
          * The last directory access time. Defaults to `new Date()`.
          */
-        atime?: Date;
+        atime?: Date | undefined;
         /**
          * The last directory change time. Defaults to `new Date()`. Updated
          * when owner or permissions change.
          */
-        ctime?: Date;
+        ctime?: Date | undefined;
         /**
          * The last directory modification time. Defaults to `new Date()`.
          * Updated when an item is added, removed, or renamed.
          */
-        mtime?: Date;
+        mtime?: Date | undefined;
         /**
          * The time of directory creation. Defaults to `new Date()`.
          */
-        birthtime?: Date;
+        birthtime?: Date | undefined;
         /**
          * Directory contents. Members will generate additional files,
          * directories, or symlinks.
          */
-        items?: DirectoryItems;
+        items?: DirectoryItems | undefined;
     }
 
     interface SymlinkOptions {
         /** Path to the source (required). */
         path: string;
         /** Symlink mode (permission and sticky bits). Defaults to `0666`. */
-        mode?: number;
+        mode?: number | undefined;
         /** The user id. Defaults to `process.getuid()`. */
-        uid?: number;
+        uid?: number | undefined;
         /** The group id. Defaults to `process.getgid()`. */
-        gid?: number;
+        gid?: number | undefined;
         /** The last symlink access time. Defaults to `new Date()`. */
-        atime?: Date;
+        atime?: Date | undefined;
         /** The last symlink change time. Defaults to `new Date()`. */
-        ctime?: Date;
+        ctime?: Date | undefined;
         /** The last symlink modification time. Defaults to `new Date()`. */
-        mtime?: Date;
+        mtime?: Date | undefined;
         /** The time of symlink creation. Defaults to `new Date()`. */
-        birthtime?: Date;
+        birthtime?: Date | undefined;
     }
 
     interface LoaderOptions {
         /** File content isn't loaded until explicitly read. */
-        lazy?: boolean;
+        lazy?: boolean | undefined;
         /** Load all files and directories recursively. */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
     }
 
     function getPathParts(filepath: string): string[];

--- a/types/mockery/index.d.ts
+++ b/types/mockery/index.d.ts
@@ -6,9 +6,9 @@
 
 
 interface MockeryEnableArgs {
-    useCleanCache?: boolean;
-    warnOnReplace?: boolean;
-    warnOnUnregistered?: boolean;
+    useCleanCache?: boolean | undefined;
+    warnOnReplace?: boolean | undefined;
+    warnOnUnregistered?: boolean | undefined;
 }
 
 export declare function enable(args?: MockeryEnableArgs): void;

--- a/types/moment-duration-format/index.d.ts
+++ b/types/moment-duration-format/index.d.ts
@@ -33,29 +33,29 @@ declare module "moment" {
     );
 
     interface DurationFormatSettings {
-        trim?: false | UnitOfTrimV1 | UnitOfTrim | string | Array<UnitOfTrim | string>;
-        largest?: number;
-        trunc?: true;
-        stopTrim?: string;
+        trim?: false | UnitOfTrimV1 | UnitOfTrim | string | Array<UnitOfTrim | string> | undefined;
+        largest?: number | undefined;
+        trunc?: true | undefined;
+        stopTrim?: string | undefined;
 
-        minValue?: number;
-        maxValue?: number;
+        minValue?: number | undefined;
+        maxValue?: number | undefined;
 
-        useGrouping?: boolean;
-        precision?: number;
-        decimalSeparator?: string;
-        groupingSeparator?: string;
-        grouping?: number[];
+        useGrouping?: boolean | undefined;
+        precision?: number | undefined;
+        decimalSeparator?: string | undefined;
+        groupingSeparator?: string | undefined;
+        grouping?: number[] | undefined;
 
-        useSignificantDigits?: true;
+        useSignificantDigits?: true | undefined;
 
-        forceLength?: boolean;
-        template?: string | TemplateFunction;
+        forceLength?: boolean | undefined;
+        template?: string | TemplateFunction | undefined;
 
-        userLocale?: string;
-        usePlural?: boolean;
-        useLeftUnits?: boolean;
-        useToLocaleString?: boolean;
+        userLocale?: string | undefined;
+        usePlural?: boolean | undefined;
+        useLeftUnits?: boolean | undefined;
+        useToLocaleString?: boolean | undefined;
     }
 
     type DurationLabelType = "long" | "standard" | "short";
@@ -80,12 +80,12 @@ declare module "moment" {
     }
 
     interface LocaleSpecification {
-        durationLabelsLong?: DurationLabelDef;
-        durationLabelsStandard?: DurationLabelDef;
-        durationLabelsShort?: DurationLabelDef;
-        durationTimeTemplates?: DurationTimeDef;
-        durationLabelTypes?: DurationLabelTypeDef[];
-        durationPluralKey?: (token: string, integerValue: number, decimalValue: number) => string;
+        durationLabelsLong?: DurationLabelDef | undefined;
+        durationLabelsStandard?: DurationLabelDef | undefined;
+        durationLabelsShort?: DurationLabelDef | undefined;
+        durationTimeTemplates?: DurationTimeDef | undefined;
+        durationLabelTypes?: DurationLabelTypeDef[] | undefined;
+        durationPluralKey?: ((token: string, integerValue: number, decimalValue: number) => string) | undefined;
     }
 
     type TemplateFunction = ((this: DurationFormatSettings) => string);

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -144,7 +144,7 @@ export class MongoClient extends EventEmitter {
      */
     watch<TSchema extends object = { _id: ObjectId }>(
         pipeline?: object[],
-        options?: ChangeStreamOptions & { session?: ClientSession },
+        options?: ChangeStreamOptions & { session?: ClientSession | undefined },
     ): ChangeStream<TSchema>;
     /**
      * Runs a given operation with an implicitly created session. The lifetime of the session will be handled without the need for user interaction.
@@ -286,17 +286,17 @@ interface WriteConcern {
      * propagated to a specified number of mongod hosts
      * @default 1
      */
-    w?: number | "majority" | string;
+    w?: number | "majority" | string | undefined;
     /**
      * requests acknowledgement from MongoDB that the write operation has
      * been written to the journal
      * @default false
      */
-    j?: boolean;
+    j?: boolean | undefined;
     /**
      * a time limit, in milliseconds, for the write concern
      */
-    wtimeout?: number;
+    wtimeout?: number | undefined;
 }
 
 /**
@@ -311,11 +311,11 @@ export interface SessionOptions {
      * Whether causal consistency should be enabled on this session
      * @default true
      */
-    causalConsistency?: boolean;
+    causalConsistency?: boolean | undefined;
     /**
      * The default TransactionOptions to use for transactions started on this session.
      */
-    defaultTransactionOptions?: TransactionOptions;
+    defaultTransactionOptions?: TransactionOptions | undefined;
 }
 
 /**
@@ -327,9 +327,9 @@ export interface SessionOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/global.html#TransactionOptions
  */
 export interface TransactionOptions {
-    readConcern?: ReadConcern;
-    writeConcern?: WriteConcern;
-    readPreference?: ReadPreferenceOrMode;
+    readConcern?: ReadConcern | undefined;
+    writeConcern?: WriteConcern | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
 }
 
 /**
@@ -337,8 +337,8 @@ export interface TransactionOptions {
  * @param returnNonCachedInstance Control if you want to return a cached instance or have a new one created
  */
 export interface MongoClientCommonOption {
-    noListener?: boolean;
-    returnNonCachedInstance?: boolean;
+    noListener?: boolean | undefined;
+    returnNonCachedInstance?: boolean | undefined;
 }
 
 /**
@@ -387,7 +387,7 @@ export class MongoError extends Error {
      */
     hasErrorLabel(label: string): boolean;
     readonly errorLabels: string[];
-    code?: number | string;
+    code?: number | string | undefined;
     /**
      * While not documented, the `errmsg` prop is AFAIK the only way to find out
      * which unique index caused a duplicate key error. When you have multiple
@@ -406,7 +406,7 @@ export class MongoError extends Error {
      * multiple places in the source code, for example
      * {@link https://github.com/mongodb/node-mongodb-native/blob/a12aa15ac3eaae3ad5c4166ea1423aec4560f155/test/functional/find_tests.js#L1111 here}.
      */
-    errmsg?: string;
+    errmsg?: string | undefined;
     name: string;
 }
 
@@ -438,7 +438,7 @@ export class MongoTimeoutError extends MongoError {
      * An optional reason context for the timeout, generally an error
      * saved during flow of monitoring and selecting servers
      */
-    reason?: string | object;
+    reason?: string | object | undefined;
 }
 
 /**
@@ -461,7 +461,7 @@ export class MongoWriteConcernError extends MongoError {
     /**
      * The result document (provided if ok: 1)
      */
-    result?: object;
+    result?: object | undefined;
 }
 /**
  * An error indicating an unsuccessful Bulk Write
@@ -488,23 +488,23 @@ export interface MongoClientOptions
     /**
      * The logging level (error/warn/info/debug)
      */
-    loggerLevel?: string;
+    loggerLevel?: string | undefined;
 
     /**
      * Custom logger object
      */
-    logger?: object | log;
+    logger?: object | log | undefined;
 
     /**
      * Validate MongoClient passed in options for correctness
      * @default false
      */
-    validateOptions?: object | boolean;
+    validateOptions?: object | boolean | undefined;
 
     /**
      * The name of the application that created this MongoClient instance.
      */
-    appname?: string;
+    appname?: string | undefined;
 
     /**
      * Authentication credentials
@@ -518,7 +518,7 @@ export interface MongoClientOptions
          * The password for auth
          */
         password: string;
-    };
+    } | undefined;
 
     /**
      * Determines whether or not to use the new url parser. Enables the new, spec-compliant
@@ -526,13 +526,13 @@ export interface MongoClientOptions
      * the original parser, and aims to outright replace that parser in the near future.
      * @default true
      */
-    useNewUrlParser?: boolean;
+    useNewUrlParser?: boolean | undefined;
 
     /**
      * Number of retries for a tailable cursor
      * @default 5
      */
-    numberOfRetries?: number;
+    numberOfRetries?: number | undefined;
 
     /**
      * An authentication mechanism to use for connection authentication,
@@ -548,24 +548,24 @@ export interface MongoClientOptions
         | "MONGODB-AWS"
         | "SCRAM-SHA-1"
         | "SCRAM-SHA-256"
-        | string;
+        | string | undefined;
 
     /** Type of compression to use */
     compression?: {
         /** The selected compressors in preference order */
-        compressors?: Array<"snappy" | "zlib">;
-    };
+        compressors?: Array<"snappy" | "zlib"> | undefined;
+    } | undefined;
 
     /**
      * Enable directConnection
      * @default false
      */
-    directConnection?: boolean;
+    directConnection?: boolean | undefined;
 
     /*
      * Optionally enable client side auto encryption.
      */
-    autoEncryption?: AutoEncryptionOptions;
+    autoEncryption?: AutoEncryptionOptions | undefined;
 }
 
 /**
@@ -579,23 +579,23 @@ export interface AutoEncryptionExtraOptions {
      * values in a command. Defaults to "mongodb:///var/mongocryptd.sock" if
      * domain sockets are available or "mongodb://localhost:27020" otherwise.
      */
-    mongocryptdURI?: string;
+    mongocryptdURI?: string | undefined;
 
     /**
      * If true, autoEncryption will not attempt to spawn a mongocryptd before
      * connecting.
      */
-    mongocryptdBypassSpawn?: boolean;
+    mongocryptdBypassSpawn?: boolean | undefined;
 
     /**
      * The path to the mongocryptd executable on the system.
      */
-    mongocryptdSpawnPath?: string;
+    mongocryptdSpawnPath?: string | undefined;
 
     /**
      * Command line arguments to use when auto-spawning a mongocryptd.
      */
-    mongocryptdSpawnArgs?: string[];
+    mongocryptdSpawnArgs?: string[] | undefined;
 }
 
 /**
@@ -612,13 +612,13 @@ export interface KMSProviders {
         /**
          * The access key used for the AWS KMS provider.
          */
-        accessKeyId?: string;
+        accessKeyId?: string | undefined;
 
         /**
          * The secret access key used for the AWS KMS provider.
          */
-        secretAccessKey?: string;
-    };
+        secretAccessKey?: string | undefined;
+    } | undefined;
 
     /**
      * Configuration options for using `gcp` as your KMS provider.
@@ -627,20 +627,20 @@ export interface KMSProviders {
         /**
          * The service account email to authenticate.
          */
-        email?: string;
+        email?: string | undefined;
 
         /**
          * A PKCS#8 encrypted key. This can either be a base64 string or a
          * binary representation.
          */
-        privateKey?: string | Buffer;
+        privateKey?: string | Buffer | undefined;
 
         /**
          * If present, a host with optional port. E.g. "example.com" or
          * "example.com:443". Defaults to "oauth2.googleapis.com".
          */
-        endpoint?: string;
-    };
+        endpoint?: string | undefined;
+    } | undefined;
 
     /**
      * Configuration options for using 'local' as your KMS provider.
@@ -650,8 +650,8 @@ export interface KMSProviders {
          * The master key used to encrypt/decrypt data keys. A 96-byte long
          * Buffer.
          */
-        key?: Buffer;
-    };
+        key?: Buffer | undefined;
+    } | undefined;
 }
 
 /**
@@ -663,34 +663,34 @@ export interface AutoEncryptionOptions {
     /**
      * A MongoClient used to fetch keys from a key vault
      */
-    keyVaultClient?: MongoClient;
+    keyVaultClient?: MongoClient | undefined;
 
     /**
      * The namespace where keys are stored in the key vault.
      */
-    keyVaultNamespace?: string;
+    keyVaultNamespace?: string | undefined;
 
     /**
      * Configuration options that are used by specific KMS providers during key
      * generation, encryption, and decryption.
      */
-    kmsProviders?: KMSProviders;
+    kmsProviders?: KMSProviders | undefined;
 
     /**
      * A map of namespaces to a local JSON schema for encryption.
      */
-    schemaMap?: object;
+    schemaMap?: object | undefined;
 
     /**
      * Allows the user to bypass auto encryption, maintaining implicit
      * decryption.
      */
-    bypassAutoEncryption?: boolean;
+    bypassAutoEncryption?: boolean | undefined;
 
     /**
      * Extra options related to the mongocryptd process.
      */
-    extraOptions?: AutoEncryptionExtraOptions;
+    extraOptions?: AutoEncryptionExtraOptions | undefined;
 }
 
 export interface SSLOptions {
@@ -699,60 +699,60 @@ export interface SSLOptions {
      *
      * @see https://nodejs.org/dist/latest/docs/api/tls.html#tls_tls_createsecurecontext_options
      */
-    ciphers?: string;
+    ciphers?: string | undefined;
     /**
      * Passed directly through to tls.createSecureContext.
      *
      * @see https://nodejs.org/dist/latest/docs/api/tls.html#tls_tls_createsecurecontext_options
      */
-    ecdhCurve?: string;
+    ecdhCurve?: string | undefined;
     /**
      * Number of connections for each server instance; set to 5 as default for legacy reasons
      * @default 5
      */
-    poolSize?: number;
+    poolSize?: number | undefined;
     /**
      * If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
      */
-    minSize?: number;
+    minSize?: number | undefined;
     /**
      * Use ssl connection (needs to have a mongod server with ssl support)
      */
-    ssl?: boolean;
+    ssl?: boolean | undefined;
     /**
      * Validate mongod server certificate against ca (mongod server >=2.4 with ssl support required)
      * @default true
      */
-    sslValidate?: boolean;
+    sslValidate?: boolean | undefined;
     /**
      * Server identity checking during SSL
      * @default true
      */
-    checkServerIdentity?: boolean | typeof checkServerIdentity;
+    checkServerIdentity?: boolean | typeof checkServerIdentity | undefined;
     /**
      * Array of valid certificates either as Buffers or Strings
      */
-    sslCA?: ReadonlyArray<Buffer | string>;
+    sslCA?: ReadonlyArray<Buffer | string> | undefined;
     /**
      * SSL Certificate revocation list binary buffer
      */
-    sslCRL?: ReadonlyArray<Buffer | string>;
+    sslCRL?: ReadonlyArray<Buffer | string> | undefined;
     /**
      * SSL Certificate binary buffer
      */
-    sslCert?: Buffer | string;
+    sslCert?: Buffer | string | undefined;
     /**
      * SSL Key file binary buffer
      */
-    sslKey?: Buffer | string;
+    sslKey?: Buffer | string | undefined;
     /**
      * SSL Certificate pass phrase
      */
-    sslPass?: Buffer | string;
+    sslPass?: Buffer | string | undefined;
     /**
      * String containing the server name requested via TLS SNI.
      */
-    servername?: string;
+    servername?: string | undefined;
 }
 
 export interface TLSOptions {
@@ -760,35 +760,35 @@ export interface TLSOptions {
      * Enable TLS connections
      * @default false
      */
-    tls?: boolean;
+    tls?: boolean | undefined;
     /**
      * Relax TLS constraints, disabling validation
      * @default false
      */
-    tlsInsecure?: boolean;
+    tlsInsecure?: boolean | undefined;
     /**
      * Path to file with either a single or bundle of certificate authorities
      * to be considered trusted when making a TLS connection
      */
-    tlsCAFile?: string;
+    tlsCAFile?: string | undefined;
     /**
      * Path to the client certificate file or the client private key file;
      * in the case that they both are needed, the files should be concatenated
      */
-    tlsCertificateKeyFile?: string;
+    tlsCertificateKeyFile?: string | undefined;
     /**
      * The password to decrypt the client private key to be used for TLS connections
      */
-    tlsCertificateKeyFilePassword?: string;
+    tlsCertificateKeyFilePassword?: string | undefined;
     /**
      * Specifies whether or not the driver should error when the server’s TLS certificate is invalid
      */
-    tlsAllowInvalidCertificates?: boolean;
+    tlsAllowInvalidCertificates?: boolean | undefined;
     /**
      * Specifies whether or not the driver should error when there is a mismatch between the server’s hostname
      * and the hostname specified by the TLS certificate
      */
-    tlsAllowInvalidHostnames?: boolean;
+    tlsAllowInvalidHostnames?: boolean | undefined;
 }
 
 export interface HighAvailabilityOptions {
@@ -796,27 +796,27 @@ export interface HighAvailabilityOptions {
      * Turn on high availability monitoring
      * @default true
      */
-    ha?: boolean;
+    ha?: boolean | undefined;
     /**
      * The High availability period for replicaset inquiry
      * @default 10000
      */
-    haInterval?: number;
+    haInterval?: number | undefined;
     /**
      * @default false
      */
-    domainsEnabled?: boolean;
+    domainsEnabled?: boolean | undefined;
 
     /**
      * The ReadPreference mode as listed
      * {@link https://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html here}
      */
-    readPreference?: ReadPreferenceOrMode;
+    readPreference?: ReadPreferenceOrMode | undefined;
     /**
      * An object representing read preference tags
      * @see https://docs.mongodb.com/v3.6/core/read-preference-tags/
      */
-    readPreferenceTags?: ReadPreferenceTags;
+    readPreferenceTags?: ReadPreferenceTags | undefined;
 }
 
 export type ReadPreferenceTags = ReadonlyArray<Record<string, string>>;
@@ -826,12 +826,12 @@ export type ReadPreferenceOptions = {
     /** Server mode in which the same query is dispatched in parallel to multiple replica set members. */
     hedge?: {
         /** Explicitly enable or disable hedged reads. */
-        enabled?: boolean;
-    };
+        enabled?: boolean | undefined;
+    } | undefined;
     /**
      * Max secondary read staleness in seconds, Minimum value is 90 seconds.
      */
-    maxStalenessSeconds?: number;
+    maxStalenessSeconds?: number | undefined;
 };
 
 /**
@@ -871,97 +871,97 @@ export interface DbCreateOptions extends CommonOptions {
     /**
      * If the database authentication is dependent on another databaseName.
      */
-    authSource?: string;
+    authSource?: string | undefined;
     /**
      * Force server to assign `_id` fields instead of driver
      * @default false
      */
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     /**
      * Use c++ bson parser
      * @default false
      */
-    native_parser?: boolean;
+    native_parser?: boolean | undefined;
     /**
      * Serialize functions on any object
      * @default false
      */
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     /**
      * Specify if the BSON serializer should ignore undefined fields
      * @default false
      */
-    ignoreUndefined?: boolean;
+    ignoreUndefined?: boolean | undefined;
     /**
      * Return document results as raw BSON buffers
      * @default false
      */
-    raw?: boolean;
+    raw?: boolean | undefined;
     /**
      * Promotes Long values to number if they fit inside the 53 bits resolution
      * @default true
      */
-    promoteLongs?: boolean;
+    promoteLongs?: boolean | undefined;
     /**
      * Promotes Binary BSON values to native Node Buffers
      * @default false
      */
-    promoteBuffers?: boolean;
+    promoteBuffers?: boolean | undefined;
     /**
      * Promotes BSON values to native types where possible, set to false to only receive wrapper types
      * @default true
      */
-    promoteValues?: boolean;
+    promoteValues?: boolean | undefined;
     /**
      * The preferred read preference. Use {@link ReadPreference} class.
      */
-    readPreference?: ReadPreferenceOrMode;
+    readPreference?: ReadPreferenceOrMode | undefined;
     /**
      * A primary key factory object for generation of custom `_id` keys.
      */
-    pkFactory?: object;
+    pkFactory?: object | undefined;
     /**
      * A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible
      */
-    promiseLibrary?: PromiseConstructor;
+    promiseLibrary?: PromiseConstructor | undefined;
     /**
      * @see https://docs.mongodb.com/v3.6/reference/read-concern/#read-concern
      * @since MongoDB 3.2
      */
-    readConcern?: ReadConcern | string;
+    readConcern?: ReadConcern | string | undefined;
     /**
      * Sets a cap on how many operations the driver will buffer up before giving up on getting a
      * working connection, default is -1 which is unlimited.
      */
-    bufferMaxEntries?: number;
+    bufferMaxEntries?: number | undefined;
 }
 
 export interface UnifiedTopologyOptions {
     /**
      * Enables the new unified topology layer
      */
-    useUnifiedTopology?: boolean;
+    useUnifiedTopology?: boolean | undefined;
 
     /**
      * **Only applies to the unified topology**
      * The size of the latency window for selecting among multiple suitable servers
      * @default 15
      */
-    localThresholdMS?: number;
+    localThresholdMS?: number | undefined;
 
     /**
      * With `useUnifiedTopology`, the MongoDB driver will try to find a server to send any given operation to
      * and keep retrying for `serverSelectionTimeoutMS` milliseconds.
      * @default 30000
      */
-    serverSelectionTimeoutMS?: number;
+    serverSelectionTimeoutMS?: number | undefined;
 
     /**
      * **Only applies to the unified topology**
      * The frequency with which topology updates are scheduled
      * @default 10000
      */
-    heartbeatFrequencyMS?: number;
+    heartbeatFrequencyMS?: number | undefined;
 
     /**
      *  **Only applies to the unified topology**
@@ -969,21 +969,21 @@ export interface UnifiedTopologyOptions {
      * This includes in use and available connections
      * @default 10
      */
-    maxPoolSize?: number;
+    maxPoolSize?: number | undefined;
 
     /**
      * **Only applies to the unified topology**
      * The minimum number of connections that MUST exist at any moment in a single connection pool
      * @default 0
      */
-    minPoolSize?: number;
+    minPoolSize?: number | undefined;
 
     /**
      * **Only applies to the unified topology**
      * The maximum amount of time a connection should remain idle in the connection pool before being marked idle
      * @default Infinity
      */
-    maxIdleTimeMS?: number;
+    maxIdleTimeMS?: number | undefined;
 
     /**
      * **Only applies to the unified topology**
@@ -991,7 +991,7 @@ export interface UnifiedTopologyOptions {
      * The default is 0 which means there is no limit.
      * @default 0
      */
-    waitQueueTimeoutMS?: number;
+    waitQueueTimeoutMS?: number | undefined;
 }
 
 /**
@@ -1004,27 +1004,27 @@ export interface SocketOptions {
      * Reconnect on error
      * @default true
      */
-    autoReconnect?: boolean;
+    autoReconnect?: boolean | undefined;
     /**
      * TCP Socket NoDelay option
      * @default true
      */
-    noDelay?: boolean;
+    noDelay?: boolean | undefined;
     /**
      * TCP KeepAlive enabled on the socket
      * @default true
      */
-    keepAlive?: boolean;
+    keepAlive?: boolean | undefined;
     /**
      * TCP KeepAlive initial delay before sending first keep-alive packet when idle
      * @default 30000
      */
-    keepAliveInitialDelay?: number;
+    keepAliveInitialDelay?: number | undefined;
     /**
      * TCP Connection timeout setting
      * @default 10000
      */
-    connectTimeoutMS?: number;
+    connectTimeoutMS?: number | undefined;
     /**
      * Version of IP stack. Can be 4, 6 or null
      * @default null
@@ -1032,12 +1032,12 @@ export interface SocketOptions {
      * If null, will attempt to connect with IPv6, and will fall back to IPv4 on failure
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html
      */
-    family?: 4 | 6 | null;
+    family?: 4 | 6 | null | undefined;
     /**
      * TCP Socket timeout setting
      * @default 360000
      */
-    socketTimeoutMS?: number;
+    socketTimeoutMS?: number | undefined;
 }
 
 /**
@@ -1053,43 +1053,43 @@ export interface ServerOptions extends SSLOptions {
      * reconnectFailed event.
      * @default 30
      */
-    reconnectTries?: number;
+    reconnectTries?: number | undefined;
     /**
      * Will wait # milliseconds between retries
      * @default 1000
      */
-    reconnectInterval?: number;
+    reconnectInterval?: number | undefined;
     /**
      * @default true
      */
-    monitoring?: boolean;
+    monitoring?: boolean | undefined;
 
     /**
      * Enable command monitoring for this client
      * @default false
      */
-    monitorCommands?: boolean;
+    monitorCommands?: boolean | undefined;
 
     /**
      * Socket Options
      */
-    socketOptions?: SocketOptions;
+    socketOptions?: SocketOptions | undefined;
 
     /**
      * The High availability period for replicaset inquiry
      * @default 10000
      */
-    haInterval?: number;
+    haInterval?: number | undefined;
     /**
      * @default false
      */
-    domainsEnabled?: boolean;
+    domainsEnabled?: boolean | undefined;
 
     /**
      * Specify a file sync write concern
      * @default false
      */
-    fsync?: boolean;
+    fsync?: boolean | undefined;
 }
 
 /**
@@ -1102,12 +1102,12 @@ export interface MongosOptions extends SSLOptions, HighAvailabilityOptions {
      * Cutoff latency point in MS for MongoS proxy selection
      * @default 15
      */
-    acceptableLatencyMS?: number;
+    acceptableLatencyMS?: number | undefined;
 
     /**
      * Socket Options
      */
-    socketOptions?: SocketOptions;
+    socketOptions?: SocketOptions | undefined;
 }
 
 /**
@@ -1119,27 +1119,27 @@ export interface ReplSetOptions extends SSLOptions, HighAvailabilityOptions {
     /**
      * The max staleness to secondary reads (values under 10 seconds cannot be guaranteed);
      */
-    maxStalenessSeconds?: number;
+    maxStalenessSeconds?: number | undefined;
     /**
      * The name of the replicaset to connect to.
      */
-    replicaSet?: string;
+    replicaSet?: string | undefined;
     /**
      * Range of servers to pick when using NEAREST (lowest ping ms + the latency fence, ex: range of 1 to (1 + 15) ms)
      * @default 15
      */
-    secondaryAcceptableLatencyMS?: number;
+    secondaryAcceptableLatencyMS?: number | undefined;
     /**
      * If the driver should connect even if no primary is available
      * @default false
      */
-    connectWithNoPrimary?: boolean;
+    connectWithNoPrimary?: boolean | undefined;
     /**
      * Optional socket options
      *
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Server.html
      */
-    socketOptions?: SocketOptions;
+    socketOptions?: SocketOptions | undefined;
 }
 
 export type ProfilingLevel = "off" | "slow_only" | "all";
@@ -1224,11 +1224,11 @@ export class Db extends EventEmitter {
     command(command: object, callback: MongoCallback<any>): void;
     command(
         command: object,
-        options?: { readPreference?: ReadPreferenceOrMode; session?: ClientSession },
+        options?: { readPreference?: ReadPreferenceOrMode | undefined; session?: ClientSession | undefined },
     ): Promise<any>;
     command(
         command: object,
-        options: { readPreference: ReadPreferenceOrMode; session?: ClientSession },
+        options: { readPreference: ReadPreferenceOrMode; session?: ClientSession | undefined },
         callback: MongoCallback<any>,
     ): void;
     /**
@@ -1297,11 +1297,11 @@ export class Db extends EventEmitter {
     executeDbAdminCommand(command: object, callback: MongoCallback<any>): void;
     executeDbAdminCommand(
         command: object,
-        options?: { readPreference?: ReadPreferenceOrMode; session?: ClientSession },
+        options?: { readPreference?: ReadPreferenceOrMode | undefined; session?: ClientSession | undefined },
     ): Promise<any>;
     executeDbAdminCommand(
         command: object,
-        options: { readPreference?: ReadPreferenceOrMode; session?: ClientSession },
+        options: { readPreference?: ReadPreferenceOrMode | undefined; session?: ClientSession | undefined },
         callback: MongoCallback<any>,
     ): void;
     /**
@@ -1314,10 +1314,10 @@ export class Db extends EventEmitter {
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#indexInformation
      */
     indexInformation(name: string, callback: MongoCallback<any>): void;
-    indexInformation(name: string, options?: { full?: boolean; readPreference?: ReadPreferenceOrMode }): Promise<any>;
+    indexInformation(name: string, options?: { full?: boolean | undefined; readPreference?: ReadPreferenceOrMode | undefined }): Promise<any>;
     indexInformation(
         name: string,
-        options: { full?: boolean; readPreference?: ReadPreferenceOrMode },
+        options: { full?: boolean | undefined; readPreference?: ReadPreferenceOrMode | undefined },
         callback: MongoCallback<any>,
     ): void;
     /**
@@ -1330,10 +1330,10 @@ export class Db extends EventEmitter {
     listCollections(
         filter?: object,
         options?: {
-            nameOnly?: boolean;
-            batchSize?: number;
-            readPreference?: ReadPreferenceOrMode;
-            session?: ClientSession;
+            nameOnly?: boolean | undefined;
+            batchSize?: number | undefined;
+            readPreference?: ReadPreferenceOrMode | undefined;
+            session?: ClientSession | undefined;
         },
     ): CommandCursor;
     /**
@@ -1343,8 +1343,8 @@ export class Db extends EventEmitter {
      * @deprecated Query the system.profile collection directly.
      */
     profilingInfo(callback: MongoCallback<any>): void;
-    profilingInfo(options?: { session?: ClientSession }): Promise<void>;
-    profilingInfo(options: { session?: ClientSession }, callback: MongoCallback<void>): void;
+    profilingInfo(options?: { session?: ClientSession | undefined }): Promise<void>;
+    profilingInfo(options: { session?: ClientSession | undefined }, callback: MongoCallback<void>): void;
     /**
      * Retrieve the current profiling Level for MongoDB
      *
@@ -1354,8 +1354,8 @@ export class Db extends EventEmitter {
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#profilingLevel
      */
     profilingLevel(callback: MongoCallback<ProfilingLevel>): void;
-    profilingLevel(options?: { session?: ClientSession }): Promise<ProfilingLevel>;
-    profilingLevel(options: { session?: ClientSession }, callback: MongoCallback<ProfilingLevel>): void;
+    profilingLevel(options?: { session?: ClientSession | undefined }): Promise<ProfilingLevel>;
+    profilingLevel(options: { session?: ClientSession | undefined }, callback: MongoCallback<ProfilingLevel>): void;
     /**
      * Remove a user from a database
      *
@@ -1386,12 +1386,12 @@ export class Db extends EventEmitter {
     renameCollection<TSchema = DefaultSchema>(
         fromCollection: string,
         toCollection: string,
-        options?: { dropTarget?: boolean },
+        options?: { dropTarget?: boolean | undefined },
     ): Promise<Collection<TSchema>>;
     renameCollection<TSchema = DefaultSchema>(
         fromCollection: string,
         toCollection: string,
-        options: { dropTarget?: boolean },
+        options: { dropTarget?: boolean | undefined },
         callback: MongoCallback<Collection<TSchema>>,
     ): void;
     /**
@@ -1404,10 +1404,10 @@ export class Db extends EventEmitter {
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#setProfilingLevel
      */
     setProfilingLevel(level: ProfilingLevel, callback: MongoCallback<ProfilingLevel>): void;
-    setProfilingLevel(level: ProfilingLevel, options?: { session?: ClientSession }): Promise<ProfilingLevel>;
+    setProfilingLevel(level: ProfilingLevel, options?: { session?: ClientSession | undefined }): Promise<ProfilingLevel>;
     setProfilingLevel(
         level: ProfilingLevel,
-        options: { session?: ClientSession },
+        options: { session?: ClientSession | undefined },
         callback: MongoCallback<ProfilingLevel>,
     ): void;
     /**
@@ -1419,8 +1419,8 @@ export class Db extends EventEmitter {
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#stats
      */
     stats(callback: MongoCallback<any>): void;
-    stats(options?: { scale?: number }): Promise<any>;
-    stats(options: { scale?: number }, callback: MongoCallback<any>): void;
+    stats(options?: { scale?: number | undefined }): Promise<any>;
+    stats(options: { scale?: number | undefined }, callback: MongoCallback<any>): void;
     /**
      * Unref all sockets
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#unref
@@ -1438,13 +1438,13 @@ export class Db extends EventEmitter {
      */
     watch<TSchema extends object = { _id: ObjectId }>(
         pipeline?: object[],
-        options?: ChangeStreamOptions & { session?: ClientSession },
+        options?: ChangeStreamOptions & { session?: ClientSession | undefined },
     ): ChangeStream<TSchema>;
 }
 
 export interface CommonOptions extends WriteConcern {
-    session?: ClientSession;
-    writeConcern?: WriteConcern | string;
+    session?: ClientSession | undefined;
+    writeConcern?: WriteConcern | string | undefined;
 }
 
 /**
@@ -1497,8 +1497,8 @@ export class Mongos extends EventEmitter {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#addUser
  */
 export interface DbAddUserOptions extends CommonOptions {
-    customData?: object;
-    roles?: object[];
+    customData?: object | undefined;
+    roles?: object[] | undefined;
 }
 
 /**
@@ -1507,31 +1507,31 @@ export interface DbAddUserOptions extends CommonOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#createCollection
  */
 export interface CollectionCreateOptions extends CommonOptions {
-    raw?: boolean;
-    pkFactory?: object;
-    readPreference?: ReadPreferenceOrMode;
-    serializeFunctions?: boolean;
+    raw?: boolean | undefined;
+    pkFactory?: object | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
+    serializeFunctions?: boolean | undefined;
     /**
      * @deprecated
      * @see https://jira.mongodb.org/browse/NODE-2746
      */
-    strict?: boolean;
-    capped?: boolean;
+    strict?: boolean | undefined;
+    capped?: boolean | undefined;
     /**
      * @deprecated
      */
-    autoIndexId?: boolean;
-    size?: number;
-    max?: number;
-    flags?: number;
-    storageEngine?: object;
-    validator?: object;
-    validationLevel?: "off" | "strict" | "moderate";
-    validationAction?: "error" | "warn";
-    indexOptionDefaults?: object;
-    viewOn?: string;
-    pipeline?: any[];
-    collation?: CollationDocument;
+    autoIndexId?: boolean | undefined;
+    size?: number | undefined;
+    max?: number | undefined;
+    flags?: number | undefined;
+    storageEngine?: object | undefined;
+    validator?: object | undefined;
+    validationLevel?: "off" | "strict" | "moderate" | undefined;
+    validationAction?: "error" | "warn" | undefined;
+    indexOptionDefaults?: object | undefined;
+    viewOn?: string | undefined;
+    pipeline?: any[] | undefined;
+    collation?: CollationDocument | undefined;
 }
 
 /**
@@ -1540,12 +1540,12 @@ export interface CollectionCreateOptions extends CommonOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#collection
  */
 export interface DbCollectionOptions extends CommonOptions {
-    raw?: boolean;
-    pkFactory?: object;
-    readPreference?: ReadPreferenceOrMode;
-    serializeFunctions?: boolean;
-    strict?: boolean;
-    readConcern?: ReadConcern;
+    raw?: boolean | undefined;
+    pkFactory?: object | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
+    serializeFunctions?: boolean | undefined;
+    strict?: boolean | undefined;
+    readConcern?: ReadConcern | undefined;
 }
 
 /**
@@ -1557,48 +1557,48 @@ export interface IndexOptions extends CommonOptions {
     /**
      * Creates an unique index.
      */
-    unique?: boolean;
+    unique?: boolean | undefined;
     /**
      * Creates a sparse index.
      */
-    sparse?: boolean;
+    sparse?: boolean | undefined;
     /**
      * Creates the index in the background, yielding whenever possible.
      */
-    background?: boolean;
+    background?: boolean | undefined;
     /**
      * A unique index cannot be created on a key that has pre-existing duplicate values.
      *
      * If you would like to create the index anyway, keeping the first document the database indexes and
      * deleting all subsequent documents that have duplicate value
      */
-    dropDups?: boolean;
+    dropDups?: boolean | undefined;
     /**
      * For geo spatial indexes set the lower bound for the co-ordinates.
      */
-    min?: number;
+    min?: number | undefined;
     /**
      * For geo spatial indexes set the high bound for the co-ordinates.
      */
-    max?: number;
+    max?: number | undefined;
     /**
      * Specify the format version of the indexes.
      */
-    v?: number;
+    v?: number | undefined;
     /**
      * Allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher)
      */
-    expireAfterSeconds?: number;
+    expireAfterSeconds?: number | undefined;
     /**
      * Override the auto generated index name (useful if the resulting name is larger than 128 bytes)
      */
-    name?: string;
+    name?: string | undefined;
     /**
      * Creates a partial index based on the given filter object (MongoDB 3.2 or higher)
      */
     partialFilterExpression?: any;
-    collation?: CollationDocument;
-    default_language?: string;
+    collation?: CollationDocument | undefined;
+    default_language?: string | undefined;
 }
 
 /**
@@ -1629,8 +1629,8 @@ export interface Admin {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#buildInfo
      */
-    buildInfo(options?: { session?: ClientSession }): Promise<any>;
-    buildInfo(options: { session?: ClientSession }, callback: MongoCallback<any>): void;
+    buildInfo(options?: { session?: ClientSession | undefined }): Promise<any>;
+    buildInfo(options: { session?: ClientSession | undefined }, callback: MongoCallback<any>): void;
     buildInfo(callback: MongoCallback<any>): void;
     /**
      * Execute a command
@@ -1642,10 +1642,10 @@ export interface Admin {
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#command
      */
     command(command: object, callback: MongoCallback<any>): void;
-    command(command: object, options?: { readPreference?: ReadPreferenceOrMode; maxTimeMS?: number }): Promise<any>;
+    command(command: object, options?: { readPreference?: ReadPreferenceOrMode | undefined; maxTimeMS?: number | undefined }): Promise<any>;
     command(
         command: object,
-        options: { readPreference?: ReadPreferenceOrMode; maxTimeMS?: number },
+        options: { readPreference?: ReadPreferenceOrMode | undefined; maxTimeMS?: number | undefined },
         callback: MongoCallback<any>,
     ): void;
     /**
@@ -1656,8 +1656,8 @@ export interface Admin {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#listDatabases
      */
-    listDatabases(options?: { nameOnly?: boolean; session?: ClientSession }): Promise<any>;
-    listDatabases(options: { nameOnly?: boolean; session?: ClientSession }, callback: MongoCallback<any>): void;
+    listDatabases(options?: { nameOnly?: boolean | undefined; session?: ClientSession | undefined }): Promise<any>;
+    listDatabases(options: { nameOnly?: boolean | undefined; session?: ClientSession | undefined }, callback: MongoCallback<any>): void;
     listDatabases(callback: MongoCallback<any>): void;
     /**
      * Ping the MongoDB server and retrieve results
@@ -1667,8 +1667,8 @@ export interface Admin {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#ping
      */
-    ping(options?: { session?: ClientSession }): Promise<any>;
-    ping(options: { session?: ClientSession }, callback: MongoCallback<any>): void;
+    ping(options?: { session?: ClientSession | undefined }): Promise<any>;
+    ping(options: { session?: ClientSession | undefined }, callback: MongoCallback<any>): void;
     ping(callback: MongoCallback<any>): void;
     /**
      * Remove a user from a database
@@ -1690,8 +1690,8 @@ export interface Admin {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#replSetGetStatus
      */
-    replSetGetStatus(options?: { session?: ClientSession }): Promise<any>;
-    replSetGetStatus(options: { session?: ClientSession }, callback: MongoCallback<any>): void;
+    replSetGetStatus(options?: { session?: ClientSession | undefined }): Promise<any>;
+    replSetGetStatus(options: { session?: ClientSession | undefined }, callback: MongoCallback<any>): void;
     replSetGetStatus(callback: MongoCallback<any>): void;
     /**
      * Retrieve the server information for the current instance of the db client
@@ -1711,8 +1711,8 @@ export interface Admin {
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#serverStatus
      */
-    serverStatus(options?: { session?: ClientSession }): Promise<any>;
-    serverStatus(options: { session?: ClientSession }, callback: MongoCallback<any>): void;
+    serverStatus(options?: { session?: ClientSession | undefined }): Promise<any>;
+    serverStatus(options: { session?: ClientSession | undefined }, callback: MongoCallback<any>): void;
     serverStatus(callback: MongoCallback<any>): void;
     /**
      * Validate an existing collection
@@ -1735,8 +1735,8 @@ export interface Admin {
  */
 export interface AddUserOptions extends CommonOptions {
     fsync: boolean;
-    customData?: object;
-    roles?: object[];
+    customData?: object | undefined;
+    roles?: object[] | undefined;
 }
 
 /**
@@ -1745,7 +1745,7 @@ export interface AddUserOptions extends CommonOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Admin.html#removeUser
  */
 export interface FSyncOptions extends CommonOptions {
-    fsync?: boolean;
+    fsync?: boolean | undefined;
 }
 
 // TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions
@@ -1766,7 +1766,7 @@ type ExtractIdType<TSchema> = TSchema extends { _id: infer U } // user has defin
 // this makes _id optional
 export type OptionalId<TSchema extends { _id?: any }> = ObjectId extends TSchema["_id"]
     ? // a Schema with ObjectId _id type or "any" or "indexed type" provided
-      EnhancedOmit<TSchema, "_id"> & { _id?: ExtractIdType<TSchema> }
+      EnhancedOmit<TSchema, "_id"> & { _id?: ExtractIdType<TSchema> | undefined }
     : // a Schema provided but _id type is not ObjectId
       WithId<TSchema>;
 
@@ -1888,10 +1888,10 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#createIndexes
      */
     createIndexes(indexSpecs: IndexSpecification[], callback: MongoCallback<any>): void;
-    createIndexes(indexSpecs: IndexSpecification[], options?: { session?: ClientSession }): Promise<any>;
+    createIndexes(indexSpecs: IndexSpecification[], options?: { session?: ClientSession | undefined }): Promise<any>;
     createIndexes(
         indexSpecs: IndexSpecification[],
-        options: { session?: ClientSession },
+        options: { session?: ClientSession | undefined },
         callback: MongoCallback<any>,
     ): void;
     /**
@@ -1922,11 +1922,11 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     deleteOne(filter: FilterQuery<TSchema>, callback: MongoCallback<DeleteWriteOpResultObject>): void;
     deleteOne(
         filter: FilterQuery<TSchema>,
-        options?: CommonOptions & { bypassDocumentValidation?: boolean },
+        options?: CommonOptions & { bypassDocumentValidation?: boolean | undefined },
     ): Promise<DeleteWriteOpResultObject>;
     deleteOne(
         filter: FilterQuery<TSchema>,
-        options: CommonOptions & { bypassDocumentValidation?: boolean },
+        options: CommonOptions & { bypassDocumentValidation?: boolean | undefined },
         callback: MongoCallback<DeleteWriteOpResultObject>,
     ): void;
     /**
@@ -1989,8 +1989,8 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#dropIndex
      */
     dropIndex(indexName: string, callback: MongoCallback<any>): void;
-    dropIndex(indexName: string, options?: CommonOptions & { maxTimeMS?: number }): Promise<any>;
-    dropIndex(indexName: string, options: CommonOptions & { maxTimeMS?: number }, callback: MongoCallback<any>): void;
+    dropIndex(indexName: string, options?: CommonOptions & { maxTimeMS?: number | undefined }): Promise<any>;
+    dropIndex(indexName: string, options: CommonOptions & { maxTimeMS?: number | undefined }, callback: MongoCallback<any>): void;
     /**
      * Drops all indexes from this collection.
      *
@@ -1999,9 +1999,9 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @returns Promise if no callback is passed
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#dropIndexes
      */
-    dropIndexes(options?: { session?: ClientSession; maxTimeMS?: number }): Promise<any>;
+    dropIndexes(options?: { session?: ClientSession | undefined; maxTimeMS?: number | undefined }): Promise<any>;
     dropIndexes(callback?: MongoCallback<any>): void;
-    dropIndexes(options: { session?: ClientSession; maxTimeMS?: number }, callback: MongoCallback<any>): void;
+    dropIndexes(options: { session?: ClientSession | undefined; maxTimeMS?: number | undefined }, callback: MongoCallback<any>): void;
     /**
      * Gets an estimate of the count of documents in a collection using collection metadata.
      *
@@ -2175,7 +2175,7 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
         reduce: Function | Code,
         finalize: Function | Code,
         command: boolean,
-        options?: { readPreference?: ReadPreferenceOrMode; session?: ClientSession },
+        options?: { readPreference?: ReadPreferenceOrMode | undefined; session?: ClientSession | undefined },
     ): Promise<any>;
     group(
         keys: object | any[] | Function | Code,
@@ -2185,8 +2185,8 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
         finalize: Function | Code,
         command: boolean,
         options: {
-            readPreference?: ReadPreferenceOrMode;
-            session?: ClientSession;
+            readPreference?: ReadPreferenceOrMode | undefined;
+            session?: ClientSession | undefined;
         },
         callback: MongoCallback<any>,
     ): void;
@@ -2200,7 +2200,7 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      */
     indexes(options?: { session: ClientSession }): Promise<any>;
     indexes(callback: MongoCallback<any>): void;
-    indexes(options: { session?: ClientSession }, callback: MongoCallback<any>): void;
+    indexes(options: { session?: ClientSession | undefined }, callback: MongoCallback<any>): void;
     /**
      * Checks if one or more indexes exist on the collection, fails on first non-existing index
      *
@@ -2324,9 +2324,9 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#listIndexes
      */
     listIndexes(options?: {
-        batchSize?: number;
-        readPreference?: ReadPreferenceOrMode;
-        session?: ClientSession;
+        batchSize?: number | undefined;
+        readPreference?: ReadPreferenceOrMode | undefined;
+        session?: ClientSession | undefined;
     }): CommandCursor;
     /**
      * Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection.
@@ -2401,10 +2401,10 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @deprecated Use use deleteOne, deleteMany or bulkWrite
      */
     remove(selector: object, callback: MongoCallback<WriteOpResult>): void;
-    remove(selector: object, options?: CommonOptions & { single?: boolean }): Promise<WriteOpResult>;
+    remove(selector: object, options?: CommonOptions & { single?: boolean | undefined }): Promise<WriteOpResult>;
     remove(
         selector: object,
-        options?: CommonOptions & { single?: boolean },
+        options?: CommonOptions & { single?: boolean | undefined },
         callback?: MongoCallback<WriteOpResult>,
     ): void;
     /**
@@ -2417,10 +2417,10 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#rename
      */
     rename(newName: string, callback: MongoCallback<Collection<TSchema>>): void;
-    rename(newName: string, options?: { dropTarget?: boolean; session?: ClientSession }): Promise<Collection<TSchema>>;
+    rename(newName: string, options?: { dropTarget?: boolean | undefined; session?: ClientSession | undefined }): Promise<Collection<TSchema>>;
     rename(
         newName: string,
-        options: { dropTarget?: boolean; session?: ClientSession },
+        options: { dropTarget?: boolean | undefined; session?: ClientSession | undefined },
         callback: MongoCallback<Collection<TSchema>>,
     ): void;
     /**
@@ -2464,8 +2464,8 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#stats
      */
     stats(callback: MongoCallback<CollStats>): void;
-    stats(options?: { scale: number; session?: ClientSession }): Promise<CollStats>;
-    stats(options: { scale: number; session?: ClientSession }, callback: MongoCallback<CollStats>): void;
+    stats(options?: { scale: number; session?: ClientSession | undefined }): Promise<CollStats>;
+    stats(options: { scale: number; session?: ClientSession | undefined }, callback: MongoCallback<CollStats>): void;
     /**
      * Updates documents
      *
@@ -2485,12 +2485,12 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     update(
         filter: FilterQuery<TSchema>,
         update: UpdateQuery<TSchema> | Partial<TSchema>,
-        options?: UpdateOneOptions & { multi?: boolean },
+        options?: UpdateOneOptions & { multi?: boolean | undefined },
     ): Promise<WriteOpResult>;
     update(
         filter: FilterQuery<TSchema>,
         update: UpdateQuery<TSchema> | Partial<TSchema>,
-        options: UpdateOneOptions & { multi?: boolean },
+        options: UpdateOneOptions & { multi?: boolean | undefined },
         callback: MongoCallback<WriteOpResult>,
     ): void;
     /**
@@ -2555,9 +2555,9 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
      */
     watch<T = TSchema>(
         pipeline?: object[],
-        options?: ChangeStreamOptions & { session?: ClientSession },
+        options?: ChangeStreamOptions & { session?: ClientSession | undefined },
     ): ChangeStream<T>;
-    watch<T = TSchema>(options?: ChangeStreamOptions & { session?: ClientSession }): ChangeStream<T>;
+    watch<T = TSchema>(options?: ChangeStreamOptions & { session?: ClientSession | undefined }): ChangeStream<T>;
 }
 
 /** Update Query */
@@ -2617,7 +2617,7 @@ export type MetaProjectionOperators =
 
 export type SchemaMember<T, V> = { [P in keyof T]?: V } | { [key: string]: V };
 
-export type SortOptionObject<T> = SchemaMember<T, number | { $meta?: MetaSortOperators }>;
+export type SortOptionObject<T> = SchemaMember<T, number | { $meta?: MetaSortOperators | undefined }>;
 
 export type AddToSetOperators<Type> = {
     $each: Type;
@@ -2625,9 +2625,9 @@ export type AddToSetOperators<Type> = {
 
 export type ArrayOperator<Type> = {
     $each: Type;
-    $slice?: number;
-    $position?: number;
-    $sort?: SortValues | Record<string, SortValues>;
+    $slice?: number | undefined;
+    $position?: number | undefined;
+    $sort?: SortValues | Record<string, SortValues> | undefined;
 };
 
 export type SetFields<TSchema> = ({
@@ -2690,25 +2690,25 @@ export type PullAllOperator<TSchema> = ({
  *
  */
 export type UpdateQuery<TSchema> = {
-    $currentDate?: OnlyFieldsOfType<TSchema, Date | Timestamp, true | { $type: "date" | "timestamp" }>;
-    $inc?: OnlyFieldsOfType<TSchema, NumericTypes | undefined>;
-    $min?: MatchKeysAndValues<TSchema>;
-    $max?: MatchKeysAndValues<TSchema>;
-    $mul?: OnlyFieldsOfType<TSchema, NumericTypes | undefined>;
-    $rename?: { [key: string]: string };
-    $set?: MatchKeysAndValues<TSchema>;
-    $setOnInsert?: MatchKeysAndValues<TSchema>;
-    $unset?: OnlyFieldsOfType<TSchema, any, "" | 1 | true>;
+    $currentDate?: OnlyFieldsOfType<TSchema, Date | Timestamp, true | { $type: "date" | "timestamp" }> | undefined;
+    $inc?: OnlyFieldsOfType<TSchema, NumericTypes | undefined> | undefined;
+    $min?: MatchKeysAndValues<TSchema> | undefined;
+    $max?: MatchKeysAndValues<TSchema> | undefined;
+    $mul?: OnlyFieldsOfType<TSchema, NumericTypes | undefined> | undefined;
+    $rename?: { [key: string]: string } | undefined;
+    $set?: MatchKeysAndValues<TSchema> | undefined;
+    $setOnInsert?: MatchKeysAndValues<TSchema> | undefined;
+    $unset?: OnlyFieldsOfType<TSchema, any, "" | 1 | true> | undefined;
 
-    $addToSet?: SetFields<TSchema>;
-    $pop?: OnlyFieldsOfType<TSchema, ReadonlyArray<any>, 1 | -1>;
-    $pull?: PullOperator<TSchema>;
-    $push?: PushOperator<TSchema>;
-    $pullAll?: PullAllOperator<TSchema>;
+    $addToSet?: SetFields<TSchema> | undefined;
+    $pop?: OnlyFieldsOfType<TSchema, ReadonlyArray<any>, 1 | -1> | undefined;
+    $pull?: PullOperator<TSchema> | undefined;
+    $push?: PushOperator<TSchema> | undefined;
+    $pullAll?: PullAllOperator<TSchema> | undefined;
 
     $bit?: {
         [key: string]: { [key in "and" | "or" | "xor"]?: number };
-    };
+    } | undefined;
 };
 
 /**
@@ -2831,66 +2831,66 @@ type MongoAltQuery<T> = T extends ReadonlyArray<infer U> ? T | RegExpForString<U
  */
 export type QuerySelector<T> = {
     // Comparison
-    $eq?: T;
-    $gt?: T;
-    $gte?: T;
-    $in?: T[];
-    $lt?: T;
-    $lte?: T;
-    $ne?: T;
-    $nin?: T[];
+    $eq?: T | undefined;
+    $gt?: T | undefined;
+    $gte?: T | undefined;
+    $in?: T[] | undefined;
+    $lt?: T | undefined;
+    $lte?: T | undefined;
+    $ne?: T | undefined;
+    $nin?: T[] | undefined;
     // Logical
-    $not?: T extends string ? QuerySelector<T> | RegExp : QuerySelector<T>;
+    $not?: T extends string ? QuerySelector<T> | RegExp : QuerySelector<T> | undefined;
     // Element
     /**
      * When `true`, `$exists` matches the documents that contain the field,
      * including documents where the field value is null.
      */
-    $exists?: boolean;
-    $type?: BSONType | BSONTypeAlias;
+    $exists?: boolean | undefined;
+    $type?: BSONType | BSONTypeAlias | undefined;
     // Evaluation
     $expr?: any;
     $jsonSchema?: any;
-    $mod?: T extends number ? [number, number] : never;
-    $regex?: T extends string ? RegExp | string : never;
-    $options?: T extends string ? string : never;
+    $mod?: T extends number ? [number, number] : never | undefined;
+    $regex?: T extends string ? RegExp | string : never | undefined;
+    $options?: T extends string ? string : never | undefined;
     // Geospatial
     // TODO: define better types for geo queries
-    $geoIntersects?: { $geometry: object };
-    $geoWithin?: object;
-    $near?: object;
-    $nearSphere?: object;
-    $maxDistance?: number;
+    $geoIntersects?: { $geometry: object } | undefined;
+    $geoWithin?: object | undefined;
+    $near?: object | undefined;
+    $nearSphere?: object | undefined;
+    $maxDistance?: number | undefined;
     // Array
     // TODO: define better types for $all and $elemMatch
-    $all?: T extends ReadonlyArray<infer U> ? any[] : never;
-    $elemMatch?: T extends ReadonlyArray<infer U> ? object : never;
-    $size?: T extends ReadonlyArray<infer U> ? number : never;
+    $all?: T extends ReadonlyArray<infer U> ? any[] : never | undefined;
+    $elemMatch?: T extends ReadonlyArray<infer U> ? object : never | undefined;
+    $size?: T extends ReadonlyArray<infer U> ? number : never | undefined;
     // Bitwise
-    $bitsAllClear?: BitwiseQuery;
-    $bitsAllSet?: BitwiseQuery;
-    $bitsAnyClear?: BitwiseQuery;
-    $bitsAnySet?: BitwiseQuery;
+    $bitsAllClear?: BitwiseQuery | undefined;
+    $bitsAllSet?: BitwiseQuery | undefined;
+    $bitsAnyClear?: BitwiseQuery | undefined;
+    $bitsAnySet?: BitwiseQuery | undefined;
 };
 
 export type RootQuerySelector<T> = {
     /** @see https://docs.mongodb.com/v3.6/reference/operator/query/and/#op._S_and */
-    $and?: Array<FilterQuery<T>>;
+    $and?: Array<FilterQuery<T>> | undefined;
     /** @see https://docs.mongodb.com/v3.6/reference/operator/query/nor/#op._S_nor */
-    $nor?: Array<FilterQuery<T>>;
+    $nor?: Array<FilterQuery<T>> | undefined;
     /** @see https://docs.mongodb.com/v3.6/reference/operator/query/or/#op._S_or */
-    $or?: Array<FilterQuery<T>>;
+    $or?: Array<FilterQuery<T>> | undefined;
     /** @see https://docs.mongodb.com/v3.6/reference/operator/query/text */
     $text?: {
         $search: string;
-        $language?: string;
-        $caseSensitive?: boolean;
-        $diacriticSensitive?: boolean;
-    };
+        $language?: string | undefined;
+        $caseSensitive?: boolean | undefined;
+        $diacriticSensitive?: boolean | undefined;
+    } | undefined;
     /** @see https://docs.mongodb.com/v3.6/reference/operator/query/where/#op._S_where */
-    $where?: string | Function;
+    $where?: string | Function | undefined;
     /** @see https://docs.mongodb.com/v3.6/reference/operator/query/comment/#op._S_comment */
-    $comment?: string;
+    $comment?: string | undefined;
     // we could not find a proper TypeScript generic to support nested queries e.g. 'user.friends.name'
     // this will mark all unrecognized properties as any (including nested queries)
     [key: string]: any;
@@ -2925,11 +2925,11 @@ export type BulkWriteInsertOneOperation<TSchema> = {
  * @see https://docs.mongodb.com/v3.6/reference/method/db.collection.bulkWrite/#updateone-and-updatemany
  */
 export type BulkWriteUpdateOperation<TSchema> = {
-    arrayFilters?: object[];
-    collation?: object;
+    arrayFilters?: object[] | undefined;
+    collation?: object | undefined;
     filter: FilterQuery<TSchema>;
     update: UpdateQuery<TSchema>;
-    upsert?: boolean;
+    upsert?: boolean | undefined;
 };
 export type BulkWriteUpdateOneOperation<TSchema> = {
     updateOne: BulkWriteUpdateOperation<TSchema>;
@@ -2952,10 +2952,10 @@ export type BulkWriteUpdateManyOperation<TSchema> = {
  */
 export type BulkWriteReplaceOneOperation<TSchema> = {
     replaceOne: {
-        collation?: object;
+        collation?: object | undefined;
         filter: FilterQuery<TSchema>;
         replacement: TSchema;
-        upsert?: boolean;
+        upsert?: boolean | undefined;
     };
 };
 
@@ -2967,7 +2967,7 @@ export type BulkWriteReplaceOneOperation<TSchema> = {
  * @see https://docs.mongodb.com/v3.6/reference/method/db.collection.bulkWrite/#deleteone-and-deletemany
  */
 export type BulkWriteDeleteOperation<TSchema> = {
-    collation?: object;
+    collation?: object | undefined;
     filter: FilterQuery<TSchema>;
 };
 export type BulkWriteDeleteOneOperation<TSchema> = {
@@ -3035,7 +3035,7 @@ export interface CollStats {
     /**
      * A number that indicates the user-set flags on the collection. userFlags only appears when using the mmapv1 storage engine.
      */
-    userFlags?: number;
+    userFlags?: number | undefined;
     /**
      * Total index size in bytes.
      */
@@ -3059,7 +3059,7 @@ export interface CollStats {
      * The maximum size of a capped collection.
      */
     maxSize: number;
-    wiredTiger?: WiredTigerData;
+    wiredTiger?: WiredTigerData | undefined;
     indexDetails?: any;
     ok: number;
 }
@@ -3209,38 +3209,38 @@ export interface CollectionAggregationOptions {
     /**
      * The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
      */
-    readPreference?: ReadPreferenceOrMode;
+    readPreference?: ReadPreferenceOrMode | undefined;
     /**
      * Return the query as cursor, on 2.6 > it returns as a real cursor
      * on pre 2.6 it returns as an emulated cursor.
      */
-    cursor?: { batchSize?: number };
+    cursor?: { batchSize?: number | undefined } | undefined;
     /**
      * Explain returns the aggregation execution plan (requires mongodb 2.6 >).
      */
-    explain?: boolean;
+    explain?: boolean | undefined;
     /**
      * Lets the server know if it can use disk to store
      * temporary results for the aggregation (requires mongodb 2.6 >).
      */
-    allowDiskUse?: boolean;
+    allowDiskUse?: boolean | undefined;
     /**
      * specifies a cumulative time limit in milliseconds for processing operations
      * on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
      */
-    maxTimeMS?: number;
+    maxTimeMS?: number | undefined;
     /**
      * Allow driver to bypass schema validation in MongoDB 3.2 or higher.
      */
-    bypassDocumentValidation?: boolean;
-    hint?: string | object;
-    raw?: boolean;
-    promoteLongs?: boolean;
-    promoteValues?: boolean;
-    promoteBuffers?: boolean;
-    collation?: CollationDocument;
-    comment?: string;
-    session?: ClientSession;
+    bypassDocumentValidation?: boolean | undefined;
+    hint?: string | object | undefined;
+    raw?: boolean | undefined;
+    promoteLongs?: boolean | undefined;
+    promoteValues?: boolean | undefined;
+    promoteBuffers?: boolean | undefined;
+    collation?: CollationDocument | undefined;
+    comment?: string | undefined;
+    session?: ClientSession | undefined;
 }
 
 /**
@@ -3252,19 +3252,19 @@ export interface CollectionInsertManyOptions extends CommonOptions {
     /**
      * Serialize functions on any object.
      */
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     /**
      * Force server to assign _id values instead of driver.
      */
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     /**
      * Allow driver to bypass schema validation in MongoDB 3.2 or higher.
      */
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
     /**
      * If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
      */
-    ordered?: boolean;
+    ordered?: boolean | undefined;
 }
 
 /**
@@ -3276,17 +3276,17 @@ export interface CollectionBulkWriteOptions extends CommonOptions {
     /**
      * Serialize functions on any object.
      */
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     /**
      * Execute write operation in ordered or unordered fashion.
      */
-    ordered?: boolean;
+    ordered?: boolean | undefined;
     /**
      * Allow driver to bypass schema validation in MongoDB 3.2 or higher.
      */
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
     //Force server to assign _id values instead of driver.
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
 }
 
 /**
@@ -3295,13 +3295,13 @@ export interface CollectionBulkWriteOptions extends CommonOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#~BulkWriteOpResult
  */
 export interface BulkWriteOpResultObject {
-    insertedCount?: number;
-    matchedCount?: number;
-    modifiedCount?: number;
-    deletedCount?: number;
-    upsertedCount?: number;
-    insertedIds?: { [index: number]: any };
-    upsertedIds?: { [index: number]: any };
+    insertedCount?: number | undefined;
+    matchedCount?: number | undefined;
+    modifiedCount?: number | undefined;
+    deletedCount?: number | undefined;
+    upsertedCount?: number | undefined;
+    insertedIds?: { [index: number]: any } | undefined;
+    upsertedIds?: { [index: number]: any } | undefined;
     result?: any;
 }
 
@@ -3314,27 +3314,27 @@ export interface MongoCountPreferences {
     /**
      * The limit of documents to count.
      */
-    limit?: number;
+    limit?: number | undefined;
     /**
      * The number of documents to skip for the count.
      */
-    skip?: number;
+    skip?: number | undefined;
     /**
      * An index name hint for the query.
      */
-    hint?: string;
+    hint?: string | undefined;
     /**
      * The preferred read preference
      */
-    readPreference?: ReadPreferenceOrMode;
+    readPreference?: ReadPreferenceOrMode | undefined;
     /**
      * Number of miliseconds to wait before aborting the query.
      */
-    maxTimeMS?: number;
+    maxTimeMS?: number | undefined;
     /**
      * Optional session to use for this operation
      */
-    session?: ClientSession;
+    session?: ClientSession | undefined;
 }
 
 /**
@@ -3346,15 +3346,15 @@ export interface MongoDistinctPreferences {
     /**
      * The preferred read preference
      */
-    readPreference?: ReadPreferenceOrMode;
+    readPreference?: ReadPreferenceOrMode | undefined;
     /**
      * Number of miliseconds to wait before aborting the query.
      */
-    maxTimeMS?: number;
+    maxTimeMS?: number | undefined;
     /**
      * Optional session to use for this operation
      */
-    session?: ClientSession;
+    session?: ClientSession | undefined;
 }
 
 /**
@@ -3366,14 +3366,14 @@ export interface DeleteWriteOpResultObject {
     //The raw result returned from MongoDB, field will vary depending on server version.
     result: {
         //Is 1 if the command executed correctly.
-        ok?: number;
+        ok?: number | undefined;
         //The total count of documents deleted.
-        n?: number;
+        n?: number | undefined;
     };
     //The connection object used for the operation.
     connection?: any;
     //The number of documents deleted.
-    deletedCount?: number;
+    deletedCount?: number | undefined;
 }
 
 /**
@@ -3383,11 +3383,11 @@ export interface DeleteWriteOpResultObject {
  */
 export interface FindAndModifyWriteOpResultObject<TSchema> {
     //Document returned from findAndModify command.
-    value?: TSchema;
+    value?: TSchema | undefined;
     //The raw lastErrorObject returned from the command.
     lastErrorObject?: any;
     //Is 1 if the command executed correctly.
-    ok?: number;
+    ok?: number | undefined;
 }
 
 /**
@@ -3396,14 +3396,14 @@ export interface FindAndModifyWriteOpResultObject<TSchema> {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndReplace
  */
 export interface FindOneAndReplaceOption<T> extends CommonOptions {
-    projection?: SchemaMember<T, ProjectionOperators | number | boolean | any>;
-    sort?: SortOptionObject<T>;
-    maxTimeMS?: number;
-    upsert?: boolean;
-    returnDocument?: 'after' | 'before';
+    projection?: SchemaMember<T, ProjectionOperators | number | boolean | any> | undefined;
+    sort?: SortOptionObject<T> | undefined;
+    maxTimeMS?: number | undefined;
+    upsert?: boolean | undefined;
+    returnDocument?: 'after' | 'before' | undefined;
     /** @deprecated Use returnDocument */
-    returnOriginal?: boolean;
-    collation?: CollationDocument;
+    returnOriginal?: boolean | undefined;
+    collation?: CollationDocument | undefined;
 }
 
 /**
@@ -3413,10 +3413,10 @@ export interface FindOneAndReplaceOption<T> extends CommonOptions {
  */
 export interface ProjectionOperators {
     /** @see https://docs.mongodb.com/v3.6/reference/operator/projection/elemMatch/#proj._S_elemMatch */
-    $elemMatch?: object;
+    $elemMatch?: object | undefined;
     /** @see https://docs.mongodb.com/v3.6/reference/operator/projection/slice/#proj._S_slice */
-    $slice?: number | [number, number];
-    $meta?: MetaProjectionOperators;
+    $slice?: number | [number, number] | undefined;
+    $meta?: MetaProjectionOperators | undefined;
 }
 
 /**
@@ -3425,7 +3425,7 @@ export interface ProjectionOperators {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndUpdate
  */
 export interface FindOneAndUpdateOption<T> extends FindOneAndReplaceOption<T> {
-    arrayFilters?: object[];
+    arrayFilters?: object[] | undefined;
 }
 
 /**
@@ -3434,11 +3434,11 @@ export interface FindOneAndUpdateOption<T> extends FindOneAndReplaceOption<T> {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndDelete
  */
 export interface FindOneAndDeleteOption<T> {
-    projection?: SchemaMember<T, ProjectionOperators | number | boolean | any>;
-    sort?: SortOptionObject<T>;
-    maxTimeMS?: number;
-    session?: ClientSession;
-    collation?: CollationDocument;
+    projection?: SchemaMember<T, ProjectionOperators | number | boolean | any> | undefined;
+    sort?: SortOptionObject<T> | undefined;
+    maxTimeMS?: number | undefined;
+    session?: ClientSession | undefined;
+    collation?: CollationDocument | undefined;
 }
 
 /**
@@ -3447,11 +3447,11 @@ export interface FindOneAndDeleteOption<T> {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#geoHaystackSearch
  */
 export interface GeoHaystackSearchOptions {
-    readPreference?: ReadPreferenceOrMode;
-    maxDistance?: number;
-    search?: object;
-    limit?: number;
-    session?: ClientSession;
+    readPreference?: ReadPreferenceOrMode | undefined;
+    maxDistance?: number | undefined;
+    search?: object | undefined;
+    limit?: number | undefined;
+    session?: ClientSession | undefined;
 }
 
 /**
@@ -3761,36 +3761,36 @@ export interface UnorderedBulkOperation {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne
  */
 export interface FindOneOptions<T> {
-    limit?: number;
-    sort?: Array<[string, number]> | SortOptionObject<T>;
-    projection?: SchemaMember<T, ProjectionOperators | number | boolean | any>;
+    limit?: number | undefined;
+    sort?: Array<[string, number]> | SortOptionObject<T> | undefined;
+    projection?: SchemaMember<T, ProjectionOperators | number | boolean | any> | undefined;
     /**
      * @deprecated Use options.projection instead
      */
-    fields?: { [P in keyof T]: boolean | number };
-    skip?: number;
-    hint?: object;
-    explain?: boolean;
-    snapshot?: boolean;
-    timeout?: boolean;
-    tailable?: boolean;
-    awaitData?: boolean;
-    batchSize?: number;
-    returnKey?: boolean;
-    maxScan?: number;
-    min?: number;
-    max?: number;
-    showDiskLoc?: boolean;
-    comment?: string;
-    raw?: boolean;
-    promoteLongs?: boolean;
-    promoteValues?: boolean;
-    promoteBuffers?: boolean;
-    readPreference?: ReadPreferenceOrMode;
-    partial?: boolean;
-    maxTimeMS?: number;
-    collation?: CollationDocument;
-    session?: ClientSession;
+    fields?: { [P in keyof T]: boolean | number } | undefined;
+    skip?: number | undefined;
+    hint?: object | undefined;
+    explain?: boolean | undefined;
+    snapshot?: boolean | undefined;
+    timeout?: boolean | undefined;
+    tailable?: boolean | undefined;
+    awaitData?: boolean | undefined;
+    batchSize?: number | undefined;
+    returnKey?: boolean | undefined;
+    maxScan?: number | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
+    showDiskLoc?: boolean | undefined;
+    comment?: string | undefined;
+    raw?: boolean | undefined;
+    promoteLongs?: boolean | undefined;
+    promoteValues?: boolean | undefined;
+    promoteBuffers?: boolean | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
+    partial?: boolean | undefined;
+    maxTimeMS?: number | undefined;
+    collation?: CollationDocument | undefined;
+    session?: ClientSession | undefined;
 }
 
 /**
@@ -3802,15 +3802,15 @@ export interface CollectionInsertOneOptions extends CommonOptions {
     /**
      * Serialize functions on any object.
      */
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     /**
      * Force server to assign _id values instead of driver.
      */
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     /**
      * Allow driver to bypass schema validation in MongoDB 3.2 or higher.
      */
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 /**
@@ -3845,11 +3845,11 @@ export interface InsertOneWriteOpResult<TSchema extends { _id: any }> {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#parallelCollectionScan
  */
 export interface ParallelCollectionScanOptions {
-    readPreference?: ReadPreferenceOrMode;
-    batchSize?: number;
-    numCursors?: number;
-    raw?: boolean;
-    session?: ClientSession;
+    readPreference?: ReadPreferenceOrMode | undefined;
+    batchSize?: number | undefined;
+    numCursors?: number | undefined;
+    raw?: boolean | undefined;
+    session?: ClientSession | undefined;
 }
 
 /**
@@ -3858,8 +3858,8 @@ export interface ParallelCollectionScanOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#replaceOne
  */
 export interface ReplaceOneOptions extends CommonOptions {
-    upsert?: boolean;
-    bypassDocumentValidation?: boolean;
+    upsert?: boolean | undefined;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 /**
@@ -3868,7 +3868,7 @@ export interface ReplaceOneOptions extends CommonOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#updateOne
  */
 export interface UpdateOneOptions extends ReplaceOneOptions {
-    arrayFilters?: object[];
+    arrayFilters?: object[] | undefined;
 }
 
 /**
@@ -3877,8 +3877,8 @@ export interface UpdateOneOptions extends ReplaceOneOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#updateMany
  */
 export interface UpdateManyOptions extends CommonOptions {
-    upsert?: boolean;
-    arrayFilters?: object[];
+    upsert?: boolean | undefined;
+    arrayFilters?: object[] | undefined;
 }
 
 /**
@@ -3910,18 +3910,18 @@ export interface ReplaceWriteOpResult extends UpdateWriteOpResult {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#mapReduce
  */
 export interface MapReduceOptions {
-    readPreference?: ReadPreferenceOrMode;
-    out?: object;
-    query?: object;
-    sort?: object;
-    limit?: number;
-    keeptemp?: boolean;
-    finalize?: Function | string;
-    scope?: object;
-    jsMode?: boolean;
-    verbose?: boolean;
-    bypassDocumentValidation?: boolean;
-    session?: ClientSession;
+    readPreference?: ReadPreferenceOrMode | undefined;
+    out?: object | undefined;
+    query?: object | undefined;
+    sort?: object | undefined;
+    limit?: number | undefined;
+    keeptemp?: boolean | undefined;
+    finalize?: Function | string | undefined;
+    scope?: object | undefined;
+    jsMode?: boolean | undefined;
+    verbose?: boolean | undefined;
+    bypassDocumentValidation?: boolean | undefined;
+    session?: ClientSession | undefined;
 }
 
 export type CollectionMapFunction<TSchema> = (this: TSchema) => void;
@@ -4216,7 +4216,7 @@ export class Cursor<T = Default> extends Readable {
      * @param options Optional settings
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#stream
      */
-    stream(options?: { transform?: (document: T) => any }): Cursor<T>;
+    stream(options?: { transform?: ((document: T) => any) | undefined }): Cursor<T>;
     /**
      * Returns an array of documents. The caller is responsible for making sure that there
      * is enough memory to store the results. Note that the array only contains partial
@@ -4236,7 +4236,7 @@ export class Cursor<T = Default> extends Readable {
      * @param options Optional settings
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#transformStream
      */
-    transformStream(options?: { transform?: (document: T) => any }): Cursor<T>;
+    transformStream(options?: { transform?: ((document: T) => any) | undefined }): Cursor<T>;
     /**
      * This is useful in certain cases where a stream is being consumed by a parser,
      * which needs to "un-consume" some data that it has optimistically pulled out of the source, so that the stream can be passed on to some other party.
@@ -4253,11 +4253,11 @@ export class Cursor<T = Default> extends Readable {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#count
  */
 export interface CursorCommentOptions {
-    skip?: number;
-    limit?: number;
-    maxTimeMS?: number;
-    hint?: string;
-    readPreference?: ReadPreferenceOrMode;
+    skip?: number | undefined;
+    limit?: number | undefined;
+    maxTimeMS?: number | undefined;
+    hint?: string | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
 }
 
 /**
@@ -4484,7 +4484,7 @@ export class AggregationCursor<T = Default> extends Cursor<T> {
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/AggregationCursor.html#unwind
      */
     unwind<U = T>(
-        field: string | { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean },
+        field: string | { path: string; includeArrayIndex?: string | undefined; preserveNullAndEmptyArrays?: boolean | undefined },
     ): AggregationCursor<U>;
 }
 
@@ -4703,10 +4703,10 @@ export class GridFSBucket extends EventEmitter {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucket.html
  */
 export interface GridFSBucketOptions {
-    bucketName?: string;
-    chunkSizeBytes?: number;
-    writeConcern?: WriteConcern;
-    readPreference?: ReadPreferenceOrMode;
+    bucketName?: string | undefined;
+    chunkSizeBytes?: number | undefined;
+    writeConcern?: WriteConcern | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
 }
 
 /**
@@ -4722,12 +4722,12 @@ export interface GridFSBucketErrorCallback extends MongoCallback<void> {}
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucket.html#find
  */
 export interface GridFSBucketFindOptions {
-    batchSize?: number;
-    limit?: number;
-    maxTimeMS?: number;
-    noCursorTimeout?: boolean;
-    skip?: number;
-    sort?: object;
+    batchSize?: number | undefined;
+    limit?: number | undefined;
+    maxTimeMS?: number | undefined;
+    noCursorTimeout?: boolean | undefined;
+    skip?: number | undefined;
+    sort?: object | undefined;
 }
 
 /**
@@ -4736,10 +4736,10 @@ export interface GridFSBucketFindOptions {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucket.html#openUploadStream
  */
 export interface GridFSBucketOpenUploadStreamOptions {
-    chunkSizeBytes?: number;
-    metadata?: object;
-    contentType?: string;
-    aliases?: string[];
+    chunkSizeBytes?: number | undefined;
+    metadata?: object | undefined;
+    contentType?: string | undefined;
+    aliases?: string[] | undefined;
 }
 
 /**
@@ -4770,10 +4770,10 @@ export class GridFSBucketReadStream extends Readable {
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucketReadStream.html
  */
 export interface GridFSBucketReadStreamOptions {
-    sort?: number;
-    skip?: number;
-    start?: number;
-    end?: number;
+    sort?: number | undefined;
+    skip?: number | undefined;
+    start?: number | undefined;
+    end?: number | undefined;
 }
 
 /**
@@ -4808,16 +4808,16 @@ export interface GridFSBucketWriteStreamOptions extends WriteConcern {
     /**
      * Custom file id for the GridFS file.
      */
-    id?: GridFSBucketWriteStreamId;
+    id?: GridFSBucketWriteStreamId | undefined;
     /**
      * The chunk size to use, in bytes
      */
-    chunkSizeBytes?: number;
+    chunkSizeBytes?: number | undefined;
     /**
      * If true, disables adding an md5 field to file data
      * @default false
      */
-    disableMD5?: boolean;
+    disableMD5?: boolean | undefined;
 }
 
 /**
@@ -4965,7 +4965,7 @@ export class ChangeStream<TSchema extends { [key: string]: any } = DefaultSchema
      * @param options Optional settings
      * @see https://mongodb.github.io/node-mongodb-native/3.6/api/ChangeStream.html#stream
      */
-    stream(options?: { transform?: Function }): Cursor;
+    stream(options?: { transform?: Function | undefined }): Cursor;
 }
 
 export class ResumeToken {}
@@ -4991,16 +4991,16 @@ export interface ChangeEventBase<TSchema extends { [key: string]: any } = Defaul
         coll: string;
     };
     clusterTime: Timestamp;
-    txnNumber?: number;
+    txnNumber?: number | undefined;
     lsid?: {
         id: any;
         uid: any;
-    };
+    } | undefined;
 }
 export interface ChangeEventCR<TSchema extends { [key: string]: any } = DefaultSchema>
     extends ChangeEventBase<TSchema> {
     operationType: "insert" | "replace";
-    fullDocument?: TSchema;
+    fullDocument?: TSchema | undefined;
     documentKey: {
         _id: ExtractIdType<TSchema>;
     };
@@ -5017,7 +5017,7 @@ export interface ChangeEventUpdate<TSchema extends { [key: string]: any } = Defa
         updatedFields: FieldUpdates<TSchema>;
         removedFields: Array<keyof TSchema | string>;
     };
-    fullDocument?: TSchema;
+    fullDocument?: TSchema | undefined;
     documentKey: {
         _id: ExtractIdType<TSchema>;
     };
@@ -5064,14 +5064,14 @@ export type ChangeEvent<TSchema extends object = { _id: ObjectId }> =
  * @see https://mongodb.github.io/node-mongodb-native/3.6/api/global.html#ChangeStreamOptions
  */
 export interface ChangeStreamOptions {
-    fullDocument?: "default" | "updateLookup";
-    maxAwaitTimeMS?: number;
-    resumeAfter?: ResumeToken;
-    startAfter?: ResumeToken;
-    startAtOperationTime?: Timestamp;
-    batchSize?: number;
-    collation?: CollationDocument;
-    readPreference?: ReadPreferenceOrMode;
+    fullDocument?: "default" | "updateLookup" | undefined;
+    maxAwaitTimeMS?: number | undefined;
+    resumeAfter?: ResumeToken | undefined;
+    startAfter?: ResumeToken | undefined;
+    startAtOperationTime?: Timestamp | undefined;
+    batchSize?: number | undefined;
+    collation?: CollationDocument | undefined;
+    readPreference?: ReadPreferenceOrMode | undefined;
 }
 
 type GridFSBucketWriteStreamId = string | number | object | ObjectId;
@@ -5080,11 +5080,11 @@ export interface LoggerOptions {
     /**
      * Custom logger function
      */
-    loggerLevel?: string;
+    loggerLevel?: string | undefined;
     /**
      * Override default global log level.
      */
-    logger?: log;
+    logger?: log | undefined;
 }
 
 export type log = (message?: string, state?: LoggerState) => void;
@@ -5193,14 +5193,14 @@ export class Logger {
  */
 export interface CollationDocument {
     locale: string;
-    strength?: number;
-    caseLevel?: boolean;
-    caseFirst?: string;
-    numericOrdering?: boolean;
-    alternate?: string;
-    maxVariable?: string;
-    backwards?: boolean;
-    normalization?: boolean;
+    strength?: number | undefined;
+    caseLevel?: boolean | undefined;
+    caseFirst?: string | undefined;
+    numericOrdering?: boolean | undefined;
+    alternate?: string | undefined;
+    maxVariable?: string | undefined;
+    backwards?: boolean | undefined;
+    normalization?: boolean | undefined;
 }
 
 /**
@@ -5210,21 +5210,21 @@ export interface CollationDocument {
  */
 export interface IndexSpecification {
     key: object;
-    name?: string;
-    background?: boolean;
-    unique?: boolean;
-    partialFilterExpression?: object;
-    sparse?: boolean;
-    expireAfterSeconds?: number;
-    storageEngine?: object;
-    weights?: object;
-    default_language?: string;
-    language_override?: string;
-    textIndexVersion?: number;
-    "2dsphereIndexVersion"?: number;
-    bits?: number;
-    min?: number;
-    max?: number;
-    bucketSize?: number;
-    collation?: CollationDocument;
+    name?: string | undefined;
+    background?: boolean | undefined;
+    unique?: boolean | undefined;
+    partialFilterExpression?: object | undefined;
+    sparse?: boolean | undefined;
+    expireAfterSeconds?: number | undefined;
+    storageEngine?: object | undefined;
+    weights?: object | undefined;
+    default_language?: string | undefined;
+    language_override?: string | undefined;
+    textIndexVersion?: number | undefined;
+    "2dsphereIndexVersion"?: number | undefined;
+    bits?: number | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
+    bucketSize?: number | undefined;
+    collation?: CollationDocument | undefined;
 }

--- a/types/mongodb/test/collection/bulkWrite.ts
+++ b/types/mongodb/test/collection/bulkWrite.ts
@@ -18,10 +18,10 @@ async function run() {
         _id: ObjectID;
         stringField: string;
         numberField: number;
-        optionalNumberField?: number;
+        optionalNumberField?: number | undefined;
         dateField: Date;
         fruitTags: string[];
-        maybeFruitTags?: FruitTypes[];
+        maybeFruitTags?: FruitTypes[] | undefined;
         readonlyFruitTags: ReadonlyArray<string>;
         subInterfaceField: SubTestSchema;
         subInterfaceArray: SubTestSchema[];

--- a/types/mongodb/test/collection/filterQuery.ts
+++ b/types/mongodb/test/collection/filterQuery.ts
@@ -19,16 +19,16 @@ async function run() {
     // a collection model for all possible MongoDB BSON types and TypeScript types
     interface UserModel {
         _id: ObjectId; // ObjectId field
-        name?: string; // optional field
+        name?: string | undefined; // optional field
         family: string; // string field
         age: number; // number field
         gender: 'male' | 'female' | 'other'; // union field
         isBanned: boolean; // boolean field
-        addedBy?: UserModel; // object field (Embedded/Nested Documents)
+        addedBy?: UserModel | undefined; // object field (Embedded/Nested Documents)
         createdAt: Date; // date field
         schools: string[]; // array of string
         scores: number[]; // array of number
-        friends?: ReadonlyArray<UserModel>; // readonly array of objects
+        friends?: ReadonlyArray<UserModel> | undefined; // readonly array of objects
     }
 
     const sampleUser: UserModel = {

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -15,7 +15,7 @@ async function run() {
     // test with collection type
     interface TestModel {
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         fruitTags: string[];
         readonlyFruitTags: ReadonlyArray<string>;
     }

--- a/types/mongodb/test/collection/insertX.ts
+++ b/types/mongodb/test/collection/insertX.ts
@@ -45,7 +45,7 @@ async function run() {
      */
     interface TestModel {
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         fruitTags: string[];
     }
     type TestModelWithId = TestModel & { _id: ObjectId };
@@ -84,7 +84,7 @@ async function run() {
     interface TestModelWithCustomId {
         _id: number;
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         fruitTags: string[];
     }
     const collectionWithId = db.collection<TestModelWithCustomId>('testCollection');
@@ -126,7 +126,7 @@ async function run() {
     interface TestModelWithCustomObjectId {
         _id: ObjectId;
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         fruitTags: string[];
     }
     const collectionWithObjectId = db.collection<TestModelWithCustomObjectId>('testCollection');
@@ -146,7 +146,7 @@ async function run() {
      */
     interface IndexTypeTestModel {
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         [key: string]: any;
     }
     const indexTypeCollection1 = db.collection<IndexTypeTestModel>('testCollection');
@@ -192,7 +192,7 @@ async function run() {
     interface IndexTypeTestModelWithId {
         _id: number;
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         [key: string]: any;
     }
     const indexTypeCollection2 = db.collection<IndexTypeTestModelWithId>('testCollection');
@@ -249,7 +249,7 @@ async function run() {
     interface IndexTypeTestModelWithObjectId {
         _id: ObjectId;
         stringField: string;
-        numberField?: number;
+        numberField?: number | undefined;
         [key: string]: any;
     }
     const indexTypeCollection3 = db.collection<IndexTypeTestModelWithObjectId>('testCollection');

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -9,7 +9,7 @@ async function run() {
     interface SubTestModel {
         _id: ObjectId;
         field1: string;
-        field2?: string;
+        field2?: string | undefined;
     }
 
     type FruitTypes = 'apple' | 'pear';
@@ -22,13 +22,13 @@ async function run() {
         doubleField: Double;
         int32Field: Int32;
         longField: Long;
-        optionalNumberField?: number;
+        optionalNumberField?: number | undefined;
         dateField: Date;
         otherDateField: Date;
         oneMoreDateField: Date;
         fruitTags: string[];
         readonlyFruitTags: ReadonlyArray<string>;
-        maybeFruitTags?: FruitTypes[];
+        maybeFruitTags?: FruitTypes[] | undefined;
         subInterfaceField: SubTestModel;
         subInterfaceArray: SubTestModel[];
         timestampField: Timestamp;
@@ -259,7 +259,7 @@ async function run() {
 async function testPushWithId () {
     interface Model {
         _id: ObjectId;
-        foo: Array<{ _id?: string, name: string }>;
+        foo: Array<{ _id?: string | undefined, name: string }>;
     }
 
     const client = await connect(connectionString);

--- a/types/mongodb/v1/index.d.ts
+++ b/types/mongodb/v1/index.d.ts
@@ -116,14 +116,14 @@ export declare class Db {
     public _callHandler(id: any, document: any, err: any): any;
     public _hasHandler(id: any): any;
     public _removeHandler(id: any): any;
-    public _findHandler(id: any): { id: string; callback?: Function };
+    public _findHandler(id: any): { id: string; callback?: Function | undefined };
     public __executeQueryCommand(self: any, db_command: any, options: any, callback?: any): void;
 
     public DEFAULT_URL: string;
 
     public connect(
         url: string,
-        options: { uri_decode_auth?: boolean },
+        options: { uri_decode_auth?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -183,20 +183,20 @@ export declare class Binary {
 
 export interface SocketOptions {
     //= set seconds before connection times out default:0
-    timeout?: number;
+    timeout?: number | undefined;
     //= Disables the Nagle algorithm default:true
-    noDelay?: boolean;
+    noDelay?: boolean | undefined;
     //= Set if keepAlive is used default:0 , which means no keepAlive, set higher than 0 for keepAlive
-    keepAlive?: number;
+    keepAlive?: number | undefined;
     //= ‘ascii’|’utf8’|’base64’ default:null
-    encoding?: string;
+    encoding?: string | undefined;
 }
 
 export interface ServerOptions {
     // - to reconnect automatically, default:false
-    auto_reconnect?: boolean;
+    auto_reconnect?: boolean | undefined;
     // - specify the number of connections in the pool default:1
-    poolSize?: number;
+    poolSize?: number | undefined;
     // - a collection of pr socket settings
     socketOptions?: any;
 }
@@ -213,49 +213,49 @@ export interface DbCreateOptions {
     w?: any;
 
     // set the timeout for waiting for write concern to finish (combines with w option).
-    wtimeout?: number;
+    wtimeout?: number | undefined;
 
     //  write waits for fsync before returning. default:false.
-    fsync?: boolean;
+    fsync?: boolean | undefined;
 
     // write waits for journal sync before returning. default:false.
-    journal?: boolean;
+    journal?: boolean | undefined;
 
     // the prefered read preference. use 'ReadPreference' class.
-    readPreference?: string;
+    readPreference?: string | undefined;
 
     // use c++ bson parser. default:false.
-    native_parser?: boolean;
+    native_parser?: boolean | undefined;
 
     // force server to create _id fields instead of client. default:false.
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
 
     // custom primary key factory to generate _id values (see Custom primary keys).
-    pkFactory?: PKFactory;
+    pkFactory?: PKFactory | undefined;
 
     // serialize functions. default:false.
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
 
     // peform operations using raw bson buffers. default:false.
-    raw?: boolean;
+    raw?: boolean | undefined;
 
     // record query statistics during execution. default:false.
-    recordQueryStats?: boolean;
+    recordQueryStats?: boolean | undefined;
 
     // number of miliseconds between retries. default:5000.
-    retryMiliSeconds?: number;
+    retryMiliSeconds?: number | undefined;
 
     // number of retries off connection. default:5.
-    numberOfRetries?: number;
+    numberOfRetries?: number | undefined;
 
     // an object representing a logger that you want to use, needs to support functions debug, log, error. default:null.
-    logger?: Object;
+    logger?: Object | undefined;
 
     // force setting of SlaveOk flag on queries (only use when explicitly connecting to a secondary server). default:null.
-    slaveOk?: number;
+    slaveOk?: number | undefined;
 
     // when deserializing a Long will fit it into a Number if it’s smaller than 53 bits. default:true.
-    promoteLongs?: boolean;
+    promoteLongs?: boolean | undefined;
 }
 
 export declare class ReadPreference {
@@ -270,19 +270,19 @@ export declare class ReadPreference {
 // Current definition by documentation version 1.3.13 (28.08.2013)
 export interface CollectionCreateOptions {
     // the prefered read preference. use 'ReadPreference' class.
-    readPreference?: string;
+    readPreference?: string | undefined;
 
     // Allow reads from secondaries. default:false.
-    slaveOk?: boolean;
+    slaveOk?: boolean | undefined;
 
     // serialize functions on the document. default:false.
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
 
     // perform all operations using raw bson objects. default:false.
-    raw?: boolean;
+    raw?: boolean | undefined;
 
     // object overriding the basic ObjectID primary key generation.
-    pkFactory?: PKFactory;
+    pkFactory?: PKFactory | undefined;
 }
 
 // Documentation: http://docs.mongodb.org/manual/reference/command/collStats/
@@ -335,7 +335,7 @@ export interface Collection {
     insert(query: any, callback?: (err: Error, result: any) => void): void;
     insert(
         query: any,
-        options: { safe?: any; continueOnError?: boolean; keepGoing?: boolean; serializeFunctions?: boolean },
+        options: { safe?: any; continueOnError?: boolean | undefined; keepGoing?: boolean | undefined; serializeFunctions?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -345,10 +345,10 @@ export interface Collection {
         doc: any,
         options: {
             w?: any;
-            wtimeout?: number;
-            j?: boolean;
-            serializeFunctions?: boolean;
-            forceServerObjectId?: boolean;
+            wtimeout?: number | undefined;
+            j?: boolean | undefined;
+            serializeFunctions?: boolean | undefined;
+            forceServerObjectId?: boolean | undefined;
         },
         callback?: (err: Error, result: any) => void,
     ): void;
@@ -359,10 +359,10 @@ export interface Collection {
         docs: any,
         options: {
             w?: any;
-            wtimeout?: number;
-            j?: boolean;
-            serializeFunctions?: boolean;
-            forceServerObjectId?: boolean;
+            wtimeout?: number | undefined;
+            j?: boolean | undefined;
+            serializeFunctions?: boolean | undefined;
+            forceServerObjectId?: boolean | undefined;
         },
         callback?: (err: Error, result: any) => void,
     ): void;
@@ -373,7 +373,7 @@ export interface Collection {
     remove(selector: Object, callback?: (err: Error, result: any) => void): void;
     remove(
         selector: Object,
-        options: { safe?: any; single?: boolean },
+        options: { safe?: any; single?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -381,7 +381,7 @@ export interface Collection {
     deleteOne(filter: any, callback?: (err: Error, result: any) => void): void;
     deleteOne(
         filter: any,
-        options: { w?: any; wtimeout?: number; j?: boolean },
+        options: { w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -389,7 +389,7 @@ export interface Collection {
     deleteMany(filter: any, callback?: (err: Error, result: any) => void): void;
     deleteMany(
         filter: any,
-        options: { w?: any; wtimeout?: number; j?: boolean },
+        options: { w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -398,7 +398,7 @@ export interface Collection {
     save(doc: any, callback: (err: Error, result: any) => void): void;
     save(
         doc: any,
-        options: { w?: any; wtimeout?: number; j?: boolean },
+        options: { w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
         callback: (err: Error, result: any) => void,
     ): void;
     /**
@@ -409,7 +409,7 @@ export interface Collection {
     update(
         selector: Object,
         document: any,
-        options: { safe?: boolean; upsert?: any; multi?: boolean; serializeFunctions?: boolean },
+        options: { safe?: boolean | undefined; upsert?: any; multi?: boolean | undefined; serializeFunctions?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -418,7 +418,7 @@ export interface Collection {
     updateOne(
         filter: Object,
         update: any,
-        options: { upsert?: boolean; w?: any; wtimeout?: number; j?: boolean },
+        options: { upsert?: boolean | undefined; w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -427,7 +427,7 @@ export interface Collection {
     updateMany(
         filter: Object,
         update: any,
-        options: { upsert?: boolean; w?: any; wtimeout?: number; j?: boolean },
+        options: { upsert?: boolean | undefined; w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -453,7 +453,7 @@ export interface Collection {
         query: Object,
         sort: any[],
         doc: Object,
-        options: { safe?: any; remove?: boolean; upsert?: boolean; new?: boolean },
+        options: { safe?: any; remove?: boolean | undefined; upsert?: boolean | undefined; new?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
     /**
@@ -472,7 +472,7 @@ export interface Collection {
     findOneAndDelete(filter: any, callback?: (err: Error, result: any) => void): void;
     findOneAndDelete(
         filter: any,
-        options: { projection?: any; sort?: any; maxTimeMS?: number },
+        options: { projection?: any; sort?: any; maxTimeMS?: number | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -481,7 +481,7 @@ export interface Collection {
     findOneAndReplace(
         filter: any,
         replacement: any,
-        options: { projection?: any; sort?: any; maxTimeMS?: number; upsert?: boolean; returnOriginal?: boolean },
+        options: { projection?: any; sort?: any; maxTimeMS?: number | undefined; upsert?: boolean | undefined; returnOriginal?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -490,7 +490,7 @@ export interface Collection {
     findOneAndUpdate(
         filter: any,
         update: any,
-        options: { projection?: any; sort?: any; maxTimeMS?: number; upsert?: boolean; returnOriginal?: boolean },
+        options: { projection?: any; sort?: any; maxTimeMS?: number | undefined; upsert?: boolean | undefined; returnOriginal?: boolean | undefined },
         callback?: (err: Error, result: any) => void,
     ): void;
 
@@ -593,32 +593,32 @@ export interface Collection {
 }
 
 export interface MapReduceOptions {
-    out?: Object;
-    query?: Object;
-    sort?: Object;
-    limit?: number;
-    keeptemp?: boolean;
+    out?: Object | undefined;
+    query?: Object | undefined;
+    sort?: Object | undefined;
+    limit?: number | undefined;
+    keeptemp?: boolean | undefined;
     finalize?: any;
-    scope?: Object;
-    jsMode?: boolean;
-    verbose?: boolean;
-    readPreference?: string;
+    scope?: Object | undefined;
+    jsMode?: boolean | undefined;
+    verbose?: boolean | undefined;
+    readPreference?: string | undefined;
 }
 
 export interface IndexOptions {
     w?: any;
-    wtimeout?: number;
-    fsync?: boolean;
-    journal?: boolean;
-    unique?: boolean;
-    sparse?: boolean;
-    background?: boolean;
-    dropDups?: boolean;
-    min?: number;
-    max?: number;
-    v?: number;
-    expireAfterSeconds?: number;
-    name?: string;
+    wtimeout?: number | undefined;
+    fsync?: boolean | undefined;
+    journal?: boolean | undefined;
+    unique?: boolean | undefined;
+    sparse?: boolean | undefined;
+    background?: boolean | undefined;
+    dropDups?: boolean | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
+    v?: number | undefined;
+    expireAfterSeconds?: number | undefined;
+    name?: string | undefined;
 }
 
 // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/cursor.html
@@ -667,37 +667,37 @@ export declare class CursorStream {
 }
 
 export interface CollectionFindOptions {
-    limit?: number;
+    limit?: number | undefined;
     sort?: any;
-    fields?: Object;
-    skip?: number;
-    hint?: Object;
-    explain?: boolean;
-    snapshot?: boolean;
-    timeout?: boolean;
-    tailtable?: boolean;
-    tailableRetryInterval?: number;
-    numberOfRetries?: number;
-    awaitdata?: boolean;
-    oplogReplay?: boolean;
-    exhaust?: boolean;
-    batchSize?: number;
-    returnKey?: boolean;
-    maxScan?: number;
-    min?: number;
-    max?: number;
-    showDiskLoc?: boolean;
-    comment?: String;
-    raw?: boolean;
-    readPreference?: String;
-    partial?: boolean;
+    fields?: Object | undefined;
+    skip?: number | undefined;
+    hint?: Object | undefined;
+    explain?: boolean | undefined;
+    snapshot?: boolean | undefined;
+    timeout?: boolean | undefined;
+    tailtable?: boolean | undefined;
+    tailableRetryInterval?: number | undefined;
+    numberOfRetries?: number | undefined;
+    awaitdata?: boolean | undefined;
+    oplogReplay?: boolean | undefined;
+    exhaust?: boolean | undefined;
+    batchSize?: number | undefined;
+    returnKey?: boolean | undefined;
+    maxScan?: number | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
+    showDiskLoc?: boolean | undefined;
+    comment?: String | undefined;
+    raw?: boolean | undefined;
+    readPreference?: String | undefined;
+    partial?: boolean | undefined;
 }
 
 export interface MongoCollectionOptions {
     safe?: any;
     serializeFunctions?: any;
-    strict?: boolean;
-    raw?: boolean;
+    strict?: boolean | undefined;
+    raw?: boolean | undefined;
     pkFactory?: any;
-    readPreference?: string;
+    readPreference?: string | undefined;
 }

--- a/types/mongodb/v2/index.d.ts
+++ b/types/mongodb/v2/index.d.ts
@@ -44,7 +44,7 @@ export interface MongoCallback<T> {
 export class MongoError extends Error {
     constructor(message: string);
     static create(options: Object): MongoError;
-    code?: number;
+    code?: number | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.2/api/MongoClient.html#.connect
@@ -57,43 +57,43 @@ export interface MongoClientOptions
         SSLOptions,
         HighAvailabilityOptions {
     // The logging level (error/warn/info/debug)
-    loggerLevel?: string;
+    loggerLevel?: string | undefined;
     // Custom logger object
-    logger?: Object;
+    logger?: Object | undefined;
     // Default: false;
-    validateOptions?: Object;
+    validateOptions?: Object | undefined;
 }
 
 export interface SSLOptions {
     // Default:5; Number of connections for each server instance
-    poolSize?: number;
+    poolSize?: number | undefined;
     // Use ssl connection (needs to have a mongod server with ssl support)
-    ssl?: boolean;
+    ssl?: boolean | undefined;
     // Default: true; Validate mongod server certificate against ca (mongod server >=2.4 with ssl support required)
-    sslValidate?: Object;
+    sslValidate?: Object | undefined;
     // Default: true; Server identity checking during SSL
-    checkServerIdentity?: boolean | Function;
+    checkServerIdentity?: boolean | Function | undefined;
     // Array of valid certificates either as Buffers or Strings
-    sslCA?: Array<Buffer | string>;
+    sslCA?: Array<Buffer | string> | undefined;
     // SSL Certificate revocation list binary buffer
-    sslCRL?: Buffer;
+    sslCRL?: Buffer | undefined;
     // SSL Certificate binary buffer
-    sslCert?: Buffer | string;
+    sslCert?: Buffer | string | undefined;
     // SSL Key file binary buffer
-    sslKey?: Buffer | string;
+    sslKey?: Buffer | string | undefined;
     // SSL Certificate pass phrase
-    sslPass?: Buffer | string;
+    sslPass?: Buffer | string | undefined;
     // String containing the server name requested via TLS SNI.
-    servername?: string;
+    servername?: string | undefined;
 }
 
 export interface HighAvailabilityOptions {
     // Default: true; Turn on high availability monitoring.
-    ha?: boolean;
+    ha?: boolean | undefined;
     // Default: 10000; The High availability period for replicaset inquiry
-    haInterval?: number;
+    haInterval?: number | undefined;
     // Default: false;
-    domainsEnabled?: boolean;
+    domainsEnabled?: boolean | undefined;
 }
 
 // See http://mongodb.github.io/node-mongodb-native/2.2/api/ReadPreference.html
@@ -101,7 +101,7 @@ export class ReadPreference {
     constructor(mode: string, tags: Object);
     mode: string;
     tags: any;
-    options: { maxStalenessSeconds?: number }; // Max Secondary Read Stalleness in Seconds
+    options: { maxStalenessSeconds?: number | undefined }; // Max Secondary Read Stalleness in Seconds
     static PRIMARY: string;
     static PRIMARY_PREFERRED: string;
     static SECONDARY: string;
@@ -114,90 +114,90 @@ export class ReadPreference {
 // http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html
 export interface DbCreateOptions {
     // If the database authentication is dependent on another databaseName.
-    authSource?: string;
+    authSource?: string | undefined;
     // Default: null;https://docs.mongodb.com/manual/reference/write-concern/#write-concern
-    w?: number | string;
+    w?: number | string | undefined;
     // The write concern timeout to finish (combining with w option).
-    wtimeout?: number;
+    wtimeout?: number | undefined;
     // Specify a journal write concern.
-    j?: boolean;
+    j?: boolean | undefined;
     // Default: false; Force server to create _id fields instead of client.
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     // Default: false; Use c++ bson parser.
-    native_parser?: boolean;
+    native_parser?: boolean | undefined;
     // Serialize functions on any object.
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     // Specify if the BSON serializer should ignore undefined fields.
-    ignoreUndefined?: boolean;
+    ignoreUndefined?: boolean | undefined;
     // Return document results as raw BSON buffers.
-    raw?: boolean;
+    raw?: boolean | undefined;
     // Default: true; Promotes Long values to number if they fit inside the 53 bits resolution.
-    promoteLongs?: boolean;
+    promoteLongs?: boolean | undefined;
     // Default: -1 (unlimited); Amount of operations the driver buffers up untill discard any new ones
-    promoteBuffers?: number;
+    promoteBuffers?: number | undefined;
     // the prefered read preference. use 'ReadPreference' class.
-    readPreference?: ReadPreference | string;
+    readPreference?: ReadPreference | string | undefined;
     // Default: true; Promotes BSON values to native types where possible, set to false to only receive wrapper types.
-    promoteValues?: Object;
+    promoteValues?: Object | undefined;
     // Custom primary key factory to generate _id values (see Custom primary keys).
-    pkFactory?: Object;
+    pkFactory?: Object | undefined;
     // ES6 compatible promise constructor
-    promiseLibrary?: Object;
+    promiseLibrary?: Object | undefined;
     // https://docs.mongodb.com/manual/reference/read-concern/#read-concern
-    readConcern?: { level?: Object };
+    readConcern?: { level?: Object | undefined } | undefined;
     // Sets a cap on how many operations the driver will buffer up before giving up on getting a
     // working connection, default is -1 which is unlimited.
-    bufferMaxEntries?: number;
+    bufferMaxEntries?: number | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.2/api/Server.html
 export interface SocketOptions {
     // Reconnect on error. default:false
-    autoReconnect?: boolean;
+    autoReconnect?: boolean | undefined;
     // TCP Socket NoDelay option. default:true
-    noDelay?: boolean;
+    noDelay?: boolean | undefined;
     // TCP KeepAlive enabled on the socket. default:true
-    keepAlive?: boolean;
+    keepAlive?: boolean | undefined;
     // TCP KeepAlive initial delay before sending first keep-alive packet when idle. default:300000
-    keepAliveInitialDelay?: number;
+    keepAliveInitialDelay?: number | undefined;
     // TCP Connection timeout setting. default 0
-    connectTimeoutMS?: number;
+    connectTimeoutMS?: number | undefined;
     // TCP Socket timeout setting. default 0
-    socketTimeoutMS?: number;
+    socketTimeoutMS?: number | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.2/api/Server.html
 export interface ServerOptions extends SSLOptions {
     // Default: 30;
-    reconnectTries?: number;
+    reconnectTries?: number | undefined;
     // Default: 1000;
-    reconnectInterval?: number;
+    reconnectInterval?: number | undefined;
     // Default: true;
-    monitoring?: boolean;
-    socketOptions?: SocketOptions;
+    monitoring?: boolean | undefined;
+    socketOptions?: SocketOptions | undefined;
     // Default: 10000; The High availability period for replicaset inquiry
-    haInterval?: number;
+    haInterval?: number | undefined;
     // Default: false;
-    domainsEnabled?: boolean;
+    domainsEnabled?: boolean | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.2/api/Mongos.html
 export interface MongosOptions extends SSLOptions, HighAvailabilityOptions {
     // Default: 15; Cutoff latency point in MS for MongoS proxy selection
-    acceptableLatencyMS?: number;
-    socketOptions?: SocketOptions;
+    acceptableLatencyMS?: number | undefined;
+    socketOptions?: SocketOptions | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.2/api/ReplSet.html
 export interface ReplSetOptions extends SSLOptions, HighAvailabilityOptions {
     // The max staleness to secondary reads (values under 10 seconds cannot be guaranteed);
-    maxStalenessSeconds?: number;
+    maxStalenessSeconds?: number | undefined;
     // The name of the replicaset to connect to.
-    replicaSet?: string;
+    replicaSet?: string | undefined;
     // Default: 15 ; Range of servers to pick when using NEAREST (lowest ping ms + the latency fence, ex: range of 1 to (1 + 15) ms)
-    secondaryAcceptableLatencyMS?: number;
-    connectWithNoPrimary?: boolean;
-    socketOptions?: SocketOptions;
+    secondaryAcceptableLatencyMS?: number | undefined;
+    connectWithNoPrimary?: boolean | undefined;
+    socketOptions?: SocketOptions | undefined;
 }
 
 // Class documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html
@@ -260,7 +260,7 @@ export class Db extends EventEmitter {
     createIndex(name: string, fieldOrSpec: string | Object, options: IndexOptions, callback: MongoCallback<any>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#db
     db(dbName: string): Db;
-    db(dbName: string, options: { noListener?: boolean; returnNonCachedInstance?: boolean }): Db;
+    db(dbName: string, options: { noListener?: boolean | undefined; returnNonCachedInstance?: boolean | undefined }): Db;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#dropCollection
     dropCollection(name: string): Promise<boolean>;
     dropCollection(name: string, callback: MongoCallback<boolean>): void;
@@ -277,42 +277,42 @@ export class Db extends EventEmitter {
     executeDbAdminCommand(command: Object, callback: MongoCallback<any>): void;
     executeDbAdminCommand(
         command: Object,
-        options?: { readPreference?: ReadPreference | string; maxTimeMS?: number },
+        options?: { readPreference?: ReadPreference | string | undefined; maxTimeMS?: number | undefined },
     ): Promise<any>;
     executeDbAdminCommand(
         command: Object,
-        options: { readPreference?: ReadPreference | string; maxTimeMS?: number },
+        options: { readPreference?: ReadPreference | string | undefined; maxTimeMS?: number | undefined },
         callback: MongoCallback<any>,
     ): void;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#indexInformation
     indexInformation(name: string, callback: MongoCallback<any>): void;
     indexInformation(
         name: string,
-        options?: { full?: boolean; readPreference?: ReadPreference | string },
+        options?: { full?: boolean | undefined; readPreference?: ReadPreference | string | undefined },
     ): Promise<any>;
     indexInformation(
         name: string,
-        options: { full?: boolean; readPreference?: ReadPreference | string },
+        options: { full?: boolean | undefined; readPreference?: ReadPreference | string | undefined },
         callback: MongoCallback<any>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#listCollections
     listCollections(
         filter?: Object,
-        options?: { batchSize?: number; readPreference?: ReadPreference | string },
+        options?: { batchSize?: number | undefined; readPreference?: ReadPreference | string | undefined },
     ): CommandCursor;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#logout
     logout(callback: MongoCallback<any>): void;
-    logout(options?: { dbName?: string }): Promise<any>;
-    logout(options: { dbName?: string }, callback: MongoCallback<any>): void;
+    logout(options?: { dbName?: string | undefined }): Promise<any>;
+    logout(options: { dbName?: string | undefined }, callback: MongoCallback<any>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#open
     open(): Promise<Db>;
     open(callback: MongoCallback<Db>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#removeUser
     removeUser(username: string, callback: MongoCallback<any>): void;
-    removeUser(username: string, options?: { w?: number | string; wtimeout?: number; j?: boolean }): Promise<any>;
+    removeUser(username: string, options?: { w?: number | string | undefined; wtimeout?: number | undefined; j?: boolean | undefined }): Promise<any>;
     removeUser(
         username: string,
-        options: { w?: number | string; wtimeout?: number; j?: boolean },
+        options: { w?: number | string | undefined; wtimeout?: number | undefined; j?: boolean | undefined },
         callback: MongoCallback<any>,
     ): void;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#renameCollection
@@ -324,18 +324,18 @@ export class Db extends EventEmitter {
     renameCollection<TSchema = Default>(
         fromCollection: string,
         toCollection: string,
-        options?: { dropTarget?: boolean },
+        options?: { dropTarget?: boolean | undefined },
     ): Promise<Collection<TSchema>>;
     renameCollection<TSchema = Default>(
         fromCollection: string,
         toCollection: string,
-        options: { dropTarget?: boolean },
+        options: { dropTarget?: boolean | undefined },
         callback: MongoCallback<Collection<TSchema>>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#stats
     stats(callback: MongoCallback<any>): void;
-    stats(options?: { scale?: number }): Promise<any>;
-    stats(options: { scale?: number }, callback: MongoCallback<any>): void;
+    stats(options?: { scale?: number | undefined }): Promise<any>;
+    stats(options: { scale?: number | undefined }, callback: MongoCallback<any>): void;
 }
 
 // Deprecated http://mongodb.github.io/node-mongodb-native/2.1/api/Server.html
@@ -361,79 +361,79 @@ export class Mongos extends EventEmitter {
 
 // http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#addUser
 export interface DbAddUserOptions {
-    w?: string | number;
-    wtimeout?: number;
-    j?: boolean;
-    customData?: Object;
-    roles?: Object[];
+    w?: string | number | undefined;
+    wtimeout?: number | undefined;
+    j?: boolean | undefined;
+    customData?: Object | undefined;
+    roles?: Object[] | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#createCollection
 export interface CollectionCreateOptions {
-    w?: number | string;
-    wtimeout?: number;
-    j?: boolean;
-    raw?: boolean;
-    pkFactory?: Object;
-    readPreference?: ReadPreference | string;
-    serializeFunctions?: boolean;
-    strict?: boolean;
-    capped?: boolean;
-    autoIndexId?: boolean;
-    size?: number;
-    max?: number;
-    flags?: number;
-    storageEngine?: object;
-    validator?: object;
-    validationLevel?: 'off' | 'strict' | 'moderate';
-    validationAction?: 'error' | 'warn';
-    indexOptionDefaults?: object;
-    viewOn?: string;
-    pipeline?: any[];
-    collation?: object;
+    w?: number | string | undefined;
+    wtimeout?: number | undefined;
+    j?: boolean | undefined;
+    raw?: boolean | undefined;
+    pkFactory?: Object | undefined;
+    readPreference?: ReadPreference | string | undefined;
+    serializeFunctions?: boolean | undefined;
+    strict?: boolean | undefined;
+    capped?: boolean | undefined;
+    autoIndexId?: boolean | undefined;
+    size?: number | undefined;
+    max?: number | undefined;
+    flags?: number | undefined;
+    storageEngine?: object | undefined;
+    validator?: object | undefined;
+    validationLevel?: 'off' | 'strict' | 'moderate' | undefined;
+    validationAction?: 'error' | 'warn' | undefined;
+    indexOptionDefaults?: object | undefined;
+    viewOn?: string | undefined;
+    pipeline?: any[] | undefined;
+    collation?: object | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#collection
 export interface DbCollectionOptions {
-    w?: number | string;
-    wtimeout?: number;
-    j?: boolean;
-    raw?: boolean;
-    pkFactory?: Object;
-    readPreference?: ReadPreference | string;
-    serializeFunctions?: boolean;
-    strict?: boolean;
-    readConcern?: { level: Object };
+    w?: number | string | undefined;
+    wtimeout?: number | undefined;
+    j?: boolean | undefined;
+    raw?: boolean | undefined;
+    pkFactory?: Object | undefined;
+    readPreference?: ReadPreference | string | undefined;
+    serializeFunctions?: boolean | undefined;
+    strict?: boolean | undefined;
+    readConcern?: { level: Object } | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#createIndex
 export interface IndexOptions {
     // The write concern.
-    w?: number | string;
+    w?: number | string | undefined;
     // The write concern timeout.
-    wtimeout?: number;
+    wtimeout?: number | undefined;
     // Specify a journal write concern.
-    j?: boolean;
+    j?: boolean | undefined;
     // Creates an unique index.
-    unique?: boolean;
+    unique?: boolean | undefined;
     // Creates a sparse index.
-    sparse?: boolean;
+    sparse?: boolean | undefined;
     // Creates the index in the background, yielding whenever possible.
-    background?: boolean;
+    background?: boolean | undefined;
     // A unique index cannot be created on a key that has pre-existing duplicate values.
     // If you would like to create the index anyway, keeping the first document the database indexes and
     // deleting all subsequent documents that have duplicate value
-    dropDups?: boolean;
+    dropDups?: boolean | undefined;
     // For geo spatial indexes set the lower bound for the co-ordinates.
-    min?: number;
+    min?: number | undefined;
     // For geo spatial indexes set the high bound for the co-ordinates.
-    max?: number;
+    max?: number | undefined;
     // Specify the format version of the indexes.
-    v?: number;
+    v?: number | undefined;
     // Allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher)
-    expireAfterSeconds?: number;
+    expireAfterSeconds?: number | undefined;
     // Override the auto generated index name (useful if the resulting name is larger than 128 bytes)
-    name?: string;
+    name?: string | undefined;
     // Creates a partial index based on the given filter object (MongoDB 3.2 or higher)
     partialFilterExpression?: any;
 }
@@ -453,10 +453,10 @@ export interface Admin {
     buildInfo(callback: MongoCallback<any>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Admin.html#command
     command(command: Object, callback: MongoCallback<any>): void;
-    command(command: Object, options?: { readPreference?: ReadPreference | string; maxTimeMS?: number }): Promise<any>;
+    command(command: Object, options?: { readPreference?: ReadPreference | string | undefined; maxTimeMS?: number | undefined }): Promise<any>;
     command(
         command: Object,
-        options: { readPreference?: ReadPreference | string; maxTimeMS?: number },
+        options: { readPreference?: ReadPreference | string | undefined; maxTimeMS?: number | undefined },
         callback: MongoCallback<any>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Admin.html#listDatabases
@@ -498,20 +498,20 @@ export interface Admin {
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Admin.html#addUser
 export interface AddUserOptions {
-    w?: number | string;
-    wtimeout?: number;
-    j?: boolean;
+    w?: number | string | undefined;
+    wtimeout?: number | undefined;
+    j?: boolean | undefined;
     fsync: boolean;
-    customData?: Object;
-    roles?: Object[];
+    customData?: Object | undefined;
+    roles?: Object[] | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Admin.html#removeUser
 export interface FSyncOptions {
-    w?: number | string;
-    wtimeout?: number;
-    j?: boolean;
-    fsync?: boolean;
+    w?: number | string | undefined;
+    wtimeout?: number | undefined;
+    j?: boolean | undefined;
+    fsync?: boolean | undefined;
 }
 
 // Documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html
@@ -560,20 +560,20 @@ export interface Collection<TSchema = Default> {
     deleteOne(filter: Object, callback: MongoCallback<DeleteWriteOpResultObject>): void;
     deleteOne(
         filter: Object,
-        options?: { w?: number | string; wtimmeout?: number; j?: boolean; bypassDocumentValidation?: boolean },
+        options?: { w?: number | string | undefined; wtimmeout?: number | undefined; j?: boolean | undefined; bypassDocumentValidation?: boolean | undefined },
     ): Promise<DeleteWriteOpResultObject>;
     deleteOne(
         filter: Object,
-        options: { w?: number | string; wtimmeout?: number; j?: boolean; bypassDocumentValidation?: boolean },
+        options: { w?: number | string | undefined; wtimmeout?: number | undefined; j?: boolean | undefined; bypassDocumentValidation?: boolean | undefined },
         callback: MongoCallback<DeleteWriteOpResultObject>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#distinct
     distinct(key: string, query: Object, callback: MongoCallback<any>): void;
-    distinct(key: string, query: Object, options?: { readPreference?: ReadPreference | string }): Promise<any>;
+    distinct(key: string, query: Object, options?: { readPreference?: ReadPreference | string | undefined }): Promise<any>;
     distinct(
         key: string,
         query: Object,
-        options: { readPreference?: ReadPreference | string },
+        options: { readPreference?: ReadPreference | string | undefined },
         callback: MongoCallback<any>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#drop
@@ -598,11 +598,11 @@ export interface Collection<TSchema = Default> {
     findOneAndDelete(filter: Object, callback: MongoCallback<FindAndModifyWriteOpResultObject<TSchema>>): void;
     findOneAndDelete(
         filter: Object,
-        options?: { projection?: Object; sort?: Object; maxTimeMS?: number },
+        options?: { projection?: Object | undefined; sort?: Object | undefined; maxTimeMS?: number | undefined },
     ): Promise<FindAndModifyWriteOpResultObject<TSchema>>;
     findOneAndDelete(
         filter: Object,
-        options: { projection?: Object; sort?: Object; maxTimeMS?: number },
+        options: { projection?: Object | undefined; sort?: Object | undefined; maxTimeMS?: number | undefined },
         callback: MongoCallback<FindAndModifyWriteOpResultObject<TSchema>>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOneAndReplace
@@ -664,7 +664,7 @@ export interface Collection<TSchema = Default> {
         reduce: Function | Code,
         finalize: Function | Code,
         command: boolean,
-        options?: { readPreference?: ReadPreference | string },
+        options?: { readPreference?: ReadPreference | string | undefined },
     ): Promise<any>;
     group(
         keys: Object | Array<any> | Function | Code,
@@ -673,7 +673,7 @@ export interface Collection<TSchema = Default> {
         reduce: Function | Code,
         finalize: Function | Code,
         command: boolean,
-        options: { readPreference?: ReadPreference | string },
+        options: { readPreference?: ReadPreference | string | undefined },
         callback: MongoCallback<any>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#indexes
@@ -713,7 +713,7 @@ export interface Collection<TSchema = Default> {
     isCapped(): Promise<any>;
     isCapped(callback: MongoCallback<any>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#listIndexes
-    listIndexes(options?: { batchSize?: number; readPreference?: ReadPreference | string }): CommandCursor;
+    listIndexes(options?: { batchSize?: number | undefined; readPreference?: ReadPreference | string | undefined }): CommandCursor;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#mapReduce
     mapReduce(map: Function | string, reduce: Function | string, callback: MongoCallback<any>): void;
     mapReduce(map: Function | string, reduce: Function | string, options?: MapReduceOptions): Promise<any>;
@@ -737,17 +737,17 @@ export interface Collection<TSchema = Default> {
     /** @deprecated Use use deleteOne, deleteMany or bulkWrite */
     remove(selector: Object, callback: MongoCallback<WriteOpResult>): void;
     /** @deprecated Use use deleteOne, deleteMany or bulkWrite */
-    remove(selector: Object, options?: CollectionOptions & { single?: boolean }): Promise<WriteOpResult>;
+    remove(selector: Object, options?: CollectionOptions & { single?: boolean | undefined }): Promise<WriteOpResult>;
     /** @deprecated Use use deleteOne, deleteMany or bulkWrite */
     remove(
         selector: Object,
-        options?: CollectionOptions & { single?: boolean },
+        options?: CollectionOptions & { single?: boolean | undefined },
         callback?: MongoCallback<WriteOpResult>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#rename
     rename(newName: string, callback: MongoCallback<Collection<TSchema>>): void;
-    rename(newName: string, options?: { dropTarget?: boolean }): Promise<Collection<TSchema>>;
-    rename(newName: string, options: { dropTarget?: boolean }, callback: MongoCallback<Collection<TSchema>>): void;
+    rename(newName: string, options?: { dropTarget?: boolean | undefined }): Promise<Collection<TSchema>>;
+    rename(newName: string, options: { dropTarget?: boolean | undefined }, callback: MongoCallback<Collection<TSchema>>): void;
     //http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#replaceOne
     replaceOne(filter: Object, doc: Object, callback: MongoCallback<ReplaceWriteOpResult>): void;
     replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<ReplaceWriteOpResult>;
@@ -772,12 +772,12 @@ export interface Collection<TSchema = Default> {
     /** @deprecated use updateOne, updateMany or bulkWrite */
     update(filter: Object, update: Object, callback: MongoCallback<WriteOpResult>): void;
     /** @deprecated use updateOne, updateMany or bulkWrite */
-    update(filter: Object, update: Object, options?: ReplaceOneOptions & { multi?: boolean }): Promise<WriteOpResult>;
+    update(filter: Object, update: Object, options?: ReplaceOneOptions & { multi?: boolean | undefined }): Promise<WriteOpResult>;
     /** @deprecated use updateOne, updateMany or bulkWrite */
     update(
         filter: Object,
         update: Object,
-        options: ReplaceOneOptions & { multi?: boolean },
+        options: ReplaceOneOptions & { multi?: boolean | undefined },
         callback: MongoCallback<WriteOpResult>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#updateMany
@@ -785,12 +785,12 @@ export interface Collection<TSchema = Default> {
     updateMany(
         filter: Object,
         update: Object,
-        options?: { upsert?: boolean; w?: any; wtimeout?: number; j?: boolean },
+        options?: { upsert?: boolean | undefined; w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
     ): Promise<UpdateWriteOpResult>;
     updateMany(
         filter: Object,
         update: Object,
-        options: { upsert?: boolean; w?: any; wtimeout?: number; j?: boolean },
+        options: { upsert?: boolean | undefined; w?: any; wtimeout?: number | undefined; j?: boolean | undefined },
         callback: MongoCallback<UpdateWriteOpResult>,
     ): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#updateOne
@@ -825,7 +825,7 @@ export interface CollStats {
     // Padding can speed up updates if documents grow.
     paddingFactor: number;
     // A number that indicates the user-set flags on the collection. userFlags only appears when using the mmapv1 storage engine.
-    userFlags?: number;
+    userFlags?: number | undefined;
     // Total index size in bytes.
     totalIndexSize: number;
     // Size of specific indexes in bytes.
@@ -839,7 +839,7 @@ export interface CollStats {
     max: number;
     // The maximum size of a capped collection.
     maxSize: number;
-    wiredTiger?: WiredTigerData;
+    wiredTiger?: WiredTigerData | undefined;
     indexDetails?: any;
     ok: number;
 }
@@ -982,65 +982,65 @@ export interface WiredTigerData {
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#aggregate
 export interface CollectionAggregationOptions {
-    readPreference?: ReadPreference | string;
+    readPreference?: ReadPreference | string | undefined;
     // Return the query as cursor, on 2.6 > it returns as a real cursor
     // on pre 2.6 it returns as an emulated cursor.
-    cursor?: { batchSize: number };
+    cursor?: { batchSize: number } | undefined;
     // Explain returns the aggregation execution plan (requires mongodb 2.6 >).
-    explain?: boolean;
+    explain?: boolean | undefined;
     // lets the server know if it can use disk to store
     // temporary results for the aggregation (requires mongodb 2.6 >).
-    allowDiskUse?: boolean;
+    allowDiskUse?: boolean | undefined;
     // specifies a cumulative time limit in milliseconds for processing operations
     // on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
-    maxTimeMS?: number;
+    maxTimeMS?: number | undefined;
     // Allow driver to bypass schema validation in MongoDB 3.2 or higher.
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#insertMany
 export interface CollectionInsertManyOptions {
     // The write concern.
-    w?: number | string;
+    w?: number | string | undefined;
     // The write concern timeout.
-    wtimeout?: number;
+    wtimeout?: number | undefined;
     // Specify a journal write concern.
-    j?: boolean;
+    j?: boolean | undefined;
     // Serialize functions on any object.
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     //Force server to assign _id values instead of driver.
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     // Allow driver to bypass schema validation in MongoDB 3.2 or higher.
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
     // If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
-    ordered?: boolean;
+    ordered?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#bulkWrite
 export interface CollectionBulkWriteOptions {
     // The write concern.
-    w?: number | string;
+    w?: number | string | undefined;
     // The write concern timeout.
-    wtimeout?: number;
+    wtimeout?: number | undefined;
     // Specify a journal write concern.
-    j?: boolean;
+    j?: boolean | undefined;
     // Serialize functions on any object.
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     //Force server to assign _id values instead of driver.
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     // Execute write operation in ordered or unordered fashion.
-    ordered?: boolean;
+    ordered?: boolean | undefined;
     // Allow driver to bypass schema validation in MongoDB 3.2 or higher.
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~BulkWriteOpResult
 export interface BulkWriteOpResultObject {
-    insertedCount?: number;
-    matchedCount?: number;
-    modifiedCount?: number;
-    deletedCount?: number;
-    upsertedCount?: number;
+    insertedCount?: number | undefined;
+    matchedCount?: number | undefined;
+    modifiedCount?: number | undefined;
+    deletedCount?: number | undefined;
+    upsertedCount?: number | undefined;
     insertedIds?: any;
     upsertedIds?: any;
     result?: any;
@@ -1049,13 +1049,13 @@ export interface BulkWriteOpResultObject {
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#count
 export interface MongoCountPreferences {
     // The limit of documents to count.
-    limit?: number;
+    limit?: number | undefined;
     // The number of documents to skip for the count.
-    skip?: number;
+    skip?: number | undefined;
     // An index name hint for the query.
-    hint?: string;
+    hint?: string | undefined;
     // The preferred read preference
-    readPreference?: ReadPreference | string;
+    readPreference?: ReadPreference | string | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~deleteWriteOpResult
@@ -1063,54 +1063,54 @@ export interface DeleteWriteOpResultObject {
     //The raw result returned from MongoDB, field will vary depending on server version.
     result: {
         //Is 1 if the command executed correctly.
-        ok?: number;
+        ok?: number | undefined;
         //The total count of documents deleted.
-        n?: number;
+        n?: number | undefined;
     };
     //The connection object used for the operation.
     connection?: any;
     //The number of documents deleted.
-    deletedCount?: number;
+    deletedCount?: number | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~findAndModifyWriteOpResult
 export interface FindAndModifyWriteOpResultObject<TSchema = Default> {
     //Document returned from findAndModify command.
-    value?: TSchema;
+    value?: TSchema | undefined;
     //The raw lastErrorObject returned from the command.
     lastErrorObject?: any;
     //Is 1 if the command executed correctly.
-    ok?: number;
+    ok?: number | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOneAndReplace
 export interface FindOneAndReplaceOption {
-    projection?: Object;
-    sort?: Object;
-    maxTimeMS?: number;
-    upsert?: boolean;
-    returnOriginal?: boolean;
+    projection?: Object | undefined;
+    sort?: Object | undefined;
+    maxTimeMS?: number | undefined;
+    upsert?: boolean | undefined;
+    returnOriginal?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#geoHaystackSearch
 export interface GeoHaystackSearchOptions {
-    readPreference?: ReadPreference | string;
-    maxDistance?: number;
-    search?: Object;
-    limit?: number;
+    readPreference?: ReadPreference | string | undefined;
+    maxDistance?: number | undefined;
+    search?: Object | undefined;
+    limit?: number | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#geoNear
 export interface GeoNearOptions {
-    readPreference?: ReadPreference | string;
-    num?: number;
-    minDistance?: number;
-    maxDistance?: number;
-    distanceMultiplier?: number;
-    query?: Object;
-    spherical?: boolean;
-    uniqueDocs?: boolean;
-    includeLocs?: boolean;
+    readPreference?: ReadPreference | string | undefined;
+    num?: number | undefined;
+    minDistance?: number | undefined;
+    maxDistance?: number | undefined;
+    distanceMultiplier?: number | undefined;
+    query?: Object | undefined;
+    spherical?: boolean | undefined;
+    uniqueDocs?: boolean | undefined;
+    includeLocs?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Code.html
@@ -1123,11 +1123,11 @@ export class Code {
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#deleteMany
 export interface CollectionOptions {
     //The write concern.
-    w?: number | string;
+    w?: number | string | undefined;
     //The write concern timeout.
-    wtimeout?: number;
+    wtimeout?: number | undefined;
     //Specify a journal write concern.
-    j?: boolean;
+    j?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/OrderedBulkOperation.html
@@ -1219,26 +1219,26 @@ export interface FindOperatorsUnordered {
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOne
 export interface FindOneOptions {
-    limit?: number;
-    sort?: Array<any> | Object;
-    fields?: Object;
-    skip?: number;
-    hint?: Object;
-    explain?: boolean;
-    snapshot?: boolean;
-    timeout?: boolean;
-    tailable?: boolean;
-    batchSize?: number;
-    returnKey?: boolean;
-    maxScan?: number;
-    min?: number;
-    max?: number;
-    showDiskLoc?: boolean;
-    comment?: string;
-    raw?: boolean;
-    readPreference?: ReadPreference | string;
-    partial?: boolean;
-    maxTimeMS?: number;
+    limit?: number | undefined;
+    sort?: Array<any> | Object | undefined;
+    fields?: Object | undefined;
+    skip?: number | undefined;
+    hint?: Object | undefined;
+    explain?: boolean | undefined;
+    snapshot?: boolean | undefined;
+    timeout?: boolean | undefined;
+    tailable?: boolean | undefined;
+    batchSize?: number | undefined;
+    returnKey?: boolean | undefined;
+    maxScan?: number | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
+    showDiskLoc?: boolean | undefined;
+    comment?: string | undefined;
+    raw?: boolean | undefined;
+    readPreference?: ReadPreference | string | undefined;
+    partial?: boolean | undefined;
+    maxTimeMS?: number | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~insertWriteOpResult
@@ -1253,17 +1253,17 @@ export interface InsertWriteOpResult {
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#insertOne
 export interface CollectionInsertOneOptions {
     // The write concern.
-    w?: number | string;
+    w?: number | string | undefined;
     // The write concern timeout.
-    wtimeout?: number;
+    wtimeout?: number | undefined;
     // Specify a journal write concern.
-    j?: boolean;
+    j?: boolean | undefined;
     // Serialize functions on any object.
-    serializeFunctions?: boolean;
+    serializeFunctions?: boolean | undefined;
     //Force server to assign _id values instead of driver.
-    forceServerObjectId?: boolean;
+    forceServerObjectId?: boolean | undefined;
     //Allow driver to bypass schema validation in MongoDB 3.2 or higher.
-    bypassDocumentValidation?: boolean;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~insertOneWriteOpResult
@@ -1277,19 +1277,19 @@ export interface InsertOneWriteOpResult {
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#parallelCollectionScan
 export interface ParallelCollectionScanOptions {
-    readPreference?: ReadPreference | string;
-    batchSize?: number;
-    numCursors?: number;
-    raw?: boolean;
+    readPreference?: ReadPreference | string | undefined;
+    batchSize?: number | undefined;
+    numCursors?: number | undefined;
+    raw?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#replaceOne
 export interface ReplaceOneOptions {
-    upsert?: boolean;
-    w?: number | string;
-    wtimeout?: number;
-    j?: boolean;
-    bypassDocumentValidation?: boolean;
+    upsert?: boolean | undefined;
+    w?: number | string | undefined;
+    wtimeout?: number | undefined;
+    j?: boolean | undefined;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~updateWriteOpResult
@@ -1309,17 +1309,17 @@ export interface ReplaceWriteOpResult extends UpdateWriteOpResult {
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#mapReduce
 export interface MapReduceOptions {
-    readPreference?: ReadPreference | string;
-    out?: Object;
-    query?: Object;
-    sort?: Object;
-    limit?: number;
-    keeptemp?: boolean;
-    finalize?: Function | string;
-    scope?: Object;
-    jsMode?: boolean;
-    verbose?: boolean;
-    bypassDocumentValidation?: boolean;
+    readPreference?: ReadPreference | string | undefined;
+    out?: Object | undefined;
+    query?: Object | undefined;
+    sort?: Object | undefined;
+    limit?: number | undefined;
+    keeptemp?: boolean | undefined;
+    finalize?: Function | string | undefined;
+    scope?: Object | undefined;
+    jsMode?: boolean | undefined;
+    verbose?: boolean | undefined;
+    bypassDocumentValidation?: boolean | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~WriteOpResult
@@ -1410,7 +1410,7 @@ export class Cursor<T = Default> extends Readable {
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#sort
     sort(keyOrList: string | Object[] | Object, direction?: number): Cursor<T>;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#stream
-    stream(options?: { transform?: Function }): Cursor<T>;
+    stream(options?: { transform?: Function | undefined }): Cursor<T>;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#toArray
     toArray(): Promise<T[]>;
     toArray(callback: MongoCallback<T[]>): void;
@@ -1420,11 +1420,11 @@ export class Cursor<T = Default> extends Readable {
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#count
 export interface CursorCommentOptions {
-    skip?: number;
-    limit?: number;
-    maxTimeMS?: number;
-    hint?: string;
-    readPreference?: ReadPreference | string;
+    skip?: number | undefined;
+    limit?: number | undefined;
+    maxTimeMS?: number | undefined;
+    hint?: string | undefined;
+    readPreference?: ReadPreference | string | undefined;
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#~iteratorCallback
@@ -1552,10 +1552,10 @@ export class GridFSBucket {
 
 // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html
 export interface GridFSBucketOptions {
-    bucketName?: string;
-    chunkSizeBytes?: number;
-    writeConcern?: Object;
-    ReadPreference?: Object;
+    bucketName?: string | undefined;
+    chunkSizeBytes?: number | undefined;
+    writeConcern?: Object | undefined;
+    ReadPreference?: Object | undefined;
 }
 
 // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#~errorCallback
@@ -1565,20 +1565,20 @@ export interface GridFSBucketErrorCallback {
 
 // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#find
 export interface GridFSBucketFindOptions {
-    batchSize?: number;
-    limit?: number;
-    maxTimeMS?: number;
-    noCursorTimeout?: boolean;
-    skip?: number;
-    sort?: Object;
+    batchSize?: number | undefined;
+    limit?: number | undefined;
+    maxTimeMS?: number | undefined;
+    noCursorTimeout?: boolean | undefined;
+    skip?: number | undefined;
+    sort?: Object | undefined;
 }
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openUploadStream
 export interface GridFSBucketOpenUploadStreamOptions {
-    chunkSizeBytes?: number;
-    metadata?: Object;
-    contentType?: string;
-    aliases?: Array<string>;
+    chunkSizeBytes?: number | undefined;
+    metadata?: Object | undefined;
+    contentType?: string | undefined;
+    aliases?: Array<string> | undefined;
 }
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketReadStream.html
@@ -1595,10 +1595,10 @@ export class GridFSBucketReadStream extends Readable {
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketReadStream.html
 export interface GridFSBucketReadStreamOptions {
-    sort?: number;
-    skip?: number;
-    start?: number;
-    end?: number;
+    sort?: number | undefined;
+    skip?: number | undefined;
+    start?: number | undefined;
+    end?: number | undefined;
 }
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html
@@ -1609,11 +1609,11 @@ export class GridFSBucketWriteStream extends Writable {
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html
 export interface GridFSBucketWriteStreamOptions {
-    id?: GridFSBucketWriteStreamId;
-    chunkSizeBytes?: number;
-    w?: number;
-    wtimeout?: number;
-    j?: number;
+    id?: GridFSBucketWriteStreamId | undefined;
+    chunkSizeBytes?: number | undefined;
+    w?: number | undefined;
+    wtimeout?: number | undefined;
+    j?: number | undefined;
 }
 
 type GridFSBucketWriteStreamId = string | number | Object | ObjectID;

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -156,14 +156,14 @@ declare namespace morgan {
          * When set to true, defaults to 1000 ms.
          * @deprecated
          */
-        buffer?: boolean;
+        buffer?: boolean | undefined;
 
         /***
          * Write log line on request instead of response. This means that a
          * requests will be logged even if the server crashes, but data from the
          * response cannot be logged (like the response code).
          */
-        immediate?: boolean;
+        immediate?: boolean | undefined;
 
         /***
          * Function to determine if logging is skipped, defaults to false. This
@@ -175,7 +175,7 @@ declare namespace morgan {
          * Output stream for writing log lines, defaults to process.stdout.
          * @param str
          */
-        stream?: StreamOptions;
+        stream?: StreamOptions | undefined;
     }
 }
 

--- a/types/move-concurrently/index.d.ts
+++ b/types/move-concurrently/index.d.ts
@@ -14,17 +14,17 @@ declare namespace move {
         /**
          * (Default: 1) The maximum number of concurrent copies to do at once.
          */
-        maxConcurrency?: number;
+        maxConcurrency?: number | undefined;
         /**
          * (Default: process.platform === 'win32') If true enables Windows symlink semantics.
          * This requires an extra stat to determine if the destination of a symlink is a file or directory.
          * If symlinking a directory fails then we'll try making a junction instead.
          */
-        isWindows?: boolean;
+        isWindows?: boolean | undefined;
         /**
          * (Default: global.Promise) The promise implementation to use, defaults to Node's.
          */
-        Promise?: new (...args: any[]) => T;
+        Promise?: new (...args: any[]) => T | undefined;
         /**
          * (Default: require('fs')) The filesystem module to use. Can be used to use graceful-fs or to inject a mock.
          */

--- a/types/moxios/index.d.ts
+++ b/types/moxios/index.d.ts
@@ -8,9 +8,9 @@ import { AxiosInstance, AxiosRequestConfig } from "axios";
 
 interface Item {
     response?: any;
-    responseText?: string;
-    status?: number;
-    statusText?: string;
+    responseText?: string | undefined;
+    status?: number | undefined;
+    statusText?: string | undefined;
     headers?: any;
 }
 
@@ -112,11 +112,11 @@ declare class Response {
 
     config: AxiosRequestConfig;
     data?: any;
-    status?: number;
-    statusText?: string;
+    status?: number | undefined;
+    statusText?: string | undefined;
     headers: any;
     request: Request;
-    code?: string;
+    code?: string | undefined;
 }
 
 declare let moxios: {

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -126,8 +126,8 @@ export interface IColumnMetadata {
         length: number;
         type: (() => ISqlType) | ISqlType;
         udt?: any;
-        scale?: number;
-        precision?: number;
+        scale?: number | undefined;
+        precision?: number | undefined;
         nullable: boolean;
         caseSensitive: boolean;
         identity: boolean;
@@ -164,50 +164,50 @@ export declare var ISOLATION_LEVEL: {
 }
 
 export interface IOptions extends tds.ConnectionOptions {
-    beforeConnect?: void;
-    connectionString?: string;
-    enableArithAbort?: boolean;
-    instanceName?: string;
-    trustedConnection?: boolean;
-    useUTC?: boolean;
+    beforeConnect?: void | undefined;
+    connectionString?: string | undefined;
+    enableArithAbort?: boolean | undefined;
+    instanceName?: string | undefined;
+    trustedConnection?: boolean | undefined;
+    useUTC?: boolean | undefined;
 }
 
 export declare var pool: ConnectionPool;
 
 export interface PoolOpts<T> extends Omit<PoolOptions<T>, 'create' | 'destroy' | 'min' | 'max'> {
-    create?: CallbackOrPromise<T>;
-    destroy?: (resource: T) => any;
-    min?: number;
-    max?: number;
+    create?: CallbackOrPromise<T> | undefined;
+    destroy?: ((resource: T) => any) | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
 }
 
 export interface config {
-    driver?: string;
-    user?: string;
-    password?: string;
+    driver?: string | undefined;
+    user?: string | undefined;
+    password?: string | undefined;
     server: string;
-    port?: number;
-    domain?: string;
-    database?: string;
-    connectionTimeout?: number;
-    requestTimeout?: number;
-    stream?: boolean;
-    parseJSON?: boolean;
-    options?: IOptions;
-    pool?: PoolOpts<Connection>;
-    arrayRowMode?: boolean;
+    port?: number | undefined;
+    domain?: string | undefined;
+    database?: string | undefined;
+    connectionTimeout?: number | undefined;
+    requestTimeout?: number | undefined;
+    stream?: boolean | undefined;
+    parseJSON?: boolean | undefined;
+    options?: IOptions | undefined;
+    pool?: PoolOpts<Connection> | undefined;
+    arrayRowMode?: boolean | undefined;
     /**
      * Invoked before opening the connection. The parameter conn is the configured
      * tedious Connection. It can be used for attaching event handlers.
      */
-    beforeConnect?: (conn: Connection) => void
+    beforeConnect?: ((conn: Connection) => void) | undefined
 }
 
 export declare class MSSQLError extends Error {
     constructor(message: Error | string, code?: string);
     public code: string;
     public name: string;
-    public originalError?: Error;
+    public originalError?: Error | undefined;
 }
 
 export declare class ConnectionPool extends events.EventEmitter {
@@ -243,11 +243,11 @@ export declare class ConnectionPool extends events.EventEmitter {
 export declare class ConnectionError extends MSSQLError {}
 
 export interface IColumnOptions {
-    nullable?: boolean;
-    primary?: boolean;
-    identity?: boolean;
-    readOnly?: boolean;
-    length?: number
+    nullable?: boolean | undefined;
+    primary?: boolean | undefined;
+    identity?: boolean | undefined;
+    readOnly?: boolean | undefined;
+    length?: number | undefined
 }
 
 export interface IColumn extends ISqlType {
@@ -271,11 +271,11 @@ export declare class Table {
     public columns: columns;
     public rows: rows;
     public constructor(tableName?: string);
-    public schema?: string;
-    public database?: string;
-    public name?: string;
-    public path?: string;
-    public temporary?: boolean;
+    public schema?: string | undefined;
+    public database?: string | undefined;
+    public name?: string | undefined;
+    public path?: string | undefined;
+    public temporary?: boolean | undefined;
 }
 
 interface IRequestParameters {
@@ -296,13 +296,13 @@ interface IRequestParameters {
  */
 export interface IBulkOptions {
     /** Honors constraints during bulk load, using T-SQL CHECK_CONSTRAINTS. (default: false) */
-    checkConstraints?: boolean;
+    checkConstraints?: boolean | undefined;
     /** Honors insert triggers during bulk load, using the T-SQL FIRE_TRIGGERS. (default: false) */
-    fireTriggers?: boolean;
+    fireTriggers?: boolean | undefined;
     /** Honors null value passed, ignores the default values set on table, using T-SQL KEEP_NULLS. (default: false) */
-    keepNulls?: boolean;
+    keepNulls?: boolean | undefined;
     /** Places a bulk update(BU) lock on table while performing bulk load, using T-SQL TABLOCK. (default: false) */
-    tableLock?: boolean;
+    tableLock?: boolean | undefined;
 }
 
 export declare class Request extends events.EventEmitter {
@@ -346,12 +346,12 @@ export declare class Request extends events.EventEmitter {
 }
 
 export declare class RequestError extends MSSQLError {
-    public number?: number;
-    public lineNumber?: number;
-    public state?: string;
-    public class?: string;
-    public serverName?: string;
-    public procName?: string;
+    public number?: number | undefined;
+    public lineNumber?: number | undefined;
+    public state?: string | undefined;
+    public class?: string | undefined;
+    public serverName?: string | undefined;
+    public procName?: string | undefined;
 }
 
 export declare class Transaction extends events.EventEmitter {

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -49,14 +49,14 @@ declare global {
 
         interface Request {
             /** `Multer.File` object populated by `single()` middleware. */
-            file?: Multer.File;
+            file?: Multer.File | undefined;
             /**
              * Array or dictionary of `Multer.File` object populated by `array()`,
              * `fields()`, and `any()` middleware.
              */
             files?: {
                 [fieldname: string]: Multer.File[];
-            } | Multer.File[];
+            } | Multer.File[] | undefined;
         }
     }
 }
@@ -167,7 +167,7 @@ declare namespace multer {
         /** Descriptive error message. */
         message: string;
         /** Name of the multipart form field associated with this error. */
-        field?: string;
+        field?: string | undefined;
     }
 
     /**
@@ -186,7 +186,7 @@ declare namespace multer {
          * A `StorageEngine` responsible for processing files uploaded via Multer.
          * Takes precedence over `dest`.
          */
-        storage?: StorageEngine;
+        storage?: StorageEngine | undefined;
         /**
          * The destination directory for uploaded files. If `storage` is not set
          * and `dest` is, Multer will create a `DiskStorage` instance configured
@@ -194,7 +194,7 @@ declare namespace multer {
          *
          * Ignored if `storage` is set.
          */
-        dest?: string;
+        dest?: string | undefined;
         /**
          * An object specifying various limits on incoming data. This object is
          * passed to Busboy directly, and the details of properties can be found
@@ -202,22 +202,22 @@ declare namespace multer {
          */
         limits?: {
             /** Maximum size of each form field name in bytes. (Default: 100) */
-            fieldNameSize?: number;
+            fieldNameSize?: number | undefined;
             /** Maximum size of each form field value in bytes. (Default: 1048576) */
-            fieldSize?: number;
+            fieldSize?: number | undefined;
             /** Maximum number of non-file form fields. (Default: Infinity) */
-            fields?: number;
+            fields?: number | undefined;
             /** Maximum size of each file in bytes. (Default: Infinity) */
-            fileSize?: number;
+            fileSize?: number | undefined;
             /** Maximum number of file fields. (Default: Infinity) */
-            files?: number;
+            files?: number | undefined;
             /** Maximum number of parts (non-file fields + files). (Default: Infinity) */
-            parts?: number;
+            parts?: number | undefined;
             /** Maximum number of headers. (Default: 2000) */
-            headerPairs?: number;
-        };
+            headerPairs?: number | undefined;
+        } | undefined;
         /** Preserve the full path of the original filename rather than the basename. (Default: false) */
-        preservePath?: boolean;
+        preservePath?: boolean | undefined;
         /**
          * Optional function to control which files are uploaded. This is called
          * for every file that is processed.
@@ -289,7 +289,7 @@ declare namespace multer {
             req: Request,
             file: Express.Multer.File,
             callback: (error: Error | null, destination: string) => void
-        ) => void);
+        ) => void) | undefined;
         /**
          * A function that determines the name of the uploaded file. If nothing
          * is passed, Multer will generate a 32 character pseudorandom hex string
@@ -314,7 +314,7 @@ declare namespace multer {
         /** The field name. */
         name: string;
         /** Optional maximum number of files per field to accept. (Default: Infinity) */
-        maxCount?: number;
+        maxCount?: number | undefined;
     }
 }
 

--- a/types/multicast-dns/index.d.ts
+++ b/types/multicast-dns/index.d.ts
@@ -44,64 +44,64 @@ declare namespace mDNS {
          *
          * @default 5353
          */
-        port?: number;
+        port?: number | undefined;
 
         /**
          * Set the socket type.
          *
          * @default 'udp4'
          */
-        type?: SocketType;
+        type?: SocketType | undefined;
 
         /**
          * Set the UDP ip.
          */
-        ip?: string;
+        ip?: string | undefined;
 
         /**
          * Explicitly specify a network interface. Will use all interfaces when not specified.
          */
-        interface?: string;
+        interface?: string | undefined;
 
         /**
          * Explicitly pass a constructed socket to use.
          */
-        socket?: Socket;
+        socket?: Socket | undefined;
 
         /**
          * Set the `reuseAddr` option when creating the socket.
          *
          * @default true
          */
-        reuseAddr?: boolean;
+        reuseAddr?: boolean | undefined;
 
         /**
          * The interface to bind to or `false` to prevent binding.
          *
          * @default Options.interface
          */
-        bind?: false | string;
+        bind?: false | string | undefined;
 
         /**
          * Use UDP multicasting.
          *
          * @default true
          */
-        multicast?: boolean;
+        multicast?: boolean | undefined;
 
         /**
          * Set the multicast ttl.
          *
          * @default 255
          */
-        ttl?: number;
+        ttl?: number | undefined;
 
         /**
          * Receive your own packets.
          *
          * @default true
          */
-        loopback?: boolean;
+        loopback?: boolean | undefined;
     }
 
     type FullPacket = Required<Packet>;
@@ -124,7 +124,7 @@ declare namespace mDNS {
 
     interface RemoteInfoOutgoing {
         port: number;
-        address?: string;
+        address?: string | undefined;
     }
 
     interface MulticastDNS extends EventEmitter {

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -419,8 +419,8 @@ type PartialsOrLookupFn = Record<string, string> | PartialLookupFn;
 type PartialLookupFn = (partialName: string) => string | undefined;
 
 interface RenderOptions {
-    escape?: EscapeFunction;
-    tags?: OpeningAndClosingTags;
+    escape?: EscapeFunction | undefined;
+    tags?: OpeningAndClosingTags | undefined;
 }
 
 interface TemplateCache {

--- a/types/mute-stream/index.d.ts
+++ b/types/mute-stream/index.d.ts
@@ -13,7 +13,7 @@ declare namespace MuteStream {
          * Set to a string to replace each character with the specified string when muted.
          * (So you can show **** instead of the password, for example.)
          */
-        replace?: string;
+        replace?: string | undefined;
 
         /**
          * If you are using a replacement char, and also using a prompt with a readline stream
@@ -21,7 +21,7 @@ declare namespace MuteStream {
          * will work properly. Otherwise, pressing backspace will overwrite the prompt with the
          * replacement character, which is weird.
          */
-        prompt?: string;
+        prompt?: string | undefined;
     }
 }
 

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -228,12 +228,12 @@ export interface Query {
     /**
      * Values for template query
      */
-    values?: string[];
+    values?: string[] | undefined;
 
     /**
      * Default true
      */
-    typeCast?: TypeCast;
+    typeCast?: TypeCast | undefined;
 
     /**
      * Default false
@@ -327,7 +327,7 @@ export interface QueryOptions {
      * operations through the client. This means that when a timeout is reached, the connection it occurred on will be
      * destroyed and no further operations can be performed.
      */
-    timeout?: number;
+    timeout?: number | undefined;
 
     /**
      * Either a boolean or string. If true, tables will be nested objects. If string (e.g. '_'), tables will be
@@ -355,78 +355,78 @@ export interface QueryOptions {
      *
      * You can find which field function you need to use by looking at: RowDataPacket.prototype._typeCast
      */
-    typeCast?: TypeCast;
+    typeCast?: TypeCast | undefined;
 }
 
 export interface ConnectionOptions {
     /**
      * The MySQL user to authenticate as
      */
-    user?: string;
+    user?: string | undefined;
 
     /**
      * The password of that MySQL user
      */
-    password?: string;
+    password?: string | undefined;
 
     /**
      * Name of the database to use for this connection
      */
-    database?: string;
+    database?: string | undefined;
 
     /**
      * The charset for the connection. This is called "collation" in the SQL-level of MySQL (like utf8_general_ci).
      * If a SQL-level charset is specified (like utf8mb4) then the default collation for that charset is used.
      * (Default: 'UTF8_GENERAL_CI')
      */
-    charset?: string;
+    charset?: string | undefined;
 
     /**
      * Number of milliseconds
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 export interface ConnectionConfig extends ConnectionOptions {
     /**
      * The hostname of the database you are connecting to. (Default: localhost)
      */
-    host?: string;
+    host?: string | undefined;
 
     /**
      * The port number to connect to. (Default: 3306)
      */
-    port?: number;
+    port?: number | undefined;
 
     /**
      * The source IP address to use for TCP connection
      */
-    localAddress?: string;
+    localAddress?: string | undefined;
 
     /**
      * The path to a unix domain socket to connect to. When used host and port are ignored
      */
-    socketPath?: string;
+    socketPath?: string | undefined;
 
     /**
      * The timezone used to store local dates. (Default: 'local')
      */
-    timezone?: string;
+    timezone?: string | undefined;
 
     /**
      * The milliseconds before a timeout occurs during the initial connection to the MySQL server. (Default: 10 seconds)
      */
-    connectTimeout?: number;
+    connectTimeout?: number | undefined;
 
     /**
      * Stringify objects instead of converting to values. (Default: 'false')
      */
-    stringifyObjects?: boolean;
+    stringifyObjects?: boolean | undefined;
 
     /**
      * Allow connecting to MySQL instances that ask for the old (insecure) authentication method. (Default: false)
      */
-    insecureAuth?: boolean;
+    insecureAuth?: boolean | undefined;
 
     /**
      * Determines if column values should be converted to native JavaScript types. It is not recommended (and may go away / change in the future)
@@ -448,7 +448,7 @@ export interface ConnectionConfig extends ConnectionOptions {
      *
      * You can find which field function you need to use by looking at: RowDataPacket.prototype._typeCast
      */
-    typeCast?: TypeCast;
+    typeCast?: TypeCast | undefined;
 
     /**
      * A custom query format function
@@ -459,7 +459,7 @@ export interface ConnectionConfig extends ConnectionOptions {
      * When dealing with big numbers (BIGINT and DECIMAL columns) in the database, you should enable this option
      * (Default: false)
      */
-    supportBigNumbers?: boolean;
+    supportBigNumbers?: boolean | undefined;
 
     /**
      * Enabling both supportBigNumbers and bigNumberStrings forces big numbers (BIGINT and DECIMAL columns) to be
@@ -469,13 +469,13 @@ export interface ConnectionConfig extends ConnectionOptions {
      * (which happens when they exceed the [-2^53, +2^53] range), otherwise they will be returned as Number objects.
      * This option is ignored if supportBigNumbers is disabled.
      */
-    bigNumberStrings?: boolean;
+    bigNumberStrings?: boolean | undefined;
 
     /**
      * Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript
      * Date objects. Can be true/false or an array of type names to keep as strings. (Default: false)
      */
-    dateStrings?: boolean | Array<'TIMESTAMP' | 'DATETIME' | 'DATE'>;
+    dateStrings?: boolean | Array<'TIMESTAMP' | 'DATETIME' | 'DATE'> | undefined;
 
     /**
      * This will print all incoming and outgoing packets on stdout.
@@ -483,28 +483,28 @@ export interface ConnectionConfig extends ConnectionOptions {
      *
      * (Default: false)
      */
-    debug?: boolean | string[] | Types[];
+    debug?: boolean | string[] | Types[] | undefined;
 
     /**
      * Generates stack traces on errors to include call site of library entrance ("long stack traces"). Slight
      * performance penalty for most calls. (Default: true)
      */
-    trace?: boolean;
+    trace?: boolean | undefined;
 
     /**
      * Allow multiple mysql statements per query. Be careful with this, it exposes you to SQL injection attacks. (Default: false)
      */
-    multipleStatements?: boolean;
+    multipleStatements?: boolean | undefined;
 
     /**
      * List of connection flags to use other than the default ones. It is also possible to blacklist default ones
      */
-    flags?: string | string[];
+    flags?: string | string[] | undefined;
 
     /**
      * object with ssl parameters or a string containing name of ssl profile
      */
-    ssl?: string | (tls.SecureContextOptions & { rejectUnauthorized?: boolean });
+    ssl?: string | (tls.SecureContextOptions & { rejectUnauthorized?: boolean | undefined }) | undefined;
 }
 
 export interface PoolSpecificConfig {
@@ -512,25 +512,25 @@ export interface PoolSpecificConfig {
      * The milliseconds before a timeout occurs during the connection acquisition. This is slightly different from connectTimeout,
      * because acquiring a pool connection does not always involve making a connection. (Default: 10 seconds)
      */
-    acquireTimeout?: number;
+    acquireTimeout?: number | undefined;
 
     /**
      * Determines the pool's action when no connections are available and the limit has been reached. If true, the pool will queue
      * the connection request and call it when one becomes available. If false, the pool will immediately call back with an error.
      * (Default: true)
      */
-    waitForConnections?: boolean;
+    waitForConnections?: boolean | undefined;
 
     /**
      * The maximum number of connections to create at once. (Default: 10)
      */
-    connectionLimit?: number;
+    connectionLimit?: number | undefined;
 
     /**
      * The maximum number of connection requests the pool will queue before returning an error from getConnection. If set to 0, there
      * is no limit to the number of queued connection requests. (Default: 0)
      */
-    queueLimit?: number;
+    queueLimit?: number | undefined;
 }
 
 export interface PoolConfig extends PoolSpecificConfig, ConnectionConfig {
@@ -544,19 +544,19 @@ export interface PoolClusterConfig {
     /**
      * If true, PoolCluster will attempt to reconnect when connection fails. (Default: true)
      */
-    canRetry?: boolean;
+    canRetry?: boolean | undefined;
 
     /**
      * If connection fails, node's errorCount increases. When errorCount is greater than removeNodeErrorCount,
      * remove a node in the PoolCluster. (Default: 5)
      */
-    removeNodeErrorCount?: number;
+    removeNodeErrorCount?: number | undefined;
 
     /**
      * If connection fails, specifies the number of milliseconds before another connection attempt will be made.
      * If set to 0, then node will be removed instead and never re-used. (Default: 0)
      */
-    restoreNodeTimeout?: number;
+    restoreNodeTimeout?: number | undefined;
 
     /**
      * The default selector. (Default: RR)
@@ -564,7 +564,7 @@ export interface PoolClusterConfig {
      * RANDOM: Select the node by random function.
      * ORDER: Select the first node available unconditionally.
      */
-    defaultSelector?: string;
+    defaultSelector?: string | undefined;
 }
 
 export interface MysqlError extends Error {
@@ -583,22 +583,22 @@ export interface MysqlError extends Error {
     /**
      * The sql state marker
      */
-    sqlStateMarker?: string;
+    sqlStateMarker?: string | undefined;
 
     /**
      * The sql state
      */
-    sqlState?: string;
+    sqlState?: string | undefined;
 
     /**
      * The field count
      */
-    fieldCount?: number;
+    fieldCount?: number | undefined;
 
     /**
      * The stack trace for the error
      */
-    stack?: string;
+    stack?: string | undefined;
 
     /**
      * Boolean, indicating if this error is terminal to the connection object.
@@ -608,12 +608,12 @@ export interface MysqlError extends Error {
     /**
      * SQL of failed query
      */
-    sql?: string;
+    sql?: string | undefined;
 
     /**
      * Error message from MySQL
      */
-    sqlMessage?: string;
+    sqlMessage?: string | undefined;
 }
 
 // Result from an insert, update, or delete statement.
@@ -627,8 +627,8 @@ export interface OkPacket {
      * The insert id after inserting a row into a table with an auto increment primary key.
      */
     insertId: number;
-    serverStatus?: number;
-    warningCount?: number;
+    serverStatus?: number | undefined;
+    warningCount?: number | undefined;
     /**
      * The server result message from an insert, update, or delete statement.
      */
@@ -685,7 +685,7 @@ export interface UntypedFieldInfo {
     length: number;
     flags: number;
     decimals: number;
-    default?: string;
+    default?: string | undefined;
     zeroFill: boolean;
     protocol41: boolean;
 }

--- a/types/mz/child_process.d.ts
+++ b/types/mz/child_process.d.ts
@@ -21,12 +21,12 @@ export function exec(
 ): ChildProcess;
 export function exec(
     command: string,
-    options: ({ encoding?: BufferEncoding } & ExecOptions) | null | undefined,
+    options: ({ encoding?: BufferEncoding | undefined } & ExecOptions) | null | undefined,
     callback: (error: ExecException | null, stdout: string, stderr: string) => void
 ): ChildProcess;
 export function exec(
     command: string,
-    options: ({ encoding?: string | null } & ExecOptions) | null | undefined,
+    options: ({ encoding?: string | null | undefined } & ExecOptions) | null | undefined,
     callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void
 ): ChildProcess;
 
@@ -36,11 +36,11 @@ export function exec(
 ): Promise<[Buffer, Buffer]>;
 export function exec(
     command: string,
-    options?: ({ encoding?: BufferEncoding } & ExecOptions) | null
+    options?: ({ encoding?: BufferEncoding | undefined } & ExecOptions) | null
 ): Promise<[string, string]>;
 export function exec(
     command: string,
-    options?: ({ encoding?: string | null } & ExecOptions) | null
+    options?: ({ encoding?: string | null | undefined } & ExecOptions) | null
 ): Promise<[string | Buffer, string | Buffer]>;
 
 interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
@@ -48,7 +48,7 @@ interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
 }
 
 interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-    encoding?: string | null;
+    encoding?: string | null | undefined;
 }
 
 // no `options` definitely means stdout/stderr are `string`.

--- a/types/mz/fs.d.ts
+++ b/types/mz/fs.d.ts
@@ -341,7 +341,7 @@ export function symlink(target: PathLike, path: PathLike, type?: string | null):
  */
 export function readlink(
     path: PathLike,
-    options: { encoding?: BufferEncoding | null } | BufferEncoding | null | undefined,
+    options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, linkString: string) => void
 ): void;
 
@@ -369,7 +369,7 @@ export function readlink(
  */
 export function readlink(
     path: PathLike,
-    options: { encoding?: string | null } | string | null | undefined,
+    options: { encoding?: string | null | undefined } | string | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, linkString: string | Buffer) => void
 ): void;
 
@@ -395,7 +395,7 @@ export function readlink(
  */
 export function readlink(
     path: PathLike,
-    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null
 ): Promise<string>;
 
 /**
@@ -418,7 +418,7 @@ export function readlink(path: PathLike, options: { encoding: "buffer" } | "buff
  */
 export function readlink(
     path: PathLike,
-    options?: { encoding?: string | null } | string | null
+    options?: { encoding?: string | null | undefined } | string | null
 ): Promise<string | Buffer>;
 
 /**
@@ -431,7 +431,7 @@ export function readlink(
  */
 export function realpath(
     path: PathLike,
-    options: { encoding?: BufferEncoding | null } | BufferEncoding | null | undefined,
+    options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, resolvedPath: string) => void
 ): void;
 
@@ -459,7 +459,7 @@ export function realpath(
  */
 export function realpath(
     path: PathLike,
-    options: { encoding?: string | null } | string | null | undefined,
+    options: { encoding?: string | null | undefined } | string | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, resolvedPath: string | Buffer) => void
 ): void;
 
@@ -485,7 +485,7 @@ export function realpath(
  */
 export function realpath(
     path: PathLike,
-    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null
 ): Promise<string>;
 
 /**
@@ -508,13 +508,13 @@ export function realpath(path: PathLike, options: { encoding: "buffer" } | "buff
  */
 export function realpath(
     path: PathLike,
-    options?: { encoding?: string | null } | string | null
+    options?: { encoding?: string | null | undefined } | string | null
 ): Promise<string | Buffer>;
 
 export namespace realpath {
     function native(
         path: PathLike,
-        options: { encoding?: BufferEncoding | null } | BufferEncoding | null | undefined,
+        options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, resolvedPath: string) => void
     ): void;
     function native(
@@ -524,19 +524,19 @@ export namespace realpath {
     ): void;
     function native(
         path: PathLike,
-        options: { encoding?: string | null } | string | null | undefined,
+        options: { encoding?: string | null | undefined } | string | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, resolvedPath: string | Buffer) => void
     ): void;
     function native(path: PathLike, callback: (err: NodeJS.ErrnoException | null, resolvedPath: string) => void): void;
 
     function native(
         path: PathLike,
-        options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+        options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null
     ): Promise<string>;
     function native(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
     function native(
         path: PathLike,
-        options: { encoding?: string | null } | string | null | undefined
+        options: { encoding?: string | null | undefined } | string | null | undefined
     ): Promise<string | Buffer>;
 }
 
@@ -630,7 +630,7 @@ export function mkdir(path: PathLike, options?: number | string | MakeDirectoryO
  */
 export function mkdtemp(
     prefix: string,
-    options: { encoding?: BufferEncoding | null } | BufferEncoding | null | undefined,
+    options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, folder: string) => void
 ): void;
 
@@ -658,7 +658,7 @@ export function mkdtemp(
  */
 export function mkdtemp(
     prefix: string,
-    options: { encoding?: string | null } | string | null | undefined,
+    options: { encoding?: string | null | undefined } | string | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, folder: string | Buffer) => void
 ): void;
 
@@ -682,7 +682,7 @@ export function mkdtemp(prefix: string, callback: (err: NodeJS.ErrnoException | 
  */
 export function mkdtemp(
     prefix: string,
-    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null
 ): Promise<string>;
 
 /***
@@ -705,7 +705,7 @@ export function mkdtemp(prefix: string, options: { encoding: "buffer" } | "buffe
  */
 export function mkdtemp(
     prefix: string,
-    options?: { encoding?: string | null } | string | null
+    options?: { encoding?: string | null | undefined } | string | null
 ): Promise<string | Buffer>;
 
 /**
@@ -718,7 +718,7 @@ export function mkdtemp(
  */
 export function readdir(
     path: PathLike,
-    options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null | undefined,
+    options: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, files: string[]) => void
 ): void;
 
@@ -732,7 +732,7 @@ export function readdir(
  */
 export function readdir(
     path: PathLike,
-    options: { encoding: "buffer"; withFileTypes?: false } | "buffer",
+    options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer",
     callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void
 ): void;
 
@@ -746,7 +746,7 @@ export function readdir(
  */
 export function readdir(
     path: PathLike,
-    options: { encoding?: string | null; withFileTypes?: false } | string | null | undefined,
+    options: { encoding?: string | null | undefined; withFileTypes?: false | undefined } | string | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, files: string[] | Buffer[]) => void
 ): void;
 
@@ -769,7 +769,7 @@ export function readdir(path: PathLike, callback: (err: NodeJS.ErrnoException | 
  */
 export function readdir(
     path: PathLike,
-    options: { encoding?: string | null; withFileTypes: true },
+    options: { encoding?: string | null | undefined; withFileTypes: true },
     callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void
 ): void;
 
@@ -783,7 +783,7 @@ export function readdir(
  */
 export function readdir(
     path: PathLike,
-    options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null
+    options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null
 ): Promise<string[]>;
 
 /**
@@ -796,7 +796,7 @@ export function readdir(
  */
 export function readdir(
     path: PathLike,
-    options: "buffer" | { encoding: "buffer"; withFileTypes?: false }
+    options: "buffer" | { encoding: "buffer"; withFileTypes?: false | undefined }
 ): Promise<Buffer[]>;
 
 /**
@@ -809,7 +809,7 @@ export function readdir(
  */
 export function readdir(
     path: PathLike,
-    options?: { encoding?: string | null; withFileTypes?: false } | string | null
+    options?: { encoding?: string | null | undefined; withFileTypes?: false | undefined } | string | null
 ): Promise<string[] | Buffer[]>;
 
 /**
@@ -820,7 +820,7 @@ export function readdir(
  * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
  * @param options If called with `withFileTypes: true` the result data will be an array of Dirent
  */
-export function readdir(path: PathLike, options: { encoding?: string | null; withFileTypes: true }): Promise<Dirent[]>;
+export function readdir(path: PathLike, options: { encoding?: string | null | undefined; withFileTypes: true }): Promise<Dirent[]>;
 
 /**
  * Asynchronous `close(2)`.
@@ -1116,7 +1116,7 @@ export function read<TBuffer extends NodeJS.ArrayBufferView>(
  */
 export function readFile(
     path: PathLike | number,
-    options: { encoding?: null; flag?: string } | null | undefined,
+    options: { encoding?: null | undefined; flag?: string | undefined } | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void
 ): void;
 
@@ -1131,7 +1131,7 @@ export function readFile(
  */
 export function readFile(
     path: PathLike | number,
-    options: { encoding: string; flag?: string } | string,
+    options: { encoding: string; flag?: string | undefined } | string,
     callback: (err: NodeJS.ErrnoException | null, data: string) => void
 ): void;
 
@@ -1146,7 +1146,7 @@ export function readFile(
  */
 export function readFile(
     path: PathLike | number,
-    options: { encoding?: string | null; flag?: string } | string | null | undefined,
+    options: { encoding?: string | null | undefined; flag?: string | undefined } | string | null | undefined,
     callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void
 ): void;
 
@@ -1169,7 +1169,7 @@ export function readFile(
  * @param options An object that may contain an optional flag.
  * If a flag is not provided, it defaults to `'r'`.
  */
-export function readFile(path: PathLike | number, options?: { encoding?: null; flag?: string } | null): Promise<Buffer>;
+export function readFile(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined } | null): Promise<Buffer>;
 
 /**
  * Asynchronously reads the entire contents of a file.
@@ -1182,7 +1182,7 @@ export function readFile(path: PathLike | number, options?: { encoding?: null; f
  */
 export function readFile(
     path: PathLike | number,
-    options: { encoding: string; flag?: string } | string
+    options: { encoding: string; flag?: string | undefined } | string
 ): Promise<string>;
 
 /**
@@ -1196,7 +1196,7 @@ export function readFile(
  */
 export function readFile(
     path: PathLike | number,
-    options?: { encoding?: string | null; flag?: string } | string | null
+    options?: { encoding?: string | null | undefined; flag?: string | undefined } | string | null
 ): Promise<string | Buffer>;
 
 /**
@@ -1294,7 +1294,7 @@ export function appendFile(file: PathLike | number, data: any, options?: WriteFi
  */
 export function watchFile(
     filename: PathLike,
-    options: { persistent?: boolean; interval?: number } | undefined,
+    options: { persistent?: boolean | undefined; interval?: number | undefined } | undefined,
     listener: (curr: Stats, prev: Stats) => void
 ): void;
 
@@ -1324,7 +1324,7 @@ export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: S
 export function watch(
     filename: PathLike,
     options:
-        { encoding?: BufferEncoding | null; persistent?: boolean; recursive?: boolean } |
+        { encoding?: BufferEncoding | null | undefined; persistent?: boolean | undefined; recursive?: boolean | undefined } |
         BufferEncoding |
         undefined |
         null,
@@ -1342,7 +1342,7 @@ export function watch(
  */
 export function watch(
     filename: PathLike,
-    options: { encoding: "buffer"; persistent?: boolean; recursive?: boolean } | "buffer",
+    options: { encoding: "buffer"; persistent?: boolean | undefined; recursive?: boolean | undefined } | "buffer",
     listener?: (event: string, filename: Buffer) => void
 ): FSWatcher;
 
@@ -1357,7 +1357,7 @@ export function watch(
  */
 export function watch(
     filename: PathLike,
-    options: { encoding?: string | null; persistent?: boolean; recursive?: boolean } | string | null,
+    options: { encoding?: string | null | undefined; persistent?: boolean | undefined; recursive?: boolean | undefined } | string | null,
     listener?: (event: string, filename: string | Buffer) => void
 ): FSWatcher;
 

--- a/types/mz/readline.d.ts
+++ b/types/mz/readline.d.ts
@@ -19,7 +19,7 @@ export type AsyncCompleter =
 export type Completer = AsyncCompleter | readline.Completer;
 
 export interface ReadLineOptions extends readline.ReadLineOptions {
-    completer?: Completer;
+    completer?: Completer | undefined;
 }
 
 export function createInterface(

--- a/types/nconf/index.d.ts
+++ b/types/nconf/index.d.ts
@@ -61,17 +61,17 @@ export interface IOptions {
 
 export interface ISecureFileOptions {
     secret: string;
-    alg?: string;
+    alg?: string | undefined;
 }
 
 export interface IFileOptions {
-    type?: string;
-    file?: string;
-    dir?: string;
-    search?: boolean;
-    format?: IFormat;
-    json_spacing?: number;
-    secure?: ISecureFileOptions;
+    type?: string | undefined;
+    file?: string | undefined;
+    dir?: string | undefined;
+    search?: boolean | undefined;
+    format?: IFormat | undefined;
+    json_spacing?: number | undefined;
+    secure?: ISecureFileOptions | undefined;
 }
 
 export interface ICallbackFunction {

--- a/types/ncp/index.d.ts
+++ b/types/ncp/index.d.ts
@@ -21,13 +21,13 @@ declare namespace ncp {
     }
 
     interface Options {
-        filter?: RegExp | ((filename: string) => boolean);
-        transform?: (read: NodeJS.ReadableStream, write: NodeJS.WritableStream, file: File) => void;
-        clobber?: boolean;
-        dereference?: boolean;
-        stopOnErr?: boolean;
-        errs?: fs.PathLike;
-        limit?: number;
+        filter?: RegExp | ((filename: string) => boolean) | undefined;
+        transform?: ((read: NodeJS.ReadableStream, write: NodeJS.WritableStream, file: File) => void) | undefined;
+        clobber?: boolean | undefined;
+        dereference?: boolean | undefined;
+        stopOnErr?: boolean | undefined;
+        errs?: fs.PathLike | undefined;
+        limit?: number | undefined;
     }
 }
 

--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -18,7 +18,7 @@ declare namespace core {
         body: any;
         raw: Buffer;
         bytes: number;
-        cookies?: Cookies;
+        cookies?: Cookies | undefined;
     }
 
     type ReadableStream = NodeJS.ReadableStream;
@@ -42,63 +42,63 @@ declare namespace core {
          * Returns error if connection takes longer than X milisecs to establish.
          * Defaults to 10000 (10 secs). 0 means no timeout.
          */
-        open_timeout?: number;
+        open_timeout?: number | undefined;
         /**
          * Alias for open_timeout
          */
-        timeout?: RequestOptions['open_timeout'];
+        timeout?: RequestOptions['open_timeout'] | undefined;
 
         /**
          * Returns error if no response headers are received in X milisecs,
          * counting from when the connection is opened. Defaults to `0` (no response timeout).
          */
-        response_timeout?: number;
+        response_timeout?: number | undefined;
 
         /**
          * Returns error if data transfer takes longer than X milisecs,
          * after connection is established. Defaults to 0 (no timeout).
          */
-        read_timeout?: number;
+        read_timeout?: number | undefined;
         /**
          * Number of redirects to follow. Defaults to 0.
          */
-        follow_max?: number;
+        follow_max?: number | undefined;
         /**
          * Alias for follow_max
          */
-        follow?: RequestOptions['follow_max'];
+        follow?: RequestOptions['follow_max'] | undefined;
 
         /**
          * Enables multipart/form-data encoding. Defaults to false.
          * Use it when uploading files.
          */
-        multipart?: boolean;
+        multipart?: boolean | undefined;
         /**
          * Uses an http.Agent of your choice, instead of the global, default one.
          * Useful for tweaking the behaviour at the connection level, such as when doing tunneling.
          */
-        agent?: http.Agent | boolean;
+        agent?: http.Agent | boolean | undefined;
         /**
          * Forwards request through HTTP(s) proxy.
          * Eg. proxy: 'http://user:pass@proxy.server.com:3128'.
          * For more advanced proxying/tunneling use a custom agent.
          */
-        proxy?: string;
+        proxy?: string | undefined;
         /**
          * Object containing custom HTTP headers for request.
          */
-        headers?: {};
+        headers?: {} | undefined;
         /**
          * Determines what to do with provided username/password.
          * Options are auto, digest or basic (default).
          * auto will detect the type of authentication depending on the response headers.
          */
-        auth?: "auto" | "digest" | "basic";
+        auth?: "auto" | "digest" | "basic" | undefined;
         /**
          * When true, sets content type to application/json and sends request body as JSON string,
          * instead of a query string.
          */
-        json?: boolean;
+        json?: boolean | undefined;
         /**
          * When sending streams, this lets manually set the Content-Length header
          * --if the stream's bytecount is known beforehand--,
@@ -108,54 +108,54 @@ declare namespace core {
          * or leave unset for the default behavior,
          * which is no Content-Length header for stream payloads.
          */
-        stream_length?: number;
+        stream_length?: number | undefined;
 
         /**
          * IP address. Passed to http/https request. Local interface from which the request should be emitted.
          */
-        localAddress?: string;
+        localAddress?: string | undefined;
 
         /**
          * Anonymous function taking request (or redirect location if following redirects) URI as an argument and modifying it given logic.
          * It has to return a valid URI string for successful request.
          */
-        uri_modifier?: (uri: string) => string;
+        uri_modifier?: ((uri: string) => string) | undefined;
 
         // These properties are overwritten by those in the 'headers' field
         /**
          * Builds and sets a Cookie header from a { key: 'value' } object.
          */
-        cookies?: Cookies;
+        cookies?: Cookies | undefined;
         /**
          * If true, sets 'Accept-Encoding' header to 'gzip,deflate',
          * and inflates content if zipped.
          * Defaults to false.
          */
-        compressed?: boolean;
+        compressed?: boolean | undefined;
         // Overwritten if present in the URI
         /**
          * For HTTP basic auth.
          */
-        username?: string;
+        username?: string | undefined;
         /**
          * For HTTP basic auth. Requires username to be passed, but is optional.
          */
-        password?: string;
+        password?: string | undefined;
         /**
          * Sets 'Accept' HTTP header. Defaults to &#x2a;&#x2f;&#x2a;.
          */
-        accept?: string;
+        accept?: string | undefined;
         /**
          * Sets 'Connection' HTTP header.
          * Not set by default, unless running Node < 0.11.4
          * in which case it defaults to close.
          */
-        connection?: string;
+        connection?: string | undefined;
         /**
          * Sets the 'User-Agent' HTTP header.
          * Defaults to Needle/{version} (Node.js {node_version}).
          */
-        user_agent?: string;
+        user_agent?: string | undefined;
         /**
          * Sets the 'Content-Type' header.
          * Unset by default, unless you're sending data
@@ -164,7 +164,7 @@ declare namespace core {
          * That is, of course, unless the option is passed,
          * either here or through options.headers.
          */
-        content_type?: string;
+        content_type?: string | undefined;
     }
 
     interface ResponseOptions {
@@ -172,11 +172,11 @@ declare namespace core {
          * Whether to decode the text responses to UTF-8,
          * if Content-Type header shows a different charset. Defaults to true.
          */
-        decode_response?: boolean;
+        decode_response?: boolean | undefined;
         /**
          * Alias for decode_response
          */
-        decode?: ResponseOptions['decode_response'];
+        decode?: ResponseOptions['decode_response'] | undefined;
 
         /**
          * Whether to parse XML or JSON response bodies automagically.
@@ -184,23 +184,23 @@ declare namespace core {
          * You can also set this to 'xml' or 'json' in which case Needle
          * will only parse the response if the content type matches.
          */
-        parse_response?: boolean | 'json' | 'xml';
+        parse_response?: boolean | 'json' | 'xml' | undefined;
         /**
          * Alias for parse_response
          */
-        parse?: ResponseOptions['parse_response'];
+        parse?: ResponseOptions['parse_response'] | undefined;
 
         /**
          * Whether to parse response’s Set-Cookie header.
          * Defaults to true.
          * If parsed, response cookies will be available at resp.cookies.
          */
-        parse_cookies?: boolean;
+        parse_cookies?: boolean | undefined;
         /**
          * Dump response output to file.
          * This occurs after parsing and charset decoding is done.
          */
-        output?: string;
+        output?: string | undefined;
     }
 
     interface RedirectOptions {
@@ -209,35 +209,35 @@ declare namespace core {
          * as part of the following request.
          * false by default.
          */
-        follow_set_cookie?: boolean;
+        follow_set_cookie?: boolean | undefined;
         /**
          * Sets the 'Referer' header to the requested URI
          * when following a redirect.
          * false by default.
          */
-        follow_set_referer?: boolean;
+        follow_set_referer?: boolean | undefined;
         /**
          * If enabled, resends the request using the original verb
          * instead of being rewritten to get with no data.
          * false by default.
          */
-        follow_keep_method?: boolean;
+        follow_keep_method?: boolean | undefined;
         /**
          * When true, Needle will only follow redirects that point to the same host
          * as the original request.
          * false by default.
          */
-        follow_if_same_host?: boolean;
+        follow_if_same_host?: boolean | undefined;
         /**
          * When true, Needle will only follow redirects that point to the same protocol
          * as the original request.
          * false by default.
          */
-        follow_if_same_protocol?: boolean;
+        follow_if_same_protocol?: boolean | undefined;
         /**
          * Unless true, Needle will not follow redirects that point to same location (as set in the response header) as the original request URL. false by default.
          */
-        follow_if_same_location?: boolean;
+        follow_if_same_location?: boolean | undefined;
     }
 
     interface KeyValue {

--- a/types/needle/v0/index.d.ts
+++ b/types/needle/v0/index.d.ts
@@ -20,38 +20,38 @@ declare module "needle" {
         type NeedleCallback = (error: Error, response: NeedleResponse, body: any) => void;
 
         interface RequestOptions {
-            timeout?: number;
-            follow?: number;
-            follow_max?: number;
-            multipart?: boolean;
-            proxy?: string;
-            agent?: string;
-            headers?: {};
-            auth?: string; // auto | digest | basic (default)
-            json?: boolean;
+            timeout?: number | undefined;
+            follow?: number | undefined;
+            follow_max?: number | undefined;
+            multipart?: boolean | undefined;
+            proxy?: string | undefined;
+            agent?: string | undefined;
+            headers?: {} | undefined;
+            auth?: string | undefined; // auto | digest | basic (default)
+            json?: boolean | undefined;
 
             // These properties are overwritten by those in the 'headers' field
-            compressed?: boolean;
-            cookies?: { [name: string]: any; };
+            compressed?: boolean | undefined;
+            cookies?: { [name: string]: any; } | undefined;
             // Overwritten if present in the URI
-            username?: string;
-            password?: string;
+            username?: string | undefined;
+            password?: string | undefined;
         }
 
         interface ResponseOptions {
-            decode?: boolean;
-            parse?: boolean;
+            decode?: boolean | undefined;
+            parse?: boolean | undefined;
             output?: any;
         }
 
         interface TLSOptions {
             pfx?: any;
             key?: any;
-            passphrase?: string;
+            passphrase?: string | undefined;
             cert?: any;
             ca?: any;
             ciphers?: any;
-            rejectUnauthorized?: boolean;
+            rejectUnauthorized?: boolean | undefined;
             secureProtocol?: any;
         }
 

--- a/types/needle/v1/index.d.ts
+++ b/types/needle/v1/index.d.ts
@@ -27,59 +27,59 @@ declare module "needle" {
         type NeedleOptions = RequestOptions & ResponseOptions & RedirectOptions & https.RequestOptions;
 
         interface RequestOptions {
-            open_timeout?: number;
-            read_timeout?: number;
+            open_timeout?: number | undefined;
+            read_timeout?: number | undefined;
             /**
              * Alias for open_timeout
              */
-            timeout?: number;
+            timeout?: number | undefined;
 
-            follow_max?: number;
+            follow_max?: number | undefined;
             /**
              * Alias for follow_max
              */
-            follow?: number;
+            follow?: number | undefined;
 
-            multipart?: boolean;
-            agent?: http.Agent | boolean;
-            proxy?: string;
-            headers?: {};
-            auth?: "auto" | "digest" | "basic";
-            json?: boolean;
+            multipart?: boolean | undefined;
+            agent?: http.Agent | boolean | undefined;
+            proxy?: string | undefined;
+            headers?: {} | undefined;
+            auth?: "auto" | "digest" | "basic" | undefined;
+            json?: boolean | undefined;
 
             // These properties are overwritten by those in the 'headers' field
-            cookies?: Cookies;
-            compressed?: boolean;
+            cookies?: Cookies | undefined;
+            compressed?: boolean | undefined;
             // Overwritten if present in the URI
-            username?: string;
-            password?: string;
-            accept?: string;
-            connection?: string;
-            user_agent?: string;
+            username?: string | undefined;
+            password?: string | undefined;
+            accept?: string | undefined;
+            connection?: string | undefined;
+            user_agent?: string | undefined;
         }
 
         interface ResponseOptions {
-            decode_response?: boolean;
+            decode_response?: boolean | undefined;
             /**
              * Alias for decode_response
              */
-            decode?: boolean;
-            parse_response?: boolean;
+            decode?: boolean | undefined;
+            parse_response?: boolean | undefined;
             /**
              * Alias for parse_response
              */
-            parse?: boolean;
+            parse?: boolean | undefined;
 
-            parse_cookies?: boolean;
-            output?: string;
+            parse_cookies?: boolean | undefined;
+            output?: string | undefined;
         }
 
         interface RedirectOptions {
-            follow_set_cookie?: boolean;
-            follow_set_referer?: boolean;
-            follow_keep_method?: boolean;
-            follow_if_same_host?: boolean;
-            follow_if_same_protocol?: boolean;
+            follow_set_cookie?: boolean | undefined;
+            follow_set_referer?: boolean | undefined;
+            follow_keep_method?: boolean | undefined;
+            follow_if_same_host?: boolean | undefined;
+            follow_if_same_protocol?: boolean | undefined;
         }
 
         interface KeyValue {

--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -118,11 +118,11 @@ declare namespace NewRelic {
         /** Start time in ms since epoch */
         start: number;
         /** End time in ms since epoch.  Defaults to same as start resulting in trace object with a duration of zero. */
-        end?: number;
+        end?: number | undefined;
         /** Origin of event */
-        origin?: string;
+        origin?: string | undefined;
         /** Event type */
-        type?: string;
+        type?: string | undefined;
     }
 
     interface BrowserInteraction {

--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -344,7 +344,7 @@ export const instrumentMessages: Instrument;
  */
 export function shutdown(cb?: (error?: Error) => void): void;
 export function shutdown(
-    options?: { collectPendingData?: boolean; timeout?: number; waitForIdle?: boolean },
+    options?: { collectPendingData?: boolean | undefined; timeout?: number | undefined; waitForIdle?: boolean | undefined },
     cb?: (error?: Error) => void,
 ): void;
 
@@ -370,7 +370,7 @@ export function getTraceMetadata(): TraceMetadata;
 export function setLambdaHandler<T extends (...args: any[]) => any>(handler: T): T;
 
 export interface Instrument {
-    (opts: { moduleName: string; onRequire: () => void; onError?: (err: Error) => void }): void;
+    (opts: { moduleName: string; onRequire: () => void; onError?: ((err: Error) => void) | undefined }): void;
     (moduleName: string, onRequire: () => void, onError?: (err: Error) => void): void;
 }
 
@@ -435,12 +435,12 @@ export interface LinkingMetadata {
     /**
      * The current trace ID
      */
-    'trace.id'?: string;
+    'trace.id'?: string | undefined;
 
     /**
      * The current span ID
      */
-    'span.id'?: string;
+    'span.id'?: string | undefined;
 
     /**
      * The application name specified in the connect request as
@@ -457,7 +457,7 @@ export interface LinkingMetadata {
     /**
      * The entity ID returned in the connect reply as entity_guid
      */
-    'entity.guid'?: string;
+    'entity.guid'?: string | undefined;
 
     /**
      * The hostname as specified in the connect request as
@@ -471,10 +471,10 @@ export interface TraceMetadata {
     /**
      * The current trace ID
      */
-    traceId?: string;
+    traceId?: string | undefined;
 
     /**
      * The current span ID
      */
-    spanId?: string;
+    spanId?: string | undefined;
 }

--- a/types/node-cron/index.d.ts
+++ b/types/node-cron/index.d.ts
@@ -25,9 +25,9 @@ export interface ScheduleOptions {
      *
      * Defaults to `true`
      */
-    scheduled?: boolean;
+    scheduled?: boolean | undefined;
     /**
      * The timezone that is used for job scheduling
      */
-    timezone?: Timezone;
+    timezone?: Timezone | undefined;
 }

--- a/types/node-dir/index.d.ts
+++ b/types/node-dir/index.d.ts
@@ -10,34 +10,34 @@ import { ReadStream } from "fs";
 
 export interface Options {
     // file encoding (defaults to 'utf8')
-    encoding?: string;
+    encoding?: string | undefined;
 
     // a regex pattern or array to specify filenames to ignore
-    exclude?: RegExp | string[];
+    exclude?: RegExp | string[] | undefined;
 
     // a regex pattern or array to specify directories to ignore
-    excludeDir?: RegExp | string[];
+    excludeDir?: RegExp | string[] | undefined;
 
     // a regex pattern or array to specify filenames to operate on
-    match?: RegExp | string[];
+    match?: RegExp | string[] | undefined;
 
     // a regex pattern or array to specify directories to recurse
-    matchDir?: RegExp | string[];
+    matchDir?: RegExp | string[] | undefined;
 
     // whether to recurse subdirectories when reading files (defaults to true)
-    recursive?: boolean;
+    recursive?: boolean | undefined;
 
     // sort files in each directory in descending order
-    reverse?: boolean;
+    reverse?: boolean | undefined;
 
     // whether to aggregate only the base filename rather than the full filepath
-    shortName?: boolean;
+    shortName?: boolean | undefined;
 
     // sort files in each directory in ascending order (defaults to true)
-    sort?: boolean;
+    sort?: boolean | undefined;
 
     // control if done function called on error (defaults to true)
-    doneOnErr?: boolean;
+    doneOnErr?: boolean | undefined;
 }
 
 export interface FileCallback {

--- a/types/node-fetch/externals.d.ts
+++ b/types/node-fetch/externals.d.ts
@@ -6,13 +6,13 @@ export interface AbortSignal {
     aborted: boolean;
 
     addEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
-        capture?: boolean,
-        once?: boolean,
-        passive?: boolean
+        capture?: boolean | undefined,
+        once?: boolean | undefined,
+        passive?: boolean | undefined
     }) => void;
 
     removeEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
-        capture?: boolean
+        capture?: boolean | undefined
     }) => void;
 
     dispatchEvent: (event: any) => boolean;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -31,12 +31,12 @@ export class Request extends Body {
     url: string;
 
     // node-fetch extensions to the whatwg/fetch spec
-    agent?: Agent | ((parsedUrl: URL) => Agent);
+    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined;
     compress: boolean;
     counter: number;
     follow: number;
     hostname: string;
-    port?: number;
+    port?: number | undefined;
     protocol: string;
     size: number;
     timeout: number;
@@ -44,18 +44,18 @@ export class Request extends Body {
 
 export interface RequestInit {
     // whatwg/fetch standard options
-    body?: BodyInit;
-    headers?: HeadersInit;
-    method?: string;
-    redirect?: RequestRedirect;
-    signal?: AbortSignal | null;
+    body?: BodyInit | undefined;
+    headers?: HeadersInit | undefined;
+    method?: string | undefined;
+    redirect?: RequestRedirect | undefined;
+    signal?: AbortSignal | null | undefined;
 
     // node-fetch extensions
-    agent?: Agent | ((parsedUrl: URL) => Agent); // =null http.Agent instance, allows custom proxy, certificate etc.
-    compress?: boolean; // =true support gzip/deflate content encoding. false to disable
-    follow?: number; // =20 maximum redirect count. 0 to not follow redirect
-    size?: number; // =0 maximum response body size in bytes. 0 to disable
-    timeout?: number; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined; // =null http.Agent instance, allows custom proxy, certificate etc.
+    compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
+    follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
+    size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
+    timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
 
     // node-fetch does not support mode, cache or credentials options
 }
@@ -126,8 +126,8 @@ export class Headers implements Iterable<[string, string]> {
 type BlobPart = ArrayBuffer | ArrayBufferView | Blob | string;
 
 interface BlobOptions {
-    type?: string;
-    endings?: "transparent" | "native";
+    type?: string | undefined;
+    endings?: "transparent" | "native" | undefined;
 }
 
 export class Blob {
@@ -139,7 +139,7 @@ export class Blob {
 }
 
 export class Body {
-    constructor(body?: any, opts?: { size?: number; timeout?: number });
+    constructor(body?: any, opts?: { size?: number | undefined; timeout?: number | undefined });
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     body: NodeJS.ReadableStream;
@@ -153,15 +153,15 @@ export class Body {
 }
 
 interface SystemError extends Error {
-    code?: string;
+    code?: string | undefined;
 }
 
 export class FetchError extends Error {
     name: "FetchError";
     constructor(message: string, type: string, systemError?: SystemError);
     type: string;
-    code?: string;
-    errno?: string;
+    code?: string | undefined;
+    errno?: string | undefined;
 }
 
 export class Response extends Body {
@@ -187,12 +187,12 @@ export type ResponseType =
     | "opaqueredirect";
 
 export interface ResponseInit {
-    headers?: HeadersInit;
-    size?: number;
-    status?: number;
-    statusText?: string;
-    timeout?: number;
-    url?: string;
+    headers?: HeadersInit | undefined;
+    size?: number | undefined;
+    status?: number | undefined;
+    statusText?: string | undefined;
+    timeout?: number | undefined;
+    url?: string | undefined;
 }
 
 interface URLLike {

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -56,13 +56,13 @@ function test_fetchUrlWithRequestObject() {
             aborted: false,
 
             addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
-                capture?: boolean,
-                once?: boolean,
-                passive?: boolean
+                capture?: boolean | undefined,
+                once?: boolean | undefined,
+                passive?: boolean | undefined
             }) => undefined,
 
             removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
-                capture?: boolean
+                capture?: boolean | undefined
             }) => undefined,
 
             dispatchEvent: (event: any) => false,
@@ -108,13 +108,13 @@ function test_fetchUrlObjectWithRequestObject() {
             aborted: false,
 
             addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
-                capture?: boolean,
-                once?: boolean,
-                passive?: boolean
+                capture?: boolean | undefined,
+                once?: boolean | undefined,
+                passive?: boolean | undefined
             }) => undefined,
 
             removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
-                capture?: boolean
+                capture?: boolean | undefined
             }) => undefined,
 
             dispatchEvent: (event: any) => false,

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -96,7 +96,7 @@ declare module "node-forge" {
     namespace pem {
 
         interface EncodeOptions {
-            maxline?: number;
+            maxline?: number | undefined;
         }
 
         interface ObjectPEM {
@@ -105,7 +105,7 @@ declare module "node-forge" {
             procType?: any;
             contentDomain?: any;
             dekInfo?: any;
-            headers?: any[];
+            headers?: any[] | undefined;
         }
 
         function encode(msg: ObjectPEM, options?: EncodeOptions): string;
@@ -117,26 +117,26 @@ declare module "node-forge" {
         type PublicKey = rsa.PublicKey | ed25519.Key;
         type PrivateKey = rsa.PrivateKey | ed25519.Key;
         type EncryptionOptions = {
-            algorithm?: 'aes128' | 'aes192' | 'aes256' | '3des';
-            count?: number;
-            saltSize?: number;
-            prfAlgorithm?: 'sha1' | 'sha224' | 'sha256' | 'sha384' | 'sha512';
-            legacy?: boolean;
+            algorithm?: 'aes128' | 'aes192' | 'aes256' | '3des' | undefined;
+            count?: number | undefined;
+            saltSize?: number | undefined;
+            prfAlgorithm?: 'sha1' | 'sha224' | 'sha256' | 'sha384' | 'sha512' | undefined;
+            legacy?: boolean | undefined;
         };
 
         interface ByteBufferFingerprintOptions {
             /**
              * @description The type of fingerprint. If not specified, defaults to 'RSAPublicKey'
              */
-            type?: 'SubjectPublicKeyInfo' | 'RSAPublicKey';
+            type?: 'SubjectPublicKeyInfo' | 'RSAPublicKey' | undefined;
             /**
              * @description the delimiter to use between bytes for `hex` encoded output
              */
-            delimiter?: string;
+            delimiter?: string | undefined;
             /**
              * @description if not specified defaults to `md.md5`
              */
-            md?: md.MessageDigest;
+            md?: md.MessageDigest | undefined;
         }
 
         interface HexFingerprintOptions extends ByteBufferFingerprintOptions {
@@ -193,13 +193,13 @@ declare module "node-forge" {
             }
 
             interface GenerateKeyPairOptions {
-                bits?: number;
-                e?: number;
-                workerScript?: string;
-                workers?: number;
-                workLoad?: number;
+                bits?: number | undefined;
+                e?: number | undefined;
+                workerScript?: string | undefined;
+                workers?: number | undefined;
+                workLoad?: number | undefined;
                 prng?: any;
-                algorithm?: string;
+                algorithm?: string | undefined;
             }
 
             function setPublicKey(n: jsbn.BigInteger, e: jsbn.BigInteger): PublicKey;
@@ -231,7 +231,7 @@ declare module "node-forge" {
             }
 
             // generateKeyPair does not currently accept `util.ByteBuffer` as the seed.
-            function generateKeyPair(options?: { seed?: NativeBuffer | string }): {
+            function generateKeyPair(options?: { seed?: NativeBuffer | string | undefined }): {
                 publicKey: NativeBuffer;
                 privateKey: NativeBuffer;
             };
@@ -249,16 +249,16 @@ declare module "node-forge" {
         }
 
         interface CertificateFieldOptions {
-            name?: string;
-            type?: string;
-            shortName?: string;
+            name?: string | undefined;
+            type?: string | undefined;
+            shortName?: string | undefined;
         }
 
         interface CertificateField extends CertificateFieldOptions {
-            valueConstructed?: boolean;
-            valueTagClass?: asn1.Class;
-            value?: any[] | string;
-            extensions?: any[];
+            valueConstructed?: boolean | undefined;
+            valueTagClass?: asn1.Class | undefined;
+            value?: any[] | string | undefined;
+            extensions?: any[] | undefined;
         }
 
 
@@ -377,15 +377,15 @@ declare module "node-forge" {
             /**
              * OID
              */
-            type?: string;
+            type?: string | undefined;
             /**
              * Long name
              */
-            name?: string;
+            name?: string | undefined;
             /**
              * Short name
              */
-            shortName?: string;
+            shortName?: string | undefined;
         }
 
         interface Attribute {
@@ -396,7 +396,7 @@ declare module "node-forge" {
             /**
              * Short name, if available (e.g. 'CN' for 'commonName')
              */
-            shortName?: string;
+            shortName?: string | undefined;
             /**
              * OID, e.g. '1.2.840.113549.1.9.7'
              */
@@ -412,7 +412,7 @@ declare module "node-forge" {
             /**
              * Extensions
              */
-            extensions?: any[]
+            extensions?: any[] | undefined
         }
 
         interface CAStore {
@@ -448,8 +448,8 @@ declare module "node-forge" {
             caStore: CAStore,
             chain: Certificate[],
             options?: ((verified: boolean | string, depth: number, certs: Certificate[]) => boolean) | {
-                verify?: (verified: boolean | string, depth: number, certs: Certificate[]) => boolean,
-                validityCheckDate?: Date | null
+                verify?: ((verified: boolean | string, depth: number, certs: Certificate[]) => boolean) | undefined,
+                validityCheckDate?: Date | null | undefined
             }): boolean;
 
         function pemToDer(pem: PEM): util.ByteStringBuffer;
@@ -513,15 +513,15 @@ declare module "node-forge" {
             /**
              * @description the delimiter to use between bytes for `hex` encoded output
              */
-            delimiter?: string;
+            delimiter?: string | undefined;
             /**
              * @description if not specified, the function will return `ByteStringBuffer`
              */
-            encoding?: 'hex' | 'binary';
+            encoding?: 'hex' | 'binary' | undefined;
             /**
              * @description if not specified defaults to `md.md5`
              */
-            md?: md.MessageDigest;
+            md?: md.MessageDigest | undefined;
         }
 
         /**
@@ -687,17 +687,17 @@ declare module "node-forge" {
     namespace pkcs12 {
 
         interface BagsFilter {
-            localKeyId?: string;
-            localKeyIdHex?: string;
-            friendlyName?: string;
-            bagType?: string;
+            localKeyId?: string | undefined;
+            localKeyIdHex?: string | undefined;
+            friendlyName?: string | undefined;
+            bagType?: string | undefined;
         }
 
         interface Bag {
             type: string;
             attributes: any;
-            key?: pki.PrivateKey;
-            cert?: pki.Certificate;
+            key?: pki.PrivateKey | undefined;
+            cert?: pki.Certificate | undefined;
             asn1: asn1.Asn1
         }
 
@@ -709,8 +709,8 @@ declare module "node-forge" {
             }[];
             getBags: (filter: BagsFilter) => {
                 [key: string]: Bag[] | undefined;
-                localKeyId?: Bag[];
-                friendlyName?: Bag[];
+                localKeyId?: Bag[] | undefined;
+                friendlyName?: Bag[] | undefined;
             };
             getBagsByFriendlyName: (fiendlyName: string, bagType: string) => Bag[]
             getBagsByLocalKeyId: (localKeyId: string, bagType: string) => Bag[]
@@ -724,13 +724,13 @@ declare module "node-forge" {
             cert: pki.Certificate | pki.Certificate[],
             password: string | null,
             options?: {
-                algorithm?: 'aes128' | 'aes192' | 'aes256' | '3des',
-                count?: number,
-                saltSize?: number,
-                useMac?: boolean,
-                localKeyId?: Hex,
-                friendlyName?: string,
-                generateLocalKeyId?: boolean,
+                algorithm?: 'aes128' | 'aes192' | 'aes256' | '3des' | undefined,
+                count?: number | undefined,
+                saltSize?: number | undefined,
+                useMac?: boolean | undefined,
+                localKeyId?: Hex | undefined,
+                friendlyName?: string | undefined,
+                generateLocalKeyId?: boolean | undefined,
             },
         ): asn1.Asn1;
 
@@ -746,8 +746,8 @@ declare module "node-forge" {
 
     namespace pkcs7 {
         interface PkcsSignedData {
-            content?: string | util.ByteBuffer;
-            contentInfo?: { value: any[] };
+            content?: string | util.ByteBuffer | undefined;
+            contentInfo?: { value: any[] } | undefined;
 
             certificates: pki.Certificate[];
 
@@ -756,10 +756,10 @@ declare module "node-forge" {
                 key: pki.rsa.PrivateKey | string;
                 certificate: pki.Certificate | string;
                 digestAlgorithm: string;
-                authenticatedAttributes?: { type: string; value?: string }[];
+                authenticatedAttributes?: { type: string; value?: string | undefined }[] | undefined;
             }): void;
             sign(options?:{
-                detached?: boolean
+                detached?: boolean | undefined
             }): void;
             toAsn1(): asn1.Asn1;
         }
@@ -767,7 +767,7 @@ declare module "node-forge" {
         function createSignedData(): PkcsSignedData;
 
         interface PkcsEnvelopedData {
-            content?: string | util.ByteBuffer;
+            content?: string | util.ByteBuffer | undefined;
             addRecipient(certificate: pki.Certificate): void;
             encrypt(): void;
             toAsn1(): asn1.Asn1;
@@ -840,10 +840,10 @@ declare module "node-forge" {
         function createDecipher(algorithm: Algorithm, payload: util.ByteBuffer | Bytes): BlockCipher;
 
         interface StartOptions {
-            iv?: util.ByteBuffer | Byte[] | Bytes;
-            tag?: util.ByteStringBuffer;
-            tagLength?: number;
-            additionalData?: string;
+            iv?: util.ByteBuffer | Byte[] | Bytes | undefined;
+            tag?: util.ByteStringBuffer | undefined;
+            tagLength?: number | undefined;
+            additionalData?: string | undefined;
         }
 
         interface BlockCipher {
@@ -1062,7 +1062,7 @@ declare module "node-forge" {
             version: ProtocolVersion;
             length: number;
             fragment: util.ByteBuffer;
-            ready?: boolean;
+            ready?: boolean | undefined;
         }
 
         interface Session {
@@ -1101,17 +1101,17 @@ declare module "node-forge" {
             alert: Alert;
         }
 
-        type Verified = true | { message?: string; alert?: Alert.Description };
+        type Verified = true | { message?: string | undefined; alert?: Alert.Description | undefined };
 
         function createConnection(options: {
-            server?: boolean;
-            sessionId?: Bytes | null;
-            caStore?: pki.CAStore | ReadonlyArray<pki.Certificate>;
-            sessionCache?: SessionCache | { [key: string]: Session };
-            cipherSuites?: CipherSuite[];
+            server?: boolean | undefined;
+            sessionId?: Bytes | null | undefined;
+            caStore?: pki.CAStore | ReadonlyArray<pki.Certificate> | undefined;
+            sessionCache?: SessionCache | { [key: string]: Session } | undefined;
+            cipherSuites?: CipherSuite[] | undefined;
             connected(conn: Connection): void;
-            virtualHost?: string;
-            verifyClient?: boolean;
+            virtualHost?: string | undefined;
+            verifyClient?: boolean | undefined;
             verify?(
                 conn: Connection,
                 verified: Verified,

--- a/types/node-ipc/index.d.ts
+++ b/types/node-ipc/index.d.ts
@@ -199,8 +199,8 @@ declare namespace NodeIPC {
         broadcast(event: string, value?: any): Client;
     }
     interface SocketConfig {
-        address?: string;
-        port?: number;
+        address?: string | undefined;
+        port?: number | undefined;
     }
     interface Config {
         /**
@@ -312,28 +312,28 @@ declare namespace NodeIPC {
             /**
              * Default: false
              */
-            localAddress?: boolean;
+            localAddress?: boolean | undefined;
             /**
              * Default: false
              */
-            localPort?: boolean;
+            localPort?: boolean | undefined;
             /**
              * Default: false
              */
-            family?: boolean;
+            family?: boolean | undefined;
             /**
              * Default: false
              */
-            hints?: boolean;
+            hints?: boolean | undefined;
             /**
              * Default: false
              */
-            lookup?: boolean;
+            lookup?: boolean | undefined;
         };
         tls: {
-            rejectUnauthorized?: boolean;
-            public?: string;
-            private?: string;
+            rejectUnauthorized?: boolean | undefined;
+            public?: string | undefined;
+            private?: string | undefined;
         };
     }
 }

--- a/types/node-jose/index.d.ts
+++ b/types/node-jose/index.d.ts
@@ -10,35 +10,35 @@ export function canYouSee(ks: JWK.Key | JWK.KeyStore, opts: object): JWS.Verifie
 
 export namespace JWA {
     interface DecryptEncryptOptions {
-        aad?: Buffer;
-        adata?: Buffer;
-        iv?: Buffer;
-        tag?: Buffer; // Not used in encrypt
-        mac?: Buffer; // Not used in encrypt
-        epu?: Buffer; // encryption party info
-        epv?: Buffer; // encryption party info
-        kdata?: Buffer;
-        epk?: Buffer; // ephemeral pub key used in ec
-        enc?: string; // algorithm to use in ec
-        alg?: string; // variation of enc, probably oversight in lib code
-        apu?: Buffer; // agreement party info used in ec
-        apv?: Buffer; // agreement party info used in ec
-        p2s?: Buffer; // used in pbes
-        p2c?: number; // used in pbes
+        aad?: Buffer | undefined;
+        adata?: Buffer | undefined;
+        iv?: Buffer | undefined;
+        tag?: Buffer | undefined; // Not used in encrypt
+        mac?: Buffer | undefined; // Not used in encrypt
+        epu?: Buffer | undefined; // encryption party info
+        epv?: Buffer | undefined; // encryption party info
+        kdata?: Buffer | undefined;
+        epk?: Buffer | undefined; // ephemeral pub key used in ec
+        enc?: string | undefined; // algorithm to use in ec
+        alg?: string | undefined; // variation of enc, probably oversight in lib code
+        apu?: Buffer | undefined; // agreement party info used in ec
+        apv?: Buffer | undefined; // agreement party info used in ec
+        p2s?: Buffer | undefined; // used in pbes
+        p2c?: number | undefined; // used in pbes
     }
 
     interface DeriveOptions {
-        length?: number; // key length
-        otherInfo?: Buffer; // info used in concatkdf
-        public?: Buffer; // public key used in ecdh
-        hash?: Buffer; // hash used in ecdh
-        salt?: Buffer; // salt value used in hkdf
-        info?: Buffer; // app identifier info used in hkdf
+        length?: number | undefined; // key length
+        otherInfo?: Buffer | undefined; // info used in concatkdf
+        public?: Buffer | undefined; // public key used in ecdh
+        hash?: Buffer | undefined; // hash used in ecdh
+        salt?: Buffer | undefined; // salt value used in hkdf
+        info?: Buffer | undefined; // app identifier info used in hkdf
     }
 
     interface EncryptReturn {
         data: Buffer; // The cipher text
-        tag?: Buffer; // The tag used in some algorithms
+        tag?: Buffer | undefined; // The tag used in some algorithms
     }
 
     interface SignReturn {
@@ -47,7 +47,7 @@ export namespace JWA {
     }
 
     interface SignVerifyOptions {
-        loose?: boolean;
+        loose?: boolean | undefined;
     }
 
     interface VerifyReturn {
@@ -92,12 +92,12 @@ export namespace JWA {
 
 export namespace JWE {
     interface EncryptOptions {
-        format?: 'general' | 'compact' | 'flattened';
-        zip?: boolean | 'DEF';
-        fields?: object;
-        contentAlg?: string;
-        protect?: string | string[];
-        iv?: string | Buffer;
+        format?: 'general' | 'compact' | 'flattened' | undefined;
+        zip?: boolean | 'DEF' | undefined;
+        fields?: object | undefined;
+        contentAlg?: string | undefined;
+        protect?: string | string[] | undefined;
+        iv?: string | Buffer | undefined;
     }
 
     function createEncrypt(keys: JWK.Key | JWK.Key[]): Encryptor;
@@ -187,9 +187,9 @@ export namespace JWK {
     }
 
     interface KeyStoreGetFilter {
-        kty?: string;
-        use?: KeyUse;
-        alg?: string;
+        kty?: string | undefined;
+        use?: KeyUse | undefined;
+        alg?: string | undefined;
     }
 
     interface KeyStoreGetOptions extends KeyStoreGetFilter {
@@ -267,10 +267,10 @@ export namespace JWK {
 
 export namespace JWS {
     interface SignOptions {
-        format?: 'compact' | 'flattened';
-        alg?: string;
-        compact?: boolean;
-        fields?: object;
+        format?: 'compact' | 'flattened' | undefined;
+        alg?: string | undefined;
+        compact?: boolean | undefined;
+        fields?: object | undefined;
     }
 
     function createSign(keys: JWK.Key | JWK.Key[]): Signer;
@@ -281,7 +281,7 @@ export namespace JWS {
      */
     function createVerify(
         input?: string | JWK.Key | JWK.KeyStore | object,
-        opts?: { allowEmbeddedKey?: boolean; algorithms?: string[]; handlers?: any }
+        opts?: { allowEmbeddedKey?: boolean | undefined; algorithms?: string[] | undefined; handlers?: any }
     ): Verifier;
 
     interface CreateSignResult {
@@ -317,7 +317,7 @@ export namespace JWS {
     }
 
     interface Verifier {
-        verify(input: string, opts?: { allowEmbeddedKey?: boolean }): Promise<VerificationResult>;
+        verify(input: string, opts?: { allowEmbeddedKey?: boolean | undefined }): Promise<VerificationResult>;
     }
 
     interface Exp {
@@ -325,8 +325,8 @@ export namespace JWS {
     }
 
     interface VerifyOptions {
-        allowEmbeddedKey?: boolean;
-        algorithms?: string[];
+        allowEmbeddedKey?: boolean | undefined;
+        algorithms?: string[] | undefined;
         handlers: { exp: boolean | Exp };
     }
 }

--- a/types/node-notifier/index.d.ts
+++ b/types/node-notifier/index.d.ts
@@ -29,20 +29,20 @@ declare namespace nodeNotifier {
     }
 
     interface Notification {
-        title?: string;
-        message?: string;
+        title?: string | undefined;
+        message?: string | undefined;
         /** Absolute path (not balloons) */
-        icon?: string;
+        icon?: string | undefined;
         /** Wait with callback until user action is taken on notification */
-        wait?: boolean;
+        wait?: boolean | undefined;
     }
 
     interface NotificationMetadata {
-        activationType?: string;
-        activationAt?: string;
-        deliveredAt?: string;
-        activationValue?: string;
-        activationValueIndex?: string;
+        activationType?: string | undefined;
+        activationAt?: string | undefined;
+        deliveredAt?: string | undefined;
+        activationValue?: string | undefined;
+        activationValueIndex?: string | undefined;
     }
 
     interface NotificationCallback {
@@ -50,8 +50,8 @@ declare namespace nodeNotifier {
     }
 
     interface Option {
-        withFallback?: boolean;
-        customPath?: string;
+        withFallback?: boolean | undefined;
+        customPath?: string | undefined;
     }
 }
 

--- a/types/node-notifier/notifiers/balloon.d.ts
+++ b/types/node-notifier/notifiers/balloon.d.ts
@@ -7,15 +7,15 @@ declare class WindowsBalloon {
 
 declare namespace WindowsBalloon {
     interface Notification {
-        title?: string;
-        message?: string;
-        sound?: boolean;
+        title?: string | undefined;
+        message?: string | undefined;
+        sound?: boolean | undefined;
         /** How long to show balloons in ms */
-        time?: number;
+        time?: number | undefined;
         /** Wait with callback until user action is taken on notification */
-        wait?: boolean;
+        wait?: boolean | undefined;
         /** The notification type */
-        type?: 'info' | 'warn' | 'error';
+        type?: 'info' | 'warn' | 'error' | undefined;
     }
 }
 

--- a/types/node-notifier/notifiers/growl.d.ts
+++ b/types/node-notifier/notifiers/growl.d.ts
@@ -7,18 +7,18 @@ declare class Growl {
 
 declare namespace Growl {
     interface Option {
-        name?: string;
-        host?: string;
-        port?: number;
+        name?: string | undefined;
+        host?: string | undefined;
+        port?: number | undefined;
     }
 
     interface Notification extends notifier.Notification {
         /** whether or not to sticky the notification (defaults to false) */
-        sticky?: boolean;
+        sticky?: boolean | undefined;
         /** type of notification to use (defaults to the first registered type) */
-        label?: string;
+        label?: string | undefined;
         /** the priority of the notification from lowest (-2) to highest (2) */
-        priority?: number;
+        priority?: number | undefined;
     }
 }
 

--- a/types/node-notifier/notifiers/notificationcenter.d.ts
+++ b/types/node-notifier/notifiers/notificationcenter.d.ts
@@ -13,12 +13,12 @@ declare namespace NotificationCenter {
         /**
          * Case Sensitive string for location of sound file, or use one of macOS' native sounds.
          */
-        sound?: boolean | string;
-        subtitle?: string;
+        sound?: boolean | string | undefined;
+        subtitle?: string | undefined;
         /** Attach image? (Absolute path) */
-        contentImage?: string;
+        contentImage?: string | undefined;
         /** URL to open on click */
-        open?: string;
+        open?: string | undefined;
         /**
          * The amount of seconds before the notification closes.
          * Takes precedence over wait if both are defined.
@@ -27,18 +27,18 @@ declare namespace NotificationCenter {
          * set `timeout` to `false`.
          * If you are using action it is recommended to set `timeout` to a high value to ensure the user has time to respond.
          */
-        timeout?: number | false;
+        timeout?: number | false | undefined;
         /** Label for cancel button */
-        closeLabel?: string;
+        closeLabel?: string | undefined;
         /** Action label or list of labels in case of dropdown. */
-        actions?: string | string[];
+        actions?: string | string[] | undefined;
         /** Label to be used if there are multiple actions */
-        dropdownLabel?: string;
+        dropdownLabel?: string | undefined;
         /**
          * If notification should take input.
          * Value passed as third argument in callback and event emitter.
          */
-        reply?: boolean;
+        reply?: boolean | undefined;
     }
 }
 

--- a/types/node-notifier/notifiers/notifysend.d.ts
+++ b/types/node-notifier/notifiers/notifysend.d.ts
@@ -7,19 +7,19 @@ declare class NotifySend {
 
 declare namespace NotifySend {
     interface Notification {
-        title?: string;
-        message?: string;
-        icon?: string;
+        title?: string | undefined;
+        message?: string | undefined;
+        icon?: string | undefined;
         /** Shorthand for timeout 5 seconds if true. Timeout option overrides wait */
-        wait?: boolean;
+        wait?: boolean | undefined;
         /** Specifies the urgency level  (low,  normal,  critical). */
-        urgency?: string;
+        urgency?: string | undefined;
         /** Specifies  the  timeout  in  seconds at which to expire the notification. Defaults to 10 seconds */
-        timeout?: number | false;
+        timeout?: number | false | undefined;
         /** Specifies the notification category */
-        category?: string;
+        category?: string | undefined;
         /** Specifies basic extra data to pass. Valid types are int, double, string and byte. */
-        hint?: string;
+        hint?: string | undefined;
     }
 }
 

--- a/types/node-notifier/notifiers/toaster.d.ts
+++ b/types/node-notifier/notifiers/toaster.d.ts
@@ -10,18 +10,18 @@ declare namespace WindowsToaster {
         /**
          * Defined by http://msdn.microsoft.com/en-us/library/windows/apps/hh761492.aspx
          */
-        sound?: boolean | string;
+        sound?: boolean | string | undefined;
         /** ID to use for closing notification. */
-        id?: number;
+        id?: number | undefined;
         /** App.ID and app Name. Defaults to no value, causing SnoreToast text to be visible. */
-        appID?: string;
+        appID?: string | undefined;
         /** Refer to previously created notification to close. */
-        remove?: number;
+        remove?: number | undefined;
         /**
          * Creates a shortcut <path> in the start menu which point to the
          * executable <application>, appID used for the notifications.
          */
-        install?: string;
+        install?: string | undefined;
     }
 }
 

--- a/types/node-notifier/v5/index.d.ts
+++ b/types/node-notifier/v5/index.d.ts
@@ -42,20 +42,20 @@ declare module "node-notifier" {
         }
 
         interface Notification {
-            title?: string;
-            message?: string;
+            title?: string | undefined;
+            message?: string | undefined;
             /** Absolute path (not balloons) */
-            icon?: string;
+            icon?: string | undefined;
             /** Wait with callback until user action is taken on notification */
-            wait?: boolean;
+            wait?: boolean | undefined;
         }
 
         interface NotificationMetadata {
-            activationType?: string;
-            activationAt?: string;
-            deliveredAt?: string;
-            activationValue?: string;
-            activationValueIndex?: string;
+            activationType?: string | undefined;
+            activationAt?: string | undefined;
+            deliveredAt?: string | undefined;
+            activationValue?: string | undefined;
+            activationValueIndex?: string | undefined;
           }
 
           interface NotificationCallback {
@@ -67,8 +67,8 @@ declare module "node-notifier" {
           }
 
         interface Option {
-            withFallback?: boolean;
-            customPath?: string;
+            withFallback?: boolean | undefined;
+            customPath?: string | undefined;
         }
     }
 
@@ -90,28 +90,28 @@ declare module "node-notifier/notifiers/notificationcenter" {
             /**
              * Case Sensitive string for location of sound file, or use one of macOS' native sounds.
              */
-            sound?: boolean | string;
-            subtitle?: string;
+            sound?: boolean | string | undefined;
+            subtitle?: string | undefined;
             /** Attach image? (Absolute path) */
-            contentImage?: string;
+            contentImage?: string | undefined;
             /** URL to open on click */
-            open?: string;
+            open?: string | undefined;
             /**
              * The amount of seconds before the notification closes.
              * Takes precedence over wait if both are defined.
              */
-            timeout?: number;
+            timeout?: number | undefined;
             /** Label for cancel button */
-            closeLabel?: string;
+            closeLabel?: string | undefined;
             /** Action label or list of labels in case of dropdown. */
-            actions?: string | string[];
+            actions?: string | string[] | undefined;
             /** Label to be used if there are multiple actions */
-            dropdownLabel?: string;
+            dropdownLabel?: string | undefined;
             /**
              * If notification should take input.
              * Value passed as third argument in callback and event emitter.
              */
-            reply?: boolean;
+            reply?: boolean | undefined;
         }
     }
 
@@ -128,17 +128,17 @@ declare module "node-notifier/notifiers/notifysend" {
 
     namespace NotifySend {
         interface Notification {
-            title?: string;
-            message?: string;
-            icon?: string;
+            title?: string | undefined;
+            message?: string | undefined;
+            icon?: string | undefined;
             /** Specifies the urgency level  (low,  normal,  critical). */
-            urgency?: string;
+            urgency?: string | undefined;
             /** Specifies  the  timeout  in  milliseconds at which to expire the notification */
-            time?: number;
+            time?: number | undefined;
             /** Specifies the notification category */
-            category?: string;
+            category?: string | undefined;
             /** Specifies basic extra data to pass. Valid types are int, double, string and byte. */
-            hint?: string;
+            hint?: string | undefined;
         }
     }
 
@@ -158,18 +158,18 @@ declare module "node-notifier/notifiers/toaster" {
             /**
              * Defined by http://msdn.microsoft.com/en-us/library/windows/apps/hh761492.aspx
              */
-            sound?: boolean | string;
+            sound?: boolean | string | undefined;
             /** ID to use for closing notification. */
-            id?: number;
+            id?: number | undefined;
             /** App.ID and app Name. Defaults to no value, causing SnoreToast text to be visible. */
-            appID?: string;
+            appID?: string | undefined;
             /** Refer to previously created notification to close. */
-            remove?: number;
+            remove?: number | undefined;
             /**
              * Creates a shortcut <path> in the start menu which point to the
              * executable <application>, appID used for the notifications.
             */
-            install?: string;
+            install?: string | undefined;
         }
     }
 
@@ -186,18 +186,18 @@ declare module "node-notifier/notifiers/growl" {
 
     namespace Growl {
         interface Option {
-            name?: string;
-            host?: string;
-            port?: number;
+            name?: string | undefined;
+            host?: string | undefined;
+            port?: number | undefined;
         }
 
         interface Notification extends notifier.Notification {
             /** whether or not to sticky the notification (defaults to false) */
-            sticky?: boolean;
+            sticky?: boolean | undefined;
             /** type of notification to use (defaults to the first registered type) */
-            label?: string;
+            label?: string | undefined;
             /** the priority of the notification from lowest (-2) to highest (2) */
-            priority?: number;
+            priority?: number | undefined;
         }
     }
 
@@ -214,14 +214,14 @@ declare module "node-notifier/notifiers/balloon" {
 
     namespace WindowsBalloon {
         interface Notification {
-            title?: string;
-            message?: string;
+            title?: string | undefined;
+            message?: string | undefined;
             /** How long to show balloons in ms */
-            time?: number;
+            time?: number | undefined;
             /** Wait with callback until user action is taken on notification */
-            wait?: boolean;
+            wait?: boolean | undefined;
             /** The notification type */
-            type?: 'info' | 'warn' | 'error';
+            type?: 'info' | 'warn' | 'error' | undefined;
         }
     }
 

--- a/types/node-sass/index.d.ts
+++ b/types/node-sass/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="node" />
 
-export type ImporterReturnType = { file: string } | { file?: string; contents: string } | Error | null | types.Null | types.Error;
+export type ImporterReturnType = { file: string } | { file?: string | undefined; contents: string } | Error | null | types.Null | types.Error;
 
 /**
  * The context value is a value that is shared for the duration of a single render.
@@ -77,30 +77,30 @@ export type SassFunction = SyncSassFunction | AsyncSassFunction;
 export type FunctionDeclarations<FunctionType extends SassFunction = SassFunction> = Record<string, FunctionType>;
 
 export interface Options {
-    file?: string;
-    data?: string;
-    importer?: Importer | Importer[];
-    functions?: FunctionDeclarations;
-    includePaths?: string[];
-    indentedSyntax?: boolean;
-    indentType?: string;
-    indentWidth?: number;
-    linefeed?: string;
-    omitSourceMapUrl?: boolean;
-    outFile?: string;
-    outputStyle?: "compact" | "compressed" | "expanded" | "nested";
-    precision?: number;
-    sourceComments?: boolean;
-    sourceMap?: boolean | string;
-    sourceMapContents?: boolean;
-    sourceMapEmbed?: boolean;
-    sourceMapRoot?: string;
+    file?: string | undefined;
+    data?: string | undefined;
+    importer?: Importer | Importer[] | undefined;
+    functions?: FunctionDeclarations | undefined;
+    includePaths?: string[] | undefined;
+    indentedSyntax?: boolean | undefined;
+    indentType?: string | undefined;
+    indentWidth?: number | undefined;
+    linefeed?: string | undefined;
+    omitSourceMapUrl?: boolean | undefined;
+    outFile?: string | undefined;
+    outputStyle?: "compact" | "compressed" | "expanded" | "nested" | undefined;
+    precision?: number | undefined;
+    sourceComments?: boolean | undefined;
+    sourceMap?: boolean | string | undefined;
+    sourceMapContents?: boolean | undefined;
+    sourceMapEmbed?: boolean | undefined;
+    sourceMapRoot?: string | undefined;
     [key: string]: any;
 }
 
 export interface SyncOptions extends Options {
-    functions?: FunctionDeclarations<SyncSassFunction>;
-    importer?: SyncImporter | SyncImporter[];
+    functions?: FunctionDeclarations<SyncSassFunction> | undefined;
+    importer?: SyncImporter | SyncImporter[] | undefined;
 }
 
 /**

--- a/types/node-schedule/index.d.ts
+++ b/types/node-schedule/index.d.ts
@@ -135,11 +135,11 @@ export interface RecurrenceSpecDateRange {
     /**
      * Starting date in date range.
      */
-    start?: Date | string | number;
+    start?: Date | string | number | undefined;
     /**
      * Ending date in date range.
      */
-    end?: Date | string | number;
+    end?: Date | string | number | undefined;
     /**
      * Cron expression string.
      */
@@ -147,7 +147,7 @@ export interface RecurrenceSpecDateRange {
     /**
      * Timezone
      */
-    tz?: Timezone;
+    tz?: Timezone | undefined;
 }
 
 /**
@@ -157,17 +157,17 @@ export interface RecurrenceSpecObjLit {
     /**
      * Day of the month.
      */
-    date?: RecurrenceSegment;
-    dayOfWeek?: RecurrenceSegment;
-    hour?: RecurrenceSegment;
-    minute?: RecurrenceSegment;
-    month?: RecurrenceSegment;
-    second?: RecurrenceSegment;
-    year?: RecurrenceSegment;
+    date?: RecurrenceSegment | undefined;
+    dayOfWeek?: RecurrenceSegment | undefined;
+    hour?: RecurrenceSegment | undefined;
+    minute?: RecurrenceSegment | undefined;
+    month?: RecurrenceSegment | undefined;
+    second?: RecurrenceSegment | undefined;
+    year?: RecurrenceSegment | undefined;
     /**
      * Timezone
      */
-    tz?: Timezone;
+    tz?: Timezone | undefined;
 }
 
 export class Invocation {

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -75,143 +75,143 @@ declare namespace TelegramBot {
 
     /// METHODS OPTIONS ///
     interface PollingOptions {
-        interval?: string | number;
-        autoStart?: boolean;
-        params?: GetUpdatesOptions;
+        interval?: string | number | undefined;
+        autoStart?: boolean | undefined;
+        params?: GetUpdatesOptions | undefined;
     }
 
     interface WebHookOptions {
-        host?: string;
-        port?: number;
-        key?: string;
-        cert?: string;
-        pfx?: string;
-        autoOpen?: boolean;
-        https?: ServerOptions;
-        healthEndpoint?: string;
+        host?: string | undefined;
+        port?: number | undefined;
+        key?: string | undefined;
+        cert?: string | undefined;
+        pfx?: string | undefined;
+        autoOpen?: boolean | undefined;
+        https?: ServerOptions | undefined;
+        healthEndpoint?: string | undefined;
     }
 
     interface ConstructorOptions {
-        polling?: boolean | PollingOptions;
-        webHook?: boolean | WebHookOptions;
-        onlyFirstMatch?: boolean;
-        request?: Options;
-        baseApiUrl?: string;
-        filepath?: boolean;
+        polling?: boolean | PollingOptions | undefined;
+        webHook?: boolean | WebHookOptions | undefined;
+        onlyFirstMatch?: boolean | undefined;
+        request?: Options | undefined;
+        baseApiUrl?: string | undefined;
+        filepath?: boolean | undefined;
     }
 
     interface StartPollingOptions extends ConstructorOptions {
-        restart?: boolean;
+        restart?: boolean | undefined;
     }
 
     interface StopPollingOptions {
-        cancel?: boolean;
-        reason?: string;
+        cancel?: boolean | undefined;
+        reason?: string | undefined;
     }
 
     interface SetWebHookOptions {
-        url?: string;
-        certificate?: string | Stream;
-        max_connections?: number;
-        allowed_updates?: string[];
+        url?: string | undefined;
+        certificate?: string | Stream | undefined;
+        max_connections?: number | undefined;
+        allowed_updates?: string[] | undefined;
     }
 
     interface GetUpdatesOptions {
-        offset?: number;
-        limit?: number;
-        timeout?: number;
-        allowed_updates?: string[];
+        offset?: number | undefined;
+        limit?: number | undefined;
+        timeout?: number | undefined;
+        allowed_updates?: string[] | undefined;
     }
 
     interface SendBasicOptions {
-        disable_notification?: boolean;
-        reply_to_message_id?: number;
-        reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply;
+        disable_notification?: boolean | undefined;
+        reply_to_message_id?: number | undefined;
+        reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply | undefined;
     }
 
     interface SendMessageOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        disable_web_page_preview?: boolean;
+        parse_mode?: ParseMode | undefined;
+        disable_web_page_preview?: boolean | undefined;
     }
 
     interface AnswerInlineQueryOptions {
-        cache_time?: number;
-        is_personal?: boolean;
-        next_offset?: string;
-        switch_pm_text?: string;
-        switch_pm_parameter?: string;
+        cache_time?: number | undefined;
+        is_personal?: boolean | undefined;
+        next_offset?: string | undefined;
+        switch_pm_text?: string | undefined;
+        switch_pm_parameter?: string | undefined;
     }
 
     interface ForwardMessageOptions {
-        disable_notification?: boolean;
+        disable_notification?: boolean | undefined;
     }
 
     interface SendPhotoOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        caption?: string;
+        parse_mode?: ParseMode | undefined;
+        caption?: string | undefined;
     }
 
     interface SendAudioOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        caption?: string;
-        duration?: number;
-        performer?: string;
-        title?: string;
+        parse_mode?: ParseMode | undefined;
+        caption?: string | undefined;
+        duration?: number | undefined;
+        performer?: string | undefined;
+        title?: string | undefined;
     }
 
     interface SendAnimationOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        caption?: string;
-        duration?: number;
-        width?: number;
-        height?: number;
+        parse_mode?: ParseMode | undefined;
+        caption?: string | undefined;
+        duration?: number | undefined;
+        width?: number | undefined;
+        height?: number | undefined;
     }
 
     interface SendDocumentOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        caption?: string;
+        parse_mode?: ParseMode | undefined;
+        caption?: string | undefined;
     }
 
     interface SendMediaGroupOptions {
-        disable_notification?: boolean;
-        reply_to_message_id?: number;
+        disable_notification?: boolean | undefined;
+        reply_to_message_id?: number | undefined;
     }
 
     interface SendPollOptions extends SendBasicOptions {
-        is_anonymous?: boolean;
-        type?: PollType;
-        allows_multiple_answers?: boolean;
-        correct_option_id?: number;
-        explanation?: string;
-        explanation_parse_mode?: ParseMode;
-        open_period?: number;
-        close_date?: number;
-        is_closed?: boolean;
+        is_anonymous?: boolean | undefined;
+        type?: PollType | undefined;
+        allows_multiple_answers?: boolean | undefined;
+        correct_option_id?: number | undefined;
+        explanation?: string | undefined;
+        explanation_parse_mode?: ParseMode | undefined;
+        open_period?: number | undefined;
+        close_date?: number | undefined;
+        is_closed?: boolean | undefined;
     }
 
     interface StopPollOptions {
-        reply_markup?: InlineKeyboardMarkup;
+        reply_markup?: InlineKeyboardMarkup | undefined;
     }
 
     type SendStickerOptions = SendBasicOptions;
 
     interface SendVideoOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        duration?: number;
-        width?: number;
-        height?: number;
-        caption?: string;
+        parse_mode?: ParseMode | undefined;
+        duration?: number | undefined;
+        width?: number | undefined;
+        height?: number | undefined;
+        caption?: string | undefined;
     }
 
     interface SendVoiceOptions extends SendBasicOptions {
-        parse_mode?: ParseMode;
-        caption?: string;
-        duration?: number;
+        parse_mode?: ParseMode | undefined;
+        caption?: string | undefined;
+        duration?: number | undefined;
     }
 
     interface SendVideoNoteOptions extends SendBasicOptions {
-        duration?: number;
-        length?: number;
+        duration?: number | undefined;
+        length?: number | undefined;
     }
 
     type SendLocationOptions = SendBasicOptions;
@@ -221,82 +221,82 @@ declare namespace TelegramBot {
     type StopMessageLiveLocationOptions = EditMessageCaptionOptions;
 
     interface SendVenueOptions extends SendBasicOptions {
-        foursquare_id?: string;
+        foursquare_id?: string | undefined;
     }
 
     interface SendContactOptions extends SendBasicOptions {
-        last_name?: string;
-        vcard?: string;
+        last_name?: string | undefined;
+        vcard?: string | undefined;
     }
 
     type SendGameOptions = SendBasicOptions;
 
     interface SendInvoiceOptions extends SendBasicOptions {
-        provider_data?: string;
-        photo_url?: string;
-        photo_size?: number;
-        photo_width?: number;
-        photo_height?: number;
-        need_name?: boolean;
-        need_phone_number?: boolean;
-        need_email?: boolean;
-        need_shipping_address?: boolean;
-        is_flexible?: boolean;
+        provider_data?: string | undefined;
+        photo_url?: string | undefined;
+        photo_size?: number | undefined;
+        photo_width?: number | undefined;
+        photo_height?: number | undefined;
+        need_name?: boolean | undefined;
+        need_phone_number?: boolean | undefined;
+        need_email?: boolean | undefined;
+        need_shipping_address?: boolean | undefined;
+        is_flexible?: boolean | undefined;
     }
 
     interface CopyMessageOptions extends SendBasicOptions {
-        caption?: string;
-        parse_mode?: ParseMode;
-        caption_entities?: MessageEntity[];
-        allow_sending_without_reply?: boolean;
+        caption?: string | undefined;
+        parse_mode?: ParseMode | undefined;
+        caption_entities?: MessageEntity[] | undefined;
+        allow_sending_without_reply?: boolean | undefined;
     }
 
     interface RestrictChatMemberOptions {
-        until_date?: number;
-        can_send_messages?: boolean;
-        can_send_media_messages?: boolean;
-        can_send_polls?: boolean;
-        can_send_other_messages?: boolean;
-        can_add_web_page_previews?: boolean;
-        can_change_info?: boolean;
-        can_invite_users?: boolean;
-        can_pin_messages?: boolean;
+        until_date?: number | undefined;
+        can_send_messages?: boolean | undefined;
+        can_send_media_messages?: boolean | undefined;
+        can_send_polls?: boolean | undefined;
+        can_send_other_messages?: boolean | undefined;
+        can_add_web_page_previews?: boolean | undefined;
+        can_change_info?: boolean | undefined;
+        can_invite_users?: boolean | undefined;
+        can_pin_messages?: boolean | undefined;
     }
 
     interface PromoteChatMemberOptions {
-        can_change_info?: boolean;
-        can_post_messages?: boolean;
-        can_edit_messages?: boolean;
-        can_delete_messages?: boolean;
-        can_invite_users?: boolean;
-        can_restrict_members?: boolean;
-        can_pin_messages?: boolean;
-        can_promote_members?: boolean;
+        can_change_info?: boolean | undefined;
+        can_post_messages?: boolean | undefined;
+        can_edit_messages?: boolean | undefined;
+        can_delete_messages?: boolean | undefined;
+        can_invite_users?: boolean | undefined;
+        can_restrict_members?: boolean | undefined;
+        can_pin_messages?: boolean | undefined;
+        can_promote_members?: boolean | undefined;
     }
 
     interface AnswerCallbackQueryOptions {
         callback_query_id: string;
-        text?: string;
-        show_alert?: boolean;
-        url?: string;
-        cache_time?: number;
+        text?: string | undefined;
+        show_alert?: boolean | undefined;
+        url?: string | undefined;
+        cache_time?: number | undefined;
     }
 
     interface EditMessageTextOptions extends EditMessageCaptionOptions {
-        parse_mode?: ParseMode;
-        disable_web_page_preview?: boolean;
+        parse_mode?: ParseMode | undefined;
+        disable_web_page_preview?: boolean | undefined;
     }
 
     interface EditMessageCaptionOptions extends EditMessageReplyMarkupOptions {
-        reply_markup?: InlineKeyboardMarkup;
-        parse_mode?: ParseMode;
-        caption_entities?: MessageEntity[];
+        reply_markup?: InlineKeyboardMarkup | undefined;
+        parse_mode?: ParseMode | undefined;
+        caption_entities?: MessageEntity[] | undefined;
     }
 
     interface EditMessageReplyMarkupOptions {
-        chat_id?: number | string;
-        message_id?: number;
-        inline_message_id?: string;
+        chat_id?: number | string | undefined;
+        message_id?: number | undefined;
+        inline_message_id?: string | undefined;
     }
 
     interface EditMessageMediaOptions {
@@ -307,35 +307,35 @@ declare namespace TelegramBot {
     }
 
     interface GetUserProfilePhotosOptions {
-        offset?: number;
-        limit?: number;
+        offset?: number | undefined;
+        limit?: number | undefined;
     }
 
     interface SetGameScoreOptions {
-        force?: boolean;
-        disable_edit_message?: boolean;
-        chat_id?: number;
-        message_id?: number;
-        inline_message_id?: string;
+        force?: boolean | undefined;
+        disable_edit_message?: boolean | undefined;
+        chat_id?: number | undefined;
+        message_id?: number | undefined;
+        inline_message_id?: string | undefined;
     }
 
     interface GetGameHighScoresOptions {
-        chat_id?: number;
-        message_id?: number;
-        inline_message_id?: string;
+        chat_id?: number | undefined;
+        message_id?: number | undefined;
+        inline_message_id?: string | undefined;
     }
 
     interface AnswerShippingQueryOptions {
-        shipping_options?: ShippingOption[];
-        error_message?: string;
+        shipping_options?: ShippingOption[] | undefined;
+        error_message?: string | undefined;
     }
 
     interface AnswerPreCheckoutQueryOptions {
-        error_message?: string;
+        error_message?: string | undefined;
     }
 
     interface SendDiceOptions extends SendBasicOptions {
-        emoji?: string;
+        emoji?: string | undefined;
     }
 
     /// TELEGRAM TYPES ///
@@ -347,14 +347,14 @@ declare namespace TelegramBot {
 
     interface EncryptedPassportElement {
         type: string;
-        data?: string;
-        phone_number?: string;
-        email?: string;
-        files?: PassportFile[];
-        front_side?: PassportFile;
-        reverse_side?: PassportFile;
-        selfie?: PassportFile;
-        translation?: PassportFile[];
+        data?: string | undefined;
+        phone_number?: string | undefined;
+        email?: string | undefined;
+        files?: PassportFile[] | undefined;
+        front_side?: PassportFile | undefined;
+        reverse_side?: PassportFile | undefined;
+        selfie?: PassportFile | undefined;
+        translation?: PassportFile[] | undefined;
         hash: string;
     }
 
@@ -371,117 +371,117 @@ declare namespace TelegramBot {
 
     interface Update {
         update_id: number;
-        message?: Message;
-        edited_message?: Message;
-        channel_post?: Message;
-        edited_channel_post?: Message;
-        inline_query?: InlineQuery;
-        chosen_inline_result?: ChosenInlineResult;
-        callback_query?: CallbackQuery;
-        shipping_query?: ShippingQuery;
-        pre_checkout_query?: PreCheckoutQuery;
+        message?: Message | undefined;
+        edited_message?: Message | undefined;
+        channel_post?: Message | undefined;
+        edited_channel_post?: Message | undefined;
+        inline_query?: InlineQuery | undefined;
+        chosen_inline_result?: ChosenInlineResult | undefined;
+        callback_query?: CallbackQuery | undefined;
+        shipping_query?: ShippingQuery | undefined;
+        pre_checkout_query?: PreCheckoutQuery | undefined;
     }
 
     interface WebhookInfo {
         url: string;
         has_custom_certificate: boolean;
         pending_update_count: number;
-        last_error_date?: number;
-        last_error_message?: string;
-        max_connections?: number;
-        allowed_updates?: string[];
+        last_error_date?: number | undefined;
+        last_error_message?: string | undefined;
+        max_connections?: number | undefined;
+        allowed_updates?: string[] | undefined;
     }
 
     interface User {
         id: number;
         is_bot: boolean;
         first_name: string;
-        last_name?: string;
-        username?: string;
-        language_code?: string;
+        last_name?: string | undefined;
+        username?: string | undefined;
+        language_code?: string | undefined;
     }
 
     interface Chat {
         id: number;
         type: ChatType;
-        title?: string;
-        username?: string;
-        first_name?: string;
-        last_name?: string;
-        photo?: ChatPhoto;
-        description?: string;
-        invite_link?: string;
-        pinned_message?: Message;
-        permissions?: ChatPermissions;
-        can_set_sticker_set?: boolean;
-        sticker_set_name?: string;
+        title?: string | undefined;
+        username?: string | undefined;
+        first_name?: string | undefined;
+        last_name?: string | undefined;
+        photo?: ChatPhoto | undefined;
+        description?: string | undefined;
+        invite_link?: string | undefined;
+        pinned_message?: Message | undefined;
+        permissions?: ChatPermissions | undefined;
+        can_set_sticker_set?: boolean | undefined;
+        sticker_set_name?: string | undefined;
         /**
          * @deprecated since version Telegram Bot API 4.4 - July 29, 2019
          */
-        all_members_are_administrators?: boolean;
+        all_members_are_administrators?: boolean | undefined;
     }
 
     interface Message {
         message_id: number;
-        from?: User;
+        from?: User | undefined;
         date: number;
         chat: Chat;
-        forward_from?: User;
-        forward_from_chat?: Chat;
-        forward_from_message_id?: number;
-        forward_signature?: string;
-        forward_sender_name?: string;
-        forward_date?: number;
-        reply_to_message?: Message;
-        edit_date?: number;
-        media_group_id?: string;
-        author_signature?: string;
-        text?: string;
-        entities?: MessageEntity[];
-        caption_entities?: MessageEntity[];
-        audio?: Audio;
-        document?: Document;
-        animation?: Animation;
-        game?: Game;
-        photo?: PhotoSize[];
-        sticker?: Sticker;
-        video?: Video;
-        voice?: Voice;
-        video_note?: VideoNote;
-        caption?: string;
-        contact?: Contact;
-        location?: Location;
-        venue?: Venue;
-        poll?: Poll;
-        new_chat_members?: User[];
-        left_chat_member?: User;
-        new_chat_title?: string;
-        new_chat_photo?: PhotoSize[];
-        delete_chat_photo?: boolean;
-        group_chat_created?: boolean;
-        supergroup_chat_created?: boolean;
-        channel_chat_created?: boolean;
-        migrate_to_chat_id?: number;
-        migrate_from_chat_id?: number;
-        pinned_message?: Message;
-        invoice?: Invoice;
-        successful_payment?: SuccessfulPayment;
-        connected_website?: string;
-        passport_data?: PassportData;
-        reply_markup?: InlineKeyboardMarkup;
+        forward_from?: User | undefined;
+        forward_from_chat?: Chat | undefined;
+        forward_from_message_id?: number | undefined;
+        forward_signature?: string | undefined;
+        forward_sender_name?: string | undefined;
+        forward_date?: number | undefined;
+        reply_to_message?: Message | undefined;
+        edit_date?: number | undefined;
+        media_group_id?: string | undefined;
+        author_signature?: string | undefined;
+        text?: string | undefined;
+        entities?: MessageEntity[] | undefined;
+        caption_entities?: MessageEntity[] | undefined;
+        audio?: Audio | undefined;
+        document?: Document | undefined;
+        animation?: Animation | undefined;
+        game?: Game | undefined;
+        photo?: PhotoSize[] | undefined;
+        sticker?: Sticker | undefined;
+        video?: Video | undefined;
+        voice?: Voice | undefined;
+        video_note?: VideoNote | undefined;
+        caption?: string | undefined;
+        contact?: Contact | undefined;
+        location?: Location | undefined;
+        venue?: Venue | undefined;
+        poll?: Poll | undefined;
+        new_chat_members?: User[] | undefined;
+        left_chat_member?: User | undefined;
+        new_chat_title?: string | undefined;
+        new_chat_photo?: PhotoSize[] | undefined;
+        delete_chat_photo?: boolean | undefined;
+        group_chat_created?: boolean | undefined;
+        supergroup_chat_created?: boolean | undefined;
+        channel_chat_created?: boolean | undefined;
+        migrate_to_chat_id?: number | undefined;
+        migrate_from_chat_id?: number | undefined;
+        pinned_message?: Message | undefined;
+        invoice?: Invoice | undefined;
+        successful_payment?: SuccessfulPayment | undefined;
+        connected_website?: string | undefined;
+        passport_data?: PassportData | undefined;
+        reply_markup?: InlineKeyboardMarkup | undefined;
     }
 
     interface MessageEntity {
         type: MessageEntityType;
         offset: number;
         length: number;
-        url?: string;
-        user?: User;
+        url?: string | undefined;
+        user?: User | undefined;
     }
 
     interface FileBase {
         file_id: string;
-        file_size?: number;
+        file_size?: number | undefined;
     }
 
     interface PhotoSize extends FileBase {
@@ -491,35 +491,35 @@ declare namespace TelegramBot {
 
     interface Audio extends FileBase {
         duration: number;
-        performer?: string;
-        title?: string;
-        mime_type?: string;
-        thumb?: PhotoSize;
+        performer?: string | undefined;
+        title?: string | undefined;
+        mime_type?: string | undefined;
+        thumb?: PhotoSize | undefined;
     }
 
     interface Document extends FileBase {
-        thumb?: PhotoSize;
-        file_name?: string;
-        mime_type?: string;
+        thumb?: PhotoSize | undefined;
+        file_name?: string | undefined;
+        mime_type?: string | undefined;
     }
 
     interface Video extends FileBase {
         width: number;
         height: number;
         duration: number;
-        thumb?: PhotoSize;
-        mime_type?: string;
+        thumb?: PhotoSize | undefined;
+        mime_type?: string | undefined;
     }
 
     interface Voice extends FileBase {
         duration: number;
-        mime_type?: string;
+        mime_type?: string | undefined;
     }
 
     interface InputMediaBase {
         media: string;
-        caption?: string;
-        parse_mode?: ParseMode;
+        caption?: string | undefined;
+        parse_mode?: ParseMode | undefined;
     }
 
     interface InputMediaPhoto extends InputMediaBase {
@@ -528,10 +528,10 @@ declare namespace TelegramBot {
 
     interface InputMediaVideo extends InputMediaBase {
         type: 'video';
-        width?: number;
-        height?: number;
-        duration?: number;
-        supports_streaming?: boolean;
+        width?: number | undefined;
+        height?: number | undefined;
+        duration?: number | undefined;
+        supports_streaming?: boolean | undefined;
     }
 
     type InputMedia = InputMediaPhoto | InputMediaVideo;
@@ -539,15 +539,15 @@ declare namespace TelegramBot {
     interface VideoNote extends FileBase {
         length: number;
         duration: number;
-        thumb?: PhotoSize;
+        thumb?: PhotoSize | undefined;
     }
 
     interface Contact {
         phone_number: string;
         first_name: string;
-        last_name?: string;
-        user_id?: number;
-        vcard?: string;
+        last_name?: string | undefined;
+        user_id?: number | undefined;
+        vcard?: string | undefined;
     }
 
     interface Location {
@@ -559,8 +559,8 @@ declare namespace TelegramBot {
         location: Location;
         title: string;
         address: string;
-        foursquare_id?: string;
-        foursquare_type?: string;
+        foursquare_id?: string | undefined;
+        foursquare_type?: string | undefined;
     }
 
     type PollType = "regular" | "quiz";
@@ -593,25 +593,25 @@ declare namespace TelegramBot {
     }
 
     interface File extends FileBase {
-        file_path?: string;
+        file_path?: string | undefined;
     }
 
     interface ReplyKeyboardMarkup {
         keyboard: KeyboardButton[][];
-        resize_keyboard?: boolean;
-        one_time_keyboard?: boolean;
-        selective?: boolean;
+        resize_keyboard?: boolean | undefined;
+        one_time_keyboard?: boolean | undefined;
+        selective?: boolean | undefined;
     }
 
     interface KeyboardButton {
         text: string;
-        request_contact?: boolean;
-        request_location?: boolean;
+        request_contact?: boolean | undefined;
+        request_location?: boolean | undefined;
     }
 
     interface ReplyKeyboardRemove {
         remove_keyboard: boolean;
-        selective?: boolean;
+        selective?: boolean | undefined;
     }
 
     interface InlineKeyboardMarkup {
@@ -620,35 +620,35 @@ declare namespace TelegramBot {
 
     interface InlineKeyboardButton {
         text: string;
-        url?: string;
-        login_url?: LoginUrl;
-        callback_data?: string;
-        switch_inline_query?: string;
-        switch_inline_query_current_chat?: string;
-        callback_game?: CallbackGame;
-        pay?: boolean;
+        url?: string | undefined;
+        login_url?: LoginUrl | undefined;
+        callback_data?: string | undefined;
+        switch_inline_query?: string | undefined;
+        switch_inline_query_current_chat?: string | undefined;
+        callback_game?: CallbackGame | undefined;
+        pay?: boolean | undefined;
     }
 
     interface LoginUrl {
         url: string;
-        forward_text?: string;
-        bot_username?: string;
-        request_write_acces?: boolean;
+        forward_text?: string | undefined;
+        bot_username?: string | undefined;
+        request_write_acces?: boolean | undefined;
     }
 
     interface CallbackQuery {
         id: string;
         from: User;
-        message?: Message;
-        inline_message_id?: string;
+        message?: Message | undefined;
+        inline_message_id?: string | undefined;
         chat_instance: string;
-        data?: string;
-        game_short_name?: string;
+        data?: string | undefined;
+        game_short_name?: string | undefined;
     }
 
     interface ForceReply {
         force_reply: boolean;
-        selective?: boolean;
+        selective?: boolean | undefined;
     }
 
     interface ChatPhoto {
@@ -659,33 +659,33 @@ declare namespace TelegramBot {
     interface ChatMember {
         user: User;
         status: ChatMemberStatus;
-        until_date?: number;
-        can_be_edited?: boolean;
-        can_post_messages?: boolean;
-        can_edit_messages?: boolean;
-        can_delete_messages?: boolean;
-        can_restrict_members?: boolean;
-        can_promote_members?: boolean;
-        can_change_info?: boolean;
-        can_invite_users?: boolean;
-        can_pin_messages?: boolean;
-        is_member?: boolean;
-        can_send_messages?: boolean;
-        can_send_media_messages?: boolean;
+        until_date?: number | undefined;
+        can_be_edited?: boolean | undefined;
+        can_post_messages?: boolean | undefined;
+        can_edit_messages?: boolean | undefined;
+        can_delete_messages?: boolean | undefined;
+        can_restrict_members?: boolean | undefined;
+        can_promote_members?: boolean | undefined;
+        can_change_info?: boolean | undefined;
+        can_invite_users?: boolean | undefined;
+        can_pin_messages?: boolean | undefined;
+        is_member?: boolean | undefined;
+        can_send_messages?: boolean | undefined;
+        can_send_media_messages?: boolean | undefined;
         can_send_polls: boolean;
-        can_send_other_messages?: boolean;
-        can_add_web_page_previews?: boolean;
+        can_send_other_messages?: boolean | undefined;
+        can_add_web_page_previews?: boolean | undefined;
     }
 
     interface ChatPermissions {
-        can_send_messages?: boolean;
-        can_send_media_messages?: boolean;
-        can_send_polls?: boolean;
-        can_send_other_messages?: boolean;
-        can_add_web_page_previews?: boolean;
-        can_change_info?: boolean;
-        can_invite_users?: boolean;
-        can_pin_messages?: boolean;
+        can_send_messages?: boolean | undefined;
+        can_send_media_messages?: boolean | undefined;
+        can_send_polls?: boolean | undefined;
+        can_send_other_messages?: boolean | undefined;
+        can_add_web_page_previews?: boolean | undefined;
+        can_change_info?: boolean | undefined;
+        can_invite_users?: boolean | undefined;
+        can_pin_messages?: boolean | undefined;
     }
 
     interface Sticker {
@@ -694,11 +694,11 @@ declare namespace TelegramBot {
         is_animated: boolean;
         width: number;
         height: number;
-        thumb?: PhotoSize;
-        emoji?: string;
-        set_name?: string;
-        mask_position?: MaskPosition;
-        file_size?: number;
+        thumb?: PhotoSize | undefined;
+        emoji?: string | undefined;
+        set_name?: string | undefined;
+        mask_position?: MaskPosition | undefined;
+        file_size?: number | undefined;
     }
 
     interface StickerSet {
@@ -718,62 +718,62 @@ declare namespace TelegramBot {
     interface InlineQuery {
         id: string;
         from: User;
-        location?: Location;
+        location?: Location | undefined;
         query: string;
         offset: string;
     }
 
     interface InlineQueryResultBase {
         id: string;
-        reply_markup?: InlineKeyboardMarkup;
+        reply_markup?: InlineKeyboardMarkup | undefined;
     }
 
     interface InlineQueryResultArticle extends InlineQueryResultBase {
         type: 'article';
         title: string;
         input_message_content: InputMessageContent;
-        url?: string;
-        hide_url?: boolean;
-        description?: string;
-        thumb_url?: string;
-        thumb_width?: number;
-        thumb_height?: number;
+        url?: string | undefined;
+        hide_url?: boolean | undefined;
+        description?: string | undefined;
+        thumb_url?: string | undefined;
+        thumb_width?: number | undefined;
+        thumb_height?: number | undefined;
     }
 
     interface InlineQueryResultPhoto extends InlineQueryResultBase {
         type: 'photo';
         photo_url: string;
         thumb_url: string;
-        photo_width?: number;
-        photo_height?: number;
-        title?: string;
-        description?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        photo_width?: number | undefined;
+        photo_height?: number | undefined;
+        title?: string | undefined;
+        description?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultGif extends InlineQueryResultBase {
         type: 'gif';
         gif_url: string;
-        gif_width?: number;
-        gif_height?: number;
-        gif_duration?: number;
-        thumb_url?: string;
-        title?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        gif_width?: number | undefined;
+        gif_height?: number | undefined;
+        gif_duration?: number | undefined;
+        thumb_url?: string | undefined;
+        title?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultMpeg4Gif extends InlineQueryResultBase {
         type: 'mpeg4_gif';
         mpeg4_url: string;
-        mpeg4_width?: number;
-        mpeg4_height?: number;
-        mpeg4_duration?: number;
-        thumb_url?: string;
-        title?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        mpeg4_width?: number | undefined;
+        mpeg4_height?: number | undefined;
+        mpeg4_duration?: number | undefined;
+        thumb_url?: string | undefined;
+        title?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultVideo extends InlineQueryResultBase {
@@ -782,54 +782,54 @@ declare namespace TelegramBot {
         mime_type: string;
         thumb_url: string;
         title: string;
-        caption?: string;
-        video_width?: number;
-        video_height?: number;
-        video_duration?: number;
-        description?: string;
-        input_message_content?: InputMessageContent;
+        caption?: string | undefined;
+        video_width?: number | undefined;
+        video_height?: number | undefined;
+        video_duration?: number | undefined;
+        description?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultAudio extends InlineQueryResultBase {
         type: 'audio';
         audio_url: string;
         title: string;
-        caption?: string;
-        performer?: string;
-        audio_duration?: number;
-        input_message_content?: InputMessageContent;
+        caption?: string | undefined;
+        performer?: string | undefined;
+        audio_duration?: number | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultVoice extends InlineQueryResultBase {
         type: 'voice';
         voice_url: string;
         title: string;
-        caption?: string;
-        voice_duration?: number;
-        input_message_content?: InputMessageContent;
+        caption?: string | undefined;
+        voice_duration?: number | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultDocument extends InlineQueryResultBase {
         type: 'document';
         title: string;
-        caption?: string;
+        caption?: string | undefined;
         document_url: string;
         mime_type: string;
-        description?: string;
-        input_message_content?: InputMessageContent;
-        thumb_url?: string;
-        thumb_width?: number;
-        thumb_height?: number;
+        description?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
+        thumb_url?: string | undefined;
+        thumb_width?: number | undefined;
+        thumb_height?: number | undefined;
     }
 
     interface InlineQueryResultLocationBase extends InlineQueryResultBase {
         latitude: number;
         longitude: number;
         title: string;
-        input_message_content?: InputMessageContent;
-        thumb_url?: string;
-        thumb_width?: number;
-        thumb_height?: number;
+        input_message_content?: InputMessageContent | undefined;
+        thumb_url?: string | undefined;
+        thumb_width?: number | undefined;
+        thumb_height?: number | undefined;
     }
 
     interface InlineQueryResultLocation extends InlineQueryResultLocationBase {
@@ -839,18 +839,18 @@ declare namespace TelegramBot {
     interface InlineQueryResultVenue extends InlineQueryResultLocationBase {
         type: 'venue';
         address: string;
-        foursquare_id?: string;
+        foursquare_id?: string | undefined;
     }
 
     interface InlineQueryResultContact extends InlineQueryResultBase {
         type: 'contact';
         phone_number: string;
         first_name: string;
-        last_name?: string;
-        input_message_content?: InputMessageContent;
-        thumb_url?: string;
-        thumb_width?: number;
-        thumb_height?: number;
+        last_name?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
+        thumb_url?: string | undefined;
+        thumb_width?: number | undefined;
+        thumb_height?: number | undefined;
     }
 
     interface InlineQueryResultGame extends InlineQueryResultBase {
@@ -861,65 +861,65 @@ declare namespace TelegramBot {
     interface InlineQueryResultCachedPhoto extends InlineQueryResultBase {
         type: 'photo';
         photo_file_id: string;
-        title?: string;
-        description?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        title?: string | undefined;
+        description?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedGif extends InlineQueryResultBase {
         type: 'gif';
         gif_file_id: string;
-        title?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        title?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedMpeg4Gif extends InlineQueryResultBase {
         type: 'mpeg4_gif';
         mpeg4_file_id: string;
-        title?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        title?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedSticker extends InlineQueryResultBase {
         type: 'sticker';
         sticker_file_id: string;
-        input_message_content?: InputMessageContent;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedDocument extends InlineQueryResultBase {
         type: 'document';
         title: string;
         document_file_id: string;
-        description?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        description?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedVideo extends InlineQueryResultBase {
         type: 'video';
         video_file_id: string;
         title: string;
-        description?: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        description?: string | undefined;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedVoice extends InlineQueryResultBase {
         type: 'voice';
         voice_file_id: string;
         title: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     interface InlineQueryResultCachedAudio extends InlineQueryResultBase {
         type: 'audio';
         audio_file_id: string;
-        caption?: string;
-        input_message_content?: InputMessageContent;
+        caption?: string | undefined;
+        input_message_content?: InputMessageContent | undefined;
     }
 
     type InlineQueryResult =
@@ -948,8 +948,8 @@ declare namespace TelegramBot {
 
     interface InputTextMessageContent extends InputMessageContent {
         message_text: string;
-        parse_mode?: ParseMode;
-        disable_web_page_preview?: boolean;
+        parse_mode?: ParseMode | undefined;
+        disable_web_page_preview?: boolean | undefined;
     }
 
     interface InputLocationMessageContent extends InputMessageContent {
@@ -960,26 +960,26 @@ declare namespace TelegramBot {
     interface InputVenueMessageContent extends InputLocationMessageContent {
         title: string;
         address: string;
-        foursquare_id?: string;
+        foursquare_id?: string | undefined;
     }
 
     interface InputContactMessageContent extends InputMessageContent {
         phone_number: string;
         first_name: string;
-        last_name?: string;
+        last_name?: string | undefined;
     }
 
     interface ChosenInlineResult {
         result_id: string;
         from: User;
-        location?: Location;
-        inline_message_id?: string;
+        location?: Location | undefined;
+        inline_message_id?: string | undefined;
         query: string;
     }
 
     interface ResponseParameters {
-        migrate_to_chat_id?: number;
-        retry_after?: number;
+        migrate_to_chat_id?: number | undefined;
+        retry_after?: number | undefined;
     }
 
     interface LabeledPrice {
@@ -1005,10 +1005,10 @@ declare namespace TelegramBot {
     }
 
     interface OrderInfo {
-        name?: string;
-        phone_number?: string;
-        email?: string;
-        shipping_address?: ShippingAddress;
+        name?: string | undefined;
+        phone_number?: string | undefined;
+        email?: string | undefined;
+        shipping_address?: ShippingAddress | undefined;
     }
 
     interface ShippingOption {
@@ -1021,8 +1021,8 @@ declare namespace TelegramBot {
         currency: string;
         total_amount: number;
         invoice_payload: string;
-        shipping_option_id?: string;
-        order_info?: OrderInfo;
+        shipping_option_id?: string | undefined;
+        order_info?: OrderInfo | undefined;
         telegram_payment_charge_id: string;
         provider_payment_charge_id: string;
     }
@@ -1040,26 +1040,26 @@ declare namespace TelegramBot {
         currency: string;
         total_amount: number;
         invoice_payload: string;
-        shipping_option_id?: string;
-        order_info?: OrderInfo;
+        shipping_option_id?: string | undefined;
+        order_info?: OrderInfo | undefined;
     }
 
     interface Game {
         title: string;
         description: string;
         photo: PhotoSize[];
-        text?: string;
-        text_entities?: MessageEntity[];
-        animation?: Animation;
+        text?: string | undefined;
+        text_entities?: MessageEntity[] | undefined;
+        animation?: Animation | undefined;
     }
 
     interface Animation extends FileBase {
         width: number;
         height: number;
         duration: number;
-        thumb?: PhotoSize;
-        file_name?: string;
-        mime_type?: string;
+        thumb?: PhotoSize | undefined;
+        file_name?: string | undefined;
+        mime_type?: string | undefined;
     }
 
     type CallbackGame = object;
@@ -1071,7 +1071,7 @@ declare namespace TelegramBot {
     }
 
     interface Metadata {
-        type?: MessageType;
+        type?: MessageType | undefined;
     }
 
     interface BotCommand {

--- a/types/node-uuid/index.d.ts
+++ b/types/node-uuid/index.d.ts
@@ -13,25 +13,25 @@ export interface UUIDOptions {
      * Node id as Array of 6 bytes (per 4.1.6).
      * Default: Randomly generated ID. See note 1.
      */
-    node?: any[];
+    node?: any[] | undefined;
 
     /**
      * (Number between 0 - 0x3fff) RFC clock sequence.
      * Default: An internally maintained clockseq is used.
      */
-    clockseq?: number;
+    clockseq?: number | undefined;
 
     /**
      * (Number | Date) Time in milliseconds since unix Epoch.
      * Default: The current time is used.
      */
-    msecs?: number|Date;
+    msecs?: number|Date | undefined;
 
     /**
      * (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if msecs is unspecified.
      * Default: internal uuid counter is used, as per 4.2.1.2.
      */
-    nsecs?: number;
+    nsecs?: number | undefined;
 }
 
 export interface UUID {


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers widely used packages (more than 100,000 downloads per
month) from mini-css-extract-plugin to node-uuid
microsoft/dtslint#335