### PR TITLE
Add undefined to optional properties, Node

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -11,16 +11,16 @@ declare module 'assert' {
 
             constructor(options?: {
                 /** If provided, the error message is set to this value. */
-                message?: string;
+                message?: string | undefined;
                 /** The `actual` property on the error instance. */
-                actual?: unknown;
+                actual?: unknown | undefined;
                 /** The `expected` property on the error instance. */
-                expected?: unknown;
+                expected?: unknown | undefined;
                 /** The `operator` property on the error instance. */
-                operator?: string;
+                operator?: string | undefined;
                 /** If provided, the generated stack trace omits frames before this function. */
                 // tslint:disable-next-line:ban-types
-                stackStartFn?: Function;
+                stackStartFn?: Function | undefined;
             });
         }
 

--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -87,7 +87,7 @@ declare module 'async_hooks' {
        * The ID of the execution context that created this async event.
        * @default executionAsyncId()
        */
-      triggerAsyncId?: number;
+      triggerAsyncId?: number | undefined;
 
       /**
        * Disables automatic `emitDestroy` when the object is garbage collected.
@@ -96,7 +96,7 @@ declare module 'async_hooks' {
        * sensitive API's `emitDestroy` is called with it.
        * @default false
        */
-      requireManualDestroy?: boolean;
+      requireManualDestroy?: boolean | undefined;
     }
 
     /**

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -28,14 +28,14 @@ declare module 'buffer' {
         /**
          * @default 'utf8'
          */
-        encoding?: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
 
         /**
          * The Blob content-type. The intent is for `type` to convey
          * the MIME media type of the data, however no validation of the type format
          * is performed.
          */
-        type?: string;
+        type?: string | undefined;
     }
 
     /**

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -11,7 +11,7 @@ declare module 'child_process' {
         stdin: Writable | null;
         stdout: Readable | null;
         stderr: Readable | null;
-        readonly channel?: Pipe | null;
+        readonly channel?: Pipe | null | undefined;
         readonly stdio: [
             Writable | null, // stdin
             Readable | null, // stdout
@@ -20,7 +20,7 @@ declare module 'child_process' {
             Readable | Writable | null | undefined // extra
         ];
         readonly killed: boolean;
-        readonly pid?: number;
+        readonly pid?: number | undefined;
         readonly connected: boolean;
         readonly exitCode: number | null;
         readonly signalCode: NodeJS.Signals | null;
@@ -126,7 +126,7 @@ declare module 'child_process' {
     }
 
     interface MessageOptions {
-        keepOpen?: boolean;
+        keepOpen?: boolean | undefined;
     }
 
     type IOType = "overlapped" | "pipe" | "ignore" | "inherit";
@@ -140,51 +140,46 @@ declare module 'child_process' {
          * Specify the kind of serialization used for sending messages between processes.
          * @default 'json'
          */
-        serialization?: SerializationType;
+        serialization?: SerializationType | undefined;
 
         /**
          * The signal value to be used when the spawned process will be killed by the abort signal.
          * @default 'SIGTERM'
          */
-        killSignal?: NodeJS.Signals | number;
-
-        /**
-         * In milliseconds the maximum amount of time the process is allowed to run.
-         */
-        timeout?: number;
+        killSignal?: NodeJS.Signals | number | undefined;
     }
 
     interface ProcessEnvOptions {
-        uid?: number;
-        gid?: number;
-        cwd?: string;
-        env?: NodeJS.ProcessEnv;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        cwd?: string | undefined;
+        env?: NodeJS.ProcessEnv | undefined;
     }
 
     interface CommonOptions extends ProcessEnvOptions {
         /**
          * @default true
          */
-        windowsHide?: boolean;
+        windowsHide?: boolean | undefined;
         /**
          * @default 0
          */
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
-        argv0?: string;
-        stdio?: StdioOptions;
-        shell?: boolean | string;
-        windowsVerbatimArguments?: boolean;
+        argv0?: string | undefined;
+        stdio?: StdioOptions | undefined;
+        shell?: boolean | string | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
 
     interface SpawnOptions extends CommonSpawnOptions {
-        detached?: boolean;
+        detached?: boolean | undefined;
     }
 
     interface SpawnOptionsWithoutStdio extends SpawnOptions {
-        stdio?: StdioPipeNamed | StdioPipe[];
+        stdio?: StdioPipeNamed | StdioPipe[] | undefined;
     }
 
     type StdioNull = 'inherit' | 'ignore' | Stream;
@@ -284,9 +279,9 @@ declare module 'child_process' {
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {
-        shell?: string;
-        maxBuffer?: number;
-        killSignal?: NodeJS.Signals | number;
+        shell?: string | undefined;
+        maxBuffer?: number | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
     }
 
     interface ExecOptionsWithStringEncoding extends ExecOptions {
@@ -298,10 +293,10 @@ declare module 'child_process' {
     }
 
     interface ExecException extends Error {
-        cmd?: string;
-        killed?: boolean;
-        code?: number;
-        signal?: NodeJS.Signals;
+        cmd?: string | undefined;
+        killed?: boolean | undefined;
+        code?: number | undefined;
+        signal?: NodeJS.Signals | undefined;
     }
 
     // no `options` definitely means stdout/stderr are `string`.
@@ -345,11 +340,11 @@ declare module 'child_process' {
     }
 
     interface ExecFileOptions extends CommonOptions, Abortable {
-        maxBuffer?: number;
-        killSignal?: NodeJS.Signals | number;
-        windowsVerbatimArguments?: boolean;
-        shell?: boolean | string;
-        signal?: AbortSignal;
+        maxBuffer?: number | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
+        shell?: boolean | string | undefined;
+        signal?: AbortSignal | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
@@ -450,26 +445,26 @@ declare module 'child_process' {
     }
 
     interface ForkOptions extends ProcessEnvOptions, MessagingOptions, Abortable {
-        execPath?: string;
-        execArgv?: string[];
-        silent?: boolean;
-        stdio?: StdioOptions;
-        detached?: boolean;
-        windowsVerbatimArguments?: boolean;
+        execPath?: string | undefined;
+        execArgv?: string[] | undefined;
+        silent?: boolean | undefined;
+        stdio?: StdioOptions | undefined;
+        detached?: boolean | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
     function fork(modulePath: string, options?: ForkOptions): ChildProcess;
     function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
     interface SpawnSyncOptions extends CommonSpawnOptions {
-        input?: string | NodeJS.ArrayBufferView;
-        maxBuffer?: number;
-        encoding?: BufferEncoding | 'buffer' | null;
+        input?: string | NodeJS.ArrayBufferView | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: BufferEncoding | 'buffer' | null | undefined;
     }
     interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
     }
     interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
-        encoding?: 'buffer' | null;
+        encoding?: 'buffer' | null | undefined;
     }
     interface SpawnSyncReturns<T> {
         pid: number;
@@ -478,7 +473,7 @@ declare module 'child_process' {
         stderr: T;
         status: number | null;
         signal: NodeJS.Signals | null;
-        error?: Error;
+        error?: Error | undefined;
     }
     function spawnSync(command: string): SpawnSyncReturns<Buffer>;
     function spawnSync(command: string, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
@@ -488,30 +483,32 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptionsWithBufferEncoding): SpawnSyncReturns<Buffer>;
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
 
-    interface CommonExecOptions extends ProcessEnvOptions {
-        input?: string | NodeJS.ArrayBufferView;
-        stdio?: StdioOptions;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: BufferEncoding | 'buffer' | null;
-    }
-
-    interface ExecSyncOptions extends CommonExecOptions {
-        shell?: string;
+    interface ExecSyncOptions extends CommonOptions {
+        input?: string | Uint8Array | undefined;
+        stdio?: StdioOptions | undefined;
+        shell?: string | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: BufferEncoding | 'buffer' | null | undefined;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;
     }
     interface ExecSyncOptionsWithBufferEncoding extends ExecSyncOptions {
-        encoding?: 'buffer' | null;
+        encoding?: 'buffer' | null | undefined;
     }
     function execSync(command: string): Buffer;
     function execSync(command: string, options?: ExecSyncOptionsWithStringEncoding): string;
     function execSync(command: string, options?: ExecSyncOptionsWithBufferEncoding): Buffer;
     function execSync(command: string, options?: ExecSyncOptions): Buffer;
 
-    interface ExecFileSyncOptions extends CommonExecOptions {
-        shell?: boolean | string;
+    interface ExecFileSyncOptions extends CommonOptions {
+        input?: string | NodeJS.ArrayBufferView | undefined;
+        stdio?: StdioOptions | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: BufferEncoding | undefined;
+        shell?: boolean | string | undefined;
     }
     interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
         encoding: BufferEncoding;

--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -1,27 +1,27 @@
-// Requires `esModuleInterop: true`
 declare module 'cluster' {
     import * as child from 'child_process';
     import EventEmitter = require('events');
     import * as net from 'net';
 
-    export interface ClusterSettings {
-        execArgv?: string[]; // default: process.execArgv
-        exec?: string;
-        args?: string[];
-        silent?: boolean;
-        stdio?: any[];
-        uid?: number;
-        gid?: number;
-        inspectPort?: number | (() => number);
+    // interfaces
+    interface ClusterSettings {
+        execArgv?: string[] | undefined; // default: process.execArgv
+        exec?: string | undefined;
+        args?: string[] | undefined;
+        silent?: boolean | undefined;
+        stdio?: any[] | undefined;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        inspectPort?: number | (() => number) | undefined;
     }
 
-    export interface Address {
+    interface Address {
         address: string;
         port: number;
         addressType: number | "udp4" | "udp6";  // 4, 6, -1, "udp4", "udp6"
     }
 
-    export class Worker extends EventEmitter {
+    class Worker extends EventEmitter {
         id: number;
         process: child.ChildProcess;
         send(message: child.Serializable, sendHandle?: child.SendHandle, callback?: (error: Error | null) => void): boolean;
@@ -90,23 +90,17 @@ declare module 'cluster' {
         prependOnceListener(event: "online", listener: () => void): this;
     }
 
-    export interface Cluster extends EventEmitter {
+    interface Cluster extends EventEmitter {
+        Worker: Worker;
         disconnect(callback?: () => void): void;
         fork(env?: any): Worker;
-        /** @deprecated since v16.0.0 - use setupPrimary. */
-        readonly isMaster: boolean;
-        readonly isPrimary: boolean;
-        readonly isWorker: boolean;
+        isMaster: boolean;
+        isWorker: boolean;
         schedulingPolicy: number;
-        readonly settings: ClusterSettings;
-        /** @deprecated since v16.0.0 - use setupPrimary. */
+        settings: ClusterSettings;
         setupMaster(settings?: ClusterSettings): void;
-        /**
-         * `setupPrimary` is used to change the default 'fork' behavior. Once called, the settings will be present in cluster.settings.
-         */
-        setupPrimary(settings?: ClusterSettings): void;
-        readonly worker?: Worker;
-        readonly workers?: NodeJS.Dict<Worker>;
+        worker?: Worker | undefined;
+        workers?: NodeJS.Dict<Worker> | undefined;
 
         readonly SCHED_NONE: number;
         readonly SCHED_RR: number;
@@ -153,7 +147,7 @@ declare module 'cluster' {
         once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
         once(event: "fork", listener: (worker: Worker) => void): this;
         once(event: "listening", listener: (worker: Worker, address: Address) => void): this;
-        once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this; // the handle is a net.Socket or net.Server object, or undefined.
+        once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
         once(event: "online", listener: (worker: Worker) => void): this;
         once(event: "setup", listener: (settings: ClusterSettings) => void): this;
 
@@ -162,8 +156,7 @@ declare module 'cluster' {
         prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
         prependListener(event: "fork", listener: (worker: Worker) => void): this;
         prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): this;
-        // the handle is a net.Socket or net.Server object, or undefined.
-        prependListener(event: "message", listener: (worker: Worker, message: any, handle?: net.Socket | net.Server) => void): this;
+        prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
         prependListener(event: "online", listener: (worker: Worker) => void): this;
         prependListener(event: "setup", listener: (settings: ClusterSettings) => void): this;
 
@@ -178,10 +171,92 @@ declare module 'cluster' {
         prependOnceListener(event: "setup", listener: (settings: ClusterSettings) => void): this;
     }
 
-    const cluster: Cluster;
-    export default cluster;
-}
+    const SCHED_NONE: number;
+    const SCHED_RR: number;
 
-declare module 'node:cluster' {
-    export * from 'cluster';
+    function disconnect(callback?: () => void): void;
+    function fork(env?: any): Worker;
+    const isMaster: boolean;
+    const isWorker: boolean;
+    let schedulingPolicy: number;
+    const settings: ClusterSettings;
+    function setupMaster(settings?: ClusterSettings): void;
+    const worker: Worker;
+    const workers: NodeJS.Dict<Worker>;
+
+    /**
+     * events.EventEmitter
+     *   1. disconnect
+     *   2. exit
+     *   3. fork
+     *   4. listening
+     *   5. message
+     *   6. online
+     *   7. setup
+     */
+    function addListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function addListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function addListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function addListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     // the handle is a net.Socket or net.Server object, or undefined.
+    function addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+    function addListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    function addListener(event: "setup", listener: (settings: ClusterSettings) => void): Cluster;
+
+    function emit(event: string | symbol, ...args: any[]): boolean;
+    function emit(event: "disconnect", worker: Worker): boolean;
+    function emit(event: "exit", worker: Worker, code: number, signal: string): boolean;
+    function emit(event: "fork", worker: Worker): boolean;
+    function emit(event: "listening", worker: Worker, address: Address): boolean;
+    function emit(event: "message", worker: Worker, message: any, handle: net.Socket | net.Server): boolean;
+    function emit(event: "online", worker: Worker): boolean;
+    function emit(event: "setup", settings: ClusterSettings): boolean;
+
+    function on(event: string, listener: (...args: any[]) => void): Cluster;
+    function on(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function on(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function on(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    function on(event: "online", listener: (worker: Worker) => void): Cluster;
+    function on(event: "setup", listener: (settings: ClusterSettings) => void): Cluster;
+
+    function once(event: string, listener: (...args: any[]) => void): Cluster;
+    function once(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function once(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function once(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    function once(event: "online", listener: (worker: Worker) => void): Cluster;
+    function once(event: "setup", listener: (settings: ClusterSettings) => void): Cluster;
+
+    function removeListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function removeAllListeners(event?: string): Cluster;
+    function setMaxListeners(n: number): Cluster;
+    function getMaxListeners(): number;
+    function listeners(event: string): Function[];
+    function listenerCount(type: string): number;
+
+    function prependListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function prependListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function prependListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     // the handle is a net.Socket or net.Server object, or undefined.
+    function prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+    function prependListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    function prependListener(event: "setup", listener: (settings: ClusterSettings) => void): Cluster;
+
+    function prependOnceListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function prependOnceListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     // the handle is a net.Socket or net.Server object, or undefined.
+    function prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+    function prependOnceListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    function prependOnceListener(event: "setup", listener: (settings: ClusterSettings) => void): Cluster;
+
+    function eventNames(): string[];
 }

--- a/types/node/console.d.ts
+++ b/types/node/console.d.ts
@@ -4,7 +4,7 @@ declare module 'console' {
     global {
         // This needs to be global to avoid TS2403 in case lib.dom.d.ts is present in the same build
         interface Console {
-            Console: console.ConsoleConstructor;
+            Console: NodeJS.ConsoleConstructor;
             /**
              * A simple assertion test that verifies whether `value` is truthy.
              * If it is not, an `AssertionError` is thrown.
@@ -106,29 +106,28 @@ declare module 'console' {
             timeStamp(label?: string): void;
         }
 
-        namespace console {
+        var console: Console;
+
+        namespace NodeJS {
             interface ConsoleConstructorOptions {
-                stdout: NodeJS.WritableStream;
-                stderr?: NodeJS.WritableStream;
-                ignoreErrors?: boolean;
-                colorMode?: boolean | 'auto';
-                inspectOptions?: InspectOptions;
+                stdout: WritableStream;
+                stderr?: WritableStream | undefined;
+                ignoreErrors?: boolean | undefined;
+                colorMode?: boolean | 'auto' | undefined;
+                inspectOptions?: InspectOptions | undefined;
             }
 
             interface ConsoleConstructor {
                 prototype: Console;
-                new(stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream, ignoreErrors?: boolean): Console;
+                new(stdout: WritableStream, stderr?: WritableStream, ignoreErrors?: boolean): Console;
                 new(options: ConsoleConstructorOptions): Console;
             }
-        }
 
-        var console: Console;
+            interface Global {
+                console: typeof console;
+            }
+        }
     }
 
-    export = globalThis.console;
-}
-
-declare module 'node:console' {
-    import console = require('console');
     export = console;
 }

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -154,7 +154,7 @@ declare module 'crypto' {
          * For XOF hash functions such as `shake256`, the
          * outputLength option can be used to specify the desired output length in bytes.
          */
-        outputLength?: number;
+        outputLength?: number | undefined;
     }
 
     /** @deprecated since v10.0.0 */
@@ -193,71 +193,67 @@ declare module 'crypto' {
     interface KeyExportOptions<T extends KeyFormat> {
         type: 'pkcs1' | 'spki' | 'pkcs8' | 'sec1';
         format: T;
-        cipher?: string;
-        passphrase?: string | Buffer;
+        cipher?: string | undefined;
+        passphrase?: string | Buffer | undefined;
     }
+
     interface JwkKeyExportOptions {
         format: 'jwk';
     }
+
     interface JsonWebKey {
-        crv?: string;
-        d?: string;
-        dp?: string;
-        dq?: string;
-        e?: string;
-        k?: string;
-        kty?: string;
-        n?: string;
-        p?: string;
-        q?: string;
-        qi?: string;
-        x?: string;
-        y?: string;
-        [key: string]: unknown;
+        crv?: string | undefined;
+        d?: string | undefined;
+        dp?: string | undefined;
+        dq?: string | undefined;
+        e?: string | undefined;
+        k?: string | undefined;
+        kty?: string | undefined;
+        n?: string | undefined;
+        p?: string | undefined;
+        q?: string | undefined;
+        qi?: string | undefined;
+        x?: string | undefined;
+        y?: string | undefined;
     }
 
     interface AsymmetricKeyDetails {
         /**
          * Key size in bits (RSA, DSA).
          */
-        modulusLength?: number;
+        modulusLength?: number | undefined;
         /**
          * Public exponent (RSA).
          */
-        publicExponent?: bigint;
+        publicExponent?: bigint | undefined;
         /**
          * Size of q in bits (DSA).
          */
-        divisorLength?: number;
+        divisorLength?: number | undefined;
         /**
          * Name of the curve (EC).
          */
-        namedCurve?: string;
-    }
-
-    interface JwkKeyExportOptions {
-        format: 'jwk';
+        namedCurve?: string | undefined;
     }
 
     class KeyObject {
         private constructor();
-        asymmetricKeyType?: KeyType;
+        asymmetricKeyType?: KeyType | undefined;
         /**
          * For asymmetric keys, this property represents the size of the embedded key in
          * bytes. This property is `undefined` for symmetric keys.
          */
-        asymmetricKeySize?: number;
+        asymmetricKeySize?: number | undefined;
         /**
          * This property exists only on asymmetric keys. Depending on the type of the key,
          * this object contains information about the key. None of the information obtained
          * through this property can be used to uniquely identify a key or to compromise the
          * security of the key.
          */
-        asymmetricKeyDetails?: AsymmetricKeyDetails;
+        asymmetricKeyDetails?: AsymmetricKeyDetails | undefined;
         export(options: KeyExportOptions<'pem'>): string | Buffer;
         export(options?: KeyExportOptions<'der'>): Buffer;
-        export(options?: JwkKeyExportOptions): JsonWebKey;
-        symmetricKeySize?: number;
+        symmetricKeySize?: number | undefined;
         type: KeyObjectType;
     }
 
@@ -272,7 +268,7 @@ declare module 'crypto' {
         authTagLength: number;
     }
     interface CipherGCMOptions extends stream.TransformOptions {
-        authTagLength?: number;
+        authTagLength?: number | undefined;
     }
     /** @deprecated since v10.0.0 use `createCipheriv()` */
     function createCipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): CipherCCM;
@@ -369,26 +365,21 @@ declare module 'crypto' {
 
     interface PrivateKeyInput {
         key: string | Buffer;
-        format?: KeyFormat;
-        type?: 'pkcs1' | 'pkcs8' | 'sec1';
-        passphrase?: string | Buffer;
+        format?: KeyFormat | undefined;
+        type?: 'pkcs1' | 'pkcs8' | 'sec1' | undefined;
+        passphrase?: string | Buffer | undefined;
     }
 
     interface PublicKeyInput {
         key: string | Buffer;
-        format?: KeyFormat;
-        type?: 'pkcs1' | 'spki';
+        format?: KeyFormat | undefined;
+        type?: 'pkcs1' | 'spki' | undefined;
     }
 
     function generateKey(type: 'hmac' | 'aes', options: {length: number}, callback: (err: Error | null, key: KeyObject) => void): void;
 
-    interface JsonWebKeyInput {
-        key: JsonWebKey;
-        format: 'jwk';
-    }
-
-    function createPrivateKey(key: PrivateKeyInput | string | Buffer | JsonWebKeyInput): KeyObject;
-    function createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject | JsonWebKeyInput): KeyObject;
+    function createPrivateKey(key: PrivateKeyInput | string | Buffer): KeyObject;
+    function createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject): KeyObject;
     function createSecretKey(key: NodeJS.ArrayBufferView): KeyObject;
 
     function createSign(algorithm: string, options?: stream.WritableOptions): Signer;
@@ -399,9 +390,9 @@ declare module 'crypto' {
         /**
          * @See crypto.constants.RSA_PKCS1_PADDING
          */
-        padding?: number;
-        saltLength?: number;
-        dsaEncoding?: DSAEncoding;
+        padding?: number | undefined;
+        saltLength?: number | undefined;
+        dsaEncoding?: DSAEncoding | undefined;
     }
 
     interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions { }
@@ -530,13 +521,13 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
-        cost?: number;
-        blockSize?: number;
-        parallelization?: number;
-        N?: number;
-        r?: number;
-        p?: number;
-        maxmem?: number;
+        cost?: number | undefined;
+        blockSize?: number | undefined;
+        parallelization?: number | undefined;
+        N?: number | undefined;
+        r?: number | undefined;
+        p?: number | undefined;
+        maxmem?: number | undefined;
     }
     function scrypt(
         password: BinaryLike,
@@ -555,17 +546,17 @@ declare module 'crypto' {
 
     interface RsaPublicKey {
         key: KeyLike;
-        padding?: number;
+        padding?: number | undefined;
     }
     interface RsaPrivateKey {
         key: KeyLike;
-        passphrase?: string;
+        passphrase?: string | undefined;
         /**
          * @default 'sha1'
          */
-        oaepHash?: string;
-        oaepLabel?: NodeJS.TypedArray;
-        padding?: number;
+        oaepHash?: string | undefined;
+        oaepLabel?: NodeJS.TypedArray | undefined;
+        padding?: number | undefined;
     }
     function publicEncrypt(key: RsaPublicKey | RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     function publicDecrypt(key: RsaPublicKey | RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
@@ -611,8 +602,8 @@ declare module 'crypto' {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        cipher?: string;
-        passphrase?: string;
+        cipher?: string | undefined;
+        passphrase?: string | undefined;
     }
 
     interface KeyPairKeyObjectResult {
@@ -660,7 +651,7 @@ declare module 'crypto' {
         /**
          * @default 0x10001
          */
-        publicExponent?: number;
+        publicExponent?: number | undefined;
     }
 
     interface DSAKeyPairKeyObjectOptions {
@@ -683,7 +674,7 @@ declare module 'crypto' {
         /**
          * @default 0x10001
          */
-        publicExponent?: number;
+        publicExponent?: number | undefined;
 
         publicKeyEncoding: {
             type: 'pkcs1' | 'spki';
@@ -1270,11 +1261,11 @@ declare module 'crypto' {
         /**
          * A test key length.
          */
-        keyLength?: number;
+        keyLength?: number | undefined;
         /**
          * A test IV length.
          */
-        ivLength?: number;
+        ivLength?: number | undefined;
     }
 
     interface CipherInfo {
@@ -1290,12 +1281,12 @@ declare module 'crypto' {
          * The block size of the cipher in bytes.
          * This property is omitted when mode is 'stream'.
          */
-        blockSize?: number;
+        blockSize?: number | undefined;
         /**
          * The expected or default initialization vector length in bytes.
          * This property is omitted if the cipher does not use an initialization vector.
          */
-        ivLength?: number;
+        ivLength?: number | undefined;
         /**
          * The expected or default key length in bytes.
          */
@@ -1374,7 +1365,7 @@ declare module 'crypto' {
          *
          * @default `false`
          */
-        disableEntropyCache?: boolean;
+        disableEntropyCache?: boolean | undefined;
     }
 
     function randomUUID(options?: RandomUUIDOptions): string;
@@ -1450,7 +1441,7 @@ declare module 'crypto' {
         /**
          * The issuer certificate or `undefined` if the issuer certificate is not available.
          */
-        readonly issuerCertificate?: X509Certificate;
+        readonly issuerCertificate?: X509Certificate | undefined;
 
         /**
          * The public key for this certificate.
@@ -1537,13 +1528,13 @@ declare module 'crypto' {
     type LargeNumberLike = NodeJS.ArrayBufferView | SharedArrayBuffer | ArrayBuffer | bigint;
 
     interface GeneratePrimeOptions {
-        add?: LargeNumberLike;
-        rem?: LargeNumberLike;
+        add?: LargeNumberLike | undefined;
+        rem?: LargeNumberLike | undefined;
         /**
          * @default false
          */
-        safe?: boolean;
-        bigint?: boolean;
+        safe?: boolean | undefined;
+        bigint?: boolean | undefined;
     }
 
     interface GeneratePrimeOptionsBigInt extends GeneratePrimeOptions {
@@ -1551,7 +1542,7 @@ declare module 'crypto' {
     }
 
     interface GeneratePrimeOptionsArrayBuffer extends GeneratePrimeOptions {
-        bigint?: false;
+        bigint?: false | undefined;
     }
 
     function generatePrime(size: number, callback: (err: Error | null, prime: ArrayBuffer) => void): void;
@@ -1573,7 +1564,7 @@ declare module 'crypto' {
          *
          * @default 0
          */
-        checks?: number;
+        checks?: number | undefined;
     }
 
     /**

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -11,24 +11,24 @@ declare module 'dgram' {
     }
 
     interface BindOptions {
-        port?: number;
-        address?: string;
-        exclusive?: boolean;
-        fd?: number;
+        port?: number | undefined;
+        address?: string | undefined;
+        exclusive?: boolean | undefined;
+        fd?: number | undefined;
     }
 
     type SocketType = "udp4" | "udp6";
 
     interface SocketOptions extends Abortable {
         type: SocketType;
-        reuseAddr?: boolean;
+        reuseAddr?: boolean | undefined;
         /**
          * @default false
          */
-        ipv6Only?: boolean;
-        recvBufferSize?: number;
-        sendBufferSize?: number;
-        lookup?: (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
+        ipv6Only?: boolean | undefined;
+        recvBufferSize?: number | undefined;
+        sendBufferSize?: number | undefined;
+        lookup?: ((hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void) | undefined;
     }
 
     function createSocket(type: SocketType, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;

--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -11,14 +11,14 @@ declare module 'dns' {
     export const ALL: number;
 
     export interface LookupOptions {
-        family?: number;
-        hints?: number;
-        all?: boolean;
-        verbatim?: boolean;
+        family?: number | undefined;
+        hints?: number | undefined;
+        all?: boolean | undefined;
+        verbatim?: boolean | undefined;
     }
 
     export interface LookupOneOptions extends LookupOptions {
-        all?: false;
+        all?: false | undefined;
     }
 
     export interface LookupAllOptions extends LookupOptions {
@@ -75,11 +75,11 @@ declare module 'dns' {
 
     export interface CaaRecord {
         critial: number;
-        issue?: string;
-        issuewild?: string;
-        iodef?: string;
-        contactemail?: string;
-        contactphone?: string;
+        issue?: string | undefined;
+        issuewild?: string | undefined;
+        iodef?: string | undefined;
+        contactemail?: string | undefined;
+        contactphone?: string | undefined;
     }
 
     export interface MxRecord {
@@ -293,7 +293,7 @@ declare module 'dns' {
     export const CANCELLED: string;
 
     export interface ResolverOptions {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     export class Resolver {

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -3,7 +3,7 @@ declare module 'events' {
         /**
          * Enables automatic capturing of promise rejection.
          */
-        captureRejections?: boolean;
+        captureRejections?: boolean | undefined;
     }
 
     interface NodeEventTarget {
@@ -15,7 +15,7 @@ declare module 'events' {
     }
 
     interface StaticEventEmitterOptions {
-        signal?: AbortSignal;
+        signal?: AbortSignal | undefined;
     }
 
     interface EventEmitter extends NodeJS.EventEmitter {}
@@ -62,7 +62,7 @@ declare module 'events' {
             /**
              * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
              */
-            signal?: AbortSignal;
+            signal?: AbortSignal | undefined;
         }
     }
 

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -15,7 +15,7 @@ declare module 'fs' {
     export type BufferEncodingOption = 'buffer' | { encoding: 'buffer' };
 
     export interface BaseEncodingOptions {
-        encoding?: BufferEncoding | null;
+        encoding?: BufferEncoding | null | undefined;
     }
 
     export type OpenMode = number | string;
@@ -532,7 +532,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function stat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function stat(path: PathLike, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     export function stat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -542,18 +542,18 @@ declare module 'fs' {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     export interface StatSyncFn<TDescriptor = PathLike> extends Function {
         (path: TDescriptor, options?: undefined): Stats;
-        (path: TDescriptor, options?: StatOptions & { bigint?: false; throwIfNoEntry: false }): Stats | undefined;
+        (path: TDescriptor, options?: StatOptions & { bigint?: false | undefined; throwIfNoEntry: false }): Stats | undefined;
         (path: TDescriptor, options: StatOptions & { bigint: true; throwIfNoEntry: false }): BigIntStats | undefined;
-        (path: TDescriptor, options?: StatOptions & { bigint?: false }): Stats;
+        (path: TDescriptor, options?: StatOptions & { bigint?: false | undefined }): Stats;
         (path: TDescriptor, options: StatOptions & { bigint: true }): BigIntStats;
-        (path: TDescriptor, options: StatOptions & { bigint: boolean; throwIfNoEntry?: false }): Stats | BigIntStats;
+        (path: TDescriptor, options: StatOptions & { bigint: boolean; throwIfNoEntry?: false | undefined }): Stats | BigIntStats;
         (path: TDescriptor, options?: StatOptions): Stats | BigIntStats | undefined;
     }
 
@@ -568,7 +568,7 @@ declare module 'fs' {
      * @param fd A file descriptor.
      */
     export function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function fstat(fd: number, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function fstat(fd: number, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     export function fstat(fd: number, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -578,7 +578,7 @@ declare module 'fs' {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(fd: number, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(fd: number, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -594,7 +594,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function lstat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     export function lstat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -604,7 +604,7 @@ declare module 'fs' {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -874,13 +874,24 @@ declare module 'fs' {
          * `true`.
          * @default 0
          */
-        maxRetries?: number;
+        maxRetries?: number | undefined;
+        /**
+         * @deprecated since v14.14.0 In future versions of Node.js,
+         * `fs.rmdir(path, { recursive: true })` will throw if `path` does not exist or is a file.
+         * Use `fs.rm(path, { recursive: true, force: true })` instead.
+         *
+         * If `true`, perform a recursive directory removal. In
+         * recursive mode, errors are not reported if `path` does not exist, and
+         * operations are retried on failure.
+         * @default false
+         */
+        recursive?: boolean | undefined;
         /**
          * The amount of time in milliseconds to wait between retries.
          * This option is ignored if the `recursive` option is not `true`.
          * @default 100
          */
-        retryDelay?: number;
+        retryDelay?: number | undefined;
     }
 
     /**
@@ -910,7 +921,7 @@ declare module 'fs' {
          * When `true`, exceptions will be ignored if `path` does not exist.
          * @default false
          */
-        force?: boolean;
+        force?: boolean | undefined;
         /**
          * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
          * `EPERM` error is encountered, Node.js will retry the operation with a linear
@@ -919,19 +930,20 @@ declare module 'fs' {
          * `true`.
          * @default 0
          */
-        maxRetries?: number;
+        maxRetries?: number | undefined;
         /**
          * If `true`, perform a recursive directory removal. In
-         * recursive mode, operations are retried on failure.
+         * recursive mode, errors are not reported if `path` does not exist, and
+         * operations are retried on failure.
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * The amount of time in milliseconds to wait between retries.
          * This option is ignored if the `recursive` option is not `true`.
          * @default 100
          */
-        retryDelay?: number;
+        retryDelay?: number | undefined;
     }
 
     /**
@@ -959,12 +971,12 @@ declare module 'fs' {
          * If a folder was created, the path to the first created folder will be returned.
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * A file mode. If a string is passed, it is parsed as an octal integer. If not specified
          * @default 0o777
          */
-        mode?: Mode;
+        mode?: Mode | undefined;
     }
 
     /**
@@ -981,7 +993,7 @@ declare module 'fs' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdir(path: PathLike, options: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null | undefined, callback: NoParamCallback): void;
+    export function mkdir(path: PathLike, options: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null | undefined, callback: NoParamCallback): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -1013,7 +1025,7 @@ declare module 'fs' {
          * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
          * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
          */
-        function __promisify__(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null): Promise<void>;
+        function __promisify__(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null): Promise<void>;
 
         /**
          * Asynchronous mkdir(2) - create a directory.
@@ -1038,7 +1050,7 @@ declare module 'fs' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdirSync(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null): void;
+    export function mkdirSync(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null): void;
 
     /**
      * Synchronous mkdir(2) - create a directory.
@@ -1127,7 +1139,7 @@ declare module 'fs' {
      */
     export function readdir(
         path: PathLike,
-        options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | undefined | null,
+        options: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, files: string[]) => void,
     ): void;
 
@@ -1136,7 +1148,11 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer", callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void): void;
+    export function readdir(
+        path: PathLike,
+        options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer",
+        callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void
+    ): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -1145,7 +1161,7 @@ declare module 'fs' {
      */
     export function readdir(
         path: PathLike,
-        options: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | undefined | null,
+        options: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, files: string[] | Buffer[]) => void,
     ): void;
 
@@ -1169,21 +1185,21 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false }): Promise<Buffer[]>;
+        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false | undefined }): Promise<Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): Promise<string[] | Buffer[]>;
+        function __promisify__(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[] | Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
@@ -1198,21 +1214,21 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): string[];
+    export function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): string[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Buffer[];
+    export function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer"): Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): string[] | Buffer[];
+    export function readdirSync(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): string[] | Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
@@ -1511,15 +1527,15 @@ declare module 'fs' {
         /**
          * @default 0
          */
-        offset?: number;
+        offset?: number | undefined;
         /**
          * @default `length of buffer`
          */
-        length?: number;
+        length?: number | undefined;
         /**
          * @default null
          */
-        position?: ReadPosition | null;
+        position?: ReadPosition | null | undefined;
     }
 
     /**
@@ -1547,7 +1563,7 @@ declare module 'fs' {
      */
     export function readFile(
         path: PathLike | number,
-        options: { encoding?: null; flag?: string; } & Abortable | undefined | null,
+        options: { encoding?: null | undefined; flag?: string | undefined; } & Abortable | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
     ): void;
 
@@ -1560,7 +1576,7 @@ declare module 'fs' {
      */
     export function readFile(
         path: PathLike | number,
-        options: { encoding: BufferEncoding; flag?: string; } & Abortable | string,
+        options: { encoding: BufferEncoding; flag?: string | undefined; } & Abortable | string,
         callback: (err: NodeJS.ErrnoException | null, data: string) => void,
     ): void;
 
@@ -1574,7 +1590,7 @@ declare module 'fs' {
     export function readFile(
         path: PathLike | number,
         // TODO: unify the options across all readfile functions
-        options: BaseEncodingOptions & { flag?: string; } & Abortable | string | undefined | null,
+        options: BaseEncodingOptions & { flag?: string | undefined; } & Abortable | string | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
     ): void;
 
@@ -1594,7 +1610,7 @@ declare module 'fs' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Promise<Buffer>;
+        function __promisify__(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined; } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1604,7 +1620,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | string): Promise<string>;
+        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string | undefined; } | string): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1614,7 +1630,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -1623,7 +1639,7 @@ declare module 'fs' {
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      * @param options An object that may contain an optional flag. If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Buffer;
+    export function readFileSync(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined; } | null): Buffer;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -1632,7 +1648,7 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | BufferEncoding): string;
+    export function readFileSync(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string | undefined; } | BufferEncoding): string;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -1641,9 +1657,9 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | BufferEncoding | null): string | Buffer;
+    export function readFileSync(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | BufferEncoding | null): string | Buffer;
 
-    export type WriteFileOptions = (BaseEncodingOptions & Abortable & { mode?: Mode; flag?: string; }) | string | null;
+    export type WriteFileOptions = (BaseEncodingOptions & Abortable & { mode?: Mode | undefined; flag?: string | undefined; }) | string | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -1750,7 +1766,7 @@ declare module 'fs' {
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      */
-    export function watchFile(filename: PathLike, options: { persistent?: boolean; interval?: number; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
+    export function watchFile(filename: PathLike, options: { persistent?: boolean | undefined; interval?: number | undefined; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
 
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
@@ -1765,9 +1781,9 @@ declare module 'fs' {
     export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
 
     export interface WatchOptions extends Abortable {
-        encoding?: BufferEncoding | "buffer";
-        persistent?: boolean;
-        recursive?: boolean;
+        encoding?: BufferEncoding | "buffer" | undefined;
+        persistent?: boolean | undefined;
+        recursive?: boolean | undefined;
     }
 
     export type WatchListener<T> = (event: "rename" | "change", filename: T) => void;
@@ -2026,21 +2042,21 @@ declare module 'fs' {
     export function accessSync(path: PathLike, mode?: number): void;
 
     interface StreamOptions {
-        flags?: string;
-        encoding?: BufferEncoding;
-        fd?: number | promises.FileHandle;
-        mode?: number;
-        autoClose?: boolean;
+        flags?: string | undefined;
+        encoding?: BufferEncoding | undefined;
+        fd?: number | promises.FileHandle | undefined;
+        mode?: number | undefined;
+        autoClose?: boolean | undefined;
         /**
          * @default false
          */
-        emitClose?: boolean;
-        start?: number;
-        highWaterMark?: number;
+        emitClose?: boolean | undefined;
+        start?: number | undefined;
+        highWaterMark?: number | undefined;
     }
 
     interface ReadStreamOptions extends StreamOptions {
-        end?: number;
+        end?: number | undefined;
     }
 
     /**
@@ -2187,14 +2203,14 @@ declare module 'fs' {
     export function readvSync(fd: number, buffers: ReadonlyArray<NodeJS.ArrayBufferView>, position?: number): number;
 
     export interface OpenDirOptions {
-        encoding?: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
         /**
          * Number of directory entries that are buffered
          * internally when reading from the directory. Higher values lead to better
          * performance but higher memory usage.
          * @default 32
          */
-        bufferSize?: number;
+        bufferSize?: number | undefined;
     }
 
     export function opendirSync(path: string, options?: OpenDirOptions): Dir;
@@ -2221,11 +2237,7 @@ declare module 'fs' {
     }
 
     export interface StatOptions {
-        bigint?: boolean;
-        throwIfNoEntry?: boolean;
+        bigint?: boolean | undefined;
+        throwIfNoEntry?: boolean | undefined;
     }
-}
-
-declare module 'node:fs' {
-    export * from 'fs';
 }

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -1,6 +1,5 @@
 declare module 'fs/promises' {
     import { Abortable } from 'events';
-    import { Stream } from 'stream';
     import {
         Stats,
         BigIntStats,
@@ -37,7 +36,7 @@ declare module 'fs/promises' {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'a'` is used.
          */
-        appendFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } | BufferEncoding | null): Promise<void>;
+        appendFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } | BufferEncoding | null): Promise<void>;
 
         /**
          * Asynchronous fchown(2) - Change ownership of a file.
@@ -76,7 +75,7 @@ declare module 'fs/promises' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        readFile(options?: { encoding?: null, flag?: OpenMode } | null): Promise<Buffer>;
+        readFile(options?: { encoding?: null | undefined, flag?: OpenMode | undefined } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
@@ -84,7 +83,7 @@ declare module 'fs/promises' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        readFile(options: { encoding: BufferEncoding, flag?: OpenMode } | BufferEncoding): Promise<string>;
+        readFile(options: { encoding: BufferEncoding, flag?: OpenMode | undefined } | BufferEncoding): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
@@ -92,12 +91,12 @@ declare module 'fs/promises' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        readFile(options?: BaseEncodingOptions & { flag?: OpenMode } | BufferEncoding | null): Promise<string | Buffer>;
+        readFile(options?: BaseEncodingOptions & { flag?: OpenMode | undefined } | BufferEncoding | null): Promise<string | Buffer>;
 
         /**
          * Asynchronous fstat(2) - Get file status.
          */
-        stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        stat(opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
         stat(opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -146,7 +145,7 @@ declare module 'fs/promises' {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'w'` is used.
          */
-        writeFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } & Abortable | BufferEncoding | null): Promise<void>;
+        writeFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } & Abortable | BufferEncoding | null): Promise<void>;
 
         /**
          * See `fs.writev` promisified version.
@@ -296,7 +295,7 @@ declare module 'fs/promises' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    function mkdir(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null): Promise<void>;
+    function mkdir(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null): Promise<void>;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -311,21 +310,21 @@ declare module 'fs/promises' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Promise<Buffer[]>;
+    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer"): Promise<Buffer[]>;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): Promise<string[] | Buffer[]>;
+    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[] | Buffer[]>;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -368,7 +367,7 @@ declare module 'fs/promises' {
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    function lstat(path: PathLike, opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
     function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
     function lstat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -376,7 +375,7 @@ declare module 'fs/promises' {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    function stat(path: PathLike, opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
     function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
     function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -515,9 +514,9 @@ declare module 'fs/promises' {
      */
     function writeFile(
         path: PathLike | FileHandle,
-        data: string | NodeJS.ArrayBufferView | Iterable<string | NodeJS.ArrayBufferView> | AsyncIterable<string | NodeJS.ArrayBufferView> | Stream,
-        options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } & Abortable | BufferEncoding | null
-        ): Promise<void>;
+        data: string | Uint8Array,
+        options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } & Abortable | BufferEncoding | null
+    ): Promise<void>;
 
     /**
      * Asynchronously append data to a file, creating the file if it does not exist.
@@ -531,7 +530,11 @@ declare module 'fs/promises' {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'a'` is used.
      */
-    function appendFile(path: PathLike | FileHandle, data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } | BufferEncoding | null): Promise<void>;
+    function appendFile(
+        path: PathLike | FileHandle,
+        data: string | Uint8Array,
+        options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } | BufferEncoding | null
+    ): Promise<void>;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -540,7 +543,7 @@ declare module 'fs/promises' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | FileHandle, options?: { encoding?: null, flag?: OpenMode } & Abortable | null): Promise<Buffer>;
+    function readFile(path: PathLike | FileHandle, options?: { encoding?: null | undefined, flag?: OpenMode | undefined } & Abortable | null): Promise<Buffer>;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -549,7 +552,7 @@ declare module 'fs/promises' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: OpenMode } & Abortable | BufferEncoding): Promise<string>;
+    function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: OpenMode | undefined } & Abortable | BufferEncoding): Promise<string>;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -558,7 +561,7 @@ declare module 'fs/promises' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | FileHandle, options?: BaseEncodingOptions & Abortable & { flag?: OpenMode } | BufferEncoding | null): Promise<string | Buffer>;
+    function readFile(path: PathLike | FileHandle, options?: BaseEncodingOptions & Abortable & { flag?: OpenMode | undefined } | BufferEncoding | null): Promise<string | Buffer>;
 
     function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
 

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -8,7 +8,7 @@ interface ErrorConstructor {
      *
      * @see https://v8.dev/docs/stack-trace-api#customizing-stack-traces
      */
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
+    prepareStackTrace?: ((err: Error, stackTraces: NodeJS.CallSite[]) => any) | undefined;
 
     stackTraceLimit: number;
 }
@@ -24,6 +24,10 @@ interface String {
     trimStart(): string;
     /** Returns a copy with trailing whitespace removed. */
     trimEnd(): string;
+}
+
+interface ImportMeta {
+    url: string;
 }
 
 /*-----------------------------------------------*
@@ -43,16 +47,269 @@ declare var console: Console;
 declare var __filename: string;
 declare var __dirname: string;
 
+declare function setTimeout(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
+declare namespace setTimeout {
+    function __promisify__(ms: number): Promise<void>;
+    function __promisify__<T>(ms: number, value: T): Promise<T>;
+}
+declare function clearTimeout(timeoutId: NodeJS.Timeout): void;
+declare function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
+declare function clearInterval(intervalId: NodeJS.Timeout): void;
+declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
+declare namespace setImmediate {
+    function __promisify__(): Promise<void>;
+    function __promisify__<T>(value: T): Promise<T>;
+}
+declare function clearImmediate(immediateId: NodeJS.Immediate): void;
+
+declare function queueMicrotask(callback: () => void): void;
+
 declare var require: NodeRequire;
 declare var module: NodeModule;
 
 // Same as module.exports
 declare var exports: any;
 
+// Buffer class
+type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex";
+
+type WithImplicitCoercion<T> = T | { valueOf(): T };
+
 /**
- * Only available if `--expose-gc` is passed to the process.
+ * Raw data is stored in instances of the Buffer class.
+ * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
+ * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
  */
-declare var gc: undefined | (() => void);
+declare class Buffer extends Uint8Array {
+    /**
+     * Allocates a new buffer containing the given {str}.
+     *
+     * @param str String to store in buffer.
+     * @param encoding encoding to use, optional.  Default is 'utf8'
+     * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
+     */
+    constructor(str: string, encoding?: BufferEncoding);
+    /**
+     * Allocates a new buffer of {size} octets.
+     *
+     * @param size count of octets to allocate.
+     * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
+     */
+    constructor(size: number);
+    /**
+     * Allocates a new buffer containing the given {array} of octets.
+     *
+     * @param array The octets to store.
+     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+     */
+    constructor(array: Uint8Array);
+    /**
+     * Produces a Buffer backed by the same allocated memory as
+     * the given {ArrayBuffer}/{SharedArrayBuffer}.
+     *
+     *
+     * @param arrayBuffer The ArrayBuffer with which to share memory.
+     * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
+     */
+    constructor(arrayBuffer: ArrayBuffer | SharedArrayBuffer);
+    /**
+     * Allocates a new buffer containing the given {array} of octets.
+     *
+     * @param array The octets to store.
+     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+     */
+    constructor(array: ReadonlyArray<any>);
+    /**
+     * Copies the passed {buffer} data onto a new {Buffer} instance.
+     *
+     * @param buffer The buffer to copy.
+     * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
+     */
+    constructor(buffer: Buffer);
+    /**
+     * When passed a reference to the .buffer property of a TypedArray instance,
+     * the newly created Buffer will share the same allocated memory as the TypedArray.
+     * The optional {byteOffset} and {length} arguments specify a memory range
+     * within the {arrayBuffer} that will be shared by the Buffer.
+     *
+     * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
+     */
+    static from(arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>, byteOffset?: number, length?: number): Buffer;
+    /**
+     * Creates a new Buffer using the passed {data}
+     * @param data data to create a new Buffer
+     */
+    static from(data: Uint8Array | ReadonlyArray<number>): Buffer;
+    static from(data: WithImplicitCoercion<Uint8Array | ReadonlyArray<number> | string>): Buffer;
+    /**
+     * Creates a new Buffer containing the given JavaScript string {str}.
+     * If provided, the {encoding} parameter identifies the character encoding.
+     * If not provided, {encoding} defaults to 'utf8'.
+     */
+    static from(str: WithImplicitCoercion<string> | { [Symbol.toPrimitive](hint: 'string'): string }, encoding?: BufferEncoding): Buffer;
+    /**
+     * Creates a new Buffer using the passed {data}
+     * @param values to create a new Buffer
+     */
+    static of(...items: number[]): Buffer;
+    /**
+     * Returns true if {obj} is a Buffer
+     *
+     * @param obj object to test.
+     */
+    static isBuffer(obj: any): obj is Buffer;
+    /**
+     * Returns true if {encoding} is a valid encoding argument.
+     * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+     *
+     * @param encoding string to test.
+     */
+    static isEncoding(encoding: string): encoding is BufferEncoding;
+    /**
+     * Gives the actual byte length of a string. encoding defaults to 'utf8'.
+     * This is not the same as String.prototype.length since that returns the number of characters in a string.
+     *
+     * @param string string to test.
+     * @param encoding encoding used to evaluate (defaults to 'utf8')
+     */
+    static byteLength(
+        string: string | NodeJS.ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+        encoding?: BufferEncoding
+    ): number;
+    /**
+     * Returns a buffer which is the result of concatenating all the buffers in the list together.
+     *
+     * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
+     * If the list has exactly one item, then the first item of the list is returned.
+     * If the list has more than one item, then a new Buffer is created.
+     *
+     * @param list An array of Buffer objects to concatenate
+     * @param totalLength Total length of the buffers when concatenated.
+     *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
+     */
+    static concat(list: ReadonlyArray<Uint8Array>, totalLength?: number): Buffer;
+    /**
+     * The same as buf1.compare(buf2).
+     */
+    static compare(buf1: Uint8Array, buf2: Uint8Array): number;
+    /**
+     * Allocates a new buffer of {size} octets.
+     *
+     * @param size count of octets to allocate.
+     * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
+     *    If parameter is omitted, buffer will be filled with zeros.
+     * @param encoding encoding used for call to buf.fill while initalizing
+     */
+    static alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
+    /**
+     * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
+     * of the newly created Buffer are unknown and may contain sensitive data.
+     *
+     * @param size count of octets to allocate
+     */
+    static allocUnsafe(size: number): Buffer;
+    /**
+     * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
+     * of the newly created Buffer are unknown and may contain sensitive data.
+     *
+     * @param size count of octets to allocate
+     */
+    static allocUnsafeSlow(size: number): Buffer;
+    /**
+     * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
+     */
+    static poolSize: number;
+
+    write(string: string, encoding?: BufferEncoding): number;
+    write(string: string, offset: number, encoding?: BufferEncoding): number;
+    write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
+    toString(encoding?: BufferEncoding, start?: number, end?: number): string;
+    toJSON(): { type: 'Buffer'; data: number[] };
+    equals(otherBuffer: Uint8Array): boolean;
+    compare(
+        otherBuffer: Uint8Array,
+        targetStart?: number,
+        targetEnd?: number,
+        sourceStart?: number,
+        sourceEnd?: number
+    ): number;
+    copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+    /**
+     * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
+     *
+     * This method is incompatible with `Uint8Array#slice()`, which returns a copy of the original memory.
+     *
+     * @param begin Where the new `Buffer` will start. Default: `0`.
+     * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
+     */
+    slice(begin?: number, end?: number): Buffer;
+    /**
+     * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
+     *
+     * This method is compatible with `Uint8Array#subarray()`.
+     *
+     * @param begin Where the new `Buffer` will start. Default: `0`.
+     * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
+     */
+    subarray(begin?: number, end?: number): Buffer;
+    writeBigInt64BE(value: bigint, offset?: number): number;
+    writeBigInt64LE(value: bigint, offset?: number): number;
+    writeBigUInt64BE(value: bigint, offset?: number): number;
+    writeBigUInt64LE(value: bigint, offset?: number): number;
+    writeUIntLE(value: number, offset: number, byteLength: number): number;
+    writeUIntBE(value: number, offset: number, byteLength: number): number;
+    writeIntLE(value: number, offset: number, byteLength: number): number;
+    writeIntBE(value: number, offset: number, byteLength: number): number;
+    readBigUInt64BE(offset?: number): bigint;
+    readBigUInt64LE(offset?: number): bigint;
+    readBigInt64BE(offset?: number): bigint;
+    readBigInt64LE(offset?: number): bigint;
+    readUIntLE(offset: number, byteLength: number): number;
+    readUIntBE(offset: number, byteLength: number): number;
+    readIntLE(offset: number, byteLength: number): number;
+    readIntBE(offset: number, byteLength: number): number;
+    readUInt8(offset?: number): number;
+    readUInt16LE(offset?: number): number;
+    readUInt16BE(offset?: number): number;
+    readUInt32LE(offset?: number): number;
+    readUInt32BE(offset?: number): number;
+    readInt8(offset?: number): number;
+    readInt16LE(offset?: number): number;
+    readInt16BE(offset?: number): number;
+    readInt32LE(offset?: number): number;
+    readInt32BE(offset?: number): number;
+    readFloatLE(offset?: number): number;
+    readFloatBE(offset?: number): number;
+    readDoubleLE(offset?: number): number;
+    readDoubleBE(offset?: number): number;
+    reverse(): this;
+    swap16(): Buffer;
+    swap32(): Buffer;
+    swap64(): Buffer;
+    writeUInt8(value: number, offset?: number): number;
+    writeUInt16LE(value: number, offset?: number): number;
+    writeUInt16BE(value: number, offset?: number): number;
+    writeUInt32LE(value: number, offset?: number): number;
+    writeUInt32BE(value: number, offset?: number): number;
+    writeInt8(value: number, offset?: number): number;
+    writeInt16LE(value: number, offset?: number): number;
+    writeInt16BE(value: number, offset?: number): number;
+    writeInt32LE(value: number, offset?: number): number;
+    writeInt32BE(value: number, offset?: number): number;
+    writeFloatLE(value: number, offset?: number): number;
+    writeFloatBE(value: number, offset?: number): number;
+    writeDoubleLE(value: number, offset?: number): number;
+    writeDoubleBE(value: number, offset?: number): number;
+
+    fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+
+    indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: BufferEncoding): number;
+    lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: BufferEncoding): number;
+    entries(): IterableIterator<[number, number]>;
+    includes(value: string | number | Buffer, byteOffset?: number, encoding?: BufferEncoding): boolean;
+    keys(): IterableIterator<number>;
+    values(): IterableIterator<number>;
+}
 
 //#region borrowed
 // from https://github.com/microsoft/TypeScript/blob/38da7c600c83e7b31193a62495239a0fe478cb67/lib/lib.webworker.d.ts#L633 until moved to separate lib
@@ -95,11 +352,52 @@ declare var AbortSignal: {
 *                                               *
 *-----------------------------------------------*/
 declare namespace NodeJS {
+    interface InspectOptions {
+        /**
+         * If set to `true`, getters are going to be
+         * inspected as well. If set to `'get'` only getters without setter are going
+         * to be inspected. If set to `'set'` only getters having a corresponding
+         * setter are going to be inspected. This might cause side effects depending on
+         * the getter function.
+         * @default `false`
+         */
+        getters?: 'get' | 'set' | boolean | undefined;
+        showHidden?: boolean | undefined;
+        /**
+         * @default 2
+         */
+        depth?: number | null | undefined;
+        colors?: boolean | undefined;
+        customInspect?: boolean | undefined;
+        showProxy?: boolean | undefined;
+        maxArrayLength?: number | null | undefined;
+        /**
+         * Specifies the maximum number of characters to
+         * include when formatting. Set to `null` or `Infinity` to show all elements.
+         * Set to `0` or negative to show no characters.
+         * @default 10000
+         */
+        maxStringLength?: number | null | undefined;
+        breakLength?: number | undefined;
+        /**
+         * Setting this to `false` causes each object key
+         * to be displayed on a new line. It will also add new lines to text that is
+         * longer than `breakLength`. If set to a number, the most `n` inner elements
+         * are united on a single line as long as all properties fit into
+         * `breakLength`. Short array elements are also grouped together. Note that no
+         * text will be reduced below 16 characters, no matter the `breakLength` size.
+         * For more information, see the example below.
+         * @default `true`
+         */
+        compact?: boolean | number | undefined;
+        sorted?: boolean | ((a: string, b: string) => number) | undefined;
+    }
+
     interface CallSite {
         /**
          * Value of "this"
          */
-        getThis(): unknown;
+        getThis(): any;
 
         /**
          * Type of "this" as a string.
@@ -170,11 +468,11 @@ declare namespace NodeJS {
     }
 
     interface ErrnoException extends Error {
-        errno?: number;
-        code?: string;
-        path?: string;
-        syscall?: string;
-        stack?: string;
+        errno?: number | undefined;
+        code?: string | undefined;
+        path?: string | undefined;
+        syscall?: string | undefined;
+        stack?: string | undefined;
     }
 
     interface ReadableStream extends EventEmitter {
@@ -184,7 +482,7 @@ declare namespace NodeJS {
         pause(): this;
         resume(): this;
         isPaused(): boolean;
-        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
         unpipe(destination?: WritableStream): this;
         unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
         wrap(oldStream: ReadableStream): this;
@@ -202,9 +500,92 @@ declare namespace NodeJS {
 
     interface ReadWriteStream extends ReadableStream, WritableStream { }
 
+    interface Global {
+        AbortController: typeof AbortController;
+        AbortSignal: typeof AbortSignal;
+        Array: typeof Array;
+        ArrayBuffer: typeof ArrayBuffer;
+        Boolean: typeof Boolean;
+        Buffer: typeof Buffer;
+        DataView: typeof DataView;
+        Date: typeof Date;
+        Error: typeof Error;
+        EvalError: typeof EvalError;
+        Float32Array: typeof Float32Array;
+        Float64Array: typeof Float64Array;
+        Function: typeof Function;
+        Infinity: typeof Infinity;
+        Int16Array: typeof Int16Array;
+        Int32Array: typeof Int32Array;
+        Int8Array: typeof Int8Array;
+        Intl: typeof Intl;
+        JSON: typeof JSON;
+        Map: MapConstructor;
+        Math: typeof Math;
+        NaN: typeof NaN;
+        Number: typeof Number;
+        Object: typeof Object;
+        Promise: typeof Promise;
+        RangeError: typeof RangeError;
+        ReferenceError: typeof ReferenceError;
+        RegExp: typeof RegExp;
+        Set: SetConstructor;
+        String: typeof String;
+        Symbol: Function;
+        SyntaxError: typeof SyntaxError;
+        TypeError: typeof TypeError;
+        URIError: typeof URIError;
+        Uint16Array: typeof Uint16Array;
+        Uint32Array: typeof Uint32Array;
+        Uint8Array: typeof Uint8Array;
+        Uint8ClampedArray: typeof Uint8ClampedArray;
+        WeakMap: WeakMapConstructor;
+        WeakSet: WeakSetConstructor;
+        clearImmediate: (immediateId: Immediate) => void;
+        clearInterval: (intervalId: Timeout) => void;
+        clearTimeout: (timeoutId: Timeout) => void;
+        decodeURI: typeof decodeURI;
+        decodeURIComponent: typeof decodeURIComponent;
+        encodeURI: typeof encodeURI;
+        encodeURIComponent: typeof encodeURIComponent;
+        escape: (str: string) => string;
+        eval: typeof eval;
+        global: Global;
+        isFinite: typeof isFinite;
+        isNaN: typeof isNaN;
+        parseFloat: typeof parseFloat;
+        parseInt: typeof parseInt;
+        setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => Immediate;
+        setInterval: (callback: (...args: any[]) => void, ms?: number, ...args: any[]) => Timeout;
+        setTimeout: (callback: (...args: any[]) => void, ms?: number, ...args: any[]) => Timeout;
+        queueMicrotask: typeof queueMicrotask;
+        undefined: typeof undefined;
+        unescape: (str: string) => string;
+        gc: () => void;
+        v8debug?: any;
+    }
+
     interface RefCounted {
         ref(): this;
         unref(): this;
+    }
+
+    // compatibility with older typings
+    interface Timer extends RefCounted {
+        hasRef(): boolean;
+        refresh(): this;
+        [Symbol.toPrimitive](): number;
+    }
+
+    interface Immediate extends RefCounted {
+        hasRef(): boolean;
+        _onImmediate: Function; // to distinguish it from the Timeout class
+    }
+
+    interface Timeout extends Timer {
+        hasRef(): boolean;
+        refresh(): this;
+        [Symbol.toPrimitive](): number;
     }
 
     type TypedArray =
@@ -233,7 +614,7 @@ declare namespace NodeJS {
     }
 
     interface RequireResolve {
-        (id: string, options?: { paths?: string[]; }): string;
+        (id: string, options?: { paths?: string[] | undefined; }): string;
         paths(request: string): string[] | null;
     }
 

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -5,69 +5,69 @@ declare module 'http' {
 
     // incoming headers will never contain number
     interface IncomingHttpHeaders extends NodeJS.Dict<string | string[]> {
-        'accept'?: string;
-        'accept-language'?: string;
-        'accept-patch'?: string;
-        'accept-ranges'?: string;
-        'access-control-allow-credentials'?: string;
-        'access-control-allow-headers'?: string;
-        'access-control-allow-methods'?: string;
-        'access-control-allow-origin'?: string;
-        'access-control-expose-headers'?: string;
-        'access-control-max-age'?: string;
-        'access-control-request-headers'?: string;
-        'access-control-request-method'?: string;
-        'age'?: string;
-        'allow'?: string;
-        'alt-svc'?: string;
-        'authorization'?: string;
-        'cache-control'?: string;
-        'connection'?: string;
-        'content-disposition'?: string;
-        'content-encoding'?: string;
-        'content-language'?: string;
-        'content-length'?: string;
-        'content-location'?: string;
-        'content-range'?: string;
-        'content-type'?: string;
-        'cookie'?: string;
-        'date'?: string;
-        'etag'?: string;
-        'expect'?: string;
-        'expires'?: string;
-        'forwarded'?: string;
-        'from'?: string;
-        'host'?: string;
-        'if-match'?: string;
-        'if-modified-since'?: string;
-        'if-none-match'?: string;
-        'if-unmodified-since'?: string;
-        'last-modified'?: string;
-        'location'?: string;
-        'origin'?: string;
-        'pragma'?: string;
-        'proxy-authenticate'?: string;
-        'proxy-authorization'?: string;
-        'public-key-pins'?: string;
-        'range'?: string;
-        'referer'?: string;
-        'retry-after'?: string;
-        'sec-websocket-accept'?: string;
-        'sec-websocket-extensions'?: string;
-        'sec-websocket-key'?: string;
-        'sec-websocket-protocol'?: string;
-        'sec-websocket-version'?: string;
-        'set-cookie'?: string[];
-        'strict-transport-security'?: string;
-        'tk'?: string;
-        'trailer'?: string;
-        'transfer-encoding'?: string;
-        'upgrade'?: string;
-        'user-agent'?: string;
-        'vary'?: string;
-        'via'?: string;
-        'warning'?: string;
-        'www-authenticate'?: string;
+        'accept'?: string | undefined;
+        'accept-language'?: string | undefined;
+        'accept-patch'?: string | undefined;
+        'accept-ranges'?: string | undefined;
+        'access-control-allow-credentials'?: string | undefined;
+        'access-control-allow-headers'?: string | undefined;
+        'access-control-allow-methods'?: string | undefined;
+        'access-control-allow-origin'?: string | undefined;
+        'access-control-expose-headers'?: string | undefined;
+        'access-control-max-age'?: string | undefined;
+        'access-control-request-headers'?: string | undefined;
+        'access-control-request-method'?: string | undefined;
+        'age'?: string | undefined;
+        'allow'?: string | undefined;
+        'alt-svc'?: string | undefined;
+        'authorization'?: string | undefined;
+        'cache-control'?: string | undefined;
+        'connection'?: string | undefined;
+        'content-disposition'?: string | undefined;
+        'content-encoding'?: string | undefined;
+        'content-language'?: string | undefined;
+        'content-length'?: string | undefined;
+        'content-location'?: string | undefined;
+        'content-range'?: string | undefined;
+        'content-type'?: string | undefined;
+        'cookie'?: string | undefined;
+        'date'?: string | undefined;
+        'etag'?: string | undefined;
+        'expect'?: string | undefined;
+        'expires'?: string | undefined;
+        'forwarded'?: string | undefined;
+        'from'?: string | undefined;
+        'host'?: string | undefined;
+        'if-match'?: string | undefined;
+        'if-modified-since'?: string | undefined;
+        'if-none-match'?: string | undefined;
+        'if-unmodified-since'?: string | undefined;
+        'last-modified'?: string | undefined;
+        'location'?: string | undefined;
+        'origin'?: string | undefined;
+        'pragma'?: string | undefined;
+        'proxy-authenticate'?: string | undefined;
+        'proxy-authorization'?: string | undefined;
+        'public-key-pins'?: string | undefined;
+        'range'?: string | undefined;
+        'referer'?: string | undefined;
+        'retry-after'?: string | undefined;
+        'sec-websocket-accept'?: string | undefined;
+        'sec-websocket-extensions'?: string | undefined;
+        'sec-websocket-key'?: string | undefined;
+        'sec-websocket-protocol'?: string | undefined;
+        'sec-websocket-version'?: string | undefined;
+        'set-cookie'?: string[] | undefined;
+        'strict-transport-security'?: string | undefined;
+        'tk'?: string | undefined;
+        'trailer'?: string | undefined;
+        'transfer-encoding'?: string | undefined;
+        'upgrade'?: string | undefined;
+        'user-agent'?: string | undefined;
+        'vary'?: string | undefined;
+        'via'?: string | undefined;
+        'warning'?: string | undefined;
+        'www-authenticate'?: string | undefined;
     }
 
     // outgoing headers allows numbers (as they are converted internally to strings)
@@ -77,48 +77,48 @@ declare module 'http' {
     }
 
     interface ClientRequestArgs {
-        abort?: AbortSignal;
-        protocol?: string | null;
-        host?: string | null;
-        hostname?: string | null;
-        family?: number;
-        port?: number | string | null;
-        defaultPort?: number | string;
-        localAddress?: string;
-        socketPath?: string;
+        abort?: AbortSignal | undefined;
+        protocol?: string | null | undefined;
+        host?: string | null | undefined;
+        hostname?: string | null | undefined;
+        family?: number | undefined;
+        port?: number | string | null | undefined;
+        defaultPort?: number | string | undefined;
+        localAddress?: string | undefined;
+        socketPath?: string | undefined;
         /**
          * @default 8192
          */
-        maxHeaderSize?: number;
-        method?: string;
-        path?: string | null;
-        headers?: OutgoingHttpHeaders;
-        auth?: string | null;
-        agent?: Agent | boolean;
-        _defaultAgent?: Agent;
-        timeout?: number;
-        setHost?: boolean;
+        maxHeaderSize?: number | undefined;
+        method?: string | undefined;
+        path?: string | null | undefined;
+        headers?: OutgoingHttpHeaders | undefined;
+        auth?: string | null | undefined;
+        agent?: Agent | boolean | undefined;
+        _defaultAgent?: Agent | undefined;
+        timeout?: number | undefined;
+        setHost?: boolean | undefined;
         // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L278
-        createConnection?: (options: ClientRequestArgs, oncreate: (err: Error, socket: Socket) => void) => Socket;
+        createConnection?: ((options: ClientRequestArgs, oncreate: (err: Error, socket: Socket) => void) => Socket) | undefined;
     }
 
     interface ServerOptions {
-        IncomingMessage?: typeof IncomingMessage;
-        ServerResponse?: typeof ServerResponse;
+        IncomingMessage?: typeof IncomingMessage | undefined;
+        ServerResponse?: typeof ServerResponse | undefined;
         /**
          * Optionally overrides the value of
          * `--max-http-header-size` for requests received by this server, i.e.
          * the maximum length of request headers in bytes.
          * @default 8192
          */
-        maxHeaderSize?: number;
+        maxHeaderSize?: number | undefined;
         /**
          * Use an insecure HTTP parser that accepts invalid HTTP headers when true.
          * Using the insecure parser should be avoided.
          * See --insecure-http-parser for more information.
          * @default false
          */
-        insecureHTTPParser?: boolean;
+        insecureHTTPParser?: boolean | undefined;
     }
 
     type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
@@ -337,19 +337,19 @@ declare module 'http' {
         /**
          * Only valid for request obtained from http.Server.
          */
-        method?: string;
+        method?: string | undefined;
         /**
          * Only valid for request obtained from http.Server.
          */
-        url?: string;
+        url?: string | undefined;
         /**
          * Only valid for response obtained from http.ClientRequest.
          */
-        statusCode?: number;
+        statusCode?: number | undefined;
         /**
          * Only valid for response obtained from http.ClientRequest.
          */
-        statusMessage?: string;
+        statusMessage?: string | undefined;
         destroy(error?: Error): void;
     }
 
@@ -357,33 +357,33 @@ declare module 'http' {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
-        keepAlive?: boolean;
+        keepAlive?: boolean | undefined;
         /**
          * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
          * Only relevant if keepAlive is set to true.
          */
-        keepAliveMsecs?: number;
+        keepAliveMsecs?: number | undefined;
         /**
          * Maximum number of sockets to allow per host. Default for Node 0.10 is 5, default for Node 0.12 is Infinity
          */
-        maxSockets?: number;
+        maxSockets?: number | undefined;
         /**
          * Maximum number of sockets allowed for all hosts in total. Each request will use a new socket until the maximum is reached. Default: Infinity.
          */
-        maxTotalSockets?: number;
+        maxTotalSockets?: number | undefined;
         /**
          * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
          */
-        maxFreeSockets?: number;
+        maxFreeSockets?: number | undefined;
         /**
          * Socket timeout in milliseconds. This will set the timeout after the socket is connected.
          */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * Scheduling strategy to apply when picking the next free socket to use.
          * @default `lifo`
          */
-        scheduling?: 'fifo' | 'lifo';
+        scheduling?: 'fifo' | 'lifo' | undefined;
     }
 
     class Agent {

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -15,37 +15,37 @@ declare module 'http2' {
     export { OutgoingHttpHeaders } from 'http';
 
     export interface IncomingHttpStatusHeader {
-        ":status"?: number;
+        ":status"?: number | undefined;
     }
 
     export interface IncomingHttpHeaders extends Http1IncomingHttpHeaders {
-        ":path"?: string;
-        ":method"?: string;
-        ":authority"?: string;
-        ":scheme"?: string;
+        ":path"?: string | undefined;
+        ":method"?: string | undefined;
+        ":authority"?: string | undefined;
+        ":scheme"?: string | undefined;
     }
 
     // Http2Stream
 
     export interface StreamPriorityOptions {
-        exclusive?: boolean;
-        parent?: number;
-        weight?: number;
-        silent?: boolean;
+        exclusive?: boolean | undefined;
+        parent?: number | undefined;
+        weight?: number | undefined;
+        silent?: boolean | undefined;
     }
 
     export interface StreamState {
-        localWindowSize?: number;
-        state?: number;
-        localClose?: number;
-        remoteClose?: number;
-        sumDependencyWeight?: number;
-        weight?: number;
+        localWindowSize?: number | undefined;
+        state?: number | undefined;
+        localClose?: number | undefined;
+        remoteClose?: number | undefined;
+        sumDependencyWeight?: number | undefined;
+        weight?: number | undefined;
     }
 
     export interface ServerStreamResponseOptions {
-        endStream?: boolean;
-        waitForTrailers?: boolean;
+        endStream?: boolean | undefined;
+        waitForTrailers?: boolean | undefined;
     }
 
     export interface StatOptions {
@@ -55,9 +55,9 @@ declare module 'http2' {
 
     export interface ServerStreamFileResponseOptions {
         statCheck?(stats: fs.Stats, headers: OutgoingHttpHeaders, statOptions: StatOptions): void | boolean;
-        waitForTrailers?: boolean;
-        offset?: number;
-        length?: number;
+        waitForTrailers?: boolean | undefined;
+        offset?: number | undefined;
+        length?: number | undefined;
     }
 
     export interface ServerStreamFileResponseOptionsWithError extends ServerStreamFileResponseOptions {
@@ -74,12 +74,12 @@ declare module 'http2' {
          * indicating that no additional data should be received and the readable side of the Http2Stream will be closed.
          */
         readonly endAfterHeaders: boolean;
-        readonly id?: number;
+        readonly id?: number | undefined;
         readonly pending: boolean;
         readonly rstCode: number;
         readonly sentHeaders: OutgoingHttpHeaders;
-        readonly sentInfoHeaders?: OutgoingHttpHeaders[];
-        readonly sentTrailers?: OutgoingHttpHeaders;
+        readonly sentInfoHeaders?: OutgoingHttpHeaders[] | undefined;
+        readonly sentTrailers?: OutgoingHttpHeaders | undefined;
         readonly session: Http2Session;
         readonly state: StreamState;
 
@@ -237,43 +237,43 @@ declare module 'http2' {
     // Http2Session
 
     export interface Settings {
-        headerTableSize?: number;
-        enablePush?: boolean;
-        initialWindowSize?: number;
-        maxFrameSize?: number;
-        maxConcurrentStreams?: number;
-        maxHeaderListSize?: number;
-        enableConnectProtocol?: boolean;
+        headerTableSize?: number | undefined;
+        enablePush?: boolean | undefined;
+        initialWindowSize?: number | undefined;
+        maxFrameSize?: number | undefined;
+        maxConcurrentStreams?: number | undefined;
+        maxHeaderListSize?: number | undefined;
+        enableConnectProtocol?: boolean | undefined;
     }
 
     export interface ClientSessionRequestOptions {
-        endStream?: boolean;
-        exclusive?: boolean;
-        parent?: number;
-        weight?: number;
-        waitForTrailers?: boolean;
+        endStream?: boolean | undefined;
+        exclusive?: boolean | undefined;
+        parent?: number | undefined;
+        weight?: number | undefined;
+        waitForTrailers?: boolean | undefined;
     }
 
     export interface SessionState {
-        effectiveLocalWindowSize?: number;
-        effectiveRecvDataLength?: number;
-        nextStreamID?: number;
-        localWindowSize?: number;
-        lastProcStreamID?: number;
-        remoteWindowSize?: number;
-        outboundQueueSize?: number;
-        deflateDynamicTableSize?: number;
-        inflateDynamicTableSize?: number;
+        effectiveLocalWindowSize?: number | undefined;
+        effectiveRecvDataLength?: number | undefined;
+        nextStreamID?: number | undefined;
+        localWindowSize?: number | undefined;
+        lastProcStreamID?: number | undefined;
+        remoteWindowSize?: number | undefined;
+        outboundQueueSize?: number | undefined;
+        deflateDynamicTableSize?: number | undefined;
+        inflateDynamicTableSize?: number | undefined;
     }
 
     export interface Http2Session extends EventEmitter {
-        readonly alpnProtocol?: string;
+        readonly alpnProtocol?: string | undefined;
         readonly closed: boolean;
         readonly connecting: boolean;
         readonly destroyed: boolean;
-        readonly encrypted?: boolean;
+        readonly encrypted?: boolean | undefined;
         readonly localSettings: Settings;
-        readonly originSet?: string[];
+        readonly originSet?: string[] | undefined;
         readonly pendingSettingsAck: boolean;
         readonly remoteSettings: Settings;
         readonly socket: net.Socket | tls.TLSSocket;
@@ -430,37 +430,37 @@ declare module 'http2' {
     // Http2Server
 
     export interface SessionOptions {
-        maxDeflateDynamicTableSize?: number;
-        maxSessionMemory?: number;
-        maxHeaderListPairs?: number;
-        maxOutstandingPings?: number;
-        maxSendHeaderBlockLength?: number;
-        paddingStrategy?: number;
-        peerMaxConcurrentStreams?: number;
-        settings?: Settings;
+        maxDeflateDynamicTableSize?: number | undefined;
+        maxSessionMemory?: number | undefined;
+        maxHeaderListPairs?: number | undefined;
+        maxOutstandingPings?: number | undefined;
+        maxSendHeaderBlockLength?: number | undefined;
+        paddingStrategy?: number | undefined;
+        peerMaxConcurrentStreams?: number | undefined;
+        settings?: Settings | undefined;
         /**
          * Specifies a timeout in milliseconds that
          * a server should wait when an [`'unknownProtocol'`][] is emitted. If the
          * socket has not been destroyed by that time the server will destroy it.
          * @default 100000
          */
-        unknownProtocolTimeout?: number;
+        unknownProtocolTimeout?: number | undefined;
 
         selectPadding?(frameLen: number, maxFrameLen: number): number;
         createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
 
     export interface ClientSessionOptions extends SessionOptions {
-        maxReservedRemoteStreams?: number;
-        createConnection?: (authority: url.URL, option: SessionOptions) => stream.Duplex;
-        protocol?: 'http:' | 'https:';
+        maxReservedRemoteStreams?: number | undefined;
+        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
+        protocol?: 'http:' | 'https:' | undefined;
     }
 
     export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage;
-        Http1ServerResponse?: typeof ServerResponse;
-        Http2ServerRequest?: typeof Http2ServerRequest;
-        Http2ServerResponse?: typeof Http2ServerResponse;
+        Http1IncomingMessage?: typeof IncomingMessage | undefined;
+        Http1ServerResponse?: typeof ServerResponse | undefined;
+        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
+        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
     }
 
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
@@ -469,8 +469,8 @@ declare module 'http2' {
     export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
-        allowHTTP1?: boolean;
-        origins?: string[];
+        allowHTTP1?: boolean | undefined;
+        origins?: string[] | undefined;
     }
 
     interface HTTP2ServerCommon {

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -6,13 +6,13 @@ declare module 'https' {
     type ServerOptions = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions;
 
     type RequestOptions = http.RequestOptions & tls.SecureContextOptions & {
-        rejectUnauthorized?: boolean; // Defaults to true
-        servername?: string; // SNI TLS Extension
+        rejectUnauthorized?: boolean | undefined; // Defaults to true
+        servername?: string | undefined; // SNI TLS Extension
     };
 
     interface AgentOptions extends http.AgentOptions, tls.ConnectionOptions {
-        rejectUnauthorized?: boolean;
-        maxCachedSessions?: number;
+        rejectUnauthorized?: boolean | undefined;
+        maxCachedSessions?: number | undefined;
     }
 
     class Agent extends http.Agent {

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -68,11 +68,11 @@ declare module 'inspector' {
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
             /**
              * Object class (constructor) name. Specified for <code>object</code> type values only.
              */
-            className?: string;
+            className?: string | undefined;
             /**
              * Remote object value in case of primitive values or JSON values (if it was requested).
              */
@@ -80,24 +80,24 @@ declare module 'inspector' {
             /**
              * Primitive value which can not be JSON-stringified does not have <code>value</code>, but gets this property.
              */
-            unserializableValue?: UnserializableValue;
+            unserializableValue?: UnserializableValue | undefined;
             /**
              * String representation of the object.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * Unique object identifier (for non-primitive values).
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
             /**
              * Preview containing abbreviated property values. Specified for <code>object</code> type values only.
              * @experimental
              */
-            preview?: ObjectPreview;
+            preview?: ObjectPreview | undefined;
             /**
              * @experimental
              */
-            customPreview?: CustomPreview;
+            customPreview?: CustomPreview | undefined;
         }
 
         /**
@@ -108,7 +108,7 @@ declare module 'inspector' {
             hasBody: boolean;
             formatterObjectId: RemoteObjectId;
             bindRemoteObjectFunctionId: RemoteObjectId;
-            configObjectId?: RemoteObjectId;
+            configObjectId?: RemoteObjectId | undefined;
         }
 
         /**
@@ -123,11 +123,11 @@ declare module 'inspector' {
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
             /**
              * String representation of the object.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * True iff some of the properties or entries of the original object did not fit.
              */
@@ -139,7 +139,7 @@ declare module 'inspector' {
             /**
              * List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only.
              */
-            entries?: EntryPreview[];
+            entries?: EntryPreview[] | undefined;
         }
 
         /**
@@ -157,15 +157,15 @@ declare module 'inspector' {
             /**
              * User-friendly property value string.
              */
-            value?: string;
+            value?: string | undefined;
             /**
              * Nested value preview.
              */
-            valuePreview?: ObjectPreview;
+            valuePreview?: ObjectPreview | undefined;
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
         }
 
         /**
@@ -175,7 +175,7 @@ declare module 'inspector' {
             /**
              * Preview of the key. Specified for map-like collection entries.
              */
-            key?: ObjectPreview;
+            key?: ObjectPreview | undefined;
             /**
              * Preview of the value.
              */
@@ -193,19 +193,19 @@ declare module 'inspector' {
             /**
              * The value associated with the property.
              */
-            value?: RemoteObject;
+            value?: RemoteObject | undefined;
             /**
              * True if the value associated with the property may be changed (data descriptors only).
              */
-            writable?: boolean;
+            writable?: boolean | undefined;
             /**
              * A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only).
              */
-            get?: RemoteObject;
+            get?: RemoteObject | undefined;
             /**
              * A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only).
              */
-            set?: RemoteObject;
+            set?: RemoteObject | undefined;
             /**
              * True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.
              */
@@ -217,15 +217,15 @@ declare module 'inspector' {
             /**
              * True if the result was thrown during the evaluation.
              */
-            wasThrown?: boolean;
+            wasThrown?: boolean | undefined;
             /**
              * True if the property is owned for the object.
              */
-            isOwn?: boolean;
+            isOwn?: boolean | undefined;
             /**
              * Property symbol object, if the property is of the <code>symbol</code> type.
              */
-            symbol?: RemoteObject;
+            symbol?: RemoteObject | undefined;
         }
 
         /**
@@ -239,7 +239,7 @@ declare module 'inspector' {
             /**
              * The value associated with the property.
              */
-            value?: RemoteObject;
+            value?: RemoteObject | undefined;
         }
 
         /**
@@ -253,11 +253,11 @@ declare module 'inspector' {
             /**
              * Primitive value which can not be JSON-stringified.
              */
-            unserializableValue?: UnserializableValue;
+            unserializableValue?: UnserializableValue | undefined;
             /**
              * Remote object handle.
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
         }
 
         /**
@@ -284,7 +284,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            auxData?: {};
+            auxData?: {} | undefined;
         }
 
         /**
@@ -310,23 +310,23 @@ declare module 'inspector' {
             /**
              * Script ID of the exception location.
              */
-            scriptId?: ScriptId;
+            scriptId?: ScriptId | undefined;
             /**
              * URL of the exception location, to be used when the script was not reported.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * JavaScript stack trace if available.
              */
-            stackTrace?: StackTrace;
+            stackTrace?: StackTrace | undefined;
             /**
              * Exception object if available.
              */
-            exception?: RemoteObject;
+            exception?: RemoteObject | undefined;
             /**
              * Identifier of the context where exception happened.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         /**
@@ -367,7 +367,7 @@ declare module 'inspector' {
             /**
              * String label of this stack trace. For async traces this may be a name of the function that initiated the async call.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * JavaScript function name.
              */
@@ -375,12 +375,12 @@ declare module 'inspector' {
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              */
-            parent?: StackTrace;
+            parent?: StackTrace | undefined;
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              * @experimental
              */
-            parentId?: StackTraceId;
+            parentId?: StackTraceId | undefined;
         }
 
         /**
@@ -395,7 +395,7 @@ declare module 'inspector' {
          */
         interface StackTraceId {
             id: string;
-            debuggerId?: UniqueDebuggerId;
+            debuggerId?: UniqueDebuggerId | undefined;
         }
 
         interface EvaluateParameterType {
@@ -406,36 +406,36 @@ declare module 'inspector' {
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * Determines whether Command Line API should be available during the evaluation.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Specifies in which execution context to perform evaluation. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            contextId?: ExecutionContextId;
+            contextId?: ExecutionContextId | undefined;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should be treated as initiated by user in the UI.
              */
-            userGesture?: boolean;
+            userGesture?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
         }
 
         interface AwaitPromiseParameterType {
@@ -446,11 +446,11 @@ declare module 'inspector' {
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
         }
 
         interface CallFunctionOnParameterType {
@@ -461,40 +461,40 @@ declare module 'inspector' {
             /**
              * Identifier of the object to call function on. Either objectId or executionContextId should be specified.
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
             /**
              * Call arguments. All call arguments must belong to the same JavaScript world as the target object.
              */
-            arguments?: CallArgument[];
+            arguments?: CallArgument[] | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object which should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should be treated as initiated by user in the UI.
              */
-            userGesture?: boolean;
+            userGesture?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
             /**
              * Specifies execution context which global object will be used to call function on. Either executionContextId or objectId should be specified.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
             /**
              * Symbolic group name that can be used to release multiple objects. If objectGroup is not specified and objectId is, objectGroup will be inherited from object.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
         }
 
         interface GetPropertiesParameterType {
@@ -505,17 +505,17 @@ declare module 'inspector' {
             /**
              * If true, returns properties belonging only to the element itself, not to its prototype chain.
              */
-            ownProperties?: boolean;
+            ownProperties?: boolean | undefined;
             /**
              * If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.
              * @experimental
              */
-            accessorPropertiesOnly?: boolean;
+            accessorPropertiesOnly?: boolean | undefined;
             /**
              * Whether preview should be generated for the results.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
         }
 
         interface ReleaseObjectParameterType {
@@ -552,7 +552,7 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         interface RunScriptParameterType {
@@ -563,31 +563,31 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Determines whether Command Line API should be available during the evaluation.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object which should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
         }
 
         interface QueryObjectsParameterType {
@@ -601,7 +601,7 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to lookup global scope variables.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         interface EvaluateReturnType {
@@ -612,7 +612,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface AwaitPromiseReturnType {
@@ -623,7 +623,7 @@ declare module 'inspector' {
             /**
              * Exception details if stack strace is available.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface CallFunctionOnReturnType {
@@ -634,7 +634,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface GetPropertiesReturnType {
@@ -645,22 +645,22 @@ declare module 'inspector' {
             /**
              * Internal object properties (only of the element itself).
              */
-            internalProperties?: InternalPropertyDescriptor[];
+            internalProperties?: InternalPropertyDescriptor[] | undefined;
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface CompileScriptReturnType {
             /**
              * Id of the script.
              */
-            scriptId?: ScriptId;
+            scriptId?: ScriptId | undefined;
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface RunScriptReturnType {
@@ -671,7 +671,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface QueryObjectsReturnType {
@@ -738,12 +738,12 @@ declare module 'inspector' {
             /**
              * Stack trace captured when the call was made.
              */
-            stackTrace?: StackTrace;
+            stackTrace?: StackTrace | undefined;
             /**
              * Console context descriptor for calls on non-default console context (not console.*): 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call on named context.
              * @experimental
              */
-            context?: string;
+            context?: string | undefined;
         }
 
         interface InspectRequestedEventDataType {
@@ -778,7 +778,7 @@ declare module 'inspector' {
             /**
              * Column number in the script (0-based).
              */
-            columnNumber?: number;
+            columnNumber?: number | undefined;
         }
 
         /**
@@ -805,7 +805,7 @@ declare module 'inspector' {
             /**
              * Location in the source code.
              */
-            functionLocation?: Location;
+            functionLocation?: Location | undefined;
             /**
              * Location in the source code.
              */
@@ -825,7 +825,7 @@ declare module 'inspector' {
             /**
              * The value being returned, if the function is at return point.
              */
-            returnValue?: Runtime.RemoteObject;
+            returnValue?: Runtime.RemoteObject | undefined;
         }
 
         /**
@@ -840,15 +840,15 @@ declare module 'inspector' {
              * Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties.
              */
             object: Runtime.RemoteObject;
-            name?: string;
+            name?: string | undefined;
             /**
              * Location in the source code where scope starts
              */
-            startLocation?: Location;
+            startLocation?: Location | undefined;
             /**
              * Location in the source code where scope ends
              */
-            endLocation?: Location;
+            endLocation?: Location | undefined;
         }
 
         /**
@@ -877,8 +877,8 @@ declare module 'inspector' {
             /**
              * Column number in the script (0-based).
              */
-            columnNumber?: number;
-            type?: string;
+            columnNumber?: number | undefined;
+            type?: string | undefined;
         }
 
         interface SetBreakpointsActiveParameterType {
@@ -903,23 +903,23 @@ declare module 'inspector' {
             /**
              * URL of the resources to set breakpoint on.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified.
              */
-            urlRegex?: string;
+            urlRegex?: string | undefined;
             /**
              * Script hash of the resources to set breakpoint on.
              */
-            scriptHash?: string;
+            scriptHash?: string | undefined;
             /**
              * Offset in the line to set breakpoint at.
              */
-            columnNumber?: number;
+            columnNumber?: number | undefined;
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
              */
-            condition?: string;
+            condition?: string | undefined;
         }
 
         interface SetBreakpointParameterType {
@@ -930,7 +930,7 @@ declare module 'inspector' {
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
              */
-            condition?: string;
+            condition?: string | undefined;
         }
 
         interface RemoveBreakpointParameterType {
@@ -945,11 +945,11 @@ declare module 'inspector' {
             /**
              * End of range to search possible breakpoint locations in (excluding). When not specified, end of scripts is used as end of range.
              */
-            end?: Location;
+            end?: Location | undefined;
             /**
              * Only consider locations which are in the same (non-nested) function as start.
              */
-            restrictToFunction?: boolean;
+            restrictToFunction?: boolean | undefined;
         }
 
         interface ContinueToLocationParameterType {
@@ -957,7 +957,7 @@ declare module 'inspector' {
              * Location to continue to.
              */
             location: Location;
-            targetCallFrames?: string;
+            targetCallFrames?: string | undefined;
         }
 
         interface PauseOnAsyncCallParameterType {
@@ -972,7 +972,7 @@ declare module 'inspector' {
              * Debugger will issue additional Debugger.paused notification if any async task is scheduled before next pause.
              * @experimental
              */
-            breakOnAsyncCall?: boolean;
+            breakOnAsyncCall?: boolean | undefined;
         }
 
         interface GetStackTraceParameterType {
@@ -991,11 +991,11 @@ declare module 'inspector' {
             /**
              * If true, search is case sensitive.
              */
-            caseSensitive?: boolean;
+            caseSensitive?: boolean | undefined;
             /**
              * If true, treats string parameter as regex.
              */
-            isRegex?: boolean;
+            isRegex?: boolean | undefined;
         }
 
         interface SetScriptSourceParameterType {
@@ -1010,7 +1010,7 @@ declare module 'inspector' {
             /**
              *  If true the change will not actually be applied. Dry run may be used to get result description without actually modifying the code.
              */
-            dryRun?: boolean;
+            dryRun?: boolean | undefined;
         }
 
         interface RestartFrameParameterType {
@@ -1046,28 +1046,28 @@ declare module 'inspector' {
             /**
              * String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>).
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * Specifies whether command line API should be available to the evaluated expression, defaults to false.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether to throw an exception if side effect cannot be ruled out during evaluation.
              */
-            throwOnSideEffect?: boolean;
+            throwOnSideEffect?: boolean | undefined;
         }
 
         interface SetVariableValueParameterType {
@@ -1170,24 +1170,24 @@ declare module 'inspector' {
             /**
              * New stack trace in case editing has happened while VM was stopped.
              */
-            callFrames?: CallFrame[];
+            callFrames?: CallFrame[] | undefined;
             /**
              * Whether current call stack  was modified after applying the changes.
              */
-            stackChanged?: boolean;
+            stackChanged?: boolean | undefined;
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
             /**
              * Exception details if any.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: Runtime.ExceptionDetails | undefined;
         }
 
         interface RestartFrameReturnType {
@@ -1198,12 +1198,12 @@ declare module 'inspector' {
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
         }
 
         interface GetScriptSourceReturnType {
@@ -1221,7 +1221,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: Runtime.ExceptionDetails | undefined;
         }
 
         interface ScriptParsedEventDataType {
@@ -1260,33 +1260,33 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {};
+            executionContextAuxData?: {} | undefined;
             /**
              * True, if this script is generated as a result of the live edit operation.
              * @experimental
              */
-            isLiveEdit?: boolean;
+            isLiveEdit?: boolean | undefined;
             /**
              * URL of source map associated with script (if any).
              */
-            sourceMapURL?: string;
+            sourceMapURL?: string | undefined;
             /**
              * True, if this script has sourceURL.
              */
-            hasSourceURL?: boolean;
+            hasSourceURL?: boolean | undefined;
             /**
              * True, if this script is ES6 module.
              */
-            isModule?: boolean;
+            isModule?: boolean | undefined;
             /**
              * This script length.
              */
-            length?: number;
+            length?: number | undefined;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
              * @experimental
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: Runtime.StackTrace | undefined;
         }
 
         interface ScriptFailedToParseEventDataType {
@@ -1325,28 +1325,28 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {};
+            executionContextAuxData?: {} | undefined;
             /**
              * URL of source map associated with script (if any).
              */
-            sourceMapURL?: string;
+            sourceMapURL?: string | undefined;
             /**
              * True, if this script has sourceURL.
              */
-            hasSourceURL?: boolean;
+            hasSourceURL?: boolean | undefined;
             /**
              * True, if this script is ES6 module.
              */
-            isModule?: boolean;
+            isModule?: boolean | undefined;
             /**
              * This script length.
              */
-            length?: number;
+            length?: number | undefined;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
              * @experimental
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: Runtime.StackTrace | undefined;
         }
 
         interface BreakpointResolvedEventDataType {
@@ -1372,25 +1372,25 @@ declare module 'inspector' {
             /**
              * Object containing break-specific auxiliary properties.
              */
-            data?: {};
+            data?: {} | undefined;
             /**
              * Hit breakpoints IDs
              */
-            hitBreakpoints?: string[];
+            hitBreakpoints?: string[] | undefined;
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
             /**
              * Just scheduled async call will have this stack trace as parent stack during async execution. This field is available only after <code>Debugger.stepInto</code> call with <code>breakOnAsynCall</code> flag.
              * @experimental
              */
-            asyncCallStackTraceId?: Runtime.StackTraceId;
+            asyncCallStackTraceId?: Runtime.StackTraceId | undefined;
         }
     }
 
@@ -1414,15 +1414,15 @@ declare module 'inspector' {
             /**
              * URL of the message origin.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * Line number in the resource that generated this message (1-based).
              */
-            line?: number;
+            line?: number | undefined;
             /**
              * Column number in the resource that generated this message (1-based).
              */
-            column?: number;
+            column?: number | undefined;
         }
 
         interface MessageAddedEventDataType {
@@ -1449,19 +1449,19 @@ declare module 'inspector' {
             /**
              * Number of samples where this node was on top of the call stack.
              */
-            hitCount?: number;
+            hitCount?: number | undefined;
             /**
              * Child node ids.
              */
-            children?: number[];
+            children?: number[] | undefined;
             /**
              * The reason of being not optimized. The function may be deoptimized or marked as don't optimize.
              */
-            deoptReason?: string;
+            deoptReason?: string | undefined;
             /**
              * An array of source position ticks.
              */
-            positionTicks?: PositionTickInfo[];
+            positionTicks?: PositionTickInfo[] | undefined;
         }
 
         /**
@@ -1483,11 +1483,11 @@ declare module 'inspector' {
             /**
              * Ids of samples top nodes.
              */
-            samples?: number[];
+            samples?: number[] | undefined;
             /**
              * Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime.
              */
-            timeDeltas?: number[];
+            timeDeltas?: number[] | undefined;
         }
 
         /**
@@ -1614,11 +1614,11 @@ declare module 'inspector' {
             /**
              * Collect accurate call counts beyond simple 'covered' or 'not covered'.
              */
-            callCount?: boolean;
+            callCount?: boolean | undefined;
             /**
              * Collect block-based coverage.
              */
-            detailed?: boolean;
+            detailed?: boolean | undefined;
         }
 
         interface StopReturnType {
@@ -1658,7 +1658,7 @@ declare module 'inspector' {
             /**
              * Profile title passed as an argument to console.profile().
              */
-            title?: string;
+            title?: string | undefined;
         }
 
         interface ConsoleProfileFinishedEventDataType {
@@ -1671,7 +1671,7 @@ declare module 'inspector' {
             /**
              * Profile title passed as an argument to console.profile().
              */
-            title?: string;
+            title?: string | undefined;
         }
     }
 
@@ -1707,21 +1707,21 @@ declare module 'inspector' {
         }
 
         interface StartTrackingHeapObjectsParameterType {
-            trackAllocations?: boolean;
+            trackAllocations?: boolean | undefined;
         }
 
         interface StopTrackingHeapObjectsParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped.
              */
-            reportProgress?: boolean;
+            reportProgress?: boolean | undefined;
         }
 
         interface TakeHeapSnapshotParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.
              */
-            reportProgress?: boolean;
+            reportProgress?: boolean | undefined;
         }
 
         interface GetObjectByHeapObjectIdParameterType {
@@ -1729,7 +1729,7 @@ declare module 'inspector' {
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
         }
 
         interface AddInspectedHeapObjectParameterType {
@@ -1750,7 +1750,7 @@ declare module 'inspector' {
             /**
              * Average sample interval in bytes. Poisson distribution is used for the intervals. The default value is 32768 bytes.
              */
-            samplingInterval?: number;
+            samplingInterval?: number | undefined;
         }
 
         interface GetObjectByHeapObjectIdReturnType {
@@ -1788,7 +1788,7 @@ declare module 'inspector' {
         interface ReportHeapSnapshotProgressEventDataType {
             done: number;
             total: number;
-            finished?: boolean;
+            finished?: boolean | undefined;
         }
 
         interface LastSeenObjectIdEventDataType {
@@ -1801,6 +1801,100 @@ declare module 'inspector' {
              * An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment.
              */
             statsUpdate: number[];
+        }
+    }
+
+    namespace NodeTracing {
+        interface TraceConfig {
+            /**
+             * Controls how the trace buffer stores data.
+             */
+            recordMode?: string | undefined;
+            /**
+             * Included category filters.
+             */
+            includedCategories: string[];
+        }
+
+        interface StartParameterType {
+            traceConfig: TraceConfig;
+        }
+
+        interface GetCategoriesReturnType {
+            /**
+             * A list of supported tracing categories.
+             */
+            categories: string[];
+        }
+
+        interface DataCollectedEventDataType {
+            value: Array<{}>;
+        }
+    }
+
+    namespace NodeWorker {
+        type WorkerID = string;
+
+        /**
+         * Unique identifier of attached debugging session.
+         */
+        type SessionID = string;
+
+        interface WorkerInfo {
+            workerId: WorkerID;
+            type: string;
+            title: string;
+            url: string;
+        }
+
+        interface SendMessageToWorkerParameterType {
+            message: string;
+            /**
+             * Identifier of the session.
+             */
+            sessionId: SessionID;
+        }
+
+        interface EnableParameterType {
+            /**
+             * Whether to new workers should be paused until the frontend sends `Runtime.runIfWaitingForDebugger`
+             * message to run them.
+             */
+            waitForDebuggerOnStart: boolean;
+        }
+
+        interface DetachParameterType {
+            sessionId: SessionID;
+        }
+
+        interface AttachedToWorkerEventDataType {
+            /**
+             * Identifier assigned to the session used to send/receive messages.
+             */
+            sessionId: SessionID;
+            workerInfo: WorkerInfo;
+            waitingForDebugger: boolean;
+        }
+
+        interface DetachedFromWorkerEventDataType {
+            /**
+             * Detached session identifier.
+             */
+            sessionId: SessionID;
+        }
+
+        interface ReceivedMessageFromWorkerEventDataType {
+            /**
+             * Identifier of a session which sends a message.
+             */
+            sessionId: SessionID;
+            message: string;
+        }
+    }
+
+    namespace NodeRuntime {
+        interface NotifyWhenWaitingForDisconnectParameterType {
+            enabled: boolean;
         }
     }
 
@@ -2203,6 +2297,53 @@ declare module 'inspector' {
 
         post(method: "HeapProfiler.getSamplingProfile", callback?: (err: Error | null, params: HeapProfiler.GetSamplingProfileReturnType) => void): void;
 
+        /**
+         * Gets supported tracing categories.
+         */
+        post(method: "NodeTracing.getCategories", callback?: (err: Error | null, params: NodeTracing.GetCategoriesReturnType) => void): void;
+
+        /**
+         * Start trace events collection.
+         */
+        post(method: "NodeTracing.start", params?: NodeTracing.StartParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "NodeTracing.start", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Stop trace events collection. Remaining collected events will be sent as a sequence of
+         * dataCollected events followed by tracingComplete event.
+         */
+        post(method: "NodeTracing.stop", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Sends protocol message over session with given id.
+         */
+        post(method: "NodeWorker.sendMessageToWorker", params?: NodeWorker.SendMessageToWorkerParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "NodeWorker.sendMessageToWorker", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Instructs the inspector to attach to running workers. Will also attach to new workers
+         * as they start
+         */
+        post(method: "NodeWorker.enable", params?: NodeWorker.EnableParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "NodeWorker.enable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Detaches from all running workers and disables attaching to new workers as they are started.
+         */
+        post(method: "NodeWorker.disable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Detached from the worker with given sessionId.
+         */
+        post(method: "NodeWorker.detach", params?: NodeWorker.DetachParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "NodeWorker.detach", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Enable the `NodeRuntime.waitingForDisconnect`.
+         */
+        post(method: "NodeRuntime.notifyWhenWaitingForDisconnect", params?: NodeRuntime.NotifyWhenWaitingForDisconnectParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "NodeRuntime.notifyWhenWaitingForDisconnect", callback?: (err: Error | null) => void): void;
+
         // Events
 
         addListener(event: string, listener: (...args: any[]) => void): this;
@@ -2297,6 +2438,41 @@ declare module 'inspector' {
          */
         addListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
 
+        /**
+         * Contains an bucket of collected trace events.
+         */
+        addListener(event: "NodeTracing.dataCollected", listener: (message: InspectorNotification<NodeTracing.DataCollectedEventDataType>) => void): this;
+
+        /**
+         * Signals that tracing is stopped and there is no trace buffers pending flush, all data were
+         * delivered via dataCollected events.
+         */
+        addListener(event: "NodeTracing.tracingComplete", listener: () => void): this;
+
+        /**
+         * Issued when attached to a worker.
+         */
+        addListener(event: "NodeWorker.attachedToWorker", listener: (message: InspectorNotification<NodeWorker.AttachedToWorkerEventDataType>) => void): this;
+
+        /**
+         * Issued when detached from the worker.
+         */
+        addListener(event: "NodeWorker.detachedFromWorker", listener: (message: InspectorNotification<NodeWorker.DetachedFromWorkerEventDataType>) => void): this;
+
+        /**
+         * Notifies about a new protocol message received from the session
+         * (session ID is provided in attachedToWorker notification).
+         */
+        addListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
+
+        /**
+         * This event is fired instead of `Runtime.executionContextDestroyed` when
+         * enabled.
+         * It is fired when the Node process finished all code execution and is
+         * waiting for all frontends to disconnect.
+         */
+        addListener(event: "NodeRuntime.waitingForDisconnect", listener: () => void): this;
+
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "inspectorNotification", message: InspectorNotification<{}>): boolean;
         emit(event: "Runtime.executionContextCreated", message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>): boolean;
@@ -2319,6 +2495,12 @@ declare module 'inspector' {
         emit(event: "HeapProfiler.reportHeapSnapshotProgress", message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>): boolean;
         emit(event: "HeapProfiler.lastSeenObjectId", message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>): boolean;
         emit(event: "HeapProfiler.heapStatsUpdate", message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>): boolean;
+        emit(event: "NodeTracing.dataCollected", message: InspectorNotification<NodeTracing.DataCollectedEventDataType>): boolean;
+        emit(event: "NodeTracing.tracingComplete"): boolean;
+        emit(event: "NodeWorker.attachedToWorker", message: InspectorNotification<NodeWorker.AttachedToWorkerEventDataType>): boolean;
+        emit(event: "NodeWorker.detachedFromWorker", message: InspectorNotification<NodeWorker.DetachedFromWorkerEventDataType>): boolean;
+        emit(event: "NodeWorker.receivedMessageFromWorker", message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>): boolean;
+        emit(event: "NodeRuntime.waitingForDisconnect"): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
 
@@ -2412,6 +2594,41 @@ declare module 'inspector' {
          */
         on(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
 
+        /**
+         * Contains an bucket of collected trace events.
+         */
+        on(event: "NodeTracing.dataCollected", listener: (message: InspectorNotification<NodeTracing.DataCollectedEventDataType>) => void): this;
+
+        /**
+         * Signals that tracing is stopped and there is no trace buffers pending flush, all data were
+         * delivered via dataCollected events.
+         */
+        on(event: "NodeTracing.tracingComplete", listener: () => void): this;
+
+        /**
+         * Issued when attached to a worker.
+         */
+        on(event: "NodeWorker.attachedToWorker", listener: (message: InspectorNotification<NodeWorker.AttachedToWorkerEventDataType>) => void): this;
+
+        /**
+         * Issued when detached from the worker.
+         */
+        on(event: "NodeWorker.detachedFromWorker", listener: (message: InspectorNotification<NodeWorker.DetachedFromWorkerEventDataType>) => void): this;
+
+        /**
+         * Notifies about a new protocol message received from the session
+         * (session ID is provided in attachedToWorker notification).
+         */
+        on(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
+
+        /**
+         * This event is fired instead of `Runtime.executionContextDestroyed` when
+         * enabled.
+         * It is fired when the Node process finished all code execution and is
+         * waiting for all frontends to disconnect.
+         */
+        on(event: "NodeRuntime.waitingForDisconnect", listener: () => void): this;
+
         once(event: string, listener: (...args: any[]) => void): this;
 
         /**
@@ -2503,6 +2720,41 @@ declare module 'inspector' {
          * If heap objects tracking has been started then backend may send update for one or more fragments
          */
         once(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+
+        /**
+         * Contains an bucket of collected trace events.
+         */
+        once(event: "NodeTracing.dataCollected", listener: (message: InspectorNotification<NodeTracing.DataCollectedEventDataType>) => void): this;
+
+        /**
+         * Signals that tracing is stopped and there is no trace buffers pending flush, all data were
+         * delivered via dataCollected events.
+         */
+        once(event: "NodeTracing.tracingComplete", listener: () => void): this;
+
+        /**
+         * Issued when attached to a worker.
+         */
+        once(event: "NodeWorker.attachedToWorker", listener: (message: InspectorNotification<NodeWorker.AttachedToWorkerEventDataType>) => void): this;
+
+        /**
+         * Issued when detached from the worker.
+         */
+        once(event: "NodeWorker.detachedFromWorker", listener: (message: InspectorNotification<NodeWorker.DetachedFromWorkerEventDataType>) => void): this;
+
+        /**
+         * Notifies about a new protocol message received from the session
+         * (session ID is provided in attachedToWorker notification).
+         */
+        once(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
+
+        /**
+         * This event is fired instead of `Runtime.executionContextDestroyed` when
+         * enabled.
+         * It is fired when the Node process finished all code execution and is
+         * waiting for all frontends to disconnect.
+         */
+        once(event: "NodeRuntime.waitingForDisconnect", listener: () => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
 
@@ -2596,6 +2848,41 @@ declare module 'inspector' {
          */
         prependListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
 
+        /**
+         * Contains an bucket of collected trace events.
+         */
+        prependListener(event: "NodeTracing.dataCollected", listener: (message: InspectorNotification<NodeTracing.DataCollectedEventDataType>) => void): this;
+
+        /**
+         * Signals that tracing is stopped and there is no trace buffers pending flush, all data were
+         * delivered via dataCollected events.
+         */
+        prependListener(event: "NodeTracing.tracingComplete", listener: () => void): this;
+
+        /**
+         * Issued when attached to a worker.
+         */
+        prependListener(event: "NodeWorker.attachedToWorker", listener: (message: InspectorNotification<NodeWorker.AttachedToWorkerEventDataType>) => void): this;
+
+        /**
+         * Issued when detached from the worker.
+         */
+        prependListener(event: "NodeWorker.detachedFromWorker", listener: (message: InspectorNotification<NodeWorker.DetachedFromWorkerEventDataType>) => void): this;
+
+        /**
+         * Notifies about a new protocol message received from the session
+         * (session ID is provided in attachedToWorker notification).
+         */
+        prependListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
+
+        /**
+         * This event is fired instead of `Runtime.executionContextDestroyed` when
+         * enabled.
+         * It is fired when the Node process finished all code execution and is
+         * waiting for all frontends to disconnect.
+         */
+        prependListener(event: "NodeRuntime.waitingForDisconnect", listener: () => void): this;
+
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
 
         /**
@@ -2687,6 +2974,41 @@ declare module 'inspector' {
          * If heap objects tracking has been started then backend may send update for one or more fragments
          */
         prependOnceListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+
+        /**
+         * Contains an bucket of collected trace events.
+         */
+        prependOnceListener(event: "NodeTracing.dataCollected", listener: (message: InspectorNotification<NodeTracing.DataCollectedEventDataType>) => void): this;
+
+        /**
+         * Signals that tracing is stopped and there is no trace buffers pending flush, all data were
+         * delivered via dataCollected events.
+         */
+        prependOnceListener(event: "NodeTracing.tracingComplete", listener: () => void): this;
+
+        /**
+         * Issued when attached to a worker.
+         */
+        prependOnceListener(event: "NodeWorker.attachedToWorker", listener: (message: InspectorNotification<NodeWorker.AttachedToWorkerEventDataType>) => void): this;
+
+        /**
+         * Issued when detached from the worker.
+         */
+        prependOnceListener(event: "NodeWorker.detachedFromWorker", listener: (message: InspectorNotification<NodeWorker.DetachedFromWorkerEventDataType>) => void): this;
+
+        /**
+         * Notifies about a new protocol message received from the session
+         * (session ID is provided in attachedToWorker notification).
+         */
+        prependOnceListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
+
+        /**
+         * This event is fired instead of `Runtime.executionContextDestroyed` when
+         * enabled.
+         * It is fired when the Node process finished all code execution and is
+         * waiting for all frontends to disconnect.
+         */
+        prependOnceListener(event: "NodeRuntime.waitingForDisconnect", listener: () => void): this;
     }
 
     // Top Level API
@@ -2716,8 +3038,4 @@ declare module 'inspector' {
      * An exception will be thrown if there is no active inspector.
      */
     function waitForDebugger(): void;
-}
-
-declare module 'node:inspector' {
-    export * from 'inspector';
 }

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -16,10 +16,10 @@ declare module 'net' {
     }
 
     interface SocketConstructorOpts {
-        fd?: number;
-        allowHalfOpen?: boolean;
-        readable?: boolean;
-        writable?: boolean;
+        fd?: number | undefined;
+        allowHalfOpen?: boolean | undefined;
+        readable?: boolean | undefined;
+        writable?: boolean | undefined;
     }
 
     interface OnReadOpts {
@@ -38,17 +38,17 @@ declare module 'net' {
          * Note: this will cause the streaming functionality to not provide any data, however events like 'error', 'end', and 'close' will
          * still be emitted as normal and methods like pause() and resume() will also behave as expected.
          */
-        onread?: OnReadOpts;
+        onread?: OnReadOpts | undefined;
     }
 
     interface TcpSocketConnectOpts extends ConnectOpts {
         port: number;
-        host?: string;
-        localAddress?: string;
-        localPort?: number;
-        hints?: number;
-        family?: number;
-        lookup?: LookupFunction;
+        host?: string | undefined;
+        localAddress?: string | undefined;
+        localPort?: number | undefined;
+        hints?: number | undefined;
+        family?: number | undefined;
+        lookup?: LookupFunction | undefined;
     }
 
     interface IpcSocketConnectOpts extends ConnectOpts {
@@ -87,9 +87,9 @@ declare module 'net' {
         readonly destroyed: boolean;
         readonly localAddress: string;
         readonly localPort: number;
-        readonly remoteAddress?: string;
-        readonly remoteFamily?: string;
-        readonly remotePort?: number;
+        readonly remoteAddress?: string | undefined;
+        readonly remoteFamily?: string | undefined;
+        readonly remotePort?: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): void;
@@ -169,17 +169,17 @@ declare module 'net' {
     }
 
     interface ListenOptions extends Abortable {
-        port?: number;
-        host?: string;
-        backlog?: number;
-        path?: string;
-        exclusive?: boolean;
-        readableAll?: boolean;
-        writableAll?: boolean;
+        port?: number | undefined;
+        host?: string | undefined;
+        backlog?: number | undefined;
+        path?: string | undefined;
+        exclusive?: boolean | undefined;
+        readableAll?: boolean | undefined;
+        writableAll?: boolean | undefined;
         /**
          * @default false
          */
-        ipv6Only?: boolean;
+        ipv6Only?: boolean | undefined;
     }
 
     interface ServerOpts {
@@ -187,13 +187,13 @@ declare module 'net' {
          * Indicates whether half-opened TCP connections are allowed.
          * @default false
          */
-        allowHalfOpen?: boolean;
+        allowHalfOpen?: boolean | undefined;
 
         /**
          * Indicates whether the socket should be paused on incoming connections.
          * @default false
          */
-        pauseOnConnect?: boolean;
+        pauseOnConnect?: boolean | undefined;
     }
 
     // https://github.com/nodejs/node/blob/master/lib/net.js
@@ -307,11 +307,11 @@ declare module 'net' {
     }
 
     interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
@@ -333,21 +333,21 @@ declare module 'net' {
          * The network address as either an IPv4 or IPv6 string.
          * @default 127.0.0.1
          */
-        address?: string;
+        address?: string | undefined;
         /**
          * @default `'ipv4'`
          */
-        family?: IPVersion;
+        family?: IPVersion | undefined;
         /**
          * An IPv6 flow-label used only if `family` is `'ipv6'`.
          * @default 0
          */
-        flowlabel?: number;
+        flowlabel?: number | undefined;
         /**
          * An IP port.
          * @default 0
          */
-        port?: number;
+        port?: number | undefined;
     }
 
     // TODO: Mark as clonable if `kClone` symbol is set in node.

--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -40,23 +40,23 @@ declare module 'path' {
             /**
              * The root of the path such as '/' or 'c:\'
              */
-            root?: string;
+            root?: string | undefined;
             /**
              * The full directory path such as '/home/user/dir' or 'c:\path\dir'
              */
-            dir?: string;
+            dir?: string | undefined;
             /**
              * The file name including extension (if any) such as 'index.html'
              */
-            base?: string;
+            base?: string | undefined;
             /**
              * The file extension (if any) such as '.html'
              */
-            ext?: string;
+            ext?: string | undefined;
             /**
              * The file name without extension (if any) such as 'index'
              */
-            name?: string;
+            name?: string | undefined;
         }
 
         interface PlatformPath {

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -3,22 +3,6 @@ declare module 'perf_hooks' {
 
     type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
 
-    interface NodeGCPerformanceDetail {
-        /**
-         * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies
-         * the type of garbage collection operation that occurred.
-         * See perf_hooks.constants for valid values.
-         */
-        readonly kind?: number;
-
-        /**
-         * When `performanceEntry.entryType` is equal to 'gc', the `performance.flags`
-         * property contains additional information about garbage collection operation.
-         * See perf_hooks.constants for valid values.
-         */
-        readonly flags?: number;
-    }
-
     class PerformanceEntry {
         protected constructor();
         /**
@@ -43,7 +27,19 @@ declare module 'perf_hooks' {
          */
         readonly entryType: EntryType;
 
-        readonly details?: NodeGCPerformanceDetail | unknown; // TODO: Narrow this based on entry type.
+        /**
+         * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies
+         * the type of garbage collection operation that occurred.
+         * See perf_hooks.constants for valid values.
+         */
+        readonly kind?: number | undefined;
+
+        /**
+         * When `performanceEntry.entryType` is equal to 'gc', the `performance.flags`
+         * property contains additional information about garbage collection operation.
+         * See perf_hooks.constants for valid values.
+         */
+        readonly flags?: number | undefined;
     }
 
     class PerformanceNodeTiming extends PerformanceEntry {
@@ -98,46 +94,6 @@ declare module 'perf_hooks' {
         util2?: EventLoopUtilization,
     ) => EventLoopUtilization;
 
-    interface MarkOptions {
-        /**
-         * Additional optional detail to include with the mark.
-         */
-        detail?: unknown;
-        /**
-         * An optional timestamp to be used as the mark time.
-         * @default `performance.now()`.
-         */
-        startTime?: number;
-    }
-
-    interface MeasureOptions {
-        /**
-         * Additional optional detail to include with the mark.
-         */
-        detail?: unknown;
-        /**
-         * Duration between start and end times.
-         */
-        duration?: number;
-        /**
-         * Timestamp to be used as the end time, or a string identifying a previously recorded mark.
-         */
-        end?: number | string;
-        /**
-         * Timestamp to be used as the start time, or a string identifying a previously recorded mark.
-         */
-        start?: number | string;
-    }
-
-    interface TimerifyOptions {
-        /**
-         * A histogram object created using
-         * `perf_hooks.createHistogram()` that will record runtime durations in
-         * nanoseconds.
-         */
-        histogram?: RecordableHistogram;
-    }
-
     interface Performance {
         /**
          * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
@@ -153,7 +109,7 @@ declare module 'perf_hooks' {
          * Performance marks are used to mark specific significant moments in the Performance Timeline.
          * @param name
          */
-        mark(name?: string, options?: MarkOptions): void;
+        mark(name?: string): void;
 
         /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
@@ -171,7 +127,6 @@ declare module 'perf_hooks' {
          * @param endMark
          */
         measure(name: string, startMark?: string, endMark?: string): void;
-        measure(name: string, options: MeasureOptions): void;
 
         /**
          * An instance of the PerformanceNodeTiming class that provides performance metrics for specific Node.js operational milestones.
@@ -193,7 +148,7 @@ declare module 'perf_hooks' {
          * A PerformanceObserver must be subscribed to the 'function' event type in order for the timing details to be accessed.
          * @param fn
          */
-        timerify<T extends (...params: any[]) => any>(fn: T, options?: TimerifyOptions): T;
+        timerify<T extends (...optionalParams: any[]) => any>(fn: T): T;
 
         /**
          * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
@@ -233,10 +188,12 @@ declare module 'perf_hooks' {
         disconnect(): void;
 
         /**
-         * Subscribes the PerformanceObserver instance to notifications of new PerformanceEntry instances identified by options.entryTypes or options.type.
+         * Subscribes the PerformanceObserver instance to notifications of new PerformanceEntry instances identified by options.entryTypes.
          * When options.buffered is false, the callback will be invoked once for every PerformanceEntry instance.
+         * Property buffered defaults to false.
+         * @param options
          */
-        observe(options: { entryTypes: ReadonlyArray<EntryType> } | { type: EntryType }): void;
+        observe(options: { entryTypes: ReadonlyArray<EntryType>; buffered?: boolean | undefined }): void;
     }
 
     namespace constants {
@@ -262,7 +219,7 @@ declare module 'perf_hooks' {
          * Must be greater than zero.
          * @default 10
          */
-        resolution?: number;
+        resolution?: number | undefined;
     }
 
     interface Histogram {
@@ -335,23 +292,19 @@ declare module 'perf_hooks' {
          * The minimum recordable value. Must be an integer value greater than 0.
          * @default 1
          */
-        min?: number | bigint;
+        min?: number | bigint | undefined;
 
         /**
          * The maximum recordable value. Must be an integer value greater than min.
          * @default Number.MAX_SAFE_INTEGER
          */
-        max?: number | bigint;
+        max?: number | bigint | undefined;
         /**
          * The number of accuracy digits. Must be a number between 1 and 5.
          * @default 3
          */
-        figures?: number;
+        figures?: number | undefined;
     }
 
     function createHistogram(options?: CreateHistogramOptions): RecordableHistogram;
-}
-
-declare module 'node:perf_hooks' {
-    export * from 'perf_hooks';
 }

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -38,10 +38,10 @@ declare module 'process' {
 
             interface ProcessRelease {
                 name: string;
-                sourceUrl?: string;
-                headersUrl?: string;
-                libUrl?: string;
-                lts?: string;
+                sourceUrl?: string | undefined;
+                headersUrl?: string | undefined;
+                libUrl?: string | undefined;
+                lts?: string | undefined;
             }
 
             interface ProcessVersions extends Dict<string> {
@@ -89,7 +89,7 @@ declare module 'process' {
             type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<any>, value: any) => void;
 
             interface Socket extends ReadWriteStream {
-                isTTY?: true;
+                isTTY?: true | undefined;
             }
 
             // Alias for compatibility
@@ -190,24 +190,24 @@ declare module 'process' {
                  *
                  * @default 'Warning'
                  */
-                type?: string;
+                type?: string | undefined;
 
                 /**
                  * A unique identifier for the warning instance being emitted.
                  */
-                code?: string;
+                code?: string | undefined;
 
                 /**
                  * When `warning` is a `string`, `ctor` is an optional function used to limit the generated stack trace.
                  *
                  * @default process.emitWarning
                  */
-                ctor?: Function;
+                ctor?: Function | undefined;
 
                 /**
                  * Additional text to include with the error.
                  */
-                detail?: string;
+                detail?: string | undefined;
             }
 
             interface ProcessConfig {
@@ -280,7 +280,7 @@ declare module 'process' {
 
                 env: ProcessEnv;
                 exit(code?: number): never;
-                exitCode?: number;
+                exitCode?: number | undefined;
                 getgid(): number;
                 setgid(id: number | string): void;
                 getuid(): number;
@@ -303,7 +303,7 @@ declare module 'process' {
                 readonly arch: string;
                 readonly platform: Platform;
                 /** @deprecated since v14.0.0 - use `require.main` instead. */
-                mainModule?: Module;
+                mainModule?: Module | undefined;
                 memoryUsage: MemoryUsageFn;
                 cpuUsage(previousValue?: CpuUsage): CpuUsage;
                 nextTick(callback: Function, ...args: any[]): void;
@@ -332,7 +332,7 @@ declare module 'process' {
                 hrtime: HRTime;
 
                 // Worker
-                send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean}, callback?: (error: Error | null) => void): boolean;
+                send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean | undefined}, callback?: (error: Error | null) => void): boolean;
                 disconnect(): void;
                 connected: boolean;
 
@@ -346,7 +346,7 @@ declare module 'process' {
                 /**
                  * Only available with `--experimental-report`
                  */
-                report?: ProcessReport;
+                report?: ProcessReport | undefined;
 
                 resourceUsage(): ResourceUsage;
 

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -1,11 +1,11 @@
 declare module 'querystring' {
     interface StringifyOptions {
-        encodeURIComponent?: (str: string) => string;
+        encodeURIComponent?: ((str: string) => string) | undefined;
     }
 
     interface ParseOptions {
-        maxKeys?: number;
-        decodeURIComponent?: (str: string) => string;
+        maxKeys?: number | undefined;
+        decodeURIComponent?: ((str: string) => string) | undefined;
     }
 
     interface ParsedUrlQuery extends NodeJS.Dict<string | string[]> { }

--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -2,11 +2,11 @@ declare module 'readline' {
     import { Abortable, EventEmitter } from 'events';
 
     interface Key {
-        sequence?: string;
-        name?: string;
-        ctrl?: boolean;
-        meta?: boolean;
-        shift?: boolean;
+        sequence?: string | undefined;
+        name?: string | undefined;
+        ctrl?: boolean | undefined;
+        meta?: boolean | undefined;
+        shift?: boolean | undefined;
     }
 
     class Interface extends EventEmitter {
@@ -138,28 +138,28 @@ declare module 'readline' {
 
     interface ReadLineOptions {
         input: NodeJS.ReadableStream;
-        output?: NodeJS.WritableStream;
-        completer?: Completer | AsyncCompleter;
-        terminal?: boolean;
+        output?: NodeJS.WritableStream | undefined;
+        completer?: Completer | AsyncCompleter | undefined;
+        terminal?: boolean | undefined;
         /**
          *  Initial list of history lines. This option makes sense
          * only if `terminal` is set to `true` by the user or by an internal `output`
          * check, otherwise the history caching mechanism is not initialized at all.
          * @default []
          */
-        history?: string[];
-        historySize?: number;
-        prompt?: string;
-        crlfDelay?: number;
+        history?: string[] | undefined;
+        historySize?: number | undefined;
+        prompt?: string | undefined;
+        crlfDelay?: number | undefined;
         /**
          * If `true`, when a new input line added
          * to the history list duplicates an older one, this removes the older line
          * from the list.
          * @default false
          */
-        removeHistoryDuplicates?: boolean;
-        escapeCodeTimeout?: number;
-        tabSize?: number;
+        removeHistoryDuplicates?: boolean | undefined;
+        escapeCodeTimeout?: number | undefined;
+        tabSize?: number | undefined;
     }
 
     function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -8,24 +8,24 @@ declare module 'repl' {
          * The input prompt to display.
          * @default "> "
          */
-        prompt?: string;
+        prompt?: string | undefined;
         /**
          * The `Readable` stream from which REPL input will be read.
          * @default process.stdin
          */
-        input?: NodeJS.ReadableStream;
+        input?: NodeJS.ReadableStream | undefined;
         /**
          * The `Writable` stream to which REPL output will be written.
          * @default process.stdout
          */
-        output?: NodeJS.WritableStream;
+        output?: NodeJS.WritableStream | undefined;
         /**
          * If `true`, specifies that the output should be treated as a TTY terminal, and have
          * ANSI/VT100 escape codes written to it.
          * Default: checking the value of the `isTTY` property on the output stream upon
          * instantiation.
          */
-        terminal?: boolean;
+        terminal?: boolean | undefined;
         /**
          * The function to be used when evaluating each given line of input.
          * Default: an async wrapper for the JavaScript `eval()` function. An `eval` function can
@@ -35,45 +35,45 @@ declare module 'repl' {
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
-        eval?: REPLEval;
+        eval?: REPLEval | undefined;
         /**
          * Defines if the repl prints output previews or not.
          * @default `true` Always `false` in case `terminal` is falsy.
          */
-        preview?: boolean;
+        preview?: boolean | undefined;
         /**
          * If `true`, specifies that the default `writer` function should include ANSI color
          * styling to REPL output. If a custom `writer` function is provided then this has no
          * effect.
          * Default: the REPL instance's `terminal` value.
          */
-        useColors?: boolean;
+        useColors?: boolean | undefined;
         /**
          * If `true`, specifies that the default evaluation function will use the JavaScript
          * `global` as the context as opposed to creating a new separate context for the REPL
          * instance. The node CLI REPL sets this value to `true`.
          * Default: `false`.
          */
-        useGlobal?: boolean;
+        useGlobal?: boolean | undefined;
         /**
          * If `true`, specifies that the default writer will not output the return value of a
          * command if it evaluates to `undefined`.
          * Default: `false`.
          */
-        ignoreUndefined?: boolean;
+        ignoreUndefined?: boolean | undefined;
         /**
          * The function to invoke to format the output of each command before writing to `output`.
          * Default: a wrapper for `util.inspect`.
          *
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
          */
-        writer?: REPLWriter;
+        writer?: REPLWriter | undefined;
         /**
          * An optional function used for custom Tab auto completion.
          *
          * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
-        completer?: Completer | AsyncCompleter;
+        completer?: Completer | AsyncCompleter | undefined;
         /**
          * A flag that specifies whether the default evaluator executes all JavaScript commands in
          * strict mode or default (sloppy) mode.
@@ -82,13 +82,13 @@ declare module 'repl' {
          * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
          *   prefacing every repl statement with `'use strict'`.
          */
-        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
+        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT | undefined;
         /**
          * Stop evaluating the current piece of code when `SIGINT` is received, i.e. `Ctrl+C` is
          * pressed. This cannot be used together with a custom `eval` function.
          * Default: `false`.
          */
-        breakEvalOnSigint?: boolean;
+        breakEvalOnSigint?: boolean | undefined;
     }
 
     type REPLEval = (this: REPLServer, evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
@@ -106,7 +106,7 @@ declare module 'repl' {
         /**
          * Help text to be displayed when `.help` is entered.
          */
-        help?: string;
+        help?: string | undefined;
         /**
          * The function to execute, optionally accepting a single string argument.
          */

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -3,7 +3,7 @@ declare module 'stream' {
     import * as streamPromises from "stream/promises";
 
     class internal extends EventEmitter {
-        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
     }
 
     namespace internal {
@@ -12,16 +12,16 @@ declare module 'stream' {
         }
 
         interface StreamOptions<T extends Stream> extends Abortable {
-            emitClose?: boolean;
-            highWaterMark?: number;
-            objectMode?: boolean;
+            emitClose?: boolean | undefined;
+            highWaterMark?: number | undefined;
+            objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
             destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
-            autoDestroy?: boolean;
+            autoDestroy?: boolean | undefined;
         }
 
         interface ReadableOptions extends StreamOptions<Readable> {
-            encoding?: BufferEncoding;
+            encoding?: BufferEncoding | undefined;
             read?(this: Readable, size: number): void;
         }
 
@@ -132,8 +132,8 @@ declare module 'stream' {
         }
 
         interface WritableOptions extends StreamOptions<Writable> {
-            decodeStrings?: boolean;
-            defaultEncoding?: BufferEncoding;
+            decodeStrings?: boolean | undefined;
+            defaultEncoding?: BufferEncoding | undefined;
             write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
             writev?(this: Writable, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             final?(this: Writable, callback: (error?: Error | null) => void): void;
@@ -232,12 +232,12 @@ declare module 'stream' {
         }
 
         interface DuplexOptions extends ReadableOptions, WritableOptions {
-            allowHalfOpen?: boolean;
-            readableObjectMode?: boolean;
-            writableObjectMode?: boolean;
-            readableHighWaterMark?: number;
-            writableHighWaterMark?: number;
-            writableCorked?: number;
+            allowHalfOpen?: boolean | undefined;
+            readableObjectMode?: boolean | undefined;
+            writableObjectMode?: boolean | undefined;
+            readableHighWaterMark?: number | undefined;
+            writableHighWaterMark?: number | undefined;
+            writableCorked?: number | undefined;
             construct?(this: Duplex, callback: (error?: Error | null) => void): void;
             read?(this: Duplex, size: number): void;
             write?(this: Duplex, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
@@ -302,9 +302,9 @@ declare module 'stream' {
         function addAbortSignal<T extends Stream>(signal: AbortSignal, stream: T): T;
 
         interface FinishedOptions extends Abortable {
-            error?: boolean;
-            readable?: boolean;
-            writable?: boolean;
+            error?: boolean | undefined;
+            readable?: boolean | undefined;
+            writable?: boolean | undefined;
         }
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -8,7 +8,7 @@ declare module 'timers' {
          * should not require the Node.js event loop to remain active.
          * @default true
          */
-        ref?: boolean;
+        ref?: boolean | undefined;
     }
 
     let setTimeout: typeof global.setTimeout;

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -76,7 +76,7 @@ declare module 'tls' {
         /**
          * The name property is available only when type is 'ECDH'.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * The size of parameter of an ephemeral key exchange.
          */
@@ -91,7 +91,7 @@ declare module 'tls' {
         /**
          * Optional passphrase.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface PxfObject {
@@ -102,7 +102,7 @@ declare module 'tls' {
         /**
          * Optional passphrase.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
@@ -110,22 +110,22 @@ declare module 'tls' {
          * If true the TLS socket will be instantiated in server-mode.
          * Defaults to false.
          */
-        isServer?: boolean;
+        isServer?: boolean | undefined;
         /**
          * An optional net.Server instance.
          */
-        server?: net.Server;
+        server?: net.Server | undefined;
 
         /**
          * An optional Buffer instance containing a TLS session.
          */
-        session?: Buffer;
+        session?: Buffer | undefined;
         /**
          * If true, specifies that the OCSP status request extension will be
          * added to the client hello and an 'OCSPResponse' event will be
          * emitted on the socket before establishing a secure communication
          */
-        requestOCSP?: boolean;
+        requestOCSP?: boolean | undefined;
     }
 
     class TLSSocket extends net.Socket {
@@ -153,7 +153,7 @@ declare module 'tls' {
          * String containing the selected ALPN protocol.
          * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string;
+        alpnProtocol?: string | undefined;
 
         /**
          * Returns an object representing the local certificate. The returned
@@ -265,7 +265,7 @@ declare module 'tls' {
          * is successfully completed.
          * @return `undefined` when socket is destroy, `false` if negotiaion can't be initiated.
          */
-        renegotiate(options: { rejectUnauthorized?: boolean, requestCert?: boolean }, callback: (err: Error | null) => void): undefined | boolean;
+        renegotiate(options: { rejectUnauthorized?: boolean | undefined, requestCert?: boolean | undefined }, callback: (err: Error | null) => void): undefined | boolean;
         /**
          * Set maximum TLS fragment size (default and maximum value is: 16384, minimum is: 512).
          * Smaller fragment size decreases buffering latency on the client: large fragments are buffered by
@@ -355,25 +355,25 @@ declare module 'tls' {
         /**
          * An optional TLS context object from tls.createSecureContext()
          */
-        secureContext?: SecureContext;
+        secureContext?: SecureContext | undefined;
 
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false
          */
-        enableTrace?: boolean;
+        enableTrace?: boolean | undefined;
         /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
-        requestCert?: boolean;
+        requestCert?: boolean | undefined;
         /**
          * An array of strings or a Buffer naming possible ALPN protocols.
          * (Protocols should be ordered by their priority.)
          */
-        ALPNProtocols?: string[] | Uint8Array[] | Uint8Array;
+        ALPNProtocols?: string[] | Uint8Array[] | Uint8Array | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments
@@ -383,14 +383,14 @@ declare module 'tls' {
          * SecureContext.) If SNICallback wasn't provided the default callback
          * with high-level API will be used (see below).
          */
-        SNICallback?: (servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void;
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void) | undefined;
         /**
          * If true the server will reject any connection which is not
          * authorized with the list of supplied CAs. This option only has an
          * effect if requestCert is true.
          * @default true
          */
-        rejectUnauthorized?: boolean;
+        rejectUnauthorized?: boolean | undefined;
     }
 
     interface TlsOptions extends SecureContextOptions, CommonConnectionOptions, net.ServerOpts {
@@ -400,17 +400,17 @@ declare module 'tls' {
          * the tls.Server object whenever a handshake times out. Default:
          * 120000 (120 seconds).
          */
-        handshakeTimeout?: number;
+        handshakeTimeout?: number | undefined;
         /**
          * The number of seconds after which a TLS session created by the
          * server will no longer be resumable. See Session Resumption for more
          * information. Default: 300.
          */
-        sessionTimeout?: number;
+        sessionTimeout?: number | undefined;
         /**
          * 48-bytes of cryptographically strong pseudo-random data.
          */
-        ticketKeys?: Buffer;
+        ticketKeys?: Buffer | undefined;
 
         /**
          *
@@ -439,7 +439,7 @@ declare module 'tls' {
          * in TLS 1.3. Upon failing to set pskIdentityHint `tlsClientError` will be
          * emitted with `ERR_TLS_PSK_SET_IDENTIY_HINT_FAILED` code.
          */
-        pskIdentityHint?: string;
+        pskIdentityHint?: string | undefined;
     }
 
     interface PSKCallbackNegotation {
@@ -448,16 +448,16 @@ declare module 'tls' {
     }
 
     interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
-        host?: string;
-        port?: number;
-        path?: string; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
-        socket?: net.Socket; // Establish secure connection on a given socket rather than creating a new socket
-        checkServerIdentity?: typeof checkServerIdentity;
-        servername?: string; // SNI TLS Extension
-        session?: Buffer;
-        minDHSize?: number;
-        lookup?: net.LookupFunction;
-        timeout?: number;
+        host?: string | undefined;
+        port?: number | undefined;
+        path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
+        socket?: net.Socket | undefined; // Establish secure connection on a given socket rather than creating a new socket
+        checkServerIdentity?: typeof checkServerIdentity | undefined;
+        servername?: string | undefined; // SNI TLS Extension
+        session?: Buffer | undefined;
+        minDHSize?: number | undefined;
+        lookup?: net.LookupFunction | undefined;
+        timeout?: number | undefined;
         /**
          * When negotiating TLS-PSK (pre-shared keys), this function is called
          * with optional identity `hint` provided by the server or `null`
@@ -580,7 +580,7 @@ declare module 'tls' {
          * the well-known CAs curated by Mozilla. Mozilla's CAs are completely
          * replaced when CAs are explicitly specified using this option.
          */
-        ca?: string | Buffer | Array<string | Buffer>;
+        ca?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          *  Cert chains in PEM format. One cert chain should be provided per
          *  private key. Each cert chain should consist of the PEM formatted
@@ -592,29 +592,29 @@ declare module 'tls' {
          *  intermediate certificates are not provided, the peer will not be
          *  able to validate the certificate, and the handshake will fail.
          */
-        cert?: string | Buffer | Array<string | Buffer>;
+        cert?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          *  Colon-separated list of supported signature algorithms. The list
          *  can contain digest algorithms (SHA256, MD5 etc.), public key
          *  algorithms (RSA-PSS, ECDSA etc.), combination of both (e.g
          *  'RSA+SHA384') or TLS v1.3 scheme names (e.g. rsa_pss_pss_sha512).
          */
-        sigalgs?: string;
+        sigalgs?: string | undefined;
         /**
          * Cipher suite specification, replacing the default. For more
          * information, see modifying the default cipher suite. Permitted
          * ciphers can be obtained via tls.getCiphers(). Cipher names must be
          * uppercased in order for OpenSSL to accept them.
          */
-        ciphers?: string;
+        ciphers?: string | undefined;
         /**
          * Name of an OpenSSL engine which can provide the client certificate.
          */
-        clientCertEngine?: string;
+        clientCertEngine?: string | undefined;
         /**
          * PEM formatted CRLs (Certificate Revocation Lists).
          */
-        crl?: string | Buffer | Array<string | Buffer>;
+        crl?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          * Diffie Hellman parameters, required for Perfect Forward Secrecy. Use
          * openssl dhparam to create the parameters. The key length must be
@@ -623,7 +623,7 @@ declare module 'tls' {
          * stronger security. If omitted or invalid, the parameters are
          * silently discarded and DHE ciphers will not be available.
          */
-        dhparam?: string | Buffer;
+        dhparam?: string | Buffer | undefined;
         /**
          * A string describing a named curve or a colon separated list of curve
          * NIDs or names, for example P-521:P-384:P-256, to use for ECDH key
@@ -633,13 +633,13 @@ declare module 'tls' {
          * name and description of each available elliptic curve. Default:
          * tls.DEFAULT_ECDH_CURVE.
          */
-        ecdhCurve?: string;
+        ecdhCurve?: string | undefined;
         /**
          * Attempt to use the server's cipher suite preferences instead of the
          * client's. When true, causes SSL_OP_CIPHER_SERVER_PREFERENCE to be
          * set in secureOptions
          */
-        honorCipherOrder?: boolean;
+        honorCipherOrder?: boolean | undefined;
         /**
          * Private keys in PEM format. PEM allows the option of private keys
          * being encrypted. Encrypted keys will be decrypted with
@@ -650,18 +650,18 @@ declare module 'tls' {
          * object.passphrase is optional. Encrypted keys will be decrypted with
          * object.passphrase if provided, or options.passphrase if it is not.
          */
-        key?: string | Buffer | Array<Buffer | KeyObject>;
+        key?: string | Buffer | Array<Buffer | KeyObject> | undefined;
         /**
          * Name of an OpenSSL engine to get private key from. Should be used
          * together with privateKeyIdentifier.
          */
-        privateKeyEngine?: string;
+        privateKeyEngine?: string | undefined;
         /**
          * Identifier of a private key managed by an OpenSSL engine. Should be
          * used together with privateKeyEngine. Should not be set together with
          * key, because both options define a private key in different ways.
          */
-        privateKeyIdentifier?: string;
+        privateKeyIdentifier?: string | undefined;
         /**
          * Optionally set the maximum TLS version to allow. One
          * of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
@@ -670,7 +670,7 @@ declare module 'tls' {
          * `--tls-max-v1.2` sets the default to `'TLSv1.2'`. Using `--tls-max-v1.3` sets the default to
          * `'TLSv1.3'`. If multiple of the options are provided, the highest maximum is used.
          */
-        maxVersion?: SecureVersion;
+        maxVersion?: SecureVersion | undefined;
         /**
          * Optionally set the minimum TLS version to allow. One
          * of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
@@ -681,11 +681,11 @@ declare module 'tls' {
          * `'TLSv1.1'`. Using `--tls-min-v1.3` sets the default to
          * 'TLSv1.3'. If multiple of the options are provided, the lowest minimum is used.
          */
-        minVersion?: SecureVersion;
+        minVersion?: SecureVersion | undefined;
         /**
          * Shared passphrase used for a single private key and/or a PFX.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
         /**
          * PFX or PKCS12 encoded private key and certificate chain. pfx is an
          * alternative to providing key and cert individually. PFX is usually
@@ -696,13 +696,13 @@ declare module 'tls' {
          * object.passphrase is optional. Encrypted PFX will be decrypted with
          * object.passphrase if provided, or options.passphrase if it is not.
          */
-        pfx?: string | Buffer | Array<string | Buffer | PxfObject>;
+        pfx?: string | Buffer | Array<string | Buffer | PxfObject> | undefined;
         /**
          * Optionally affect the OpenSSL protocol behavior, which is not
          * usually necessary. This should be used carefully if at all! Value is
          * a numeric bitmask of the SSL_OP_* options from OpenSSL Options
          */
-        secureOptions?: number; // Value is a numeric bitmask of the `SSL_OP_*` options
+        secureOptions?: number | undefined; // Value is a numeric bitmask of the `SSL_OP_*` options
         /**
          * Legacy mechanism to select the TLS protocol version to use, it does
          * not support independent control of the minimum and maximum version,
@@ -714,23 +714,23 @@ declare module 'tls' {
          * TLS versions less than 1.2, but it may be required for
          * interoperability. Default: none, see minVersion.
          */
-        secureProtocol?: string;
+        secureProtocol?: string | undefined;
         /**
          * Opaque identifier used by servers to ensure session state is not
          * shared between applications. Unused by clients.
          */
-        sessionIdContext?: string;
+        sessionIdContext?: string | undefined;
         /**
          * 48-bytes of cryptographically strong pseudo-random data.
          * See Session Resumption for more information.
          */
-        ticketKeys?: Buffer;
+        ticketKeys?: Buffer | undefined;
         /**
          * The number of seconds after which a TLS session created by the
          * server will no longer be resumable. See Session Resumption for more
          * information. Default: 300.
          */
-        sessionTimeout?: number;
+        sessionTimeout?: number | undefined;
     }
 
     interface SecureContext {

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -3,17 +3,17 @@ declare module 'url' {
 
     // Input to `url.format`
     interface UrlObject {
-        auth?: string | null;
-        hash?: string | null;
-        host?: string | null;
-        hostname?: string | null;
-        href?: string | null;
-        pathname?: string | null;
-        protocol?: string | null;
-        search?: string | null;
-        slashes?: boolean | null;
-        port?: string | number | null;
-        query?: string | null | ParsedUrlQueryInput;
+        auth?: string | null | undefined;
+        hash?: string | null | undefined;
+        host?: string | null | undefined;
+        hostname?: string | null | undefined;
+        href?: string | null | undefined;
+        pathname?: string | null | undefined;
+        protocol?: string | null | undefined;
+        search?: string | null | undefined;
+        slashes?: boolean | null | undefined;
+        port?: string | number | null | undefined;
+        query?: string | null | ParsedUrlQueryInput | undefined;
     }
 
     // Output of `url.parse`
@@ -73,10 +73,10 @@ declare module 'url' {
     function pathToFileURL(url: string): URL;
 
     interface URLFormatOptions {
-        auth?: boolean;
-        fragment?: boolean;
-        search?: boolean;
-        unicode?: boolean;
+        auth?: boolean | undefined;
+        fragment?: boolean | undefined;
+        search?: boolean | undefined;
+        unicode?: boolean | undefined;
     }
 
     class URL {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -10,24 +10,24 @@ declare module 'util' {
          * the getter function.
          * @default `false`
          */
-        getters?: 'get' | 'set' | boolean;
-        showHidden?: boolean;
+        getters?: 'get' | 'set' | boolean | undefined;
+        showHidden?: boolean | undefined;
         /**
          * @default 2
          */
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-        showProxy?: boolean;
-        maxArrayLength?: number | null;
+        depth?: number | null | undefined;
+        colors?: boolean | undefined;
+        customInspect?: boolean | undefined;
+        showProxy?: boolean | undefined;
+        maxArrayLength?: number | null | undefined;
         /**
          * Specifies the maximum number of characters to
          * include when formatting. Set to `null` or `Infinity` to show all elements.
          * Set to `0` or negative to show no characters.
          * @default 10000
          */
-        maxStringLength?: number | null;
-        breakLength?: number;
+        maxStringLength?: number | null | undefined;
+        breakLength?: number | undefined;
         /**
          * Setting this to `false` causes each object key
          * to be displayed on a new line. It will also add new lines to text that is
@@ -38,8 +38,8 @@ declare module 'util' {
          * For more information, see the example below.
          * @default `true`
          */
-        compact?: boolean | number;
-        sorted?: boolean | ((a: string, b: string) => number);
+        compact?: boolean | number | undefined;
+        sorted?: boolean | ((a: string, b: string) => number) | undefined;
     }
 
     export type Style = 'special' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null' | 'string' | 'symbol' | 'date' | 'regexp' | 'module';
@@ -168,11 +168,11 @@ declare module 'util' {
         readonly ignoreBOM: boolean;
         constructor(
           encoding?: string,
-          options?: { fatal?: boolean; ignoreBOM?: boolean }
+          options?: { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined }
         );
         decode(
           input?: NodeJS.ArrayBufferView | ArrayBuffer | null,
-          options?: { stream?: boolean }
+          options?: { stream?: boolean | undefined }
         ): string;
     }
 

--- a/types/node/v12/assert.d.ts
+++ b/types/node/v12/assert.d.ts
@@ -11,12 +11,12 @@ declare module 'assert' {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string;
+                message?: string | undefined;
                 actual?: any;
                 expected?: any;
-                operator?: string;
+                operator?: string | undefined;
                 // tslint:disable-next-line:ban-types
-                stackStartFn?: Function;
+                stackStartFn?: Function | undefined;
             });
         }
 

--- a/types/node/v12/async_hooks.d.ts
+++ b/types/node/v12/async_hooks.d.ts
@@ -87,7 +87,7 @@ declare module 'async_hooks' {
        * The ID of the execution context that created this async event.
        * @default executionAsyncId()
        */
-      triggerAsyncId?: number;
+      triggerAsyncId?: number | undefined;
 
       /**
        * Disables automatic `emitDestroy` when the object is garbage collected.
@@ -96,7 +96,7 @@ declare module 'async_hooks' {
        * sensitive API's `emitDestroy` is called with it.
        * @default false
        */
-      requireManualDestroy?: boolean;
+      requireManualDestroy?: boolean | undefined;
     }
 
     /**

--- a/types/node/v12/child_process.d.ts
+++ b/types/node/v12/child_process.d.ts
@@ -7,7 +7,7 @@ declare module 'child_process' {
         stdin: Writable | null;
         stdout: Readable | null;
         stderr: Readable | null;
-        readonly channel?: Pipe | null;
+        readonly channel?: Pipe | null | undefined;
         readonly stdio: [
             Writable | null, // stdin
             Readable | null, // stdout
@@ -115,39 +115,39 @@ declare module 'child_process' {
     }
 
     interface MessageOptions {
-        keepOpen?: boolean;
+        keepOpen?: boolean | undefined;
     }
 
     type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | "inherit" | Stream | number | null | undefined)>;
 
     interface ProcessEnvOptions {
-        uid?: number;
-        gid?: number;
-        cwd?: string;
-        env?: NodeJS.ProcessEnv;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        cwd?: string | undefined;
+        env?: NodeJS.ProcessEnv | undefined;
     }
 
     interface CommonOptions extends ProcessEnvOptions {
         /**
          * @default true
          */
-        windowsHide?: boolean;
+        windowsHide?: boolean | undefined;
         /**
          * @default 0
          */
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     interface SpawnOptions extends CommonOptions {
-        argv0?: string;
-        stdio?: StdioOptions;
-        detached?: boolean;
-        shell?: boolean | string;
-        windowsVerbatimArguments?: boolean;
+        argv0?: string | undefined;
+        stdio?: StdioOptions | undefined;
+        detached?: boolean | undefined;
+        shell?: boolean | string | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
 
     interface SpawnOptionsWithoutStdio extends SpawnOptions {
-        stdio?: 'pipe' | Array<null | undefined | 'pipe'>;
+        stdio?: 'pipe' | Array<null | undefined | 'pipe'> | undefined;
     }
 
     type StdioNull = 'inherit' | 'ignore' | Stream;
@@ -246,9 +246,9 @@ declare module 'child_process' {
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {
-        shell?: string;
-        maxBuffer?: number;
-        killSignal?: NodeJS.Signals | number;
+        shell?: string | undefined;
+        maxBuffer?: number | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
     }
 
     interface ExecOptionsWithStringEncoding extends ExecOptions {
@@ -260,10 +260,10 @@ declare module 'child_process' {
     }
 
     interface ExecException extends Error {
-        cmd?: string;
-        killed?: boolean;
-        code?: number;
-        signal?: NodeJS.Signals;
+        cmd?: string | undefined;
+        killed?: boolean | undefined;
+        code?: number | undefined;
+        signal?: NodeJS.Signals | undefined;
     }
 
     // no `options` definitely means stdout/stderr are `string`.
@@ -285,7 +285,7 @@ declare module 'child_process' {
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function exec(
         command: string,
-        options: ({ encoding?: string | null } & ExecOptions) | undefined | null,
+        options: ({ encoding?: string | null | undefined } & ExecOptions) | undefined | null,
         callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
 
@@ -299,14 +299,14 @@ declare module 'child_process' {
         function __promisify__(command: string, options: { encoding: "buffer" | null } & ExecOptions): PromiseWithChild<{ stdout: Buffer, stderr: Buffer }>;
         function __promisify__(command: string, options: { encoding: BufferEncoding } & ExecOptions): PromiseWithChild<{ stdout: string, stderr: string }>;
         function __promisify__(command: string, options: ExecOptions): PromiseWithChild<{ stdout: string, stderr: string }>;
-        function __promisify__(command: string, options?: ({ encoding?: string | null } & ExecOptions) | null): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(command: string, options?: ({ encoding?: string | null | undefined } & ExecOptions) | null): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
     interface ExecFileOptions extends CommonOptions {
-        maxBuffer?: number;
-        killSignal?: NodeJS.Signals | number;
-        windowsVerbatimArguments?: boolean;
-        shell?: boolean | string;
+        maxBuffer?: number | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
+        shell?: boolean | string | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
@@ -319,9 +319,9 @@ declare module 'child_process' {
     }
 
     function execFile(file: string): ChildProcess;
-    function execFile(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
+    function execFile(file: string, options: ({ encoding?: string | null | undefined } & ExecFileOptions) | undefined | null): ChildProcess;
     function execFile(file: string, args?: ReadonlyArray<string> | null): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null | undefined } & ExecFileOptions) | undefined | null): ChildProcess;
 
     // no `options` definitely means stdout/stderr are `string`.
     function execFile(file: string, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
@@ -371,13 +371,13 @@ declare module 'child_process' {
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
-        options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        options: ({ encoding?: string | null | undefined } & ExecFileOptions) | undefined | null,
         callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
-        options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        options: ({ encoding?: string | null | undefined } & ExecFileOptions) | undefined | null,
         callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
 
@@ -397,34 +397,37 @@ declare module 'child_process' {
         ): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
         function __promisify__(file: string, options: ExecFileOptions): PromiseWithChild<{ stdout: string, stderr: string }>;
         function __promisify__(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptions): PromiseWithChild<{ stdout: string, stderr: string }>;
-        function __promisify__(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(
+            file: string,
+            options: ({ encoding?: string | null | undefined } & ExecFileOptions) | undefined | null
+        ): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
         function __promisify__(
             file: string,
             args: ReadonlyArray<string> | undefined | null,
-            options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+            options: ({ encoding?: string | null | undefined } & ExecFileOptions) | undefined | null,
         ): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
     interface ForkOptions extends ProcessEnvOptions {
-        execPath?: string;
-        execArgv?: string[];
-        silent?: boolean;
-        stdio?: StdioOptions;
-        detached?: boolean;
-        windowsVerbatimArguments?: boolean;
+        execPath?: string | undefined;
+        execArgv?: string[] | undefined;
+        silent?: boolean | undefined;
+        stdio?: StdioOptions | undefined;
+        detached?: boolean | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
     function fork(modulePath: string, options?: ForkOptions): ChildProcess;
     function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
     interface SpawnSyncOptions extends CommonOptions {
-        argv0?: string; // Not specified in the docs
-        input?: string | NodeJS.ArrayBufferView;
-        stdio?: StdioOptions;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: string;
-        shell?: boolean | string;
-        windowsVerbatimArguments?: boolean;
+        argv0?: string | undefined; // Not specified in the docs
+        input?: string | NodeJS.ArrayBufferView | undefined;
+        stdio?: StdioOptions | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: string | undefined;
+        shell?: boolean | string | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
     interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
@@ -439,7 +442,7 @@ declare module 'child_process' {
         stderr: T;
         status: number | null;
         signal: NodeJS.Signals | null;
-        error?: Error;
+        error?: Error | undefined;
     }
     function spawnSync(command: string): SpawnSyncReturns<Buffer>;
     function spawnSync(command: string, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
@@ -450,12 +453,12 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
 
     interface ExecSyncOptions extends CommonOptions {
-        input?: string | Uint8Array;
-        stdio?: StdioOptions;
-        shell?: string;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: string;
+        input?: string | Uint8Array | undefined;
+        stdio?: StdioOptions | undefined;
+        shell?: string | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: string | undefined;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;
@@ -469,12 +472,12 @@ declare module 'child_process' {
     function execSync(command: string, options?: ExecSyncOptions): Buffer;
 
     interface ExecFileSyncOptions extends CommonOptions {
-        input?: string | NodeJS.ArrayBufferView;
-        stdio?: StdioOptions;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: string;
-        shell?: boolean | string;
+        input?: string | NodeJS.ArrayBufferView | undefined;
+        stdio?: StdioOptions | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: string | undefined;
+        shell?: boolean | string | undefined;
     }
     interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
         encoding: BufferEncoding;

--- a/types/node/v12/cluster.d.ts
+++ b/types/node/v12/cluster.d.ts
@@ -5,14 +5,14 @@ declare module 'cluster' {
 
     // interfaces
     interface ClusterSettings {
-        execArgv?: string[]; // default: process.execArgv
-        exec?: string;
-        args?: string[];
-        silent?: boolean;
-        stdio?: any[];
-        uid?: number;
-        gid?: number;
-        inspectPort?: number | (() => number);
+        execArgv?: string[] | undefined; // default: process.execArgv
+        exec?: string | undefined;
+        args?: string[] | undefined;
+        silent?: boolean | undefined;
+        stdio?: any[] | undefined;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        inspectPort?: number | (() => number) | undefined;
     }
 
     interface Address {
@@ -99,10 +99,10 @@ declare module 'cluster' {
         // TODO: cluster.schedulingPolicy
         settings: ClusterSettings;
         setupMaster(settings?: ClusterSettings): void;
-        worker?: Worker;
+        worker?: Worker | undefined;
         workers?: {
             [index: string]: Worker | undefined
-        };
+        } | undefined;
 
         /**
          * events.EventEmitter

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -112,7 +112,7 @@ declare module 'crypto' {
          * For XOF hash functions such as `shake256`, the
          * outputLength option can be used to specify the desired output length in bytes.
          */
-        outputLength?: number;
+        outputLength?: number | undefined;
     }
 
     /** @deprecated since v10.0.0 */
@@ -147,21 +147,21 @@ declare module 'crypto' {
     interface KeyExportOptions<T extends KeyFormat> {
         type: 'pkcs1' | 'spki' | 'pkcs8' | 'sec1';
         format: T;
-        cipher?: string;
-        passphrase?: string | Buffer;
+        cipher?: string | undefined;
+        passphrase?: string | Buffer | undefined;
     }
 
     class KeyObject {
         private constructor();
-        asymmetricKeyType?: KeyType;
+        asymmetricKeyType?: KeyType | undefined;
         /**
          * For asymmetric keys, this property represents the size of the embedded key in
          * bytes. This property is `undefined` for symmetric keys.
          */
-        asymmetricKeySize?: number;
+        asymmetricKeySize?: number | undefined;
         export(options: KeyExportOptions<'pem'>): string | Buffer;
         export(options?: KeyExportOptions<'der'>): Buffer;
-        symmetricKeySize?: number;
+        symmetricKeySize?: number | undefined;
         type: KeyObjectType;
     }
 
@@ -176,7 +176,7 @@ declare module 'crypto' {
         authTagLength: number;
     }
     interface CipherGCMOptions extends stream.TransformOptions {
-        authTagLength?: number;
+        authTagLength?: number | undefined;
     }
     /** @deprecated since v10.0.0 use createCipheriv() */
     function createCipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): CipherCCM;
@@ -289,15 +289,15 @@ declare module 'crypto' {
 
     interface PrivateKeyInput {
         key: string | Buffer;
-        format?: KeyFormat;
-        type?: 'pkcs1' | 'pkcs8' | 'sec1';
-        passphrase?: string | Buffer;
+        format?: KeyFormat | undefined;
+        type?: 'pkcs1' | 'pkcs8' | 'sec1' | undefined;
+        passphrase?: string | Buffer | undefined;
     }
 
     interface PublicKeyInput {
         key: string | Buffer;
-        format?: KeyFormat;
-        type?: 'pkcs1' | 'spki';
+        format?: KeyFormat | undefined;
+        type?: 'pkcs1' | 'spki' | undefined;
     }
 
     function createPrivateKey(key: PrivateKeyInput | string | Buffer): KeyObject;
@@ -312,9 +312,9 @@ declare module 'crypto' {
         /**
          * @See crypto.constants.RSA_PKCS1_PADDING
          */
-        padding?: number;
-        saltLength?: number;
-        dsaEncoding?: DSAEncoding;
+        padding?: number | undefined;
+        saltLength?: number | undefined;
+        dsaEncoding?: DSAEncoding | undefined;
     }
 
     interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {}
@@ -443,13 +443,13 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
-        cost?: number;
-        blockSize?: number;
-        parallelization?: number;
-        N?: number;
-        r?: number;
-        p?: number;
-        maxmem?: number;
+        cost?: number | undefined;
+        blockSize?: number | undefined;
+        parallelization?: number | undefined;
+        N?: number | undefined;
+        r?: number | undefined;
+        p?: number | undefined;
+        maxmem?: number | undefined;
     }
     function scrypt(
         password: BinaryLike,
@@ -468,17 +468,17 @@ declare module 'crypto' {
 
     interface RsaPublicKey {
         key: KeyLike;
-        padding?: number;
+        padding?: number | undefined;
     }
     interface RsaPrivateKey {
         key: KeyLike;
-        passphrase?: string;
+        passphrase?: string | undefined;
         /**
          * @default 'sha1'
          */
-        oaepHash?: string;
-        oaepLabel?: NodeJS.TypedArray;
-        padding?: number;
+        oaepHash?: string | undefined;
+        oaepLabel?: NodeJS.TypedArray | undefined;
+        padding?: number | undefined;
     }
     function publicEncrypt(key: RsaPublicKey | RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     function publicDecrypt(key: RsaPublicKey | RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
@@ -524,8 +524,8 @@ declare module 'crypto' {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        cipher?: string;
-        passphrase?: string;
+        cipher?: string | undefined;
+        passphrase?: string | undefined;
     }
 
     interface KeyPairKeyObjectResult {
@@ -573,7 +573,7 @@ declare module 'crypto' {
         /**
          * @default 0x10001
          */
-        publicExponent?: number;
+        publicExponent?: number | undefined;
     }
 
     interface DSAKeyPairKeyObjectOptions {
@@ -596,7 +596,7 @@ declare module 'crypto' {
         /**
          * @default 0x10001
          */
-        publicExponent?: number;
+        publicExponent?: number | undefined;
 
         publicKeyEncoding: {
             type: 'pkcs1' | 'spki';

--- a/types/node/v12/dgram.d.ts
+++ b/types/node/v12/dgram.d.ts
@@ -11,24 +11,24 @@ declare module 'dgram' {
     }
 
     interface BindOptions {
-        port?: number;
-        address?: string;
-        exclusive?: boolean;
-        fd?: number;
+        port?: number | undefined;
+        address?: string | undefined;
+        exclusive?: boolean | undefined;
+        fd?: number | undefined;
     }
 
     type SocketType = "udp4" | "udp6";
 
     interface SocketOptions {
         type: SocketType;
-        reuseAddr?: boolean;
+        reuseAddr?: boolean | undefined;
         /**
          * @default false
          */
-        ipv6Only?: boolean;
-        recvBufferSize?: number;
-        sendBufferSize?: number;
-        lookup?: (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
+        ipv6Only?: boolean | undefined;
+        recvBufferSize?: number | undefined;
+        sendBufferSize?: number | undefined;
+        lookup?: ((hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void) | undefined;
     }
 
     function createSocket(type: SocketType, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;

--- a/types/node/v12/dns.d.ts
+++ b/types/node/v12/dns.d.ts
@@ -4,14 +4,14 @@ declare module 'dns' {
     const V4MAPPED: number;
 
     interface LookupOptions {
-        family?: number;
-        hints?: number;
-        all?: boolean;
-        verbatim?: boolean;
+        family?: number | undefined;
+        hints?: number | undefined;
+        all?: boolean | undefined;
+        verbatim?: boolean | undefined;
     }
 
     interface LookupOneOptions extends LookupOptions {
-        all?: false;
+        all?: false | undefined;
     }
 
     interface LookupAllOptions extends LookupOptions {
@@ -272,7 +272,7 @@ declare module 'dns' {
     const CANCELLED: string;
 
     interface ResolverOptions {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     class Resolver {

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -456,7 +456,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function stat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     function stat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -466,7 +466,7 @@ declare module 'fs' {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -475,7 +475,7 @@ declare module 'fs' {
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
+    function statSync(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Stats;
     function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function statSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
@@ -485,7 +485,7 @@ declare module 'fs' {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(fd: number, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(fd: number, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -494,7 +494,7 @@ declare module 'fs' {
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
+    function fstatSync(fd: number, options?: StatOptions & { bigint?: false | undefined }): Stats;
     function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
     function fstatSync(fd: number, options?: StatOptions): Stats | BigIntStats;
 
@@ -503,7 +503,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function lstat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     function lstat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -513,7 +513,7 @@ declare module 'fs' {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -522,7 +522,7 @@ declare module 'fs' {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
+    function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Stats;
     function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function lstatSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
@@ -596,7 +596,7 @@ declare module 'fs' {
      */
     function readlink(
         path: PathLike,
-        options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null,
+        options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, linkString: string) => void
     ): void;
 
@@ -612,7 +612,11 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlink(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException | null, linkString: string | Buffer) => void): void;
+    function readlink(
+        path: PathLike,
+        options: { encoding?: string | null | undefined } | string | undefined | null,
+        callback: (err: NodeJS.ErrnoException | null, linkString: string | Buffer) => void
+    ): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
@@ -627,7 +631,7 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
@@ -641,7 +645,7 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -649,7 +653,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlinkSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function readlinkSync(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): string;
 
     /**
      * Synchronous readlink(2) - read value of a symbolic link.
@@ -663,7 +667,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlinkSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function readlinkSync(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): string | Buffer;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
@@ -672,7 +676,7 @@ declare module 'fs' {
      */
     function realpath(
         path: PathLike,
-        options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null,
+        options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, resolvedPath: string) => void
     ): void;
 
@@ -688,7 +692,11 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpath(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException | null, resolvedPath: string | Buffer) => void): void;
+    function realpath(
+        path: PathLike,
+        options: { encoding?: string | null | undefined } | string | undefined | null,
+        callback: (err: NodeJS.ErrnoException | null, resolvedPath: string | Buffer) => void
+    ): void;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
@@ -703,7 +711,7 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
@@ -717,15 +725,19 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): Promise<string | Buffer>;
 
         function native(
             path: PathLike,
-            options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null,
+            options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | undefined | null,
             callback: (err: NodeJS.ErrnoException | null, resolvedPath: string) => void
         ): void;
         function native(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException | null, resolvedPath: Buffer) => void): void;
-        function native(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException | null, resolvedPath: string | Buffer) => void): void;
+        function native(
+            path: PathLike,
+            options: { encoding?: string | null | undefined } | string | undefined | null,
+            callback: (err: NodeJS.ErrnoException | null, resolvedPath: string | Buffer) => void
+        ): void;
         function native(path: PathLike, callback: (err: NodeJS.ErrnoException | null, resolvedPath: string) => void): void;
     }
 
@@ -734,7 +746,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpathSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function realpathSync(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): string;
 
     /**
      * Synchronous realpath(3) - return the canonicalized absolute pathname.
@@ -748,12 +760,12 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpathSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function realpathSync(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): string | Buffer;
 
     namespace realpathSync {
-        function native(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+        function native(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): string;
         function native(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
-        function native(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+        function native(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): string | Buffer;
     }
 
     /**
@@ -785,7 +797,7 @@ declare module 'fs' {
          * option is ignored if the `recursive` option is not `true`.
          * @default 3
          */
-        maxRetries?: number;
+        maxRetries?: number | undefined;
         /**
          * If `true`, perform a recursive directory removal. In
          * recursive mode, errors are not reported if `path` does not exist, and
@@ -793,7 +805,7 @@ declare module 'fs' {
          * @experimental
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * If an `EMFILE` error is encountered, Node.js will
          * retry the operation with a linear backoff of 1ms longer on each try until the
@@ -801,7 +813,7 @@ declare module 'fs' {
          * option is not `true`.
          * @default 1000
          */
-        emfileWait?: number;
+        emfileWait?: number | undefined;
     }
 
     /**
@@ -831,12 +843,12 @@ declare module 'fs' {
          * Indicates whether parent folders should be created.
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * A file mode. If a string is passed, it is parsed as an octal integer. If not specified
          * @default 0o777.
          */
-        mode?: number | string;
+        mode?: number | string | undefined;
     }
 
     /**
@@ -877,7 +889,11 @@ declare module 'fs' {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtemp(prefix: string, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException | null, folder: string) => void): void;
+    function mkdtemp(
+        prefix: string,
+        options: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | undefined | null,
+        callback: (err: NodeJS.ErrnoException | null, folder: string) => void
+    ): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
@@ -891,7 +907,11 @@ declare module 'fs' {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtemp(prefix: string, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException | null, folder: string | Buffer) => void): void;
+    function mkdtemp(
+        prefix: string,
+        options: { encoding?: string | null | undefined } | string | undefined | null,
+        callback: (err: NodeJS.ErrnoException | null, folder: string | Buffer) => void
+    ): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
@@ -906,7 +926,7 @@ declare module 'fs' {
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(prefix: string, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronously creates a unique temporary directory.
@@ -920,7 +940,7 @@ declare module 'fs' {
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(prefix: string, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(prefix: string, options?: { encoding?: string | null | undefined } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -928,7 +948,7 @@ declare module 'fs' {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtempSync(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function mkdtempSync(prefix: string, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): string;
 
     /**
      * Synchronously creates a unique temporary directory.
@@ -942,7 +962,7 @@ declare module 'fs' {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtempSync(prefix: string, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function mkdtempSync(prefix: string, options?: { encoding?: string | null | undefined } | string | null): string | Buffer;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -951,7 +971,7 @@ declare module 'fs' {
      */
     function readdir(
         path: PathLike,
-        options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | undefined | null,
+        options: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, files: string[]) => void,
     ): void;
 
@@ -960,7 +980,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer", callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void): void;
+    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer", callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -969,7 +989,7 @@ declare module 'fs' {
      */
     function readdir(
         path: PathLike,
-        options: { encoding?: string | null; withFileTypes?: false } | string | undefined | null,
+        options: { encoding?: string | null | undefined; withFileTypes?: false | undefined } | string | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, files: string[] | Buffer[]) => void,
     ): void;
 
@@ -984,7 +1004,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
      */
-    function readdir(path: PathLike, options: { encoding?: string | null; withFileTypes: true }, callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void): void;
+    function readdir(path: PathLike, options: { encoding?: string | null | undefined; withFileTypes: true }, callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace readdir {
@@ -993,28 +1013,28 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false }): Promise<Buffer[]>;
+        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false | undefined }): Promise<Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): Promise<string[] | Buffer[]>;
+        function __promisify__(path: PathLike, options?: { encoding?: string | null | undefined; withFileTypes?: false | undefined } | string | null): Promise<string[] | Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options If called with `withFileTypes: true` the result data will be an array of Dirent
          */
-        function __promisify__(path: PathLike, options: { encoding?: string | null; withFileTypes: true }): Promise<Dirent[]>;
+        function __promisify__(path: PathLike, options: { encoding?: string | null | undefined; withFileTypes: true }): Promise<Dirent[]>;
     }
 
     /**
@@ -1022,28 +1042,28 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): string[];
+    function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): string[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Buffer[];
+    function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer"): Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdirSync(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): string[] | Buffer[];
+    function readdirSync(path: PathLike, options?: { encoding?: string | null | undefined; withFileTypes?: false | undefined } | string | null): string[] | Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
      */
-    function readdirSync(path: PathLike, options: { encoding?: string | null; withFileTypes: true }): Dirent[];
+    function readdirSync(path: PathLike, options: { encoding?: string | null | undefined; withFileTypes: true }): Dirent[];
 
     /**
      * Asynchronous close(2) - close a file descriptor.
@@ -1346,7 +1366,11 @@ declare module 'fs' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | number, options: { encoding?: null; flag?: string; } | undefined | null, callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void): void;
+    function readFile(
+        path: PathLike | number,
+        options: { encoding?: null | undefined; flag?: string | undefined; } | undefined | null,
+        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void
+    ): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -1356,7 +1380,7 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | number, options: { encoding: string; flag?: string; } | string, callback: (err: NodeJS.ErrnoException | null, data: string) => void): void;
+    function readFile(path: PathLike | number, options: { encoding: string; flag?: string | undefined; } | string, callback: (err: NodeJS.ErrnoException | null, data: string) => void): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -1368,7 +1392,7 @@ declare module 'fs' {
      */
     function readFile(
         path: PathLike | number,
-        options: { encoding?: string | null; flag?: string; } | string | undefined | null,
+        options: { encoding?: string | null | undefined; flag?: string | undefined; } | string | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
     ): void;
 
@@ -1388,7 +1412,7 @@ declare module 'fs' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Promise<Buffer>;
+        function __promisify__(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined; } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1398,7 +1422,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options: { encoding: string; flag?: string; } | string): Promise<string>;
+        function __promisify__(path: PathLike | number, options: { encoding: string; flag?: string | undefined; } | string): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1408,7 +1432,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options?: { encoding?: string | null | undefined; flag?: string | undefined; } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -1418,7 +1442,7 @@ declare module 'fs' {
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      * @param options An object that may contain an optional flag. If a flag is not provided, it defaults to `'r'`.
      */
-    function readFileSync(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Buffer;
+    function readFileSync(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined; } | null): Buffer;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -1428,7 +1452,7 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFileSync(path: PathLike | number, options: { encoding: string; flag?: string; } | string): string;
+    function readFileSync(path: PathLike | number, options: { encoding: string; flag?: string | undefined; } | string): string;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -1438,9 +1462,9 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFileSync(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): string | Buffer;
+    function readFileSync(path: PathLike | number, options?: { encoding?: string | null | undefined; flag?: string | undefined; } | string | null): string | Buffer;
 
-    type WriteFileOptions = { encoding?: string | null; mode?: number | string; flag?: string; } | string | null;
+    type WriteFileOptions = { encoding?: string | null | undefined; mode?: number | string | undefined; flag?: string | undefined; } | string | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -1553,7 +1577,7 @@ declare module 'fs' {
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      */
-    function watchFile(filename: PathLike, options: { persistent?: boolean; interval?: number; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
+    function watchFile(filename: PathLike, options: { persistent?: boolean | undefined; interval?: number | undefined; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
 
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
@@ -1580,7 +1604,7 @@ declare module 'fs' {
      */
     function watch(
         filename: PathLike,
-        options: { encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | BufferEncoding | undefined | null,
+        options: { encoding?: BufferEncoding | null | undefined, persistent?: boolean | undefined, recursive?: boolean | undefined } | BufferEncoding | undefined | null,
         listener?: (event: string, filename: string) => void,
     ): FSWatcher;
 
@@ -1593,7 +1617,11 @@ declare module 'fs' {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    function watch(filename: PathLike, options: { encoding: "buffer", persistent?: boolean, recursive?: boolean } | "buffer", listener?: (event: string, filename: Buffer) => void): FSWatcher;
+    function watch(
+        filename: PathLike,
+        options: { encoding: "buffer", persistent?: boolean | undefined, recursive?: boolean | undefined } | "buffer",
+        listener?: (event: string, filename: Buffer) => void
+    ): FSWatcher;
 
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
@@ -1606,7 +1634,7 @@ declare module 'fs' {
      */
     function watch(
         filename: PathLike,
-        options: { encoding?: string | null, persistent?: boolean, recursive?: boolean } | string | null,
+        options: { encoding?: string | null | undefined, persistent?: boolean | undefined, recursive?: boolean | undefined } | string | null,
         listener?: (event: string, filename: string | Buffer) => void,
     ): FSWatcher;
 
@@ -1841,18 +1869,18 @@ declare module 'fs' {
      * URL support is _experimental_.
      */
     function createReadStream(path: PathLike, options?: string | {
-        flags?: string;
-        encoding?: string;
-        fd?: number;
-        mode?: number;
-        autoClose?: boolean;
+        flags?: string | undefined;
+        encoding?: string | undefined;
+        fd?: number | undefined;
+        mode?: number | undefined;
+        autoClose?: boolean | undefined;
         /**
          * @default false
          */
-        emitClose?: boolean;
-        start?: number;
-        end?: number;
-        highWaterMark?: number;
+        emitClose?: boolean | undefined;
+        start?: number | undefined;
+        end?: number | undefined;
+        highWaterMark?: number | undefined;
     }): ReadStream;
 
     /**
@@ -1861,14 +1889,14 @@ declare module 'fs' {
      * URL support is _experimental_.
      */
     function createWriteStream(path: PathLike, options?: string | {
-        flags?: string;
-        encoding?: string;
-        fd?: number;
-        mode?: number;
-        autoClose?: boolean;
-        emitClose?: boolean;
-        start?: number;
-        highWaterMark?: number;
+        flags?: string | undefined;
+        encoding?: string | undefined;
+        fd?: number | undefined;
+        mode?: number | undefined;
+        autoClose?: boolean | undefined;
+        emitClose?: boolean | undefined;
+        start?: number | undefined;
+        highWaterMark?: number | undefined;
     }): WriteStream;
 
     /**
@@ -1977,7 +2005,7 @@ declare module 'fs' {
     function writevSync(fd: number, buffers: ReadonlyArray<NodeJS.ArrayBufferView>, position?: number): number;
 
     interface OpenDirOptions {
-        encoding?: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
 
     function opendirSync(path: string, options?: OpenDirOptions): Dir;
@@ -2006,7 +2034,7 @@ declare module 'fs' {
              * If `mode` is a string, it is parsed as an octal integer.
              * If `flag` is not supplied, the default of `'a'` is used.
              */
-            appendFile(data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+            appendFile(data: any, options?: { encoding?: string | null | undefined, mode?: string | number | undefined, flag?: string | number | undefined } | string | null): Promise<void>;
 
             /**
              * Asynchronous fchown(2) - Change ownership of a file.
@@ -2045,7 +2073,7 @@ declare module 'fs' {
              * @param options An object that may contain an optional flag.
              * If a flag is not provided, it defaults to `'r'`.
              */
-            readFile(options?: { encoding?: null, flag?: string | number } | null): Promise<Buffer>;
+            readFile(options?: { encoding?: null | undefined, flag?: string | number | undefined } | null): Promise<Buffer>;
 
             /**
              * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
@@ -2053,7 +2081,7 @@ declare module 'fs' {
              * @param options An object that may contain an optional flag.
              * If a flag is not provided, it defaults to `'r'`.
              */
-            readFile(options: { encoding: BufferEncoding, flag?: string | number } | BufferEncoding): Promise<string>;
+            readFile(options: { encoding: BufferEncoding, flag?: string | number | undefined } | BufferEncoding): Promise<string>;
 
             /**
              * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
@@ -2061,12 +2089,12 @@ declare module 'fs' {
              * @param options An object that may contain an optional flag.
              * If a flag is not provided, it defaults to `'r'`.
              */
-            readFile(options?: { encoding?: string | null, flag?: string | number } | string | null): Promise<string | Buffer>;
+            readFile(options?: { encoding?: string | null | undefined, flag?: string | number | undefined } | string | null): Promise<string | Buffer>;
 
             /**
              * Asynchronous fstat(2) - Get file status.
              */
-            stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+            stat(opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
             stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
             stat(opts: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -2115,7 +2143,7 @@ declare module 'fs' {
              * If `mode` is a string, it is parsed as an octal integer.
              * If `flag` is not supplied, the default of `'w'` is used.
              */
-            writeFile(data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+            writeFile(data: any, options?: { encoding?: string | null | undefined, mode?: string | number | undefined, flag?: string | number | undefined } | string | null): Promise<void>;
 
             /**
              * See `fs.writev` promisified version.
@@ -2254,35 +2282,35 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readdir(path: PathLike, options?: { encoding?: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+        function readdir(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined; withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Promise<Buffer[]>;
+        function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer"): Promise<Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readdir(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): Promise<string[] | Buffer[]>;
+        function readdir(path: PathLike, options?: { encoding?: string | null | undefined; withFileTypes?: false | undefined } | string | null): Promise<string[] | Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
          */
-        function readdir(path: PathLike, options: { encoding?: string | null; withFileTypes: true }): Promise<Dirent[]>;
+        function readdir(path: PathLike, options: { encoding?: string | null | undefined; withFileTypes: true }): Promise<Dirent[]>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readlink(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function readlink(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
@@ -2296,7 +2324,7 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readlink(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function readlink(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): Promise<string | Buffer>;
 
         /**
          * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
@@ -2311,7 +2339,7 @@ declare module 'fs' {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function lstat(path: PathLike, opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function lstat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -2319,7 +2347,7 @@ declare module 'fs' {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function stat(path: PathLike, opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -2406,7 +2434,7 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function realpath(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function realpath(path: PathLike, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
@@ -2420,14 +2448,14 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function realpath(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function realpath(path: PathLike, options?: { encoding?: string | null | undefined } | string | null): Promise<string | Buffer>;
 
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function mkdtemp(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function mkdtemp(prefix: string, options?: { encoding?: BufferEncoding | null | undefined } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronously creates a unique temporary directory.
@@ -2441,7 +2469,7 @@ declare module 'fs' {
          * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function mkdtemp(prefix: string, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function mkdtemp(prefix: string, options?: { encoding?: string | null | undefined } | string | null): Promise<string | Buffer>;
 
         /**
          * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -2456,7 +2484,15 @@ declare module 'fs' {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'w'` is used.
          */
-        function writeFile(path: PathLike | FileHandle, data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+        function writeFile(
+            path: PathLike | FileHandle,
+            data: any,
+            options?: {
+                encoding?: string | null | undefined,
+                mode?: string | number | undefined,
+                flag?: string | number | undefined
+            } | string | null
+        ): Promise<void>;
 
         /**
          * Asynchronously append data to a file, creating the file if it does not exist.
@@ -2470,7 +2506,15 @@ declare module 'fs' {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'a'` is used.
          */
-        function appendFile(path: PathLike | FileHandle, data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+        function appendFile(
+            path: PathLike | FileHandle,
+            data: any,
+            options?: {
+                encoding?: string | null | undefined,
+                mode?: string | number | undefined,
+                flag?: string | number | undefined
+            } | string | null
+        ): Promise<void>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -2479,7 +2523,7 @@ declare module 'fs' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function readFile(path: PathLike | FileHandle, options?: { encoding?: null, flag?: string | number } | null): Promise<Buffer>;
+        function readFile(path: PathLike | FileHandle, options?: { encoding?: null | undefined, flag?: string | number | undefined } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -2488,7 +2532,7 @@ declare module 'fs' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: string | number } | BufferEncoding): Promise<string>;
+        function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: string | number | undefined } | BufferEncoding): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -2497,7 +2541,7 @@ declare module 'fs' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function readFile(path: PathLike | FileHandle, options?: { encoding?: string | null, flag?: string | number } | string | null): Promise<string | Buffer>;
+        function readFile(path: PathLike | FileHandle, options?: { encoding?: string | null | undefined, flag?: string | number | undefined } | string | null): Promise<string | Buffer>;
 
         function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
     }

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -124,7 +124,7 @@ interface Console {
 }
 
 interface Error {
-    stack?: string;
+    stack?: string | undefined;
 }
 
 // Declare "static" methods in Error
@@ -137,7 +137,7 @@ interface ErrorConstructor {
      *
      * @see https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
      */
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
+    prepareStackTrace?: ((err: Error, stackTraces: NodeJS.CallSite[]) => any) | undefined;
 
     stackTraceLimit: number;
 }
@@ -211,7 +211,7 @@ interface NodeRequire extends NodeRequireFunction {
 }
 
 interface RequireResolve {
-    (id: string, options?: { paths?: string[]; }): string;
+    (id: string, options?: { paths?: string[] | undefined; }): string;
     paths(request: string): string[] | null;
 }
 
@@ -511,17 +511,17 @@ declare namespace NodeJS {
          * the getter function.
          * @default `false`
          */
-        getters?: 'get' | 'set' | boolean;
-        showHidden?: boolean;
+        getters?: 'get' | 'set' | boolean | undefined;
+        showHidden?: boolean | undefined;
         /**
          * @default 2
          */
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-        showProxy?: boolean;
-        maxArrayLength?: number | null;
-        breakLength?: number;
+        depth?: number | null | undefined;
+        colors?: boolean | undefined;
+        customInspect?: boolean | undefined;
+        showProxy?: boolean | undefined;
+        maxArrayLength?: number | null | undefined;
+        breakLength?: number | undefined;
         /**
          * Setting this to `false` causes each object key
          * to be displayed on a new line. It will also add new lines to text that is
@@ -532,16 +532,16 @@ declare namespace NodeJS {
          * For more information, see the example below.
          * @default `true`
          */
-        compact?: boolean | number;
-        sorted?: boolean | ((a: string, b: string) => number);
+        compact?: boolean | number | undefined;
+        sorted?: boolean | ((a: string, b: string) => number) | undefined;
     }
 
     interface ConsoleConstructorOptions {
         stdout: WritableStream;
-        stderr?: WritableStream;
-        ignoreErrors?: boolean;
-        colorMode?: boolean | 'auto';
-        inspectOptions?: InspectOptions;
+        stderr?: WritableStream | undefined;
+        ignoreErrors?: boolean | undefined;
+        colorMode?: boolean | 'auto' | undefined;
+        inspectOptions?: InspectOptions | undefined;
     }
 
     interface ConsoleConstructor {
@@ -625,11 +625,11 @@ declare namespace NodeJS {
     }
 
     interface ErrnoException extends Error {
-        errno?: number;
-        code?: string;
-        path?: string;
-        syscall?: string;
-        stack?: string;
+        errno?: number | undefined;
+        code?: string | undefined;
+        path?: string | undefined;
+        syscall?: string | undefined;
+        stack?: string | undefined;
     }
 
     class EventEmitter {
@@ -658,7 +658,7 @@ declare namespace NodeJS {
         pause(): this;
         resume(): this;
         isPaused(): boolean;
-        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
         unpipe(destination?: WritableStream): this;
         unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
         wrap(oldStream: ReadableStream): this;
@@ -704,10 +704,10 @@ declare namespace NodeJS {
 
     interface ProcessRelease {
         name: string;
-        sourceUrl?: string;
-        headersUrl?: string;
-        libUrl?: string;
-        lts?: string;
+        sourceUrl?: string | undefined;
+        headersUrl?: string | undefined;
+        libUrl?: string | undefined;
+        lts?: string | undefined;
     }
 
     interface ProcessVersions {
@@ -754,7 +754,7 @@ declare namespace NodeJS {
     type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<any>, value: any) => void;
 
     interface Socket extends ReadWriteStream {
-        isTTY?: true;
+        isTTY?: true | undefined;
     }
 
     interface ProcessEnv {
@@ -856,24 +856,24 @@ declare namespace NodeJS {
          *
          * @default 'Warning'
          */
-        type?: string;
+        type?: string | undefined;
 
         /**
          * A unique identifier for the warning instance being emitted.
          */
-        code?: string;
+        code?: string | undefined;
 
         /**
          * When `warning` is a `string`, `ctor` is an optional function used to limit the generated stack trace.
          *
          * @default process.emitWarning
          */
-        ctor?: Function;
+        ctor?: Function | undefined;
 
         /**
          * Additional text to include with the error.
          */
-        detail?: string;
+        detail?: string | undefined;
     }
 
     interface Process extends EventEmitter {
@@ -913,7 +913,7 @@ declare namespace NodeJS {
 
         env: ProcessEnv;
         exit(code?: number): never;
-        exitCode?: number;
+        exitCode?: number | undefined;
         getgid(): number;
         setgid(id: number | string): void;
         getuid(): number;
@@ -960,7 +960,7 @@ declare namespace NodeJS {
         title: string;
         arch: string;
         platform: Platform;
-        mainModule?: NodeModule;
+        mainModule?: NodeModule | undefined;
         memoryUsage(): MemoryUsage;
         cpuUsage(previousValue?: CpuUsage): CpuUsage;
         nextTick(callback: Function, ...args: any[]): void;
@@ -990,7 +990,7 @@ declare namespace NodeJS {
         domain: Domain;
 
         // Worker
-        send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean}, callback?: (error: Error | null) => void): boolean;
+        send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean | undefined}, callback?: (error: Error | null) => void): boolean;
         disconnect(): void;
         connected: boolean;
 
@@ -1004,7 +1004,7 @@ declare namespace NodeJS {
         /**
          * Only available with `--experimental-report`
          */
-        report?: ProcessReport;
+        report?: ProcessReport | undefined;
 
         resourceUsage(): ResourceUsage;
 

--- a/types/node/v12/http.d.ts
+++ b/types/node/v12/http.d.ts
@@ -5,64 +5,64 @@ declare module 'http' {
 
     // incoming headers will never contain number
     interface IncomingHttpHeaders {
-        'accept'?: string;
-        'accept-language'?: string;
-        'accept-patch'?: string;
-        'accept-ranges'?: string;
-        'access-control-allow-credentials'?: string;
-        'access-control-allow-headers'?: string;
-        'access-control-allow-methods'?: string;
-        'access-control-allow-origin'?: string;
-        'access-control-expose-headers'?: string;
-        'access-control-max-age'?: string;
-        'access-control-request-headers'?: string;
-        'access-control-request-method'?: string;
-        'age'?: string;
-        'allow'?: string;
-        'alt-svc'?: string;
-        'authorization'?: string;
-        'cache-control'?: string;
-        'connection'?: string;
-        'content-disposition'?: string;
-        'content-encoding'?: string;
-        'content-language'?: string;
-        'content-length'?: string;
-        'content-location'?: string;
-        'content-range'?: string;
-        'content-type'?: string;
-        'cookie'?: string;
-        'date'?: string;
-        'etag'?: string;
-        'expect'?: string;
-        'expires'?: string;
-        'forwarded'?: string;
-        'from'?: string;
-        'host'?: string;
-        'if-match'?: string;
-        'if-modified-since'?: string;
-        'if-none-match'?: string;
-        'if-unmodified-since'?: string;
-        'last-modified'?: string;
-        'location'?: string;
-        'origin'?: string;
-        'pragma'?: string;
-        'proxy-authenticate'?: string;
-        'proxy-authorization'?: string;
-        'public-key-pins'?: string;
-        'range'?: string;
-        'referer'?: string;
-        'retry-after'?: string;
-        'set-cookie'?: string[];
-        'strict-transport-security'?: string;
-        'tk'?: string;
-        'trailer'?: string;
-        'transfer-encoding'?: string;
-        'upgrade'?: string;
-        'user-agent'?: string;
-        'vary'?: string;
-        'via'?: string;
-        'warning'?: string;
-        'www-authenticate'?: string;
+        'accept'?: string | undefined;
+        'accept-language'?: string | undefined;
+        'accept-patch'?: string | undefined;
+        'accept-ranges'?: string | undefined;
+        'access-control-allow-credentials'?: string | undefined;
+        'access-control-allow-headers'?: string | undefined;
+        'access-control-allow-methods'?: string | undefined;
+        'access-control-allow-origin'?: string | undefined;
+        'access-control-expose-headers'?: string | undefined;
+        'access-control-max-age'?: string | undefined;
+        'access-control-request-headers'?: string | undefined;
+        'access-control-request-method'?: string | undefined;
+        'age'?: string | undefined;
+        'allow'?: string | undefined;
+        'alt-svc'?: string | undefined;
+        'authorization'?: string | undefined;
+        'cache-control'?: string | undefined;
+        'connection'?: string | undefined;
+        'content-disposition'?: string | undefined;
+        'content-encoding'?: string | undefined;
+        'content-language'?: string | undefined;
+        'content-length'?: string | undefined;
+        'content-location'?: string | undefined;
+        'content-range'?: string | undefined;
+        'content-type'?: string | undefined;
+        'cookie'?: string | undefined;
+        'date'?: string | undefined;
+        'etag'?: string | undefined;
+        'expect'?: string | undefined;
+        'expires'?: string | undefined;
+        'forwarded'?: string | undefined;
+        'from'?: string | undefined;
+        'host'?: string | undefined;
+        'if-match'?: string | undefined;
+        'if-modified-since'?: string | undefined;
+        'if-none-match'?: string | undefined;
+        'if-unmodified-since'?: string | undefined;
+        'last-modified'?: string | undefined;
+        'location'?: string | undefined;
+        'origin'?: string | undefined;
+        'pragma'?: string | undefined;
+        'proxy-authenticate'?: string | undefined;
+        'proxy-authorization'?: string | undefined;
+        'public-key-pins'?: string | undefined;
+        'range'?: string | undefined;
+        'referer'?: string | undefined;
+        'retry-after'?: string | undefined;
+        'set-cookie'?: string[] | undefined;
+        'strict-transport-security'?: string | undefined;
+        'tk'?: string | undefined;
+        'trailer'?: string | undefined;
+        'transfer-encoding'?: string | undefined;
+        'upgrade'?: string | undefined;
+        'user-agent'?: string | undefined;
+        'vary'?: string | undefined;
+        'via'?: string | undefined;
+        'warning'?: string | undefined;
+        'www-authenticate'?: string | undefined;
         [header: string]: string | string[] | undefined;
     }
 
@@ -72,29 +72,29 @@ declare module 'http' {
     }
 
     interface ClientRequestArgs {
-        protocol?: string | null;
-        host?: string | null;
-        hostname?: string | null;
-        family?: number;
-        port?: number | string | null;
-        defaultPort?: number | string;
-        localAddress?: string;
-        socketPath?: string;
-        method?: string;
-        path?: string | null;
-        headers?: OutgoingHttpHeaders;
-        auth?: string | null;
-        agent?: Agent | boolean;
-        _defaultAgent?: Agent;
-        timeout?: number;
-        setHost?: boolean;
+        protocol?: string | null | undefined;
+        host?: string | null | undefined;
+        hostname?: string | null | undefined;
+        family?: number | undefined;
+        port?: number | string | null | undefined;
+        defaultPort?: number | string | undefined;
+        localAddress?: string | undefined;
+        socketPath?: string | undefined;
+        method?: string | undefined;
+        path?: string | null | undefined;
+        headers?: OutgoingHttpHeaders | undefined;
+        auth?: string | null | undefined;
+        agent?: Agent | boolean | undefined;
+        _defaultAgent?: Agent | undefined;
+        timeout?: number | undefined;
+        setHost?: boolean | undefined;
         // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L278
-        createConnection?: (options: ClientRequestArgs, oncreate: (err: Error, socket: Socket) => void) => Socket;
+        createConnection?: ((options: ClientRequestArgs, oncreate: (err: Error, socket: Socket) => void) => Socket) | undefined;
     }
 
     interface ServerOptions {
-        IncomingMessage?: typeof IncomingMessage;
-        ServerResponse?: typeof ServerResponse;
+        IncomingMessage?: typeof IncomingMessage | undefined;
+        ServerResponse?: typeof ServerResponse | undefined;
     }
 
     type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
@@ -289,19 +289,19 @@ declare module 'http' {
         /**
          * Only valid for request obtained from http.Server.
          */
-        method?: string;
+        method?: string | undefined;
         /**
          * Only valid for request obtained from http.Server.
          */
-        url?: string;
+        url?: string | undefined;
         /**
          * Only valid for response obtained from http.ClientRequest.
          */
-        statusCode?: number;
+        statusCode?: number | undefined;
         /**
          * Only valid for response obtained from http.ClientRequest.
          */
-        statusMessage?: string;
+        statusMessage?: string | undefined;
         socket: Socket;
         destroy(error?: Error): void;
     }
@@ -310,32 +310,32 @@ declare module 'http' {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
-        keepAlive?: boolean;
+        keepAlive?: boolean | undefined;
         /**
          * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
          * Only relevant if keepAlive is set to true.
          */
-        keepAliveMsecs?: number;
+        keepAliveMsecs?: number | undefined;
         /**
          * Maximum number of sockets to allow per host. Default for Node 0.10 is 5, default for Node 0.12 is Infinity
          */
-        maxSockets?: number;
+        maxSockets?: number | undefined;
         /**
          * Maximum number of sockets allowed for all hosts in total. Each request will use a new socket until the maximum is reached. Default: Infinity.
          */
-        maxTotalSockets?: number;
+        maxTotalSockets?: number | undefined;
         /**
          * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
          */
-        maxFreeSockets?: number;
+        maxFreeSockets?: number | undefined;
         /**
          * Socket timeout in milliseconds. This will set the timeout after the socket is connected.
          */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * Scheduling strategy to apply when picking the next free socket to use. Default: 'fifo'.
          */
-        scheduling?: 'fifo' | 'lifo';
+        scheduling?: 'fifo' | 'lifo' | undefined;
     }
 
     class Agent {

--- a/types/node/v12/http2.d.ts
+++ b/types/node/v12/http2.d.ts
@@ -15,37 +15,37 @@ declare module 'http2' {
     export { OutgoingHttpHeaders } from 'http';
 
     export interface IncomingHttpStatusHeader {
-        ":status"?: number;
+        ":status"?: number | undefined;
     }
 
     export interface IncomingHttpHeaders extends Http1IncomingHttpHeaders {
-        ":path"?: string;
-        ":method"?: string;
-        ":authority"?: string;
-        ":scheme"?: string;
+        ":path"?: string | undefined;
+        ":method"?: string | undefined;
+        ":authority"?: string | undefined;
+        ":scheme"?: string | undefined;
     }
 
     // Http2Stream
 
     export interface StreamPriorityOptions {
-        exclusive?: boolean;
-        parent?: number;
-        weight?: number;
-        silent?: boolean;
+        exclusive?: boolean | undefined;
+        parent?: number | undefined;
+        weight?: number | undefined;
+        silent?: boolean | undefined;
     }
 
     export interface StreamState {
-        localWindowSize?: number;
-        state?: number;
-        localClose?: number;
-        remoteClose?: number;
-        sumDependencyWeight?: number;
-        weight?: number;
+        localWindowSize?: number | undefined;
+        state?: number | undefined;
+        localClose?: number | undefined;
+        remoteClose?: number | undefined;
+        sumDependencyWeight?: number | undefined;
+        weight?: number | undefined;
     }
 
     export interface ServerStreamResponseOptions {
-        endStream?: boolean;
-        waitForTrailers?: boolean;
+        endStream?: boolean | undefined;
+        waitForTrailers?: boolean | undefined;
     }
 
     export interface StatOptions {
@@ -55,9 +55,9 @@ declare module 'http2' {
 
     export interface ServerStreamFileResponseOptions {
         statCheck?(stats: fs.Stats, headers: OutgoingHttpHeaders, statOptions: StatOptions): void | boolean;
-        waitForTrailers?: boolean;
-        offset?: number;
-        length?: number;
+        waitForTrailers?: boolean | undefined;
+        offset?: number | undefined;
+        length?: number | undefined;
     }
 
     export interface ServerStreamFileResponseOptionsWithError extends ServerStreamFileResponseOptions {
@@ -74,12 +74,12 @@ declare module 'http2' {
          * indicating that no additional data should be received and the readable side of the Http2Stream will be closed.
          */
         readonly endAfterHeaders: boolean;
-        readonly id?: number;
+        readonly id?: number | undefined;
         readonly pending: boolean;
         readonly rstCode: number;
         readonly sentHeaders: OutgoingHttpHeaders;
-        readonly sentInfoHeaders?: OutgoingHttpHeaders[];
-        readonly sentTrailers?: OutgoingHttpHeaders;
+        readonly sentInfoHeaders?: OutgoingHttpHeaders[] | undefined;
+        readonly sentTrailers?: OutgoingHttpHeaders | undefined;
         readonly session: Http2Session;
         readonly state: StreamState;
 
@@ -237,43 +237,43 @@ declare module 'http2' {
     // Http2Session
 
     export interface Settings {
-        headerTableSize?: number;
-        enablePush?: boolean;
-        initialWindowSize?: number;
-        maxFrameSize?: number;
-        maxConcurrentStreams?: number;
-        maxHeaderListSize?: number;
-        enableConnectProtocol?: boolean;
+        headerTableSize?: number | undefined;
+        enablePush?: boolean | undefined;
+        initialWindowSize?: number | undefined;
+        maxFrameSize?: number | undefined;
+        maxConcurrentStreams?: number | undefined;
+        maxHeaderListSize?: number | undefined;
+        enableConnectProtocol?: boolean | undefined;
     }
 
     export interface ClientSessionRequestOptions {
-        endStream?: boolean;
-        exclusive?: boolean;
-        parent?: number;
-        weight?: number;
-        waitForTrailers?: boolean;
+        endStream?: boolean | undefined;
+        exclusive?: boolean | undefined;
+        parent?: number | undefined;
+        weight?: number | undefined;
+        waitForTrailers?: boolean | undefined;
     }
 
     export interface SessionState {
-        effectiveLocalWindowSize?: number;
-        effectiveRecvDataLength?: number;
-        nextStreamID?: number;
-        localWindowSize?: number;
-        lastProcStreamID?: number;
-        remoteWindowSize?: number;
-        outboundQueueSize?: number;
-        deflateDynamicTableSize?: number;
-        inflateDynamicTableSize?: number;
+        effectiveLocalWindowSize?: number | undefined;
+        effectiveRecvDataLength?: number | undefined;
+        nextStreamID?: number | undefined;
+        localWindowSize?: number | undefined;
+        lastProcStreamID?: number | undefined;
+        remoteWindowSize?: number | undefined;
+        outboundQueueSize?: number | undefined;
+        deflateDynamicTableSize?: number | undefined;
+        inflateDynamicTableSize?: number | undefined;
     }
 
     export interface Http2Session extends EventEmitter {
-        readonly alpnProtocol?: string;
+        readonly alpnProtocol?: string | undefined;
         readonly closed: boolean;
         readonly connecting: boolean;
         readonly destroyed: boolean;
-        readonly encrypted?: boolean;
+        readonly encrypted?: boolean | undefined;
         readonly localSettings: Settings;
-        readonly originSet?: string[];
+        readonly originSet?: string[] | undefined;
         readonly pendingSettingsAck: boolean;
         readonly remoteSettings: Settings;
         readonly socket: net.Socket | tls.TLSSocket;
@@ -429,29 +429,29 @@ declare module 'http2' {
     // Http2Server
 
     export interface SessionOptions {
-        maxDeflateDynamicTableSize?: number;
-        maxSessionMemory?: number;
-        maxHeaderListPairs?: number;
-        maxOutstandingPings?: number;
-        maxSendHeaderBlockLength?: number;
-        paddingStrategy?: number;
-        peerMaxConcurrentStreams?: number;
-        settings?: Settings;
+        maxDeflateDynamicTableSize?: number | undefined;
+        maxSessionMemory?: number | undefined;
+        maxHeaderListPairs?: number | undefined;
+        maxOutstandingPings?: number | undefined;
+        maxSendHeaderBlockLength?: number | undefined;
+        paddingStrategy?: number | undefined;
+        peerMaxConcurrentStreams?: number | undefined;
+        settings?: Settings | undefined;
 
         selectPadding?(frameLen: number, maxFrameLen: number): number;
         createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
 
     export interface ClientSessionOptions extends SessionOptions {
-        maxReservedRemoteStreams?: number;
-        createConnection?: (authority: url.URL, option: SessionOptions) => stream.Duplex;
+        maxReservedRemoteStreams?: number | undefined;
+        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
     }
 
     export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage;
-        Http1ServerResponse?: typeof ServerResponse;
-        Http2ServerRequest?: typeof Http2ServerRequest;
-        Http2ServerResponse?: typeof Http2ServerResponse;
+        Http1IncomingMessage?: typeof IncomingMessage | undefined;
+        Http1ServerResponse?: typeof ServerResponse | undefined;
+        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
+        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
     }
 
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
@@ -460,8 +460,8 @@ declare module 'http2' {
     export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
-        allowHTTP1?: boolean;
-        origins?: string[];
+        allowHTTP1?: boolean | undefined;
+        origins?: string[] | undefined;
     }
 
     export interface Http2Server extends net.Server {

--- a/types/node/v12/https.d.ts
+++ b/types/node/v12/https.d.ts
@@ -6,13 +6,13 @@ declare module 'https' {
     type ServerOptions = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions;
 
     type RequestOptions = http.RequestOptions & tls.SecureContextOptions & {
-        rejectUnauthorized?: boolean; // Defaults to true
-        servername?: string; // SNI TLS Extension
+        rejectUnauthorized?: boolean | undefined; // Defaults to true
+        servername?: string | undefined; // SNI TLS Extension
     };
 
     interface AgentOptions extends http.AgentOptions, tls.ConnectionOptions {
-        rejectUnauthorized?: boolean;
-        maxCachedSessions?: number;
+        rejectUnauthorized?: boolean | undefined;
+        maxCachedSessions?: number | undefined;
     }
 
     class Agent extends http.Agent {

--- a/types/node/v12/inspector.d.ts
+++ b/types/node/v12/inspector.d.ts
@@ -68,11 +68,11 @@ declare module 'inspector' {
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
             /**
              * Object class (constructor) name. Specified for <code>object</code> type values only.
              */
-            className?: string;
+            className?: string | undefined;
             /**
              * Remote object value in case of primitive values or JSON values (if it was requested).
              */
@@ -80,24 +80,24 @@ declare module 'inspector' {
             /**
              * Primitive value which can not be JSON-stringified does not have <code>value</code>, but gets this property.
              */
-            unserializableValue?: UnserializableValue;
+            unserializableValue?: UnserializableValue | undefined;
             /**
              * String representation of the object.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * Unique object identifier (for non-primitive values).
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
             /**
              * Preview containing abbreviated property values. Specified for <code>object</code> type values only.
              * @experimental
              */
-            preview?: ObjectPreview;
+            preview?: ObjectPreview | undefined;
             /**
              * @experimental
              */
-            customPreview?: CustomPreview;
+            customPreview?: CustomPreview | undefined;
         }
 
         /**
@@ -108,7 +108,7 @@ declare module 'inspector' {
             hasBody: boolean;
             formatterObjectId: RemoteObjectId;
             bindRemoteObjectFunctionId: RemoteObjectId;
-            configObjectId?: RemoteObjectId;
+            configObjectId?: RemoteObjectId | undefined;
         }
 
         /**
@@ -123,11 +123,11 @@ declare module 'inspector' {
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
             /**
              * String representation of the object.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * True iff some of the properties or entries of the original object did not fit.
              */
@@ -139,7 +139,7 @@ declare module 'inspector' {
             /**
              * List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only.
              */
-            entries?: EntryPreview[];
+            entries?: EntryPreview[] | undefined;
         }
 
         /**
@@ -157,15 +157,15 @@ declare module 'inspector' {
             /**
              * User-friendly property value string.
              */
-            value?: string;
+            value?: string | undefined;
             /**
              * Nested value preview.
              */
-            valuePreview?: ObjectPreview;
+            valuePreview?: ObjectPreview | undefined;
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
         }
 
         /**
@@ -175,7 +175,7 @@ declare module 'inspector' {
             /**
              * Preview of the key. Specified for map-like collection entries.
              */
-            key?: ObjectPreview;
+            key?: ObjectPreview | undefined;
             /**
              * Preview of the value.
              */
@@ -193,19 +193,19 @@ declare module 'inspector' {
             /**
              * The value associated with the property.
              */
-            value?: RemoteObject;
+            value?: RemoteObject | undefined;
             /**
              * True if the value associated with the property may be changed (data descriptors only).
              */
-            writable?: boolean;
+            writable?: boolean | undefined;
             /**
              * A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only).
              */
-            get?: RemoteObject;
+            get?: RemoteObject | undefined;
             /**
              * A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only).
              */
-            set?: RemoteObject;
+            set?: RemoteObject | undefined;
             /**
              * True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.
              */
@@ -217,15 +217,15 @@ declare module 'inspector' {
             /**
              * True if the result was thrown during the evaluation.
              */
-            wasThrown?: boolean;
+            wasThrown?: boolean | undefined;
             /**
              * True if the property is owned for the object.
              */
-            isOwn?: boolean;
+            isOwn?: boolean | undefined;
             /**
              * Property symbol object, if the property is of the <code>symbol</code> type.
              */
-            symbol?: RemoteObject;
+            symbol?: RemoteObject | undefined;
         }
 
         /**
@@ -239,7 +239,7 @@ declare module 'inspector' {
             /**
              * The value associated with the property.
              */
-            value?: RemoteObject;
+            value?: RemoteObject | undefined;
         }
 
         /**
@@ -253,11 +253,11 @@ declare module 'inspector' {
             /**
              * Primitive value which can not be JSON-stringified.
              */
-            unserializableValue?: UnserializableValue;
+            unserializableValue?: UnserializableValue | undefined;
             /**
              * Remote object handle.
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
         }
 
         /**
@@ -284,7 +284,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            auxData?: {};
+            auxData?: {} | undefined;
         }
 
         /**
@@ -310,23 +310,23 @@ declare module 'inspector' {
             /**
              * Script ID of the exception location.
              */
-            scriptId?: ScriptId;
+            scriptId?: ScriptId | undefined;
             /**
              * URL of the exception location, to be used when the script was not reported.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * JavaScript stack trace if available.
              */
-            stackTrace?: StackTrace;
+            stackTrace?: StackTrace | undefined;
             /**
              * Exception object if available.
              */
-            exception?: RemoteObject;
+            exception?: RemoteObject | undefined;
             /**
              * Identifier of the context where exception happened.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         /**
@@ -367,7 +367,7 @@ declare module 'inspector' {
             /**
              * String label of this stack trace. For async traces this may be a name of the function that initiated the async call.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * JavaScript function name.
              */
@@ -375,12 +375,12 @@ declare module 'inspector' {
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              */
-            parent?: StackTrace;
+            parent?: StackTrace | undefined;
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              * @experimental
              */
-            parentId?: StackTraceId;
+            parentId?: StackTraceId | undefined;
         }
 
         /**
@@ -395,7 +395,7 @@ declare module 'inspector' {
          */
         interface StackTraceId {
             id: string;
-            debuggerId?: UniqueDebuggerId;
+            debuggerId?: UniqueDebuggerId | undefined;
         }
 
         interface EvaluateParameterType {
@@ -406,36 +406,36 @@ declare module 'inspector' {
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * Determines whether Command Line API should be available during the evaluation.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Specifies in which execution context to perform evaluation. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            contextId?: ExecutionContextId;
+            contextId?: ExecutionContextId | undefined;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should be treated as initiated by user in the UI.
              */
-            userGesture?: boolean;
+            userGesture?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
         }
 
         interface AwaitPromiseParameterType {
@@ -446,11 +446,11 @@ declare module 'inspector' {
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
         }
 
         interface CallFunctionOnParameterType {
@@ -461,40 +461,40 @@ declare module 'inspector' {
             /**
              * Identifier of the object to call function on. Either objectId or executionContextId should be specified.
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
             /**
              * Call arguments. All call arguments must belong to the same JavaScript world as the target object.
              */
-            arguments?: CallArgument[];
+            arguments?: CallArgument[] | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object which should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should be treated as initiated by user in the UI.
              */
-            userGesture?: boolean;
+            userGesture?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
             /**
              * Specifies execution context which global object will be used to call function on. Either executionContextId or objectId should be specified.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
             /**
              * Symbolic group name that can be used to release multiple objects. If objectGroup is not specified and objectId is, objectGroup will be inherited from object.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
         }
 
         interface GetPropertiesParameterType {
@@ -505,17 +505,17 @@ declare module 'inspector' {
             /**
              * If true, returns properties belonging only to the element itself, not to its prototype chain.
              */
-            ownProperties?: boolean;
+            ownProperties?: boolean | undefined;
             /**
              * If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.
              * @experimental
              */
-            accessorPropertiesOnly?: boolean;
+            accessorPropertiesOnly?: boolean | undefined;
             /**
              * Whether preview should be generated for the results.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
         }
 
         interface ReleaseObjectParameterType {
@@ -552,7 +552,7 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         interface RunScriptParameterType {
@@ -563,31 +563,31 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Determines whether Command Line API should be available during the evaluation.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object which should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
         }
 
         interface QueryObjectsParameterType {
@@ -601,7 +601,7 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to lookup global scope variables.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         interface EvaluateReturnType {
@@ -612,7 +612,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface AwaitPromiseReturnType {
@@ -623,7 +623,7 @@ declare module 'inspector' {
             /**
              * Exception details if stack strace is available.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface CallFunctionOnReturnType {
@@ -634,7 +634,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface GetPropertiesReturnType {
@@ -645,22 +645,22 @@ declare module 'inspector' {
             /**
              * Internal object properties (only of the element itself).
              */
-            internalProperties?: InternalPropertyDescriptor[];
+            internalProperties?: InternalPropertyDescriptor[] | undefined;
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface CompileScriptReturnType {
             /**
              * Id of the script.
              */
-            scriptId?: ScriptId;
+            scriptId?: ScriptId | undefined;
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface RunScriptReturnType {
@@ -671,7 +671,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface QueryObjectsReturnType {
@@ -738,12 +738,12 @@ declare module 'inspector' {
             /**
              * Stack trace captured when the call was made.
              */
-            stackTrace?: StackTrace;
+            stackTrace?: StackTrace | undefined;
             /**
              * Console context descriptor for calls on non-default console context (not console.*): 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call on named context.
              * @experimental
              */
-            context?: string;
+            context?: string | undefined;
         }
 
         interface InspectRequestedEventDataType {
@@ -778,7 +778,7 @@ declare module 'inspector' {
             /**
              * Column number in the script (0-based).
              */
-            columnNumber?: number;
+            columnNumber?: number | undefined;
         }
 
         /**
@@ -805,7 +805,7 @@ declare module 'inspector' {
             /**
              * Location in the source code.
              */
-            functionLocation?: Location;
+            functionLocation?: Location | undefined;
             /**
              * Location in the source code.
              */
@@ -825,7 +825,7 @@ declare module 'inspector' {
             /**
              * The value being returned, if the function is at return point.
              */
-            returnValue?: Runtime.RemoteObject;
+            returnValue?: Runtime.RemoteObject | undefined;
         }
 
         /**
@@ -840,15 +840,15 @@ declare module 'inspector' {
              * Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties.
              */
             object: Runtime.RemoteObject;
-            name?: string;
+            name?: string | undefined;
             /**
              * Location in the source code where scope starts
              */
-            startLocation?: Location;
+            startLocation?: Location | undefined;
             /**
              * Location in the source code where scope ends
              */
-            endLocation?: Location;
+            endLocation?: Location | undefined;
         }
 
         /**
@@ -877,8 +877,8 @@ declare module 'inspector' {
             /**
              * Column number in the script (0-based).
              */
-            columnNumber?: number;
-            type?: string;
+            columnNumber?: number | undefined;
+            type?: string | undefined;
         }
 
         interface SetBreakpointsActiveParameterType {
@@ -903,23 +903,23 @@ declare module 'inspector' {
             /**
              * URL of the resources to set breakpoint on.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified.
              */
-            urlRegex?: string;
+            urlRegex?: string | undefined;
             /**
              * Script hash of the resources to set breakpoint on.
              */
-            scriptHash?: string;
+            scriptHash?: string | undefined;
             /**
              * Offset in the line to set breakpoint at.
              */
-            columnNumber?: number;
+            columnNumber?: number | undefined;
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
              */
-            condition?: string;
+            condition?: string | undefined;
         }
 
         interface SetBreakpointParameterType {
@@ -930,7 +930,7 @@ declare module 'inspector' {
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
              */
-            condition?: string;
+            condition?: string | undefined;
         }
 
         interface RemoveBreakpointParameterType {
@@ -945,11 +945,11 @@ declare module 'inspector' {
             /**
              * End of range to search possible breakpoint locations in (excluding). When not specified, end of scripts is used as end of range.
              */
-            end?: Location;
+            end?: Location | undefined;
             /**
              * Only consider locations which are in the same (non-nested) function as start.
              */
-            restrictToFunction?: boolean;
+            restrictToFunction?: boolean | undefined;
         }
 
         interface ContinueToLocationParameterType {
@@ -957,7 +957,7 @@ declare module 'inspector' {
              * Location to continue to.
              */
             location: Location;
-            targetCallFrames?: string;
+            targetCallFrames?: string | undefined;
         }
 
         interface PauseOnAsyncCallParameterType {
@@ -972,7 +972,7 @@ declare module 'inspector' {
              * Debugger will issue additional Debugger.paused notification if any async task is scheduled before next pause.
              * @experimental
              */
-            breakOnAsyncCall?: boolean;
+            breakOnAsyncCall?: boolean | undefined;
         }
 
         interface GetStackTraceParameterType {
@@ -991,11 +991,11 @@ declare module 'inspector' {
             /**
              * If true, search is case sensitive.
              */
-            caseSensitive?: boolean;
+            caseSensitive?: boolean | undefined;
             /**
              * If true, treats string parameter as regex.
              */
-            isRegex?: boolean;
+            isRegex?: boolean | undefined;
         }
 
         interface SetScriptSourceParameterType {
@@ -1010,7 +1010,7 @@ declare module 'inspector' {
             /**
              *  If true the change will not actually be applied. Dry run may be used to get result description without actually modifying the code.
              */
-            dryRun?: boolean;
+            dryRun?: boolean | undefined;
         }
 
         interface RestartFrameParameterType {
@@ -1046,28 +1046,28 @@ declare module 'inspector' {
             /**
              * String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>).
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * Specifies whether command line API should be available to the evaluated expression, defaults to false.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether to throw an exception if side effect cannot be ruled out during evaluation.
              */
-            throwOnSideEffect?: boolean;
+            throwOnSideEffect?: boolean | undefined;
         }
 
         interface SetVariableValueParameterType {
@@ -1170,24 +1170,24 @@ declare module 'inspector' {
             /**
              * New stack trace in case editing has happened while VM was stopped.
              */
-            callFrames?: CallFrame[];
+            callFrames?: CallFrame[] | undefined;
             /**
              * Whether current call stack  was modified after applying the changes.
              */
-            stackChanged?: boolean;
+            stackChanged?: boolean | undefined;
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
             /**
              * Exception details if any.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: Runtime.ExceptionDetails | undefined;
         }
 
         interface RestartFrameReturnType {
@@ -1198,12 +1198,12 @@ declare module 'inspector' {
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
         }
 
         interface GetScriptSourceReturnType {
@@ -1221,7 +1221,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: Runtime.ExceptionDetails | undefined;
         }
 
         interface ScriptParsedEventDataType {
@@ -1260,33 +1260,33 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {};
+            executionContextAuxData?: {} | undefined;
             /**
              * True, if this script is generated as a result of the live edit operation.
              * @experimental
              */
-            isLiveEdit?: boolean;
+            isLiveEdit?: boolean | undefined;
             /**
              * URL of source map associated with script (if any).
              */
-            sourceMapURL?: string;
+            sourceMapURL?: string | undefined;
             /**
              * True, if this script has sourceURL.
              */
-            hasSourceURL?: boolean;
+            hasSourceURL?: boolean | undefined;
             /**
              * True, if this script is ES6 module.
              */
-            isModule?: boolean;
+            isModule?: boolean | undefined;
             /**
              * This script length.
              */
-            length?: number;
+            length?: number | undefined;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
              * @experimental
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: Runtime.StackTrace | undefined;
         }
 
         interface ScriptFailedToParseEventDataType {
@@ -1325,28 +1325,28 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {};
+            executionContextAuxData?: {} | undefined;
             /**
              * URL of source map associated with script (if any).
              */
-            sourceMapURL?: string;
+            sourceMapURL?: string | undefined;
             /**
              * True, if this script has sourceURL.
              */
-            hasSourceURL?: boolean;
+            hasSourceURL?: boolean | undefined;
             /**
              * True, if this script is ES6 module.
              */
-            isModule?: boolean;
+            isModule?: boolean | undefined;
             /**
              * This script length.
              */
-            length?: number;
+            length?: number | undefined;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
              * @experimental
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: Runtime.StackTrace | undefined;
         }
 
         interface BreakpointResolvedEventDataType {
@@ -1372,25 +1372,25 @@ declare module 'inspector' {
             /**
              * Object containing break-specific auxiliary properties.
              */
-            data?: {};
+            data?: {} | undefined;
             /**
              * Hit breakpoints IDs
              */
-            hitBreakpoints?: string[];
+            hitBreakpoints?: string[] | undefined;
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
             /**
              * Just scheduled async call will have this stack trace as parent stack during async execution. This field is available only after <code>Debugger.stepInto</code> call with <code>breakOnAsynCall</code> flag.
              * @experimental
              */
-            asyncCallStackTraceId?: Runtime.StackTraceId;
+            asyncCallStackTraceId?: Runtime.StackTraceId | undefined;
         }
     }
 
@@ -1414,15 +1414,15 @@ declare module 'inspector' {
             /**
              * URL of the message origin.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * Line number in the resource that generated this message (1-based).
              */
-            line?: number;
+            line?: number | undefined;
             /**
              * Column number in the resource that generated this message (1-based).
              */
-            column?: number;
+            column?: number | undefined;
         }
 
         interface MessageAddedEventDataType {
@@ -1449,19 +1449,19 @@ declare module 'inspector' {
             /**
              * Number of samples where this node was on top of the call stack.
              */
-            hitCount?: number;
+            hitCount?: number | undefined;
             /**
              * Child node ids.
              */
-            children?: number[];
+            children?: number[] | undefined;
             /**
              * The reason of being not optimized. The function may be deoptimized or marked as don't optimize.
              */
-            deoptReason?: string;
+            deoptReason?: string | undefined;
             /**
              * An array of source position ticks.
              */
-            positionTicks?: PositionTickInfo[];
+            positionTicks?: PositionTickInfo[] | undefined;
         }
 
         /**
@@ -1483,11 +1483,11 @@ declare module 'inspector' {
             /**
              * Ids of samples top nodes.
              */
-            samples?: number[];
+            samples?: number[] | undefined;
             /**
              * Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime.
              */
-            timeDeltas?: number[];
+            timeDeltas?: number[] | undefined;
         }
 
         /**
@@ -1614,11 +1614,11 @@ declare module 'inspector' {
             /**
              * Collect accurate call counts beyond simple 'covered' or 'not covered'.
              */
-            callCount?: boolean;
+            callCount?: boolean | undefined;
             /**
              * Collect block-based coverage.
              */
-            detailed?: boolean;
+            detailed?: boolean | undefined;
         }
 
         interface StopReturnType {
@@ -1658,7 +1658,7 @@ declare module 'inspector' {
             /**
              * Profile title passed as an argument to console.profile().
              */
-            title?: string;
+            title?: string | undefined;
         }
 
         interface ConsoleProfileFinishedEventDataType {
@@ -1671,7 +1671,7 @@ declare module 'inspector' {
             /**
              * Profile title passed as an argument to console.profile().
              */
-            title?: string;
+            title?: string | undefined;
         }
     }
 
@@ -1707,21 +1707,21 @@ declare module 'inspector' {
         }
 
         interface StartTrackingHeapObjectsParameterType {
-            trackAllocations?: boolean;
+            trackAllocations?: boolean | undefined;
         }
 
         interface StopTrackingHeapObjectsParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped.
              */
-            reportProgress?: boolean;
+            reportProgress?: boolean | undefined;
         }
 
         interface TakeHeapSnapshotParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.
              */
-            reportProgress?: boolean;
+            reportProgress?: boolean | undefined;
         }
 
         interface GetObjectByHeapObjectIdParameterType {
@@ -1729,7 +1729,7 @@ declare module 'inspector' {
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
         }
 
         interface AddInspectedHeapObjectParameterType {
@@ -1750,7 +1750,7 @@ declare module 'inspector' {
             /**
              * Average sample interval in bytes. Poisson distribution is used for the intervals. The default value is 32768 bytes.
              */
-            samplingInterval?: number;
+            samplingInterval?: number | undefined;
         }
 
         interface GetObjectByHeapObjectIdReturnType {
@@ -1788,7 +1788,7 @@ declare module 'inspector' {
         interface ReportHeapSnapshotProgressEventDataType {
             done: number;
             total: number;
-            finished?: boolean;
+            finished?: boolean | undefined;
         }
 
         interface LastSeenObjectIdEventDataType {
@@ -1809,7 +1809,7 @@ declare module 'inspector' {
             /**
              * Controls how the trace buffer stores data.
              */
-            recordMode?: string;
+            recordMode?: string | undefined;
             /**
              * Included category filters.
              */

--- a/types/node/v12/net.d.ts
+++ b/types/node/v12/net.d.ts
@@ -16,10 +16,10 @@ declare module 'net' {
     }
 
     interface SocketConstructorOpts {
-        fd?: number;
-        allowHalfOpen?: boolean;
-        readable?: boolean;
-        writable?: boolean;
+        fd?: number | undefined;
+        allowHalfOpen?: boolean | undefined;
+        readable?: boolean | undefined;
+        writable?: boolean | undefined;
     }
 
     interface OnReadOpts {
@@ -38,17 +38,17 @@ declare module 'net' {
          * Note: this will cause the streaming functionality to not provide any data, however events like 'error', 'end', and 'close' will
          * still be emitted as normal and methods like pause() and resume() will also behave as expected.
          */
-        onread?: OnReadOpts;
+        onread?: OnReadOpts | undefined;
     }
 
     interface TcpSocketConnectOpts extends ConnectOpts {
         port: number;
-        host?: string;
-        localAddress?: string;
-        localPort?: number;
-        hints?: number;
-        family?: number;
-        lookup?: LookupFunction;
+        host?: string | undefined;
+        localAddress?: string | undefined;
+        localPort?: number | undefined;
+        hints?: number | undefined;
+        family?: number | undefined;
+        lookup?: LookupFunction | undefined;
     }
 
     interface IpcSocketConnectOpts extends ConnectOpts {
@@ -86,9 +86,9 @@ declare module 'net' {
         readonly destroyed: boolean;
         readonly localAddress: string;
         readonly localPort: number;
-        readonly remoteAddress?: string;
-        readonly remoteFamily?: string;
-        readonly remotePort?: number;
+        readonly remoteAddress?: string | undefined;
+        readonly remoteFamily?: string | undefined;
+        readonly remotePort?: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): void;
@@ -168,23 +168,23 @@ declare module 'net' {
     }
 
     interface ListenOptions {
-        port?: number;
-        host?: string;
-        backlog?: number;
-        path?: string;
-        exclusive?: boolean;
-        readableAll?: boolean;
-        writableAll?: boolean;
+        port?: number | undefined;
+        host?: string | undefined;
+        backlog?: number | undefined;
+        path?: string | undefined;
+        exclusive?: boolean | undefined;
+        readableAll?: boolean | undefined;
+        writableAll?: boolean | undefined;
         /**
          * @default false
          */
-        ipv6Only?: boolean;
+        ipv6Only?: boolean | undefined;
     }
 
     // https://github.com/nodejs/node/blob/master/lib/net.js
     class Server extends EventEmitter {
         constructor(connectionListener?: (socket: Socket) => void);
-        constructor(options?: { allowHalfOpen?: boolean, pauseOnConnect?: boolean }, connectionListener?: (socket: Socket) => void);
+        constructor(options?: { allowHalfOpen?: boolean | undefined, pauseOnConnect?: boolean | undefined }, connectionListener?: (socket: Socket) => void);
 
         listen(port?: number, hostname?: string, backlog?: number, listeningListener?: () => void): this;
         listen(port?: number, hostname?: string, listeningListener?: () => void): this;
@@ -249,17 +249,17 @@ declare module 'net' {
     }
 
     interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
 
     function createServer(connectionListener?: (socket: Socket) => void): Server;
-    function createServer(options?: { allowHalfOpen?: boolean, pauseOnConnect?: boolean }, connectionListener?: (socket: Socket) => void): Server;
+    function createServer(options?: { allowHalfOpen?: boolean | undefined, pauseOnConnect?: boolean | undefined }, connectionListener?: (socket: Socket) => void): Server;
     function connect(options: NetConnectOpts, connectionListener?: () => void): Socket;
     function connect(port: number, host?: string, connectionListener?: () => void): Socket;
     function connect(path: string, connectionListener?: () => void): Socket;

--- a/types/node/v12/path.d.ts
+++ b/types/node/v12/path.d.ts
@@ -28,23 +28,23 @@ declare module 'path' {
         /**
          * The root of the path such as '/' or 'c:\'
          */
-        root?: string;
+        root?: string | undefined;
         /**
          * The full directory path such as '/home/user/dir' or 'c:\path\dir'
          */
-        dir?: string;
+        dir?: string | undefined;
         /**
          * The file name including extension (if any) such as 'index.html'
          */
-        base?: string;
+        base?: string | undefined;
         /**
          * The file extension (if any) such as '.html'
          */
-        ext?: string;
+        ext?: string | undefined;
         /**
          * The file name without extension (if any) such as 'index'
          */
-        name?: string;
+        name?: string | undefined;
     }
 
     /**

--- a/types/node/v12/perf_hooks.d.ts
+++ b/types/node/v12/perf_hooks.d.ts
@@ -29,7 +29,7 @@ declare module 'perf_hooks' {
          * the type of garbage collection operation that occurred.
          * The value may be one of perf_hooks.constants.
          */
-        readonly kind?: number;
+        readonly kind?: number | undefined;
     }
 
     interface PerformanceNodeTiming extends PerformanceEntry {
@@ -182,7 +182,7 @@ declare module 'perf_hooks' {
          * Property buffered defaults to false.
          * @param options
          */
-        observe(options: { entryTypes: ReadonlyArray<string>; buffered?: boolean }): void;
+        observe(options: { entryTypes: ReadonlyArray<string>; buffered?: boolean | undefined }): void;
     }
 
     namespace constants {
@@ -200,7 +200,7 @@ declare module 'perf_hooks' {
          * Must be greater than zero.
          * @default 10
          */
-        resolution?: number;
+        resolution?: number | undefined;
     }
 
     interface EventLoopDelayMonitor {

--- a/types/node/v12/querystring.d.ts
+++ b/types/node/v12/querystring.d.ts
@@ -1,11 +1,11 @@
 declare module 'querystring' {
     interface StringifyOptions {
-        encodeURIComponent?: (str: string) => string;
+        encodeURIComponent?: ((str: string) => string) | undefined;
     }
 
     interface ParseOptions {
-        maxKeys?: number;
-        decodeURIComponent?: (str: string) => string;
+        maxKeys?: number | undefined;
+        decodeURIComponent?: ((str: string) => string) | undefined;
     }
 
     interface ParsedUrlQuery { [key: string]: string | string[]; }

--- a/types/node/v12/readline.d.ts
+++ b/types/node/v12/readline.d.ts
@@ -2,11 +2,11 @@ declare module 'readline' {
     import EventEmitter = require('events');
 
     interface Key {
-        sequence?: string;
-        name?: string;
-        ctrl?: boolean;
-        meta?: boolean;
-        shift?: boolean;
+        sequence?: string | undefined;
+        name?: string | undefined;
+        ctrl?: boolean | undefined;
+        meta?: boolean | undefined;
+        shift?: boolean | undefined;
     }
 
     class Interface extends EventEmitter {
@@ -122,14 +122,14 @@ declare module 'readline' {
 
     interface ReadLineOptions {
         input: NodeJS.ReadableStream;
-        output?: NodeJS.WritableStream;
-        completer?: Completer | AsyncCompleter;
-        terminal?: boolean;
-        historySize?: number;
-        prompt?: string;
-        crlfDelay?: number;
-        removeHistoryDuplicates?: boolean;
-        escapeCodeTimeout?: number;
+        output?: NodeJS.WritableStream | undefined;
+        completer?: Completer | AsyncCompleter | undefined;
+        terminal?: boolean | undefined;
+        historySize?: number | undefined;
+        prompt?: string | undefined;
+        crlfDelay?: number | undefined;
+        removeHistoryDuplicates?: boolean | undefined;
+        escapeCodeTimeout?: number | undefined;
     }
 
     function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;

--- a/types/node/v12/repl.d.ts
+++ b/types/node/v12/repl.d.ts
@@ -8,24 +8,24 @@ declare module 'repl' {
          * The input prompt to display.
          * @default "> "
          */
-        prompt?: string;
+        prompt?: string | undefined;
         /**
          * The `Readable` stream from which REPL input will be read.
          * @default process.stdin
          */
-        input?: NodeJS.ReadableStream;
+        input?: NodeJS.ReadableStream | undefined;
         /**
          * The `Writable` stream to which REPL output will be written.
          * @default process.stdout
          */
-        output?: NodeJS.WritableStream;
+        output?: NodeJS.WritableStream | undefined;
         /**
          * If `true`, specifies that the output should be treated as a TTY terminal, and have
          * ANSI/VT100 escape codes written to it.
          * Default: checking the value of the `isTTY` property on the output stream upon
          * instantiation.
          */
-        terminal?: boolean;
+        terminal?: boolean | undefined;
         /**
          * The function to be used when evaluating each given line of input.
          * Default: an async wrapper for the JavaScript `eval()` function. An `eval` function can
@@ -35,40 +35,40 @@ declare module 'repl' {
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
-        eval?: REPLEval;
+        eval?: REPLEval | undefined;
         /**
          * If `true`, specifies that the default `writer` function should include ANSI color
          * styling to REPL output. If a custom `writer` function is provided then this has no
          * effect.
          * Default: the REPL instance's `terminal` value.
          */
-        useColors?: boolean;
+        useColors?: boolean | undefined;
         /**
          * If `true`, specifies that the default evaluation function will use the JavaScript
          * `global` as the context as opposed to creating a new separate context for the REPL
          * instance. The node CLI REPL sets this value to `true`.
          * Default: `false`.
          */
-        useGlobal?: boolean;
+        useGlobal?: boolean | undefined;
         /**
          * If `true`, specifies that the default writer will not output the return value of a
          * command if it evaluates to `undefined`.
          * Default: `false`.
          */
-        ignoreUndefined?: boolean;
+        ignoreUndefined?: boolean | undefined;
         /**
          * The function to invoke to format the output of each command before writing to `output`.
          * Default: a wrapper for `util.inspect`.
          *
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
          */
-        writer?: REPLWriter;
+        writer?: REPLWriter | undefined;
         /**
          * An optional function used for custom Tab auto completion.
          *
          * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
-        completer?: Completer | AsyncCompleter;
+        completer?: Completer | AsyncCompleter | undefined;
         /**
          * A flag that specifies whether the default evaluator executes all JavaScript commands in
          * strict mode or default (sloppy) mode.
@@ -77,13 +77,13 @@ declare module 'repl' {
          * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
          *   prefacing every repl statement with `'use strict'`.
          */
-        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
+        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT | undefined;
         /**
          * Stop evaluating the current piece of code when `SIGINT` is received, i.e. `Ctrl+C` is
          * pressed. This cannot be used together with a custom `eval` function.
          * Default: `false`.
          */
-        breakEvalOnSigint?: boolean;
+        breakEvalOnSigint?: boolean | undefined;
     }
 
     type REPLEval = (this: REPLServer, evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
@@ -101,7 +101,7 @@ declare module 'repl' {
         /**
          * Help text to be displayed when `.help` is entered.
          */
-        help?: string;
+        help?: string | undefined;
         /**
          * The function to execute, optionally accepting a single string argument.
          */

--- a/types/node/v12/stream.d.ts
+++ b/types/node/v12/stream.d.ts
@@ -2,19 +2,19 @@ declare module 'stream' {
     import EventEmitter = require('events');
 
     class internal extends EventEmitter {
-        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
     }
 
     namespace internal {
         class Stream extends internal { }
 
         interface ReadableOptions {
-            highWaterMark?: number;
-            encoding?: string;
-            objectMode?: boolean;
+            highWaterMark?: number | undefined;
+            encoding?: string | undefined;
+            objectMode?: boolean | undefined;
             read?(this: Readable, size: number): void;
             destroy?(this: Readable, error: Error | null, callback: (error: Error | null) => void): void;
-            autoDestroy?: boolean;
+            autoDestroy?: boolean | undefined;
         }
 
         class Readable extends Stream implements NodeJS.ReadableStream {
@@ -107,16 +107,16 @@ declare module 'stream' {
         }
 
         interface WritableOptions {
-            highWaterMark?: number;
-            decodeStrings?: boolean;
-            defaultEncoding?: string;
-            objectMode?: boolean;
-            emitClose?: boolean;
+            highWaterMark?: number | undefined;
+            decodeStrings?: boolean | undefined;
+            defaultEncoding?: string | undefined;
+            objectMode?: boolean | undefined;
+            emitClose?: boolean | undefined;
             write?(this: Writable, chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
             writev?(this: Writable, chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
             destroy?(this: Writable, error: Error | null, callback: (error: Error | null) => void): void;
             final?(this: Writable, callback: (error?: Error | null) => void): void;
-            autoDestroy?: boolean;
+            autoDestroy?: boolean | undefined;
         }
 
         class Writable extends Stream implements NodeJS.WritableStream {
@@ -210,11 +210,11 @@ declare module 'stream' {
         }
 
         interface DuplexOptions extends ReadableOptions, WritableOptions {
-            allowHalfOpen?: boolean;
-            readableObjectMode?: boolean;
-            writableObjectMode?: boolean;
-            readableHighWaterMark?: number;
-            writableHighWaterMark?: number;
+            allowHalfOpen?: boolean | undefined;
+            readableObjectMode?: boolean | undefined;
+            writableObjectMode?: boolean | undefined;
+            readableHighWaterMark?: number | undefined;
+            writableHighWaterMark?: number | undefined;
             read?(this: Duplex, size: number): void;
             write?(this: Duplex, chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
             writev?(this: Duplex, chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
@@ -266,9 +266,9 @@ declare module 'stream' {
         class PassThrough extends Transform { }
 
         interface FinishedOptions {
-            error?: boolean;
-            readable?: boolean;
-            writable?: boolean;
+            error?: boolean | undefined;
+            readable?: boolean | undefined;
+            writable?: boolean | undefined;
         }
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;

--- a/types/node/v12/tls.d.ts
+++ b/types/node/v12/tls.d.ts
@@ -70,7 +70,7 @@ declare module 'tls' {
         /**
          * The name property is available only when type is 'ECDH'.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * The size of parameter of an ephemeral key exchange.
          */
@@ -85,7 +85,7 @@ declare module 'tls' {
         /**
          * Optional passphrase.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface PxfObject {
@@ -96,7 +96,7 @@ declare module 'tls' {
         /**
          * Optional passphrase.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
@@ -104,22 +104,22 @@ declare module 'tls' {
          * If true the TLS socket will be instantiated in server-mode.
          * Defaults to false.
          */
-        isServer?: boolean;
+        isServer?: boolean | undefined;
         /**
          * An optional net.Server instance.
          */
-        server?: net.Server;
+        server?: net.Server | undefined;
 
         /**
          * An optional Buffer instance containing a TLS session.
          */
-        session?: Buffer;
+        session?: Buffer | undefined;
         /**
          * If true, specifies that the OCSP status request extension will be
          * added to the client hello and an 'OCSPResponse' event will be
          * emitted on the socket before establishing a secure communication
          */
-        requestOCSP?: boolean;
+        requestOCSP?: boolean | undefined;
     }
 
     class TLSSocket extends net.Socket {
@@ -147,7 +147,7 @@ declare module 'tls' {
          * String containing the selected ALPN protocol.
          * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string;
+        alpnProtocol?: string | undefined;
 
         /**
          * Returns an object representing the local certificate. The returned
@@ -259,7 +259,7 @@ declare module 'tls' {
          * is successfully completed.
          * @return `undefined` when socket is destroy, `false` if negotiaion can't be initiated.
          */
-        renegotiate(options: { rejectUnauthorized?: boolean, requestCert?: boolean }, callback: (err: Error | null) => void): undefined | boolean;
+        renegotiate(options: { rejectUnauthorized?: boolean | undefined, requestCert?: boolean | undefined }, callback: (err: Error | null) => void): undefined | boolean;
         /**
          * Set maximum TLS fragment size (default and maximum value is: 16384, minimum is: 512).
          * Smaller fragment size decreases buffering latency on the client: large fragments are buffered by
@@ -331,25 +331,25 @@ declare module 'tls' {
         /**
          * An optional TLS context object from tls.createSecureContext()
          */
-        secureContext?: SecureContext;
+        secureContext?: SecureContext | undefined;
 
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false
          */
-        enableTrace?: boolean;
+        enableTrace?: boolean | undefined;
         /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
-        requestCert?: boolean;
+        requestCert?: boolean | undefined;
         /**
          * An array of strings or a Buffer naming possible ALPN protocols.
          * (Protocols should be ordered by their priority.)
          */
-        ALPNProtocols?: string[] | Uint8Array[] | Uint8Array;
+        ALPNProtocols?: string[] | Uint8Array[] | Uint8Array | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments
@@ -359,14 +359,14 @@ declare module 'tls' {
          * SecureContext.) If SNICallback wasn't provided the default callback
          * with high-level API will be used (see below).
          */
-        SNICallback?: (servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void;
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void) | undefined;
         /**
          * If true the server will reject any connection which is not
          * authorized with the list of supplied CAs. This option only has an
          * effect if requestCert is true.
          * @default true
          */
-        rejectUnauthorized?: boolean;
+        rejectUnauthorized?: boolean | undefined;
     }
 
     interface TlsOptions extends SecureContextOptions, CommonConnectionOptions {
@@ -376,30 +376,30 @@ declare module 'tls' {
          * the tls.Server object whenever a handshake times out. Default:
          * 120000 (120 seconds).
          */
-        handshakeTimeout?: number;
+        handshakeTimeout?: number | undefined;
         /**
          * The number of seconds after which a TLS session created by the
          * server will no longer be resumable. See Session Resumption for more
          * information. Default: 300.
          */
-        sessionTimeout?: number;
+        sessionTimeout?: number | undefined;
         /**
          * 48-bytes of cryptographically strong pseudo-random data.
          */
-        ticketKeys?: Buffer;
+        ticketKeys?: Buffer | undefined;
     }
 
     interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
-        host?: string;
-        port?: number;
-        path?: string; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
-        socket?: net.Socket; // Establish secure connection on a given socket rather than creating a new socket
-        checkServerIdentity?: typeof checkServerIdentity;
-        servername?: string; // SNI TLS Extension
-        session?: Buffer;
-        minDHSize?: number;
-        lookup?: net.LookupFunction;
-        timeout?: number;
+        host?: string | undefined;
+        port?: number | undefined;
+        path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
+        socket?: net.Socket | undefined; // Establish secure connection on a given socket rather than creating a new socket
+        checkServerIdentity?: typeof checkServerIdentity | undefined;
+        servername?: string | undefined; // SNI TLS Extension
+        session?: Buffer | undefined;
+        minDHSize?: number | undefined;
+        lookup?: net.LookupFunction | undefined;
+        timeout?: number | undefined;
     }
 
     class Server extends net.Server {
@@ -498,7 +498,7 @@ declare module 'tls' {
          * the well-known CAs curated by Mozilla. Mozilla's CAs are completely
          * replaced when CAs are explicitly specified using this option.
          */
-        ca?: string | Buffer | Array<string | Buffer>;
+        ca?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          *  Cert chains in PEM format. One cert chain should be provided per
          *  private key. Each cert chain should consist of the PEM formatted
@@ -510,29 +510,29 @@ declare module 'tls' {
          *  intermediate certificates are not provided, the peer will not be
          *  able to validate the certificate, and the handshake will fail.
          */
-        cert?: string | Buffer | Array<string | Buffer>;
+        cert?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          *  Colon-separated list of supported signature algorithms. The list
          *  can contain digest algorithms (SHA256, MD5 etc.), public key
          *  algorithms (RSA-PSS, ECDSA etc.), combination of both (e.g
          *  'RSA+SHA384') or TLS v1.3 scheme names (e.g. rsa_pss_pss_sha512).
          */
-        sigalgs?: string;
+        sigalgs?: string | undefined;
         /**
          * Cipher suite specification, replacing the default. For more
          * information, see modifying the default cipher suite. Permitted
          * ciphers can be obtained via tls.getCiphers(). Cipher names must be
          * uppercased in order for OpenSSL to accept them.
          */
-        ciphers?: string;
+        ciphers?: string | undefined;
         /**
          * Name of an OpenSSL engine which can provide the client certificate.
          */
-        clientCertEngine?: string;
+        clientCertEngine?: string | undefined;
         /**
          * PEM formatted CRLs (Certificate Revocation Lists).
          */
-        crl?: string | Buffer | Array<string | Buffer>;
+        crl?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          * Diffie Hellman parameters, required for Perfect Forward Secrecy. Use
          * openssl dhparam to create the parameters. The key length must be
@@ -541,7 +541,7 @@ declare module 'tls' {
          * stronger security. If omitted or invalid, the parameters are
          * silently discarded and DHE ciphers will not be available.
          */
-        dhparam?: string | Buffer;
+        dhparam?: string | Buffer | undefined;
         /**
          * A string describing a named curve or a colon separated list of curve
          * NIDs or names, for example P-521:P-384:P-256, to use for ECDH key
@@ -551,13 +551,13 @@ declare module 'tls' {
          * name and description of each available elliptic curve. Default:
          * tls.DEFAULT_ECDH_CURVE.
          */
-        ecdhCurve?: string;
+        ecdhCurve?: string | undefined;
         /**
          * Attempt to use the server's cipher suite preferences instead of the
          * client's. When true, causes SSL_OP_CIPHER_SERVER_PREFERENCE to be
          * set in secureOptions
          */
-        honorCipherOrder?: boolean;
+        honorCipherOrder?: boolean | undefined;
         /**
          * Private keys in PEM format. PEM allows the option of private keys
          * being encrypted. Encrypted keys will be decrypted with
@@ -568,18 +568,18 @@ declare module 'tls' {
          * object.passphrase is optional. Encrypted keys will be decrypted with
          * object.passphrase if provided, or options.passphrase if it is not.
          */
-        key?: string | Buffer | Array<Buffer | KeyObject>;
+        key?: string | Buffer | Array<Buffer | KeyObject> | undefined;
         /**
          * Name of an OpenSSL engine to get private key from. Should be used
          * together with privateKeyIdentifier.
          */
-        privateKeyEngine?: string;
+        privateKeyEngine?: string | undefined;
         /**
          * Identifier of a private key managed by an OpenSSL engine. Should be
          * used together with privateKeyEngine. Should not be set together with
          * key, because both options define a private key in different ways.
          */
-        privateKeyIdentifier?: string;
+        privateKeyIdentifier?: string | undefined;
         /**
          * Optionally set the maximum TLS version to allow. One
          * of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
@@ -588,7 +588,7 @@ declare module 'tls' {
          * `--tls-max-v1.2` sets the default to `'TLSv1.2'`. Using `--tls-max-v1.3` sets the default to
          * `'TLSv1.3'`. If multiple of the options are provided, the highest maximum is used.
          */
-        maxVersion?: SecureVersion;
+        maxVersion?: SecureVersion | undefined;
         /**
          * Optionally set the minimum TLS version to allow. One
          * of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
@@ -599,11 +599,11 @@ declare module 'tls' {
          * `'TLSv1.1'`. Using `--tls-min-v1.3` sets the default to
          * 'TLSv1.3'. If multiple of the options are provided, the lowest minimum is used.
          */
-        minVersion?: SecureVersion;
+        minVersion?: SecureVersion | undefined;
         /**
          * Shared passphrase used for a single private key and/or a PFX.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
         /**
          * PFX or PKCS12 encoded private key and certificate chain. pfx is an
          * alternative to providing key and cert individually. PFX is usually
@@ -614,13 +614,13 @@ declare module 'tls' {
          * object.passphrase is optional. Encrypted PFX will be decrypted with
          * object.passphrase if provided, or options.passphrase if it is not.
          */
-        pfx?: string | Buffer | Array<string | Buffer | PxfObject>;
+        pfx?: string | Buffer | Array<string | Buffer | PxfObject> | undefined;
         /**
          * Optionally affect the OpenSSL protocol behavior, which is not
          * usually necessary. This should be used carefully if at all! Value is
          * a numeric bitmask of the SSL_OP_* options from OpenSSL Options
          */
-        secureOptions?: number; // Value is a numeric bitmask of the `SSL_OP_*` options
+        secureOptions?: number | undefined; // Value is a numeric bitmask of the `SSL_OP_*` options
         /**
          * Legacy mechanism to select the TLS protocol version to use, it does
          * not support independent control of the minimum and maximum version,
@@ -632,23 +632,23 @@ declare module 'tls' {
          * TLS versions less than 1.2, but it may be required for
          * interoperability. Default: none, see minVersion.
          */
-        secureProtocol?: string;
+        secureProtocol?: string | undefined;
         /**
          * Opaque identifier used by servers to ensure session state is not
          * shared between applications. Unused by clients.
          */
-        sessionIdContext?: string;
+        sessionIdContext?: string | undefined;
         /**
          * 48-bytes of cryptographically strong pseudo-random data.
          * See Session Resumption for more information.
          */
-        ticketKeys?: Buffer;
+        ticketKeys?: Buffer | undefined;
         /**
          * The number of seconds after which a TLS session created by the
          * server will no longer be resumable. See Session Resumption for more
          * information. Default: 300.
          */
-        sessionTimeout?: number;
+        sessionTimeout?: number | undefined;
     }
 
     interface SecureContext {

--- a/types/node/v12/url.d.ts
+++ b/types/node/v12/url.d.ts
@@ -3,18 +3,18 @@ declare module 'url' {
 
     // Input to `url.format`
     interface UrlObject {
-        auth?: string | null;
-        hash?: string | null;
-        host?: string | null;
-        hostname?: string | null;
-        href?: string | null;
-        path?: string | null;
-        pathname?: string | null;
-        protocol?: string | null;
-        search?: string | null;
-        slashes?: boolean | null;
-        port?: string | number | null;
-        query?: string | null | ParsedUrlQueryInput;
+        auth?: string | null | undefined;
+        hash?: string | null | undefined;
+        host?: string | null | undefined;
+        hostname?: string | null | undefined;
+        href?: string | null | undefined;
+        path?: string | null | undefined;
+        pathname?: string | null | undefined;
+        protocol?: string | null | undefined;
+        search?: string | null | undefined;
+        slashes?: boolean | null | undefined;
+        port?: string | number | null | undefined;
+        query?: string | null | ParsedUrlQueryInput | undefined;
     }
 
     // Output of `url.parse`
@@ -74,10 +74,10 @@ declare module 'url' {
     function pathToFileURL(url: string): URL;
 
     interface URLFormatOptions {
-        auth?: boolean;
-        fragment?: boolean;
-        search?: boolean;
-        unicode?: boolean;
+        auth?: boolean | undefined;
+        fragment?: boolean | undefined;
+        search?: boolean | undefined;
+        unicode?: boolean | undefined;
     }
 
     class URL {

--- a/types/node/v12/util.d.ts
+++ b/types/node/v12/util.d.ts
@@ -172,11 +172,11 @@ declare module 'util' {
         readonly ignoreBOM: boolean;
         constructor(
           encoding?: string,
-          options?: { fatal?: boolean; ignoreBOM?: boolean }
+          options?: { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined }
         );
         decode(
           input?: NodeJS.ArrayBufferView | ArrayBuffer | null,
-          options?: { stream?: boolean }
+          options?: { stream?: boolean | undefined }
         ): string;
     }
 

--- a/types/node/v12/vm.d.ts
+++ b/types/node/v12/vm.d.ts
@@ -7,63 +7,63 @@ declare module 'vm' {
          * Specifies the filename used in stack traces produced by this script.
          * Default: `''`.
          */
-        filename?: string;
+        filename?: string | undefined;
         /**
          * Specifies the line number offset that is displayed in stack traces produced by this script.
          * Default: `0`.
          */
-        lineOffset?: number;
+        lineOffset?: number | undefined;
         /**
          * Specifies the column number offset that is displayed in stack traces produced by this script.
          * @default 0
          */
-        columnOffset?: number;
+        columnOffset?: number | undefined;
     }
     interface ScriptOptions extends BaseOptions {
-        displayErrors?: boolean;
-        timeout?: number;
-        cachedData?: Buffer;
+        displayErrors?: boolean | undefined;
+        timeout?: number | undefined;
+        cachedData?: Buffer | undefined;
         /** @deprecated in favor of `script.createCachedData()` */
-        produceCachedData?: boolean;
+        produceCachedData?: boolean | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
         /**
          * When `true`, if an `Error` occurs while compiling the `code`, the line of code causing the error is attached to the stack trace.
          * Default: `true`.
          */
-        displayErrors?: boolean;
+        displayErrors?: boolean | undefined;
         /**
          * Specifies the number of milliseconds to execute code before terminating execution.
          * If execution is terminated, an `Error` will be thrown. This value must be a strictly positive integer.
          */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * If `true`, the execution will be terminated when `SIGINT` (Ctrl+C) is received.
          * Existing handlers for the event that have been attached via `process.on('SIGINT')` will be disabled during script execution, but will continue to work after that.
          * If execution is terminated, an `Error` will be thrown.
          * Default: `false`.
          */
-        breakOnSigint?: boolean;
+        breakOnSigint?: boolean | undefined;
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
-        cachedData?: Buffer;
+        cachedData?: Buffer | undefined;
         /**
          * Specifies whether to produce new cache data.
          * Default: `false`,
          */
-        produceCachedData?: boolean;
+        produceCachedData?: boolean | undefined;
         /**
          * The sandbox/context in which the said function should be compiled in.
          */
-        parsingContext?: Context;
+        parsingContext?: Context | undefined;
 
         /**
          * An array containing a collection of context extensions (objects wrapping the current scope) to be applied while compiling
          */
-        contextExtensions?: Object[];
+        contextExtensions?: Object[] | undefined;
     }
 
     interface CreateContextOptions {
@@ -71,7 +71,7 @@ declare module 'vm' {
          * Human-readable name of the newly created context.
          * @default 'VM Context i' Where i is an ascending numerical index of the created context.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * Corresponds to the newly created context for display purposes.
          * The origin should be formatted like a `URL`, but with only the scheme, host, and port (if necessary),
@@ -79,20 +79,20 @@ declare module 'vm' {
          * Most notably, this string should omit the trailing slash, as that denotes a path.
          * @default ''
          */
-        origin?: string;
+        origin?: string | undefined;
         codeGeneration?: {
             /**
              * If set to false any calls to eval or function constructors (Function, GeneratorFunction, etc)
              * will throw an EvalError.
              * @default true
              */
-            strings?: boolean;
+            strings?: boolean | undefined;
             /**
              * If set to false any attempt to compile a WebAssembly module will throw a WebAssembly.CompileError.
              * @default true
              */
-            wasm?: boolean;
-        };
+            wasm?: boolean | undefined;
+        } | undefined;
     }
 
     class Script {
@@ -101,7 +101,7 @@ declare module 'vm' {
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
         createCachedData(): Buffer;
-        cachedDataRejected?: boolean;
+        cachedDataRejected?: boolean | undefined;
     }
     function createContext(sandbox?: Context, options?: CreateContextOptions): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/v12/wasi.d.ts
+++ b/types/node/v12/wasi.d.ts
@@ -5,13 +5,13 @@ declare module 'wasi' {
          * see as command line arguments. The first argument is the virtual path to the
          * WASI command itself.
          */
-        args?: string[];
+        args?: string[] | undefined;
 
         /**
          * An object similar to `process.env` that the WebAssembly
          * application will see as its environment.
          */
-        env?: object;
+        env?: object | undefined;
 
         /**
          * This object represents the WebAssembly application's
@@ -19,7 +19,7 @@ declare module 'wasi' {
          * directories within the sandbox. The corresponding values in `preopens` are
          * the real paths to those directories on the host machine.
          */
-        preopens?: NodeJS.Dict<string>;
+        preopens?: NodeJS.Dict<string> | undefined;
 
         /**
          * By default, WASI applications terminate the Node.js
@@ -28,7 +28,7 @@ declare module 'wasi' {
          * process.
          * @default false
          */
-        returnOnExit?: boolean;
+        returnOnExit?: boolean | undefined;
     }
 
     class WASI {

--- a/types/node/v12/worker_threads.d.ts
+++ b/types/node/v12/worker_threads.d.ts
@@ -59,39 +59,39 @@ declare module 'worker_threads' {
     }
 
     interface WorkerOptions {
-        eval?: boolean;
-        env?: NodeJS.ProcessEnv | typeof SHARE_ENV;
+        eval?: boolean | undefined;
+        env?: NodeJS.ProcessEnv | typeof SHARE_ENV | undefined;
         workerData?: any;
-        stdin?: boolean;
-        stdout?: boolean;
-        stderr?: boolean;
-        execArgv?: string[];
-        resourceLimits?: ResourceLimits;
+        stdin?: boolean | undefined;
+        stdout?: boolean | undefined;
+        stderr?: boolean | undefined;
+        execArgv?: string[] | undefined;
+        resourceLimits?: ResourceLimits | undefined;
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: TransferListItem[];
-        trackUnmanagedFds?: boolean;
+        transferList?: TransferListItem[] | undefined;
+        trackUnmanagedFds?: boolean | undefined;
     }
 
     interface ResourceLimits {
         /**
          * The maximum size of a heap space for recently created objects.
          */
-        maxYoungGenerationSizeMb?: number;
+        maxYoungGenerationSizeMb?: number | undefined;
         /**
          * The maximum size of the main heap in MB.
          */
-        maxOldGenerationSizeMb?: number;
+        maxOldGenerationSizeMb?: number | undefined;
         /**
          * The size of a pre-allocated memory range used for generated code.
          */
-        codeRangeSizeMb?: number;
+        codeRangeSizeMb?: number | undefined;
         /**
          * The default maximum stack size for the thread. Small values may lead to unusable Worker instances.
          * @default 4
          */
-        stackSizeMb?: number;
+        stackSizeMb?: number | undefined;
     }
 
     class Worker extends EventEmitter {
@@ -99,7 +99,7 @@ declare module 'worker_threads' {
         readonly stdout: Readable;
         readonly stderr: Readable;
         readonly threadId: number;
-        readonly resourceLimits?: ResourceLimits;
+        readonly resourceLimits?: ResourceLimits | undefined;
 
         constructor(filename: string, options?: WorkerOptions);
 

--- a/types/node/v12/zlib.d.ts
+++ b/types/node/v12/zlib.d.ts
@@ -5,51 +5,51 @@ declare module 'zlib' {
         /**
          * @default constants.Z_NO_FLUSH
          */
-        flush?: number;
+        flush?: number | undefined;
         /**
          * @default constants.Z_FINISH
          */
-        finishFlush?: number;
+        finishFlush?: number | undefined;
         /**
          * @default 16*1024
          */
-        chunkSize?: number;
-        windowBits?: number;
-        level?: number; // compression only
-        memLevel?: number; // compression only
-        strategy?: number; // compression only
-        dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
-        info?: boolean;
-        maxOutputLength?: number;
+        chunkSize?: number | undefined;
+        windowBits?: number | undefined;
+        level?: number | undefined; // compression only
+        memLevel?: number | undefined; // compression only
+        strategy?: number | undefined; // compression only
+        dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
+        maxOutputLength?: number | undefined;
     }
 
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
          */
-        flush?: number;
+        flush?: number | undefined;
         /**
          * @default constants.BROTLI_OPERATION_FINISH
          */
-        finishFlush?: number;
+        finishFlush?: number | undefined;
         /**
          * @default 16*1024
          */
-        chunkSize?: number;
+        chunkSize?: number | undefined;
         params?: {
             /**
              * Each key is a `constants.BROTLI_*` constant.
              */
             [key: number]: boolean | number;
-        };
-        maxOutputLength?: number;
+        } | undefined;
+        maxOutputLength?: number | undefined;
     }
 
     interface Zlib {
         /** @deprecated Use bytesWritten instead. */
         readonly bytesRead: number;
         readonly bytesWritten: number;
-        shell?: boolean | string;
+        shell?: boolean | string | undefined;
         close(callback?: () => void): void;
         flush(kind?: number, callback?: () => void): void;
         flush(callback?: () => void): void;

--- a/types/node/v14/assert.d.ts
+++ b/types/node/v14/assert.d.ts
@@ -11,16 +11,16 @@ declare module 'assert' {
 
             constructor(options?: {
                 /** If provided, the error message is set to this value. */
-                message?: string;
+                message?: string | undefined;
                 /** The `actual` property on the error instance. */
                 actual?: any;
                 /** The `expected` property on the error instance. */
                 expected?: any;
                 /** The `operator` property on the error instance. */
-                operator?: string;
+                operator?: string | undefined;
                 /** If provided, the generated stack trace omits frames before this function. */
                 // tslint:disable-next-line:ban-types
-                stackStartFn?: Function;
+                stackStartFn?: Function | undefined;
             });
         }
 

--- a/types/node/v14/async_hooks.d.ts
+++ b/types/node/v14/async_hooks.d.ts
@@ -87,7 +87,7 @@ declare module 'async_hooks' {
        * The ID of the execution context that created this async event.
        * @default executionAsyncId()
        */
-      triggerAsyncId?: number;
+      triggerAsyncId?: number | undefined;
 
       /**
        * Disables automatic `emitDestroy` when the object is garbage collected.
@@ -96,7 +96,7 @@ declare module 'async_hooks' {
        * sensitive API's `emitDestroy` is called with it.
        * @default false
        */
-      requireManualDestroy?: boolean;
+      requireManualDestroy?: boolean | undefined;
     }
 
     /**

--- a/types/node/v14/child_process.d.ts
+++ b/types/node/v14/child_process.d.ts
@@ -11,7 +11,7 @@ declare module 'child_process' {
         stdin: Writable | null;
         stdout: Readable | null;
         stderr: Readable | null;
-        readonly channel?: Pipe | null;
+        readonly channel?: Pipe | null | undefined;
         readonly stdio: [
             Writable | null, // stdin
             Readable | null, // stdout
@@ -119,7 +119,7 @@ declare module 'child_process' {
     }
 
     interface MessageOptions {
-        keepOpen?: boolean;
+        keepOpen?: boolean | undefined;
     }
 
     type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | "inherit" | Stream | number | null | undefined)>;
@@ -131,40 +131,40 @@ declare module 'child_process' {
          * Specify the kind of serialization used for sending messages between processes.
          * @default 'json'
          */
-        serialization?: SerializationType;
+        serialization?: SerializationType | undefined;
     }
 
     interface ProcessEnvOptions {
-        uid?: number;
-        gid?: number;
-        cwd?: string;
-        env?: NodeJS.ProcessEnv;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        cwd?: string | undefined;
+        env?: NodeJS.ProcessEnv | undefined;
     }
 
     interface CommonOptions extends ProcessEnvOptions {
         /**
          * @default true
          */
-        windowsHide?: boolean;
+        windowsHide?: boolean | undefined;
         /**
          * @default 0
          */
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions {
-        argv0?: string;
-        stdio?: StdioOptions;
-        shell?: boolean | string;
-        windowsVerbatimArguments?: boolean;
+        argv0?: string | undefined;
+        stdio?: StdioOptions | undefined;
+        shell?: boolean | string | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
 
     interface SpawnOptions extends CommonSpawnOptions {
-        detached?: boolean;
+        detached?: boolean | undefined;
     }
 
     interface SpawnOptionsWithoutStdio extends SpawnOptions {
-        stdio?: 'pipe' | Array<null | undefined | 'pipe'>;
+        stdio?: 'pipe' | Array<null | undefined | 'pipe'> | undefined;
     }
 
     type StdioNull = 'inherit' | 'ignore' | Stream;
@@ -263,9 +263,9 @@ declare module 'child_process' {
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {
-        shell?: string;
-        maxBuffer?: number;
-        killSignal?: NodeJS.Signals | number;
+        shell?: string | undefined;
+        maxBuffer?: number | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
     }
 
     interface ExecOptionsWithStringEncoding extends ExecOptions {
@@ -277,10 +277,10 @@ declare module 'child_process' {
     }
 
     interface ExecException extends Error {
-        cmd?: string;
-        killed?: boolean;
-        code?: number;
-        signal?: NodeJS.Signals;
+        cmd?: string | undefined;
+        killed?: boolean | undefined;
+        code?: number | undefined;
+        signal?: NodeJS.Signals | undefined;
     }
 
     // no `options` definitely means stdout/stderr are `string`.
@@ -324,10 +324,10 @@ declare module 'child_process' {
     }
 
     interface ExecFileOptions extends CommonOptions {
-        maxBuffer?: number;
-        killSignal?: NodeJS.Signals | number;
-        windowsVerbatimArguments?: boolean;
-        shell?: boolean | string;
+        maxBuffer?: number | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
+        shell?: boolean | string | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
@@ -428,27 +428,27 @@ declare module 'child_process' {
     }
 
     interface ForkOptions extends ProcessEnvOptions, MessagingOptions {
-        execPath?: string;
-        execArgv?: string[];
-        silent?: boolean;
-        stdio?: StdioOptions;
-        detached?: boolean;
-        windowsVerbatimArguments?: boolean;
+        execPath?: string | undefined;
+        execArgv?: string[] | undefined;
+        silent?: boolean | undefined;
+        stdio?: StdioOptions | undefined;
+        detached?: boolean | undefined;
+        windowsVerbatimArguments?: boolean | undefined;
     }
     function fork(modulePath: string, options?: ForkOptions): ChildProcess;
     function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
     interface SpawnSyncOptions extends CommonSpawnOptions {
-        input?: string | NodeJS.ArrayBufferView;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: BufferEncoding | 'buffer' | null;
+        input?: string | NodeJS.ArrayBufferView | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: BufferEncoding | 'buffer' | null | undefined;
     }
     interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
     }
     interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
-        encoding?: 'buffer' | null;
+        encoding?: 'buffer' | null | undefined;
     }
     interface SpawnSyncReturns<T> {
         pid: number;
@@ -457,7 +457,7 @@ declare module 'child_process' {
         stderr: T;
         status: number | null;
         signal: NodeJS.Signals | null;
-        error?: Error;
+        error?: Error | undefined;
     }
     function spawnSync(command: string): SpawnSyncReturns<Buffer>;
     function spawnSync(command: string, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
@@ -468,18 +468,18 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
 
     interface ExecSyncOptions extends CommonOptions {
-        input?: string | Uint8Array;
-        stdio?: StdioOptions;
-        shell?: string;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: BufferEncoding | 'buffer' | null;
+        input?: string | Uint8Array | undefined;
+        stdio?: StdioOptions | undefined;
+        shell?: string | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: BufferEncoding | 'buffer' | null | undefined;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;
     }
     interface ExecSyncOptionsWithBufferEncoding extends ExecSyncOptions {
-        encoding?: 'buffer' | null;
+        encoding?: 'buffer' | null | undefined;
     }
     function execSync(command: string): Buffer;
     function execSync(command: string, options?: ExecSyncOptionsWithStringEncoding): string;
@@ -487,12 +487,12 @@ declare module 'child_process' {
     function execSync(command: string, options?: ExecSyncOptions): Buffer;
 
     interface ExecFileSyncOptions extends CommonOptions {
-        input?: string | NodeJS.ArrayBufferView;
-        stdio?: StdioOptions;
-        killSignal?: NodeJS.Signals | number;
-        maxBuffer?: number;
-        encoding?: BufferEncoding;
-        shell?: boolean | string;
+        input?: string | NodeJS.ArrayBufferView | undefined;
+        stdio?: StdioOptions | undefined;
+        killSignal?: NodeJS.Signals | number | undefined;
+        maxBuffer?: number | undefined;
+        encoding?: BufferEncoding | undefined;
+        shell?: boolean | string | undefined;
     }
     interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
         encoding: BufferEncoding;

--- a/types/node/v14/cluster.d.ts
+++ b/types/node/v14/cluster.d.ts
@@ -5,14 +5,14 @@ declare module 'cluster' {
 
     // interfaces
     interface ClusterSettings {
-        execArgv?: string[]; // default: process.execArgv
-        exec?: string;
-        args?: string[];
-        silent?: boolean;
-        stdio?: any[];
-        uid?: number;
-        gid?: number;
-        inspectPort?: number | (() => number);
+        execArgv?: string[] | undefined; // default: process.execArgv
+        exec?: string | undefined;
+        args?: string[] | undefined;
+        silent?: boolean | undefined;
+        stdio?: any[] | undefined;
+        uid?: number | undefined;
+        gid?: number | undefined;
+        inspectPort?: number | (() => number) | undefined;
     }
 
     interface Address {
@@ -99,8 +99,8 @@ declare module 'cluster' {
         schedulingPolicy: number;
         settings: ClusterSettings;
         setupMaster(settings?: ClusterSettings): void;
-        worker?: Worker;
-        workers?: NodeJS.Dict<Worker>;
+        worker?: Worker | undefined;
+        workers?: NodeJS.Dict<Worker> | undefined;
 
         readonly SCHED_NONE: number;
         readonly SCHED_RR: number;

--- a/types/node/v14/console.d.ts
+++ b/types/node/v14/console.d.ts
@@ -111,10 +111,10 @@ declare module 'console' {
         namespace NodeJS {
             interface ConsoleConstructorOptions {
                 stdout: WritableStream;
-                stderr?: WritableStream;
-                ignoreErrors?: boolean;
-                colorMode?: boolean | 'auto';
-                inspectOptions?: InspectOptions;
+                stderr?: WritableStream | undefined;
+                ignoreErrors?: boolean | undefined;
+                colorMode?: boolean | 'auto' | undefined;
+                inspectOptions?: InspectOptions | undefined;
             }
 
             interface ConsoleConstructor {

--- a/types/node/v14/crypto.d.ts
+++ b/types/node/v14/crypto.d.ts
@@ -130,7 +130,7 @@ declare module 'crypto' {
          * For XOF hash functions such as `shake256`, the
          * outputLength option can be used to specify the desired output length in bytes.
          */
-        outputLength?: number;
+        outputLength?: number | undefined;
     }
 
     /** @deprecated since v10.0.0 */
@@ -169,21 +169,21 @@ declare module 'crypto' {
     interface KeyExportOptions<T extends KeyFormat> {
         type: 'pkcs1' | 'spki' | 'pkcs8' | 'sec1';
         format: T;
-        cipher?: string;
-        passphrase?: string | Buffer;
+        cipher?: string | undefined;
+        passphrase?: string | Buffer | undefined;
     }
 
     class KeyObject {
         private constructor();
-        asymmetricKeyType?: KeyType;
+        asymmetricKeyType?: KeyType | undefined;
         /**
          * For asymmetric keys, this property represents the size of the embedded key in
          * bytes. This property is `undefined` for symmetric keys.
          */
-        asymmetricKeySize?: number;
+        asymmetricKeySize?: number | undefined;
         export(options: KeyExportOptions<'pem'>): string | Buffer;
         export(options?: KeyExportOptions<'der'>): Buffer;
-        symmetricKeySize?: number;
+        symmetricKeySize?: number | undefined;
         type: KeyObjectType;
     }
 
@@ -198,7 +198,7 @@ declare module 'crypto' {
         authTagLength: number;
     }
     interface CipherGCMOptions extends stream.TransformOptions {
-        authTagLength?: number;
+        authTagLength?: number | undefined;
     }
     /** @deprecated since v10.0.0 use `createCipheriv()` */
     function createCipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): CipherCCM;
@@ -295,15 +295,15 @@ declare module 'crypto' {
 
     interface PrivateKeyInput {
         key: string | Buffer;
-        format?: KeyFormat;
-        type?: 'pkcs1' | 'pkcs8' | 'sec1';
-        passphrase?: string | Buffer;
+        format?: KeyFormat | undefined;
+        type?: 'pkcs1' | 'pkcs8' | 'sec1' | undefined;
+        passphrase?: string | Buffer | undefined;
     }
 
     interface PublicKeyInput {
         key: string | Buffer;
-        format?: KeyFormat;
-        type?: 'pkcs1' | 'spki';
+        format?: KeyFormat | undefined;
+        type?: 'pkcs1' | 'spki' | undefined;
     }
 
     function createPrivateKey(key: PrivateKeyInput | string | Buffer): KeyObject;
@@ -318,9 +318,9 @@ declare module 'crypto' {
         /**
          * @See crypto.constants.RSA_PKCS1_PADDING
          */
-        padding?: number;
-        saltLength?: number;
-        dsaEncoding?: DSAEncoding;
+        padding?: number | undefined;
+        saltLength?: number | undefined;
+        dsaEncoding?: DSAEncoding | undefined;
     }
 
     interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {}
@@ -457,19 +457,19 @@ declare module 'crypto' {
          *
          * @default `false`
          */
-        disableEntropyCache?: boolean;
+        disableEntropyCache?: boolean | undefined;
     }
 
     function randomUUID(options?: RandomUUIDOptions): string;
 
     interface ScryptOptions {
-        cost?: number;
-        blockSize?: number;
-        parallelization?: number;
-        N?: number;
-        r?: number;
-        p?: number;
-        maxmem?: number;
+        cost?: number | undefined;
+        blockSize?: number | undefined;
+        parallelization?: number | undefined;
+        N?: number | undefined;
+        r?: number | undefined;
+        p?: number | undefined;
+        maxmem?: number | undefined;
     }
     function scrypt(
         password: BinaryLike,
@@ -488,17 +488,17 @@ declare module 'crypto' {
 
     interface RsaPublicKey {
         key: KeyLike;
-        padding?: number;
+        padding?: number | undefined;
     }
     interface RsaPrivateKey {
         key: KeyLike;
-        passphrase?: string;
+        passphrase?: string | undefined;
         /**
          * @default 'sha1'
          */
-        oaepHash?: string;
-        oaepLabel?: NodeJS.TypedArray;
-        padding?: number;
+        oaepHash?: string | undefined;
+        oaepLabel?: NodeJS.TypedArray | undefined;
+        padding?: number | undefined;
     }
     function publicEncrypt(key: RsaPublicKey | RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     function publicDecrypt(key: RsaPublicKey | RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
@@ -544,8 +544,8 @@ declare module 'crypto' {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        cipher?: string;
-        passphrase?: string;
+        cipher?: string | undefined;
+        passphrase?: string | undefined;
     }
 
     interface KeyPairKeyObjectResult {
@@ -593,7 +593,7 @@ declare module 'crypto' {
         /**
          * @default 0x10001
          */
-        publicExponent?: number;
+        publicExponent?: number | undefined;
     }
 
     interface DSAKeyPairKeyObjectOptions {
@@ -616,7 +616,7 @@ declare module 'crypto' {
         /**
          * @default 0x10001
          */
-        publicExponent?: number;
+        publicExponent?: number | undefined;
 
         publicKeyEncoding: {
             type: 'pkcs1' | 'spki';

--- a/types/node/v14/dgram.d.ts
+++ b/types/node/v14/dgram.d.ts
@@ -11,24 +11,24 @@ declare module 'dgram' {
     }
 
     interface BindOptions {
-        port?: number;
-        address?: string;
-        exclusive?: boolean;
-        fd?: number;
+        port?: number | undefined;
+        address?: string | undefined;
+        exclusive?: boolean | undefined;
+        fd?: number | undefined;
     }
 
     type SocketType = "udp4" | "udp6";
 
     interface SocketOptions {
         type: SocketType;
-        reuseAddr?: boolean;
+        reuseAddr?: boolean | undefined;
         /**
          * @default false
          */
-        ipv6Only?: boolean;
-        recvBufferSize?: number;
-        sendBufferSize?: number;
-        lookup?: (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
+        ipv6Only?: boolean | undefined;
+        recvBufferSize?: number | undefined;
+        sendBufferSize?: number | undefined;
+        lookup?: ((hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void) | undefined;
     }
 
     function createSocket(type: SocketType, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;

--- a/types/node/v14/dns.d.ts
+++ b/types/node/v14/dns.d.ts
@@ -9,14 +9,14 @@ declare module 'dns' {
     const ALL: number;
 
     interface LookupOptions {
-        family?: number;
-        hints?: number;
-        all?: boolean;
-        verbatim?: boolean;
+        family?: number | undefined;
+        hints?: number | undefined;
+        all?: boolean | undefined;
+        verbatim?: boolean | undefined;
     }
 
     interface LookupOneOptions extends LookupOptions {
-        all?: false;
+        all?: false | undefined;
     }
 
     interface LookupAllOptions extends LookupOptions {
@@ -277,7 +277,7 @@ declare module 'dns' {
     const CANCELLED: string;
 
     interface ResolverOptions {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     class Resolver {

--- a/types/node/v14/events.d.ts
+++ b/types/node/v14/events.d.ts
@@ -3,7 +3,7 @@ declare module 'events' {
         /**
          * Enables automatic capturing of promise rejection.
          */
-        captureRejections?: boolean;
+        captureRejections?: boolean | undefined;
     }
 
     interface NodeEventTarget {

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -15,7 +15,7 @@ declare module 'fs' {
     export type BufferEncodingOption = 'buffer' | { encoding: 'buffer' };
 
     export interface BaseEncodingOptions {
-        encoding?: BufferEncoding | null;
+        encoding?: BufferEncoding | null | undefined;
     }
 
     export type OpenMode = number | string;
@@ -537,7 +537,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function stat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function stat(path: PathLike, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     export function stat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -547,7 +547,7 @@ declare module 'fs' {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -556,7 +556,7 @@ declare module 'fs' {
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
+    export function statSync(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Stats;
     export function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     export function statSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
@@ -565,7 +565,7 @@ declare module 'fs' {
      * @param fd A file descriptor.
      */
     export function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function fstat(fd: number, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function fstat(fd: number, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     export function fstat(fd: number, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -575,7 +575,7 @@ declare module 'fs' {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(fd: number, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(fd: number, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -584,7 +584,7 @@ declare module 'fs' {
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
+    export function fstatSync(fd: number, options?: StatOptions & { bigint?: false | undefined }): Stats;
     export function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
     export function fstatSync(fd: number, options?: StatOptions): Stats | BigIntStats;
 
@@ -593,7 +593,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function lstat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions & { bigint?: false | undefined } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
     export function lstat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
@@ -603,7 +603,7 @@ declare module 'fs' {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
@@ -612,7 +612,7 @@ declare module 'fs' {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
+    export function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false | undefined }): Stats;
     export function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     export function lstatSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
@@ -876,7 +876,7 @@ declare module 'fs' {
          * `true`.
          * @default 0
          */
-        maxRetries?: number;
+        maxRetries?: number | undefined;
         /**
          * @deprecated since v14.14.0 In future versions of Node.js,
          * `fs.rmdir(path, { recursive: true })` will throw on nonexistent
@@ -888,13 +888,13 @@ declare module 'fs' {
          * operations are retried on failure.
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * The amount of time in milliseconds to wait between retries.
          * This option is ignored if the `recursive` option is not `true`.
          * @default 100
          */
-        retryDelay?: number;
+        retryDelay?: number | undefined;
     }
 
     /**
@@ -924,7 +924,7 @@ declare module 'fs' {
          * When `true`, exceptions will be ignored if `path` does not exist.
          * @default false
          */
-        force?: boolean;
+        force?: boolean | undefined;
         /**
          * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
          * `EPERM` error is encountered, Node.js will retry the operation with a linear
@@ -933,20 +933,20 @@ declare module 'fs' {
          * `true`.
          * @default 0
          */
-        maxRetries?: number;
+        maxRetries?: number | undefined;
         /**
          * If `true`, perform a recursive directory removal. In
          * recursive mode, errors are not reported if `path` does not exist, and
          * operations are retried on failure.
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * The amount of time in milliseconds to wait between retries.
          * This option is ignored if the `recursive` option is not `true`.
          * @default 100
          */
-        retryDelay?: number;
+        retryDelay?: number | undefined;
     }
 
     /**
@@ -974,12 +974,12 @@ declare module 'fs' {
          * If a folder was created, the path to the first created folder will be returned.
          * @default false
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * A file mode. If a string is passed, it is parsed as an octal integer. If not specified
          * @default 0o777
          */
-        mode?: Mode;
+        mode?: Mode | undefined;
     }
 
     /**
@@ -996,7 +996,7 @@ declare module 'fs' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdir(path: PathLike, options: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null | undefined, callback: NoParamCallback): void;
+    export function mkdir(path: PathLike, options: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null | undefined, callback: NoParamCallback): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -1028,7 +1028,7 @@ declare module 'fs' {
          * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
          * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
          */
-        function __promisify__(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null): Promise<void>;
+        function __promisify__(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null): Promise<void>;
 
         /**
          * Asynchronous mkdir(2) - create a directory.
@@ -1053,7 +1053,7 @@ declare module 'fs' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdirSync(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null): void;
+    export function mkdirSync(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null): void;
 
     /**
      * Synchronous mkdir(2) - create a directory.
@@ -1142,7 +1142,7 @@ declare module 'fs' {
      */
     export function readdir(
         path: PathLike,
-        options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | undefined | null,
+        options: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, files: string[]) => void,
     ): void;
 
@@ -1151,7 +1151,11 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer", callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void): void;
+    export function readdir(
+        path: PathLike,
+        options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer",
+        callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void
+    ): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -1160,7 +1164,7 @@ declare module 'fs' {
      */
     export function readdir(
         path: PathLike,
-        options: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | undefined | null,
+        options: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, files: string[] | Buffer[]) => void,
     ): void;
 
@@ -1184,21 +1188,21 @@ declare module 'fs' {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false }): Promise<Buffer[]>;
+        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false | undefined }): Promise<Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): Promise<string[] | Buffer[]>;
+        function __promisify__(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[] | Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
@@ -1213,21 +1217,21 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): string[];
+    export function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): string[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Buffer[];
+    export function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer"): Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): string[] | Buffer[];
+    export function readdirSync(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): string[] | Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
@@ -1524,15 +1528,15 @@ declare module 'fs' {
         /**
          * @default 0
          */
-        offset?: number;
+        offset?: number | undefined;
         /**
          * @default `length of buffer`
          */
-        length?: number;
+        length?: number | undefined;
         /**
          * @default null
          */
-        position?: number | null;
+        position?: number | null | undefined;
     }
 
     /**
@@ -1558,17 +1562,11 @@ declare module 'fs' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFile(path: PathLike | number, options: { encoding?: null; flag?: string; } | undefined | null, callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void): void;
-
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * URL support is _experimental_.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
-    export function readFile(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | string, callback: (err: NodeJS.ErrnoException | null, data: string) => void): void;
+    export function readFile(
+        path: PathLike | number,
+        options: { encoding?: null | undefined; flag?: string | undefined; } | undefined | null,
+        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void
+    ): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -1580,7 +1578,21 @@ declare module 'fs' {
      */
     export function readFile(
         path: PathLike | number,
-        options: BaseEncodingOptions & { flag?: string; } | string | undefined | null,
+        options: { encoding: BufferEncoding; flag?: string | undefined; } | string,
+        callback: (err: NodeJS.ErrnoException | null, data: string) => void
+    ): void;
+
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    export function readFile(
+        path: PathLike | number,
+        options: BaseEncodingOptions & { flag?: string | undefined; } | string | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
     ): void;
 
@@ -1600,7 +1612,7 @@ declare module 'fs' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Promise<Buffer>;
+        function __promisify__(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined; } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1610,7 +1622,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | string): Promise<string>;
+        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string | undefined; } | string): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1620,7 +1632,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -1630,7 +1642,7 @@ declare module 'fs' {
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      * @param options An object that may contain an optional flag. If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Buffer;
+    export function readFileSync(path: PathLike | number, options?: { encoding?: null | undefined; flag?: string | undefined; } | null): Buffer;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -1640,7 +1652,7 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | BufferEncoding): string;
+    export function readFileSync(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string | undefined; } | BufferEncoding): string;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -1650,9 +1662,9 @@ declare module 'fs' {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | BufferEncoding | null): string | Buffer;
+    export function readFileSync(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | BufferEncoding | null): string | Buffer;
 
-    export type WriteFileOptions = BaseEncodingOptions & { mode?: Mode; flag?: string; } | string | null;
+    export type WriteFileOptions = BaseEncodingOptions & { mode?: Mode | undefined; flag?: string | undefined; } | string | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -1765,7 +1777,7 @@ declare module 'fs' {
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      */
-    export function watchFile(filename: PathLike, options: { persistent?: boolean; interval?: number; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
+    export function watchFile(filename: PathLike, options: { persistent?: boolean | undefined; interval?: number | undefined; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
 
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
@@ -1792,7 +1804,7 @@ declare module 'fs' {
      */
     export function watch(
         filename: PathLike,
-        options: { encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | BufferEncoding | undefined | null,
+        options: { encoding?: BufferEncoding | null | undefined, persistent?: boolean | undefined, recursive?: boolean | undefined } | BufferEncoding | undefined | null,
         listener?: (event: "rename" | "change", filename: string) => void,
     ): FSWatcher;
 
@@ -1807,7 +1819,7 @@ declare module 'fs' {
      */
     export function watch(
         filename: PathLike,
-        options: { encoding: "buffer", persistent?: boolean, recursive?: boolean; } | "buffer",
+        options: { encoding: "buffer", persistent?: boolean | undefined, recursive?: boolean | undefined; } | "buffer",
         listener?: (event: "rename" | "change", filename: Buffer) => void
     ): FSWatcher;
 
@@ -1822,7 +1834,7 @@ declare module 'fs' {
      */
     export function watch(
         filename: PathLike,
-        options: { encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | string | null,
+        options: { encoding?: BufferEncoding | null | undefined, persistent?: boolean | undefined, recursive?: boolean | undefined } | string | null,
         listener?: (event: "rename" | "change", filename: string | Buffer) => void,
     ): FSWatcher;
 
@@ -2057,18 +2069,18 @@ declare module 'fs' {
      * URL support is _experimental_.
      */
     export function createReadStream(path: PathLike, options?: string | {
-        flags?: string;
-        encoding?: BufferEncoding;
-        fd?: number;
-        mode?: number;
-        autoClose?: boolean;
+        flags?: string | undefined;
+        encoding?: BufferEncoding | undefined;
+        fd?: number | undefined;
+        mode?: number | undefined;
+        autoClose?: boolean | undefined;
         /**
          * @default false
          */
-        emitClose?: boolean;
-        start?: number;
-        end?: number;
-        highWaterMark?: number;
+        emitClose?: boolean | undefined;
+        start?: number | undefined;
+        end?: number | undefined;
+        highWaterMark?: number | undefined;
     }): ReadStream;
 
     /**
@@ -2077,14 +2089,14 @@ declare module 'fs' {
      * URL support is _experimental_.
      */
     export function createWriteStream(path: PathLike, options?: string | {
-        flags?: string;
-        encoding?: BufferEncoding;
-        fd?: number;
-        mode?: number;
-        autoClose?: boolean;
-        emitClose?: boolean;
-        start?: number;
-        highWaterMark?: number;
+        flags?: string | undefined;
+        encoding?: BufferEncoding | undefined;
+        fd?: number | undefined;
+        mode?: number | undefined;
+        autoClose?: boolean | undefined;
+        emitClose?: boolean | undefined;
+        start?: number | undefined;
+        highWaterMark?: number | undefined;
     }): WriteStream;
 
     /**
@@ -2219,14 +2231,14 @@ declare module 'fs' {
     export function readvSync(fd: number, buffers: ReadonlyArray<NodeJS.ArrayBufferView>, position?: number): number;
 
     export interface OpenDirOptions {
-        encoding?: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
         /**
          * Number of directory entries that are buffered
          * internally when reading from the directory. Higher values lead to better
          * performance but higher memory usage.
          * @default 32
          */
-        bufferSize?: number;
+        bufferSize?: number | undefined;
     }
 
     export function opendirSync(path: string, options?: OpenDirOptions): Dir;
@@ -2253,6 +2265,6 @@ declare module 'fs' {
     }
 
     export interface StatOptions {
-        bigint?: boolean;
+        bigint?: boolean | undefined;
     }
 }

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -34,7 +34,7 @@ declare module 'fs/promises' {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'a'` is used.
          */
-        appendFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } | BufferEncoding | null): Promise<void>;
+        appendFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } | BufferEncoding | null): Promise<void>;
 
         /**
          * Asynchronous fchown(2) - Change ownership of a file.
@@ -73,7 +73,7 @@ declare module 'fs/promises' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        readFile(options?: { encoding?: null, flag?: OpenMode } | null): Promise<Buffer>;
+        readFile(options?: { encoding?: null | undefined, flag?: OpenMode | undefined } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
@@ -81,7 +81,7 @@ declare module 'fs/promises' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        readFile(options: { encoding: BufferEncoding, flag?: OpenMode } | BufferEncoding): Promise<string>;
+        readFile(options: { encoding: BufferEncoding, flag?: OpenMode | undefined } | BufferEncoding): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
@@ -89,12 +89,12 @@ declare module 'fs/promises' {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        readFile(options?: BaseEncodingOptions & { flag?: OpenMode } | BufferEncoding | null): Promise<string | Buffer>;
+        readFile(options?: BaseEncodingOptions & { flag?: OpenMode | undefined } | BufferEncoding | null): Promise<string | Buffer>;
 
         /**
          * Asynchronous fstat(2) - Get file status.
          */
-        stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        stat(opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
         stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
         stat(opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -143,7 +143,7 @@ declare module 'fs/promises' {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'w'` is used.
          */
-        writeFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } | BufferEncoding | null): Promise<void>;
+        writeFile(data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } | BufferEncoding | null): Promise<void>;
 
         /**
          * See `fs.writev` promisified version.
@@ -293,7 +293,7 @@ declare module 'fs/promises' {
      * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
      * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    function mkdir(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false; }) | null): Promise<void>;
+    function mkdir(path: PathLike, options?: Mode | (MakeDirectoryOptions & { recursive?: false | undefined; }) | null): Promise<void>;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -308,21 +308,21 @@ declare module 'fs/promises' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Promise<Buffer[]>;
+    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false | undefined } | "buffer"): Promise<Buffer[]>;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false } | BufferEncoding | null): Promise<string[] | Buffer[]>;
+    function readdir(path: PathLike, options?: BaseEncodingOptions & { withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[] | Buffer[]>;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -365,7 +365,7 @@ declare module 'fs/promises' {
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    function lstat(path: PathLike, opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
     function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
     function lstat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -373,7 +373,7 @@ declare module 'fs/promises' {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    function stat(path: PathLike, opts?: StatOptions & { bigint?: false | undefined }): Promise<Stats>;
     function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
     function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
@@ -510,7 +510,11 @@ declare module 'fs/promises' {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'w'` is used.
      */
-    function writeFile(path: PathLike | FileHandle, data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } | BufferEncoding | null): Promise<void>;
+    function writeFile(
+        path: PathLike | FileHandle,
+        data: string | Uint8Array,
+        options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } | BufferEncoding | null
+    ): Promise<void>;
 
     /**
      * Asynchronously append data to a file, creating the file if it does not exist.
@@ -524,7 +528,11 @@ declare module 'fs/promises' {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'a'` is used.
      */
-    function appendFile(path: PathLike | FileHandle, data: string | Uint8Array, options?: BaseEncodingOptions & { mode?: Mode, flag?: OpenMode } | BufferEncoding | null): Promise<void>;
+    function appendFile(
+        path: PathLike | FileHandle,
+        data: string | Uint8Array,
+        options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } | BufferEncoding | null
+    ): Promise<void>;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -533,7 +541,7 @@ declare module 'fs/promises' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | FileHandle, options?: { encoding?: null, flag?: OpenMode } | null): Promise<Buffer>;
+    function readFile(path: PathLike | FileHandle, options?: { encoding?: null | undefined, flag?: OpenMode | undefined } | null): Promise<Buffer>;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -542,7 +550,7 @@ declare module 'fs/promises' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: OpenMode } | BufferEncoding): Promise<string>;
+    function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: OpenMode | undefined } | BufferEncoding): Promise<string>;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -551,7 +559,7 @@ declare module 'fs/promises' {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | FileHandle, options?: BaseEncodingOptions & { flag?: OpenMode } | BufferEncoding | null): Promise<string | Buffer>;
+    function readFile(path: PathLike | FileHandle, options?: BaseEncodingOptions & { flag?: OpenMode | undefined } | BufferEncoding | null): Promise<string | Buffer>;
 
     function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
 }

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -8,7 +8,7 @@ interface ErrorConstructor {
      *
      * @see https://v8.dev/docs/stack-trace-api#customizing-stack-traces
      */
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
+    prepareStackTrace?: ((err: Error, stackTraces: NodeJS.CallSite[]) => any) | undefined;
 
     stackTraceLimit: number;
 }
@@ -326,24 +326,24 @@ declare namespace NodeJS {
          * the getter function.
          * @default `false`
          */
-        getters?: 'get' | 'set' | boolean;
-        showHidden?: boolean;
+        getters?: 'get' | 'set' | boolean | undefined;
+        showHidden?: boolean | undefined;
         /**
          * @default 2
          */
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-        showProxy?: boolean;
-        maxArrayLength?: number | null;
+        depth?: number | null | undefined;
+        colors?: boolean | undefined;
+        customInspect?: boolean | undefined;
+        showProxy?: boolean | undefined;
+        maxArrayLength?: number | null | undefined;
         /**
          * Specifies the maximum number of characters to
          * include when formatting. Set to `null` or `Infinity` to show all elements.
          * Set to `0` or negative to show no characters.
          * @default Infinity
          */
-        maxStringLength?: number | null;
-        breakLength?: number;
+        maxStringLength?: number | null | undefined;
+        breakLength?: number | undefined;
         /**
          * Setting this to `false` causes each object key
          * to be displayed on a new line. It will also add new lines to text that is
@@ -354,8 +354,8 @@ declare namespace NodeJS {
          * For more information, see the example below.
          * @default `true`
          */
-        compact?: boolean | number;
-        sorted?: boolean | ((a: string, b: string) => number);
+        compact?: boolean | number | undefined;
+        sorted?: boolean | ((a: string, b: string) => number) | undefined;
     }
 
     interface CallSite {
@@ -433,11 +433,11 @@ declare namespace NodeJS {
     }
 
     interface ErrnoException extends Error {
-        errno?: number;
-        code?: string;
-        path?: string;
-        syscall?: string;
-        stack?: string;
+        errno?: number | undefined;
+        code?: string | undefined;
+        path?: string | undefined;
+        syscall?: string | undefined;
+        stack?: string | undefined;
     }
 
     interface ReadableStream extends EventEmitter {
@@ -447,7 +447,7 @@ declare namespace NodeJS {
         pause(): this;
         resume(): this;
         isPaused(): boolean;
-        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
         unpipe(destination?: WritableStream): this;
         unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
         wrap(oldStream: ReadableStream): this;
@@ -577,7 +577,7 @@ declare namespace NodeJS {
     }
 
     interface RequireResolve {
-        (id: string, options?: { paths?: string[]; }): string;
+        (id: string, options?: { paths?: string[] | undefined; }): string;
         paths(request: string): string[] | null;
     }
 

--- a/types/node/v14/http.d.ts
+++ b/types/node/v14/http.d.ts
@@ -5,69 +5,69 @@ declare module 'http' {
 
     // incoming headers will never contain number
     interface IncomingHttpHeaders extends NodeJS.Dict<string | string[]> {
-        'accept'?: string;
-        'accept-language'?: string;
-        'accept-patch'?: string;
-        'accept-ranges'?: string;
-        'access-control-allow-credentials'?: string;
-        'access-control-allow-headers'?: string;
-        'access-control-allow-methods'?: string;
-        'access-control-allow-origin'?: string;
-        'access-control-expose-headers'?: string;
-        'access-control-max-age'?: string;
-        'access-control-request-headers'?: string;
-        'access-control-request-method'?: string;
-        'age'?: string;
-        'allow'?: string;
-        'alt-svc'?: string;
-        'authorization'?: string;
-        'cache-control'?: string;
-        'connection'?: string;
-        'content-disposition'?: string;
-        'content-encoding'?: string;
-        'content-language'?: string;
-        'content-length'?: string;
-        'content-location'?: string;
-        'content-range'?: string;
-        'content-type'?: string;
-        'cookie'?: string;
-        'date'?: string;
-        'etag'?: string;
-        'expect'?: string;
-        'expires'?: string;
-        'forwarded'?: string;
-        'from'?: string;
-        'host'?: string;
-        'if-match'?: string;
-        'if-modified-since'?: string;
-        'if-none-match'?: string;
-        'if-unmodified-since'?: string;
-        'last-modified'?: string;
-        'location'?: string;
-        'origin'?: string;
-        'pragma'?: string;
-        'proxy-authenticate'?: string;
-        'proxy-authorization'?: string;
-        'public-key-pins'?: string;
-        'range'?: string;
-        'referer'?: string;
-        'retry-after'?: string;
-        'sec-websocket-accept'?: string;
-        'sec-websocket-extensions'?: string;
-        'sec-websocket-key'?: string;
-        'sec-websocket-protocol'?: string;
-        'sec-websocket-version'?: string;
-        'set-cookie'?: string[];
-        'strict-transport-security'?: string;
-        'tk'?: string;
-        'trailer'?: string;
-        'transfer-encoding'?: string;
-        'upgrade'?: string;
-        'user-agent'?: string;
-        'vary'?: string;
-        'via'?: string;
-        'warning'?: string;
-        'www-authenticate'?: string;
+        'accept'?: string | undefined;
+        'accept-language'?: string | undefined;
+        'accept-patch'?: string | undefined;
+        'accept-ranges'?: string | undefined;
+        'access-control-allow-credentials'?: string | undefined;
+        'access-control-allow-headers'?: string | undefined;
+        'access-control-allow-methods'?: string | undefined;
+        'access-control-allow-origin'?: string | undefined;
+        'access-control-expose-headers'?: string | undefined;
+        'access-control-max-age'?: string | undefined;
+        'access-control-request-headers'?: string | undefined;
+        'access-control-request-method'?: string | undefined;
+        'age'?: string | undefined;
+        'allow'?: string | undefined;
+        'alt-svc'?: string | undefined;
+        'authorization'?: string | undefined;
+        'cache-control'?: string | undefined;
+        'connection'?: string | undefined;
+        'content-disposition'?: string | undefined;
+        'content-encoding'?: string | undefined;
+        'content-language'?: string | undefined;
+        'content-length'?: string | undefined;
+        'content-location'?: string | undefined;
+        'content-range'?: string | undefined;
+        'content-type'?: string | undefined;
+        'cookie'?: string | undefined;
+        'date'?: string | undefined;
+        'etag'?: string | undefined;
+        'expect'?: string | undefined;
+        'expires'?: string | undefined;
+        'forwarded'?: string | undefined;
+        'from'?: string | undefined;
+        'host'?: string | undefined;
+        'if-match'?: string | undefined;
+        'if-modified-since'?: string | undefined;
+        'if-none-match'?: string | undefined;
+        'if-unmodified-since'?: string | undefined;
+        'last-modified'?: string | undefined;
+        'location'?: string | undefined;
+        'origin'?: string | undefined;
+        'pragma'?: string | undefined;
+        'proxy-authenticate'?: string | undefined;
+        'proxy-authorization'?: string | undefined;
+        'public-key-pins'?: string | undefined;
+        'range'?: string | undefined;
+        'referer'?: string | undefined;
+        'retry-after'?: string | undefined;
+        'sec-websocket-accept'?: string | undefined;
+        'sec-websocket-extensions'?: string | undefined;
+        'sec-websocket-key'?: string | undefined;
+        'sec-websocket-protocol'?: string | undefined;
+        'sec-websocket-version'?: string | undefined;
+        'set-cookie'?: string[] | undefined;
+        'strict-transport-security'?: string | undefined;
+        'tk'?: string | undefined;
+        'trailer'?: string | undefined;
+        'transfer-encoding'?: string | undefined;
+        'upgrade'?: string | undefined;
+        'user-agent'?: string | undefined;
+        'vary'?: string | undefined;
+        'via'?: string | undefined;
+        'warning'?: string | undefined;
+        'www-authenticate'?: string | undefined;
     }
 
     // outgoing headers allows numbers (as they are converted internally to strings)
@@ -77,47 +77,47 @@ declare module 'http' {
     }
 
     interface ClientRequestArgs {
-        protocol?: string | null;
-        host?: string | null;
-        hostname?: string | null;
-        family?: number;
-        port?: number | string | null;
-        defaultPort?: number | string;
-        localAddress?: string;
-        socketPath?: string;
+        protocol?: string | null | undefined;
+        host?: string | null | undefined;
+        hostname?: string | null | undefined;
+        family?: number | undefined;
+        port?: number | string | null | undefined;
+        defaultPort?: number | string | undefined;
+        localAddress?: string | undefined;
+        socketPath?: string | undefined;
         /**
          * @default 8192
          */
-        maxHeaderSize?: number;
-        method?: string;
-        path?: string | null;
-        headers?: OutgoingHttpHeaders;
-        auth?: string | null;
-        agent?: Agent | boolean;
-        _defaultAgent?: Agent;
-        timeout?: number;
-        setHost?: boolean;
+        maxHeaderSize?: number | undefined;
+        method?: string | undefined;
+        path?: string | null | undefined;
+        headers?: OutgoingHttpHeaders | undefined;
+        auth?: string | null | undefined;
+        agent?: Agent | boolean | undefined;
+        _defaultAgent?: Agent | undefined;
+        timeout?: number | undefined;
+        setHost?: boolean | undefined;
         // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L278
-        createConnection?: (options: ClientRequestArgs, oncreate: (err: Error, socket: Socket) => void) => Socket;
+        createConnection?: ((options: ClientRequestArgs, oncreate: (err: Error, socket: Socket) => void) => Socket) | undefined;
     }
 
     interface ServerOptions {
-        IncomingMessage?: typeof IncomingMessage;
-        ServerResponse?: typeof ServerResponse;
+        IncomingMessage?: typeof IncomingMessage | undefined;
+        ServerResponse?: typeof ServerResponse | undefined;
         /**
          * Optionally overrides the value of
          * [`--max-http-header-size`][] for requests received by this server, i.e.
          * the maximum length of request headers in bytes.
          * @default 8192
          */
-        maxHeaderSize?: number;
+        maxHeaderSize?: number | undefined;
         /**
          * Use an insecure HTTP parser that accepts invalid HTTP headers when true.
          * Using the insecure parser should be avoided.
          * See --insecure-http-parser for more information.
          * @default false
          */
-        insecureHTTPParser?: boolean;
+        insecureHTTPParser?: boolean | undefined;
     }
 
     type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
@@ -330,19 +330,19 @@ declare module 'http' {
         /**
          * Only valid for request obtained from http.Server.
          */
-        method?: string;
+        method?: string | undefined;
         /**
          * Only valid for request obtained from http.Server.
          */
-        url?: string;
+        url?: string | undefined;
         /**
          * Only valid for response obtained from http.ClientRequest.
          */
-        statusCode?: number;
+        statusCode?: number | undefined;
         /**
          * Only valid for response obtained from http.ClientRequest.
          */
-        statusMessage?: string;
+        statusMessage?: string | undefined;
         destroy(error?: Error): void;
     }
 
@@ -350,32 +350,32 @@ declare module 'http' {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
-        keepAlive?: boolean;
+        keepAlive?: boolean | undefined;
         /**
          * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
          * Only relevant if keepAlive is set to true.
          */
-        keepAliveMsecs?: number;
+        keepAliveMsecs?: number | undefined;
         /**
          * Maximum number of sockets to allow per host. Default for Node 0.10 is 5, default for Node 0.12 is Infinity
          */
-        maxSockets?: number;
+        maxSockets?: number | undefined;
         /**
          * Maximum number of sockets allowed for all hosts in total. Each request will use a new socket until the maximum is reached. Default: Infinity.
          */
-        maxTotalSockets?: number;
+        maxTotalSockets?: number | undefined;
         /**
          * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
          */
-        maxFreeSockets?: number;
+        maxFreeSockets?: number | undefined;
         /**
          * Socket timeout in milliseconds. This will set the timeout after the socket is connected.
          */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * Scheduling strategy to apply when picking the next free socket to use. Default: 'fifo'.
          */
-        scheduling?: 'fifo' | 'lifo';
+        scheduling?: 'fifo' | 'lifo' | undefined;
     }
 
     class Agent {

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -15,37 +15,37 @@ declare module 'http2' {
     export { OutgoingHttpHeaders } from 'http';
 
     export interface IncomingHttpStatusHeader {
-        ":status"?: number;
+        ":status"?: number | undefined;
     }
 
     export interface IncomingHttpHeaders extends Http1IncomingHttpHeaders {
-        ":path"?: string;
-        ":method"?: string;
-        ":authority"?: string;
-        ":scheme"?: string;
+        ":path"?: string | undefined;
+        ":method"?: string | undefined;
+        ":authority"?: string | undefined;
+        ":scheme"?: string | undefined;
     }
 
     // Http2Stream
 
     export interface StreamPriorityOptions {
-        exclusive?: boolean;
-        parent?: number;
-        weight?: number;
-        silent?: boolean;
+        exclusive?: boolean | undefined;
+        parent?: number | undefined;
+        weight?: number | undefined;
+        silent?: boolean | undefined;
     }
 
     export interface StreamState {
-        localWindowSize?: number;
-        state?: number;
-        localClose?: number;
-        remoteClose?: number;
-        sumDependencyWeight?: number;
-        weight?: number;
+        localWindowSize?: number | undefined;
+        state?: number | undefined;
+        localClose?: number | undefined;
+        remoteClose?: number | undefined;
+        sumDependencyWeight?: number | undefined;
+        weight?: number | undefined;
     }
 
     export interface ServerStreamResponseOptions {
-        endStream?: boolean;
-        waitForTrailers?: boolean;
+        endStream?: boolean | undefined;
+        waitForTrailers?: boolean | undefined;
     }
 
     export interface StatOptions {
@@ -55,9 +55,9 @@ declare module 'http2' {
 
     export interface ServerStreamFileResponseOptions {
         statCheck?(stats: fs.Stats, headers: OutgoingHttpHeaders, statOptions: StatOptions): void | boolean;
-        waitForTrailers?: boolean;
-        offset?: number;
-        length?: number;
+        waitForTrailers?: boolean | undefined;
+        offset?: number | undefined;
+        length?: number | undefined;
     }
 
     export interface ServerStreamFileResponseOptionsWithError extends ServerStreamFileResponseOptions {
@@ -74,12 +74,12 @@ declare module 'http2' {
          * indicating that no additional data should be received and the readable side of the Http2Stream will be closed.
          */
         readonly endAfterHeaders: boolean;
-        readonly id?: number;
+        readonly id?: number | undefined;
         readonly pending: boolean;
         readonly rstCode: number;
         readonly sentHeaders: OutgoingHttpHeaders;
-        readonly sentInfoHeaders?: OutgoingHttpHeaders[];
-        readonly sentTrailers?: OutgoingHttpHeaders;
+        readonly sentInfoHeaders?: OutgoingHttpHeaders[] | undefined;
+        readonly sentTrailers?: OutgoingHttpHeaders | undefined;
         readonly session: Http2Session;
         readonly state: StreamState;
 
@@ -237,43 +237,43 @@ declare module 'http2' {
     // Http2Session
 
     export interface Settings {
-        headerTableSize?: number;
-        enablePush?: boolean;
-        initialWindowSize?: number;
-        maxFrameSize?: number;
-        maxConcurrentStreams?: number;
-        maxHeaderListSize?: number;
-        enableConnectProtocol?: boolean;
+        headerTableSize?: number | undefined;
+        enablePush?: boolean | undefined;
+        initialWindowSize?: number | undefined;
+        maxFrameSize?: number | undefined;
+        maxConcurrentStreams?: number | undefined;
+        maxHeaderListSize?: number | undefined;
+        enableConnectProtocol?: boolean | undefined;
     }
 
     export interface ClientSessionRequestOptions {
-        endStream?: boolean;
-        exclusive?: boolean;
-        parent?: number;
-        weight?: number;
-        waitForTrailers?: boolean;
+        endStream?: boolean | undefined;
+        exclusive?: boolean | undefined;
+        parent?: number | undefined;
+        weight?: number | undefined;
+        waitForTrailers?: boolean | undefined;
     }
 
     export interface SessionState {
-        effectiveLocalWindowSize?: number;
-        effectiveRecvDataLength?: number;
-        nextStreamID?: number;
-        localWindowSize?: number;
-        lastProcStreamID?: number;
-        remoteWindowSize?: number;
-        outboundQueueSize?: number;
-        deflateDynamicTableSize?: number;
-        inflateDynamicTableSize?: number;
+        effectiveLocalWindowSize?: number | undefined;
+        effectiveRecvDataLength?: number | undefined;
+        nextStreamID?: number | undefined;
+        localWindowSize?: number | undefined;
+        lastProcStreamID?: number | undefined;
+        remoteWindowSize?: number | undefined;
+        outboundQueueSize?: number | undefined;
+        deflateDynamicTableSize?: number | undefined;
+        inflateDynamicTableSize?: number | undefined;
     }
 
     export interface Http2Session extends EventEmitter {
-        readonly alpnProtocol?: string;
+        readonly alpnProtocol?: string | undefined;
         readonly closed: boolean;
         readonly connecting: boolean;
         readonly destroyed: boolean;
-        readonly encrypted?: boolean;
+        readonly encrypted?: boolean | undefined;
         readonly localSettings: Settings;
-        readonly originSet?: string[];
+        readonly originSet?: string[] | undefined;
         readonly pendingSettingsAck: boolean;
         readonly remoteSettings: Settings;
         readonly socket: net.Socket | tls.TLSSocket;
@@ -430,30 +430,30 @@ declare module 'http2' {
     // Http2Server
 
     export interface SessionOptions {
-        maxDeflateDynamicTableSize?: number;
-        maxSessionMemory?: number;
-        maxHeaderListPairs?: number;
-        maxOutstandingPings?: number;
-        maxSendHeaderBlockLength?: number;
-        paddingStrategy?: number;
-        peerMaxConcurrentStreams?: number;
-        settings?: Settings;
+        maxDeflateDynamicTableSize?: number | undefined;
+        maxSessionMemory?: number | undefined;
+        maxHeaderListPairs?: number | undefined;
+        maxOutstandingPings?: number | undefined;
+        maxSendHeaderBlockLength?: number | undefined;
+        paddingStrategy?: number | undefined;
+        peerMaxConcurrentStreams?: number | undefined;
+        settings?: Settings | undefined;
 
         selectPadding?(frameLen: number, maxFrameLen: number): number;
         createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
 
     export interface ClientSessionOptions extends SessionOptions {
-        maxReservedRemoteStreams?: number;
-        createConnection?: (authority: url.URL, option: SessionOptions) => stream.Duplex;
-        protocol?: 'http:' | 'https:';
+        maxReservedRemoteStreams?: number | undefined;
+        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
+        protocol?: 'http:' | 'https:' | undefined;
     }
 
     export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage;
-        Http1ServerResponse?: typeof ServerResponse;
-        Http2ServerRequest?: typeof Http2ServerRequest;
-        Http2ServerResponse?: typeof Http2ServerResponse;
+        Http1IncomingMessage?: typeof IncomingMessage | undefined;
+        Http1ServerResponse?: typeof ServerResponse | undefined;
+        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
+        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
     }
 
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
@@ -462,8 +462,8 @@ declare module 'http2' {
     export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
-        allowHTTP1?: boolean;
-        origins?: string[];
+        allowHTTP1?: boolean | undefined;
+        origins?: string[] | undefined;
     }
 
     export interface Http2Server extends net.Server {

--- a/types/node/v14/https.d.ts
+++ b/types/node/v14/https.d.ts
@@ -6,13 +6,13 @@ declare module 'https' {
     type ServerOptions = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions;
 
     type RequestOptions = http.RequestOptions & tls.SecureContextOptions & {
-        rejectUnauthorized?: boolean; // Defaults to true
-        servername?: string; // SNI TLS Extension
+        rejectUnauthorized?: boolean | undefined; // Defaults to true
+        servername?: string | undefined; // SNI TLS Extension
     };
 
     interface AgentOptions extends http.AgentOptions, tls.ConnectionOptions {
-        rejectUnauthorized?: boolean;
-        maxCachedSessions?: number;
+        rejectUnauthorized?: boolean | undefined;
+        maxCachedSessions?: number | undefined;
     }
 
     class Agent extends http.Agent {

--- a/types/node/v14/inspector.d.ts
+++ b/types/node/v14/inspector.d.ts
@@ -68,11 +68,11 @@ declare module 'inspector' {
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
             /**
              * Object class (constructor) name. Specified for <code>object</code> type values only.
              */
-            className?: string;
+            className?: string | undefined;
             /**
              * Remote object value in case of primitive values or JSON values (if it was requested).
              */
@@ -80,24 +80,24 @@ declare module 'inspector' {
             /**
              * Primitive value which can not be JSON-stringified does not have <code>value</code>, but gets this property.
              */
-            unserializableValue?: UnserializableValue;
+            unserializableValue?: UnserializableValue | undefined;
             /**
              * String representation of the object.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * Unique object identifier (for non-primitive values).
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
             /**
              * Preview containing abbreviated property values. Specified for <code>object</code> type values only.
              * @experimental
              */
-            preview?: ObjectPreview;
+            preview?: ObjectPreview | undefined;
             /**
              * @experimental
              */
-            customPreview?: CustomPreview;
+            customPreview?: CustomPreview | undefined;
         }
 
         /**
@@ -108,7 +108,7 @@ declare module 'inspector' {
             hasBody: boolean;
             formatterObjectId: RemoteObjectId;
             bindRemoteObjectFunctionId: RemoteObjectId;
-            configObjectId?: RemoteObjectId;
+            configObjectId?: RemoteObjectId | undefined;
         }
 
         /**
@@ -123,11 +123,11 @@ declare module 'inspector' {
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
             /**
              * String representation of the object.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * True iff some of the properties or entries of the original object did not fit.
              */
@@ -139,7 +139,7 @@ declare module 'inspector' {
             /**
              * List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only.
              */
-            entries?: EntryPreview[];
+            entries?: EntryPreview[] | undefined;
         }
 
         /**
@@ -157,15 +157,15 @@ declare module 'inspector' {
             /**
              * User-friendly property value string.
              */
-            value?: string;
+            value?: string | undefined;
             /**
              * Nested value preview.
              */
-            valuePreview?: ObjectPreview;
+            valuePreview?: ObjectPreview | undefined;
             /**
              * Object subtype hint. Specified for <code>object</code> type values only.
              */
-            subtype?: string;
+            subtype?: string | undefined;
         }
 
         /**
@@ -175,7 +175,7 @@ declare module 'inspector' {
             /**
              * Preview of the key. Specified for map-like collection entries.
              */
-            key?: ObjectPreview;
+            key?: ObjectPreview | undefined;
             /**
              * Preview of the value.
              */
@@ -193,19 +193,19 @@ declare module 'inspector' {
             /**
              * The value associated with the property.
              */
-            value?: RemoteObject;
+            value?: RemoteObject | undefined;
             /**
              * True if the value associated with the property may be changed (data descriptors only).
              */
-            writable?: boolean;
+            writable?: boolean | undefined;
             /**
              * A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only).
              */
-            get?: RemoteObject;
+            get?: RemoteObject | undefined;
             /**
              * A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only).
              */
-            set?: RemoteObject;
+            set?: RemoteObject | undefined;
             /**
              * True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.
              */
@@ -217,15 +217,15 @@ declare module 'inspector' {
             /**
              * True if the result was thrown during the evaluation.
              */
-            wasThrown?: boolean;
+            wasThrown?: boolean | undefined;
             /**
              * True if the property is owned for the object.
              */
-            isOwn?: boolean;
+            isOwn?: boolean | undefined;
             /**
              * Property symbol object, if the property is of the <code>symbol</code> type.
              */
-            symbol?: RemoteObject;
+            symbol?: RemoteObject | undefined;
         }
 
         /**
@@ -239,7 +239,7 @@ declare module 'inspector' {
             /**
              * The value associated with the property.
              */
-            value?: RemoteObject;
+            value?: RemoteObject | undefined;
         }
 
         /**
@@ -253,11 +253,11 @@ declare module 'inspector' {
             /**
              * Primitive value which can not be JSON-stringified.
              */
-            unserializableValue?: UnserializableValue;
+            unserializableValue?: UnserializableValue | undefined;
             /**
              * Remote object handle.
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
         }
 
         /**
@@ -284,7 +284,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            auxData?: {};
+            auxData?: {} | undefined;
         }
 
         /**
@@ -310,23 +310,23 @@ declare module 'inspector' {
             /**
              * Script ID of the exception location.
              */
-            scriptId?: ScriptId;
+            scriptId?: ScriptId | undefined;
             /**
              * URL of the exception location, to be used when the script was not reported.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * JavaScript stack trace if available.
              */
-            stackTrace?: StackTrace;
+            stackTrace?: StackTrace | undefined;
             /**
              * Exception object if available.
              */
-            exception?: RemoteObject;
+            exception?: RemoteObject | undefined;
             /**
              * Identifier of the context where exception happened.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         /**
@@ -367,7 +367,7 @@ declare module 'inspector' {
             /**
              * String label of this stack trace. For async traces this may be a name of the function that initiated the async call.
              */
-            description?: string;
+            description?: string | undefined;
             /**
              * JavaScript function name.
              */
@@ -375,12 +375,12 @@ declare module 'inspector' {
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              */
-            parent?: StackTrace;
+            parent?: StackTrace | undefined;
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              * @experimental
              */
-            parentId?: StackTraceId;
+            parentId?: StackTraceId | undefined;
         }
 
         /**
@@ -395,7 +395,7 @@ declare module 'inspector' {
          */
         interface StackTraceId {
             id: string;
-            debuggerId?: UniqueDebuggerId;
+            debuggerId?: UniqueDebuggerId | undefined;
         }
 
         interface EvaluateParameterType {
@@ -406,36 +406,36 @@ declare module 'inspector' {
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * Determines whether Command Line API should be available during the evaluation.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Specifies in which execution context to perform evaluation. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            contextId?: ExecutionContextId;
+            contextId?: ExecutionContextId | undefined;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should be treated as initiated by user in the UI.
              */
-            userGesture?: boolean;
+            userGesture?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
         }
 
         interface AwaitPromiseParameterType {
@@ -446,11 +446,11 @@ declare module 'inspector' {
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
         }
 
         interface CallFunctionOnParameterType {
@@ -461,40 +461,40 @@ declare module 'inspector' {
             /**
              * Identifier of the object to call function on. Either objectId or executionContextId should be specified.
              */
-            objectId?: RemoteObjectId;
+            objectId?: RemoteObjectId | undefined;
             /**
              * Call arguments. All call arguments must belong to the same JavaScript world as the target object.
              */
-            arguments?: CallArgument[];
+            arguments?: CallArgument[] | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object which should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should be treated as initiated by user in the UI.
              */
-            userGesture?: boolean;
+            userGesture?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
             /**
              * Specifies execution context which global object will be used to call function on. Either executionContextId or objectId should be specified.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
             /**
              * Symbolic group name that can be used to release multiple objects. If objectGroup is not specified and objectId is, objectGroup will be inherited from object.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
         }
 
         interface GetPropertiesParameterType {
@@ -505,17 +505,17 @@ declare module 'inspector' {
             /**
              * If true, returns properties belonging only to the element itself, not to its prototype chain.
              */
-            ownProperties?: boolean;
+            ownProperties?: boolean | undefined;
             /**
              * If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.
              * @experimental
              */
-            accessorPropertiesOnly?: boolean;
+            accessorPropertiesOnly?: boolean | undefined;
             /**
              * Whether preview should be generated for the results.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
         }
 
         interface ReleaseObjectParameterType {
@@ -552,7 +552,7 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         interface RunScriptParameterType {
@@ -563,31 +563,31 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Determines whether Command Line API should be available during the evaluation.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object which should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
-            awaitPromise?: boolean;
+            awaitPromise?: boolean | undefined;
         }
 
         interface QueryObjectsParameterType {
@@ -601,7 +601,7 @@ declare module 'inspector' {
             /**
              * Specifies in which execution context to lookup global scope variables.
              */
-            executionContextId?: ExecutionContextId;
+            executionContextId?: ExecutionContextId | undefined;
         }
 
         interface EvaluateReturnType {
@@ -612,7 +612,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface AwaitPromiseReturnType {
@@ -623,7 +623,7 @@ declare module 'inspector' {
             /**
              * Exception details if stack strace is available.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface CallFunctionOnReturnType {
@@ -634,7 +634,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface GetPropertiesReturnType {
@@ -645,22 +645,22 @@ declare module 'inspector' {
             /**
              * Internal object properties (only of the element itself).
              */
-            internalProperties?: InternalPropertyDescriptor[];
+            internalProperties?: InternalPropertyDescriptor[] | undefined;
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface CompileScriptReturnType {
             /**
              * Id of the script.
              */
-            scriptId?: ScriptId;
+            scriptId?: ScriptId | undefined;
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface RunScriptReturnType {
@@ -671,7 +671,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: ExceptionDetails;
+            exceptionDetails?: ExceptionDetails | undefined;
         }
 
         interface QueryObjectsReturnType {
@@ -738,12 +738,12 @@ declare module 'inspector' {
             /**
              * Stack trace captured when the call was made.
              */
-            stackTrace?: StackTrace;
+            stackTrace?: StackTrace | undefined;
             /**
              * Console context descriptor for calls on non-default console context (not console.*): 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call on named context.
              * @experimental
              */
-            context?: string;
+            context?: string | undefined;
         }
 
         interface InspectRequestedEventDataType {
@@ -778,7 +778,7 @@ declare module 'inspector' {
             /**
              * Column number in the script (0-based).
              */
-            columnNumber?: number;
+            columnNumber?: number | undefined;
         }
 
         /**
@@ -805,7 +805,7 @@ declare module 'inspector' {
             /**
              * Location in the source code.
              */
-            functionLocation?: Location;
+            functionLocation?: Location | undefined;
             /**
              * Location in the source code.
              */
@@ -825,7 +825,7 @@ declare module 'inspector' {
             /**
              * The value being returned, if the function is at return point.
              */
-            returnValue?: Runtime.RemoteObject;
+            returnValue?: Runtime.RemoteObject | undefined;
         }
 
         /**
@@ -840,15 +840,15 @@ declare module 'inspector' {
              * Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties.
              */
             object: Runtime.RemoteObject;
-            name?: string;
+            name?: string | undefined;
             /**
              * Location in the source code where scope starts
              */
-            startLocation?: Location;
+            startLocation?: Location | undefined;
             /**
              * Location in the source code where scope ends
              */
-            endLocation?: Location;
+            endLocation?: Location | undefined;
         }
 
         /**
@@ -877,8 +877,8 @@ declare module 'inspector' {
             /**
              * Column number in the script (0-based).
              */
-            columnNumber?: number;
-            type?: string;
+            columnNumber?: number | undefined;
+            type?: string | undefined;
         }
 
         interface SetBreakpointsActiveParameterType {
@@ -903,23 +903,23 @@ declare module 'inspector' {
             /**
              * URL of the resources to set breakpoint on.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified.
              */
-            urlRegex?: string;
+            urlRegex?: string | undefined;
             /**
              * Script hash of the resources to set breakpoint on.
              */
-            scriptHash?: string;
+            scriptHash?: string | undefined;
             /**
              * Offset in the line to set breakpoint at.
              */
-            columnNumber?: number;
+            columnNumber?: number | undefined;
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
              */
-            condition?: string;
+            condition?: string | undefined;
         }
 
         interface SetBreakpointParameterType {
@@ -930,7 +930,7 @@ declare module 'inspector' {
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
              */
-            condition?: string;
+            condition?: string | undefined;
         }
 
         interface RemoveBreakpointParameterType {
@@ -945,11 +945,11 @@ declare module 'inspector' {
             /**
              * End of range to search possible breakpoint locations in (excluding). When not specified, end of scripts is used as end of range.
              */
-            end?: Location;
+            end?: Location | undefined;
             /**
              * Only consider locations which are in the same (non-nested) function as start.
              */
-            restrictToFunction?: boolean;
+            restrictToFunction?: boolean | undefined;
         }
 
         interface ContinueToLocationParameterType {
@@ -957,7 +957,7 @@ declare module 'inspector' {
              * Location to continue to.
              */
             location: Location;
-            targetCallFrames?: string;
+            targetCallFrames?: string | undefined;
         }
 
         interface PauseOnAsyncCallParameterType {
@@ -972,7 +972,7 @@ declare module 'inspector' {
              * Debugger will issue additional Debugger.paused notification if any async task is scheduled before next pause.
              * @experimental
              */
-            breakOnAsyncCall?: boolean;
+            breakOnAsyncCall?: boolean | undefined;
         }
 
         interface GetStackTraceParameterType {
@@ -991,11 +991,11 @@ declare module 'inspector' {
             /**
              * If true, search is case sensitive.
              */
-            caseSensitive?: boolean;
+            caseSensitive?: boolean | undefined;
             /**
              * If true, treats string parameter as regex.
              */
-            isRegex?: boolean;
+            isRegex?: boolean | undefined;
         }
 
         interface SetScriptSourceParameterType {
@@ -1010,7 +1010,7 @@ declare module 'inspector' {
             /**
              *  If true the change will not actually be applied. Dry run may be used to get result description without actually modifying the code.
              */
-            dryRun?: boolean;
+            dryRun?: boolean | undefined;
         }
 
         interface RestartFrameParameterType {
@@ -1046,28 +1046,28 @@ declare module 'inspector' {
             /**
              * String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>).
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
             /**
              * Specifies whether command line API should be available to the evaluated expression, defaults to false.
              */
-            includeCommandLineAPI?: boolean;
+            includeCommandLineAPI?: boolean | undefined;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
              */
-            silent?: boolean;
+            silent?: boolean | undefined;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
-            returnByValue?: boolean;
+            returnByValue?: boolean | undefined;
             /**
              * Whether preview should be generated for the result.
              * @experimental
              */
-            generatePreview?: boolean;
+            generatePreview?: boolean | undefined;
             /**
              * Whether to throw an exception if side effect cannot be ruled out during evaluation.
              */
-            throwOnSideEffect?: boolean;
+            throwOnSideEffect?: boolean | undefined;
         }
 
         interface SetVariableValueParameterType {
@@ -1170,24 +1170,24 @@ declare module 'inspector' {
             /**
              * New stack trace in case editing has happened while VM was stopped.
              */
-            callFrames?: CallFrame[];
+            callFrames?: CallFrame[] | undefined;
             /**
              * Whether current call stack  was modified after applying the changes.
              */
-            stackChanged?: boolean;
+            stackChanged?: boolean | undefined;
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
             /**
              * Exception details if any.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: Runtime.ExceptionDetails | undefined;
         }
 
         interface RestartFrameReturnType {
@@ -1198,12 +1198,12 @@ declare module 'inspector' {
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
         }
 
         interface GetScriptSourceReturnType {
@@ -1221,7 +1221,7 @@ declare module 'inspector' {
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: Runtime.ExceptionDetails | undefined;
         }
 
         interface ScriptParsedEventDataType {
@@ -1260,33 +1260,33 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {};
+            executionContextAuxData?: {} | undefined;
             /**
              * True, if this script is generated as a result of the live edit operation.
              * @experimental
              */
-            isLiveEdit?: boolean;
+            isLiveEdit?: boolean | undefined;
             /**
              * URL of source map associated with script (if any).
              */
-            sourceMapURL?: string;
+            sourceMapURL?: string | undefined;
             /**
              * True, if this script has sourceURL.
              */
-            hasSourceURL?: boolean;
+            hasSourceURL?: boolean | undefined;
             /**
              * True, if this script is ES6 module.
              */
-            isModule?: boolean;
+            isModule?: boolean | undefined;
             /**
              * This script length.
              */
-            length?: number;
+            length?: number | undefined;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
              * @experimental
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: Runtime.StackTrace | undefined;
         }
 
         interface ScriptFailedToParseEventDataType {
@@ -1325,28 +1325,28 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {};
+            executionContextAuxData?: {} | undefined;
             /**
              * URL of source map associated with script (if any).
              */
-            sourceMapURL?: string;
+            sourceMapURL?: string | undefined;
             /**
              * True, if this script has sourceURL.
              */
-            hasSourceURL?: boolean;
+            hasSourceURL?: boolean | undefined;
             /**
              * True, if this script is ES6 module.
              */
-            isModule?: boolean;
+            isModule?: boolean | undefined;
             /**
              * This script length.
              */
-            length?: number;
+            length?: number | undefined;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
              * @experimental
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: Runtime.StackTrace | undefined;
         }
 
         interface BreakpointResolvedEventDataType {
@@ -1372,25 +1372,25 @@ declare module 'inspector' {
             /**
              * Object containing break-specific auxiliary properties.
              */
-            data?: {};
+            data?: {} | undefined;
             /**
              * Hit breakpoints IDs
              */
-            hitBreakpoints?: string[];
+            hitBreakpoints?: string[] | undefined;
             /**
              * Async stack trace, if any.
              */
-            asyncStackTrace?: Runtime.StackTrace;
+            asyncStackTrace?: Runtime.StackTrace | undefined;
             /**
              * Async stack trace, if any.
              * @experimental
              */
-            asyncStackTraceId?: Runtime.StackTraceId;
+            asyncStackTraceId?: Runtime.StackTraceId | undefined;
             /**
              * Just scheduled async call will have this stack trace as parent stack during async execution. This field is available only after <code>Debugger.stepInto</code> call with <code>breakOnAsynCall</code> flag.
              * @experimental
              */
-            asyncCallStackTraceId?: Runtime.StackTraceId;
+            asyncCallStackTraceId?: Runtime.StackTraceId | undefined;
         }
     }
 
@@ -1414,15 +1414,15 @@ declare module 'inspector' {
             /**
              * URL of the message origin.
              */
-            url?: string;
+            url?: string | undefined;
             /**
              * Line number in the resource that generated this message (1-based).
              */
-            line?: number;
+            line?: number | undefined;
             /**
              * Column number in the resource that generated this message (1-based).
              */
-            column?: number;
+            column?: number | undefined;
         }
 
         interface MessageAddedEventDataType {
@@ -1449,19 +1449,19 @@ declare module 'inspector' {
             /**
              * Number of samples where this node was on top of the call stack.
              */
-            hitCount?: number;
+            hitCount?: number | undefined;
             /**
              * Child node ids.
              */
-            children?: number[];
+            children?: number[] | undefined;
             /**
              * The reason of being not optimized. The function may be deoptimized or marked as don't optimize.
              */
-            deoptReason?: string;
+            deoptReason?: string | undefined;
             /**
              * An array of source position ticks.
              */
-            positionTicks?: PositionTickInfo[];
+            positionTicks?: PositionTickInfo[] | undefined;
         }
 
         /**
@@ -1483,11 +1483,11 @@ declare module 'inspector' {
             /**
              * Ids of samples top nodes.
              */
-            samples?: number[];
+            samples?: number[] | undefined;
             /**
              * Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime.
              */
-            timeDeltas?: number[];
+            timeDeltas?: number[] | undefined;
         }
 
         /**
@@ -1614,11 +1614,11 @@ declare module 'inspector' {
             /**
              * Collect accurate call counts beyond simple 'covered' or 'not covered'.
              */
-            callCount?: boolean;
+            callCount?: boolean | undefined;
             /**
              * Collect block-based coverage.
              */
-            detailed?: boolean;
+            detailed?: boolean | undefined;
         }
 
         interface StopReturnType {
@@ -1658,7 +1658,7 @@ declare module 'inspector' {
             /**
              * Profile title passed as an argument to console.profile().
              */
-            title?: string;
+            title?: string | undefined;
         }
 
         interface ConsoleProfileFinishedEventDataType {
@@ -1671,7 +1671,7 @@ declare module 'inspector' {
             /**
              * Profile title passed as an argument to console.profile().
              */
-            title?: string;
+            title?: string | undefined;
         }
     }
 
@@ -1707,21 +1707,21 @@ declare module 'inspector' {
         }
 
         interface StartTrackingHeapObjectsParameterType {
-            trackAllocations?: boolean;
+            trackAllocations?: boolean | undefined;
         }
 
         interface StopTrackingHeapObjectsParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped.
              */
-            reportProgress?: boolean;
+            reportProgress?: boolean | undefined;
         }
 
         interface TakeHeapSnapshotParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.
              */
-            reportProgress?: boolean;
+            reportProgress?: boolean | undefined;
         }
 
         interface GetObjectByHeapObjectIdParameterType {
@@ -1729,7 +1729,7 @@ declare module 'inspector' {
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
-            objectGroup?: string;
+            objectGroup?: string | undefined;
         }
 
         interface AddInspectedHeapObjectParameterType {
@@ -1750,7 +1750,7 @@ declare module 'inspector' {
             /**
              * Average sample interval in bytes. Poisson distribution is used for the intervals. The default value is 32768 bytes.
              */
-            samplingInterval?: number;
+            samplingInterval?: number | undefined;
         }
 
         interface GetObjectByHeapObjectIdReturnType {
@@ -1788,7 +1788,7 @@ declare module 'inspector' {
         interface ReportHeapSnapshotProgressEventDataType {
             done: number;
             total: number;
-            finished?: boolean;
+            finished?: boolean | undefined;
         }
 
         interface LastSeenObjectIdEventDataType {
@@ -1809,7 +1809,7 @@ declare module 'inspector' {
             /**
              * Controls how the trace buffer stores data.
              */
-            recordMode?: string;
+            recordMode?: string | undefined;
             /**
              * Included category filters.
              */

--- a/types/node/v14/net.d.ts
+++ b/types/node/v14/net.d.ts
@@ -16,10 +16,10 @@ declare module 'net' {
     }
 
     interface SocketConstructorOpts {
-        fd?: number;
-        allowHalfOpen?: boolean;
-        readable?: boolean;
-        writable?: boolean;
+        fd?: number | undefined;
+        allowHalfOpen?: boolean | undefined;
+        readable?: boolean | undefined;
+        writable?: boolean | undefined;
     }
 
     interface OnReadOpts {
@@ -38,17 +38,17 @@ declare module 'net' {
          * Note: this will cause the streaming functionality to not provide any data, however events like 'error', 'end', and 'close' will
          * still be emitted as normal and methods like pause() and resume() will also behave as expected.
          */
-        onread?: OnReadOpts;
+        onread?: OnReadOpts | undefined;
     }
 
     interface TcpSocketConnectOpts extends ConnectOpts {
         port: number;
-        host?: string;
-        localAddress?: string;
-        localPort?: number;
-        hints?: number;
-        family?: number;
-        lookup?: LookupFunction;
+        host?: string | undefined;
+        localAddress?: string | undefined;
+        localPort?: number | undefined;
+        hints?: number | undefined;
+        family?: number | undefined;
+        lookup?: LookupFunction | undefined;
     }
 
     interface IpcSocketConnectOpts extends ConnectOpts {
@@ -87,9 +87,9 @@ declare module 'net' {
         readonly destroyed: boolean;
         readonly localAddress: string;
         readonly localPort: number;
-        readonly remoteAddress?: string;
-        readonly remoteFamily?: string;
-        readonly remotePort?: number;
+        readonly remoteAddress?: string | undefined;
+        readonly remoteFamily?: string | undefined;
+        readonly remotePort?: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): void;
@@ -169,17 +169,17 @@ declare module 'net' {
     }
 
     interface ListenOptions {
-        port?: number;
-        host?: string;
-        backlog?: number;
-        path?: string;
-        exclusive?: boolean;
-        readableAll?: boolean;
-        writableAll?: boolean;
+        port?: number | undefined;
+        host?: string | undefined;
+        backlog?: number | undefined;
+        path?: string | undefined;
+        exclusive?: boolean | undefined;
+        readableAll?: boolean | undefined;
+        writableAll?: boolean | undefined;
         /**
          * @default false
          */
-        ipv6Only?: boolean;
+        ipv6Only?: boolean | undefined;
     }
 
     interface ServerOpts {
@@ -187,13 +187,13 @@ declare module 'net' {
          * Indicates whether half-opened TCP connections are allowed.
          * @default false
          */
-        allowHalfOpen?: boolean;
+        allowHalfOpen?: boolean | undefined;
 
         /**
          * Indicates whether the socket should be paused on incoming connections.
          * @default false
          */
-        pauseOnConnect?: boolean;
+        pauseOnConnect?: boolean | undefined;
     }
 
     // https://github.com/nodejs/node/blob/master/lib/net.js
@@ -264,11 +264,11 @@ declare module 'net' {
     }
 
     interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number;
+        timeout?: number | undefined;
     }
 
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;

--- a/types/node/v14/path.d.ts
+++ b/types/node/v14/path.d.ts
@@ -30,23 +30,23 @@ declare module 'path' {
             /**
              * The root of the path such as '/' or 'c:\'
              */
-            root?: string;
+            root?: string | undefined;
             /**
              * The full directory path such as '/home/user/dir' or 'c:\path\dir'
              */
-            dir?: string;
+            dir?: string | undefined;
             /**
              * The file name including extension (if any) such as 'index.html'
              */
-            base?: string;
+            base?: string | undefined;
             /**
              * The file extension (if any) such as '.html'
              */
-            ext?: string;
+            ext?: string | undefined;
             /**
              * The file name without extension (if any) such as 'index'
              */
-            name?: string;
+            name?: string | undefined;
         }
 
         interface PlatformPath {

--- a/types/node/v14/perf_hooks.d.ts
+++ b/types/node/v14/perf_hooks.d.ts
@@ -31,14 +31,14 @@ declare module 'perf_hooks' {
          * the type of garbage collection operation that occurred.
          * See perf_hooks.constants for valid values.
          */
-        readonly kind?: number;
+        readonly kind?: number | undefined;
 
         /**
          * When `performanceEntry.entryType` is equal to 'gc', the `performance.flags`
          * property contains additional information about garbage collection operation.
          * See perf_hooks.constants for valid values.
          */
-        readonly flags?: number;
+        readonly flags?: number | undefined;
     }
 
     interface PerformanceNodeTiming extends PerformanceEntry {
@@ -186,7 +186,7 @@ declare module 'perf_hooks' {
          * Property buffered defaults to false.
          * @param options
          */
-        observe(options: { entryTypes: ReadonlyArray<EntryType>; buffered?: boolean }): void;
+        observe(options: { entryTypes: ReadonlyArray<EntryType>; buffered?: boolean | undefined }): void;
     }
 
     namespace constants {
@@ -212,7 +212,7 @@ declare module 'perf_hooks' {
          * Must be greater than zero.
          * @default 10
          */
-        resolution?: number;
+        resolution?: number | undefined;
     }
 
     interface EventLoopDelayMonitor {

--- a/types/node/v14/process.d.ts
+++ b/types/node/v14/process.d.ts
@@ -26,10 +26,10 @@ declare module 'process' {
 
             interface ProcessRelease {
                 name: string;
-                sourceUrl?: string;
-                headersUrl?: string;
-                libUrl?: string;
-                lts?: string;
+                sourceUrl?: string | undefined;
+                headersUrl?: string | undefined;
+                libUrl?: string | undefined;
+                lts?: string | undefined;
             }
 
             interface ProcessVersions extends Dict<string> {
@@ -76,7 +76,7 @@ declare module 'process' {
             type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<any>, value: any) => void;
 
             interface Socket extends ReadWriteStream {
-                isTTY?: true;
+                isTTY?: true | undefined;
             }
 
             // Alias for compatibility
@@ -199,7 +199,7 @@ declare module 'process' {
                 emitWarning(warning: string | Error, name?: string, ctor?: Function): void;
                 env: ProcessEnv;
                 exit(code?: number): never;
-                exitCode?: number;
+                exitCode?: number | undefined;
                 getgid(): number;
                 setgid(id: number | string): void;
                 getuid(): number;
@@ -247,7 +247,7 @@ declare module 'process' {
                 arch: string;
                 platform: Platform;
                 /** @deprecated since v14.0.0 - use `require.main` instead. */
-                mainModule?: Module;
+                mainModule?: Module | undefined;
                 memoryUsage(): MemoryUsage;
                 cpuUsage(previousValue?: CpuUsage): CpuUsage;
                 nextTick(callback: Function, ...args: any[]): void;
@@ -277,7 +277,7 @@ declare module 'process' {
                 domain: Domain;
 
                 // Worker
-                send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean}, callback?: (error: Error | null) => void): boolean;
+                send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean | undefined}, callback?: (error: Error | null) => void): boolean;
                 disconnect(): void;
                 connected: boolean;
 
@@ -291,7 +291,7 @@ declare module 'process' {
                 /**
                  * Only available with `--experimental-report`
                  */
-                report?: ProcessReport;
+                report?: ProcessReport | undefined;
 
                 resourceUsage(): ResourceUsage;
 

--- a/types/node/v14/querystring.d.ts
+++ b/types/node/v14/querystring.d.ts
@@ -1,11 +1,11 @@
 declare module 'querystring' {
     interface StringifyOptions {
-        encodeURIComponent?: (str: string) => string;
+        encodeURIComponent?: ((str: string) => string) | undefined;
     }
 
     interface ParseOptions {
-        maxKeys?: number;
-        decodeURIComponent?: (str: string) => string;
+        maxKeys?: number | undefined;
+        decodeURIComponent?: ((str: string) => string) | undefined;
     }
 
     interface ParsedUrlQuery extends NodeJS.Dict<string | string[]> { }

--- a/types/node/v14/readline.d.ts
+++ b/types/node/v14/readline.d.ts
@@ -2,11 +2,11 @@ declare module 'readline' {
     import EventEmitter = require('events');
 
     interface Key {
-        sequence?: string;
-        name?: string;
-        ctrl?: boolean;
-        meta?: boolean;
-        shift?: boolean;
+        sequence?: string | undefined;
+        name?: string | undefined;
+        ctrl?: boolean | undefined;
+        meta?: boolean | undefined;
+        shift?: boolean | undefined;
     }
 
     class Interface extends EventEmitter {
@@ -129,15 +129,15 @@ declare module 'readline' {
 
     interface ReadLineOptions {
         input: NodeJS.ReadableStream;
-        output?: NodeJS.WritableStream;
-        completer?: Completer | AsyncCompleter;
-        terminal?: boolean;
-        historySize?: number;
-        prompt?: string;
-        crlfDelay?: number;
-        removeHistoryDuplicates?: boolean;
-        escapeCodeTimeout?: number;
-        tabSize?: number;
+        output?: NodeJS.WritableStream | undefined;
+        completer?: Completer | AsyncCompleter | undefined;
+        terminal?: boolean | undefined;
+        historySize?: number | undefined;
+        prompt?: string | undefined;
+        crlfDelay?: number | undefined;
+        removeHistoryDuplicates?: boolean | undefined;
+        escapeCodeTimeout?: number | undefined;
+        tabSize?: number | undefined;
     }
 
     function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;

--- a/types/node/v14/repl.d.ts
+++ b/types/node/v14/repl.d.ts
@@ -8,24 +8,24 @@ declare module 'repl' {
          * The input prompt to display.
          * @default "> "
          */
-        prompt?: string;
+        prompt?: string | undefined;
         /**
          * The `Readable` stream from which REPL input will be read.
          * @default process.stdin
          */
-        input?: NodeJS.ReadableStream;
+        input?: NodeJS.ReadableStream | undefined;
         /**
          * The `Writable` stream to which REPL output will be written.
          * @default process.stdout
          */
-        output?: NodeJS.WritableStream;
+        output?: NodeJS.WritableStream | undefined;
         /**
          * If `true`, specifies that the output should be treated as a TTY terminal, and have
          * ANSI/VT100 escape codes written to it.
          * Default: checking the value of the `isTTY` property on the output stream upon
          * instantiation.
          */
-        terminal?: boolean;
+        terminal?: boolean | undefined;
         /**
          * The function to be used when evaluating each given line of input.
          * Default: an async wrapper for the JavaScript `eval()` function. An `eval` function can
@@ -35,45 +35,45 @@ declare module 'repl' {
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
-        eval?: REPLEval;
+        eval?: REPLEval | undefined;
         /**
          * Defines if the repl prints output previews or not.
          * @default `true` Always `false` in case `terminal` is falsy.
          */
-        preview?: boolean;
+        preview?: boolean | undefined;
         /**
          * If `true`, specifies that the default `writer` function should include ANSI color
          * styling to REPL output. If a custom `writer` function is provided then this has no
          * effect.
          * Default: the REPL instance's `terminal` value.
          */
-        useColors?: boolean;
+        useColors?: boolean | undefined;
         /**
          * If `true`, specifies that the default evaluation function will use the JavaScript
          * `global` as the context as opposed to creating a new separate context for the REPL
          * instance. The node CLI REPL sets this value to `true`.
          * Default: `false`.
          */
-        useGlobal?: boolean;
+        useGlobal?: boolean | undefined;
         /**
          * If `true`, specifies that the default writer will not output the return value of a
          * command if it evaluates to `undefined`.
          * Default: `false`.
          */
-        ignoreUndefined?: boolean;
+        ignoreUndefined?: boolean | undefined;
         /**
          * The function to invoke to format the output of each command before writing to `output`.
          * Default: a wrapper for `util.inspect`.
          *
          * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
          */
-        writer?: REPLWriter;
+        writer?: REPLWriter | undefined;
         /**
          * An optional function used for custom Tab auto completion.
          *
          * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
-        completer?: Completer | AsyncCompleter;
+        completer?: Completer | AsyncCompleter | undefined;
         /**
          * A flag that specifies whether the default evaluator executes all JavaScript commands in
          * strict mode or default (sloppy) mode.
@@ -82,13 +82,13 @@ declare module 'repl' {
          * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
          *   prefacing every repl statement with `'use strict'`.
          */
-        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
+        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT | undefined;
         /**
          * Stop evaluating the current piece of code when `SIGINT` is received, i.e. `Ctrl+C` is
          * pressed. This cannot be used together with a custom `eval` function.
          * Default: `false`.
          */
-        breakEvalOnSigint?: boolean;
+        breakEvalOnSigint?: boolean | undefined;
     }
 
     type REPLEval = (this: REPLServer, evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
@@ -106,7 +106,7 @@ declare module 'repl' {
         /**
          * Help text to be displayed when `.help` is entered.
          */
-        help?: string;
+        help?: string | undefined;
         /**
          * The function to execute, optionally accepting a single string argument.
          */

--- a/types/node/v14/stream.d.ts
+++ b/types/node/v14/stream.d.ts
@@ -2,7 +2,7 @@ declare module 'stream' {
     import EventEmitter = require('events');
 
     class internal extends EventEmitter {
-        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
     }
 
     namespace internal {
@@ -11,12 +11,12 @@ declare module 'stream' {
         }
 
         interface ReadableOptions {
-            highWaterMark?: number;
-            encoding?: BufferEncoding;
-            objectMode?: boolean;
+            highWaterMark?: number | undefined;
+            encoding?: BufferEncoding | undefined;
+            objectMode?: boolean | undefined;
             read?(this: Readable, size: number): void;
             destroy?(this: Readable, error: Error | null, callback: (error: Error | null) => void): void;
-            autoDestroy?: boolean;
+            autoDestroy?: boolean | undefined;
         }
 
         class Readable extends Stream implements NodeJS.ReadableStream {
@@ -125,16 +125,16 @@ declare module 'stream' {
         }
 
         interface WritableOptions {
-            highWaterMark?: number;
-            decodeStrings?: boolean;
-            defaultEncoding?: BufferEncoding;
-            objectMode?: boolean;
-            emitClose?: boolean;
+            highWaterMark?: number | undefined;
+            decodeStrings?: boolean | undefined;
+            defaultEncoding?: BufferEncoding | undefined;
+            objectMode?: boolean | undefined;
+            emitClose?: boolean | undefined;
             write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
             writev?(this: Writable, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             destroy?(this: Writable, error: Error | null, callback: (error: Error | null) => void): void;
             final?(this: Writable, callback: (error?: Error | null) => void): void;
-            autoDestroy?: boolean;
+            autoDestroy?: boolean | undefined;
         }
 
         class Writable extends Stream implements NodeJS.WritableStream {
@@ -229,12 +229,12 @@ declare module 'stream' {
         }
 
         interface DuplexOptions extends ReadableOptions, WritableOptions {
-            allowHalfOpen?: boolean;
-            readableObjectMode?: boolean;
-            writableObjectMode?: boolean;
-            readableHighWaterMark?: number;
-            writableHighWaterMark?: number;
-            writableCorked?: number;
+            allowHalfOpen?: boolean | undefined;
+            readableObjectMode?: boolean | undefined;
+            writableObjectMode?: boolean | undefined;
+            readableHighWaterMark?: number | undefined;
+            writableHighWaterMark?: number | undefined;
+            writableCorked?: number | undefined;
             read?(this: Duplex, size: number): void;
             write?(this: Duplex, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
             writev?(this: Duplex, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
@@ -287,9 +287,9 @@ declare module 'stream' {
         class PassThrough extends Transform { }
 
         interface FinishedOptions {
-            error?: boolean;
-            readable?: boolean;
-            writable?: boolean;
+            error?: boolean | undefined;
+            readable?: boolean | undefined;
+            writable?: boolean | undefined;
         }
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;

--- a/types/node/v14/tls.d.ts
+++ b/types/node/v14/tls.d.ts
@@ -75,7 +75,7 @@ declare module 'tls' {
         /**
          * The name property is available only when type is 'ECDH'.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * The size of parameter of an ephemeral key exchange.
          */
@@ -90,7 +90,7 @@ declare module 'tls' {
         /**
          * Optional passphrase.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface PxfObject {
@@ -101,7 +101,7 @@ declare module 'tls' {
         /**
          * Optional passphrase.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
     }
 
     interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
@@ -109,22 +109,22 @@ declare module 'tls' {
          * If true the TLS socket will be instantiated in server-mode.
          * Defaults to false.
          */
-        isServer?: boolean;
+        isServer?: boolean | undefined;
         /**
          * An optional net.Server instance.
          */
-        server?: net.Server;
+        server?: net.Server | undefined;
 
         /**
          * An optional Buffer instance containing a TLS session.
          */
-        session?: Buffer;
+        session?: Buffer | undefined;
         /**
          * If true, specifies that the OCSP status request extension will be
          * added to the client hello and an 'OCSPResponse' event will be
          * emitted on the socket before establishing a secure communication
          */
-        requestOCSP?: boolean;
+        requestOCSP?: boolean | undefined;
     }
 
     class TLSSocket extends net.Socket {
@@ -152,7 +152,7 @@ declare module 'tls' {
          * String containing the selected ALPN protocol.
          * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string;
+        alpnProtocol?: string | undefined;
 
         /**
          * Returns an object representing the local certificate. The returned
@@ -264,7 +264,7 @@ declare module 'tls' {
          * is successfully completed.
          * @return `undefined` when socket is destroy, `false` if negotiaion can't be initiated.
          */
-        renegotiate(options: { rejectUnauthorized?: boolean, requestCert?: boolean }, callback: (err: Error | null) => void): undefined | boolean;
+        renegotiate(options: { rejectUnauthorized?: boolean | undefined, requestCert?: boolean | undefined }, callback: (err: Error | null) => void): undefined | boolean;
         /**
          * Set maximum TLS fragment size (default and maximum value is: 16384, minimum is: 512).
          * Smaller fragment size decreases buffering latency on the client: large fragments are buffered by
@@ -344,25 +344,25 @@ declare module 'tls' {
         /**
          * An optional TLS context object from tls.createSecureContext()
          */
-        secureContext?: SecureContext;
+        secureContext?: SecureContext | undefined;
 
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false
          */
-        enableTrace?: boolean;
+        enableTrace?: boolean | undefined;
         /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
-        requestCert?: boolean;
+        requestCert?: boolean | undefined;
         /**
          * An array of strings or a Buffer naming possible ALPN protocols.
          * (Protocols should be ordered by their priority.)
          */
-        ALPNProtocols?: string[] | Uint8Array[] | Uint8Array;
+        ALPNProtocols?: string[] | Uint8Array[] | Uint8Array | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments
@@ -372,14 +372,14 @@ declare module 'tls' {
          * SecureContext.) If SNICallback wasn't provided the default callback
          * with high-level API will be used (see below).
          */
-        SNICallback?: (servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void;
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void) | undefined;
         /**
          * If true the server will reject any connection which is not
          * authorized with the list of supplied CAs. This option only has an
          * effect if requestCert is true.
          * @default true
          */
-        rejectUnauthorized?: boolean;
+        rejectUnauthorized?: boolean | undefined;
     }
 
     interface TlsOptions extends SecureContextOptions, CommonConnectionOptions, net.ServerOpts {
@@ -389,17 +389,17 @@ declare module 'tls' {
          * the tls.Server object whenever a handshake times out. Default:
          * 120000 (120 seconds).
          */
-        handshakeTimeout?: number;
+        handshakeTimeout?: number | undefined;
         /**
          * The number of seconds after which a TLS session created by the
          * server will no longer be resumable. See Session Resumption for more
          * information. Default: 300.
          */
-        sessionTimeout?: number;
+        sessionTimeout?: number | undefined;
         /**
          * 48-bytes of cryptographically strong pseudo-random data.
          */
-        ticketKeys?: Buffer;
+        ticketKeys?: Buffer | undefined;
 
         /**
          *
@@ -428,7 +428,7 @@ declare module 'tls' {
          * in TLS 1.3. Upon failing to set pskIdentityHint `tlsClientError` will be
          * emitted with `ERR_TLS_PSK_SET_IDENTIY_HINT_FAILED` code.
          */
-        pskIdentityHint?: string;
+        pskIdentityHint?: string | undefined;
     }
 
     interface PSKCallbackNegotation {
@@ -437,16 +437,16 @@ declare module 'tls' {
     }
 
     interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
-        host?: string;
-        port?: number;
-        path?: string; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
-        socket?: net.Socket; // Establish secure connection on a given socket rather than creating a new socket
-        checkServerIdentity?: typeof checkServerIdentity;
-        servername?: string; // SNI TLS Extension
-        session?: Buffer;
-        minDHSize?: number;
-        lookup?: net.LookupFunction;
-        timeout?: number;
+        host?: string | undefined;
+        port?: number | undefined;
+        path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
+        socket?: net.Socket | undefined; // Establish secure connection on a given socket rather than creating a new socket
+        checkServerIdentity?: typeof checkServerIdentity | undefined;
+        servername?: string | undefined; // SNI TLS Extension
+        session?: Buffer | undefined;
+        minDHSize?: number | undefined;
+        lookup?: net.LookupFunction | undefined;
+        timeout?: number | undefined;
         /**
          * When negotiating TLS-PSK (pre-shared keys), this function is called
          * with optional identity `hint` provided by the server or `null`
@@ -566,7 +566,7 @@ declare module 'tls' {
          * the well-known CAs curated by Mozilla. Mozilla's CAs are completely
          * replaced when CAs are explicitly specified using this option.
          */
-        ca?: string | Buffer | Array<string | Buffer>;
+        ca?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          *  Cert chains in PEM format. One cert chain should be provided per
          *  private key. Each cert chain should consist of the PEM formatted
@@ -578,29 +578,29 @@ declare module 'tls' {
          *  intermediate certificates are not provided, the peer will not be
          *  able to validate the certificate, and the handshake will fail.
          */
-        cert?: string | Buffer | Array<string | Buffer>;
+        cert?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          *  Colon-separated list of supported signature algorithms. The list
          *  can contain digest algorithms (SHA256, MD5 etc.), public key
          *  algorithms (RSA-PSS, ECDSA etc.), combination of both (e.g
          *  'RSA+SHA384') or TLS v1.3 scheme names (e.g. rsa_pss_pss_sha512).
          */
-        sigalgs?: string;
+        sigalgs?: string | undefined;
         /**
          * Cipher suite specification, replacing the default. For more
          * information, see modifying the default cipher suite. Permitted
          * ciphers can be obtained via tls.getCiphers(). Cipher names must be
          * uppercased in order for OpenSSL to accept them.
          */
-        ciphers?: string;
+        ciphers?: string | undefined;
         /**
          * Name of an OpenSSL engine which can provide the client certificate.
          */
-        clientCertEngine?: string;
+        clientCertEngine?: string | undefined;
         /**
          * PEM formatted CRLs (Certificate Revocation Lists).
          */
-        crl?: string | Buffer | Array<string | Buffer>;
+        crl?: string | Buffer | Array<string | Buffer> | undefined;
         /**
          * Diffie Hellman parameters, required for Perfect Forward Secrecy. Use
          * openssl dhparam to create the parameters. The key length must be
@@ -609,7 +609,7 @@ declare module 'tls' {
          * stronger security. If omitted or invalid, the parameters are
          * silently discarded and DHE ciphers will not be available.
          */
-        dhparam?: string | Buffer;
+        dhparam?: string | Buffer | undefined;
         /**
          * A string describing a named curve or a colon separated list of curve
          * NIDs or names, for example P-521:P-384:P-256, to use for ECDH key
@@ -619,13 +619,13 @@ declare module 'tls' {
          * name and description of each available elliptic curve. Default:
          * tls.DEFAULT_ECDH_CURVE.
          */
-        ecdhCurve?: string;
+        ecdhCurve?: string | undefined;
         /**
          * Attempt to use the server's cipher suite preferences instead of the
          * client's. When true, causes SSL_OP_CIPHER_SERVER_PREFERENCE to be
          * set in secureOptions
          */
-        honorCipherOrder?: boolean;
+        honorCipherOrder?: boolean | undefined;
         /**
          * Private keys in PEM format. PEM allows the option of private keys
          * being encrypted. Encrypted keys will be decrypted with
@@ -636,18 +636,18 @@ declare module 'tls' {
          * object.passphrase is optional. Encrypted keys will be decrypted with
          * object.passphrase if provided, or options.passphrase if it is not.
          */
-        key?: string | Buffer | Array<Buffer | KeyObject>;
+        key?: string | Buffer | Array<Buffer | KeyObject> | undefined;
         /**
          * Name of an OpenSSL engine to get private key from. Should be used
          * together with privateKeyIdentifier.
          */
-        privateKeyEngine?: string;
+        privateKeyEngine?: string | undefined;
         /**
          * Identifier of a private key managed by an OpenSSL engine. Should be
          * used together with privateKeyEngine. Should not be set together with
          * key, because both options define a private key in different ways.
          */
-        privateKeyIdentifier?: string;
+        privateKeyIdentifier?: string | undefined;
         /**
          * Optionally set the maximum TLS version to allow. One
          * of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
@@ -656,7 +656,7 @@ declare module 'tls' {
          * `--tls-max-v1.2` sets the default to `'TLSv1.2'`. Using `--tls-max-v1.3` sets the default to
          * `'TLSv1.3'`. If multiple of the options are provided, the highest maximum is used.
          */
-        maxVersion?: SecureVersion;
+        maxVersion?: SecureVersion | undefined;
         /**
          * Optionally set the minimum TLS version to allow. One
          * of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
@@ -667,11 +667,11 @@ declare module 'tls' {
          * `'TLSv1.1'`. Using `--tls-min-v1.3` sets the default to
          * 'TLSv1.3'. If multiple of the options are provided, the lowest minimum is used.
          */
-        minVersion?: SecureVersion;
+        minVersion?: SecureVersion | undefined;
         /**
          * Shared passphrase used for a single private key and/or a PFX.
          */
-        passphrase?: string;
+        passphrase?: string | undefined;
         /**
          * PFX or PKCS12 encoded private key and certificate chain. pfx is an
          * alternative to providing key and cert individually. PFX is usually
@@ -682,13 +682,13 @@ declare module 'tls' {
          * object.passphrase is optional. Encrypted PFX will be decrypted with
          * object.passphrase if provided, or options.passphrase if it is not.
          */
-        pfx?: string | Buffer | Array<string | Buffer | PxfObject>;
+        pfx?: string | Buffer | Array<string | Buffer | PxfObject> | undefined;
         /**
          * Optionally affect the OpenSSL protocol behavior, which is not
          * usually necessary. This should be used carefully if at all! Value is
          * a numeric bitmask of the SSL_OP_* options from OpenSSL Options
          */
-        secureOptions?: number; // Value is a numeric bitmask of the `SSL_OP_*` options
+        secureOptions?: number | undefined; // Value is a numeric bitmask of the `SSL_OP_*` options
         /**
          * Legacy mechanism to select the TLS protocol version to use, it does
          * not support independent control of the minimum and maximum version,
@@ -700,23 +700,23 @@ declare module 'tls' {
          * TLS versions less than 1.2, but it may be required for
          * interoperability. Default: none, see minVersion.
          */
-        secureProtocol?: string;
+        secureProtocol?: string | undefined;
         /**
          * Opaque identifier used by servers to ensure session state is not
          * shared between applications. Unused by clients.
          */
-        sessionIdContext?: string;
+        sessionIdContext?: string | undefined;
         /**
          * 48-bytes of cryptographically strong pseudo-random data.
          * See Session Resumption for more information.
          */
-        ticketKeys?: Buffer;
+        ticketKeys?: Buffer | undefined;
         /**
          * The number of seconds after which a TLS session created by the
          * server will no longer be resumable. See Session Resumption for more
          * information. Default: 300.
          */
-        sessionTimeout?: number;
+        sessionTimeout?: number | undefined;
     }
 
     interface SecureContext {

--- a/types/node/v14/url.d.ts
+++ b/types/node/v14/url.d.ts
@@ -3,17 +3,17 @@ declare module 'url' {
 
     // Input to `url.format`
     interface UrlObject {
-        auth?: string | null;
-        hash?: string | null;
-        host?: string | null;
-        hostname?: string | null;
-        href?: string | null;
-        pathname?: string | null;
-        protocol?: string | null;
-        search?: string | null;
-        slashes?: boolean | null;
-        port?: string | number | null;
-        query?: string | null | ParsedUrlQueryInput;
+        auth?: string | null | undefined;
+        hash?: string | null | undefined;
+        host?: string | null | undefined;
+        hostname?: string | null | undefined;
+        href?: string | null | undefined;
+        pathname?: string | null | undefined;
+        protocol?: string | null | undefined;
+        search?: string | null | undefined;
+        slashes?: boolean | null | undefined;
+        port?: string | number | null | undefined;
+        query?: string | null | ParsedUrlQueryInput | undefined;
     }
 
     // Output of `url.parse`
@@ -73,10 +73,10 @@ declare module 'url' {
     function pathToFileURL(url: string): URL;
 
     interface URLFormatOptions {
-        auth?: boolean;
-        fragment?: boolean;
-        search?: boolean;
-        unicode?: boolean;
+        auth?: boolean | undefined;
+        fragment?: boolean | undefined;
+        search?: boolean | undefined;
+        unicode?: boolean | undefined;
     }
 
     class URL {

--- a/types/node/v14/util.d.ts
+++ b/types/node/v14/util.d.ts
@@ -179,11 +179,11 @@ declare module 'util' {
         readonly ignoreBOM: boolean;
         constructor(
           encoding?: string,
-          options?: { fatal?: boolean; ignoreBOM?: boolean }
+          options?: { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined }
         );
         decode(
           input?: NodeJS.ArrayBufferView | ArrayBuffer | null,
-          options?: { stream?: boolean }
+          options?: { stream?: boolean | undefined }
         ): string;
     }
 

--- a/types/node/v14/vm.d.ts
+++ b/types/node/v14/vm.d.ts
@@ -5,67 +5,67 @@ declare module 'vm' {
          * Specifies the filename used in stack traces produced by this script.
          * Default: `''`.
          */
-        filename?: string;
+        filename?: string | undefined;
         /**
          * Specifies the line number offset that is displayed in stack traces produced by this script.
          * Default: `0`.
          */
-        lineOffset?: number;
+        lineOffset?: number | undefined;
         /**
          * Specifies the column number offset that is displayed in stack traces produced by this script.
          * @default 0
          */
-        columnOffset?: number;
+        columnOffset?: number | undefined;
     }
     interface ScriptOptions extends BaseOptions {
-        displayErrors?: boolean;
-        timeout?: number;
-        cachedData?: Buffer;
+        displayErrors?: boolean | undefined;
+        timeout?: number | undefined;
+        cachedData?: Buffer | undefined;
         /** @deprecated in favor of `script.createCachedData()` */
-        produceCachedData?: boolean;
+        produceCachedData?: boolean | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
         /**
          * When `true`, if an `Error` occurs while compiling the `code`, the line of code causing the error is attached to the stack trace.
          * Default: `true`.
          */
-        displayErrors?: boolean;
+        displayErrors?: boolean | undefined;
         /**
          * Specifies the number of milliseconds to execute code before terminating execution.
          * If execution is terminated, an `Error` will be thrown. This value must be a strictly positive integer.
          */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * If `true`, the execution will be terminated when `SIGINT` (Ctrl+C) is received.
          * Existing handlers for the event that have been attached via `process.on('SIGINT')` will be disabled during script execution, but will continue to work after that.
          * If execution is terminated, an `Error` will be thrown.
          * Default: `false`.
          */
-        breakOnSigint?: boolean;
+        breakOnSigint?: boolean | undefined;
         /**
          * If set to `afterEvaluate`, microtasks will be run immediately after the script has run.
          */
-        microtaskMode?: 'afterEvaluate';
+        microtaskMode?: 'afterEvaluate' | undefined;
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
-        cachedData?: Buffer;
+        cachedData?: Buffer | undefined;
         /**
          * Specifies whether to produce new cache data.
          * Default: `false`,
          */
-        produceCachedData?: boolean;
+        produceCachedData?: boolean | undefined;
         /**
          * The sandbox/context in which the said function should be compiled in.
          */
-        parsingContext?: Context;
+        parsingContext?: Context | undefined;
 
         /**
          * An array containing a collection of context extensions (objects wrapping the current scope) to be applied while compiling
          */
-        contextExtensions?: Object[];
+        contextExtensions?: Object[] | undefined;
     }
 
     interface CreateContextOptions {
@@ -73,7 +73,7 @@ declare module 'vm' {
          * Human-readable name of the newly created context.
          * @default 'VM Context i' Where i is an ascending numerical index of the created context.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * Corresponds to the newly created context for display purposes.
          * The origin should be formatted like a `URL`, but with only the scheme, host, and port (if necessary),
@@ -81,24 +81,24 @@ declare module 'vm' {
          * Most notably, this string should omit the trailing slash, as that denotes a path.
          * @default ''
          */
-        origin?: string;
+        origin?: string | undefined;
         codeGeneration?: {
             /**
              * If set to false any calls to eval or function constructors (Function, GeneratorFunction, etc)
              * will throw an EvalError.
              * @default true
              */
-            strings?: boolean;
+            strings?: boolean | undefined;
             /**
              * If set to false any attempt to compile a WebAssembly module will throw a WebAssembly.CompileError.
              * @default true
              */
-            wasm?: boolean;
-        };
+            wasm?: boolean | undefined;
+        } | undefined;
         /**
          * If set to `afterEvaluate`, microtasks will be run immediately after the script has run.
          */
-        microtaskMode?: 'afterEvaluate';
+        microtaskMode?: 'afterEvaluate' | undefined;
     }
 
     type MeasureMemoryMode = 'summary' | 'detailed';
@@ -107,8 +107,8 @@ declare module 'vm' {
         /**
          * @default 'summary'
          */
-        mode?: MeasureMemoryMode;
-        context?: Context;
+        mode?: MeasureMemoryMode | undefined;
+        context?: Context | undefined;
     }
 
     interface MemoryMeasurement {
@@ -124,7 +124,7 @@ declare module 'vm' {
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
         createCachedData(): Buffer;
-        cachedDataRejected?: boolean;
+        cachedDataRejected?: boolean | undefined;
     }
     function createContext(sandbox?: Context, options?: CreateContextOptions): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/v14/wasi.d.ts
+++ b/types/node/v14/wasi.d.ts
@@ -5,13 +5,13 @@ declare module 'wasi' {
          * see as command line arguments. The first argument is the virtual path to the
          * WASI command itself.
          */
-        args?: string[];
+        args?: string[] | undefined;
 
         /**
          * An object similar to `process.env` that the WebAssembly
          * application will see as its environment.
          */
-        env?: object;
+        env?: object | undefined;
 
         /**
          * This object represents the WebAssembly application's
@@ -19,7 +19,7 @@ declare module 'wasi' {
          * directories within the sandbox. The corresponding values in `preopens` are
          * the real paths to those directories on the host machine.
          */
-        preopens?: NodeJS.Dict<string>;
+        preopens?: NodeJS.Dict<string> | undefined;
 
         /**
          * By default, WASI applications terminate the Node.js
@@ -28,25 +28,25 @@ declare module 'wasi' {
          * process.
          * @default false
          */
-        returnOnExit?: boolean;
+        returnOnExit?: boolean | undefined;
 
         /**
          * The file descriptor used as standard input in the WebAssembly application.
          * @default 0
          */
-        stdin?: number;
+        stdin?: number | undefined;
 
         /**
          * The file descriptor used as standard output in the WebAssembly application.
          * @default 1
          */
-        stdout?: number;
+        stdout?: number | undefined;
 
         /**
          * The file descriptor used as standard error in the WebAssembly application.
          * @default 2
          */
-        stderr?: number;
+        stderr?: number | undefined;
     }
 
     class WASI {

--- a/types/node/v14/worker_threads.d.ts
+++ b/types/node/v14/worker_threads.d.ts
@@ -74,40 +74,40 @@ declare module 'worker_threads' {
          * but the values will be available on the global `process.argv` as if they
          * were passed as CLI options to the script.
          */
-        argv?: any[];
-        env?: NodeJS.Dict<string> | typeof SHARE_ENV;
-        eval?: boolean;
+        argv?: any[] | undefined;
+        env?: NodeJS.Dict<string> | typeof SHARE_ENV | undefined;
+        eval?: boolean | undefined;
         workerData?: any;
-        stdin?: boolean;
-        stdout?: boolean;
-        stderr?: boolean;
-        execArgv?: string[];
-        resourceLimits?: ResourceLimits;
+        stdin?: boolean | undefined;
+        stdout?: boolean | undefined;
+        stderr?: boolean | undefined;
+        execArgv?: string[] | undefined;
+        resourceLimits?: ResourceLimits | undefined;
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: TransferListItem[];
-        trackUnmanagedFds?: boolean;
+        transferList?: TransferListItem[] | undefined;
+        trackUnmanagedFds?: boolean | undefined;
     }
 
     interface ResourceLimits {
         /**
          * The maximum size of a heap space for recently created objects.
          */
-        maxYoungGenerationSizeMb?: number;
+        maxYoungGenerationSizeMb?: number | undefined;
         /**
          * The maximum size of the main heap in MB.
          */
-        maxOldGenerationSizeMb?: number;
+        maxOldGenerationSizeMb?: number | undefined;
         /**
          * The size of a pre-allocated memory range used for generated code.
          */
-        codeRangeSizeMb?: number;
+        codeRangeSizeMb?: number | undefined;
         /**
          * The default maximum stack size for the thread. Small values may lead to unusable Worker instances.
          * @default 4
          */
-        stackSizeMb?: number;
+        stackSizeMb?: number | undefined;
     }
 
     class Worker extends EventEmitter {
@@ -115,7 +115,7 @@ declare module 'worker_threads' {
         readonly stdout: Readable;
         readonly stderr: Readable;
         readonly threadId: number;
-        readonly resourceLimits?: ResourceLimits;
+        readonly resourceLimits?: ResourceLimits | undefined;
 
         /**
          * @param filename  The path to the Worker’s main script or module.

--- a/types/node/v14/zlib.d.ts
+++ b/types/node/v14/zlib.d.ts
@@ -5,51 +5,51 @@ declare module 'zlib' {
         /**
          * @default constants.Z_NO_FLUSH
          */
-        flush?: number;
+        flush?: number | undefined;
         /**
          * @default constants.Z_FINISH
          */
-        finishFlush?: number;
+        finishFlush?: number | undefined;
         /**
          * @default 16*1024
          */
-        chunkSize?: number;
-        windowBits?: number;
-        level?: number; // compression only
-        memLevel?: number; // compression only
-        strategy?: number; // compression only
-        dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
-        info?: boolean;
-        maxOutputLength?: number;
+        chunkSize?: number | undefined;
+        windowBits?: number | undefined;
+        level?: number | undefined; // compression only
+        memLevel?: number | undefined; // compression only
+        strategy?: number | undefined; // compression only
+        dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
+        maxOutputLength?: number | undefined;
     }
 
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
          */
-        flush?: number;
+        flush?: number | undefined;
         /**
          * @default constants.BROTLI_OPERATION_FINISH
          */
-        finishFlush?: number;
+        finishFlush?: number | undefined;
         /**
          * @default 16*1024
          */
-        chunkSize?: number;
+        chunkSize?: number | undefined;
         params?: {
             /**
              * Each key is a `constants.BROTLI_*` constant.
              */
             [key: number]: boolean | number;
-        };
-        maxOutputLength?: number;
+        } | undefined;
+        maxOutputLength?: number | undefined;
     }
 
     interface Zlib {
         /** @deprecated Use bytesWritten instead. */
         readonly bytesRead: number;
         readonly bytesWritten: number;
-        shell?: boolean | string;
+        shell?: boolean | string | undefined;
         close(callback?: () => void): void;
         flush(kind?: number, callback?: () => void): void;
         flush(callback?: () => void): void;

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -5,67 +5,67 @@ declare module 'vm' {
          * Specifies the filename used in stack traces produced by this script.
          * Default: `''`.
          */
-        filename?: string;
+        filename?: string | undefined;
         /**
          * Specifies the line number offset that is displayed in stack traces produced by this script.
          * Default: `0`.
          */
-        lineOffset?: number;
+        lineOffset?: number | undefined;
         /**
          * Specifies the column number offset that is displayed in stack traces produced by this script.
          * @default 0
          */
-        columnOffset?: number;
+        columnOffset?: number | undefined;
     }
     interface ScriptOptions extends BaseOptions {
-        displayErrors?: boolean;
-        timeout?: number;
-        cachedData?: Buffer;
+        displayErrors?: boolean | undefined;
+        timeout?: number | undefined;
+        cachedData?: Buffer | undefined;
         /** @deprecated in favor of `script.createCachedData()` */
-        produceCachedData?: boolean;
+        produceCachedData?: boolean | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
         /**
          * When `true`, if an `Error` occurs while compiling the `code`, the line of code causing the error is attached to the stack trace.
          * Default: `true`.
          */
-        displayErrors?: boolean;
+        displayErrors?: boolean | undefined;
         /**
          * Specifies the number of milliseconds to execute code before terminating execution.
          * If execution is terminated, an `Error` will be thrown. This value must be a strictly positive integer.
          */
-        timeout?: number;
+        timeout?: number | undefined;
         /**
          * If `true`, the execution will be terminated when `SIGINT` (Ctrl+C) is received.
          * Existing handlers for the event that have been attached via `process.on('SIGINT')` will be disabled during script execution, but will continue to work after that.
          * If execution is terminated, an `Error` will be thrown.
          * Default: `false`.
          */
-        breakOnSigint?: boolean;
+        breakOnSigint?: boolean | undefined;
         /**
          * If set to `afterEvaluate`, microtasks will be run immediately after the script has run.
          */
-        microtaskMode?: 'afterEvaluate';
+        microtaskMode?: 'afterEvaluate' | undefined;
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
-        cachedData?: Buffer;
+        cachedData?: Buffer | undefined;
         /**
          * Specifies whether to produce new cache data.
          * Default: `false`,
          */
-        produceCachedData?: boolean;
+        produceCachedData?: boolean | undefined;
         /**
          * The sandbox/context in which the said function should be compiled in.
          */
-        parsingContext?: Context;
+        parsingContext?: Context | undefined;
 
         /**
          * An array containing a collection of context extensions (objects wrapping the current scope) to be applied while compiling
          */
-        contextExtensions?: Object[];
+        contextExtensions?: Object[] | undefined;
     }
 
     interface CreateContextOptions {
@@ -73,7 +73,7 @@ declare module 'vm' {
          * Human-readable name of the newly created context.
          * @default 'VM Context i' Where i is an ascending numerical index of the created context.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * Corresponds to the newly created context for display purposes.
          * The origin should be formatted like a `URL`, but with only the scheme, host, and port (if necessary),
@@ -81,24 +81,24 @@ declare module 'vm' {
          * Most notably, this string should omit the trailing slash, as that denotes a path.
          * @default ''
          */
-        origin?: string;
+        origin?: string | undefined;
         codeGeneration?: {
             /**
              * If set to false any calls to eval or function constructors (Function, GeneratorFunction, etc)
              * will throw an EvalError.
              * @default true
              */
-            strings?: boolean;
+            strings?: boolean | undefined;
             /**
              * If set to false any attempt to compile a WebAssembly module will throw a WebAssembly.CompileError.
              * @default true
              */
-            wasm?: boolean;
-        };
+            wasm?: boolean | undefined;
+        } | undefined;
         /**
          * If set to `afterEvaluate`, microtasks will be run immediately after the script has run.
          */
-        microtaskMode?: 'afterEvaluate';
+        microtaskMode?: 'afterEvaluate' | undefined;
     }
 
     type MeasureMemoryMode = 'summary' | 'detailed';
@@ -107,8 +107,8 @@ declare module 'vm' {
         /**
          * @default 'summary'
          */
-        mode?: MeasureMemoryMode;
-        context?: Context;
+        mode?: MeasureMemoryMode | undefined;
+        context?: Context | undefined;
     }
 
     interface MemoryMeasurement {
@@ -124,7 +124,7 @@ declare module 'vm' {
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
         createCachedData(): Buffer;
-        cachedDataRejected?: boolean;
+        cachedDataRejected?: boolean | undefined;
     }
     function createContext(sandbox?: Context, options?: CreateContextOptions): Context;
     function isContext(sandbox: Context): boolean;

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -5,13 +5,13 @@ declare module 'wasi' {
          * see as command line arguments. The first argument is the virtual path to the
          * WASI command itself.
          */
-        args?: string[];
+        args?: string[] | undefined;
 
         /**
          * An object similar to `process.env` that the WebAssembly
          * application will see as its environment.
          */
-        env?: object;
+        env?: object | undefined;
 
         /**
          * This object represents the WebAssembly application's
@@ -19,7 +19,7 @@ declare module 'wasi' {
          * directories within the sandbox. The corresponding values in `preopens` are
          * the real paths to those directories on the host machine.
          */
-        preopens?: NodeJS.Dict<string>;
+        preopens?: NodeJS.Dict<string> | undefined;
 
         /**
          * By default, WASI applications terminate the Node.js
@@ -28,25 +28,25 @@ declare module 'wasi' {
          * process.
          * @default false
          */
-        returnOnExit?: boolean;
+        returnOnExit?: boolean | undefined;
 
         /**
          * The file descriptor used as standard input in the WebAssembly application.
          * @default 0
          */
-        stdin?: number;
+        stdin?: number | undefined;
 
         /**
          * The file descriptor used as standard output in the WebAssembly application.
          * @default 1
          */
-        stdout?: number;
+        stdout?: number | undefined;
 
         /**
          * The file descriptor used as standard error in the WebAssembly application.
          * @default 2
          */
-        stderr?: number;
+        stderr?: number | undefined;
     }
 
     class WASI {

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -81,43 +81,43 @@ declare module 'worker_threads' {
          * but the values will be available on the global `process.argv` as if they
          * were passed as CLI options to the script.
          */
-        argv?: any[];
-        env?: NodeJS.Dict<string> | typeof SHARE_ENV;
-        eval?: boolean;
+        argv?: any[] | undefined;
+        env?: NodeJS.Dict<string> | typeof SHARE_ENV | undefined;
+        eval?: boolean | undefined;
         workerData?: any;
-        stdin?: boolean;
-        stdout?: boolean;
-        stderr?: boolean;
-        execArgv?: string[];
-        resourceLimits?: ResourceLimits;
+        stdin?: boolean | undefined;
+        stdout?: boolean | undefined;
+        stderr?: boolean | undefined;
+        execArgv?: string[] | undefined;
+        resourceLimits?: ResourceLimits | undefined;
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: TransferListItem[];
+        transferList?: TransferListItem[] | undefined;
         /**
          * @default true
          */
-        trackUnmanagedFds?: boolean;
+        trackUnmanagedFds?: boolean | undefined;
     }
 
     interface ResourceLimits {
         /**
          * The maximum size of a heap space for recently created objects.
          */
-        maxYoungGenerationSizeMb?: number;
+        maxYoungGenerationSizeMb?: number | undefined;
         /**
          * The maximum size of the main heap in MB.
          */
-        maxOldGenerationSizeMb?: number;
+        maxOldGenerationSizeMb?: number | undefined;
         /**
          * The size of a pre-allocated memory range used for generated code.
          */
-        codeRangeSizeMb?: number;
+        codeRangeSizeMb?: number | undefined;
         /**
          * The default maximum stack size for the thread. Small values may lead to unusable Worker instances.
          * @default 4
          */
-        stackSizeMb?: number;
+        stackSizeMb?: number | undefined;
     }
 
     class Worker extends EventEmitter {
@@ -125,7 +125,7 @@ declare module 'worker_threads' {
         readonly stdout: Readable;
         readonly stderr: Readable;
         readonly threadId: number;
-        readonly resourceLimits?: ResourceLimits;
+        readonly resourceLimits?: ResourceLimits | undefined;
         readonly performance: WorkerPerformance;
 
         /**

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -5,51 +5,51 @@ declare module 'zlib' {
         /**
          * @default constants.Z_NO_FLUSH
          */
-        flush?: number;
+        flush?: number | undefined;
         /**
          * @default constants.Z_FINISH
          */
-        finishFlush?: number;
+        finishFlush?: number | undefined;
         /**
          * @default 16*1024
          */
-        chunkSize?: number;
-        windowBits?: number;
-        level?: number; // compression only
-        memLevel?: number; // compression only
-        strategy?: number; // compression only
-        dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
-        info?: boolean;
-        maxOutputLength?: number;
+        chunkSize?: number | undefined;
+        windowBits?: number | undefined;
+        level?: number | undefined; // compression only
+        memLevel?: number | undefined; // compression only
+        strategy?: number | undefined; // compression only
+        dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
+        maxOutputLength?: number | undefined;
     }
 
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
          */
-        flush?: number;
+        flush?: number | undefined;
         /**
          * @default constants.BROTLI_OPERATION_FINISH
          */
-        finishFlush?: number;
+        finishFlush?: number | undefined;
         /**
          * @default 16*1024
          */
-        chunkSize?: number;
+        chunkSize?: number | undefined;
         params?: {
             /**
              * Each key is a `constants.BROTLI_*` constant.
              */
             [key: number]: boolean | number;
-        };
-        maxOutputLength?: number;
+        } | undefined;
+        maxOutputLength?: number | undefined;
     }
 
     interface Zlib {
         /** @deprecated Use bytesWritten instead. */
         readonly bytesRead: number;
         readonly bytesWritten: number;
-        shell?: boolean | string;
+        shell?: boolean | string | undefined;
         close(callback?: () => void): void;
         flush(kind?: number, callback?: () => void): void;
         flush(callback?: () => void): void;


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers node.
microsoft/dtslint#335