### PR TITLE
[@types/ramda] Fix fromPairs returning numeric keys

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -666,8 +666,7 @@ export function forEachObjIndexed<T>(fn: (value: T[keyof T], key: keyof T, obj: 
 /**
  * Creates a new object out of a list key-value pairs.
  */
-export function fromPairs<V>(pairs: Array<KeyValuePair<string, V>>): { [index: string]: V };
-export function fromPairs<V>(pairs: Array<KeyValuePair<number, V>>): { [index: number]: V };
+export function fromPairs<V>(pairs: Array<KeyValuePair<string, V>> | Array<KeyValuePair<number, V>>): { [index: string]: V };
 
 /**
  * Splits a list into sublists stored in an object, based on the result of

--- a/types/ramda/test/fromPairs-tests.ts
+++ b/types/ramda/test/fromPairs-tests.ts
@@ -2,4 +2,7 @@ import * as R from 'ramda';
 
 () => {
   R.fromPairs([['a', 1], ['b', 2], ['c', 3]]); // => {a: 1, b: 2, c: 3}
+
+  // $ExpectType { [index: string]: string; }
+  R.fromPairs([[1, "a"], [2, "b"]]); // => { '1': 'a', '2': 'b' }
 };


### PR DESCRIPTION
`fromPairs` had a return type of `{ [index: number]: V }` if you passed in an array with number as the first cell. This differed from the run time resulting type where the keys were always converted into string.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link to the ramda play ground demonstrating](https://ramdajs.com/repl/?v=0.27.0#?fromPairs%28%5B%5B1%2C%20%22a%22%5D%2C%20%5B2%2C%20%22b%22%5D%5D%29%20%2F%2F%20%3D%3E%20%7B%20%271%27%3A%20%27a%27%2C%20%272%27%3A%20%27b%27%20%7D)