### PR TITLE
Add undefined to optional properties, Optimist to Q

### DIFF
--- a/types/optimist/index.d.ts
+++ b/types/optimist/index.d.ts
@@ -7,11 +7,11 @@
 
 declare namespace optimist {
     interface Opt {
-        alias?: string | string[];
+        alias?: string | string[] | undefined;
         default?: any;
-        demand?: string | number | string[];
-        describe?: string;
-        type?: string;
+        demand?: string | number | string[] | undefined;
+        describe?: string | undefined;
+        type?: string | undefined;
     }
 
     interface Parser {

--- a/types/optimize-css-assets-webpack-plugin/index.d.ts
+++ b/types/optimize-css-assets-webpack-plugin/index.d.ts
@@ -19,7 +19,7 @@ declare namespace OptimizeCssAssetsPlugin {
          *
          * @default /\.css$/g
          */
-        assetNameRegExp?: RegExp;
+        assetNameRegExp?: RegExp | undefined;
         /**
          * The CSS processor used to optimize \ minimize the CSS. This should be a
          * function that follows `cssnano.process` interface (receives a CSS and
@@ -29,25 +29,25 @@ declare namespace OptimizeCssAssetsPlugin {
          */
         cssProcessor?: {
             process: (css: string, options?: object) => PromiseLike<any>;
-        };
+        } | undefined;
         /**
          * The options passed to the `cssProcessor`.
          *
          * @default {}
          */
-        cssProcessorOptions?: object;
+        cssProcessorOptions?: object | undefined;
         /**
          * The plugin options passed to the `cssProcessor`.
          *
          * @default {}
          */
-        cssProcessorPluginOptions?: object;
+        cssProcessorPluginOptions?: object | undefined;
         /**
          * A boolean indicating if the plugin can print messages to the console.
          *
          * @default true
          */
-        canPrint?: boolean;
+        canPrint?: boolean | undefined;
     }
 }
 

--- a/types/overlayscrollbars/index.d.ts
+++ b/types/overlayscrollbars/index.d.ts
@@ -38,26 +38,26 @@ declare namespace OverlayScrollbars {
 
     type UpdatedCallback = (this: OverlayScrollbars, args?: UpdatedArgs) => void;
 
-    type Coordinates = { x?: Position; y?: Position }
-        | { l?: Position; t?: Position }
-        | { left?: Position; top?: Position }
+    type Coordinates = { x?: Position | undefined; y?: Position | undefined }
+        | { l?: Position | undefined; t?: Position | undefined }
+        | { left?: Position | undefined; top?: Position | undefined }
         | [Position, Position]
         | Position
         | HTMLElement
         | JQuery
         | {
             el: HTMLElement | JQuery;
-            scroll?: ScrollBehavior | { x?: ScrollBehavior; y?: ScrollBehavior } | [ScrollBehavior, ScrollBehavior];
-            block?: BlockBehavior | { x?: BlockBehavior; y?: BlockBehavior } | [BlockBehavior, BlockBehavior];
+            scroll?: ScrollBehavior | { x?: ScrollBehavior | undefined; y?: ScrollBehavior | undefined } | [ScrollBehavior, ScrollBehavior] | undefined;
+            block?: BlockBehavior | { x?: BlockBehavior | undefined; y?: BlockBehavior | undefined } | [BlockBehavior, BlockBehavior] | undefined;
             margin?: Margin
             | {
-                top?: Margin;
-                right?: Margin;
-                bottom?: Margin;
-                left?: Margin;
+                top?: Margin | undefined;
+                right?: Margin | undefined;
+                bottom?: Margin | undefined;
+                left?: Margin | undefined;
             }
             | [Margin, Margin]
-            | [Margin, Margin, Margin, Margin];
+            | [Margin, Margin, Margin, Margin] | undefined;
         };
 
     interface OverflowChangedArgs {
@@ -88,51 +88,51 @@ declare namespace OverlayScrollbars {
     }
 
     interface Options {
-        className?: string | null;
-        resize?: ResizeBehavior;
-        sizeAutoCapable?: boolean;
-        clipAlways?: boolean;
-        normalizeRTL?: boolean;
-        paddingAbsolute?: boolean;
-        autoUpdate?: boolean | null;
-        autoUpdateInterval?: number;
-        updateOnLoad?: string | ReadonlyArray<string> | null;
+        className?: string | null | undefined;
+        resize?: ResizeBehavior | undefined;
+        sizeAutoCapable?: boolean | undefined;
+        clipAlways?: boolean | undefined;
+        normalizeRTL?: boolean | undefined;
+        paddingAbsolute?: boolean | undefined;
+        autoUpdate?: boolean | null | undefined;
+        autoUpdateInterval?: number | undefined;
+        updateOnLoad?: string | ReadonlyArray<string> | null | undefined;
         nativeScrollbarsOverlaid?: {
-            showNativeScrollbars?: boolean;
-            initialize?: boolean;
-        };
+            showNativeScrollbars?: boolean | undefined;
+            initialize?: boolean | undefined;
+        } | undefined;
         overflowBehavior?: {
-            x?: OverflowBehavior;
-            y?: OverflowBehavior;
-        };
+            x?: OverflowBehavior | undefined;
+            y?: OverflowBehavior | undefined;
+        } | undefined;
         scrollbars?: {
-            visibility?: VisibilityBehavior;
-            autoHide?: AutoHideBehavior;
-            autoHideDelay?: number;
-            dragScrolling?: boolean;
-            clickScrolling?: boolean;
-            touchSupport?: boolean;
-            snapHandle?: boolean;
-        };
+            visibility?: VisibilityBehavior | undefined;
+            autoHide?: AutoHideBehavior | undefined;
+            autoHideDelay?: number | undefined;
+            dragScrolling?: boolean | undefined;
+            clickScrolling?: boolean | undefined;
+            touchSupport?: boolean | undefined;
+            snapHandle?: boolean | undefined;
+        } | undefined;
         textarea?: {
-            dynWidth?: boolean;
-            dynHeight?: boolean;
-            inheritedAttrs?: string | ReadonlyArray<string> | null;
-        };
+            dynWidth?: boolean | undefined;
+            dynHeight?: boolean | undefined;
+            inheritedAttrs?: string | ReadonlyArray<string> | null | undefined;
+        } | undefined;
         callbacks?: {
-            onInitialized?: BasicEventCallback | null;
-            onInitializationWithdrawn?: BasicEventCallback | null;
-            onDestroyed?: BasicEventCallback | null;
-            onScrollStart?: ScrollEventCallback | null;
-            onScroll?: ScrollEventCallback | null;
-            onScrollStop?: ScrollEventCallback | null;
-            onOverflowChanged?: OverflowChangedCallback | null;
-            onOverflowAmountChanged?: OverflowAmountChangedCallback | null;
-            onDirectionChanged?: DirectionChangedCallback | null;
-            onContentSizeChanged?: SizeChangedCallback | null;
-            onHostSizeChanged?: SizeChangedCallback | null;
-            onUpdated?: UpdatedCallback | null;
-        };
+            onInitialized?: BasicEventCallback | null | undefined;
+            onInitializationWithdrawn?: BasicEventCallback | null | undefined;
+            onDestroyed?: BasicEventCallback | null | undefined;
+            onScrollStart?: ScrollEventCallback | null | undefined;
+            onScroll?: ScrollEventCallback | null | undefined;
+            onScrollStop?: ScrollEventCallback | null | undefined;
+            onOverflowChanged?: OverflowChangedCallback | null | undefined;
+            onOverflowAmountChanged?: OverflowAmountChangedCallback | null | undefined;
+            onDirectionChanged?: DirectionChangedCallback | null | undefined;
+            onContentSizeChanged?: SizeChangedCallback | null | undefined;
+            onHostSizeChanged?: SizeChangedCallback | null | undefined;
+            onUpdated?: UpdatedCallback | null | undefined;
+        } | undefined;
     }
 
     interface ScrollInfo {
@@ -245,7 +245,7 @@ declare namespace OverlayScrollbars {
     interface ExtensionInfo {
         name: string;
         extensionFactory: (this: OverlayScrollbars, defaultOptions: {}, compatibility: Compatibility, framework: any) => Extension;
-        defaultOptions?: {};
+        defaultOptions?: {} | undefined;
     }
 
     interface Globals {
@@ -311,7 +311,7 @@ interface OverlayScrollbars {
     scroll(
         coordinates: OverlayScrollbars.Coordinates,
         duration?: number,
-        easing?: OverlayScrollbars.Easing | { x?: OverlayScrollbars.Easing; y?: OverlayScrollbars.Easing } | [OverlayScrollbars.Easing, OverlayScrollbars.Easing],
+        easing?: OverlayScrollbars.Easing | { x?: OverlayScrollbars.Easing | undefined; y?: OverlayScrollbars.Easing | undefined } | [OverlayScrollbars.Easing, OverlayScrollbars.Easing],
         complete?: (...args: any[]) => any
     ): void;
     scroll(coordinates: OverlayScrollbars.Coordinates, options: {}): void;

--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -22,34 +22,34 @@ export interface PackageDist {
      * older packages on the npm registry. (Copied by Pacote to
      * `manifest._integrity`.)
      */
-    integrity?: string;
+    integrity?: string | undefined;
     /**
      * Legacy integrity value. Hexadecimal-encoded sha1 hash. (Converted to an
      * SRI string and copied by Pacote to `manifest._integrity` when
      * `dist.integrity` is not present.)
      */
-    shasum?: string;
+    shasum?: string | undefined;
     /**
      * Number of files in the tarball.
      */
-    fileCount?: number;
+    fileCount?: number | undefined;
     /**
      * Size on disk of the package when unpacked.
      */
-    unpackedSize?: number;
+    unpackedSize?: number | undefined;
     /**
      * A signature of the package by the
      * [`npmregistry`](https://keybase.io/npmregistry) Keybase account.
      * (Obviously only present for packages published to
      * https://registry.npmjs.org.)
      */
-    'npm-signature'?: string;
+    'npm-signature'?: string | undefined;
 }
 
 export interface Person {
     name: string;
-    email?: string;
-    url?: string;
+    email?: string | undefined;
+    url?: string | undefined;
 }
 
 /**
@@ -57,24 +57,24 @@ export interface Person {
  * only appear when requesting with `fullMetadata = true`.
  */
 export interface CommonMetadata {
-    author?: Person;
+    author?: Person | undefined;
     bugs?: {
-        url?: string;
-        email?: string;
-    };
-    contributors?: Person[];
-    homepage?: string;
-    keywords?: string[];
-    license?: string;
-    maintainers?: Person[];
-    readme?: string;
-    readmeFilename?: string;
+        url?: string | undefined;
+        email?: string | undefined;
+    } | undefined;
+    contributors?: Person[] | undefined;
+    homepage?: string | undefined;
+    keywords?: string[] | undefined;
+    license?: string | undefined;
+    maintainers?: Person[] | undefined;
+    readme?: string | undefined;
+    readmeFilename?: string | undefined;
     repository?: {
-        type?: string;
-        url?: string;
-        directory?: string;
-    };
-    users?: Record<string, boolean>;
+        type?: string | undefined;
+        url?: string | undefined;
+        directory?: string | undefined;
+    } | undefined;
+    users?: Record<string, boolean> | undefined;
 }
 
 /**
@@ -88,32 +88,32 @@ export interface Manifest extends CommonMetadata {
     dist: PackageDist;
 
     // These properties usually appear in all requests.
-    dependencies?: Record<string, string>;
-    optionalDependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
-    bundledDependencies?: false | string[];
+    dependencies?: Record<string, string> | undefined;
+    optionalDependencies?: Record<string, string> | undefined;
+    devDependencies?: Record<string, string> | undefined;
+    peerDependencies?: Record<string, string> | undefined;
+    bundledDependencies?: false | string[] | undefined;
 
-    bin?: Record<string, string>;
-    directories?: Record<string, string>;
-    engines?: Record<string, string>;
+    bin?: Record<string, string> | undefined;
+    directories?: Record<string, string> | undefined;
+    engines?: Record<string, string> | undefined;
 
     // These properties usually only appear when fullMetadata = true.
-    browser?: string;
-    config?: Record<string, unknown>;
-    cpu?: string[];
-    description?: string;
-    files?: string[];
-    main?: string;
-    man?: string | string[];
-    os?: string[];
-    publishConfig?: Record<string, unknown>;
-    scripts?: Record<string, string>;
+    browser?: string | undefined;
+    config?: Record<string, unknown> | undefined;
+    cpu?: string[] | undefined;
+    description?: string | undefined;
+    files?: string[] | undefined;
+    main?: string | undefined;
+    man?: string | string[] | undefined;
+    os?: string[] | undefined;
+    publishConfig?: Record<string, unknown> | undefined;
+    scripts?: Record<string, string> | undefined;
 
-    _id?: string;
-    _nodeVersion?: string;
-    _npmVersion?: string;
-    _npmUser?: Person;
+    _id?: string | undefined;
+    _nodeVersion?: string | undefined;
+    _npmVersion?: string | undefined;
+    _npmUser?: Person | undefined;
 
     // Non-standard properties from package.json may also appear.
     [key: string]: unknown;
@@ -146,7 +146,7 @@ export interface Packument extends CommonMetadata {
     time?: Record<string, string> & {
         created: string;
         modified: string;
-    };
+    } | undefined;
 
     // Non-standard properties may also appear when fullMetadata = true.
     [key: string]: unknown;
@@ -188,67 +188,67 @@ export interface PacoteOptions {
      * [`cacache`](http://npm.im/cacache). Defaults to the same cache directory
      * that npm will use by default, based on platform and environment.
      */
-    cache?: string;
+    cache?: string | undefined;
     /**
      * Base folder for resolving relative `file:` dependencies.
      */
-    where?: string;
+    where?: string | undefined;
     /**
      * Shortcut for looking up resolved values. Should be specified if known.
      */
-    resolved?: string;
+    resolved?: string | undefined;
     /**
      * Expected integrity of fetched package tarball. If specified, tarballs
      * with mismatched integrity values will raise an `EINTEGRITY` error.
      */
-    integrity?: string | Integrity;
+    integrity?: string | Integrity | undefined;
     /**
      * Permission mode mask for extracted files and directories. Defaults to
      * `0o22`.
      */
-    umask?: number;
+    umask?: number | undefined;
     /**
      * Minimum permission mode for extracted files. Defaults to `0o666`.
      */
-    fmode?: number;
+    fmode?: number | undefined;
     /**
      * Minimum permission mode for extracted directories. Defaults to `0o777`.
      */
-    dmode?: number;
+    dmode?: number | undefined;
     /**
      * A logger object with methods for various log levels. Typically, this will
      * be [`npmlog`](http://npm.im/npmlog) in the npm CLI use case, but if not
      * specified, the default is a logger that emits 'log' events on the process
      * object.
      */
-    log?: Logger;
+    log?: Logger | undefined;
     /**
      * Prefer to revalidate cache entries, even when it would not be strictly
      * necessary. Default `false`.
      */
-    preferOnline?: boolean;
+    preferOnline?: boolean | undefined;
     /**
      * When picking a manifest from a packument, only consider packages
      * published before the specified date. Default `null`.
      */
-    before?: Date | null;
+    before?: Date | null | undefined;
     /**
      * The default `dist-tag` to use when choosing a manifest from a packument.
      * Defaults to `latest`.
      */
-    defaultTag?: string;
+    defaultTag?: string | undefined;
     /**
      * The npm registry to use by default. Defaults to
      * `https://registry.npmjs.org/`.
      */
-    registry?: string;
+    registry?: string | undefined;
     /**
      * Fetch the full metadata from the registry for packuments, including
      * information not strictly required for installation (author, description,
      * etc.) Defaults to `true` when `before` is set, since the version publish
      * time is part of the extended packument metadata.
      */
-    fullMetadata?: boolean;
+    fullMetadata?: boolean | undefined;
 }
 
 export type Options = PacoteOptions & npmFetch.Options;

--- a/types/pacote/v9/index.d.ts
+++ b/types/pacote/v9/index.d.ts
@@ -37,10 +37,10 @@ export interface Manifest {
     _integrity: string;
     _shrinkwrap: Record<string, unknown> | null;
 
-    engines?: Record<string, string>;
-    cpu?: string[];
-    os?: string[];
-    _id?: string;
+    engines?: Record<string, string> | undefined;
+    cpu?: string[] | undefined;
+    os?: string[] | undefined;
+    _id?: string | undefined;
 
     [key: string]: unknown;
 }
@@ -48,49 +48,49 @@ export interface Manifest {
 export interface PackageDist {
     shasum: string;
     tarball: string;
-    integrity?: string;
-    fileCount?: number;
-    unpackedSize?: number;
+    integrity?: string | undefined;
+    fileCount?: number | undefined;
+    unpackedSize?: number | undefined;
 }
 
 export interface Human {
     name: string;
-    email?: string;
-    url?: string;
+    email?: string | undefined;
+    url?: string | undefined;
 }
 
 export interface PackageVersion {
     name: string;
     version: string;
-    dependencies?: Record<string, string>;
-    optionalDependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
+    dependencies?: Record<string, string> | undefined;
+    optionalDependencies?: Record<string, string> | undefined;
+    devDependencies?: Record<string, string> | undefined;
+    peerDependencies?: Record<string, string> | undefined;
     directories: {};
     dist: PackageDist;
     _hasShrinkwrap: boolean;
 
     // Extra metadata which may be added by the registry:
-    description?: string;
-    main?: string;
-    scripts?: Record<string, string>;
+    description?: string | undefined;
+    main?: string | undefined;
+    scripts?: Record<string, string> | undefined;
     repository?: {
         type: string;
         url: string;
-        directory?: string;
-    };
-    engines?: Record<string, string>;
-    keywords?: string[];
-    author?: Human;
-    contributors?: Human[];
-    maintainers?: Human[];
-    license?: string;
-    homepage?: string;
-    bugs?: { url: string };
-    _id?: string;
-    _nodeVersion?: string;
-    _npmVersion?: string;
-    _npmUser?: Human;
+        directory?: string | undefined;
+    } | undefined;
+    engines?: Record<string, string> | undefined;
+    keywords?: string[] | undefined;
+    author?: Human | undefined;
+    contributors?: Human[] | undefined;
+    maintainers?: Human[] | undefined;
+    license?: string | undefined;
+    homepage?: string | undefined;
+    bugs?: { url: string } | undefined;
+    _id?: string | undefined;
+    _nodeVersion?: string | undefined;
+    _npmVersion?: string | undefined;
+    _npmUser?: Human | undefined;
 
     [key: string]: unknown;
 }
@@ -111,40 +111,40 @@ export interface PacoteOptions {
      * directory dependencies. The default `opts.dirPacker` does not execute
      * `prepare` scripts, even though npm itself does.
      */
-    dirPacker?: (dir: string) => Readable;
+    dirPacker?: ((dir: string) => Readable) | undefined;
     /**
      * If passed in, will be used while resolving to filter the versions for
      * **registry dependencies** such that versions published **after**
      * `opts.enjoy-by` are not considered -- as if they'd never been published.
      */
-    'enjoy-by'?: Date | string | number;
+    'enjoy-by'?: Date | string | number | undefined;
     /** Alias for `enjoy-by` */
-    enjoyBy?: Date | string | number;
+    enjoyBy?: Date | string | number | undefined;
     /** Alias for `enjoy-by` */
-    before?: Date | string | number;
+    before?: Date | string | number | undefined;
     /**
      * If false, deprecated versions will be skipped when selecting from
      * registry range specifiers. If true, deprecations do not affect version
      * selection.
      */
-    'include-deprecated'?: boolean;
+    'include-deprecated'?: boolean | undefined;
     /** Alias for 'include-deprecated' */
-    includeDeprecated?: boolean;
+    includeDeprecated?: boolean | undefined;
     /**
      * If `true`, the full packument will be fetched when doing metadata
      * requests. By default, pacote only fetches the summarized packuments, also
      * called "corgis".
      */
-    'full-metadata'?: boolean;
+    'full-metadata'?: boolean | undefined;
     /**
      * Package version resolution tag. When processing registry spec ranges,
      * this option is used to determine what dist-tag to treat as "latest". For
      * more details about how `pacote` selects versions and how `tag` is
      * involved, see [the documentation for `npm-pick-manifest`](https://npm.im/npm-pick-manifest).
      */
-    tag?: string;
+    tag?: string | undefined;
     /** Alias for `tag` */
-    defaultTag?: string;
+    defaultTag?: string | undefined;
     /**
      * When fetching tarballs, this option can be passed in to skip registry
      * metadata lookups when downloading tarballs. If the string is a `file:`
@@ -152,13 +152,13 @@ export interface PacoteOptions {
      * to do any further lookups. This option does not bypass integrity checks
      * when `opts.integrity` is passed in.
      */
-    resolved?: string;
+    resolved?: string | undefined;
     /**
      * Passed as an argument to [`npm-package-arg`](https://npm.im/npm-package-arg)
      * when resolving `spec` arguments. Used to determine what path to resolve
      * local path specs relatively from.
      */
-    where?: string;
+    where?: string | undefined;
 }
 
 export type Options = PacoteOptions & npmFetch.Options;

--- a/types/pako/index.d.ts
+++ b/types/pako/index.d.ts
@@ -38,50 +38,50 @@ declare namespace Pako {
     }
 
     interface DeflateOptions {
-        level?: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-        windowBits?: number;
-        memLevel?: number;
-        strategy?: StrategyValues;
+        level?: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined;
+        windowBits?: number | undefined;
+        memLevel?: number | undefined;
+        strategy?: StrategyValues | undefined;
         dictionary?: any;
-        raw?: boolean;
-        to?: 'string';
-        chunkSize?: number;
-        gzip?: boolean;
-        header?: Header;
+        raw?: boolean | undefined;
+        to?: 'string' | undefined;
+        chunkSize?: number | undefined;
+        gzip?: boolean | undefined;
+        header?: Header | undefined;
     }
 
     interface DeflateFunctionOptions {
-        level?: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-        windowBits?: number;
-        memLevel?: number;
-        strategy?: StrategyValues;
+        level?: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined;
+        windowBits?: number | undefined;
+        memLevel?: number | undefined;
+        strategy?: StrategyValues | undefined;
         dictionary?: any;
-        raw?: boolean;
-        to?: 'string';
+        raw?: boolean | undefined;
+        to?: 'string' | undefined;
     }
 
     interface InflateOptions {
-        windowBits?: number;
+        windowBits?: number | undefined;
         dictionary?: any;
-        raw?: boolean;
-        to?: 'string';
-        chunkSize?: number;
+        raw?: boolean | undefined;
+        to?: 'string' | undefined;
+        chunkSize?: number | undefined;
     }
 
     interface InflateFunctionOptions {
-        windowBits?: number;
-        raw?: boolean;
-        to?: 'string';
+        windowBits?: number | undefined;
+        raw?: boolean | undefined;
+        to?: 'string' | undefined;
     }
 
     interface Header {
-        text?: boolean;
-        time?: number;
-        os?: number;
-        extra?: number[];
-        name?: string;
-        comment?: string;
-        hcrc?: boolean;
+        text?: boolean | undefined;
+        time?: number | undefined;
+        os?: number | undefined;
+        extra?: number[] | undefined;
+        name?: string | undefined;
+        comment?: string | undefined;
+        hcrc?: boolean | undefined;
     }
 
     type Data = Uint8Array | number[] | string;
@@ -137,7 +137,7 @@ declare namespace Pako {
     // https://github.com/nodeca/pako/blob/893381abcafa10fa2081ce60dae7d4d8e873a658/lib/inflate.js
     class Inflate {
         constructor(options?: InflateOptions);
-        header?: Header;
+        header?: Header | undefined;
         err: ReturnCodes;
         msg: string;
         result: Data;

--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -90,27 +90,27 @@ export class Parser {
 }
 
 export interface ParseConfig<T = any> {
-    delimiter?: string; // default: ","
-    newline?: string; // default: "\r\n"
-    quoteChar?: string; // default: '"'
-    escapeChar?: string; // default: '"'
-    header?: boolean; // default: false
-    trimHeaders?: boolean; // default: false
+    delimiter?: string | undefined; // default: ","
+    newline?: string | undefined; // default: "\r\n"
+    quoteChar?: string | undefined; // default: '"'
+    escapeChar?: string | undefined; // default: '"'
+    header?: boolean | undefined; // default: false
+    trimHeaders?: boolean | undefined; // default: false
     dynamicTyping?:
         | boolean
         | { [headerName: string]: boolean; [columnNumber: number]: boolean }
-        | ((field: string | number) => boolean); // default: false
-    preview?: number; // default: 0
-    encoding?: string; // default: ""
-    worker?: boolean; // default: false
-    comments?: boolean | string; // default: false
-    download?: boolean; // default: false
-    downloadRequestHeaders?: { [headerName: string]: string }; // default: undefined
-    skipEmptyLines?: boolean | 'greedy'; // default: false
-    fastMode?: boolean; // default: undefined
-    withCredentials?: boolean; // default: undefined
-    delimitersToGuess?: GuessableDelimiters[]; // default: [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP]
-    chunkSize?: number; // default: undefined
+        | ((field: string | number) => boolean) | undefined; // default: false
+    preview?: number | undefined; // default: 0
+    encoding?: string | undefined; // default: ""
+    worker?: boolean | undefined; // default: false
+    comments?: boolean | string | undefined; // default: false
+    download?: boolean | undefined; // default: false
+    downloadRequestHeaders?: { [headerName: string]: string } | undefined; // default: undefined
+    skipEmptyLines?: boolean | 'greedy' | undefined; // default: false
+    fastMode?: boolean | undefined; // default: undefined
+    withCredentials?: boolean | undefined; // default: undefined
+    delimitersToGuess?: GuessableDelimiters[] | undefined; // default: [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP]
+    chunkSize?: number | undefined; // default: undefined
 
     // Callbacks
     step?(results: ParseResult<T>, parser: Parser): void; // default: undefined
@@ -123,21 +123,21 @@ export interface ParseConfig<T = any> {
 }
 
 export interface UnparseConfig {
-    quotes?: boolean | boolean[] | ((value: any) => boolean); // default: false
-    quoteChar?: string; // default: '"'
-    escapeChar?: string; // default: '"'
-    escapeFormulae?: boolean; // default: false
-    delimiter?: string; // default: ","
+    quotes?: boolean | boolean[] | ((value: any) => boolean) | undefined; // default: false
+    quoteChar?: string | undefined; // default: '"'
+    escapeChar?: string | undefined; // default: '"'
+    escapeFormulae?: boolean | undefined; // default: false
+    delimiter?: string | undefined; // default: ","
     /**
      * If defined and the download property is true,
      * a POST request will be made instead of a GET request and the passed argument will be set as the body of the request.
      * @default undefined
      */
-    downloadRequestBody?: boolean;
-    header?: boolean; // default: true
-    newline?: string; // default: "\r\n"
-    skipEmptyLines?: boolean | 'greedy'; // default: false
-    columns?: string[]; // default: null
+    downloadRequestBody?: boolean | undefined;
+    header?: boolean | undefined; // default: true
+    newline?: string | undefined; // default: "\r\n"
+    skipEmptyLines?: boolean | 'greedy' | undefined; // default: false
+    columns?: string[] | undefined; // default: null
 }
 
 export interface UnparseObject {
@@ -156,7 +156,7 @@ export interface ParseMeta {
     delimiter: string; // Delimiter used
     linebreak: string; // Line break sequence used
     aborted: boolean; // Whether process was aborted
-    fields?: string[]; // Array of field names
+    fields?: string[] | undefined; // Array of field names
     truncated: boolean; // Whether preview consumed all input
     cursor: number;
 }

--- a/types/parallel-transform/index.d.ts
+++ b/types/parallel-transform/index.d.ts
@@ -11,7 +11,7 @@ type OnTransform = (chunk: any, callback: TransformCallback) => void;
 
 declare namespace ParallelTransform {
     interface Options extends TransformOptions {
-        ordered?: boolean;
+        ordered?: boolean | undefined;
     }
 }
 

--- a/types/parse5-htmlparser2-tree-adapter/index.d.ts
+++ b/types/parse5-htmlparser2-tree-adapter/index.d.ts
@@ -154,7 +154,7 @@ declare namespace treeAdapter {
         /**
          * Element source code location info. Available if location info is enabled via ParserOptions.
          */
-        sourceCodeLocation?: parse5.ElementLocation;
+        sourceCodeLocation?: parse5.ElementLocation | undefined;
     }
 
     /**
@@ -176,7 +176,7 @@ declare namespace treeAdapter {
         /**
          * Comment source code location info. Available if location info is enabled via ParserOptions.
          */
-        sourceCodeLocation?: parse5.Location;
+        sourceCodeLocation?: parse5.Location | undefined;
     }
 
     /**
@@ -198,7 +198,7 @@ declare namespace treeAdapter {
         /**
          * Comment source code location info. Available if location info is enabled via ParserOptions.
          */
-        sourceCodeLocation?: parse5.Location;
+        sourceCodeLocation?: parse5.Location | undefined;
     }
 
     /**

--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -67,7 +67,7 @@ export interface ParserOptions<T extends TreeAdapter = TreeAdapter> {
      *
      *  **Default:** `true`
      */
-    scriptingEnabled?: boolean;
+    scriptingEnabled?: boolean | undefined;
 
     /**
      * Enables source code location information. When enabled, each node (except the root node)
@@ -79,14 +79,14 @@ export interface ParserOptions<T extends TreeAdapter = TreeAdapter> {
      *
      * **Default:** `false`
      */
-    sourceCodeLocationInfo?: boolean;
+    sourceCodeLocationInfo?: boolean | undefined;
 
     /**
      * Specifies the resulting tree format.
      *
      * **Default:** `treeAdapters.default`
      */
-    treeAdapter?: T;
+    treeAdapter?: T | undefined;
 }
 
 export interface SerializerOptions<T extends TreeAdapter = TreeAdapter> {
@@ -95,7 +95,7 @@ export interface SerializerOptions<T extends TreeAdapter = TreeAdapter> {
      *
      * **Default:** `treeAdapters.default`
      */
-    treeAdapter?: T;
+    treeAdapter?: T | undefined;
 }
 
 /**
@@ -122,12 +122,12 @@ export interface Attribute {
     /**
      * The namespace of the attribute.
      */
-    namespace?: string;
+    namespace?: string | undefined;
 
     /**
      * The namespace-related prefix of the attribute.
      */
-    prefix?: string;
+    prefix?: string | undefined;
 }
 
 /**
@@ -217,7 +217,7 @@ export interface Element {
     /**
      * Element source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
-    sourceCodeLocation?: ElementLocation;
+    sourceCodeLocation?: ElementLocation | undefined;
 
     /**
      * Child nodes.
@@ -247,7 +247,7 @@ export interface CommentNode {
     /**
      * Comment source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
-    sourceCodeLocation?: Location;
+    sourceCodeLocation?: Location | undefined;
 
     /**
      * Parent node.
@@ -272,7 +272,7 @@ export interface TextNode {
     /**
      * Text node source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
-    sourceCodeLocation?: Location;
+    sourceCodeLocation?: Location | undefined;
 
     /**
      * Parent node.

--- a/types/parse5/v4/index.d.ts
+++ b/types/parse5/v4/index.d.ts
@@ -64,13 +64,13 @@ declare namespace Options {
          *
          * **Default:** `false`
          */
-        locationInfo?: boolean;
+        locationInfo?: boolean | undefined;
         /**
          * Specifies the resulting tree format.
          *
          * **Default:** `treeAdapters.default`
          */
-        treeAdapter?: AST.TreeAdapter;
+        treeAdapter?: AST.TreeAdapter | undefined;
     }
 
     export interface SAXParserOptions {
@@ -79,7 +79,7 @@ declare namespace Options {
          * When enabled, each token event handler will receive {@link MarkupData.Location} (or {@link MarkupData.StartTagLocation})
          * object as its last argument.
          */
-        locationInfo?: boolean;
+        locationInfo?: boolean | undefined;
     }
 
     export interface SerializerOptions {
@@ -88,7 +88,7 @@ declare namespace Options {
          *
          * **Default:** `treeAdapters.default`
          */
-        treeAdapter?: AST.TreeAdapter;
+        treeAdapter?: AST.TreeAdapter | undefined;
     }
 }
 
@@ -118,11 +118,11 @@ declare namespace AST {
             /**
              * The namespace of the attribute.
              */
-            namespace?: string;
+            namespace?: string | undefined;
             /**
              * The namespace-related prefix of the attribute.
              */
-            prefix?: string;
+            prefix?: string | undefined;
         }
 
         /**
@@ -218,7 +218,7 @@ declare namespace AST {
             /**
              * Element source code location info. Available if location info is enabled via {@link Options.ParserOptions}.
              */
-            __location?: MarkupData.ElementLocation;
+            __location?: MarkupData.ElementLocation | undefined;
         }
 
         /**
@@ -240,7 +240,7 @@ declare namespace AST {
             /**
              * Comment source code location info. Available if location info is enabled via {@link Options.ParserOptions}.
              */
-            __location?: MarkupData.Location;
+            __location?: MarkupData.Location | undefined;
         }
 
         /**
@@ -262,7 +262,7 @@ declare namespace AST {
             /**
              * Text node source code location info. Available if location info is enabled via {@link Options.ParserOptions}.
              */
-            __location?: MarkupData.Location;
+            __location?: MarkupData.Location | undefined;
         }
     }
 
@@ -422,7 +422,7 @@ declare namespace AST {
             /**
              * Element source code location info. Available if location info is enabled via {@link Options.ParserOptions}.
              */
-            __location?: MarkupData.ElementLocation;
+            __location?: MarkupData.ElementLocation | undefined;
         }
 
         /**
@@ -444,7 +444,7 @@ declare namespace AST {
             /**
              * Comment source code location info. Available if location info is enabled via {@link Options.ParserOptions}.
              */
-            __location?: MarkupData.Location;
+            __location?: MarkupData.Location | undefined;
         }
 
         /**
@@ -466,7 +466,7 @@ declare namespace AST {
             /**
              * Comment source code location info. Available if location info is enabled via {@link Options.ParserOptions}.
              */
-            __location?: MarkupData.Location;
+            __location?: MarkupData.Location | undefined;
         }
     }
 

--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -17,17 +17,17 @@ export type OAuth2StrategyOptionsWithoutRequiredURLs = Pick<
 >;
 
 export interface _StrategyOptionsBase extends OAuth2StrategyOptionsWithoutRequiredURLs {
-    authorizationURL?: string;
-    callbackURL?: string;
+    authorizationURL?: string | undefined;
+    callbackURL?: string | undefined;
     clientID: string;
     clientSecret: string;
-    scope?: string | string[];
-    tokenURL?: string;
-    userProfileURL?: string;
+    scope?: string | string[] | undefined;
+    tokenURL?: string | undefined;
+    userProfileURL?: string | undefined;
 }
 
 export interface StrategyOptions extends _StrategyOptionsBase {
-    passReqToCallback?: false;
+    passReqToCallback?: false | undefined;
 }
 
 export interface StrategyOptionsWithRequest extends _StrategyOptionsBase {
@@ -96,21 +96,21 @@ export class Strategy extends oauth2.Strategy {
 
 // additional Google-specific options
 export interface AuthenticateOptionsGoogle extends passport.AuthenticateOptions {
-    accessType?: 'offline' | 'online';
-    prompt?: string;
-    loginHint?: string;
-    includeGrantedScopes?: boolean;
-    display?: string;
-    hostedDomain?: string;
-    hd?: string;
+    accessType?: 'offline' | 'online' | undefined;
+    prompt?: string | undefined;
+    loginHint?: string | undefined;
+    includeGrantedScopes?: boolean | undefined;
+    display?: string | undefined;
+    hostedDomain?: string | undefined;
+    hd?: string | undefined;
     requestVisibleActions?: any;
     openIDRealm?: any;
 }
 
 export interface GoogleCallbackParameters {
     access_token: string;
-    refresh_token?: string;
-    id_token?: string;
+    refresh_token?: string | undefined;
+    id_token?: string | undefined;
     expires_in: number;
     scope: string;
     token_type: string;

--- a/types/passport-http-bearer/index.d.ts
+++ b/types/passport-http-bearer/index.d.ts
@@ -13,12 +13,12 @@ import express = require("express");
 import koa = require("koa");
 
 interface IStrategyOptions {
-    scope?: string | Array<string>;
-    realm?: string;
-    passReqToCallback?: boolean;
+    scope?: string | Array<string> | undefined;
+    realm?: string | undefined;
+    passReqToCallback?: boolean | undefined;
 }
 interface IVerifyOptions {
-    message?: string;
+    message?: string | undefined;
     scope: string | Array<string>;
 }
 

--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -20,15 +20,15 @@ export declare class Strategy extends PassportStrategy {
 }
 
 export interface StrategyOptions {
-    secretOrKey?: string | Buffer;
-    secretOrKeyProvider?: SecretOrKeyProvider;
+    secretOrKey?: string | Buffer | undefined;
+    secretOrKeyProvider?: SecretOrKeyProvider | undefined;
     jwtFromRequest: JwtFromRequestFunction;
-    issuer?: string;
-    audience?: string;
-    algorithms?: string[];
-    ignoreExpiration?: boolean;
-    passReqToCallback?: boolean;
-    jsonWebTokenOptions?: VerifyOptions;
+    issuer?: string | undefined;
+    audience?: string | undefined;
+    algorithms?: string[] | undefined;
+    ignoreExpiration?: boolean | undefined;
+    passReqToCallback?: boolean | undefined;
+    jsonWebTokenOptions?: VerifyOptions | undefined;
 }
 
 export interface VerifyCallback {

--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -10,16 +10,16 @@ import { Strategy as PassportStrategy } from "passport-strategy";
 import express = require("express");
 
 interface IStrategyOptions {
-    usernameField?: string;
-    passwordField?: string;
-    session?: boolean;
-    passReqToCallback?: false;
+    usernameField?: string | undefined;
+    passwordField?: string | undefined;
+    session?: boolean | undefined;
+    passReqToCallback?: false | undefined;
 }
 
 interface IStrategyOptionsWithRequest {
-    usernameField?: string;
-    passwordField?: string;
-    session?: boolean;
+    usernameField?: string | undefined;
+    passwordField?: string | undefined;
+    session?: boolean | undefined;
     passReqToCallback: true;
 }
 

--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -66,19 +66,19 @@ declare namespace OAuth2Strategy {
         tokenURL: string;
         clientID: string;
         clientSecret: string;
-        callbackURL?: string;
-        customHeaders?: OutgoingHttpHeaders;
-        scope?: string | string[];
-        scopeSeparator?: string;
-        sessionKey?: string;
-        store?: StateStore;
+        callbackURL?: string | undefined;
+        customHeaders?: OutgoingHttpHeaders | undefined;
+        scope?: string | string[] | undefined;
+        scopeSeparator?: string | undefined;
+        sessionKey?: string | undefined;
+        store?: StateStore | undefined;
         state?: any;
         skipUserProfile?: any;
-        pkce?: boolean;
+        pkce?: boolean | undefined;
         proxy?: any;
     }
     interface StrategyOptions extends _StrategyOptionsBase {
-        passReqToCallback?: false;
+        passReqToCallback?: false | undefined;
     }
     interface StrategyOptionsWithRequest extends _StrategyOptionsBase {
         passReqToCallback: true;
@@ -90,14 +90,14 @@ declare namespace OAuth2Strategy {
     class TokenError extends Error {
         constructor(message: string | undefined, code: string, uri?: string, status?: number);
         code: string;
-        uri?: string;
+        uri?: string | undefined;
         status: number;
     }
 
     class AuthorizationError extends Error {
         constructor(message: string | undefined, code: string, uri?: string, status?: number);
         code: string;
-        uri?: string;
+        uri?: string | undefined;
         status: number;
     }
 

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -20,8 +20,8 @@ declare global {
         interface User {}
 
         interface Request {
-            authInfo?: AuthInfo;
-            user?: User;
+            authInfo?: AuthInfo | undefined;
+            user?: User | undefined;
 
             // These declarations are merged into express's Request type
             login(user: User, done: (err: any) => void): void;
@@ -50,23 +50,23 @@ import express = require('express');
 
 declare namespace passport {
     interface AuthenticateOptions {
-        authInfo?: boolean;
-        assignProperty?: string;
-        failureFlash?: string | boolean;
-        failureMessage?: boolean | string;
-        failureRedirect?: string;
-        failWithError?: boolean;
-        session?: boolean;
-        scope?: string | string[];
-        successFlash?: string | boolean;
-        successMessage?: boolean | string;
-        successRedirect?: string;
-        successReturnToOrRedirect?: string;
-        state?: string;
-        pauseStream?: boolean;
-        userProperty?: string;
-        passReqToCallback?: boolean;
-        prompt?: string;
+        authInfo?: boolean | undefined;
+        assignProperty?: string | undefined;
+        failureFlash?: string | boolean | undefined;
+        failureMessage?: boolean | string | undefined;
+        failureRedirect?: string | undefined;
+        failWithError?: boolean | undefined;
+        session?: boolean | undefined;
+        scope?: string | string[] | undefined;
+        successFlash?: string | boolean | undefined;
+        successMessage?: boolean | string | undefined;
+        successRedirect?: string | undefined;
+        successReturnToOrRedirect?: string | undefined;
+        state?: string | undefined;
+        pauseStream?: boolean | undefined;
+        userProperty?: string | undefined;
+        passReqToCallback?: boolean | undefined;
+        prompt?: string | undefined;
     }
 
     interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet, AuthorizeOptions = AuthenticateOptions> {
@@ -95,7 +95,7 @@ declare namespace passport {
     }
 
     interface Strategy {
-        name?: string;
+        name?: string | undefined;
         authenticate(this: StrategyCreated<this>, req: express.Request, options?: any): any;
     }
 
@@ -151,19 +151,19 @@ declare namespace passport {
         provider: string;
         id: string;
         displayName: string;
-        username?: string;
+        username?: string | undefined;
         name?: {
             familyName: string;
             givenName: string;
-            middleName?: string;
-        };
+            middleName?: string | undefined;
+        } | undefined;
         emails?: Array<{
             value: string;
-            type?: string;
-        }>;
+            type?: string | undefined;
+        }> | undefined;
         photos?: Array<{
             value: string;
-        }>;
+        }> | undefined;
     }
 
     interface Framework<InitializeRet = any, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -6,7 +6,7 @@ declare global {
     namespace Express {
         interface User {
             username: string;
-            id?: number;
+            id?: number | undefined;
         }
     }
 }

--- a/types/paypal-checkout-components/modules/button.d.ts
+++ b/types/paypal-checkout-components/modules/button.d.ts
@@ -12,39 +12,39 @@ export enum FundingOption {
 export interface ButtonRenderer {
     render(
         options: {
-            env?: Environment;
-            style?: ButtonStyle;
-            locale?: string;
+            env?: Environment | undefined;
+            style?: ButtonStyle | undefined;
+            locale?: string | undefined;
 
-            payment?: () => Promise<string>;
+            payment?: (() => Promise<string>) | undefined;
             onAuthorize: (data: AuthorizationData, actions: object) => Promise<AuthorizationResponse>;
-            onCancel?: (data: CancellationData, actions: object) => void;
-            onError?: (error: string) => void;
-            onShippingChange?: () => void;
-            onAuth?: (data: string | object) => object;
-            accessToken?: () => void;
-            onClose?: () => void;
+            onCancel?: ((data: CancellationData, actions: object) => void) | undefined;
+            onError?: ((error: string) => void) | undefined;
+            onShippingChange?: (() => void) | undefined;
+            onAuth?: ((data: string | object) => object) | undefined;
+            accessToken?: (() => void) | undefined;
+            onClose?: (() => void) | undefined;
 
             funding?: {
-                allowed?: FundingOption[];
-                disallowed?: FundingOption[];
-            };
+                allowed?: FundingOption[] | undefined;
+                disallowed?: FundingOption[] | undefined;
+            } | undefined;
 
-            sessionID?: string;
-            buttonSessionID?: string;
-            meta?: object;
-            stage?: string;
-            stageUrl?: string;
-            authCode?: string;
-            localhostUrl?: string;
-            checkoutUri?: string;
-            client?: object;
-            commit?: boolean;
-            experience?: object;
-            fundingSource?: string;
-            fundingOffered?: object;
-            logLevel?: string;
-            test?: object;
+            sessionID?: string | undefined;
+            buttonSessionID?: string | undefined;
+            meta?: object | undefined;
+            stage?: string | undefined;
+            stageUrl?: string | undefined;
+            authCode?: string | undefined;
+            localhostUrl?: string | undefined;
+            checkoutUri?: string | undefined;
+            client?: object | undefined;
+            commit?: boolean | undefined;
+            experience?: object | undefined;
+            fundingSource?: string | undefined;
+            fundingOffered?: object | undefined;
+            logLevel?: string | undefined;
+            test?: object | undefined;
         },
         selector: string,
     ): void;

--- a/types/paypal-checkout-components/modules/callback-data.d.ts
+++ b/types/paypal-checkout-components/modules/callback-data.d.ts
@@ -113,7 +113,7 @@ export interface Address {
     /**
      * Extended address.
      */
-    line2?: string;
+    line2?: string | undefined;
 
     /**
      * City or locality.
@@ -138,12 +138,12 @@ export interface Address {
     /**
      * Phone number.
      */
-    phone?: string;
+    phone?: string | undefined;
 
     /**
      * Recipient of postage.
      */
-    recipientName?: string;
+    recipientName?: string | undefined;
 }
 
 export interface CreditFinancingOptions {
@@ -183,23 +183,23 @@ export interface AuthorizationResponseDetails {
     payerId: string;
     firstName: string;
     lastName: string;
-    countryCode?: string;
-    phone?: string;
+    countryCode?: string | undefined;
+    phone?: string | undefined;
 
     /**
      * User's shipping address details, only available if shipping address is enabled.
      */
-    shippingAddress?: Address;
+    shippingAddress?: Address | undefined;
 
     /**
      * User's billing address details.
      */
-    billingAddress?: Address;
+    billingAddress?: Address | undefined;
 
     /**
      * This property will only be present when the customer pays with PayPal Credit.
      */
-    creditFinancingOffered?: CreditFinancingOptions;
+    creditFinancingOffered?: CreditFinancingOptions | undefined;
 }
 
 export interface AuthorizationResponse {
@@ -253,9 +253,9 @@ export enum Intent {
 
 export interface AuthorizationData {
     payerId: string;
-    paymentId?: string;
-    billingToken?: string;
-    vault?: boolean;
+    paymentId?: string | undefined;
+    billingToken?: string | undefined;
+    vault?: boolean | undefined;
 }
 
 export interface CancellationData {

--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -65,9 +65,9 @@ declare class PDFDataRangeTransport {
 }
 
 interface PDFWorkerParameters {
-    name?: string;
+    name?: string | undefined;
     port?: any;
-    verbosity?: VerbosityLevel;
+    verbosity?: VerbosityLevel | undefined;
 }
 
 declare class PDFWorker {
@@ -97,62 +97,62 @@ interface CMapReader {
 }
 interface PDFSource {
     /** The URL of the PDF. */
-    url?: string;
+    url?: string | undefined;
     /**
      * Binary PDF data. Use typed arrays
      * (Uint8Array) to improve the memory usage. If PDF data is BASE64-encoded,
      * use atob() to convert it to a binary string first.
      */
-    data?: Uint8Array | BufferSource | string;
+    data?: Uint8Array | BufferSource | string | undefined;
     /**
      * Basic authentication headers.
      */
     httpHeaders?: {
         [key: string]: string;
-    };
+    } | undefined;
     /**
      * For decrypting password-protected PDFs.
      */
-    password?: string;
+    password?: string | undefined;
     /**
      * Indicates whether or not cross-site
      * Access-Control requests should be made using credentials such as cookies
      * or authorization headers. The default is false.
      */
-    withCredentials?: boolean;
+    withCredentials?: boolean | undefined;
     /*
      * A typed array with the first portion or
      * all of the pdf data. Used by the extension since some data is already
      * loaded before the switch to range requests.  */
-    initialData?: Uint8Array | BufferSource;
+    initialData?: Uint8Array | BufferSource | undefined;
     /*
      * The PDF file length. It's used for progress
      * reports and range requests operations.
      */
-    length?: number;
+    length?: number | undefined;
     /** range */
-    range?: PDFDataRangeTransport;
+    range?: PDFDataRangeTransport | undefined;
     /**
      * Optional parameter to specify
      * maximum number of bytes fetched per range request. The default value is
      * 2^16 = 65536. */
-    rangeChunkSize?: number;
+    rangeChunkSize?: number | undefined;
     /**
      * The worker that will be used for
      * the loading and parsing of the PDF data.
      */
-    worker?: PDFWorker;
+    worker?: PDFWorker | undefined;
     /**
      * Controls the logging level; the
      * constants from {VerbosityLevel} should be used.
      */
-    verbosity?: number;
+    verbosity?: number | undefined;
     /**
      * The base URL of the document,
      * used when attempting to recover valid absolute URLs for annotations, and
      * outline items, that (incorrectly) only specify relative URLs.
      */
-    docBaseUrl?: string;
+    docBaseUrl?: string | undefined;
     /**
      * Strategy for
      * decoding certain (simple) JPEG images in the browser. This is useful for
@@ -163,15 +163,15 @@ interface PDFSource {
      * and 'none' where JPEG images will be decoded entirely by PDF.js.
      * The default value is 'decode'.
      */
-    nativeImageDecoderSupport?: 'decode' | 'display' | 'none';
+    nativeImageDecoderSupport?: 'decode' | 'display' | 'none' | undefined;
     /**
      * The URL where the predefined
      * Adobe CMaps are located. Include trailing slash. */
-    cMapUrl?: string;
+    cMapUrl?: string | undefined;
     /**
      * Specifies if the Adobe CMaps are
      * binary packed. */
-    cMapPacked?: boolean;
+    cMapPacked?: boolean | undefined;
     /**
      * The factory that will be
      * used when reading built-in CMap files. Providing a custom factory is useful
@@ -185,39 +185,39 @@ interface PDFSource {
      * PDF data cannot be successfully parsed, instead of attempting to recover
      * whatever possible of the data. The default value is `false`.
      */
-    stopAtErrors?: boolean;
+    stopAtErrors?: boolean | undefined;
     /**
      * The maximum allowed image size
      * in total pixels, i.e. width * height. Images above this value will not be
      * rendered. Use -1 for no limit, which is also the default value.
      */
-    maxImageSize?: number;
+    maxImageSize?: number | undefined;
     /**
      * Determines if we can eval
      * strings as JS. Primarily used to improve performance of font rendering,
      * and when parsing PDF functions. The default value is `true`.
      */
-    isEvalSupported?: boolean;
+    isEvalSupported?: boolean | undefined;
     /**
      * By default fonts are
      *   converted to OpenType fonts and loaded via font face rules. If disabled,
      *   fonts will be rendered using a built-in font renderer that constructs the
      *   glyphs with primitive path commands. The default value is `false`.
      */
-    disableFontFace?: boolean;
+    disableFontFace?: boolean | undefined;
     /**
      * Disable range request loading
      *   of PDF files. When enabled, and if the server supports partial content
      *   requests, then the PDF will be fetched in chunks.
      *   The default value is `false`.
      */
-    disableRange?: boolean;
+    disableRange?: boolean | undefined;
     /**
      * Disable streaming of PDF file
      *   data. By default PDF.js attempts to load PDFs in chunks.
      *   The default value is `false`.
      */
-    disableStream?: boolean;
+    disableStream?: boolean | undefined;
     /**
      * Disable pre-fetching of PDF
      *   file data. When range requests are enabled PDF.js will automatically keep
@@ -226,18 +226,18 @@ interface PDFSource {
      *   NOTE: It is also necessary to disable streaming, see above,
      *         in order for disabling of pre-fetching to work correctly.
      */
-    disableAutoFetch?: boolean;
+    disableAutoFetch?: boolean | undefined;
     /**
      * Disable the use of
      *   `URL.createObjectURL`, for compatibility with older browsers.
      *   The default value is `false`.
      */
-    disableCreateObjectURL?: boolean;
+    disableCreateObjectURL?: boolean | undefined;
     /**
      * Enables special hooks for debugging
      * PDF.js (see `web/debugger.js`). The default value is `false`.
      */
-    pdfBug?: boolean;
+    pdfBug?: boolean | undefined;
 }
 
 interface PDFProgressData {
@@ -343,10 +343,10 @@ interface PDFPageViewport {
 
 interface ViewportParameters {
     scale: number; // The desired scale of the viewport.
-    rotation?: number; // (optional) The desired rotation, in degrees, of the viewport. If omitted it defaults to the page rotation.
-    offsetX?: number; // (optional) The horizontal, i.e. x-axis, offset. The default value is `0`.
-    offsetY?: number; // (optional) The vertical, i.e. y-axis, offset. The default value is `0`.
-    dontFlip?: boolean; // (optional) If true, the y-axis will not be flipped. The default value is `false`.
+    rotation?: number | undefined; // (optional) The desired rotation, in degrees, of the viewport. If omitted it defaults to the page rotation.
+    offsetX?: number | undefined; // (optional) The horizontal, i.e. x-axis, offset. The default value is `0`.
+    offsetY?: number | undefined; // (optional) The vertical, i.e. y-axis, offset. The default value is `0`.
+    dontFlip?: boolean | undefined; // (optional) If true, the y-axis will not be flipped. The default value is `false`.
 }
 interface PDFAnnotationData {
     subtype: string;
@@ -382,22 +382,22 @@ interface PDFRenderImageLayer {
 
 interface PDFRenderParams {
     canvasContext: CanvasRenderingContext2D;
-    viewport?: PDFPageViewport;
-    textLayer?: PDFRenderTextLayer;
-    imageLayer?: PDFRenderImageLayer;
-    renderInteractiveForms?: boolean;
-    continueCallback?: (_continue: () => void) => void;
+    viewport?: PDFPageViewport | undefined;
+    textLayer?: PDFRenderTextLayer | undefined;
+    imageLayer?: PDFRenderImageLayer | undefined;
+    renderInteractiveForms?: boolean | undefined;
+    continueCallback?: ((_continue: () => void) => void) | undefined;
 }
 
 interface PDFViewerParams {
     container: HTMLElement;
-    viewer?: HTMLElement;
+    viewer?: HTMLElement | undefined;
 }
 
 interface GetTextContentParams {
-    normalizeWhitespace?: boolean;
-    disableCombineTextItems?: boolean;
-    includeMarkedContent?: boolean;
+    normalizeWhitespace?: boolean | undefined;
+    disableCombineTextItems?: boolean | undefined;
+    includeMarkedContent?: boolean | undefined;
 }
 
 /**

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -33,20 +33,20 @@ declare namespace PDFKit {
 
 declare namespace PDFKit.Mixins {
     interface AnnotationOption {
-        Type?: string;
+        Type?: string | undefined;
         Rect?: any;
-        Border?: Array<number>;
-        SubType?: string;
-        Contents?: string;
-        Name?: string;
-        color?: string;
-        QuadPoints?: Array<number>;
+        Border?: Array<number> | undefined;
+        SubType?: string | undefined;
+        Contents?: string | undefined;
+        Name?: string | undefined;
+        color?: string | undefined;
+        QuadPoints?: Array<number> | undefined;
 
         A?: any;
         B?: any;
         C?: any;
         L?: any;
-        DA?: string;
+        DA?: string | undefined;
     }
 
     interface PDFAnnotation {
@@ -116,18 +116,18 @@ declare namespace PDFKit.Mixins {
     }
 
     interface ImageOption {
-        width?: number;
-        height?: number;
+        width?: number | undefined;
+        height?: number | undefined;
         /** Scale percentage */
-        scale?: number;
+        scale?: number | undefined;
         /** Two elements array specifying dimensions(w,h)  */
-        fit?: [number, number];
-        cover?: [number, number];
-        align?: 'center' | 'right';
-        valign?: 'center' | 'bottom';
-        link?: AnnotationOption;
-        goTo?: AnnotationOption;
-        destination?: string;
+        fit?: [number, number] | undefined;
+        cover?: [number, number] | undefined;
+        align?: 'center' | 'right' | undefined;
+        valign?: 'center' | 'bottom' | undefined;
+        link?: AnnotationOption | undefined;
+        goTo?: AnnotationOption | undefined;
+        destination?: string | undefined;
     }
 
     interface PDFImage {
@@ -140,56 +140,56 @@ declare namespace PDFKit.Mixins {
 
     interface TextOptions {
         /** Set to false to disable line wrapping all together */
-        lineBreak?: boolean;
+        lineBreak?: boolean | undefined;
         /** The width that text should be wrapped to (by default, the page width minus the left and right margin) */
-        width?: number;
+        width?: number | undefined;
         /** The maximum height that text should be clipped to */
-        height?: number;
+        height?: number | undefined;
         /** The character to display at the end of the text when it is too long. Set to true to use the default character. */
-        ellipsis?: boolean | string;
+        ellipsis?: boolean | string | undefined;
         /** The number of columns to flow the text into */
-        columns?: number;
+        columns?: number | undefined;
         /** The amount of space between each column (1/4 inch by default) */
-        columnGap?: number;
+        columnGap?: number | undefined;
         /** The amount in PDF points (72 per inch) to indent each paragraph of text */
-        indent?: number;
+        indent?: number | undefined;
         /** The amount of space between each paragraph of text */
-        paragraphGap?: number;
+        paragraphGap?: number | undefined;
         /** The amount of space between each line of text */
-        lineGap?: number;
+        lineGap?: number | undefined;
         /** The amount of space between each word in the text */
-        wordSpacing?: number;
+        wordSpacing?: number | undefined;
         /** The amount of space between each character in the text */
-        characterSpacing?: number;
+        characterSpacing?: number | undefined;
         /** Whether to fill the text (true by default) */
-        fill?: boolean;
+        fill?: boolean | undefined;
         /** Whether to stroke the text */
-        stroke?: boolean;
+        stroke?: boolean | undefined;
         /** A URL to link this text to (shortcut to create an annotation) */
-        link?: string;
+        link?: string | undefined;
         /** Whether to underline the text */
-        underline?: boolean;
+        underline?: boolean | undefined;
         /** Whether to strike out the text */
-        strike?: boolean;
+        strike?: boolean | undefined;
         /** Whether the text segment will be followed immediately by another segment. Useful for changing styling in the middle of a paragraph. */
-        continued?: boolean;
+        continued?: boolean | undefined;
         /** Whether to slant the text (angle in degrees or true) */
-        oblique?: boolean | number;
+        oblique?: boolean | number | undefined;
         /** The alignment of the text (center, justify, left, right) */
         //TODO check this
-        align?: 'center' | 'justify' | 'left' | 'right' | string;
+        align?: 'center' | 'justify' | 'left' | 'right' | string | undefined;
         /** The vertical alignment of the text with respect to its insertion point */
-        baseline?: number | 'svg-middle' | 'middle' | 'svg-central' | 'bottom' | 'ideographic' | 'alphabetic' | 'mathematical' | 'hanging' | 'top';
+        baseline?: number | 'svg-middle' | 'middle' | 'svg-central' | 'bottom' | 'ideographic' | 'alphabetic' | 'mathematical' | 'hanging' | 'top' | undefined;
         /** An array of OpenType feature tags to apply. If not provided, a set of defaults is used. */
-        features?: OpenTypeFeatures[];
+        features?: OpenTypeFeatures[] | undefined;
         /** Sets a list as unordered, ordered or lettered */
-        listType?: 'bullet' | 'numbered' | 'lettered';
+        listType?: 'bullet' | 'numbered' | 'lettered' | undefined;
         /** The radius of bullet points in a list. Works only with listType: 'bullet' */
-        bulletRadius?: number;
+        bulletRadius?: number | undefined;
         /** The indent of bullet points in a list */
-        bulletIndent?: number;
+        bulletIndent?: number | undefined;
         /** The indent of text in a list */
-        textIndent?: number;
+        textIndent?: number | undefined;
     }
 
     interface PDFText {
@@ -233,8 +233,8 @@ declare namespace PDFKit.Mixins {
         clip(rule?: RuleValue): this;
         transform(m11: number, m12: number, m21: number, m22: number, dx: number, dy: number): this;
         translate(x: number, y: number): this;
-        rotate(angle: number, options?: { origin?: number[] }): this;
-        scale(xFactor: number, yFactor?: number, options?: { origin?: number[] }): this;
+        rotate(angle: number, options?: { origin?: number[] | undefined }): this;
+        scale(xFactor: number, yFactor?: number, options?: { origin?: number[] | undefined }): this;
     }
 
     interface PDFAcroForm {
@@ -316,39 +316,39 @@ declare module 'pdfkit/js/data' {
 
 declare namespace PDFKit {
     interface DocumentInfo {
-        Producer?: string;
-        Creator?: string;
-        CreationDate?: Date;
-        Title?: string;
-        Author?: string;
-        Keywords?: string;
-        ModDate?: Date;
+        Producer?: string | undefined;
+        Creator?: string | undefined;
+        CreationDate?: Date | undefined;
+        Title?: string | undefined;
+        Author?: string | undefined;
+        Keywords?: string | undefined;
+        ModDate?: Date | undefined;
     }
 
     interface DocumentPermissions {
-        modifying?: boolean;
-        copying?: boolean;
-        annotating?: boolean;
-        fillingForms?: boolean;
-        contentAccessibility?: boolean;
-        documentAssembly?: boolean;
-        printing?: 'lowResolution' | 'highResolution';
+        modifying?: boolean | undefined;
+        copying?: boolean | undefined;
+        annotating?: boolean | undefined;
+        fillingForms?: boolean | undefined;
+        contentAccessibility?: boolean | undefined;
+        documentAssembly?: boolean | undefined;
+        printing?: 'lowResolution' | 'highResolution' | undefined;
     }
 
     interface PDFDocumentOptions {
-        compress?: boolean;
-        info?: DocumentInfo;
-        userPassword?: string;
-        ownerPassword?: string;
-        permissions?: DocumentPermissions;
-        pdfVersion?: '1.3' | '1.4' | '1.5' | '1.6' | '1.7' | '1.7ext3';
-        autoFirstPage?: boolean;
-        size?: number[] | string;
-        margin?: number;
-        margins?: { top: number; left: number; bottom: number; right: number };
-        layout?: 'portrait' | 'landscape';
+        compress?: boolean | undefined;
+        info?: DocumentInfo | undefined;
+        userPassword?: string | undefined;
+        ownerPassword?: string | undefined;
+        permissions?: DocumentPermissions | undefined;
+        pdfVersion?: '1.3' | '1.4' | '1.5' | '1.6' | '1.7' | '1.7ext3' | undefined;
+        autoFirstPage?: boolean | undefined;
+        size?: number[] | string | undefined;
+        margin?: number | undefined;
+        margins?: { top: number; left: number; bottom: number; right: number } | undefined;
+        layout?: 'portrait' | 'landscape' | undefined;
 
-        bufferPages?: boolean;
+        bufferPages?: boolean | undefined;
     }
 
     interface PDFDocument

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -32,26 +32,26 @@ export interface TFontDictionary {
 }
 
 export interface TFontFamilyTypes {
-    normal?: PDFKit.Mixins.PDFFontSource;
-    bold?: PDFKit.Mixins.PDFFontSource;
-    italics?: PDFKit.Mixins.PDFFontSource;
-    bolditalics?: PDFKit.Mixins.PDFFontSource;
+    normal?: PDFKit.Mixins.PDFFontSource | undefined;
+    bold?: PDFKit.Mixins.PDFFontSource | undefined;
+    italics?: PDFKit.Mixins.PDFFontSource | undefined;
+    bolditalics?: PDFKit.Mixins.PDFFontSource | undefined;
 }
 
 export interface TDocumentInformation {
     /** the title of the document */
-    title?: string;
+    title?: string | undefined;
     /** the name of the author */
-    author?: string;
+    author?: string | undefined;
     /** the subject of the document */
-    subject?: string;
+    subject?: string | undefined;
     /** keywords associated with the document */
-    keywords?: string;
-    creator?: string;
-    producer?: string;
-    creationDate?: Date;
-    modDate?: Date;
-    trapped?: string;
+    keywords?: string | undefined;
+    creator?: string | undefined;
+    producer?: string | undefined;
+    creationDate?: Date | undefined;
+    modDate?: Date | undefined;
+    trapped?: string | undefined;
 }
 
 export type DynamicContent = (
@@ -72,19 +72,19 @@ export type Alignment = 'left' | 'right' | 'justify' | 'center';
 export type DynamicRowSize = (row: number) => number | 'auto';
 
 export interface CustomTableLayout {
-    hLineWidth?: DynamicLayout<number>;
-    vLineWidth?: DynamicLayout<number>;
-    hLineColor?: string | DynamicLayout<string>;
-    vLineColor?: string | DynamicLayout<string>;
-    hLineStyle?: DynamicLayout<LineStyle>;
-    vLineStyle?: DynamicLayout<LineStyle>;
-    fillColor?: string | DynamicLayout<string>;
-    paddingLeft?: DynamicLayout<number>;
-    paddingRight?: DynamicLayout<number>;
-    paddingTop?: DynamicLayout<number>;
-    paddingBottom?: DynamicLayout<number>;
-    fillOpacity?: number | DynamicLayout<number>;
-    defaultBorder?: boolean;
+    hLineWidth?: DynamicLayout<number> | undefined;
+    vLineWidth?: DynamicLayout<number> | undefined;
+    hLineColor?: string | DynamicLayout<string> | undefined;
+    vLineColor?: string | DynamicLayout<string> | undefined;
+    hLineStyle?: DynamicLayout<LineStyle> | undefined;
+    vLineStyle?: DynamicLayout<LineStyle> | undefined;
+    fillColor?: string | DynamicLayout<string> | undefined;
+    paddingLeft?: DynamicLayout<number> | undefined;
+    paddingRight?: DynamicLayout<number> | undefined;
+    paddingTop?: DynamicLayout<number> | undefined;
+    paddingBottom?: DynamicLayout<number> | undefined;
+    fillOpacity?: number | DynamicLayout<number> | undefined;
+    defaultBorder?: boolean | undefined;
 }
 
 export type DynamicLayout<T> = (rowIndex: number, node: ContentTable, columnIndex: number) => T | null | undefined;
@@ -92,28 +92,28 @@ export type DynamicLayout<T> = (rowIndex: number, node: ContentTable, columnInde
 export interface LineStyle {
     dash?: {
         length: number;
-        space?: number;
-    };
+        space?: number | undefined;
+    } | undefined;
 }
 
 export type TableCell =
     | {} // Used when another cell spans over this cell
     | (Content & {
-          rowSpan?: number;
-          colSpan?: number;
-          border?: [boolean, boolean, boolean, boolean];
-          borderColor?: [string, string, string, string];
-          fillOpacity?: number;
+          rowSpan?: number | undefined;
+          colSpan?: number | undefined;
+          border?: [boolean, boolean, boolean, boolean] | undefined;
+          borderColor?: [string, string, string, string] | undefined;
+          fillOpacity?: number | undefined;
       });
 
 export interface Table {
     body: TableCell[][];
-    widths?: '*' | 'auto' | Size[];
-    heights?: number | number[] | DynamicRowSize;
-    headerRows?: number;
-    dontBreakRows?: boolean;
-    keepWithHeaderRows?: number;
-    layout?: TableLayout;
+    widths?: '*' | 'auto' | Size[] | undefined;
+    heights?: number | number[] | DynamicRowSize | undefined;
+    headerRows?: number | undefined;
+    dontBreakRows?: boolean | undefined;
+    keepWithHeaderRows?: number | undefined;
+    layout?: TableLayout | undefined;
 }
 
 export type PredefinedTableLayout = 'noBorders' | 'headerLineOnly' | 'lightHorizontalLines';
@@ -121,45 +121,45 @@ export type TableLayout = string | PredefinedTableLayout | CustomTableLayout;
 
 export interface Style {
     /** name of the font */
-    font?: string;
+    font?: string | undefined;
     /** size of the font in pt */
-    fontSize?: number;
-    fontFeatures?: PDFKit.Mixins.OpenTypeFeatures[];
+    fontSize?: number | undefined;
+    fontFeatures?: PDFKit.Mixins.OpenTypeFeatures[] | undefined;
     /** the line height (default: 1) */
-    lineHeight?: number;
+    lineHeight?: number | undefined;
     /** whether to use bold text (default: false) */
-    bold?: boolean;
+    bold?: boolean | undefined;
     /** whether to use italic text (default: false) */
-    italics?: boolean;
+    italics?: boolean | undefined;
     /** the alignment of the text */
-    alignment?: Alignment;
+    alignment?: Alignment | undefined;
     /** the color of the text (color name e.g., ‘blue’ or hexadecimal color e.g., ‘#ff5500’) */
-    color?: string;
+    color?: string | undefined;
     /** the background color of the text */
-    background?: string;
+    background?: string | undefined;
     /** the color of the bullets in a buletted list */
-    markerColor?: string;
+    markerColor?: string | undefined;
     /** the text decoration to applu (‘underline’ or ‘lineThrough’ or ‘overline’) */
-    decoration?: Decoration;
+    decoration?: Decoration | undefined;
     /** (‘dashed’ or ‘dotted’ or ‘double’ or ‘wavy’) */
-    decorationStyle?: DecorationStyle;
+    decorationStyle?: DecorationStyle | undefined;
     /** the color of the text decoration, see color */
-    decorationColor?: string;
-    margin?: Margins;
-    preserveLeadingSpaces?: boolean;
-    opacity?: number;
-    characterSpacing?: number;
-    leadingIndent?: number;
+    decorationColor?: string | undefined;
+    margin?: Margins | undefined;
+    preserveLeadingSpaces?: boolean | undefined;
+    opacity?: number | undefined;
+    characterSpacing?: number | undefined;
+    leadingIndent?: number | undefined;
     // Table-cell properties:
-    noWrap?: boolean;
+    noWrap?: boolean | undefined;
     /** the background color of a table cell */
-    fillColor?: string;
+    fillColor?: string | undefined;
     /** the background opacity of a table cell */
-    fillOpacity?: number;
+    fillOpacity?: number | undefined;
     /** optional space between columns */
-    columnGap?: Size;
-    sup?: boolean;
-    sub?: boolean;
+    columnGap?: Size | undefined;
+    sup?: boolean | undefined;
+    sub?: boolean | undefined;
     // These properties appear in the documentation but don't do anything:
     // tableCellPadding?: unknown;
     // cellBorder?: unknown;
@@ -201,25 +201,25 @@ export interface ContentColumns extends ContentBase {
 
 export interface ContentStack extends ContentBase {
     /** if true, ensures that the contents of the stack are always on the same page */
-    unbreakable?: boolean;
+    unbreakable?: boolean | undefined;
     stack: Content[];
 }
 
 /** for numbered lists set the ol key */
 export interface ContentOrderedList extends ContentBase {
     ol: OrderedListElement[];
-    type?: OrderedListType;
-    markerColor?: string;
-    separator?: string | [string, string];
-    reversed?: boolean;
-    start?: number;
+    type?: OrderedListType | undefined;
+    markerColor?: string | undefined;
+    separator?: string | [string, string] | undefined;
+    reversed?: boolean | undefined;
+    start?: number | undefined;
 }
 
 /** to treat a paragraph as a bulleted list, set an array of items under the ul key */
 export interface ContentUnorderedList extends ContentBase {
     ul: UnorderedListElement[];
-    type?: UnorderedListType;
-    markerColor?: string;
+    type?: UnorderedListType | undefined;
+    markerColor?: string | undefined;
 }
 
 export interface ContentCanvas extends ContentBase {
@@ -228,22 +228,22 @@ export interface ContentCanvas extends ContentBase {
 
 export interface ContentSvg extends ContentBase {
     svg: string;
-    width?: number;
-    height?: number;
-    fit?: [number, number];
+    width?: number | undefined;
+    height?: number | undefined;
+    fit?: [number, number] | undefined;
 }
 
 export interface ContentImage extends ContentLink, ContentBase {
     image: string;
-    width?: number;
-    height?: number;
-    fit?: [number, number];
-    cover?: ImageCover;
+    width?: number | undefined;
+    height?: number | undefined;
+    fit?: [number, number] | undefined;
+    cover?: ImageCover | undefined;
 }
 
 export interface ContentTable extends ContentBase {
     table: Table;
-    layout?: TableLayout;
+    layout?: TableLayout | undefined;
 }
 
 export interface ContentAnchor extends ContentBase {
@@ -254,9 +254,9 @@ export interface ContentAnchor extends ContentBase {
 export interface ContentTocItem extends ContentBase {
     text: string | ContentTocItem;
     tocItem: boolean | string | string[];
-    tocStyle?: string | string[] | Style;
-    tocNumberStyle?: string | string[] | Style;
-    tocMargin?: Margins;
+    tocStyle?: string | string[] | Style | undefined;
+    tocNumberStyle?: string | string[] | Style | undefined;
+    tocMargin?: Margins | undefined;
 }
 
 export interface ContentPageReference extends ContentBase {
@@ -273,50 +273,50 @@ export interface ContentToc extends ContentBase {
 
 export interface ContentQr extends ContentBase {
     qr: string;
-    foreground?: string;
-    fit?: number;
-    version?: number;
-    eccLevel?: 'L' | 'M' | 'Q' | 'H';
-    mode?: 'numeric' | 'alphanumeric' | 'octet';
-    mask?: number;
+    foreground?: string | undefined;
+    fit?: number | undefined;
+    version?: number | undefined;
+    eccLevel?: 'L' | 'M' | 'Q' | 'H' | undefined;
+    mode?: 'numeric' | 'alphanumeric' | 'octet' | undefined;
+    mask?: number | undefined;
 }
 
 export interface ContentBase extends Style {
-    style?: string | string[] | Style;
-    absolutePosition?: { x: number; y: number };
-    relativePosition?: { x: number; y: number };
-    pageBreak?: PageBreak;
-    pageOrientation?: PageOrientation;
-    headlineLevel?: number;
+    style?: string | string[] | Style | undefined;
+    absolutePosition?: { x: number; y: number } | undefined;
+    relativePosition?: { x: number; y: number } | undefined;
+    pageBreak?: PageBreak | undefined;
+    pageOrientation?: PageOrientation | undefined;
+    headlineLevel?: number | undefined;
 }
 
 export interface ContentLink {
-    link?: string;
-    linkToPage?: number;
-    linkToDestination?: string;
+    link?: string | undefined;
+    linkToPage?: number | undefined;
+    linkToDestination?: string | undefined;
 }
 
 export interface TableOfContent {
-    title?: Content;
-    textMargin?: Margins;
-    textStyle?: string | string[] | Style;
-    numberStyle?: string | string[] | Style;
-    id?: string;
+    title?: Content | undefined;
+    textMargin?: Margins | undefined;
+    textStyle?: string | string[] | Style | undefined;
+    numberStyle?: string | string[] | Style | undefined;
+    id?: string | undefined;
 }
 
 export type Column = Content & {
-    width?: Size;
+    width?: Size | undefined;
 };
 
 export type OrderedListType = 'lower-alpha' | 'upper-alpha' | 'lower-roman' | 'upper-roman' | 'none';
 export type OrderedListElement = Content & {
-    counter?: number;
-    listType?: OrderedListType;
+    counter?: number | undefined;
+    listType?: OrderedListType | undefined;
 };
 
 export type UnorderedListType = 'square' | 'circle' | 'none';
 export type UnorderedListElement = Content & {
-    listType?: UnorderedListType;
+    listType?: UnorderedListType | undefined;
 };
 
 export type CanvasElement = CanvasRect | CanvasPolyline | CanvasLine | CanvasEllipse;
@@ -327,14 +327,14 @@ export interface CanvasRect extends CanvasLineElement, CanvasFilledElement {
     y: number;
     w: number;
     h: number;
-    r?: number;
+    r?: number | undefined;
 }
 
 export interface CanvasPolyline extends CanvasLineElement, CanvasFilledElement {
     type: 'polyline';
     points: Array<{ x: number; y: number }>;
-    closePath?: boolean;
-    lineCap?: 'round' | 'square';
+    closePath?: boolean | undefined;
+    lineCap?: 'round' | 'square' | undefined;
 }
 
 export interface CanvasLine extends CanvasLineElement {
@@ -343,7 +343,7 @@ export interface CanvasLine extends CanvasLineElement {
     y1: number;
     x2: number;
     y2: number;
-    lineCap?: 'round' | 'square';
+    lineCap?: 'round' | 'square' | undefined;
 }
 
 export interface CanvasEllipse extends CanvasLineElement, CanvasFilledElement {
@@ -351,32 +351,32 @@ export interface CanvasEllipse extends CanvasLineElement, CanvasFilledElement {
     x: number;
     y: number;
     r1: number;
-    r2?: number;
+    r2?: number | undefined;
 }
 
 export interface CanvasFilledElement {
-    color?: string;
-    fillOpacity?: number;
-    linearGradient?: string[];
+    color?: string | undefined;
+    fillOpacity?: number | undefined;
+    linearGradient?: string[] | undefined;
 }
 
 export interface CanvasLineElement {
-    lineWidth?: number;
-    lineColor?: string;
+    lineWidth?: number | undefined;
+    lineColor?: string | undefined;
     dash?: {
         length: number;
-        space?: number;
-    };
+        space?: number | undefined;
+    } | undefined;
 }
 
 export type ImageAlignment = 'left' | 'right' | 'center';
 export type ImageVerticalAlignment = 'top' | 'bottom' | 'center';
 
 export interface ImageCover {
-    width?: number;
-    height?: number;
-    align?: ImageAlignment;
-    valign?: ImageVerticalAlignment;
+    width?: number | undefined;
+    height?: number | undefined;
+    align?: ImageAlignment | undefined;
+    valign?: ImageVerticalAlignment | undefined;
 }
 
 export interface StyleDictionary {
@@ -389,61 +389,61 @@ export interface Watermark {
     /** watermark text */
     text: string;
     /** opacity of text */
-    opacity?: number;
+    opacity?: number | undefined;
     /** angle of text rotation (minimal version: 0.1.60) */
-    angle?: number;
-    font?: string;
+    angle?: number | undefined;
+    font?: string | undefined;
     /** own font size of text (ideal size is calculated automatically) (minimal version: 0.1.60) */
-    fontSize?: number;
+    fontSize?: number | undefined;
     /** color of text */
-    color?: string;
+    color?: string | undefined;
     /** bold style of text */
-    bold?: boolean;
+    bold?: boolean | undefined;
     /** italics style of text */
-    italics?: boolean;
+    italics?: boolean | undefined;
 }
 
 export interface TDocumentDefinitions {
     content: Content;
-    background?: DynamicBackground | Content;
-    compress?: boolean;
-    defaultStyle?: Style;
-    footer?: DynamicContent | Content;
-    header?: DynamicContent | Content;
-    images?: { [key: string]: string };
-    info?: TDocumentInformation;
-    pageBreakBefore?: (
+    background?: DynamicBackground | Content | undefined;
+    compress?: boolean | undefined;
+    defaultStyle?: Style | undefined;
+    footer?: DynamicContent | Content | undefined;
+    header?: DynamicContent | Content | undefined;
+    images?: { [key: string]: string } | undefined;
+    info?: TDocumentInformation | undefined;
+    pageBreakBefore?: ((
         currentNode: Node,
         followingNodesOnPage: Node[],
         nodesOnNextPage: Node[],
         previousNodesOnPage: Node[],
-    ) => boolean;
-    pageMargins?: Margins;
-    pageOrientation?: PageOrientation;
-    pageSize?: PageSize;
-    styles?: StyleDictionary;
-    userPassword?: string;
-    ownerPassword?: string;
-    permissions?: PDFKit.DocumentPermissions;
-    version?: PDFVersion;
-    watermark?: string | Watermark;
+    ) => boolean) | undefined;
+    pageMargins?: Margins | undefined;
+    pageOrientation?: PageOrientation | undefined;
+    pageSize?: PageSize | undefined;
+    styles?: StyleDictionary | undefined;
+    userPassword?: string | undefined;
+    ownerPassword?: string | undefined;
+    permissions?: PDFKit.DocumentPermissions | undefined;
+    version?: PDFVersion | undefined;
+    watermark?: string | Watermark | undefined;
 }
 
 export interface Node {
-    text?: Content;
-    ul?: UnorderedListElement[];
-    ol?: OrderedListElement[];
-    table?: Table;
-    image?: string;
-    qr?: string;
-    canvas?: CanvasElement;
-    svg?: string;
-    columns?: Column[];
-    id?: string;
-    headlineLevel?: number;
-    style?: string | string[] | Style;
-    pageBreak?: PageBreak;
-    pageOrientation?: PageOrientation;
+    text?: Content | undefined;
+    ul?: UnorderedListElement[] | undefined;
+    ol?: OrderedListElement[] | undefined;
+    table?: Table | undefined;
+    image?: string | undefined;
+    qr?: string | undefined;
+    canvas?: CanvasElement | undefined;
+    svg?: string | undefined;
+    columns?: Column[] | undefined;
+    id?: string | undefined;
+    headlineLevel?: number | undefined;
+    style?: string | string[] | Style | undefined;
+    pageBreak?: PageBreak | undefined;
+    pageOrientation?: PageOrientation | undefined;
     pageNumbers: number[];
     pages: number;
     stack: boolean;
@@ -466,11 +466,11 @@ export interface ContextPageSize {
 }
 
 export interface BufferOptions {
-    fontLayoutCache?: boolean;
-    bufferPages?: boolean;
-    tableLayouts?: { [key: string]: CustomTableLayout };
-    autoPrint?: boolean;
-    progressCallback?: (progress: number) => void;
+    fontLayoutCache?: boolean | undefined;
+    bufferPages?: boolean | undefined;
+    tableLayouts?: { [key: string]: CustomTableLayout } | undefined;
+    autoPrint?: boolean | undefined;
+    progressCallback?: ((progress: number) => void) | undefined;
 }
 
 // disable automatic exporting

--- a/types/pendo-io-browser/index.d.ts
+++ b/types/pendo-io-browser/index.d.ts
@@ -7,30 +7,30 @@
 declare namespace pendo {
     interface Identity {
         /** visitor.id is required if user is logged in, otherwise an anonymous ID is generated and tracked by a cookie */
-        visitor?: IdentityMetadata;
-        account?: IdentityMetadata;
+        visitor?: IdentityMetadata | undefined;
+        account?: IdentityMetadata | undefined;
     }
 
     interface Metadata {
         [key: string]: string | number | boolean;
     }
 
-    type IdentityMetadata = { id?: string; } & Metadata;
+    type IdentityMetadata = { id?: string | undefined; } & Metadata;
 
     interface InitOptions extends Identity {
-        apiKey?: string;
-        excludeAllText?: boolean;
-        excludeTitle?: boolean;
-        disablePersistence?: boolean;
+        apiKey?: string | undefined;
+        excludeAllText?: boolean | undefined;
+        excludeTitle?: boolean | undefined;
+        disablePersistence?: boolean | undefined;
         guides?: {
-            delay?: boolean;
-            disable?: boolean;
-            timeout?: number;
+            delay?: boolean | undefined;
+            disable?: boolean | undefined;
+            timeout?: number | undefined;
             tooltip?: {
-                arrowSize?: number;
-            }
-        };
-        events?: EventCallbacks;
+                arrowSize?: number | undefined;
+            } | undefined
+        } | undefined;
+        events?: EventCallbacks | undefined;
     }
 
     interface EventCallbacks {
@@ -142,12 +142,12 @@ declare namespace pendo {
         type: string;
         elementPathRule: string;
         contentType: string;
-        contentUrl?: string;
-        contentUrlCss?: string;
-        contentUrlJs?: string;
+        contentUrl?: string | undefined;
+        contentUrlCss?: string | undefined;
+        contentUrlJs?: string | undefined;
         rank: number;
         advanceMethod: "button" | "programatic" /* sic */ | "element";
-        thumbnailUrls?: string;
+        thumbnailUrls?: string | undefined;
         attributes: {
             height: number;
             width: number;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -14,49 +14,49 @@ import { NoticeMessage } from 'pg-protocol/dist/messages';
 import { ConnectionOptions } from 'tls';
 
 export interface ClientConfig {
-    user?: string;
-    database?: string;
-    password?: string | (() => string | Promise<string>);
-    port?: number;
-    host?: string;
-    connectionString?: string;
-    keepAlive?: boolean;
-    stream?: stream.Duplex;
-    statement_timeout?: false | number;
-    parseInputDatesAsUTC?: boolean;
-    ssl?: boolean | ConnectionOptions;
-    query_timeout?: number;
-    keepAliveInitialDelayMillis?: number;
-    idle_in_transaction_session_timeout?: number;
-    application_name?: string;
-    connectionTimeoutMillis?: number;
-    types?: CustomTypesConfig;
+    user?: string | undefined;
+    database?: string | undefined;
+    password?: string | (() => string | Promise<string>) | undefined;
+    port?: number | undefined;
+    host?: string | undefined;
+    connectionString?: string | undefined;
+    keepAlive?: boolean | undefined;
+    stream?: stream.Duplex | undefined;
+    statement_timeout?: false | number | undefined;
+    parseInputDatesAsUTC?: boolean | undefined;
+    ssl?: boolean | ConnectionOptions | undefined;
+    query_timeout?: number | undefined;
+    keepAliveInitialDelayMillis?: number | undefined;
+    idle_in_transaction_session_timeout?: number | undefined;
+    application_name?: string | undefined;
+    connectionTimeoutMillis?: number | undefined;
+    types?: CustomTypesConfig | undefined;
 }
 
 export type ConnectionConfig = ClientConfig;
 
 export interface Defaults extends ClientConfig {
-    poolSize?: number;
-    poolIdleTimeout?: number;
-    reapIntervalMillis?: number;
-    binary?: boolean;
-    parseInt8?: boolean;
+    poolSize?: number | undefined;
+    poolIdleTimeout?: number | undefined;
+    reapIntervalMillis?: number | undefined;
+    binary?: boolean | undefined;
+    parseInt8?: boolean | undefined;
 }
 
 export interface PoolConfig extends ClientConfig {
     // properties from module 'node-pool'
-    max?: number;
-    min?: number;
-    idleTimeoutMillis?: number;
-    log?: (...messages: any[]) => void;
-    Promise?: PromiseConstructorLike;
+    max?: number | undefined;
+    min?: number | undefined;
+    idleTimeoutMillis?: number | undefined;
+    log?: ((...messages: any[]) => void) | undefined;
+    Promise?: PromiseConstructorLike | undefined;
 }
 
 export interface QueryConfig<I extends any[] = any[]> {
-    name?: string;
+    name?: string | undefined;
     text: string;
-    values?: I;
-    types?: CustomTypesConfig;
+    values?: I | undefined;
+    types?: CustomTypesConfig | undefined;
 }
 
 export interface CustomTypesConfig {
@@ -103,7 +103,7 @@ export interface QueryArrayResult<R extends any[] = any[]> extends QueryResultBa
 export interface Notification {
     processId: number;
     channel: string;
-    payload?: string;
+    payload?: string | undefined;
 }
 
 export interface ResultBuilder<R extends QueryResultRow = any> extends QueryResult<R> {
@@ -117,20 +117,20 @@ export interface QueryParse {
 }
 
 export interface BindConfig {
-    portal?: string;
-    statement?: string;
-    binary?: string;
-    values?: Array<Buffer | null | undefined | string>;
+    portal?: string | undefined;
+    statement?: string | undefined;
+    binary?: string | undefined;
+    values?: Array<Buffer | null | undefined | string> | undefined;
 }
 
 export interface ExecuteConfig {
-    portal?: string;
-    rows?: string;
+    portal?: string | undefined;
+    rows?: string | undefined;
 }
 
 export interface MessageConfig {
     type: string;
-    name?: string;
+    name?: string | undefined;
 }
 
 export class Connection extends events.EventEmitter {
@@ -257,11 +257,11 @@ export class ClientBase extends events.EventEmitter {
 }
 
 export class Client extends ClientBase {
-    user?: string;
-    database?: string;
+    user?: string | undefined;
+    database?: string | undefined;
     port: number;
     host: string;
-    password?: string;
+    password?: string | undefined;
     ssl: boolean;
 
     constructor(config?: string | ClientConfig);

--- a/types/pg/v6/index.d.ts
+++ b/types/pg/v6/index.d.ts
@@ -14,43 +14,43 @@ export declare function connect(config: ClientConfig, callback: (err: Error, cli
 export declare function end(): void;
 
 export interface ConnectionConfig {
-    user?: string;
-    database?: string;
-    password?: string;
-    port?: number;
-    host?: string;
+    user?: string | undefined;
+    database?: string | undefined;
+    password?: string | undefined;
+    port?: number | undefined;
+    host?: string | undefined;
 }
 
 export interface Defaults extends ConnectionConfig {
-    poolSize?: number;
-    poolIdleTimeout?: number;
-    reapIntervalMillis?: number;
-    binary?: boolean;
-    parseInt8?: boolean;
+    poolSize?: number | undefined;
+    poolIdleTimeout?: number | undefined;
+    reapIntervalMillis?: number | undefined;
+    binary?: boolean | undefined;
+    parseInt8?: boolean | undefined;
 }
 
 import { TlsOptions } from "tls";
 
 export interface ClientConfig extends ConnectionConfig {
-    ssl?: boolean | TlsOptions;
+    ssl?: boolean | TlsOptions | undefined;
 }
 
 export interface PoolConfig extends ClientConfig {
     // properties from module 'node-pool'
-    max?: number;
-    min?: number;
-    refreshIdle?: boolean;
-    idleTimeoutMillis?: number;
-    reapIntervalMillis?: number;
-    returnToHead?: boolean;
-    application_name?: string;
-    Promise?: PromiseConstructorLike;
+    max?: number | undefined;
+    min?: number | undefined;
+    refreshIdle?: boolean | undefined;
+    idleTimeoutMillis?: number | undefined;
+    reapIntervalMillis?: number | undefined;
+    returnToHead?: boolean | undefined;
+    application_name?: string | undefined;
+    Promise?: PromiseConstructorLike | undefined;
 }
 
 export interface QueryConfig {
-    name?: string;
+    name?: string | undefined;
     text: string;
-    values?: any[];
+    values?: any[] | undefined;
 }
 
 export interface QueryResult {

--- a/types/picomatch/lib/parse.d.ts
+++ b/types/picomatch/lib/parse.d.ts
@@ -1,4 +1,4 @@
-declare function parse(input: string, options: { maxLength?: number }): parse.ParseState;
+declare function parse(input: string, options: { maxLength?: number | undefined }): parse.ParseState;
 
 declare namespace parse {
     interface Token {
@@ -17,7 +17,7 @@ declare namespace parse {
         prefix: string;
         backtrack: boolean;
         negated: boolean;
-        negatedExtglob?: boolean;
+        negatedExtglob?: boolean | undefined;
         brackets: number;
         braces: number;
         parens: number;

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -54,159 +54,159 @@ declare namespace picomatch {
          * If set, then patterns without slashes will be matched against the basename of the path if it contains slashes.
          * For example, `a?b` would match the path `/xyz/123/acb`, but not `/xyz/acb/123`.
          */
-        basename?: boolean;
+        basename?: boolean | undefined;
         /**
          * Follow bash matching rules more strictly - disallows backslashes as escape characters, and treats single stars as globstars (`**`).
          */
-        bash?: boolean;
+        bash?: boolean | undefined;
         /**
          * Return regex matches in supporting methods.
          */
-        capture?: boolean;
+        capture?: boolean | undefined;
         /**
          * Allows glob to match any part of the given string(s).
          */
-        contains?: boolean;
+        contains?: boolean | undefined;
         /**
          * Current working directory. Used by `picomatch.split()`
          */
-        cwd?: string;
+        cwd?: string | undefined;
         /**
          * Debug regular expressions when an error is thrown.
          */
-        debug?: boolean;
+        debug?: boolean | undefined;
         /**
          * Enable dotfile matching. By default, dotfiles are ignored unless a `.` is explicitly defined in the pattern, or `options.dot` is true
          */
-        dot?: boolean;
+        dot?: boolean | undefined;
         /**
          * Custom function for expanding ranges in brace patterns, such as `{a..z}`.
          * The function receives the range values as two arguments, and it must return a string to be used in the generated regex.
          * It's recommended that returned strings be wrapped in parentheses.
          */
-        expandRange?: (a: string, b: string) => string;
+        expandRange?: ((a: string, b: string) => string) | undefined;
         /**
          * Throws an error if no matches are found. Based on the bash option of the same name.
          */
-        failglob?: boolean;
+        failglob?: boolean | undefined;
         /**
          * To speed up processing, full parsing is skipped for a handful common glob patterns. Disable this behavior by setting this option to `false`.
          */
-        fastpaths?: boolean;
+        fastpaths?: boolean | undefined;
         /**
          * Regex flags to use in the generated regex. If defined, the `nocase` option will be overridden.
          */
-        flags?: boolean;
+        flags?: boolean | undefined;
         /**
          * Custom function for formatting the returned string. This is useful for removing leading slashes, converting Windows paths to Posix paths, etc.
          */
-        format?: (str: string) => string;
+        format?: ((str: string) => string) | undefined;
         /**
          * One or more glob patterns for excluding strings that should not be matched from the result.
          */
-        ignore?: Glob;
+        ignore?: Glob | undefined;
         /**
          * Retain quotes in the generated regex, since quotes may also be used as an alternative to backslashes.
          */
-        keepQuotes?: boolean;
+        keepQuotes?: boolean | undefined;
         /**
          * When `true`, brackets in the glob pattern will be escaped so that only literal brackets will be matched.
          */
-        literalBrackets?: boolean;
+        literalBrackets?: boolean | undefined;
         /**
          * Support regex positive and negative lookbehinds. Note that you must be using Node 8.1.10 or higher to enable regex lookbehinds.
          */
-        lookbehinds?: boolean;
+        lookbehinds?: boolean | undefined;
         /**
          * Alias for `basename`
          */
-        matchBase?: boolean;
+        matchBase?: boolean | undefined;
         /**
          * Limit the max length of the input string. An error is thrown if the input string is longer than this value.
          */
-        maxLength?: boolean;
+        maxLength?: boolean | undefined;
         /**
          * Disable brace matching, so that `{a,b}` and `{1..3}` would be treated as literal characters.
          */
-        nobrace?: boolean;
+        nobrace?: boolean | undefined;
         /**
          * Disable brace matching, so that `{a,b}` and `{1..3}` would be treated as literal characters.
          */
-        nobracket?: boolean;
+        nobracket?: boolean | undefined;
         /**
          * Make matching case-insensitive. Equivalent to the regex `i` flag. Note that this option is overridden by the `flags` option.
          */
-        nocase?: boolean;
+        nocase?: boolean | undefined;
         /**
          * @deprecated use `nounique` instead.
          * This option will be removed in a future major release. By default duplicates are removed.
          * Disable uniquification by setting this option to false.
          */
-        nodupes?: boolean;
+        nodupes?: boolean | undefined;
         /**
          * Alias for `noextglob`
          */
-        noext?: boolean;
+        noext?: boolean | undefined;
         /**
          * Disable support for matching with extglobs (like `+(a\|b)`)
          */
-        noextglob?: boolean;
+        noextglob?: boolean | undefined;
         /**
          * Disable support for matching nested directories with globstars (`**`)
          */
-        noglobstar?: boolean;
+        noglobstar?: boolean | undefined;
         /**
          * Disable support for negating with leading `!`
          */
-        nonegate?: boolean;
+        nonegate?: boolean | undefined;
         /**
          * Disable support for regex quantifiers (like `a{1,2}`) and treat them as brace patterns to be expanded.
          */
-        noquantifiers?: boolean;
+        noquantifiers?: boolean | undefined;
         /**
          * Function to be called on ignored items.
          */
-        onIgnore?: (result: Result) => void;
+        onIgnore?: ((result: Result) => void) | undefined;
         /**
          * Function to be called on matched items.
          */
-        onMatch?: (result: Result) => void;
+        onMatch?: ((result: Result) => void) | undefined;
         /**
          * Function to be called on all items, regardless of whether or not they are matched or ignored.
          */
-        onResult?: (result: Result) => void;
+        onResult?: ((result: Result) => void) | undefined;
         /**
          * Support POSIX character classes ("posix brackets").
          */
-        posix?: boolean;
+        posix?: boolean | undefined;
         /**
          * Convert all slashes in file paths to forward slashes. This does not convert slashes in the glob pattern itself
          */
-        posixSlashes?: boolean;
+        posixSlashes?: boolean | undefined;
         /**
          * Convert all slashes in file paths to forward slashes. This does not convert slashes in the glob pattern itself
          */
-        prepend?: boolean;
+        prepend?: boolean | undefined;
         /**
          * Use regular expression rules for `+` (instead of matching literal `+`), and for stars that follow closing parentheses or brackets (as in `)*` and `]*`).
          */
-        regex?: boolean;
+        regex?: boolean | undefined;
         /**
          * Throw an error if brackets, braces, or parens are imbalanced.
          */
-        strictBrackets?: boolean;
+        strictBrackets?: boolean | undefined;
         /**
          * When true, picomatch won't match trailing slashes with single stars.
          */
-        strictSlashes?: boolean;
+        strictSlashes?: boolean | undefined;
         /**
          * Remove backslashes preceding escaped characters in the glob pattern. By default, backslashes are retained.
          */
-        unescape?: boolean;
+        unescape?: boolean | undefined;
         /**
          * Alias for `posixSlashes`, for backwards compatibility.
          */
-        unixify?: boolean;
+        unixify?: boolean | undefined;
     }
 
     function test(
@@ -214,17 +214,17 @@ declare namespace picomatch {
         regex: RegExp,
         options?: PicomatchOptions,
         test?: {},
-    ): { isMatch: boolean; match?: boolean | RegExpExecArray | null; output: string };
+    ): { isMatch: boolean; match?: boolean | RegExpExecArray | null | undefined; output: string };
 
     function matchBase(input: string, glob: RegExp | string, options?: {}, posix?: any): boolean;
 
     function isMatch(str: string | string[], patterns: Glob, options?: {}): boolean;
 
-    function parse(pattern: string[], options?: { maxLength?: number }): parseImport.ParseState[];
-    function parse(pattern: string, options?: { maxLength?: number }): parseImport.ParseState;
+    function parse(pattern: string[], options?: { maxLength?: number | undefined }): parseImport.ParseState[];
+    function parse(pattern: string, options?: { maxLength?: number | undefined }): parseImport.ParseState;
     function parse(
         pattern: Glob,
-        options?: { maxLength?: number },
+        options?: { maxLength?: number | undefined },
     ): parseImport.ParseState | parseImport.ParseState[];
 
     const scan: typeof scanImport;
@@ -243,7 +243,7 @@ declare namespace picomatch {
         returnState?: boolean,
     ): typeof compileRe;
 
-    function toRegex(source: string | RegExp, options?: { flags?: string; nocase?: boolean; debug?: boolean }): RegExp;
+    function toRegex(source: string | RegExp, options?: { flags?: string | undefined; nocase?: boolean | undefined; debug?: boolean | undefined }): RegExp;
 
     const constants: typeof constantsImport;
 }

--- a/types/picomatch/lib/scan.d.ts
+++ b/types/picomatch/lib/scan.d.ts
@@ -6,28 +6,28 @@ declare namespace scan {
          * When `true`, the returned object will include an array of strings representing each path "segment"
          * in the scanned glob pattern. This is automatically enabled when `options.tokens` is true
          */
-        parts?: boolean;
-        scanToEnd?: boolean;
-        noext?: boolean;
-        nonegate?: boolean;
-        noparen?: boolean;
-        unescape?: boolean;
+        parts?: boolean | undefined;
+        scanToEnd?: boolean | undefined;
+        noext?: boolean | undefined;
+        nonegate?: boolean | undefined;
+        noparen?: boolean | undefined;
+        unescape?: boolean | undefined;
         /**
          * When `true`, the returned object will include an array of tokens (objects),
          * representing each path "segment" in the scanned glob pattern
          */
-        tokens?: boolean;
+        tokens?: boolean | undefined;
     }
 
     interface Token {
         value: string;
         depth: number;
         isGlob: boolean;
-        backslashes?: boolean;
-        isBrace?: boolean;
-        isExtglob?: boolean;
-        isGlobstar?: boolean;
-        negated?: boolean;
+        backslashes?: boolean | undefined;
+        isBrace?: boolean | undefined;
+        isExtglob?: boolean | undefined;
+        isGlobstar?: boolean | undefined;
+        negated?: boolean | undefined;
     }
 
     interface State {
@@ -42,10 +42,10 @@ declare namespace scan {
         isExtglob: boolean;
         isGlobstar: boolean;
         negated: boolean;
-        maxDepth?: number;
-        tokens?: Token[];
-        slashes?: number[];
-        parts?: string[];
+        maxDepth?: number | undefined;
+        tokens?: Token[] | undefined;
+        slashes?: number[] | undefined;
+        parts?: string[] | undefined;
     }
 }
 

--- a/types/pify/index.d.ts
+++ b/types/pify/index.d.ts
@@ -12,12 +12,12 @@ declare function pify(input: object, options?: pify.PifyOptions): any;
 
 declare namespace pify {
     interface PifyOptions {
-        multiArgs?: boolean;
-        include?: Array<string | RegExp>;
-        exclude?: Array<string | RegExp>;
-        excludeMain?: boolean;
-        errorFirst?: boolean;
-        promiseModule?: PromiseModule;
+        multiArgs?: boolean | undefined;
+        include?: Array<string | RegExp> | undefined;
+        exclude?: Array<string | RegExp> | undefined;
+        excludeMain?: boolean | undefined;
+        errorFirst?: boolean | undefined;
+        promiseModule?: PromiseModule | undefined;
     }
 
     interface PromiseModule {

--- a/types/pikaday/index.d.ts
+++ b/types/pikaday/index.d.ts
@@ -159,81 +159,81 @@ declare namespace Pikaday {
         /**
          * Bind the datepicker to a form field.
          */
-        field?: HTMLElement | null;
+        field?: HTMLElement | null | undefined;
 
         /**
          * The default output format for toString() and field value.
          * Requires Moment.js for custom formatting.
          */
-        format?: string;
+        format?: string | undefined;
 
         /**
          * Use a different element to trigger opening the datepicker.
          * Default: field element.
          */
-        trigger?: HTMLElement | null;
+        trigger?: HTMLElement | null | undefined;
 
         /**
          * Automatically show/hide the datepicker on field focus.
          * Default: true if field is set.
          */
-        bound?: boolean;
+        bound?: boolean | undefined;
 
         /**
          * Data-attribute on the input field with an aria assistance test (only applied when bound is set)
          */
-        ariaLabel?: string;
+        ariaLabel?: string | undefined;
 
         /**
          * Preferred position of the datepicker relative to the form field
          * (e.g. 'top right'). Automatic adjustment may occur to avoid
          * displaying outside the viewport. Default: 'bottom left'.
          */
-        position?: string;
+        position?: string | undefined;
 
         /**
          * Can be set to false to not reposition the datepicker within the
          * viewport, forcing it to take the configured position. Default: true.
          */
-        reposition?: boolean;
+        reposition?: boolean | undefined;
 
         /**
          * DOM node to render calendar into, see container example.
          * Default: undefined.
          */
-        container?: HTMLElement | null;
+        container?: HTMLElement | null | undefined;
 
         /**
          * The initial date to view when first opened.
          */
-        defaultDate?: Date;
+        defaultDate?: Date | undefined;
 
         /**
          * Make the defaultDate the initial selected value.
          */
-        setDefaultDate?: boolean;
+        setDefaultDate?: boolean | undefined;
 
         /**
          * First day of the week (0: Sunday, 1: Monday, etc).
          */
-        firstDay?: number;
+        firstDay?: number | undefined;
 
         /**
          * The earliest date that can be selected (this should be a native
          * Date object - e.g. new Date() or moment().toDate()).
          */
-        minDate?: Date;
+        minDate?: Date | undefined;
 
         /**
          * The latest date that can be selected (this should be a native
          * Date object - e.g. new Date() or moment().toDate()).
          */
-        maxDate?: Date;
+        maxDate?: Date | undefined;
 
         /**
          * Disallow selection of Saturdays and Sundays.
          */
-        disableWeekends?: boolean;
+        disableWeekends?: boolean | undefined;
 
         /**
          * Callback function that gets passed a Date object for each day
@@ -245,80 +245,80 @@ declare namespace Pikaday {
          * Number of years either side (e.g. 10) or array of upper/lower range
          * (e.g. [1900, 2015]).
          */
-        yearRange?: number | number[];
+        yearRange?: number | number[] | undefined;
 
         /**
          * Show the ISO week number at the head of the row. Default: false.
          */
-        showWeekNumber?: boolean;
+        showWeekNumber?: boolean | undefined;
 
         /**
          * Select a whole week instead of a day (default false)
          */
-        pickWholeWeek?: boolean;
+        pickWholeWeek?: boolean | undefined;
 
         /**
          * Reverse the calendar for right-to-left languages. Default: false.
          */
-        isRTL?: boolean;
+        isRTL?: boolean | undefined;
 
         /**
          * Language defaults for month and weekday names.
          */
-        i18n?: PikadayI18nConfig;
+        i18n?: PikadayI18nConfig | undefined;
 
         /**
          * Additional text to append to the year in the title.
          */
-        yearSuffix?: string;
+        yearSuffix?: string | undefined;
 
         /**
          * Render the month after the year in the title. Default: false.
          */
-        showMonthAfterYear?: boolean;
+        showMonthAfterYear?: boolean | undefined;
 
         /**
          * Render days of the calendar grid that fall in the next or previous months to the current month instead of rendering an empty table cell. Default: false.
          */
-        showDaysInNextAndPreviousMonths?: boolean;
+        showDaysInNextAndPreviousMonths?: boolean | undefined;
 
         /**
          * Allows user to select date that is in the next or previous months (default: false)
          */
-        enableSelectionDaysInNextAndPreviousMonths?: boolean;
+        enableSelectionDaysInNextAndPreviousMonths?: boolean | undefined;
 
         /**
          * Number of visible calendars.
          */
-        numberOfMonths?: number;
+        numberOfMonths?: number | undefined;
 
         /**
          * When numberOfMonths is used, this will help you to choose where the
          * main calendar will be (default left, can be set to right). Only used
          * for the first display or when a selected date is not already visible.
          */
-        mainCalendar?: string;
+        mainCalendar?: string | undefined;
 
         /**
          * Array of dates that you would like to differentiate from regular days (e.g. ['Sat Jun 28 2017', 'Sun Jun 29 2017', 'Tue Jul 01 2017',])
          */
-        events?: string[];
+        events?: string[] | undefined;
 
         /**
          * Define a class name that can be used as a hook for styling different
          * themes. Default: null.
          */
-        theme?: string;
+        theme?: string | undefined;
 
         /**
          * Defines if the field is blurred when a date is selected (default true)
          */
-        blurFieldOnSelect?: boolean;
+        blurFieldOnSelect?: boolean | undefined;
 
         /**
          * The default flag for moment's strict date parsing (requires Moment.js for custom formatting). Default: false
          */
-        formatStrict?: boolean;
+        formatStrict?: boolean | undefined;
 
         /**
          * Function which will be used for formatting date object to string.
@@ -355,6 +355,6 @@ declare namespace Pikaday {
         /**
          * Enable keyboard input support. Default: true
          */
-        keyboardInput?: boolean;
+        keyboardInput?: boolean | undefined;
     }
 }

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -28,17 +28,17 @@ declare namespace PinoHttp {
      * See https://github.com/pinojs/pino-http#pinohttpopts-stream
      */
     interface Options extends LoggerOptions {
-        logger?: Logger;
-        genReqId?: GenReqId;
-        useLevel?: Level;
-        stream?: DestinationStream;
-        autoLogging?: boolean | AutoLoggingOptions;
-        customLogLevel?: (res: ServerResponse, error: Error) => Level;
-        customSuccessMessage?: (res: ServerResponse) => string;
-        customErrorMessage?: (error: Error, res: ServerResponse) => string;
-        customAttributeKeys?: CustomAttributeKeys;
-        wrapSerializers?: boolean;
-        reqCustomProps?: (req: IncomingMessage, res: ServerResponse) => object;
+        logger?: Logger | undefined;
+        genReqId?: GenReqId | undefined;
+        useLevel?: Level | undefined;
+        stream?: DestinationStream | undefined;
+        autoLogging?: boolean | AutoLoggingOptions | undefined;
+        customLogLevel?: ((res: ServerResponse, error: Error) => Level) | undefined;
+        customSuccessMessage?: ((res: ServerResponse) => string) | undefined;
+        customErrorMessage?: ((error: Error, res: ServerResponse) => string) | undefined;
+        customAttributeKeys?: CustomAttributeKeys | undefined;
+        wrapSerializers?: boolean | undefined;
+        reqCustomProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;
     }
 
     interface GenReqId {
@@ -46,15 +46,15 @@ declare namespace PinoHttp {
     }
 
     interface AutoLoggingOptions {
-        ignorePaths?: string[];
-        getPath?: (req: IncomingMessage) => string | undefined;
+        ignorePaths?: string[] | undefined;
+        getPath?: ((req: IncomingMessage) => string | undefined) | undefined;
     }
 
     interface CustomAttributeKeys {
-        req?: string;
-        res?: string;
-        err?: string;
-        responseTime?: string;
+        req?: string | undefined;
+        res?: string | undefined;
+        err?: string | undefined;
+        responseTime?: string | undefined;
     }
 
     const startTime: unique symbol;
@@ -67,7 +67,7 @@ declare module 'http' {
     }
 
     interface ServerResponse {
-        err?: Error;
+        err?: Error | undefined;
     }
 
     interface OutgoingMessage {

--- a/types/pino-pretty/index.d.ts
+++ b/types/pino-pretty/index.d.ts
@@ -19,7 +19,7 @@ declare namespace PinoPretty {
          * Hide objects from output (but not error object).
          * @default false
          */
-        hideObject?: boolean;
+        hideObject?: boolean | undefined;
         /**
          * Translate the epoch time value into a human readable date and time string. This flag also can set the format
          * string to apply when translating the date to human readable format. For a list of available pattern letters
@@ -29,37 +29,37 @@ declare namespace PinoPretty {
          *   to translate time to `yyyy-mm-dd HH:MM:ss.l o` in system timezone.
          * @default false
          */
-        translateTime?: boolean | string;
+        translateTime?: boolean | string | undefined;
         /**
          * If set to true, it will print the name of the log level as the first field in the log line.
          * @default false
          */
-        levelFirst?: boolean;
+        levelFirst?: boolean | undefined;
         /**
          * Define the key that contains the level of the log.
          * @default "level"
          */
-        levelKey?: string;
+        levelKey?: string | undefined;
         /**
          * Output the log level using the specified label.
          * @default "levelLabel"
          */
-        levelLabel?: string;
+        levelLabel?: string | undefined;
         /**
          * The key in the JSON object to use as the highlighted message.
          * @default "msg"
          */
-        messageKey?: string;
+        messageKey?: string | undefined;
         /**
          * Print each log message on a single line (errors will still be multi-line).
          * @default false
          */
-        singleLine?: boolean;
+        singleLine?: boolean | undefined;
         /**
          * The key in the JSON object to use for timestamp display.
          * @default "time"
          */
-        timestampKey?: string;
+        timestampKey?: string | undefined;
         /**
          * Format output of message, e.g. {level} - {pid} will output message: INFO - 1123
          * @default false
@@ -75,36 +75,36 @@ declare namespace PinoPretty {
          * }
          * ```
          */
-        messageFormat?: false | string | MessageFormatFunc;
+        messageFormat?: false | string | MessageFormatFunc | undefined;
         /**
          * If set to true, will add color information to the formatted output message.
          * @default false
          */
-        colorize?: boolean;
+        colorize?: boolean | undefined;
         /**
          * Appends carriage return and line feed, instead of just a line feed, to the formatted log line.
          * @default false
          */
-        crlf?: boolean;
+        crlf?: boolean | undefined;
         /**
          * Define the log keys that are associated with error like objects.
          * @default ["err", "error"]
          */
-        errorLikeObjectKeys?: string[];
+        errorLikeObjectKeys?: string[] | undefined;
         /**
          *  When formatting an error object, display this list of properties.
          *  The list should be a comma separated list of properties.
          * @default ""
          */
-        errorProps?: string;
+        errorProps?: string | undefined;
         /**
          * Specify a search pattern according to {@link http://jmespath.org|jmespath}
          */
-        search?: string;
+        search?: string | undefined;
         /**
          * Ignore one or several keys.
          * @example "time,hostname"
          */
-        ignore?: string;
+        ignore?: string | undefined;
     }
 }

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -179,10 +179,10 @@ declare namespace P {
      */
     // TODO: use SonicBoom constructor options interface when available
     interface DestinationObjectOptions {
-        fd?: string | number;
-        dest?: string;
-        minLength?: number;
-        sync?: boolean;
+        fd?: string | number | undefined;
+        dest?: string | undefined;
+        minLength?: number | undefined;
+        sync?: boolean | undefined;
     }
 
     /**
@@ -245,59 +245,59 @@ declare namespace P {
         /**
          * Avoid error causes by circular references in the object tree. Default: `true`.
          */
-        safe?: boolean;
+        safe?: boolean | undefined;
         /**
          * The name of the logger. Default: `undefined`.
          */
-        name?: string;
+        name?: string | undefined;
         /**
          * an object containing functions for custom serialization of objects.
          * These functions should return an JSONifiable object and they should never throw. When logging an object,
          * each top-level property matching the exact key of a serializer will be serialized using the defined serializer.
          */
-        serializers?: { [key: string]: SerializerFn };
+        serializers?: { [key: string]: SerializerFn } | undefined;
         /**
          * Enables or disables the inclusion of a timestamp in the log message. If a function is supplied, it must
          * synchronously return a JSON string representation of the time. If set to `false`, no timestamp will be included in the output.
          * See stdTimeFunctions for a set of available functions for passing in as a value for this option.
          * Caution: any sort of formatted time will significantly slow down Pino's performance.
          */
-        timestamp?: TimeFn | boolean;
+        timestamp?: TimeFn | boolean | undefined;
         /**
          * One of the supported levels or `silent` to disable logging. Any other value defines a custom level and
          * requires supplying a level value via `levelVal`. Default: 'info'.
          */
-        level?: LevelWithSilent | string;
+        level?: LevelWithSilent | string | undefined;
         /**
          * Outputs the level as a string instead of integer. Default: `false`.
          */
-        useLevelLabels?: boolean;
+        useLevelLabels?: boolean | undefined;
         /**
          * Changes the property `level` to any string value you pass in. Default: 'level'
          */
-        levelKey?: string;
+        levelKey?: string | undefined;
         /**
          * (DEPRECATED, use `levelKey`) Changes the property `level` to any string value you pass in. Default: 'level'
          */
-        changeLevelName?: string;
+        changeLevelName?: string | undefined;
         /**
          * Use this option to define additional logging levels.
          * The keys of the object correspond the namespace of the log level, and the values should be the numerical value of the level.
          */
-        customLevels?: { [key: string]: number };
+        customLevels?: { [key: string]: number } | undefined;
         /**
          * Use this option to only use defined `customLevels` and omit Pino's levels.
          * Logger's default `level` must be changed to a value in `customLevels` in order to use `useOnlyCustomLevels`
          * Warning: this option may not be supported by downstream transports.
          */
-        useOnlyCustomLevels?: boolean;
+        useOnlyCustomLevels?: boolean | undefined;
 
         /**
          * If provided, the `mixin` function is called each time one of the active logging methods
          * is called. The function must synchronously return an object. The properties of the
          * returned object will be added to the logged JSON.
          */
-        mixin?: MixinFn;
+        mixin?: MixinFn | undefined;
 
         /**
          * As an array, the redact option specifies paths that should have their values redacted from any log output.
@@ -310,25 +310,25 @@ declare namespace P {
          *      censor (String): Optional. A value to overwrite key which are to be redacted. Default: '[Redacted]'
          *      remove (Boolean): Optional. Instead of censoring the value, remove both the key and the value. Default: false
          */
-        redact?: string[] | redactOptions;
+        redact?: string[] | redactOptions | undefined;
 
         /**
          * When defining a custom log level via level, set to an integer value to define the new level. Default: `undefined`.
          */
-        levelVal?: number;
+        levelVal?: number | undefined;
         /**
          * The string key for the 'message' in the JSON object. Default: "msg".
          */
-        messageKey?: string;
+        messageKey?: string | undefined;
         /**
          * The string key to place any logged object under.
          */
-        nestedKey?: string;
+        nestedKey?: string | undefined;
         /**
          * Enables pino.pretty. This is intended for non-production configurations. This may be set to a configuration
          * object as outlined in http://getpino.io/#/docs/API?id=pretty. Default: `false`.
          */
-        prettyPrint?: boolean | PrettyOptions;
+        prettyPrint?: boolean | PrettyOptions | undefined;
         /**
          * Allows to optionally define which prettifier module to use.
          */
@@ -344,7 +344,7 @@ declare namespace P {
         /**
          * Enables logging. Default: `true`.
          */
-        enabled?: boolean;
+        enabled?: boolean | undefined;
         /**
          * Browser only, see http://getpino.io/#/docs/browser.
          */
@@ -356,7 +356,7 @@ declare namespace P {
              * @example
              * pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
              */
-            asObject?: boolean;
+            asObject?: boolean | undefined;
             /**
              * Instead of passing log messages to `console.log` they can be passed to a supplied function. If `write` is
              * set to a single function, all logging objects are passed to this function. If `write` is an object, it
@@ -389,13 +389,13 @@ declare namespace P {
             write?:
                 | WriteFn
                 | ({
-                      fatal?: WriteFn;
-                      error?: WriteFn;
-                      warn?: WriteFn;
-                      info?: WriteFn;
-                      debug?: WriteFn;
-                      trace?: WriteFn;
-                  } & { [logLevel: string]: WriteFn });
+                      fatal?: WriteFn | undefined;
+                      error?: WriteFn | undefined;
+                      warn?: WriteFn | undefined;
+                      info?: WriteFn | undefined;
+                      debug?: WriteFn | undefined;
+                      trace?: WriteFn | undefined;
+                  } & { [logLevel: string]: WriteFn }) | undefined;
 
             /**
              * The serializers provided to `pino` are ignored by default in the browser, including the standard
@@ -452,7 +452,7 @@ declare namespace P {
              *   }
              * })
              */
-            serialize?: boolean | string[];
+            serialize?: boolean | string[] | undefined;
 
             /**
              * Options for transmission of logs.
@@ -484,19 +484,19 @@ declare namespace P {
                  * the `send` function will be called based on the main logging `level` (set via `options.level`,
                  * defaulting to `info`).
                  */
-                level?: Level | string;
+                level?: Level | string | undefined;
                 /**
                  * Remotely record log messages.
                  *
                  * @description Called after writing the log message.
                  */
                 send: (level: Level, logEvent: LogEvent) => void;
-            };
-        };
+            } | undefined;
+        } | undefined;
         /**
          * key-value object added as child logger to each log line. If set to null the base child logger is not added
          */
-        base?: { [key: string]: any } | null;
+        base?: { [key: string]: any } | null | undefined;
 
         /**
          * An object containing functions for formatting the shape of the log lines.
@@ -510,22 +510,22 @@ declare namespace P {
              * The default shape is { level: number }.
              * The function takes two arguments, the label of the level (e.g. 'info') and the numeric value (e.g. 30).
              */
-            level?: (label: string, number: number) => object;
+            level?: ((label: string, number: number) => object) | undefined;
             /**
              * Changes the shape of the bindings.
              * The default shape is { pid, hostname }.
              * The function takes a single argument, the bindings object.
              * It will be called every time a child logger is created.
              */
-            bindings?: (bindings: Bindings) => object;
+            bindings?: ((bindings: Bindings) => object) | undefined;
             /**
              * Changes the shape of the log object.
              * This function will be called every time one of the log methods (such as .info) is called.
              * All arguments passed to the log method, except the message, will be pass to this function.
              * By default it does not change the shape of the log object.
              */
-            log?: (object: object) => object;
-        };
+            log?: ((object: object) => object) | undefined;
+        } | undefined;
 
         /**
          * An object mapping to hook functions. Hook functions allow for customizing internal logger operations.
@@ -538,8 +538,8 @@ declare namespace P {
              * log method and method is the log method itself, and level is the log level. This hook must invoke the method function by
              * using apply, like so: method.apply(this, newArgumentsArray).
              */
-            logMethod?: (args: any[], method: LogFn, level: number) => void;
-        };
+            logMethod?: ((args: any[], method: LogFn, level: number) => void) | undefined;
+        } | undefined;
     }
 
     // Re-export for backward compatibility
@@ -547,7 +547,7 @@ declare namespace P {
         /**
          * Suppress warning on first synchronous flushing.
          */
-        suppressFlushSyncWarning?: boolean;
+        suppressFlushSyncWarning?: boolean | undefined;
     };
 
     type Level = "fatal" | "error" | "warn" | "info" | "debug" | "trace";
@@ -562,8 +562,8 @@ declare namespace P {
     type LogDescriptor = Record<string, any>; // TODO replace `any` with `unknown` when TypeScript version >= 3.0
 
     interface Bindings {
-        level?: Level | string;
-        serializers?: { [key: string]: SerializerFn };
+        level?: Level | string | undefined;
+        serializers?: { [key: string]: SerializerFn } | undefined;
         [key: string]: any;
     }
 
@@ -776,7 +776,7 @@ declare namespace P {
 
     interface redactOptions {
         paths: string[];
-        censor?: string | ((v: any) => any);
-        remove?: boolean;
+        censor?: string | ((v: any) => any) | undefined;
+        remove?: boolean | undefined;
     }
 }

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -253,7 +253,7 @@ pino({ name: "my-logger" }, destinationViaOptionsObject);
 
 interface StrictShape {
     activity: string;
-    err?: unknown;
+    err?: unknown | undefined;
 }
 
 info<StrictShape>({

--- a/types/pino/v3/index.d.ts
+++ b/types/pino/v3/index.d.ts
@@ -12,8 +12,8 @@ declare function P(options: P.LoggerOptions, stream: stream.Writable | stream.Du
 
 declare namespace P {
     function pretty(opts?: {
-        timeTransOnly?: boolean;
-        levelFirst?: boolean;
+        timeTransOnly?: boolean | undefined;
+        levelFirst?: boolean | undefined;
         formatter?(log: IPinoLog): string;
     }): stream.Transform;
 
@@ -48,23 +48,23 @@ declare namespace P {
 
     interface LoggerOptions {
         // avoid error causes by circular references in the object tree, default true
-        safe?: boolean;
+        safe?: boolean | undefined;
         // the name of the logger, default undefined
-        name?: string;
+        name?: string | undefined;
         // an object containing functions for custom serialization of objects.
         // These functions should return an JSONifiable object and they should never throw
-        serializers?: Serializers;
+        serializers?: Serializers | undefined;
         // Outputs ISO time stamps ('2016-03-09T15:18:53.889Z') instead of Epoch time stamps (1457536759176).
         // WARNING: This option carries a 25% performance drop, we recommend using default Epoch timestamps and transforming logs after if required.
         // The pino -t command will do this for you (see CLI). default false.
-        slowtime?: boolean;
+        slowtime?: boolean | undefined;
         // Enables extreme mode, yields an additional 60% performance (from 250ms down to 100ms per 10000 ops).
         // There are trade-off's should be understood before usage. See Extreme mode explained. default false
-        extreme?: boolean;
+        extreme?: boolean | undefined;
         // enables logging, defaults to true.
-        enabled?: boolean;
-        level?: Level | string;
-        levelVal?: number;
+        enabled?: boolean | undefined;
+        level?: Level | string | undefined;
+        levelVal?: number | undefined;
     }
 
     interface Pino {

--- a/types/pixelmatch/index.d.ts
+++ b/types/pixelmatch/index.d.ts
@@ -30,40 +30,40 @@ declare namespace Pixelmatch {
          * Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive.
          * @default 0.1
          */
-        readonly threshold?: number;
+        readonly threshold?: number | undefined;
         /**
          * If true, disables detecting and ignoring anti-aliased pixels.
          * @default false
          */
-        readonly includeAA?: boolean;
+        readonly includeAA?: boolean | undefined;
         /**
          * Blending factor of unchanged pixels in the diff output.
          * Ranges from 0 for pure white to 1 for original brightness
          * @default 0.1
          */
-        alpha?: number;
+        alpha?: number | undefined;
         /**
          * The color of anti-aliased pixels in the diff output.
          * @default [255, 255, 0]
          */
-        aaColor?: RGBTuple;
+        aaColor?: RGBTuple | undefined;
         /**
          * The color of differing pixels in the diff output.
          * @default [255, 0, 0]
          */
-        diffColor?: RGBTuple;
+        diffColor?: RGBTuple | undefined;
         /**
          * An alternative color to use for dark on light differences to differentiate between "added" and "removed" parts.
          * If not provided, all differing pixels use the color specified by `diffColor`.
          * @default null
          */
-        diffColorAlt?: RGBTuple;
+        diffColorAlt?: RGBTuple | undefined;
         /**
          * Draw the diff over a transparent background (a mask), rather than over the original image.
          * Will not draw anti-aliased pixels (if detected)
          * @default false
          */
-        diffMask?: boolean;
+        diffMask?: boolean | undefined;
     }
 }
 

--- a/types/plaid-link/index.d.ts
+++ b/types/plaid-link/index.d.ts
@@ -21,20 +21,20 @@ export namespace Plaid {
         key: string;
         env: Environment;
         onSuccess: OnSuccess;
-        onExit?: OnExit;
-        onEvent?: OnEvent;
-        onLoad?: OnLoad;
-        language?: Language;
-        linkCustomizationName?: string;
-        countryCodes?: Country[];
-        webhook?: string;
-        userLegalName?: string;
-        userEmailAddress?: string;
-        token?: string;
-        isWebView?: boolean;
-        oauthNonce?: string;
-        oauthRedirectUri?: string;
-        oauthStateId?: string;
+        onExit?: OnExit | undefined;
+        onEvent?: OnEvent | undefined;
+        onLoad?: OnLoad | undefined;
+        language?: Language | undefined;
+        linkCustomizationName?: string | undefined;
+        countryCodes?: Country[] | undefined;
+        webhook?: string | undefined;
+        userLegalName?: string | undefined;
+        userEmailAddress?: string | undefined;
+        token?: string | undefined;
+        isWebView?: boolean | undefined;
+        oauthNonce?: string | undefined;
+        oauthRedirectUri?: string | undefined;
+        oauthStateId?: string | undefined;
     }
 
     type OnSuccess = (public_token: string, metadata: OnSuccessMetaData) => void;

--- a/types/platform/index.d.ts
+++ b/types/platform/index.d.ts
@@ -13,14 +13,14 @@ interface Platform {
     /**
      * The platform description.
      */
-    description?: string;
+    description?: string | undefined;
     /**
      * The name of the browser's layout engine.
      *
      * The list of common layout engines include:
      * "Blink", "EdgeHTML", "Gecko", "Trident" and "WebKit"
      */
-    layout?: string;
+    layout?: string | undefined;
     /**
      * The name of the product's manufacturer.
      *
@@ -29,7 +29,7 @@ interface Platform {
      * "Google", "HP", "HTC", "LG", "Microsoft", "Motorola", "Nintendo",
      * "Nokia", "Samsung" and "Sony"
      */
-    manufacturer?: string;
+    manufacturer?: string | undefined;
     /**
      * The name of the browser/environment.
      *
@@ -41,11 +41,11 @@ interface Platform {
      * Mobile versions of some browsers have "Mobile" appended to their name:
      * eg. "Chrome Mobile", "Firefox Mobile", "IE Mobile" and "Opera Mobile"
      */
-    name?: string;
+    name?: string | undefined;
     /**
      * The alpha/beta release indicator.
      */
-    prerelease?: string;
+    prerelease?: string | undefined;
     /**
      * The name of the product hosting the browser.
      *
@@ -54,19 +54,19 @@ interface Platform {
      * "BlackBerry", "Galaxy S4", "Lumia", "iPad", "iPod", "iPhone", "Kindle",
      * "Kindle Fire", "Nexus", "Nook", "PlayBook", "TouchPad" and "Transformer"
      */
-    product?: string;
+    product?: string | undefined;
     /**
      * The browser's user agent string.
      */
-    ua?: string;
+    ua?: string | undefined;
     /**
      * The version of the OS.
      */
-    version?: string;
+    version?: string | undefined;
     /**
      * The name of the operating system.
      */
-    os?: OperatingSystem;
+    os?: OperatingSystem | undefined;
     /**
      * Creates a new platform object.
      * @param [ua=navigator.userAgent] The user agent string or
@@ -83,7 +83,7 @@ interface OperatingSystem {
     /**
      * The CPU architecture the OS is built for.
      */
-    architecture?: number;
+    architecture?: number | undefined;
     /**
      * The family of the OS.
      *
@@ -92,11 +92,11 @@ interface OperatingSystem {
      * "Windows XP", "OS X", "Linux", "Ubuntu", "Debian", "Fedora", "Red Hat",
      * "SuSE", "Android", "iOS" and "Windows Phone"
      */
-    family?: string;
+    family?: string | undefined;
     /**
      * The version of the OS.
      */
-    version?: string;
+    version?: string | undefined;
     /**
      * Returns the OS string.
      */

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -88,8 +88,8 @@ export type PlotSelectedData = Partial<PlotDatum>;
 
 export interface PlotSelectionEvent {
     points: PlotDatum[];
-    range?: SelectionRange;
-    lassoPoints?: SelectionRange;
+    range?: SelectionRange | undefined;
+    lassoPoints?: SelectionRange | undefined;
 }
 
 export interface PlotRestyleEventUpdate {
@@ -105,12 +105,12 @@ export interface PlotScene {
 }
 
 export interface PlotRelayoutEvent extends Partial<Layout> {
-    'xaxis.range[0]'?: number;
-    'xaxis.range[1]'?: number;
-    'yaxis.range[0]'?: number;
-    'yaxis.range[1]'?: number;
-    'xaxis.autorange'?: boolean;
-    'yaxis.autorange'?: boolean;
+    'xaxis.range[0]'?: number | undefined;
+    'xaxis.range[1]'?: number | undefined;
+    'yaxis.range[0]'?: number | undefined;
+    'yaxis.range[1]'?: number | undefined;
+    'xaxis.autorange'?: boolean | undefined;
+    'yaxis.autorange'?: boolean | undefined;
 }
 
 export interface ClickAnnotationEvent {
@@ -280,7 +280,7 @@ export interface ToImgopts {
     format: 'jpeg' | 'png' | 'webp' | 'svg';
     width: number;
     height: number;
-    scale?: number;
+    scale?: number | undefined;
 }
 
 export interface DownloadImgopts {
@@ -877,14 +877,14 @@ export type ModeBarDefaultButtons =
 export type ButtonClickEvent = (gd: PlotlyHTMLElement, ev: MouseEvent) => void;
 
 export interface Icon {
-    height?: number;
-    width?: number;
-    ascent?: number;
-    descent?: number;
-    name?: string;
-    path?: string;
-    svg?: string;
-    transform?: string;
+    height?: number | undefined;
+    width?: number | undefined;
+    ascent?: number | undefined;
+    descent?: number | undefined;
+    name?: string | undefined;
+    path?: string | undefined;
+    svg?: string | undefined;
+    transform?: string | undefined;
 }
 
 export interface ModeBarButton {
@@ -904,7 +904,7 @@ export interface ModeBarButton {
     icon: string | Icon;
 
     /** icon positioning */
-    gravity?: string;
+    gravity?: string | undefined;
 
     /**
      * click handler associated with the button, a function of
@@ -917,13 +917,13 @@ export interface ModeBarButton {
      * attribute associated with button,
      * use this with 'val' to keep track of the state
      */
-    attr?: string;
+    attr?: string | undefined;
 
     /** initial 'attr' value, can be a function of gd */
     val?: any;
 
     /** is the button a toggle button? */
-    toggle?: boolean;
+    toggle?: boolean | undefined;
 }
 
 export interface GaugeLine {
@@ -989,8 +989,8 @@ export interface PlotNumber {
 }
 
 export interface Template {
-    data?: { [type in PlotType]?: Partial<PlotData> };
-    layout?: Partial<Layout>;
+    data?: { [type in PlotType]?: Partial<PlotData> } | undefined;
+    layout?: Partial<Layout> | undefined;
 }
 
 // Data
@@ -1021,12 +1021,12 @@ export type ErrorBar = Partial<ErrorOptions> &
         | {
               type: 'constant' | 'percent';
               value: number;
-              valueminus?: number;
+              valueminus?: number | undefined;
           }
         | {
               type: 'data';
               array: Datum[];
-              arrayminus?: Datum[];
+              arrayminus?: Datum[] | undefined;
           }
     );
 
@@ -1303,9 +1303,9 @@ export interface TransformStyle {
 
 export interface TransformAggregation {
     target: string;
-    func?: 'count' | 'sum' | 'avg' | 'median' | 'mode' | 'rms' | 'stddev' | 'min' | 'max' | 'first' | 'last';
-    funcmode?: 'sample' | 'population';
-    enabled?: boolean;
+    func?: 'count' | 'sum' | 'avg' | 'median' | 'mode' | 'rms' | 'stddev' | 'min' | 'max' | 'first' | 'last' | undefined;
+    funcmode?: 'sample' | 'population' | undefined;
+    enabled?: boolean | undefined;
 }
 
 export interface Transform {
@@ -1376,32 +1376,32 @@ export type MarkerSymbol = string | number | Array<string | number>;
  */
 export interface PlotMarker {
     symbol: MarkerSymbol;
-    color?: Color | Color[];
-    colors?: Color[];
-    colorscale?: ColorScale;
-    cauto?: boolean;
-    cmax?: number;
-    cmin?: number;
-    autocolorscale?: boolean;
-    reversescale?: boolean;
+    color?: Color | Color[] | undefined;
+    colors?: Color[] | undefined;
+    colorscale?: ColorScale | undefined;
+    cauto?: boolean | undefined;
+    cmax?: number | undefined;
+    cmin?: number | undefined;
+    autocolorscale?: boolean | undefined;
+    reversescale?: boolean | undefined;
     opacity: number | number[];
     size: number | number[];
-    maxdisplayed?: number;
-    sizeref?: number;
-    sizemax?: number;
-    sizemin?: number;
-    sizemode?: 'diameter' | 'area';
-    showscale?: boolean;
+    maxdisplayed?: number | undefined;
+    sizeref?: number | undefined;
+    sizemax?: number | undefined;
+    sizemin?: number | undefined;
+    sizemode?: 'diameter' | 'area' | undefined;
+    showscale?: boolean | undefined;
     line: Partial<ScatterMarkerLine>;
-    pad?: Partial<Padding>;
-    width?: number;
-    colorbar?: Partial<ColorBar>;
+    pad?: Partial<Padding> | undefined;
+    width?: number | undefined;
+    colorbar?: Partial<ColorBar> | undefined;
     gradient?: {
         type: 'radial' | 'horizontal' | 'vertical' | 'none';
         color: Color;
         typesrc: any;
         colorsrc: any;
-    };
+    } | undefined;
 }
 
 export type ScatterMarker = PlotMarker;
@@ -1409,14 +1409,14 @@ export type ScatterMarker = PlotMarker;
 export interface ScatterMarkerLine {
     width: number | number[];
     color: Color;
-    cauto?: boolean;
-    cmax?: number;
-    cmin?: number;
-    cmid?: number;
-    colorscale?: ColorScale;
-    autocolorscale?: boolean;
-    reversescale?: boolean;
-    coloraxis?: string;
+    cauto?: boolean | undefined;
+    cmax?: number | undefined;
+    cmin?: number | undefined;
+    cmid?: number | undefined;
+    colorscale?: ColorScale | undefined;
+    autocolorscale?: boolean | undefined;
+    reversescale?: boolean | undefined;
+    coloraxis?: string | undefined;
 }
 
 export interface ScatterLine {
@@ -2038,7 +2038,7 @@ export interface Transition {
      * Determines whether the figure's layout or traces smoothly transitions during updates that make both traces
      * and layout change. Default is "layout first".
      */
-    ordering?: 'layout first' | 'traces first';
+    ordering?: 'layout first' | 'traces first' | undefined;
 }
 
 export interface SliderStep {

--- a/types/plotly.js/lib/traces/candlestick.d.ts
+++ b/types/plotly.js/lib/traces/candlestick.d.ts
@@ -65,20 +65,20 @@ export interface CandlestickData {
     /**
      * @default width=2
      */
-    line: { width?: number };
+    line: { width?: number | undefined };
 
     increasing: {
         line?: {
-            color?: string;
-            width?: number;
-        };
+            color?: string | undefined;
+            width?: number | undefined;
+        } | undefined;
     };
 
     decreasing: {
         line?: {
-            color?: string;
-            width?: number;
-        };
+            color?: string | undefined;
+            width?: number | undefined;
+        } | undefined;
     };
 
     hoverlabel: OhclData['hoverlabel'];

--- a/types/plotly.js/lib/traces/ohcl.d.ts
+++ b/types/plotly.js/lib/traces/ohcl.d.ts
@@ -75,30 +75,30 @@ export interface OhclData {
     selectedpoints: any; // TODO: further refine
     increasing: {
         line?: {
-            color?: string;
-            width?: number;
-            dash?: Dash;
-        };
+            color?: string | undefined;
+            width?: number | undefined;
+            dash?: Dash | undefined;
+        } | undefined;
     };
     decreasing: {
         line?: {
-            color?: string;
-            width?: number;
-            dash?: Dash;
-        };
+            color?: string | undefined;
+            width?: number | undefined;
+            dash?: Dash | undefined;
+        } | undefined;
     };
 
     hoverlabel: {
-        bgcolor?: string | string[];
-        bordercolor?: string | string[];
+        bgcolor?: string | string[] | undefined;
+        bordercolor?: string | string[] | undefined;
         font?: {
-            family?: string | string[];
-            size?: number;
-            color?: string | string[];
-        };
-        align?: 'left' | 'right' | 'auto';
-        namelength?: number | number[];
-        split?: boolean;
+            family?: string | string[] | undefined;
+            size?: number | undefined;
+            color?: string | string[] | undefined;
+        } | undefined;
+        align?: 'left' | 'right' | 'auto' | undefined;
+        namelength?: number | number[] | undefined;
+        split?: boolean | undefined;
     };
     tickwidth: number;
     xcalendar: XCalendar;

--- a/types/pngjs/index.d.ts
+++ b/types/pngjs/index.d.ts
@@ -60,14 +60,14 @@ export class PNG extends Duplex {
 }
 
 export interface BaseOptions {
-    fill?: boolean;
-    height?: number;
-    width?: number;
+    fill?: boolean | undefined;
+    height?: number | undefined;
+    width?: number | undefined;
 }
 
 export interface ParserOptions {
-    checkCRC?: boolean;
-    skipRescale?: boolean;
+    checkCRC?: boolean | undefined;
+    skipRescale?: boolean | undefined;
 }
 
 export interface PackerOptions {
@@ -75,16 +75,16 @@ export interface PackerOptions {
         red: number;
         green: number;
         blue: number;
-    };
-    bitDepth?: BitDepth;
-    colorType?: ColorType;
-    deflateChunkSize?: number;
-    deflateFactory?: typeof createDeflate;
-    deflateLevel?: number;
-    deflateStrategy?: number;
-    filterType?: number | number[];
-    inputColorType?: ColorType;
-    inputHasAlpha?: boolean;
+    } | undefined;
+    bitDepth?: BitDepth | undefined;
+    colorType?: ColorType | undefined;
+    deflateChunkSize?: number | undefined;
+    deflateFactory?: typeof createDeflate | undefined;
+    deflateLevel?: number | undefined;
+    deflateStrategy?: number | undefined;
+    filterType?: number | number[] | undefined;
+    inputColorType?: ColorType | undefined;
+    inputHasAlpha?: boolean | undefined;
 }
 
 export type PNGOptions = BaseOptions & ParserOptions & PackerOptions;

--- a/types/podium/index.d.ts
+++ b/types/podium/index.d.ts
@@ -43,7 +43,7 @@ interface Podium {
      * @param callback  an optional callback method invoked when all subscribers have been notified using the signature function()
      * @see {@link https://github.com/hapijs/podium/blob/master/API.md#podiumemitcriteria-data-callback}
      */
-    emit(criteria: string | {name: string, channel?: string, tags?: string | string[]}, data: any, callback?: (() => void)): void;
+    emit(criteria: string | {name: string, channel?: string | undefined, tags?: string | string[] | undefined}, data: any, callback?: (() => void)): void;
 
     /**
      * podium.on(criteria, listener)
@@ -114,15 +114,15 @@ declare namespace Podium {
         /** the event name string (required). */
         name: string;
         /** a string or array of strings specifying the event channels available. Defaults to no channel restrictions (event updates can specify a channel or not). */
-        channels?: string | string[];
+        channels?: string | string[] | undefined;
         /** if true, the data object passed to podium.emit() is cloned before it is passed to the listeners (unless an override specified by each listener). Defaults to false (data is passed as-is). */
-        clone?: boolean;
+        clone?: boolean | undefined;
         /** if true, the data object passed to podium.emit() must be an array and the listener method is called with each array element passed as a separate argument (unless an override specified by each listener). This should only be used when the emitted data structure is known and predictable. Defaults to false (data is emitted as a single argument regardless of its type). */
-        spread?: boolean;
+        spread?: boolean | undefined;
         /** if true and the criteria object passed to podium.emit() includes tags, the tags are mapped to an object (where each tag string is the key and the value is true) which is appended to the arguments list at the end (but before the callback argument if block is set). A configuration override can be set by each listener. Defaults to false. */
-        tags?: boolean;
+        tags?: boolean | undefined;
         /** if true, the same event name can be registered multiple times where the second registration is ignored. Note that if the registration config is changed between registrations, only the first configuration is used. Defaults to false (a duplicate registration will throw an error). */
-        shared?: boolean;
+        shared?: boolean | undefined;
     }
 
     /**
@@ -134,26 +134,26 @@ declare namespace Podium {
         /** the event name string (required). */
         name: string;
         /** if true, the listener method receives an additional callback argument which must be called when the method completes. No other event will be emitted until the callback methods is called. The method signature is function(). If block is set to a positive integer, the value is used to set a timeout after which any pending events will be emitted, ignoring the eventual call to callback. Defaults to false (non blocking). */
-        block?: boolean | number;
+        block?: boolean | number | undefined;
         /** a string or array of strings specifying the event channels to subscribe to. If the event registration specified a list of allowed channels, the channels array must match the allowed channels. If channels are specified, event updates without any channel designation will not be included in the subscription. Defaults to no channels filter. */
-        channels?: string | string[];
+        channels?: string | string[] | undefined;
         /** if true, the data object passed to podium.emit() is cloned before it is passed to the listener method. Defaults to the event registration option (which defaults to false). */
-        clone?: boolean;
+        clone?: boolean | undefined;
         /** a positive integer indicating the number of times the listener can be called after which the subscription is automatically removed. A count of 1 is the same as calling podium.once(). Defaults to no limit. */
-        count?: number;
+        count?: number | undefined;
         /**
          * the event tags (if present) to subscribe to which can be one of:
          *  * a tag string.
          *  * an array of tag strings.
          *  * an object with the following:
          */
-        filter?: string | string[] | CriteriaFilterOptionsObject;
+        filter?: string | string[] | CriteriaFilterOptionsObject | undefined;
         /** if true, and the data object passed to podium.emit() is an array, the listener method is called with each array element passed as a separate argument. This should only be used when the emitted data structure is known and predictable. Defaults to the event registration option (which defaults to false). */
-        spread?: boolean;
+        spread?: boolean | undefined;
         /** if true and the criteria object passed to podium.emit() includes tags, the tags are mapped to an object (where each tag string is the key and the value is true) which is appended to the arguments list at the end (but before the callback argument if block is set). Defaults to the event registration option (which defaults to false). */
-        tags?: boolean;
+        tags?: boolean | undefined;
         /** the handler method set to receive event updates. The function signature depends on the block, spread, and tags options. */
-        listener?: Listener;
+        listener?: Listener | undefined;
     }
 
     /**
@@ -161,9 +161,9 @@ declare namespace Podium {
      */
     export interface CriteriaFilterOptionsObject {
         /** a tag string or array of tag strings. */
-        tags?: string | string[];
+        tags?: string | string[] | undefined;
         /** if true, all tags must be present for the event update to match the subscription. Defaults to false (at least one matching tag). */
-        all?: boolean;
+        all?: boolean | undefined;
     }
 
     /**

--- a/types/pollyjs__core/index.d.ts
+++ b/types/pollyjs__core/index.d.ts
@@ -21,56 +21,56 @@ export const Timing: {
 export type MatchBy<T = string, R = T> = (input: T, req: Request) => R;
 export type Headers = Record<string, string | string[]>;
 export interface PollyConfig {
-    mode?: MODE;
+    mode?: MODE | undefined;
 
-    adapters?: Array<string | typeof Adapter>;
+    adapters?: Array<string | typeof Adapter> | undefined;
     adapterOptions?: {
-        fetch?: { context?: any };
-        puppeteer?: { page?: any; requestResourceTypes?: string[] };
-        xhr?: { context?: any };
+        fetch?: { context?: any } | undefined;
+        puppeteer?: { page?: any; requestResourceTypes?: string[] | undefined } | undefined;
+        xhr?: { context?: any } | undefined;
         [key: string]: any;
-    };
+    } | undefined;
 
-    persister?: string | typeof Persister;
+    persister?: string | typeof Persister | undefined;
     persisterOptions?: {
-        keepUnusedRequests?: boolean;
-        disableSortingHarEntries?: boolean;
-        fs?: { recordingsDir?: string };
-        'local-storage'?: { context?: any; key?: string };
-        rest?: { host?: string; apiNamespace?: string };
+        keepUnusedRequests?: boolean | undefined;
+        disableSortingHarEntries?: boolean | undefined;
+        fs?: { recordingsDir?: string | undefined } | undefined;
+        'local-storage'?: { context?: any; key?: string | undefined } | undefined;
+        rest?: { host?: string | undefined; apiNamespace?: string | undefined } | undefined;
         [key: string]: any;
-    };
+    } | undefined;
 
-    logging?: boolean;
-    flushRequestsOnStop?: boolean;
+    logging?: boolean | undefined;
+    flushRequestsOnStop?: boolean | undefined;
 
-    recordIfMissing?: boolean;
-    recordFailedRequests?: boolean;
-    expiryStrategy?: EXPIRY_STRATEGY;
+    recordIfMissing?: boolean | undefined;
+    recordFailedRequests?: boolean | undefined;
+    expiryStrategy?: EXPIRY_STRATEGY | undefined;
 
-    expiresIn?: string | null;
-    timing?: ((ms: number) => Promise<void>) | (() => Promise<void>);
+    expiresIn?: string | null | undefined;
+    timing?: ((ms: number) => Promise<void>) | (() => Promise<void>) | undefined;
 
     matchRequestsBy?: {
-        method?: boolean | MatchBy;
-        headers?: boolean | { exclude: string[] } | MatchBy<Headers>;
-        body?: boolean | MatchBy<any>;
-        order?: boolean;
+        method?: boolean | MatchBy | undefined;
+        headers?: boolean | { exclude: string[] } | MatchBy<Headers> | undefined;
+        body?: boolean | MatchBy<any> | undefined;
+        order?: boolean | undefined;
 
         url?:
             | boolean
             | MatchBy
             | {
-                  protocol?: boolean | MatchBy;
-                  username?: boolean | MatchBy;
-                  password?: boolean | MatchBy;
-                  hostname?: boolean | MatchBy;
-                  port?: boolean | MatchBy<number>;
-                  pathname?: boolean | MatchBy;
-                  query?: boolean | MatchBy<{ [key: string]: any }>;
-                  hash?: boolean | MatchBy;
-              };
-    };
+                  protocol?: boolean | MatchBy | undefined;
+                  username?: boolean | MatchBy | undefined;
+                  password?: boolean | MatchBy | undefined;
+                  hostname?: boolean | MatchBy | undefined;
+                  port?: boolean | MatchBy<number> | undefined;
+                  pathname?: boolean | MatchBy | undefined;
+                  query?: boolean | MatchBy<{ [key: string]: any }> | undefined;
+                  hash?: boolean | MatchBy | undefined;
+              } | undefined;
+    } | undefined;
 }
 export interface HTTPBase {
     headers: Headers;
@@ -100,11 +100,11 @@ export interface Request extends HTTPBase {
     query: { [key: string]: string | string[] };
     readonly params: { [key: string]: string };
     recordingName: string;
-    responseTime?: number;
-    timestamp?: string;
+    responseTime?: number | undefined;
+    timestamp?: string | undefined;
     didRespond: boolean;
-    id?: string;
-    order?: number;
+    id?: string | undefined;
+    order?: number | undefined;
     action: ACTION | null;
 }
 export interface Response extends HTTPBase {

--- a/types/postcss-calc/index.d.ts
+++ b/types/postcss-calc/index.d.ts
@@ -8,11 +8,11 @@ import { Plugin } from "postcss";
 
 declare namespace calc {
     interface Options {
-        precision?: number;
-        preserve?: boolean;
-        warnWhenCannotResolve?: boolean;
-        mediaQueries?: boolean;
-        selectors?: boolean;
+        precision?: number | undefined;
+        preserve?: boolean | undefined;
+        warnWhenCannotResolve?: boolean | undefined;
+        mediaQueries?: boolean | undefined;
+        selectors?: boolean | undefined;
     }
 
     type Calc = Plugin<Options>;

--- a/types/postcss-custom-properties/index.d.ts
+++ b/types/postcss-custom-properties/index.d.ts
@@ -29,10 +29,10 @@ declare namespace postcssCustomProperties {
     interface CustomPropertiesObject {
         customProperties?: {
             [name: string]: string;
-        };
+        } | undefined;
         ['custom-properties']?: {
             [name: string]: string;
-        };
+        } | undefined;
     }
 
     interface Options {
@@ -42,7 +42,7 @@ declare namespace postcssCustomProperties {
          * By default, both of these are preserved
          * @see {@link https://github.com/postcss/postcss-custom-properties#preserve}
          */
-        preserve?: boolean;
+        preserve?: boolean | undefined;
         /**
          * The importFrom option specifies sources where Custom Properties can be imported from,
          * which might be CSS, JS, and JSON files, functions, and directly passed objects.
@@ -50,7 +50,7 @@ declare namespace postcssCustomProperties {
          * JavaScript files, JSON files, functions, and objects will need to namespace Custom Properties using the customProperties or custom-properties key.
          * @see {@link https://github.com/postcss/postcss-custom-properties#importfrom}
          */
-        importFrom?: ImportSources | ImportSources[];
+        importFrom?: ImportSources | ImportSources[] | undefined;
         /**
          * The exportTo option specifies destinations where Custom Properties can be exported to,
          * which might be CSS, JS, and JSON files, functions, and directly passed objects.
@@ -58,7 +58,7 @@ declare namespace postcssCustomProperties {
          * JavaScript files, JSON files, and objects will need to namespace Custom Properties using the customProperties or custom-properties key.
          * @see {@link https://github.com/postcss/postcss-custom-properties#exportto}
          */
-        exportTo?: ExportSources | ExportSources[];
+        exportTo?: ExportSources | ExportSources[] | undefined;
     }
 
     type CustomPropertiesPlugin = Plugin<Options> & {

--- a/types/postcss-flexbugs-fixes/index.d.ts
+++ b/types/postcss-flexbugs-fixes/index.d.ts
@@ -12,15 +12,15 @@ declare namespace postcssFlexbugsFixes {
         /**
          * @default true
          */
-        bug4?: boolean;
+        bug4?: boolean | undefined;
         /**
          * @default true
          */
-        bug6?: boolean;
+        bug6?: boolean | undefined;
         /**
          * @default true
          */
-        bug81a?: boolean;
+        bug81a?: boolean | undefined;
     }
 }
 

--- a/types/postcss-focus-within/index.d.ts
+++ b/types/postcss-focus-within/index.d.ts
@@ -18,13 +18,13 @@ declare namespace focusWithin {
          * By default, the original selector is preserved.
          * @default true
          */
-        preserve?: boolean;
+        preserve?: boolean | undefined;
         /**
          * The replaceWith option defines the selector to replace `:focus-within`.
          * By default, the replacement selector is `[focus-within]`.
          * @default `[focus-within]`
          */
-        replaceWith?: string;
+        replaceWith?: string | undefined;
     }
 
     type FocusWithin = Plugin<Options>;

--- a/types/postcss-gap-properties/index.d.ts
+++ b/types/postcss-gap-properties/index.d.ts
@@ -10,7 +10,7 @@ declare namespace GapProperties {
         /**
          * @default true
          */
-        preserve?: boolean;
+        preserve?: boolean | undefined;
     }
 
     type GapPropertiesPlugin = Plugin<Options>;

--- a/types/postcss-import/index.d.ts
+++ b/types/postcss-import/index.d.ts
@@ -35,33 +35,33 @@ declare namespace atImport {
          *
          * Default: `process.cwd()` or dirname of [the postcss from](https://github.com/postcss/postcss#node-source)
          */
-        root?: string;
+        root?: string | undefined;
 
         /**
          * A string or an array of paths in where to look for files.
          */
-        path?: string | string[];
+        path?: string | string[] | undefined;
 
         /**
          * An array of plugins to be applied on each imported files.
          */
-        plugins?: AcceptedPlugin[];
+        plugins?: AcceptedPlugin[] | undefined;
 
         /**
          * You can provide a custom path resolver with this option. This function gets `(id, basedir, importOptions)` arguments and should return a path, an array of paths or a promise resolving to
          * the path(s). If you do not return an absolute path, your path will be resolved to an absolute path using the default resolver. You can use
          * [resolve](https://github.com/substack/node-resolve) for this.
          */
-        resolve?: (
+        resolve?: ((
             id: string,
             basedir: string,
             importOptions: AtImportOptions,
-        ) => string | string[] | PromiseLike<string | string[]>;
+        ) => string | string[] | PromiseLike<string | string[]>) | undefined;
 
         /**
          * You can overwrite the default loading way by setting this option. This function gets `(filename, importOptions)` arguments and returns content or promised content.
          */
-        load?: (filename: string, importOptions: AtImportOptions) => string | Promise<string>;
+        load?: ((filename: string, importOptions: AtImportOptions) => string | Promise<string>) | undefined;
 
         /**
          * By default, similar files (based on the same content) are being skipped. It's to optimize output and skip similar files like `normalize.css` for example. If this behavior is not what you
@@ -69,13 +69,13 @@ declare namespace atImport {
          *
          * @default true
          */
-        skipDuplicates?: boolean;
+        skipDuplicates?: boolean | undefined;
 
         /**
          * An array of folder names to add to Node's resolver. Values will be appended to the default resolve directories: `["node_modules", "web_modules"]`.
          *
          * This option is only for adding additional directories to default resolver. If you provide your own resolver via the `resolve` configuration option above, then this value will be ignored.
          */
-        addModulesDirectories?: string[];
+        addModulesDirectories?: string[] | undefined;
     }
 }

--- a/types/postcss-modules-extract-imports/index.d.ts
+++ b/types/postcss-modules-extract-imports/index.d.ts
@@ -6,8 +6,8 @@ import { PluginCreator } from 'postcss';
 
 declare namespace extractImports {
     interface Options {
-        failOnWrongOrder?: boolean;
-        createImportedName?: (importName: string, importPath: string) => string;
+        failOnWrongOrder?: boolean | undefined;
+        createImportedName?: ((importName: string, importPath: string) => string) | undefined;
     }
 }
 

--- a/types/postcss-modules-local-by-default/index.d.ts
+++ b/types/postcss-modules-local-by-default/index.d.ts
@@ -8,8 +8,8 @@ import { Plugin } from "postcss";
 
 declare namespace localByDefault {
     interface Options {
-        mode?: "global" | "local" | "pure";
-        rewriteUrl?: (global: boolean, url: string) => string;
+        mode?: "global" | "local" | "pure" | undefined;
+        rewriteUrl?: ((global: boolean, url: string) => string) | undefined;
     }
 
     type LocalByDefault = Plugin<Options>;

--- a/types/postcss-modules-scope/index.d.ts
+++ b/types/postcss-modules-scope/index.d.ts
@@ -8,7 +8,7 @@ import { Plugin } from "postcss";
 
 declare namespace scope {
     interface Options {
-        generateScopedName?: (exportedName: string, path: string, css: string) => string;
+        generateScopedName?: ((exportedName: string, path: string, css: string) => string) | undefined;
     }
 
     type Scope = Plugin<Options>;

--- a/types/postcss-normalize/index.d.ts
+++ b/types/postcss-normalize/index.d.ts
@@ -10,17 +10,17 @@ declare namespace Normalize {
         /**
          * @default false
          */
-        allowDuplicates?: boolean;
+        allowDuplicates?: boolean | undefined;
 
         /**
          * @default null
          */
-        forceImport?: boolean | string;
+        forceImport?: boolean | string | undefined;
 
         /**
          * @default null
          */
-        browsers?: string;
+        browsers?: string | undefined;
     }
 
     type NormalizePlugin = Plugin<Options>;

--- a/types/postcss-preset-env/index.d.ts
+++ b/types/postcss-preset-env/index.d.ts
@@ -23,7 +23,7 @@ declare namespace postcssPresetEnv {
          * Without any configuration options, PostCSS Preset Env enables
          * **Stage 2** features.
          */
-        stage?: number;
+        stage?: number | undefined;
 
         /**
          * The features option enables or disables specific polyfills by ID.
@@ -36,7 +36,7 @@ declare namespace postcssPresetEnv {
          * Any polyfills not explicitly enabled or disabled through `features`
          * are determined by the `stage` option.
          */
-        features?: pluginOptions.features;
+        features?: pluginOptions.features | undefined;
 
         /**
          * The browsers option determines which polyfills are required based upon
@@ -51,7 +51,7 @@ declare namespace postcssPresetEnv {
          *
          * @default default
          */
-        browsers?: string | string[];
+        browsers?: string | string[] | undefined;
 
         /**
          * The `insertAfter` keys allow you to insert other PostCSS plugins
@@ -59,7 +59,7 @@ declare namespace postcssPresetEnv {
          * PostCSS plugins that must execute before or after certain polyfills.
          * `insertAfter` support chaining one or multiple plugins.
          */
-        insertAfter?: object;
+        insertAfter?: object | undefined;
 
         /**
          * The `insertBefore` keys allow you to insert other PostCSS plugins
@@ -67,7 +67,7 @@ declare namespace postcssPresetEnv {
          * PostCSS plugins that must execute before or after certain polyfills.
          * `insertBefore` support chaining one or multiple plugins.
          */
-        insertBefore?: object;
+        insertBefore?: object | undefined;
 
         /**
          * PostCSS Preset Env includes
@@ -80,14 +80,14 @@ declare namespace postcssPresetEnv {
          *
          * Passing `autoprefixer: false` disables autoprefixer.
          */
-        autoprefixer?: boolean | AutoprefixerOptions;
+        autoprefixer?: boolean | AutoprefixerOptions | undefined;
 
         /**
          * The `preserve` option determines whether all plugins should receive
          * a `preserve` option, which may preserve or remove otherwise-polyfilled CSS.
          * By default, this option is not configured.
          */
-        preserve?: boolean;
+        preserve?: boolean | undefined;
 
         /**
          * The `importFrom` option specifies sources where variables like
@@ -95,7 +95,7 @@ declare namespace postcssPresetEnv {
          * Environment Variables can be imported from, which might be
          * CSS, JS, and JSON files, functions, and directly passed objects.
          */
-        importFrom?: string | any[];
+        importFrom?: string | any[] | undefined;
 
         /**
          * The `exportTo` option specifies destinations where variables like
@@ -103,44 +103,44 @@ declare namespace postcssPresetEnv {
          * Environment Variables can be exported to, which might be
          * CSS, JS, and JSON files, functions, and directly passed objects.
          */
-        exportTo?: string | any[];
+        exportTo?: string | any[] | undefined;
     }
 
     namespace pluginOptions {
         interface features {
-            'all-property'?: boolean | object;
-            'any-link-pseudo-class'?: boolean | object;
-            'blank-pseudo-class'?: boolean | object;
-            'break-properties'?: boolean | object;
-            'case-insensitive-attributes'?: boolean | object;
-            'color-functional-notation'?: boolean | object;
-            'color-mod-function'?: boolean | object;
-            'custom-media-queries'?: boolean | object;
-            'custom-properties'?: boolean | object;
-            'custom-selectors'?: boolean | object;
-            'dir-pseudo-class'?: boolean | object;
-            'double-position-gradients'?: boolean | object;
-            'environment-variables'?: boolean | object;
-            'focus-visible-pseudo-class'?: boolean | object;
-            'focus-within-pseudo-class'?: boolean | object;
-            'font-variant-property'?: boolean | object;
-            'gap-properties'?: boolean | object;
-            'gray-function'?: boolean | object;
-            'has-pseudo-class'?: boolean | object;
-            'hexadecimal-alpha-notation'?: boolean | object;
-            'image-set-function'?: boolean | object;
-            'lab-function'?: boolean | object;
-            'logical-properties-and-values'?: boolean | object;
-            'matches-pseudo-class'?: boolean | object;
-            'media-query-ranges'?: boolean | object;
-            'nesting-rules'?: boolean | object;
-            'not-pseudo-class'?: boolean | object;
-            'overflow-property'?: boolean | object;
-            'overflow-wrap-property'?: boolean | object;
-            'place-properties'?: boolean | object;
-            'prefers-color-scheme-query'?: boolean | object;
-            'rebeccapurple-color'?: boolean | object;
-            'system-ui-font-family'?: boolean | object;
+            'all-property'?: boolean | object | undefined;
+            'any-link-pseudo-class'?: boolean | object | undefined;
+            'blank-pseudo-class'?: boolean | object | undefined;
+            'break-properties'?: boolean | object | undefined;
+            'case-insensitive-attributes'?: boolean | object | undefined;
+            'color-functional-notation'?: boolean | object | undefined;
+            'color-mod-function'?: boolean | object | undefined;
+            'custom-media-queries'?: boolean | object | undefined;
+            'custom-properties'?: boolean | object | undefined;
+            'custom-selectors'?: boolean | object | undefined;
+            'dir-pseudo-class'?: boolean | object | undefined;
+            'double-position-gradients'?: boolean | object | undefined;
+            'environment-variables'?: boolean | object | undefined;
+            'focus-visible-pseudo-class'?: boolean | object | undefined;
+            'focus-within-pseudo-class'?: boolean | object | undefined;
+            'font-variant-property'?: boolean | object | undefined;
+            'gap-properties'?: boolean | object | undefined;
+            'gray-function'?: boolean | object | undefined;
+            'has-pseudo-class'?: boolean | object | undefined;
+            'hexadecimal-alpha-notation'?: boolean | object | undefined;
+            'image-set-function'?: boolean | object | undefined;
+            'lab-function'?: boolean | object | undefined;
+            'logical-properties-and-values'?: boolean | object | undefined;
+            'matches-pseudo-class'?: boolean | object | undefined;
+            'media-query-ranges'?: boolean | object | undefined;
+            'nesting-rules'?: boolean | object | undefined;
+            'not-pseudo-class'?: boolean | object | undefined;
+            'overflow-property'?: boolean | object | undefined;
+            'overflow-wrap-property'?: boolean | object | undefined;
+            'place-properties'?: boolean | object | undefined;
+            'prefers-color-scheme-query'?: boolean | object | undefined;
+            'rebeccapurple-color'?: boolean | object | undefined;
+            'system-ui-font-family'?: boolean | object | undefined;
         }
     }
 

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -100,13 +100,13 @@ declare namespace PouchDB {
             /**
              * HTTP Status Code during HTTP or HTTP-like operations
              */
-            status?: number;
-            name?: string;
-            message?: string;
-            reason?: string;
-            error?: string | boolean;
-            id?: string;
-            rev?: RevisionId;
+            status?: number | undefined;
+            name?: string | undefined;
+            message?: string | undefined;
+            reason?: string | undefined;
+            error?: string | boolean | undefined;
+            id?: string | undefined;
+            rev?: RevisionId | undefined;
         }
         type Callback<R> = (error: Error | null, result: R | null) => void;
         type DocumentId = string;
@@ -117,7 +117,7 @@ declare namespace PouchDB {
         type AttachmentData = string | Blob | Buffer;
 
         interface Options {
-          fetch?: Fetch;
+          fetch?: Fetch | undefined;
         }
 
         interface BasicResponse {
@@ -153,8 +153,8 @@ declare namespace PouchDB {
             [DocumentId: string]: string[];
         }
         interface RevisionDiff {
-            missing?: string[];
-            possible_ancestors?: string[];
+            missing?: string[] | undefined;
+            possible_ancestors?: string[] | undefined;
         }
         interface RevisionDiffResponse {
             [DocumentId: string]: RevisionDiff;
@@ -172,18 +172,18 @@ declare namespace PouchDB {
              *
              * Only present if `GetOptions.conflicts` is `true`
              */
-            _conflicts?: RevisionId[];
+            _conflicts?: RevisionId[] | undefined;
             _rev: RevisionId;
             /** Only present if `GetOptions.revs` is `true` */
-            _revs_info?: RevisionInfo[];
+            _revs_info?: RevisionInfo[] | undefined;
             /** Only present if `GetOptions.revs_info` is `true` */
             _revisions?: {
                 ids: RevisionId[];
                 start: number;
-            };
+            } | undefined;
 
             /** Attachments where index is attachmentId */
-            _attachments?: Attachments;
+            _attachments?: Attachments | undefined;
         }
 
         /**
@@ -222,7 +222,7 @@ declare namespace PouchDB {
             content_type: string;
 
             /** MD5 hash, starts with "md5-" prefix; populated by PouchDB for new attachments */
-            digest?: string;
+            digest?: string | undefined;
 
             /**
              * {string} if `binary` was `false`
@@ -246,20 +246,20 @@ declare namespace PouchDB {
         type RemoveDocument = IdMeta & RevisionIdMeta;
 
         type PostDocument<Content extends {}> = NewDocument<Content> & {
-            filters?: {[filterName: string]: string};
+            filters?: {[filterName: string]: string} | undefined;
             views?: {[viewName: string]: {
                 map: string,
-                reduce?: string
-            }};
+                reduce?: string | undefined
+            }} | undefined;
 
             /** You can update an existing doc using _rev */
-            _rev?: RevisionId;
+            _rev?: RevisionId | undefined;
 
-            _attachments?: Attachments;
+            _attachments?: Attachments | undefined;
         };
 
         type PutDocument<Content extends {}> = PostDocument<Content> & ChangesMeta & {
-            _id?: DocumentId;
+            _id?: DocumentId | undefined;
         };
 
         interface AllDocsOptions extends Options {
@@ -271,37 +271,37 @@ declare namespace PouchDB {
              * By default, attachments are Base64-encoded.
              * @see binary
              */
-            attachments?: boolean;
+            attachments?: boolean | undefined;
             /**
              * Return attachments as Buffers.
              *
              * Requires `include_docs` to be `true`.
              * Requires `attachments` to be `true`.
              */
-            binary?: boolean;
+            binary?: boolean | undefined;
             /**
              * Include conflict information for each document.
              *
              * Requires `include_docs` to be `true`.
              */
-            conflicts?: boolean;
+            conflicts?: boolean | undefined;
             /** Reverse ordering of results. */
-            descending?: boolean;
+            descending?: boolean | undefined;
             /** Include contents for each document. */
-            include_docs?: boolean;
+            include_docs?: boolean | undefined;
             /** Maximum number of documents to return. */
-            limit?: number;
+            limit?: number | undefined;
             /**
              * Number of documents to skip before returning.
              *
              * Causes poor performance on IndexedDB and LevelDB.
              */
-            skip?: number;
+            skip?: number | undefined;
             /**
              * Include an update_seq value indicating which sequence id
              * of the underlying database the view reflects.
              */
-            update_seq?: boolean;
+            update_seq?: boolean | undefined;
         }
         interface AllDocsWithKeyOptions extends AllDocsOptions {
             /** Constrain results to documents matching this key. */
@@ -321,40 +321,40 @@ declare namespace PouchDB {
              *
              * Defaults to `true`.
              */
-            inclusive_end?: boolean;
+            inclusive_end?: boolean | undefined;
         }
         interface AllDocsMeta {
             /** Only present if `conflicts` is `true` */
-            _conflicts?: RevisionId[];
+            _conflicts?: RevisionId[] | undefined;
 
-            _attachments?: Attachments;
+            _attachments?: Attachments | undefined;
         }
         interface AllDocsResponse<Content extends {}> {
             /** The `skip` if provided, or in CouchDB the actual offset */
             offset: number;
             total_rows: number;
-            update_seq?: number | string;
+            update_seq?: number | string | undefined;
             rows: Array<{
                 /** Only present if `include_docs` was `true`. */
-                doc?: ExistingDocument<Content & AllDocsMeta>;
+                doc?: ExistingDocument<Content & AllDocsMeta> | undefined;
                 id: DocumentId;
                 key: DocumentKey;
                 value: {
                     rev: RevisionId;
-                    deleted?: boolean;
+                    deleted?: boolean | undefined;
                 }
             }>;
         }
 
         interface BulkDocsOptions extends Options {
-            new_edits?: boolean;
+            new_edits?: boolean | undefined;
         }
 
         interface BulkGetOptions extends Options {
-            docs: Array<{ id: string; rev?: RevisionId }>;
-            revs?: boolean;
-            attachments?: boolean;
-            binary?: boolean;
+            docs: Array<{ id: string; rev?: RevisionId | undefined }>;
+            revs?: boolean | undefined;
+            attachments?: boolean | undefined;
+            binary?: boolean | undefined;
         }
 
         interface BulkGetResponse<Content extends {}> {
@@ -365,82 +365,82 @@ declare namespace PouchDB {
         }
 
         interface ChangesMeta {
-            _conflicts?: RevisionId[];
-            _deleted?: boolean;
-            _attachments?: Attachments;
+            _conflicts?: RevisionId[] | undefined;
+            _deleted?: boolean | undefined;
+            _attachments?: Attachments | undefined;
         }
 
         interface ChangesOptions {
             /**
              * Does "live" changes.
              */
-            live?: boolean;
+            live?: boolean | undefined;
 
             /**
              * Start the results from the change immediately after the given sequence number.
              * You can also pass `'now'` if you want only new changes (when `live` is `true`).
              *
              */
-            since?: 'now' | number | string;
+            since?: 'now' | number | string | undefined;
 
             /**
              * Request timeout (in milliseconds).
              */
-            timeout?: number | false;
+            timeout?: number | false | undefined;
 
             /** Include contents for each document. */
-            include_docs?: boolean;
+            include_docs?: boolean | undefined;
 
             /** Maximum number of documents to return. */
-            limit?: number | false;
+            limit?: number | false | undefined;
 
             /** Include conflicts. */
-            conflicts?: boolean;
+            conflicts?: boolean | undefined;
 
             /** Include attachments. */
-            attachments?: boolean;
+            attachments?: boolean | undefined;
 
             /** Return attachment data as Blobs/Buffers, instead of as base64-encoded strings. */
-            binary?: boolean;
+            binary?: boolean | undefined;
 
             /** Reverse the order of the output documents. */
-            descending?: boolean;
+            descending?: boolean | undefined;
 
             /**
              * For http adapter only, time in milliseconds for server to give a heartbeat to keep long connections open.
              * Defaults to 10000 (10 seconds), use false to disable the default.
              */
-            heartbeat?: number | false;
+            heartbeat?: number | false | undefined;
 
             /**
              * Reference a filter function from a design document to selectively get updates.
              * To use a view function, pass '_view' here and provide a reference to the view function in options.view.
              * See filtered changes for details.
              */
-            filter?: string | ((doc: any, params: any) => any);
+            filter?: string | ((doc: any, params: any) => any) | undefined;
 
             /** Only show changes for docs with these ids (array of strings). */
-            doc_ids?: string[];
+            doc_ids?: string[] | undefined;
 
             /**
              * Object containing properties that are passed to the filter function, e.g. {"foo:"bar"},
              * where "bar" will be available in the filter function as params.query.foo.
              * To access the params, define your filter function like function (doc, params).
              */
-            query_params?: {[paramName: string]: any};
+            query_params?: {[paramName: string]: any} | undefined;
 
             /**
              * Specify a view function (e.g. 'design_doc_name/view_name' or 'view_name' as shorthand for 'view_name/view_name') to act as a filter.
              * Documents counted as “passed” for a view filter if a map function emits at least one record for them.
              * Note: options.filter must be set to '_view' for this option to work.
              */
-            view?: string;
+            view?: string | undefined;
 
             /**
              * Filter using a query/pouchdb-find selector. Note: Selectors are not supported in CouchDB 1.x.
              * Cannot be used in combination with the filter option.
              */
-            selector?: Find.Selector;
+            selector?: Find.Selector | undefined;
 
             /**
              * (previously options.returnDocs): Is available for non-http databases and defaults to true.
@@ -448,13 +448,13 @@ declare namespace PouchDB {
              * words complete always has an empty results array, and the change event is the only way to get the event.
              * Useful for large change sets where otherwise you would run out of memory.
              */
-            return_docs?: boolean;
+            return_docs?: boolean | undefined;
 
             /**
              * Only available for http databases, this configures how many changes to fetch at a time.
              * Increasing this can reduce the number of requests made. Default is 25.
              */
-            batch_size?: number;
+            batch_size?: number | undefined;
 
             /**
              * Specifies how many revisions are returned in the changes array.
@@ -462,22 +462,22 @@ declare namespace PouchDB {
              * 'all_docs' will return all leaf revisions (including conflicts and deleted former conflicts).
              * Most likely you won’t need this unless you’re writing a replicator.
              */
-            style?: 'main_only' | 'all_docs';
+            style?: 'main_only' | 'all_docs' | undefined;
 
             /**
              * Only available for http databases. Specifies that seq information only be generated every N changes.
              * Larger values can improve changes throughput with CouchDB 2.0 and later.
              * Note that last_seq is always populated regardless.
              */
-            seq_interval?: number;
+            seq_interval?: number | undefined;
         }
 
         interface ChangesResponseChange<Content extends {}> {
             id: string;
             seq: number | string;
             changes: Array<{ rev: string }>;
-            deleted?: boolean;
-            doc?: ExistingDocument<Content & ChangesMeta>;
+            deleted?: boolean | undefined;
+            doc?: ExistingDocument<Content & ChangesMeta> | undefined;
         }
 
         interface ChangesResponse<Content extends {}> {
@@ -496,25 +496,25 @@ declare namespace PouchDB {
 
         interface GetOptions extends Options {
             /** Include list of conflicting leaf revisions. */
-            conflicts?: boolean;
+            conflicts?: boolean | undefined;
             /** Specific revision to fetch */
-            rev?: RevisionId;
+            rev?: RevisionId | undefined;
             /** Include revision history of the document. */
-            revs?: boolean;
+            revs?: boolean | undefined;
             /**
              * Include a list of revisions of the document, and their
              * availability.
              */
-            revs_info?: boolean;
+            revs_info?: boolean | undefined;
 
             /** Include attachment data. */
-            attachments?: boolean;
+            attachments?: boolean | undefined;
 
             /** Return attachment data as Blobs/Buffers, instead of as base64-encoded strings. */
-            binary?: boolean;
+            binary?: boolean | undefined;
 
             /** Forces retrieving latest “leaf” revision, no matter what rev was requested. */
-            latest?: boolean;
+            latest?: boolean | undefined;
         }
 
         interface GetOpenRevisions extends Options {
@@ -526,15 +526,15 @@ declare namespace PouchDB {
             open_revs: 'all' | RevisionId[];
 
             /** Include revision history of the document. */
-            revs?: boolean;
+            revs?: boolean | undefined;
         }
 
         interface CompactOptions extends Options {
-          interval?: number;
+          interval?: number | undefined;
         }
 
         interface PutOptions extends Options {
-          force?: boolean;
+          force?: boolean | undefined;
         }
 
         interface RemoveAttachmentResponse extends BasicResponse {
@@ -553,7 +553,7 @@ declare namespace PouchDB {
             /**
              * Database name.
              */
-            name?: string;
+            name?: string | undefined;
             /**
              * Database adapter to use.
              *
@@ -561,7 +561,7 @@ declare namespace PouchDB {
              * IndexedDB to WebSQL in browsers that support both (i.e. Chrome,
              * Opera and Android 4.4+).
              */
-            adapter?: string;
+            adapter?: string | undefined;
         }
 
         interface LocalDatabaseConfiguration extends CommonDatabaseConfiguration {
@@ -571,41 +571,41 @@ declare namespace PouchDB {
              *
              * Defaults to false.
              */
-            auto_compaction?: boolean;
+            auto_compaction?: boolean | undefined;
             /**
              * How many old revisions we keep track (not a copy) of.
              */
-            revs_limit?: number;
+            revs_limit?: number | undefined;
             /**
              * Size of the database (Most significant for Safari)
              * option to set the max size in MB that Safari will grant to the local database. Valid options are: 10, 50, 100, 500 and 1000
              * ex_ new PouchDB("dbName", {size:100});
              */
-            size?: number;
+            size?: number | undefined;
             /**
              * A special constructor option, which appends a prefix to the database name
              * and can be helpful for URL-based or file-based LevelDOWN path names.
              */
-            prefix?: string;
+            prefix?: string | undefined;
             /**
              * Use a md5 hash to create a deterministic revision number for documents.
              * Setting it to false will mean that the revision number will be a random UUID.
              * Defaults to true.
              */
-            deterministic_revs?: boolean;
+            deterministic_revs?: boolean | undefined;
         }
 
         interface RemoteDatabaseConfiguration extends CommonDatabaseConfiguration {
-            fetch?: Fetch;
+            fetch?: Fetch | undefined;
 
             auth?: {
-                username?: string;
-                password?: string;
-            };
+                username?: string | undefined;
+                password?: string | undefined;
+            } | undefined;
             /**
              * Disables automatic creation of databases.
              */
-            skip_setup?: boolean;
+            skip_setup?: boolean | undefined;
         }
 
         type DatabaseConfiguration = LocalDatabaseConfiguration |
@@ -851,13 +851,13 @@ declare namespace PouchDB {
         /** Get attachment data */
         getAttachment(docId: Core.DocumentId,
                       attachmentId: Core.AttachmentId,
-                      options: { rev?: Core.RevisionId},
+                      options: { rev?: Core.RevisionId | undefined},
                       callback: Core.Callback<Blob | Buffer>): void;
 
         /** Get attachment data */
         getAttachment(docId: Core.DocumentId,
                       attachmentId: Core.AttachmentId,
-                      options?: { rev?: Core.RevisionId}): Promise<Blob | Buffer>;
+                      options?: { rev?: Core.RevisionId | undefined}): Promise<Blob | Buffer>;
 
         /** Get attachment data */
         getAttachment(docId: Core.DocumentId,

--- a/types/pouchdb-find/index.d.ts
+++ b/types/pouchdb-find/index.d.ts
@@ -29,19 +29,19 @@ declare namespace PouchDB {
             $ne?: any;
 
             /** True if the field should exist, false otherwise. */
-            $exists?: boolean;
+            $exists?: boolean | undefined;
 
             /** One of: "null", "boolean", "number", "string", "array", or "object". */
-            $type?: "null" | "boolean" | "number" | "string" | "array" | "object";
+            $type?: "null" | "boolean" | "number" | "string" | "array" | "object" | undefined;
 
             /** The document field must exist in the list provided. */
-            $in?: any[];
+            $in?: any[] | undefined;
 
             /** The document field must not exist in the list provided. */
-            $nin?: any[];
+            $nin?: any[] | undefined;
 
             /** Special condition to match the length of an array field in a document. Non-array fields cannot match this condition. */
-            $size?: number;
+            $size?: number | undefined;
 
             /**
              * Divisor and Remainder are both positive or negative integers.
@@ -49,35 +49,35 @@ declare namespace PouchDB {
              * Matches documents where (field % Divisor == Remainder) is true, and only when the document field is an integer.
              * [divisor, remainder]
              */
-            $mod?: [number, number];
+            $mod?: [number, number] | undefined;
 
             /** A regular expression pattern to match against the document field. Only matches when the field is a string value and matches the supplied regular expression. */
-            $regex?: string;
+            $regex?: string | undefined;
 
             /** Matches an array value if it contains all the elements of the argument array. */
-            $all?: any[];
+            $all?: any[] | undefined;
 
-            $elemMatch?: ConditionOperators;
+            $elemMatch?: ConditionOperators | undefined;
         }
 
         interface CombinationOperators {
             /** Matches if all the selectors in the array match. */
-            $and?: Selector[];
+            $and?: Selector[] | undefined;
 
             /** Matches if any of the selectors in the array match. All selectors must use the same index. */
-            $or?: Selector[];
+            $or?: Selector[] | undefined;
 
             /** Matches if the given selector does not match. */
-            $not?: Selector;
+            $not?: Selector | undefined;
 
             /** Matches if none of the selectors in the array match. */
-            $nor?: Selector[];
+            $nor?: Selector[] | undefined;
         }
 
         interface Selector extends CombinationOperators {
             [field: string]: Selector | Selector[] | ConditionOperators | any;
 
-            _id?: string | ConditionOperators;
+            _id?: string | ConditionOperators | undefined;
         }
 
         interface FindRequest<Content extends {}> {
@@ -85,24 +85,24 @@ declare namespace PouchDB {
             selector: Selector;
 
             /** Defines a list of fields that you want to receive. If omitted, you get the full documents. */
-            fields?: string[];
+            fields?: string[] | undefined;
 
             /** Defines a list of fields defining how you want to sort. Note that sorted fields also have to be selected in the selector. */
-            sort?: Array<string|{[propName: string]: 'asc' | 'desc'}>;
+            sort?: Array<string|{[propName: string]: 'asc' | 'desc'}> | undefined;
 
             /** Maximum number of documents to return. */
-            limit?: number;
+            limit?: number | undefined;
 
             /** Number of docs to skip before returning. */
-            skip?: number;
+            skip?: number | undefined;
 
             /** Set which index to use for the query. It can be “design-doc-name” or “[‘design-doc-name’, ‘name’]”. */
-            use_index?: string | [string, string];
+            use_index?: string | [string, string] | undefined;
         }
 
         interface FindResponse<Content extends {}> {
             docs: Array<Core.ExistingDocument<Content>>;
-            warning?: string;
+            warning?: string | undefined;
         }
 
         interface CreateIndexOptions {
@@ -111,13 +111,13 @@ declare namespace PouchDB {
                 fields: string[];
 
                 /** Name of the index, auto-generated if you don't include it */
-                name?: string;
+                name?: string | undefined;
 
                 /** Design document name (i.e. the part after '_design/', auto-generated if you don't include it */
-                ddoc?: string;
+                ddoc?: string | undefined;
 
                 /** Only supports 'json', and it's also the default */
-                type?: string;
+                type?: string | undefined;
             };
         }
 
@@ -154,7 +154,7 @@ declare namespace PouchDB {
             ddoc: string;
 
             /** Default 'json' */
-            type?: string;
+            type?: string | undefined;
         }
 
         interface DeleteIndexResponse<Content extends {}> {

--- a/types/pouchdb-replication/index.d.ts
+++ b/types/pouchdb-replication/index.d.ts
@@ -11,43 +11,43 @@ declare namespace PouchDB {
     namespace Replication {
         interface ReplicateOptions {
             /** If true, starts subscribing to future changes in the source database and continue replicating them. */
-            live?: boolean;
+            live?: boolean | undefined;
 
             /**
              * If true will attempt to retry replications in the case of failure (due to being offline),
              * using a backoff algorithm that retries at longer and longer intervals until a connection is re-established,
              * with a maximum delay of 10 minutes. Only applicable if options.live is also true.
              */
-            retry?: boolean;
+            retry?: boolean | undefined;
 
             /**
              * Reference a filter function from a design document to selectively get updates.
              * To use a view function, pass '_view' here and provide a reference to the view function in options.view.
              * See filtered changes for details.
              */
-            filter?: string | ((doc: any, params: any) => any);
+            filter?: string | ((doc: any, params: any) => any) | undefined;
 
             /** Only show changes for docs with these ids (array of strings). */
-            doc_ids?: string[];
+            doc_ids?: string[] | undefined;
 
             /**
              * Object containing properties that are passed to the filter function, e.g. {"foo:"bar"},
              * where "bar" will be available in the filter function as params.query.foo.
              * To access the params, define your filter function like function (doc, params).
              */
-            query_params?: {[paramName: string]: any};
+            query_params?: {[paramName: string]: any} | undefined;
 
             /**
              * Specify a view function (e.g. 'design_doc_name/view_name' or 'view_name' as shorthand for 'view_name/view_name') to act as a filter.
              * Documents counted as “passed” for a view filter if a map function emits at least one record for them.
              * Note: options.filter must be set to '_view' for this option to work.
              */
-            view?: string;
+            view?: string | undefined;
 
             /**
              * Filter using a query/pouchdb-find selector. Note: Selectors are not supported in CouchDB 1.x.
              */
-            selector?: Find.Selector;
+            selector?: Find.Selector | undefined;
 
             /** Replicate changes after the given sequence number. */
             since?: any;
@@ -56,7 +56,7 @@ declare namespace PouchDB {
             heartbeat?: any;
 
             /** Request timeout (in milliseconds). */
-            timeout?: number | false;
+            timeout?: number | false | undefined;
 
             /**
              * Number of change feed items to process at a time. Defaults to 100.
@@ -65,14 +65,14 @@ declare namespace PouchDB {
              * e.g. or if the documents and/or attachments are large in size or if there are many conflicted revisions.
              * If your documents are small in size, then increasing this number will probably speed replication up.
              */
-            batch_size?: number;
+            batch_size?: number | undefined;
 
             /**
              * Number of batches to process at a time. Defaults to 10.
              * This (along wtih batch_size) controls how many docs are kept in memory at a time,
              * so the maximum docs in memory at once would equal batch_size × batches_limit.
              */
-            batches_limit?: number;
+            batches_limit?: number | undefined;
 
             /**
              * Backoff function to be used in retry replication. This is a function that takes the current
@@ -89,7 +89,7 @@ declare namespace PouchDB {
              * Setting it to source will only write checkpoints on the source.
              * Setting it to target will only write checkpoints on the target.
              */
-            checkpoint?: boolean | 'target' | 'source';
+            checkpoint?: boolean | 'target' | 'source' | undefined;
         }
 
         interface ReplicationEventEmitter<Content extends {}, C, F> extends EventEmitter {
@@ -123,8 +123,8 @@ declare namespace PouchDB {
         }
 
         interface SyncOptions extends ReplicateOptions {
-            push?: ReplicateOptions;
-            pull?: ReplicateOptions;
+            push?: ReplicateOptions | undefined;
+            pull?: ReplicateOptions | undefined;
         }
 
         interface Sync<Content extends {}>
@@ -138,8 +138,8 @@ declare namespace PouchDB {
         }
 
         interface SyncResultComplete<Content extends {}> {
-            push?: ReplicationResultComplete<Content>;
-            pull?: ReplicationResultComplete<Content>;
+            push?: ReplicationResultComplete<Content> | undefined;
+            pull?: ReplicationResultComplete<Content> | undefined;
         }
     }
 

--- a/types/power-assert-formatter/index.d.ts
+++ b/types/power-assert-formatter/index.d.ts
@@ -7,18 +7,18 @@ declare function powerAssertFormatter(options?:powerAssertFormatter.Options):pow
 
 declare namespace powerAssertFormatter {
     export interface Options {
-        lineDiffThreshold?: number;
-        maxDepth?: number;
-        outputOffset?: number;
-        anonymous?: string;
-        circular?: string;
-        lineSeparator?: string;
-        ambiguousEastAsianCharWidth?: number;
-        widthOf?: Function;
-        stringify?: Function;
-        diff?: Function;
-        writerClass?: {new (): any;};
-        renderers?: any[]; // { string | Function }[]
+        lineDiffThreshold?: number | undefined;
+        maxDepth?: number | undefined;
+        outputOffset?: number | undefined;
+        anonymous?: string | undefined;
+        circular?: string | undefined;
+        lineSeparator?: string | undefined;
+        ambiguousEastAsianCharWidth?: number | undefined;
+        widthOf?: Function | undefined;
+        stringify?: Function | undefined;
+        diff?: Function | undefined;
+        writerClass?: {new (): any;} | undefined;
+        renderers?: any[] | undefined; // { string | Function }[]
     }
 
     export interface Formatter {

--- a/types/power-assert/index.d.ts
+++ b/types/power-assert/index.d.ts
@@ -23,7 +23,7 @@ declare namespace assert {
         operator: string;
         generatedMessage: boolean;
 
-        constructor(options?: { message?: string; actual?: any; expected?: any; operator?: string; stackStartFunction?: Function });
+        constructor(options?: { message?: string | undefined; actual?: any; expected?: any; operator?: string | undefined; stackStartFunction?: Function | undefined });
     }
 
     export function fail(actual?: any, expected?: any, message?: string, operator?: string): never;
@@ -53,8 +53,8 @@ declare namespace assert {
     export const strict: typeof assert;
 
     export interface Options {
-        assertion?: empower.Options;
-        output?: powerAssertFormatter.Options;
+        assertion?: empower.Options | undefined;
+        output?: powerAssertFormatter.Options | undefined;
     }
 
     export function customize(options: Options): typeof assert;

--- a/types/prettier-linter-helpers/index.d.ts
+++ b/types/prettier-linter-helpers/index.d.ts
@@ -29,6 +29,6 @@ export const generateDifferences: GenerateDifferences;
 export interface Difference {
     operation: 'insert' | 'delete' | 'replace';
     offset: number;
-    insertText?: string;
-    deleteText?: string;
+    insertText?: string | undefined;
+    deleteText?: string | undefined;
 }

--- a/types/prettier/doc.d.ts
+++ b/types/prettier/doc.d.ts
@@ -77,9 +77,9 @@ export namespace builders {
 
     interface Line {
         type: 'line';
-        soft?: boolean;
-        hard?: boolean;
-        literal?: boolean;
+        soft?: boolean | undefined;
+        hard?: boolean | undefined;
+        literal?: boolean | undefined;
     }
 
     interface LineSuffix {
@@ -105,8 +105,8 @@ export namespace builders {
     }
 
     interface GroupOptions {
-        shouldBreak?: boolean;
-        id?: symbol;
+        shouldBreak?: boolean | undefined;
+        id?: symbol | undefined;
     }
 
     function addAlignmentToDoc(doc: Doc, size: number, tabWidth: number): Doc;
@@ -134,11 +134,11 @@ export namespace builders {
     /** @see [hardlineWithoutBreakParent](https://github.com/prettier/prettier/blob/main/commands.md#hardlinewithoutbreakparent-and-literallinewithoutbreakparent) */
     const hardlineWithoutBreakParent: HardlineWithoutBreakParent;
     /** @see [ifBreak](https://github.com/prettier/prettier/blob/main/commands.md#ifbreak) */
-    function ifBreak(ifBreak: Doc, noBreak?: Doc, options?: { groupId?: symbol }): IfBreak;
+    function ifBreak(ifBreak: Doc, noBreak?: Doc, options?: { groupId?: symbol | undefined }): IfBreak;
     /** @see [indent](https://github.com/prettier/prettier/blob/main/commands.md#indent) */
     function indent(doc: Doc): Indent;
     /** @see [indentIfBreak](https://github.com/prettier/prettier/blob/main/commands.md#indentifbreak) */
-    function indentIfBreak(doc: Doc, opts: { groupId: symbol; negate?: boolean }): IndentIfBreak;
+    function indentIfBreak(doc: Doc, opts: { groupId: symbol; negate?: boolean | undefined }): IndentIfBreak;
     /** @see [join](https://github.com/prettier/prettier/blob/main/commands.md#join) */
     function join(sep: Doc, docs: Doc[]): Concat;
     /** @see [label](https://github.com/prettier/prettier/blob/main/commands.md#label) */
@@ -173,8 +173,8 @@ export namespace printer {
         options: Options,
     ): {
         formatted: string;
-        cursorNodeStart?: number;
-        cursorNodeText?: string;
+        cursorNodeStart?: number | undefined;
+        cursorNodeText?: string | undefined;
     };
     interface Options {
         /**
@@ -192,8 +192,8 @@ export namespace printer {
          * @default false
          */
         useTabs: boolean;
-        parentParser?: string;
-        __embeddedInHtml?: boolean;
+        parentParser?: string | undefined;
+        __embeddedInHtml?: boolean | undefined;
     }
 }
 

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -18,7 +18,7 @@
 //
 // It comes from this issue: microsoft/TypeScript#29729:
 //   https://github.com/microsoft/TypeScript/issues/29729#issuecomment-700527227
-export type LiteralUnion<T extends U, U = string> = T | (Pick<U, never> & { _?: never });
+export type LiteralUnion<T extends U, U = string> = T | (Pick<U, never> & { _?: never | undefined });
 
 export type AST = any;
 export type Doc = doc.builders.Doc;
@@ -183,64 +183,64 @@ export interface ParserOptions<T = any> extends RequiredOptions {
 }
 
 export interface Plugin<T = any> {
-    languages?: SupportLanguage[];
-    parsers?: { [parserName: string]: Parser<T> };
-    printers?: { [astFormat: string]: Printer<T> };
-    options?: SupportOptions;
-    defaultOptions?: Partial<RequiredOptions>;
+    languages?: SupportLanguage[] | undefined;
+    parsers?: { [parserName: string]: Parser<T> } | undefined;
+    printers?: { [astFormat: string]: Printer<T> } | undefined;
+    options?: SupportOptions | undefined;
+    defaultOptions?: Partial<RequiredOptions> | undefined;
 }
 
 export interface Parser<T = any> {
     parse: (text: string, parsers: { [parserName: string]: Parser }, options: ParserOptions<T>) => T;
     astFormat: string;
-    hasPragma?: (text: string) => boolean;
+    hasPragma?: ((text: string) => boolean) | undefined;
     locStart: (node: T) => number;
     locEnd: (node: T) => number;
-    preprocess?: (text: string, options: ParserOptions<T>) => string;
+    preprocess?: ((text: string, options: ParserOptions<T>) => string) | undefined;
 }
 
 export interface Printer<T = any> {
     print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc): Doc;
-    embed?: (
+    embed?: ((
         path: AstPath<T>,
         print: (path: AstPath<T>) => Doc,
         textToDoc: (text: string, options: Options) => Doc,
         options: ParserOptions<T>,
-    ) => Doc | null;
-    insertPragma?: (text: string) => string;
+    ) => Doc | null) | undefined;
+    insertPragma?: ((text: string) => string) | undefined;
     /**
      * @returns `null` if you want to remove this node
      * @returns `void` if you want to use modified newNode
      * @returns anything if you want to replace the node with it
      */
-    massageAstNode?: (node: any, newNode: any, parent: any) => any;
-    hasPrettierIgnore?: (path: AstPath<T>) => boolean;
-    canAttachComment?: (node: T) => boolean;
-    willPrintOwnComments?: (path: AstPath<T>) => boolean;
-    printComment?: (commentPath: AstPath<T>, options: ParserOptions<T>) => Doc;
+    massageAstNode?: ((node: any, newNode: any, parent: any) => any) | undefined;
+    hasPrettierIgnore?: ((path: AstPath<T>) => boolean) | undefined;
+    canAttachComment?: ((node: T) => boolean) | undefined;
+    willPrintOwnComments?: ((path: AstPath<T>) => boolean) | undefined;
+    printComment?: ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc) | undefined;
     handleComments?: {
-        ownLine?: (
+        ownLine?: ((
             commentNode: any,
             text: string,
             options: ParserOptions<T>,
             ast: T,
             isLastComment: boolean,
-        ) => boolean;
-        endOfLine?: (
+        ) => boolean) | undefined;
+        endOfLine?: ((
             commentNode: any,
             text: string,
             options: ParserOptions<T>,
             ast: T,
             isLastComment: boolean,
-        ) => boolean;
-        remaining?: (
+        ) => boolean) | undefined;
+        remaining?: ((
             commentNode: any,
             text: string,
             options: ParserOptions<T>,
             ast: T,
             isLastComment: boolean,
-        ) => boolean;
-    };
+        ) => boolean) | undefined;
+    } | undefined;
 }
 
 export interface CursorOptions extends Options {
@@ -248,8 +248,8 @@ export interface CursorOptions extends Options {
      * Specify where the cursor is.
      */
     cursorOffset: number;
-    rangeStart?: never;
-    rangeEnd?: never;
+    rangeStart?: never | undefined;
+    rangeEnd?: never | undefined;
 }
 
 export interface CursorResult {
@@ -280,11 +280,11 @@ export interface ResolveConfigOptions {
     /**
      * If set to `false`, all caching will be bypassed.
      */
-    useCache?: boolean;
+    useCache?: boolean | undefined;
     /**
      * Pass directly the path of the config file if you don't wish to search for it.
      */
-    config?: string;
+    config?: string | undefined;
     /**
      * If set to `true` and an `.editorconfig` file is in your project,
      * Prettier will parse it and convert its properties to the corresponding prettier configuration.
@@ -294,7 +294,7 @@ export interface ResolveConfigOptions {
      * - indent_size/tab_width
      * - max_line_length
      */
-    editorconfig?: boolean;
+    editorconfig?: boolean | undefined;
 }
 
 /**
@@ -339,18 +339,18 @@ export function clearConfigCache(): void;
 
 export interface SupportLanguage {
     name: string;
-    since?: string;
+    since?: string | undefined;
     parsers: BuiltInParserName[] | string[];
-    group?: string;
-    tmScope?: string;
-    aceMode?: string;
-    codemirrorMode?: string;
-    codemirrorMimeType?: string;
-    aliases?: string[];
-    extensions?: string[];
-    filenames?: string[];
-    linguistLanguageId?: number;
-    vscodeLanguageIds?: string[];
+    group?: string | undefined;
+    tmScope?: string | undefined;
+    aceMode?: string | undefined;
+    codemirrorMode?: string | undefined;
+    codemirrorMimeType?: string | undefined;
+    aliases?: string[] | undefined;
+    extensions?: string[] | undefined;
+    filenames?: string[] | undefined;
+    linguistLanguageId?: number | undefined;
+    vscodeLanguageIds?: string[] | undefined;
 }
 
 export interface SupportOptionRange {
@@ -364,7 +364,7 @@ export type SupportOptionType = 'int' | 'boolean' | 'choice' | 'path';
 export type CoreCategoryType = 'Config' | 'Editor' | 'Format' | 'Other' | 'Output' | 'Global' | 'Special';
 
 export interface BaseSupportOption<Type extends SupportOptionType> {
-    readonly name?: string;
+    readonly name?: string | undefined;
     since: string;
     /**
      * Usually you can use {@link CoreCategoryType}
@@ -384,54 +384,54 @@ export interface BaseSupportOption<Type extends SupportOptionType> {
      * Use a string to add an extra message to --help for the option,
      * for example to suggest a replacement option.
      */
-    deprecated?: true | string;
+    deprecated?: true | string | undefined;
     /**
      * Description to be displayed in --help. If omitted, the option won't be
      * shown at all in --help.
      */
-    description?: string;
+    description?: string | undefined;
 }
 
 export interface IntSupportOption extends BaseSupportOption<'int'> {
-    default?: number;
-    array?: false;
-    range?: SupportOptionRange;
+    default?: number | undefined;
+    array?: false | undefined;
+    range?: SupportOptionRange | undefined;
 }
 
 export interface IntArraySupportOption extends BaseSupportOption<'int'> {
-    default?: Array<{ value: number[] }>;
+    default?: Array<{ value: number[] }> | undefined;
     array: true;
 }
 
 export interface BooleanSupportOption extends BaseSupportOption<'boolean'> {
-    default?: boolean;
-    array?: false;
+    default?: boolean | undefined;
+    array?: false | undefined;
     description: string;
-    oppositeDescription?: string;
+    oppositeDescription?: string | undefined;
 }
 
 export interface BooleanArraySupportOption extends BaseSupportOption<'boolean'> {
-    default?: Array<{ value: boolean[] }>;
+    default?: Array<{ value: boolean[] }> | undefined;
     array: true;
 }
 
 export interface ChoiceSupportOption<Value = any> extends BaseSupportOption<'choice'> {
-    default?: Value | Array<{ since: string; value: Value }>;
+    default?: Value | Array<{ since: string; value: Value }> | undefined;
     description: string;
     choices: Array<{
-        since?: string;
+        since?: string | undefined;
         value: Value;
         description: string;
     }>;
 }
 
 export interface PathSupportOption extends BaseSupportOption<'path'> {
-    default?: string;
-    array?: false;
+    default?: string | undefined;
+    array?: false | undefined;
 }
 
 export interface PathArraySupportOption extends BaseSupportOption<'path'> {
-    default?: Array<{ value: string[] }>;
+    default?: Array<{ value: string[] }> | undefined;
     array: true;
 }
 
@@ -452,10 +452,10 @@ export interface SupportInfo {
 }
 
 export interface FileInfoOptions {
-    ignorePath?: string;
-    withNodeModules?: boolean;
-    plugins?: string[];
-    resolveConfig?: boolean;
+    ignorePath?: string | undefined;
+    withNodeModules?: boolean | undefined;
+    plugins?: string[] | undefined;
+    resolveConfig?: boolean | undefined;
 }
 
 export interface FileInfoResult {
@@ -482,7 +482,7 @@ export const version: string;
 // https://github.com/prettier/prettier/blob/main/src/common/util-shared.js
 export namespace util {
     interface SkipOptions {
-        backwards?: boolean;
+        backwards?: boolean | undefined;
     }
 
     type Quote = "'" | '"';
@@ -593,9 +593,9 @@ export namespace doc {
 
         interface Line {
             type: 'line';
-            soft?: boolean;
-            hard?: boolean;
-            literal?: boolean;
+            soft?: boolean | undefined;
+            hard?: boolean | undefined;
+            literal?: boolean | undefined;
         }
 
         interface LineSuffix {
@@ -621,8 +621,8 @@ export namespace doc {
         }
 
         interface GroupOptions {
-            shouldBreak?: boolean;
-            id?: symbol;
+            shouldBreak?: boolean | undefined;
+            id?: symbol | undefined;
         }
 
         function addAlignmentToDoc(doc: Doc, size: number, tabWidth: number): Doc;
@@ -650,11 +650,11 @@ export namespace doc {
         /** @see [hardlineWithoutBreakParent](https://github.com/prettier/prettier/blob/main/commands.md#hardlinewithoutbreakparent-and-literallinewithoutbreakparent) */
         const hardlineWithoutBreakParent: HardlineWithoutBreakParent;
         /** @see [ifBreak](https://github.com/prettier/prettier/blob/main/commands.md#ifbreak) */
-        function ifBreak(ifBreak: Doc, noBreak?: Doc, options?: { groupId?: symbol }): IfBreak;
+        function ifBreak(ifBreak: Doc, noBreak?: Doc, options?: { groupId?: symbol | undefined }): IfBreak;
         /** @see [indent](https://github.com/prettier/prettier/blob/main/commands.md#indent) */
         function indent(doc: Doc): Indent;
         /** @see [indentIfBreak](https://github.com/prettier/prettier/blob/main/commands.md#indentifbreak) */
-        function indentIfBreak(doc: Doc, opts: { groupId: symbol; negate?: boolean }): IndentIfBreak;
+        function indentIfBreak(doc: Doc, opts: { groupId: symbol; negate?: boolean | undefined }): IndentIfBreak;
         /** @see [join](https://github.com/prettier/prettier/blob/main/commands.md#join) */
         function join(sep: Doc, docs: Doc[]): Concat;
         /** @see [label](https://github.com/prettier/prettier/blob/main/commands.md#label) */
@@ -687,8 +687,8 @@ export namespace doc {
             options: Options,
         ): {
             formatted: string;
-            cursorNodeStart?: number;
-            cursorNodeText?: string;
+            cursorNodeStart?: number | undefined;
+            cursorNodeText?: string | undefined;
         };
         interface Options {
             /**
@@ -706,8 +706,8 @@ export namespace doc {
              * @default false
              */
             useTabs: boolean;
-            parentParser?: string;
-            __embeddedInHtml?: boolean;
+            parentParser?: string | undefined;
+            __embeddedInHtml?: boolean | undefined;
         }
     }
     namespace utils {

--- a/types/pretty-hrtime/index.d.ts
+++ b/types/pretty-hrtime/index.d.ts
@@ -9,7 +9,7 @@ declare function prettyHrtime(hrTime: [number, number], options?: prettyHrtime.O
 
 declare namespace prettyHrtime {
     interface Options {
-        verbose?: boolean;
-        precise?: boolean;
+        verbose?: boolean | undefined;
+        precise?: boolean | undefined;
     }
 }

--- a/types/prismjs/index.d.ts
+++ b/types/prismjs/index.d.ts
@@ -126,18 +126,18 @@ export function tokenize(
 ): Array<string | Token>;
 
 export interface Environment extends Record<string, any> {
-    selector?: string;
-    element?: Element;
-    language?: string;
-    grammar?: Grammar;
-    code?: string;
-    highlightedCode?: string;
-    type?: string;
-    content?: string;
-    tag?: string;
-    classes?: string[];
-    attributes?: Record<string, string>;
-    parent?: Array<string | Token>;
+    selector?: string | undefined;
+    element?: Element | undefined;
+    language?: string | undefined;
+    grammar?: Grammar | undefined;
+    code?: string | undefined;
+    highlightedCode?: string | undefined;
+    type?: string | undefined;
+    content?: string | undefined;
+    tag?: string | undefined;
+    classes?: string[] | undefined;
+    attributes?: Record<string, string> | undefined;
+    parent?: Array<string | Token> | undefined;
 }
 
 export namespace util {
@@ -171,26 +171,26 @@ export namespace util {
 export type GrammarValue = RegExp | TokenObject | Array<RegExp | TokenObject>;
 export type Grammar = GrammarRest & Record<string, GrammarValue>;
 export interface GrammarRest {
-    keyword?: GrammarValue;
-    number?: GrammarValue;
-    function?: GrammarValue;
-    string?: GrammarValue;
-    boolean?: GrammarValue;
-    operator?: GrammarValue;
-    punctuation?: GrammarValue;
-    atrule?: GrammarValue;
-    url?: GrammarValue;
-    selector?: GrammarValue;
-    property?: GrammarValue;
-    important?: GrammarValue;
-    style?: GrammarValue;
-    comment?: GrammarValue;
-    "class-name"?: GrammarValue;
+    keyword?: GrammarValue | undefined;
+    number?: GrammarValue | undefined;
+    function?: GrammarValue | undefined;
+    string?: GrammarValue | undefined;
+    boolean?: GrammarValue | undefined;
+    operator?: GrammarValue | undefined;
+    punctuation?: GrammarValue | undefined;
+    atrule?: GrammarValue | undefined;
+    url?: GrammarValue | undefined;
+    selector?: GrammarValue | undefined;
+    property?: GrammarValue | undefined;
+    important?: GrammarValue | undefined;
+    style?: GrammarValue | undefined;
+    comment?: GrammarValue | undefined;
+    "class-name"?: GrammarValue | undefined;
 
     /**
      * An optional grammar object that will appended to this grammar.
      */
-    rest?: Grammar;
+    rest?: Grammar | undefined;
 }
 
 /**
@@ -206,19 +206,19 @@ export interface TokenObject {
      * If `true`, then the first capturing group of `pattern` will (effectively) behave as a lookbehind
      * group meaning that the captured text will not be part of the matched text of the new token.
      */
-    lookbehind?: boolean;
+    lookbehind?: boolean | undefined;
 
     /**
      * Whether the token is greedy.
      *
      * @default false
      */
-    greedy?: boolean;
+    greedy?: boolean | undefined;
 
     /**
      * An optional alias or list of aliases.
      */
-    alias?: string | string[];
+    alias?: string | string[] | undefined;
 
     /**
      * The nested tokens of this token.
@@ -227,7 +227,7 @@ export interface TokenObject {
      *
      * Note that this can cause infinite recursion.
      */
-    inside?: Grammar;
+    inside?: Grammar | undefined;
 }
 export type Languages = LanguageMapProtocol & LanguageMap;
 export interface LanguageMap {

--- a/types/progress/index.d.ts
+++ b/types/progress/index.d.ts
@@ -106,46 +106,46 @@ declare namespace ProgressBar {
       /**
        * current completed index
        */
-      curr?: number;
+      curr?: number | undefined;
 
       /**
        * head character defaulting to complete character
        */
-      head?: string;
+      head?: string | undefined;
 
       /**
        * The displayed width of the progress bar defaulting to total.
        */
-      width?: number;
+      width?: number | undefined;
 
       /**
        * minimum time between updates in milliseconds defaulting to 16
        */
-      renderThrottle?: number;
+      renderThrottle?: number | undefined;
 
       /**
        * The output stream defaulting to stderr.
        */
-      stream?: NodeJS.WritableStream;
+      stream?: NodeJS.WritableStream | undefined;
 
       /**
        * Completion character defaulting to "=".
        */
-      complete?: string;
+      complete?: string | undefined;
 
       /**
        * Incomplete character defaulting to "-".
        */
-      incomplete?: string;
+      incomplete?: string | undefined;
 
       /**
        * Option to clear the bar on completion defaulting to false.
        */
-      clear?: boolean;
+      clear?: boolean | undefined;
 
       /**
        * Optional function to call when the progress bar completes.
        */
-      callback?: Function;
+      callback?: Function | undefined;
   }
 }

--- a/types/promise-polyfill/index.d.ts
+++ b/types/promise-polyfill/index.d.ts
@@ -6,7 +6,7 @@
 
 declare namespace Promise {
     interface PromisePolyfillConstructor extends PromiseConstructor {
-        _immediateFn?: (handler: (() => void) | string) => void;
+        _immediateFn?: ((handler: (() => void) | string) => void) | undefined;
     }
 }
 

--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -64,42 +64,42 @@ declare namespace prompts {
     interface Choice {
         title: string;
         value?: any;
-        disabled?: boolean;
-        selected?: boolean;
-        description?: string;
+        disabled?: boolean | undefined;
+        selected?: boolean | undefined;
+        description?: string | undefined;
     }
 
     interface Options {
-        onSubmit?: (prompt: PromptObject, answer: any, answers: any[]) => void;
-        onCancel?: (prompt: PromptObject, answers: any) => void;
+        onSubmit?: ((prompt: PromptObject, answer: any, answers: any[]) => void) | undefined;
+        onCancel?: ((prompt: PromptObject, answers: any) => void) | undefined;
     }
 
     interface PromptObject<T extends string = string> {
         type: PromptType | Falsy | PrevCaller<T, PromptType | Falsy>;
         name: ValueOrFunc<T>;
-        message?: ValueOrFunc<string>;
-        initial?: InitialReturnValue | PrevCaller<T, InitialReturnValue | Promise<InitialReturnValue>>;
-        style?: string | PrevCaller<T, string | Falsy>;
-        format?: PrevCaller<T, void>;
-        validate?: PrevCaller<T, boolean | string | Promise<boolean | string>>;
-        onState?: PrevCaller<T, void>;
-        min?: number | PrevCaller<T, number | Falsy>;
-        max?: number | PrevCaller<T, number | Falsy>;
-        float?: boolean | PrevCaller<T, boolean | Falsy>;
-        round?: number | PrevCaller<T, number | Falsy>;
-        instructions?: string | boolean;
-        increment?: number | PrevCaller<T, number | Falsy>;
-        separator?: string | PrevCaller<T, string | Falsy>;
-        active?: string | PrevCaller<T, string | Falsy>;
-        inactive?: string | PrevCaller<T, string | Falsy>;
-        choices?: Choice[] | PrevCaller<T, Choice[] | Falsy>;
-        hint?: string | PrevCaller<T, string | Falsy>;
-        warn?: string | PrevCaller<T, string | Falsy>;
-        suggest?: ((input: any, choices: Choice[]) => Promise<any>);
-        limit?: number | PrevCaller<T, number | Falsy>;
-        mask?: string | PrevCaller<T, string | Falsy>;
-        stdout?: Writable;
-        stdin?: Readable;
+        message?: ValueOrFunc<string> | undefined;
+        initial?: InitialReturnValue | PrevCaller<T, InitialReturnValue | Promise<InitialReturnValue>> | undefined;
+        style?: string | PrevCaller<T, string | Falsy> | undefined;
+        format?: PrevCaller<T, void> | undefined;
+        validate?: PrevCaller<T, boolean | string | Promise<boolean | string>> | undefined;
+        onState?: PrevCaller<T, void> | undefined;
+        min?: number | PrevCaller<T, number | Falsy> | undefined;
+        max?: number | PrevCaller<T, number | Falsy> | undefined;
+        float?: boolean | PrevCaller<T, boolean | Falsy> | undefined;
+        round?: number | PrevCaller<T, number | Falsy> | undefined;
+        instructions?: string | boolean | undefined;
+        increment?: number | PrevCaller<T, number | Falsy> | undefined;
+        separator?: string | PrevCaller<T, string | Falsy> | undefined;
+        active?: string | PrevCaller<T, string | Falsy> | undefined;
+        inactive?: string | PrevCaller<T, string | Falsy> | undefined;
+        choices?: Choice[] | PrevCaller<T, Choice[] | Falsy> | undefined;
+        hint?: string | PrevCaller<T, string | Falsy> | undefined;
+        warn?: string | PrevCaller<T, string | Falsy> | undefined;
+        suggest?: ((input: any, choices: Choice[]) => Promise<any>) | undefined;
+        limit?: number | PrevCaller<T, number | Falsy> | undefined;
+        mask?: string | PrevCaller<T, string | Falsy> | undefined;
+        stdout?: Writable | undefined;
+        stdin?: Readable | undefined;
     }
 
     type Answers<T extends string> = { [id in T]: any };

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -41,7 +41,7 @@ export interface Validator<T> {
     (props: { [key: string]: any }, propName: string, componentName: string, location: string, propFullName: string): Error | null;
     [nominalTypeHack]?: {
         type: T;
-    };
+    } | undefined;
 }
 
 export interface Requireable<T> extends Validator<T | undefined | null> {

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -11,7 +11,7 @@ interface Props {
     bool: boolean;
     element: ReactElement;
     func(foo: string): void;
-    node?: ReactNode;
+    node?: ReactNode | undefined;
     requiredNode: NonNullable<ReactNode>;
     number: number;
     object: object;
@@ -20,22 +20,22 @@ interface Props {
     instanceOf: TestClass;
     oneOf: 'a' | 'b' | 'c';
     oneOfType: string | boolean | {
-        foo?: string | null;
+        foo?: string | null | undefined;
         bar: number;
     };
     numberOrFalse: false | number;
-    nodeOrRenderFn?: ReactNode | (() => ReactNode);
+    nodeOrRenderFn?: ReactNode | (() => ReactNode) | undefined;
     arrayOf: boolean[];
     objectOf: { [K: string]: number };
     shape: {
         foo: string;
-        bar?: boolean | null;
+        bar?: boolean | null | undefined;
         baz?: any;
     };
-    optionalNumber?: number | null;
+    optionalNumber?: number | null | undefined;
     nullableNumber: number | null;
-    undefinableNumber?: number;
-    customProp?: typeof uniqueType;
+    undefinableNumber?: number | undefined;
+    customProp?: typeof uniqueType | undefined;
     component: PropTypes.ReactComponentLike;
 }
 
@@ -192,16 +192,16 @@ type UndefaultizedProps = Undefaultize<PropTypes.InferProps<typeof componentProp
 
 // $ExpectType true
 type DefaultizedPropsTest = {
-    fi?: (...args: any[]) => any;
-    foo?: string | null;
+    fi?: ((...args: any[]) => any) | undefined;
+    foo?: string | null | undefined;
     bar: number;
-    baz?: boolean | null;
-    bat?: ReactNode;
+    baz?: boolean | null | undefined;
+    bat?: ReactNode | undefined;
 } extends DefaultizedProps ? true : false;
 // $ExpectType true
 type UndefaultizedPropsTest = {
     fi: (...args: any[]) => any;
-    foo?: string | null;
+    foo?: string | null | undefined;
     bar: number;
     baz: boolean;
     bat: Exclude<ReactNode, undefined>;

--- a/types/proper-lockfile/index.d.ts
+++ b/types/proper-lockfile/index.d.ts
@@ -9,26 +9,26 @@
 import { OperationOptions } from "retry";
 
 export interface LockOptions {
-    stale?: number; // default: 10000
-    update?: number; // default: stale/2
-    retries?: number | OperationOptions; // default: 0
-    realpath?: boolean; // default: true
+    stale?: number | undefined; // default: 10000
+    update?: number | undefined; // default: stale/2
+    retries?: number | OperationOptions | undefined; // default: 0
+    realpath?: boolean | undefined; // default: true
     fs?: any; // default: graceful-fs
-    onCompromised?: (err: Error) => any; // default: (err) => throw err
-    lockfilePath?: string; // default: `${file}.lock`
+    onCompromised?: ((err: Error) => any) | undefined; // default: (err) => throw err
+    lockfilePath?: string | undefined; // default: `${file}.lock`
 }
 
 export interface UnlockOptions {
-    realpath?: boolean; // default: true
+    realpath?: boolean | undefined; // default: true
     fs?: any; // default: graceful-fs
-    lockfilePath?: string; // default: `${file}.lock`
+    lockfilePath?: string | undefined; // default: `${file}.lock`
 }
 
 export interface CheckOptions {
-    stale?: number; // default: 10000
-    realpath?: boolean; // default: true
+    stale?: number | undefined; // default: 10000
+    realpath?: boolean | undefined; // default: true
     fs?: any; // default: graceful-fs
-    lockfilePath?: string; // default: `${file}.lock`
+    lockfilePath?: string | undefined; // default: `${file}.lock`
 }
 
 export function lock(file: string, options?: LockOptions): Promise<() => Promise<void>>;

--- a/types/prosemirror-dropcursor/index.d.ts
+++ b/types/prosemirror-dropcursor/index.d.ts
@@ -17,4 +17,4 @@ import { Plugin } from 'prosemirror-state';
  * @param options.color The color of the cursor. Defaults to `black`.
  * @param options.width The precise width of the cursor in pixels. Defaults to 1.
  */
-export function dropCursor(options?: { color?: string | null; width?: number | null }): Plugin;
+export function dropCursor(options?: { color?: string | null | undefined; width?: number | null | undefined }): Plugin;

--- a/types/prosemirror-gapcursor/index.d.ts
+++ b/types/prosemirror-gapcursor/index.d.ts
@@ -35,6 +35,6 @@ declare module "prosemirror-model" {
          * property to your node specs — if it's true, gap cursor are allowed
          * everywhere in that node, if it's false they are never allowed.
          */
-        allowGapCursor?: boolean;
+        allowGapCursor?: boolean | undefined;
     }
 }

--- a/types/prosemirror-history/index.d.ts
+++ b/types/prosemirror-history/index.d.ts
@@ -25,7 +25,7 @@ export function closeHistory<S extends Schema = any>(tr: Transaction<S>): Transa
  * property](#state.Transaction.setMeta) of `false` on a transaction
  * to prevent it from being rolled back by undo.
  */
-export function history(config?: { depth?: number | null; newGroupDelay?: number | null }): Plugin;
+export function history(config?: { depth?: number | null | undefined; newGroupDelay?: number | null | undefined }): Plugin;
 /**
  * A command function that undoes the last change, if any.
  */

--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -23,7 +23,7 @@ export class ContentMatch<S extends Schema = any> {
      * Get the first matching node type at this match position that can
      * be generated.
      */
-    defaultType?: NodeType;
+    defaultType?: NodeType | undefined;
     /**
      * The number of outgoing edges this node has in the finite automaton
      * that describes the content expression.
@@ -122,11 +122,11 @@ export class Fragment<S extends Schema = any> {
     /**
      * The first child of the fragment, or `null` if it is empty.
      */
-    firstChild?: ProsemirrorNode<S> | null;
+    firstChild?: ProsemirrorNode<S> | null | undefined;
     /**
      * The last child of the fragment, or `null` if it is empty.
      */
-    lastChild?: ProsemirrorNode<S> | null;
+    lastChild?: ProsemirrorNode<S> | null | undefined;
     /**
      * The number of child nodes in this fragment.
      */
@@ -201,7 +201,7 @@ export interface ParseOptions<S extends Schema = any> {
      * `true` to preserve whitespace, but normalize newlines to
      * spaces, and `"full"` to preserve whitespace entirely.
      */
-    preserveWhitespace?: boolean | 'full' | null;
+    preserveWhitespace?: boolean | 'full' | null | undefined;
     /**
      * When given, the parser will, beside parsing the content,
      * record the document positions of the given DOM positions. It
@@ -209,33 +209,33 @@ export interface ParseOptions<S extends Schema = any> {
      * that holds the document position. DOM positions that are not
      * in the parsed content will not be written to.
      */
-    findPositions?: Array<{ node: Node; offset: number }> | null;
+    findPositions?: Array<{ node: Node; offset: number }> | null | undefined;
     /**
      * The child node index to start parsing from.
      */
-    from?: number | null;
+    from?: number | null | undefined;
     /**
      * The child node index to stop parsing at.
      */
-    to?: number | null;
+    to?: number | null | undefined;
     /**
      * By default, the content is parsed into the schema's default
      * [top node type](#model.Schema.topNodeType). You can pass this
      * option to use the type and attributes from a different node
      * as the top container.
      */
-    topNode?: ProsemirrorNode<S> | null;
+    topNode?: ProsemirrorNode<S> | null | undefined;
     /**
      * Provide the starting content match that content parsed into the
      * top node is matched against.
      */
-    topMatch?: ContentMatch | null;
+    topMatch?: ContentMatch | null | undefined;
     /**
      * A set of additional nodes to count as
      * [context](#model.ParseRule.context) when parsing, above the
      * given [top node](#model.ParseOptions.topNode).
      */
-    context?: ResolvedPos<S> | null;
+    context?: ResolvedPos<S> | null | undefined;
 }
 /**
  * A value that describes how to parse a given DOM node or inline
@@ -246,13 +246,13 @@ export interface ParseRule {
      * A CSS selector describing the kind of DOM elements to match. A
      * single rule should have _either_ a `tag` or a `style` property.
      */
-    tag?: string | null;
+    tag?: string | null | undefined;
     /**
      * The namespace to match. This should be used with `tag`.
      * Nodes are only matched when the namespace matches or this property
      * is null.
      */
-    namespace?: string | null;
+    namespace?: string | null | undefined;
     /**
      * A CSS property name to match. When given, this rule matches
      * inline styles that list that property. May also have the form
@@ -261,7 +261,7 @@ export interface ParseRule {
      * complicated filters, use [`getAttrs`](#model.ParseRule.getAttrs)
      * and return undefined to indicate that the match failed.)
      */
-    style?: string | null;
+    style?: string | null | undefined;
     /**
      * Can be used to change the order in which the parse rules in a
      * schema are tried. Those with higher priority come first. Rules
@@ -269,14 +269,14 @@ export interface ParseRule {
      * property is only meaningful in a schema—when directly
      * constructing a parser, the order of the rule array is used.
      */
-    priority?: number | null;
+    priority?: number | null | undefined;
     /**
      * By default, when a rule matches an element or style, no further
      * rules get a chance to match it. By setting this to false,
      * you indicate that even when this rule matches, other rules
      * that come after it should also run.
      */
-    consuming?: boolean | null;
+    consuming?: boolean | null | undefined;
     /**
      * When given, restricts this rule to only match when the current
      * context—the parent nodes into which the content is being
@@ -290,7 +290,7 @@ export interface ParseRule {
      * different contexts, they can be separated by a pipe (`|`)
      * character, as in `"blockquote/|list_item/"`.
      */
-    context?: string | null;
+    context?: string | null | undefined;
     /**
      * The name of the node type to create when this rule matches. Only
      * valid for rules with a `tag` property, not for style rules. Each
@@ -299,25 +299,25 @@ export interface ParseRule {
      * [mark spec](#model.MarkSpec.parseDOM), in which case the `node`
      * or `mark` property will be derived from its position).
      */
-    node?: string | null;
+    node?: string | null | undefined;
     /**
      * The name of the mark type to wrap the matched content in.
      */
-    mark?: string | null;
+    mark?: string | null | undefined;
     /**
      * When true, ignore content that matches this rule.
      */
-    ignore?: boolean | null;
+    ignore?: boolean | null | undefined;
     /**
      * When true, ignore the node that matches this rule, but do parse
      * its content.
      */
-    skip?: boolean | null;
+    skip?: boolean | null | undefined;
     /**
      * Attributes for the node or mark created by this rule. When
      * `getAttrs` is provided, it takes precedence.
      */
-    attrs?: { [key: string]: any } | null;
+    attrs?: { [key: string]: any } | null | undefined;
     /**
      * A function used to compute the attributes for the node or mark
      * created by this rule. Can also be used to describe further
@@ -328,7 +328,7 @@ export interface ParseRule {
      * Called with a DOM Element for `tag` rules, and with a string (the
      * style's value) for `style` rules.
      */
-    getAttrs?: ((p: Node | string) => { [key: string]: any } | false | null | undefined) | null;
+    getAttrs?: ((p: Node | string) => { [key: string]: any } | false | null | undefined) | null | undefined;
     /**
      * For `tag` rules that produce non-leaf nodes or marks, by default
      * the content of the DOM element is parsed as content of the mark
@@ -337,13 +337,13 @@ export interface ParseRule {
      * content element, or a function that returns the actual content
      * element to the parser.
      */
-    contentElement?: string | ((p: Node) => Node) | null;
+    contentElement?: string | ((p: Node) => Node) | null | undefined;
     /**
      * Can be used to override the content of a matched node. When
      * present, instead of parsing the node's child nodes, the result of
      * this function is used.
      */
-    getContent?: (<S extends Schema = any>(p: Node, schema: S) => Fragment<S>) | null;
+    getContent?: (<S extends Schema = any>(p: Node, schema: S) => Fragment<S>) | null | undefined;
     /**
      * Controls whether whitespace should be preserved when parsing the
      * content inside the matched element. `false` means whitespace may
@@ -351,7 +351,7 @@ export interface ParseRule {
      * but newlines normalized to spaces, and `"full"` means that
      * newlines should also be preserved.
      */
-    preserveWhitespace?: boolean | 'full' | null;
+    preserveWhitespace?: boolean | 'full' | null | undefined;
 }
 /**
  * A DOM parser represents a strategy for parsing DOM content into
@@ -488,7 +488,7 @@ declare class ProsemirrorNode<S extends Schema = any> {
     /**
      * For text nodes, this contains the node's text content.
      */
-    text?: string | null;
+    text?: string | null | undefined;
     /**
      * The size of this node, as defined by the integer-based [indexing
      * scheme](/docs/guide/#doc.indexing). For text nodes, this is the
@@ -557,12 +557,12 @@ declare class ProsemirrorNode<S extends Schema = any> {
      * Returns this node's first child, or `null` if there are no
      * children.
      */
-    firstChild?: ProsemirrorNode<S> | null;
+    firstChild?: ProsemirrorNode<S> | null | undefined;
     /**
      * Returns this node's last child, or `null` if there are no
      * children.
      */
-    lastChild?: ProsemirrorNode<S> | null;
+    lastChild?: ProsemirrorNode<S> | null | undefined;
     /**
      * Test whether two nodes represent the same piece of document.
      */
@@ -616,13 +616,13 @@ declare class ProsemirrorNode<S extends Schema = any> {
      * and return it along with its index and offset relative to this
      * node.
      */
-    childAfter(pos: number): { node?: ProsemirrorNode<S> | null; index: number; offset: number };
+    childAfter(pos: number): { node?: ProsemirrorNode<S> | null | undefined; index: number; offset: number };
     /**
      * Find the (direct) child node before the given offset, if any,
      * and return it along with its index and offset relative to this
      * node.
      */
-    childBefore(pos: number): { node?: ProsemirrorNode<S> | null; index: number; offset: number };
+    childBefore(pos: number): { node?: ProsemirrorNode<S> | null | undefined; index: number; offset: number };
     /**
      * Resolve the given position in the document, returning an
      * [object](#model.ResolvedPos) with information about its context.
@@ -856,13 +856,13 @@ export class ResolvedPos<S extends Schema = any> {
      * points into a text node, only the part of that node after the
      * position is returned.
      */
-    nodeAfter?: ProsemirrorNode<S> | null;
+    nodeAfter?: ProsemirrorNode<S> | null | undefined;
     /**
      * Get the node directly before the position, if any. If the
      * position points into a text node, only the part of that node
      * before the position is returned.
      */
-    nodeBefore?: ProsemirrorNode<S> | null;
+    nodeBefore?: ProsemirrorNode<S> | null | undefined;
     /**
      * Get the position at the given index in the parent node at the
      * given depth (which defaults to this.depth).
@@ -1132,12 +1132,12 @@ export interface SchemaSpec<N extends string = any, M extends string = any> {
      * sets](#model.Mark.addToSet) are sorted and in which [parse
      * rules](#model.MarkSpec.parseDOM) are tried.
      */
-    marks?: { [name in M]: MarkSpec } | OrderedMap<MarkSpec> | null;
+    marks?: { [name in M]: MarkSpec } | OrderedMap<MarkSpec> | null | undefined;
     /**
      * The name of the default top-level node for the schema. Defaults
      * to `"doc"`.
      */
-    topNode?: string | null;
+    topNode?: string | null | undefined;
 }
 export interface NodeSpec {
     /**
@@ -1145,7 +1145,7 @@ export interface NodeSpec {
      * guide](/docs/guide/#schema.content_expressions). When not given,
      * the node does not allow any content.
      */
-    content?: string | null;
+    content?: string | null | undefined;
     /**
      * The marks that are allowed inside of this node. May be a
      * space-separated string referring to mark names or groups, `"_"`
@@ -1153,43 +1153,43 @@ export interface NodeSpec {
      * not given, nodes with inline content default to allowing all
      * marks, other nodes default to not allowing marks.
      */
-    marks?: string | null;
+    marks?: string | null | undefined;
     /**
      * The group or space-separated groups to which this node belongs,
      * which can be referred to in the content expressions for the
      * schema.
      */
-    group?: string | null;
+    group?: string | null | undefined;
     /**
      * Should be set to true for inline nodes. (Implied for text nodes.)
      */
-    inline?: boolean | null;
+    inline?: boolean | null | undefined;
     /**
      * Can be set to true to indicate that, though this isn't a [leaf
      * node](#model.NodeType.isLeaf), it doesn't have directly editable
      * content and should be treated as a single unit in the view.
      */
-    atom?: boolean | null;
+    atom?: boolean | null | undefined;
     /**
      * The attributes that nodes of this type get.
      */
-    attrs?: { [name: string]: AttributeSpec } | null;
+    attrs?: { [name: string]: AttributeSpec } | null | undefined;
     /**
      * Controls whether nodes of this type can be selected as a [node
      * selection](#state.NodeSelection). Defaults to true for non-text
      * nodes.
      */
-    selectable?: boolean | null;
+    selectable?: boolean | null | undefined;
     /**
      * Determines whether nodes of this type can be dragged without
      * being selected. Defaults to false.
      */
-    draggable?: boolean | null;
+    draggable?: boolean | null | undefined;
     /**
      * Can be used to indicate that this node contains code, which
      * causes some commands to behave differently.
      */
-    code?: boolean | null;
+    code?: boolean | null | undefined;
     /**
      * Determines whether this node is considered an important parent
      * node during replace operations (such as paste). Non-defining (the
@@ -1200,14 +1200,14 @@ export interface NodeSpec {
      * non-default-paragraph textblock types, and possibly list items,
      * are marked as defining.
      */
-    defining?: boolean | null;
+    defining?: boolean | null | undefined;
     /**
      * When enabled (default is false), the sides of nodes of this type
      * count as boundaries that regular editing operations, like
      * backspacing or lifting, won't cross. An example of a node that
      * should probably have this enabled is a table cell.
      */
-    isolating?: boolean | null;
+    isolating?: boolean | null | undefined;
     /**
      * Defines the default way a node of this type should be serialized
      * to DOM/HTML (as used by
@@ -1222,7 +1222,7 @@ export interface NodeSpec {
      * differently, this is not supported inside the editor, so you
      * shouldn't override that in your text node spec.
      */
-    toDOM?: ((node: ProsemirrorNode) => DOMOutputSpec) | null;
+    toDOM?: ((node: ProsemirrorNode) => DOMOutputSpec) | null | undefined;
     /**
      * Associates DOM parser information with this node, which can be
      * used by [`DOMParser.fromSchema`](#model.DOMParser^fromSchema) to
@@ -1231,12 +1231,12 @@ export interface NodeSpec {
      * If you supply your own parser, you do not need to also specify
      * parsing rules in your schema.
      */
-    parseDOM?: ParseRule[] | null;
+    parseDOM?: ParseRule[] | null | undefined;
     /**
      * Defines the default way a node of this type should be serialized
      * to a string representation for debugging (e.g. in error messages).
      */
-    toDebugString?: ((node: ProsemirrorNode) => string) | null;
+    toDebugString?: ((node: ProsemirrorNode) => string) | null | undefined;
     /**
      * Allow specifying arbitrary fields on a NodeSpec.
      */
@@ -1246,13 +1246,13 @@ export interface MarkSpec {
     /**
      * The attributes that marks of this type get.
      */
-    attrs?: { [name: string]: AttributeSpec } | null;
+    attrs?: { [name: string]: AttributeSpec } | null | undefined;
     /**
      * Whether this mark should be active when the cursor is positioned
      * at its end (or at its start when that is also the start of the
      * parent node). Defaults to true.
      */
-    inclusive?: boolean | null;
+    inclusive?: boolean | null | undefined;
     /**
      * Determines which other marks this mark can coexist with. Should
      * be a space-separated strings naming other marks or groups of marks.
@@ -1268,27 +1268,27 @@ export interface MarkSpec {
      * mark's own name) to allow multiple marks of a given type to
      * coexist (as long as they have different attributes).
      */
-    excludes?: string | null;
+    excludes?: string | null | undefined;
     /**
      * The group or space-separated groups to which this mark belongs.
      */
-    group?: string | null;
+    group?: string | null | undefined;
     /**
      * Determines whether marks of this type can span multiple adjacent
      * nodes when serialized to DOM/HTML. Defaults to true.
      */
-    spanning?: boolean | null;
+    spanning?: boolean | null | undefined;
     /**
      * Defines the default way marks of this type should be serialized
      * to DOM/HTML.
      */
-    toDOM?: ((mark: Mark, inline: boolean) => DOMOutputSpec) | null;
+    toDOM?: ((mark: Mark, inline: boolean) => DOMOutputSpec) | null | undefined;
     /**
      * Associates DOM parser information with this mark (see the
      * corresponding [node spec field](#model.NodeSpec.parseDOM)). The
      * `mark` field in the rules is implied.
      */
-    parseDOM?: ParseRule[] | null;
+    parseDOM?: ParseRule[] | null | undefined;
     /**
      * Allow specifying arbitrary fields on a MarkSpec.
      */
@@ -1379,17 +1379,17 @@ export class Schema<N extends string = any, M extends string = any> {
 }
 export interface DOMOutputSpecArray {
     0: string;
-    1?: DOMOutputSpec | 0 | { [attr: string]: string | null | undefined };
-    2?: DOMOutputSpec | 0;
-    3?: DOMOutputSpec | 0;
-    4?: DOMOutputSpec | 0;
-    5?: DOMOutputSpec | 0;
-    6?: DOMOutputSpec | 0;
-    7?: DOMOutputSpec | 0;
-    8?: DOMOutputSpec | 0;
-    9?: DOMOutputSpec | 0;
+    1?: DOMOutputSpec | 0 | { [attr: string]: string | null | undefined } | undefined;
+    2?: DOMOutputSpec | 0 | undefined;
+    3?: DOMOutputSpec | 0 | undefined;
+    4?: DOMOutputSpec | 0 | undefined;
+    5?: DOMOutputSpec | 0 | undefined;
+    6?: DOMOutputSpec | 0 | undefined;
+    7?: DOMOutputSpec | 0 | undefined;
+    8?: DOMOutputSpec | 0 | undefined;
+    9?: DOMOutputSpec | 0 | undefined;
 }
-export type DOMOutputSpec = string | Node | DOMOutputSpecArray | {dom: Node, contentDOM?: Node};
+export type DOMOutputSpec = string | Node | DOMOutputSpecArray | {dom: Node, contentDOM?: Node | undefined};
 /**
  * A DOM serializer knows how to convert ProseMirror nodes and
  * marks of various types to DOM nodes.
@@ -1436,7 +1436,7 @@ export class DOMSerializer<S extends Schema = any> {
      * the spec has a hole (zero) in it, `contentDOM` will point at the
      * node with the hole.
      */
-    static renderSpec(doc: Document, structure: DOMOutputSpec): { dom: Node; contentDOM?: Node | null };
+    static renderSpec(doc: Document, structure: DOMOutputSpec): { dom: Node; contentDOM?: Node | null | undefined };
     /**
      * Build a serializer using the [`toDOM`](#model.NodeSpec.toDOM)
      * properties in a schema's node and mark specs.

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -22,19 +22,19 @@ export interface PluginSpec<T = any, S extends Schema = any> {
      * that are functions will be bound to have the plugin instance as
      * their `this` binding.
      */
-    props?: EditorProps<Plugin<T, S>, S> | null;
+    props?: EditorProps<Plugin<T, S>, S> | null | undefined;
     /**
      * Allows a plugin to define a [state field](#state.StateField), an
      * extra slot in the state object in which it can keep its own data.
      */
-    state?: StateField<T, S> | null;
+    state?: StateField<T, S> | null | undefined;
     /**
      * Can be used to make this a keyed plugin. You can have only one
      * plugin with a given key in a given state, but it is possible to
      * access the plugin's configuration and state through the key,
      * without having access to the plugin instance object.
      */
-    key?: PluginKey<T, S> | null;
+    key?: PluginKey<T, S> | null | undefined;
     /**
      * When the plugin needs to interact with the editor view, or
      * set something up in the DOM, use this field. The function
@@ -45,16 +45,16 @@ export interface PluginSpec<T = any, S extends Schema = any> {
         | ((
               p: EditorView<S>,
           ) => {
-              update?: ((view: EditorView<S>, prevState: EditorState<S>) => void) | null;
-              destroy?: (() => void) | null;
+              update?: ((view: EditorView<S>, prevState: EditorState<S>) => void) | null | undefined;
+              destroy?: (() => void) | null | undefined;
           })
-        | null;
+        | null | undefined;
     /**
      * When present, this will be called before a transaction is
      * applied by the state, allowing the plugin to cancel it (by
      * returning false).
      */
-    filterTransaction?: ((p1: Transaction<S>, p2: EditorState<S>) => boolean) | null;
+    filterTransaction?: ((p1: Transaction<S>, p2: EditorState<S>) => boolean) | null | undefined;
     /**
      * Allows the plugin to append another transaction to be applied
      * after the given array of transactions. When another plugin
@@ -69,7 +69,7 @@ export interface PluginSpec<T = any, S extends Schema = any> {
               oldState: EditorState<S>,
               newState: EditorState<S>,
           ) => Transaction<S> | null | undefined | void)
-        | null;
+        | null | undefined;
 }
 /**
  * Plugins bundle functionality that can be added to an editor.
@@ -119,12 +119,12 @@ export interface StateField<T = any, S extends Schema = Schema> {
      * Convert this field to JSON. Optional, can be left off to disable
      * JSON serialization for the field.
      */
-    toJSON?: ((this: Plugin<T, S>, value: T) => any) | null;
+    toJSON?: ((this: Plugin<T, S>, value: T) => any) | null | undefined;
     /**
      * Deserialize the JSON representation of this field. Note that the
      * `state` argument is again a half-initialized state.
      */
-    fromJSON?: ((this: Plugin<T, S>, config: { [key: string]: any }, value: any, state: EditorState<S>) => T) | null;
+    fromJSON?: ((this: Plugin<T, S>, config: { [key: string]: any }, value: any, state: EditorState<S>) => T) | null | undefined;
 }
 /**
  * A key is used to [tag](#state.PluginSpec.key)
@@ -336,7 +336,7 @@ export class TextSelection<S extends Schema = any> extends Selection<S> {
      * Returns a resolved position if this is a cursor selection (an
      * empty text selection), and null otherwise.
      */
-    $cursor?: ResolvedPos<S> | null;
+    $cursor?: ResolvedPos<S> | null | undefined;
     /**
      * Create a text selection from non-resolved positions.
      */
@@ -412,7 +412,7 @@ export class EditorState<S extends Schema = any> {
      * A set of marks to apply to the next input. Will be null when
      * no explicit marks have been set.
      */
-    storedMarks?: Array<Mark<S>> | null;
+    storedMarks?: Array<Mark<S>> | null | undefined;
     /**
      * The schema of the state's document.
      */
@@ -445,7 +445,7 @@ export class EditorState<S extends Schema = any> {
      * [`init`](#state.StateField.init) method, passing in the new
      * configuration object..
      */
-    reconfigure(config: { schema?: S | null; plugins?: Array<Plugin<any, S>> | null }): EditorState<S>;
+    reconfigure(config: { schema?: S | null | undefined; plugins?: Array<Plugin<any, S>> | null | undefined }): EditorState<S>;
     /**
      * Serialize this state to JSON. If you want to serialize the state
      * of plugins, pass an object mapping property names to use in the
@@ -456,11 +456,11 @@ export class EditorState<S extends Schema = any> {
      * Create a new state.
      */
     static create<S extends Schema = any>(config: {
-        schema?: S | null;
-        doc?: ProsemirrorNode<S> | null;
-        selection?: Selection<S> | null;
-        storedMarks?: Mark[] | null;
-        plugins?: Array<Plugin<any, S>> | null;
+        schema?: S | null | undefined;
+        doc?: ProsemirrorNode<S> | null | undefined;
+        selection?: Selection<S> | null | undefined;
+        storedMarks?: Mark[] | null | undefined;
+        plugins?: Array<Plugin<any, S>> | null | undefined;
     }): EditorState<S>;
     /**
      * Deserialize a JSON representation of a state. `config` should
@@ -470,7 +470,7 @@ export class EditorState<S extends Schema = any> {
      * instances with the property names they use in the JSON object.
      */
     static fromJSON<S extends Schema = any>(
-        config: { schema: S; plugins?: Array<Plugin<any, S>> | null },
+        config: { schema: S; plugins?: Array<Plugin<any, S>> | null | undefined },
         json: { [key: string]: any },
         pluginFields?: { [name: string]: Plugin<any, S> },
     ): EditorState<S>;
@@ -503,7 +503,7 @@ export class Transaction<S extends Schema = any> extends Transform<S> {
     /**
      * The stored marks set by this transaction, if any.
      */
-    storedMarks?: Mark[] | null;
+    storedMarks?: Mark[] | null | undefined;
     /**
      * The transaction's current selection. This defaults to the editor
      * selection [mapped](#state.Selection.map) through the steps in the

--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -280,7 +280,7 @@ export class Transform<S extends Schema = any> {
      * The wrappers are assumed to be valid in this position, and should
      * probably be computed with [`findWrapping`](#transform.findWrapping).
      */
-    wrap(range: NodeRange<S>, wrappers: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null }>): this;
+    wrap(range: NodeRange<S>, wrappers: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined }>): this;
     /**
      * Set the type of all textblocks (partly) between `from` and `to` to
      * the given node type with the given attributes.
@@ -301,7 +301,7 @@ export class Transform<S extends Schema = any> {
     split(
         pos: number,
         depth?: number,
-        typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null }>,
+        typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined }>,
     ): this;
     /**
      * Join the blocks around the given position. If depth is 2, their
@@ -464,11 +464,11 @@ export class StepResult<S extends Schema = any> {
     /**
      * The transformed document.
      */
-    doc?: ProsemirrorNode<S> | null;
+    doc?: ProsemirrorNode<S> | null | undefined;
     /**
      * Text providing information about a failed step.
      */
-    failed?: string | null;
+    failed?: string | null | undefined;
     /**
      * Create a successful step result.
      */
@@ -508,7 +508,7 @@ export function findWrapping<S extends Schema = any>(
     nodeType: NodeType<S>,
     attrs?: { [key: string]: any },
     innerRange?: NodeRange<S>,
-): Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null }> | null | undefined;
+): Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined }> | null | undefined;
 /**
  * Check whether splitting at the given position is allowed.
  */
@@ -516,7 +516,7 @@ export function canSplit<S extends Schema = any>(
     doc: ProsemirrorNode<S>,
     pos: number,
     depth?: number,
-    typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null } | null | undefined>,
+    typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined } | null | undefined>,
 ): boolean;
 /**
  * Test whether the blocks before and after a given position can be

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -48,16 +48,16 @@ export interface WidgetDecorationSpec {
      * the widget is wrapped in—those of the node before when
      * negative, those of the node after when positive.
      */
-    side?: number | null;
+    side?: number | null | undefined;
     /**
      * The precise set of marks to draw around the widget.
      */
-    marks?: Mark[] | null;
+    marks?: Mark[] | null | undefined;
     /**
      * Can be used to control which DOM events, when they bubble out
      * of this widget, the editor view should ignore.
      */
-    stopEvent?: ((event: Event) => boolean) | null;
+    stopEvent?: ((event: Event) => boolean) | null | undefined;
     /**
      * When comparing decorations of this type (in order to decide
      * whether it needs to be redrawn), ProseMirror will by default
@@ -69,7 +69,7 @@ export interface WidgetDecorationSpec {
      * the behavior of some event handler, they should get
      * different keys.
      */
-    key?: string | null;
+    key?: string | null | undefined;
 }
 /**
  * The `spec` for the inline decoration.
@@ -82,11 +82,11 @@ export interface InlineDecorationSpec {
      * won't include the new content, but you can set this to `true`
      * to make it inclusive.
      */
-    inclusiveStart?: boolean | null;
+    inclusiveStart?: boolean | null | undefined;
     /**
      * Determines how the right side of the decoration is mapped.
      */
-    inclusiveEnd?: boolean | null;
+    inclusiveEnd?: boolean | null | undefined;
 }
 /**
  * Decoration objects can be provided to the view through the
@@ -153,16 +153,16 @@ export interface DecorationAttrs {
      * A CSS class name or a space-separated set of class names to be
      * _added_ to the classes that the node already had.
      */
-    class?: string | null;
+    class?: string | null | undefined;
     /**
      * A string of CSS to be _added_ to the node's existing `style` property.
      */
-    style?: string | null;
+    style?: string | null | undefined;
     /**
      * When non-null, the target node is wrapped in a DOM element of
      * this type (and the other attributes are applied to this element).
      */
-    nodeName?: string | null;
+    nodeName?: string | null | undefined;
     /**
      * Specify additional attrs that will be mapped directly to the
      * target node's DOM attributes.
@@ -192,7 +192,7 @@ export class DecorationSet<S extends Schema = any> {
     map(
         mapping: Mapping,
         doc: ProsemirrorNode<S>,
-        options?: { onRemove?: ((decorationSpec: { [key: string]: any }) => void) | null },
+        options?: { onRemove?: ((decorationSpec: { [key: string]: any }) => void) | null | undefined },
     ): DecorationSet<S>;
     /**
      * Add the given array of decorations to the ones in the set,
@@ -247,7 +247,7 @@ export class EditorView<S extends Schema = any> {
      * information about the dragged slice and whether it is being
      * copied or moved. At any other time, it is null.
      */
-    dragging?: { slice: Slice<S>; move: boolean } | null;
+    dragging?: { slice: Slice<S>; move: boolean } | null | undefined;
     /**
      * Holds true when a composition is active.
      */
@@ -397,21 +397,21 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
      * `preventDefault` yourself (or not, if you want to allow the
      * default behavior).
      */
-    handleDOMEvents?: HandleDOMEventsProp<ThisT, S> | null;
+    handleDOMEvents?: HandleDOMEventsProp<ThisT, S> | null | undefined;
     /**
      * Called when the editor receives a `keydown` event.
      */
-    handleKeyDown?: ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
+    handleKeyDown?: ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean) | null | undefined;
     /**
      * Handler for `keypress` events.
      */
-    handleKeyPress?: ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
+    handleKeyPress?: ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean) | null | undefined;
     /**
      * Whenever the user directly input text, this handler is called
      * before the input is applied. If it returns `true`, the default
      * behavior of actually inserting the text is suppressed.
      */
-    handleTextInput?: ((this: ThisT, view: EditorView<S>, from: number, to: number, text: string) => boolean) | null;
+    handleTextInput?: ((this: ThisT, view: EditorView<S>, from: number, to: number, text: string) => boolean) | null | undefined;
     /**
      * Called for each node around a click, from the inside out. The
      * `direct` flag will be true for the inner node.
@@ -426,12 +426,12 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
               event: MouseEvent,
               direct: boolean,
           ) => boolean)
-        | null;
+        | null | undefined;
     /**
      * Called when the editor is clicked, after `handleClickOn` handlers
      * have been called.
      */
-    handleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+    handleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null | undefined;
     /**
      * Called for each node around a double click.
      */
@@ -445,11 +445,11 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
               event: MouseEvent,
               direct: boolean,
           ) => boolean)
-        | null;
+        | null | undefined;
     /**
      * Called when the editor is double-clicked, after `handleDoubleClickOn`.
      */
-    handleDoubleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+    handleDoubleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null | undefined;
     /**
      * Called for each node around a triple click.
      */
@@ -463,30 +463,30 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
               event: MouseEvent,
               direct: boolean,
           ) => boolean)
-        | null;
+        | null | undefined;
     /**
      * Called when the editor is triple-clicked, after `handleTripleClickOn`.
      */
-    handleTripleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+    handleTripleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null | undefined;
     /**
      * Can be used to override the behavior of pasting. `slice` is the
      * pasted content parsed by the editor, but you can directly access
      * the event to get at the raw content.
      */
-    handlePaste?: ((this: ThisT, view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null;
+    handlePaste?: ((this: ThisT, view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null | undefined;
     /**
      * Called when something is dropped on the editor. `moved` will be
      * true if this drop moves from the current selection (which should
      * thus be deleted).
      */
-    handleDrop?: ((this: ThisT, view: EditorView<S>, event: Event, slice: Slice<S>, moved: boolean) => boolean) | null;
+    handleDrop?: ((this: ThisT, view: EditorView<S>, event: Event, slice: Slice<S>, moved: boolean) => boolean) | null | undefined;
     /**
      * Called when the view, after updating its state, tries to scroll
      * the selection into view. A handler function may return false to
      * indicate that it did not handle the scrolling and further
      * handlers or the default behavior should be tried.
      */
-    handleScrollToSelection?: ((this: ThisT, view: EditorView<S>) => boolean) | null;
+    handleScrollToSelection?: ((this: ThisT, view: EditorView<S>) => boolean) | null | undefined;
     /**
      * Can be used to override the way a selection is created when
      * reading a DOM selection between the given anchor and head.
@@ -498,30 +498,30 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
               anchor: ResolvedPos<S>,
               head: ResolvedPos<S>,
           ) => Selection<S> | null | undefined)
-        | null;
+        | null | undefined;
     /**
      * The [parser](#model.DOMParser) to use when reading editor changes
      * from the DOM. Defaults to calling
      * [`DOMParser.fromSchema`](#model.DOMParser^fromSchema) on the
      * editor's schema.
      */
-    domParser?: DOMParser<S> | null;
+    domParser?: DOMParser<S> | null | undefined;
     /**
      * Can be used to transform pasted HTML text, _before_ it is parsed,
      * for example to clean it up.
      */
-    transformPastedHTML?: ((this: ThisT, html: string) => string) | null;
+    transformPastedHTML?: ((this: ThisT, html: string) => string) | null | undefined;
     /**
      * The [parser](#model.DOMParser) to use when reading content from
      * the clipboard. When not given, the value of the
      * [`domParser`](#view.EditorProps.domParser) prop is used.
      */
-    clipboardParser?: DOMParser<S> | null;
+    clipboardParser?: DOMParser<S> | null | undefined;
     /**
      * Transform pasted plain text. The `plain` flag will be true when
      * the text is pasted as plain text.
      */
-    transformPastedText?: ((this: ThisT, text: string, plain: boolean) => string) | null;
+    transformPastedText?: ((this: ThisT, text: string, plain: boolean) => string) | null | undefined;
     /**
      * A function to parse text from the clipboard into a document
      * slice. Called after
@@ -532,12 +532,12 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
      * The `plain` flag will be true when the text is pasted as plain
      * text.
      */
-    clipboardTextParser?: ((this: ThisT, text: string, $context: ResolvedPos<S>, plain: boolean) => Slice<S>) | null;
+    clipboardTextParser?: ((this: ThisT, text: string, $context: ResolvedPos<S>, plain: boolean) => Slice<S>) | null | undefined;
     /**
      * Can be used to transform pasted content before it is applied to
      * the document.
      */
-    transformPasted?: ((this: ThisT, p: Slice<S>) => Slice<S>) | null;
+    transformPasted?: ((this: ThisT, p: Slice<S>) => Slice<S>) | null | undefined;
     /**
      * Allows you to pass custom rendering and behavior logic for nodes
      * and marks. Should map node and mark names to constructor
@@ -561,31 +561,31 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
             getPos: (() => number) | boolean,
             decorations: Decoration[],
         ) => NodeView<S>;
-    } | null;
+    } | null | undefined;
     /**
      * The DOM serializer to use when putting content onto the
      * clipboard. If not given, the result of
      * [`DOMSerializer.fromSchema`](#model.DOMSerializer^fromSchema)
      * will be used.
      */
-    clipboardSerializer?: DOMSerializer<S> | null;
+    clipboardSerializer?: DOMSerializer<S> | null | undefined;
     /**
      * A function that will be called to get the text for the current
      * selection when copying text to the clipboard. By default, the
      * editor will use [`textBetween`](#model.Node.textBetween) on the
      * selected range.
      */
-    clipboardTextSerializer?: ((this: ThisT, p: Slice<S>) => string) | null;
+    clipboardTextSerializer?: ((this: ThisT, p: Slice<S>) => string) | null | undefined;
     /**
      * A set of [document decorations](#view.Decoration) to show in the
      * view.
      */
-    decorations?: ((this: ThisT, state: EditorState<S>) => DecorationSet<S> | null | undefined) | null;
+    decorations?: ((this: ThisT, state: EditorState<S>) => DecorationSet<S> | null | undefined) | null | undefined;
     /**
      * When this returns false, the content of the view is not directly
      * editable.
      */
-    editable?: ((this: ThisT, state: EditorState<S>) => boolean) | null;
+    editable?: ((this: ThisT, state: EditorState<S>) => boolean) | null | undefined;
     /**
      * Control the DOM attributes of the editable element. May be either
      * an object or a function going from an editor state to an object.
@@ -599,18 +599,18 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
     attributes?:
         | { [name: string]: string }
         | ((this: ThisT, p: EditorState<S>) => { [name: string]: string } | null | undefined | void)
-        | null;
+        | null | undefined;
     /**
      * Determines the distance (in pixels) between the cursor and the
      * end of the visible viewport at which point, when scrolling the
      * cursor into view, scrolling takes place. Defaults to 0.
      */
-    scrollThreshold?: number | { top: number; right: number; bottom: number; left: number } | null;
+    scrollThreshold?: number | { top: number; right: number; bottom: number; left: number } | null | undefined;
     /**
      * Determines the extra space (in pixels) that is left above or
      * below the cursor when it is scrolled into view. Defaults to 5.
      */
-    scrollMargin?: number | { top: number; right: number; bottom: number; left: number } | null;
+    scrollMargin?: number | { top: number; right: number; bottom: number; left: number } | null | undefined;
 }
 /**
  * A mapping of dom events.
@@ -640,7 +640,7 @@ export interface DirectEditorProps<S extends Schema = any> extends EditorProps<u
      * [applied](#state.EditorState.apply). The callback will be bound to have
      * the view instance as its `this` binding.
      */
-    dispatchTransaction?: ((this: EditorView<S>, tr: Transaction<S>) => void) | null;
+    dispatchTransaction?: ((this: EditorView<S>, tr: Transaction<S>) => void) | null | undefined;
 }
 /**
  * By default, document nodes are rendered using the result of the
@@ -657,7 +657,7 @@ export interface NodeView<S extends Schema = any> {
      * The outer DOM node that represents the document node. When not
      * given, the default strategy is used to create a DOM node.
      */
-    dom?: Node | null;
+    dom?: Node | null | undefined;
     /**
      * The DOM node that should hold the node's content. Only meaningful
      * if the node view also defines a `dom` property and if its node
@@ -666,7 +666,7 @@ export interface NodeView<S extends Schema = any> {
      * is not present, the node view itself is responsible for rendering
      * (or deciding not to render) its child nodes.
      */
-    contentDOM?: Node | null;
+    contentDOM?: Node | null | undefined;
     /**
      * When given, this will be called when the view is updating itself.
      * It will be given a node (possibly of a different type), and an
@@ -677,17 +677,17 @@ export interface NodeView<S extends Schema = any> {
      * no `dom` property), updating its child nodes will be handled by
      * ProseMirror.
      */
-    update?: ((node: ProsemirrorNode<S>, decorations: Decoration[]) => boolean) | null;
+    update?: ((node: ProsemirrorNode<S>, decorations: Decoration[]) => boolean) | null | undefined;
     /**
      * Can be used to override the way the node's selected status (as a
      * node selection) is displayed.
      */
-    selectNode?: (() => void) | null;
+    selectNode?: (() => void) | null | undefined;
     /**
      * When defining a `selectNode` method, you should also provide a
      * `deselectNode` method to remove the effect again.
      */
-    deselectNode?: (() => void) | null;
+    deselectNode?: (() => void) | null | undefined;
     /**
      * This will be called to handle setting the selection inside the
      * node. The `anchor` and `head` positions are relative to the start
@@ -695,13 +695,13 @@ export interface NodeView<S extends Schema = any> {
      * the DOM positions corresponding to those positions, but if you
      * override it you can do something else.
      */
-    setSelection?: ((anchor: number, head: number, root: Document) => void) | null;
+    setSelection?: ((anchor: number, head: number, root: Document) => void) | null | undefined;
     /**
      * Can be used to prevent the editor view from trying to handle some
      * or all DOM events that bubble up from the node view. Events for
      * which this returns true are not handled by the editor.
      */
-    stopEvent?: ((event: Event) => boolean) | null;
+    stopEvent?: ((event: Event) => boolean) | null | undefined;
     /**
      * Called when a DOM
      * [mutation](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
@@ -721,10 +721,10 @@ export interface NodeView<S extends Schema = any> {
                         target: Element;
                     },
           ) => boolean)
-        | null;
+        | null | undefined;
     /**
      * Called when the node view is removed from the editor or the whole
      * editor is destroyed.
      */
-    destroy?: (() => void) | null;
+    destroy?: (() => void) | null | undefined;
 }

--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -22,9 +22,9 @@ interface ObjectsResponse<DataType> {
     data: DataType;
 }
 interface PagedObjectsResponse<DataType> extends ObjectsResponse<DataType[]> {
-    prev?: string;
-    next?: string;
-    totalCount?: number;
+    prev?: string | undefined;
+    next?: string | undefined;
+    totalCount?: number | undefined;
 }
 // partial but everything can be null (even with strictNullChecks)
 type Nullable<T> = {
@@ -504,29 +504,29 @@ declare class Pubnub {
 declare namespace Pubnub {
     interface PubnubConfig {
         subscribeKey: string;
-        publishKey?: string;
-        cipherKey?: string;
-        authKey?: string;
-        logVerbosity?: boolean;
-        uuid?: string;
-        ssl?: boolean;
-        origin?: string;
-        presenceTimeout?: number;
-        heartbeatInterval?: number;
-        restore?: boolean;
-        keepAlive?: boolean;
+        publishKey?: string | undefined;
+        cipherKey?: string | undefined;
+        authKey?: string | undefined;
+        logVerbosity?: boolean | undefined;
+        uuid?: string | undefined;
+        ssl?: boolean | undefined;
+        origin?: string | undefined;
+        presenceTimeout?: number | undefined;
+        heartbeatInterval?: number | undefined;
+        restore?: boolean | undefined;
+        keepAlive?: boolean | undefined;
         keepAliveSettings?: {
-            keepAliveMsecs?: number;
-            freeSocketKeepAliveTimeout?: number;
-            timeout?: number;
-            maxSockets?: number;
-            maxFreeSockets?: number;
-        };
-        suppressLeaveEvents?: boolean;
-        secretKey?: string;
-        requestMessageCountThreshold?: number;
-        autoNetworkDetection?: boolean;
-        listenToBrowserNetworkEvents?: boolean;
+            keepAliveMsecs?: number | undefined;
+            freeSocketKeepAliveTimeout?: number | undefined;
+            timeout?: number | undefined;
+            maxSockets?: number | undefined;
+            maxFreeSockets?: number | undefined;
+        } | undefined;
+        suppressLeaveEvents?: boolean | undefined;
+        secretKey?: string | undefined;
+        requestMessageCountThreshold?: number | undefined;
+        autoNetworkDetection?: boolean | undefined;
+        listenToBrowserNetworkEvents?: boolean | undefined;
     }
 
     interface MessageEvent {
@@ -624,7 +624,7 @@ declare namespace Pubnub {
         eTag: string;
         created: string;
         updated: string;
-        custom?: object | null;
+        custom?: object | null | undefined;
     }
 
     /**
@@ -645,7 +645,7 @@ declare namespace Pubnub {
     interface MessageActionEvent {
         channel: string;
         publisher: string;
-        subscription?: string;
+        subscription?: string | undefined;
         timetoken: string;
         event: string;
         data: MessageAction;
@@ -672,7 +672,7 @@ declare namespace Pubnub {
             data: object;
         };
         subscription: string | null;
-        publisher?: string;
+        publisher?: string | undefined;
         timetoken: number;
     }
 
@@ -757,10 +757,10 @@ declare namespace Pubnub {
     interface PublishParameters {
         message: any;
         channel: string;
-        storeInHistory?: boolean;
-        sendByPost?: boolean;
+        storeInHistory?: boolean | undefined;
+        sendByPost?: boolean | undefined;
         meta?: any;
-        ttl?: number;
+        ttl?: number | undefined;
     }
 
     interface PublishResponse {
@@ -781,37 +781,37 @@ declare namespace Pubnub {
     interface HistoryParameters {
         channel: string;
         count: number;
-        stringifiedTimeToken?: boolean;
-        includeTimetoken?: boolean;
-        reverse?: boolean;
-        start?: string | number; // timetoken
-        end?: string | number; // timetoken
-        includeMeta?: boolean;
+        stringifiedTimeToken?: boolean | undefined;
+        includeTimetoken?: boolean | undefined;
+        reverse?: boolean | undefined;
+        start?: string | number | undefined; // timetoken
+        end?: string | number | undefined; // timetoken
+        includeMeta?: boolean | undefined;
     }
 
     interface HistoryMessage {
         entry: any;
-        timetoken?: string | number;
-        meta?: object;
+        timetoken?: string | number | undefined;
+        meta?: object | undefined;
     }
 
     interface HistoryResponse {
-        endTimeToken?: string | number;
-        startTimeToken?: string | number;
+        endTimeToken?: string | number | undefined;
+        startTimeToken?: string | number | undefined;
         messages: HistoryMessage[];
     }
 
     interface FetchMessagesParameters {
         channels: string[];
-        count?: number;
-        stringifiedTimeToken?: boolean;
-        start?: string | number; // timetoken
-        end?: string | number; // timetoken
-        withMessageActions?: boolean;
-        includeMessageType?: boolean;
-        includeUUID?: boolean;
-        includeMeta?: boolean;
-        includeMessageActions?: boolean;
+        count?: number | undefined;
+        stringifiedTimeToken?: boolean | undefined;
+        start?: string | number | undefined; // timetoken
+        end?: string | number | undefined; // timetoken
+        withMessageActions?: boolean | undefined;
+        includeMessageType?: boolean | undefined;
+        includeUUID?: boolean | undefined;
+        includeMeta?: boolean | undefined;
+        includeMessageActions?: boolean | undefined;
     }
 
     interface FetchMessagesResponse {
@@ -820,11 +820,11 @@ declare namespace Pubnub {
                 channel: string;
                 message: any;
                 timetoken: string | number;
-                messageType?: string | number;
-                uuid?: string;
+                messageType?: string | number | undefined;
+                uuid?: string | undefined;
                 meta?: {
                     [key: string]: any;
-                };
+                } | undefined;
                 actions: {
                     [type: string]: {
                         [value: string]: Array<{
@@ -839,8 +839,8 @@ declare namespace Pubnub {
 
     interface DeleteMessagesParameters {
         channel: string;
-        start?: string | number; // timetoken
-        end?: string | number; // timetoken
+        start?: string | number | undefined; // timetoken
+        end?: string | number | undefined; // timetoken
     }
 
     interface MessageCountsParameters {
@@ -889,32 +889,32 @@ declare namespace Pubnub {
 
     interface PubnubStatus {
         error: boolean;
-        category?: string; // see Pubnub.Categories
+        category?: string | undefined; // see Pubnub.Categories
         operation: string; // see Pubnub.Operations
         statusCode: number;
-        errorData?: Error;
+        errorData?: Error | undefined;
     }
 
     // fire
     interface FireParameters {
         message: any;
         channel: string;
-        sendByPost?: boolean;
+        sendByPost?: boolean | undefined;
         meta?: any;
     }
 
     // subscribe
     interface SubscribeParameters {
-        channels?: string[];
-        channelGroups?: string[];
-        withPresence?: boolean;
-        timetoken?: number;
+        channels?: string[] | undefined;
+        channelGroups?: string[] | undefined;
+        withPresence?: boolean | undefined;
+        timetoken?: number | undefined;
     }
 
     // unsubscribe
     interface UnsubscribeParameters {
-        channels?: string[];
-        channelGroups?: string[];
+        channels?: string[] | undefined;
+        channelGroups?: string[] | undefined;
     }
 
     // channelGroups
@@ -1000,10 +1000,10 @@ declare namespace Pubnub {
 
     // hereNow
     interface HereNowParameters {
-        channels?: string[];
-        channelGroups?: string[];
-        includeUUIDs?: boolean;
-        includeState?: boolean;
+        channels?: string[] | undefined;
+        channelGroups?: string[] | undefined;
+        includeUUIDs?: boolean | undefined;
+        includeState?: boolean | undefined;
     }
 
     interface HereNowResponse {
@@ -1023,7 +1023,7 @@ declare namespace Pubnub {
 
     // whereNow
     interface WhereNowParameters {
-        uuid?: string;
+        uuid?: string | undefined;
     }
 
     interface WhereNowResponse {
@@ -1032,8 +1032,8 @@ declare namespace Pubnub {
 
     // setState
     interface SetStateParameters {
-        channels?: string[];
-        channelGroups?: string[];
+        channels?: string[] | undefined;
+        channelGroups?: string[] | undefined;
         state?: any;
     }
 
@@ -1043,9 +1043,9 @@ declare namespace Pubnub {
 
     // getState
     interface GetStateParameters {
-        uuid?: string;
-        channels?: string[];
-        channelGroups?: string[];
+        uuid?: string | undefined;
+        channels?: string[] | undefined;
+        channelGroups?: string[] | undefined;
     }
 
     interface GetStateResponse {
@@ -1056,18 +1056,18 @@ declare namespace Pubnub {
 
     // grant
     interface GrantParameters {
-        channels?: string[];
-        channelGroups?: string[];
-        uuids?: string[];
-        authKeys?: string[];
-        ttl?: number;
-        read?: boolean;
-        write?: boolean;
-        manage?: boolean;
-        delete?: boolean;
-        get?: boolean;
-        join?: boolean;
-        update?: boolean;
+        channels?: string[] | undefined;
+        channelGroups?: string[] | undefined;
+        uuids?: string[] | undefined;
+        authKeys?: string[] | undefined;
+        ttl?: number | undefined;
+        read?: boolean | undefined;
+        write?: boolean | undefined;
+        manage?: boolean | undefined;
+        delete?: boolean | undefined;
+        get?: boolean | undefined;
+        join?: boolean | undefined;
+        update?: boolean | undefined;
     }
 
     // Objects v1
@@ -1080,18 +1080,18 @@ declare namespace Pubnub {
         updated: string;
         custom?: {
             [key: string]: string;
-        } | null;
+        } | null | undefined;
     }
 
     interface GetObjectsParameters {
-        limit?: number;
+        limit?: number | undefined;
         page?: {
-            next?: string;
-            prev?: string;
-        };
+            next?: string | undefined;
+            prev?: string | undefined;
+        } | undefined;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type DeleteObjectResponse = ObjectsResponse<null>;
@@ -1099,21 +1099,21 @@ declare namespace Pubnub {
     // User
     interface UserData extends ObjectData {
         name: string;
-        externalId?: string | null;
-        profileUrl?: string | null;
-        email?: string | null;
+        externalId?: string | null | undefined;
+        profileUrl?: string | null | undefined;
+        email?: string | null | undefined;
     }
 
     interface UserInputParameters {
         id: string;
         name: string;
-        externalId?: string | null;
-        profileUrl?: string | null;
-        email?: string | null;
-        custom?: object | null;
+        externalId?: string | null | undefined;
+        profileUrl?: string | null | undefined;
+        email?: string | null | undefined;
+        custom?: object | null | undefined;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type GetUsersResponse = ObjectsResponse<UserData[]>;
@@ -1123,8 +1123,8 @@ declare namespace Pubnub {
     interface GetUserParameters {
         userId: string;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type GetUserResponse = ObjectsResponse<UserData>;
@@ -1133,17 +1133,17 @@ declare namespace Pubnub {
     interface SpaceData extends ObjectData {
         id: string;
         name: string;
-        description?: string | null;
+        description?: string | null | undefined;
     }
 
     interface SpaceInputParameters {
         id: string;
         name: string;
-        description?: string | null;
-        custom?: object | null;
+        description?: string | null | undefined;
+        custom?: object | null | undefined;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type DeleteSpaceResponse = ObjectsResponse<null>;
@@ -1153,8 +1153,8 @@ declare namespace Pubnub {
     interface GetSpaceParameters {
         spaceId: string;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type GetSpaceResponse = ObjectsResponse<SpaceData>;
@@ -1170,7 +1170,7 @@ declare namespace Pubnub {
         userId: string;
         spaces: Array<{
             id: string;
-            custom?: object | null;
+            custom?: object | null | undefined;
         }>;
     }
 
@@ -1190,7 +1190,7 @@ declare namespace Pubnub {
         spaceId: string;
         users: Array<{
             id: string;
-            custom?: object | null;
+            custom?: object | null | undefined;
         }>;
     }
 
@@ -1224,55 +1224,55 @@ declare namespace Pubnub {
 
     interface GetMessageActionsParameters {
         channel: string;
-        start?: string;
-        end?: string;
-        limit?: number;
+        start?: string | undefined;
+        end?: string | undefined;
+        limit?: number | undefined;
     }
 
     interface GetMessageActionsResponse {
         data: MessageAction[];
-        start?: string;
-        end?: string;
+        start?: string | undefined;
+        end?: string | undefined;
     }
     // files
     interface ListFilesParameters {
         channel: string;
-        limit?: number;
-        next?: string;
+        limit?: number | undefined;
+        next?: string | undefined;
     }
     interface SendFileParameters {
         channel: string;
         file: StreamFileInput | BufferFileInput | UriFileInput;
         message?: any;
-        cipherKey?: string;
-        storeInHistory?: boolean;
-        ttl?: number;
+        cipherKey?: string | undefined;
+        storeInHistory?: boolean | undefined;
+        ttl?: number | undefined;
         meta?: any;
     }
 
     interface StreamFileInput {
         stream: any;
         name: string;
-        mimeType?: string;
+        mimeType?: string | undefined;
     }
 
     interface BufferFileInput {
         data: any;
         name: string;
-        mimeType?: string;
+        mimeType?: string | undefined;
     }
 
     interface UriFileInput {
         uri: string;
         name: string;
-        mimeType?: string;
+        mimeType?: string | undefined;
     }
 
     interface DownloadFileParameters {
         channel: string;
         id: string;
         name: string;
-        cipherKey?: string;
+        cipherKey?: string | undefined;
     }
 
     interface FileInputParameters {
@@ -1286,8 +1286,8 @@ declare namespace Pubnub {
         message?: any;
         fileId: string;
         fileName: string;
-        storeInHistory?: boolean;
-        ttl?: number;
+        storeInHistory?: boolean | undefined;
+        ttl?: number | undefined;
         meta?: any;
     }
 
@@ -1328,11 +1328,11 @@ declare namespace Pubnub {
         id: string;
         eTag: string;
         updated: string;
-        custom?: Custom | null;
+        custom?: Custom | null | undefined;
     }
 
     interface v2ObjectParam<Custom extends ObjectCustom> {
-        custom?: Custom;
+        custom?: Custom | undefined;
     }
 
     // UUID metadata
@@ -1348,42 +1348,42 @@ declare namespace Pubnub {
     interface UUIDMetadataObject<Custom extends ObjectCustom> extends v2ObjectData<Custom>, Nullable<UUIDMetadataFields> { }
 
     interface SetUUIDMetadataParameters<Custom extends ObjectCustom> {
-        uuid?: string;
+        uuid?: string | undefined;
         data: UUIDMetadata<Custom>;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type SetUUIDMetadataResponse<Custom extends ObjectCustom> = ObjectsResponse<UUIDMetadataObject<Custom>>;
 
     interface RemoveUUIDMetadataParameters {
-        uuid?: string;
+        uuid?: string | undefined;
     }
 
     type RemoveUUIDMetadataResponse = ObjectsResponse<{}>;
 
     interface GetAllMetadataParameters {
         include?: {
-            totalCount?: boolean;
-            customFields?: boolean;
-        };
-        filter?: string;
-        sort?: object;
-        limit?: number;
+            totalCount?: boolean | undefined;
+            customFields?: boolean | undefined;
+        } | undefined;
+        filter?: string | undefined;
+        sort?: object | undefined;
+        limit?: number | undefined;
         page?: {
-            next?: string;
-            prev?: string;
-        };
+            next?: string | undefined;
+            prev?: string | undefined;
+        } | undefined;
     }
 
     type GetAllUUIDMetadataResponse<Custom extends ObjectCustom> = PagedObjectsResponse<UUIDMetadataObject<Custom>>;
 
     interface GetUUIDMetadataParameters {
-        uuid?: string;
+        uuid?: string | undefined;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type GetUUIDMetadataResponse<Custom extends ObjectCustom> = ObjectsResponse<UUIDMetadataObject<Custom>>;
@@ -1403,8 +1403,8 @@ declare namespace Pubnub {
         channel: string;
         data: ChannelMetadata<Custom>;
         include?: {
-            customFields?: boolean;
-        };
+            customFields?: boolean | undefined;
+        } | undefined;
     }
 
     type SetChannelMetadataResponse<Custom extends ObjectCustom> = ObjectsResponse<ChannelMetadataObject<Custom>>;
@@ -1423,7 +1423,7 @@ declare namespace Pubnub {
         channel: string;
         include?: {
             customFields: boolean;
-        };
+        } | undefined;
     }
 
     type GetChannelMetadataResponse<Custom extends ObjectCustom> = ObjectsResponse<ChannelMetadataObject<Custom>>;
@@ -1440,34 +1440,34 @@ declare namespace Pubnub {
 
     interface UUIDMembersParameters {
         include?: {
-            totalCount?: boolean;
-            customFields?: boolean;
-            UUIDFields?: boolean;
-            customUUIDFields?: boolean;
-        };
-        filter?: string;
-        sort?: object;
-        limit?: number;
+            totalCount?: boolean | undefined;
+            customFields?: boolean | undefined;
+            UUIDFields?: boolean | undefined;
+            customUUIDFields?: boolean | undefined;
+        } | undefined;
+        filter?: string | undefined;
+        sort?: object | undefined;
+        limit?: number | undefined;
         page?: {
-            next?: string;
-            prev?: string;
-        };
+            next?: string | undefined;
+            prev?: string | undefined;
+        } | undefined;
     }
 
     interface ChannelMembersParameters {
         include?: {
-            totalCount?: boolean;
-            customFields?: boolean;
-            channelFields?: boolean;
-            customChannelFields?: boolean;
-        };
-        filter?: string;
-        sort?: object;
-        limit?: number;
+            totalCount?: boolean | undefined;
+            customFields?: boolean | undefined;
+            channelFields?: boolean | undefined;
+            customChannelFields?: boolean | undefined;
+        } | undefined;
+        filter?: string | undefined;
+        sort?: object | undefined;
+        limit?: number | undefined;
         page?: {
-            next?: string;
-            prev?: string;
-        };
+            next?: string | undefined;
+            prev?: string | undefined;
+        } | undefined;
     }
 
     interface GetChannelMembersParameters extends UUIDMembersParameters {
@@ -1484,21 +1484,21 @@ declare namespace Pubnub {
         > = PagedObjectsResponse<ChannelMembershipObject<MembershipCustom, ChannelCustom>>;
 
     interface GetMembershipsParametersv2 extends ChannelMembersParameters {
-        uuid?: string;
+        uuid?: string | undefined;
     }
 
     interface SetCustom<Custom extends ObjectCustom> {
         id: string;
-        custom?: Custom;
+        custom?: Custom | undefined;
     }
 
     interface SetMembershipsParameters<Custom extends ObjectCustom> extends ChannelMembersParameters {
-        uuid?: string;
-        channels?: Array<string | SetCustom<Custom>>;
+        uuid?: string | undefined;
+        channels?: Array<string | SetCustom<Custom>> | undefined;
     }
 
     interface RemoveMembershipsParameters extends ChannelMembersParameters {
-        uuid?: string;
+        uuid?: string | undefined;
         channels: string[];
     }
 
@@ -1514,10 +1514,10 @@ declare namespace Pubnub {
 
     // encrypt & decrypt
     interface CryptoParameters {
-        encryptKey?: boolean;
-        keyEncoding?: string;
-        keyLength?: number;
-        mode?: string;
+        encryptKey?: boolean | undefined;
+        keyEncoding?: string | undefined;
+        keyLength?: number | undefined;
+        mode?: string | undefined;
     }
 
     // fetch time
@@ -1527,54 +1527,54 @@ declare namespace Pubnub {
 
     // APNS2
     interface APNS2Configuration {
-        collapseId?: string;
-        expirationDate?: Date;
+        collapseId?: string | undefined;
+        expirationDate?: Date | undefined;
         targets: APNS2Target[];
     }
 
     interface APNS2Target {
         topic: string;
-        environment?: 'development' | 'production';
-        excludedDevices?: string[];
+        environment?: 'development' | 'production' | undefined;
+        excludedDevices?: string[] | undefined;
     }
     // NotificationPayloads
 
     interface BaseNotificationPayload {
-        subtitle?: string;
+        subtitle?: string | undefined;
         payload: object;
-        badge?: number;
-        sound?: string;
-        title?: string;
-        body?: string;
+        badge?: number | undefined;
+        sound?: string | undefined;
+        title?: string | undefined;
+        body?: string | undefined;
     }
 
     interface APNSNotificationPayload extends BaseNotificationPayload {
         configurations: APNS2Configuration[];
-        apnsPushType?: string;
+        apnsPushType?: string | undefined;
         isSilent: boolean;
     }
 
     interface MPNSNotificationPayload extends BaseNotificationPayload {
-        backContent?: string;
-        backTitle?: string;
-        count?: number;
-        type?: string;
+        backContent?: string | undefined;
+        backTitle?: string | undefined;
+        count?: number | undefined;
+        type?: string | undefined;
     }
 
     interface FCMNotificationPayload extends BaseNotificationPayload {
         isSilent: boolean;
-        icon?: string;
-        tag?: string;
+        icon?: string | undefined;
+        tag?: string | undefined;
     }
 
     interface NotificationsPayload {
         payload: { apns: object; mpns: object; fcm: object };
         debugging: boolean;
-        subtitle?: string;
-        badge?: number;
-        sound?: string;
-        title?: string;
-        body?: string;
+        subtitle?: string | undefined;
+        badge?: number | undefined;
+        sound?: string | undefined;
+        title?: string | undefined;
+        body?: string | undefined;
         apns: APNSNotificationPayload;
         mpns: MPNSNotificationPayload;
         fcm: FCMNotificationPayload;

--- a/types/pug/index.d.ts
+++ b/types/pug/index.d.ts
@@ -17,29 +17,29 @@ declare module 'pug' {
     ////////////////////////////////////////////////////////////
     export interface Options {
         /** The name of the file being compiled. Used in exceptions, and required for relative includes and extends. Defaults to 'Pug'. */
-        filename?: string,
+        filename?: string | undefined,
         /** The root directory of all absolute inclusion. */
-        basedir?: string,
+        basedir?: string | undefined,
         /** If the doctype is not specified as part of the template, you can specify it here. It is sometimes useful to get self-closing tags and remove mirroring of boolean attributes; see doctype documentation for more information. */
-        doctype?: string,
+        doctype?: string | undefined,
         /** Adds whitespace to the resulting HTML to make it easier for a human to read using '  ' as indentation. If a string is specified, that will be used as indentation instead (e.g. '\t'). Defaults to false. */
-        pretty?: boolean | string,
+        pretty?: boolean | string | undefined,
         /** Hash table of custom filters. Defaults to undefined. */
         filters?: any,
         /** Use a self namespace to hold the locals. It will speed up the compilation, but instead of writing variable you will have to write self.variable to access a property of the locals object. Defaults to false. */
-        self?: boolean,
+        self?: boolean | undefined,
         /** If set to true, the tokens and function body are logged to stdout. */
-        debug?: boolean,
+        debug?: boolean | undefined,
         /** If set to true, the function source will be included in the compiled template for better error messages (sometimes useful in development). It is enabled by default unless used with Express in production mode. */
-        compileDebug?: boolean,
+        compileDebug?: boolean | undefined,
         /** Add a list of global names to make accessible in templates. */
-        globals?: Array<string>,
+        globals?: Array<string> | undefined,
         /** If set to true, compiled functions are cached. filename must be set as the cache key. Only applies to render functions. Defaults to false. */
-        cache?: boolean,
+        cache?: boolean | undefined,
         /** Inline runtime functions instead of require-ing them from a shared version. For compileClient functions, the default is true so that one does not have to include the runtime. For all other compilation or rendering types, the default is false. */
-        inlineRuntimeFunctions?: boolean,
+        inlineRuntimeFunctions?: boolean | undefined,
         /** The name of the template function. Only applies to compileClient functions. Defaults to 'template'. */
-        name?: string
+        name?: string | undefined
     }
 
     ////////////////////////////////////////////////////////////

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -69,7 +69,7 @@ export type SerializableOrJSHandle = Serializable | JSHandle;
  * [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729). It will be removed as soon as
  * it's not needed anymore.
  */
-type LiteralUnion<LiteralType> = LiteralType | (string & { _?: never });
+type LiteralUnion<LiteralType> = LiteralType | (string & { _?: never | undefined });
 
 export type Platform = LiteralUnion<'mac' | 'win32' | 'win64' | 'linux'>;
 export type Product = LiteralUnion<'chrome' | 'firefox'>;
@@ -295,10 +295,10 @@ export interface Keyboard {
      * @param key Name of key to press, such as ArrowLeft.
      * @param options Specifies a input text event.
      */
-    down(key: string, options?: { text?: string }): Promise<void>;
+    down(key: string, options?: { text?: string | undefined }): Promise<void>;
 
     /** Shortcut for `keyboard.down` and `keyboard.up`. */
-    press(key: string, options?: { text?: string; delay?: number }): Promise<void>;
+    press(key: string, options?: { text?: string | undefined; delay?: number | undefined }): Promise<void>;
 
     /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
     sendCharacter(char: string): Promise<void>;
@@ -308,7 +308,7 @@ export interface Keyboard {
      * @param text A text to type into a focused element.
      * @param options Specifies the typing options.
      */
-    type(text: string, options?: { delay?: number }): Promise<void>;
+    type(text: string, options?: { delay?: number | undefined }): Promise<void>;
 
     /**
      * Dispatches a keyup event.
@@ -322,17 +322,17 @@ export interface MousePressOptions {
      * left, right, or middle.
      * @default left
      */
-    button?: MouseButtons;
+    button?: MouseButtons | undefined;
     /**
      * The number of clicks.
      * @default 1
      */
-    clickCount?: number;
+    clickCount?: number | undefined;
 }
 
 export interface MouseWheelOptions {
-    deltaX?: number;
-    deltaY?: number;
+    deltaX?: number | undefined;
+    deltaY?: number | undefined;
 }
 
 export interface MouseWheelOptions {
@@ -340,12 +340,12 @@ export interface MouseWheelOptions {
      * X delta in CSS pixels for mouse wheel event. Positive values emulate a scroll up and negative values a scroll down event.
      * @default 0
      */
-    deltaX?: number;
+    deltaX?: number | undefined;
     /**
      * Y delta in CSS pixels for mouse wheel event. Positive values emulate a scroll right and negative values a scroll left event.
      * @default 0
      */
-    deltaY?: number;
+    deltaY?: number | undefined;
 }
 
 export interface Mouse {
@@ -414,9 +414,9 @@ export interface Tracing {
 }
 
 export interface TracingStartOptions {
-    path?: string;
-    screenshots?: boolean;
-    categories?: string[];
+    path?: string | undefined;
+    screenshots?: boolean | undefined;
+    categories?: string[] | undefined;
 }
 
 export type DialogType = 'alert' | 'beforeunload' | 'confirm' | 'prompt';
@@ -466,15 +466,15 @@ export interface ConsoleMessageLocation {
     /**
      * URL of the resource if known.
      */
-    url?: string;
+    url?: string | undefined;
     /**
      * Line number in the resource if known
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
     /**
      * Column number in the resource if known.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /** ConsoleMessage objects are dispatched by page via the 'console' event. */
@@ -497,14 +497,14 @@ export type MouseButtons = 'left' | 'right' | 'middle';
 
 export interface ClickOptions {
     /** @default MouseButtons.Left */
-    button?: MouseButtons;
+    button?: MouseButtons | undefined;
     /** @default 1 */
-    clickCount?: number;
+    clickCount?: number | undefined;
     /**
      * Time to wait between mousedown and mouseup in milliseconds.
      * @default 0
      */
-    delay?: number;
+    delay?: number | undefined;
 }
 
 export type SameSiteSetting = 'Strict' | 'Lax';
@@ -536,9 +536,9 @@ export interface Cookie {
 export interface DeleteCookie {
     /** The cookie name. */
     name: string;
-    url?: string;
-    domain?: string;
-    path?: string;
+    url?: string | undefined;
+    domain?: string | undefined;
+    path?: string | undefined;
 }
 
 export interface SetCookie {
@@ -547,21 +547,21 @@ export interface SetCookie {
     /** The cookie value. */
     value: string;
     /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
-    url?: string;
+    url?: string | undefined;
     /** The cookie domain. */
-    domain?: string;
+    domain?: string | undefined;
     /** The cookie path. */
-    path?: string;
+    path?: string | undefined;
     /** The cookie Unix expiration time in seconds. */
-    expires?: number;
+    expires?: number | undefined;
     /** The cookie http only flag. */
-    httpOnly?: boolean;
+    httpOnly?: boolean | undefined;
     /** The session cookie flag. */
-    session?: boolean;
+    session?: boolean | undefined;
     /** The cookie secure flag. */
-    secure?: boolean;
+    secure?: boolean | undefined;
     /** The cookie same site definition. */
-    sameSite?: SameSiteSetting;
+    sameSite?: SameSiteSetting | undefined;
 }
 
 export interface Viewport {
@@ -573,22 +573,22 @@ export interface Viewport {
      * Specify device scale factor (can be thought of as dpr).
      * @default 1
      */
-    deviceScaleFactor?: number;
+    deviceScaleFactor?: number | undefined;
     /**
      * Whether the `meta viewport` tag is taken into account.
      * @default false
      */
-    isMobile?: boolean;
+    isMobile?: boolean | undefined;
     /**
      * Specifies if viewport supports touch events.
      * @default false
      */
-    hasTouch?: boolean;
+    hasTouch?: boolean | undefined;
     /**
      * Specifies if viewport is in landscape mode.
      * @default false
      */
-    isLandscape?: boolean;
+    isLandscape?: boolean | undefined;
 }
 
 /** Page emulation options. */
@@ -609,7 +609,7 @@ export interface Timeoutable {
      * Maximum navigation time in milliseconds, pass 0 to disable timeout.
      * @default 30000
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 /** The navigation options. */
@@ -618,7 +618,7 @@ export interface NavigationOptions extends Timeoutable {
      * When to consider navigation succeeded.
      * @default load Navigation is consider when the `load` event is fired.
      */
-    waitUntil?: LoadEvent | LoadEvent[];
+    waitUntil?: LoadEvent | LoadEvent[] | undefined;
 }
 
 /**
@@ -630,7 +630,7 @@ export interface DirectNavigationOptions extends NavigationOptions {
      * If provided it will take preference over the referer header value set by
      * [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
      */
-    referer?: string;
+    referer?: string | undefined;
 }
 
 /** Accepts values labeled with units. If number, treat as pixels. */
@@ -644,17 +644,17 @@ export interface PDFOptions {
      * If `path` is a relative path, then it is resolved relative to current working directory.
      * If no path is provided, the PDF won't be saved to the disk.
      */
-    path?: string;
+    path?: string | undefined;
     /**
      * Scale of the webpage rendering.
      * @default 1
      */
-    scale?: number;
+    scale?: number | undefined;
     /**
      * Display header and footer.
      * @default false
      */
-    displayHeaderFooter?: boolean;
+    displayHeaderFooter?: boolean | undefined;
     /**
      * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
      * - `date` formatted print date
@@ -663,7 +663,7 @@ export interface PDFOptions {
      * - `pageNumber` current page number
      * - `totalPages` total pages in the document
      */
-    headerTemplate?: string;
+    headerTemplate?: string | undefined;
     /**
      * HTML template for the print footer. Should be valid HTML markup with following classes used to inject printing values into them:
      * - `date` formatted print date
@@ -672,48 +672,48 @@ export interface PDFOptions {
      * - `pageNumber` current page number
      * - `totalPages` total pages in the document
      */
-    footerTemplate?: string;
+    footerTemplate?: string | undefined;
     /**
      * Print background graphics.
      * @default false
      */
-    printBackground?: boolean;
+    printBackground?: boolean | undefined;
     /**
      * Paper orientation.
      * @default false
      */
-    landscape?: boolean;
+    landscape?: boolean | undefined;
     /**
      * Paper ranges to print, e.g., '1-5, 8, 11-13'.
      * @default '' which means print all pages.
      */
-    pageRanges?: string;
+    pageRanges?: string | undefined;
     /**
      * Paper format. If set, takes priority over width or height options.
      * @default 'Letter'
      */
-    format?: PDFFormat;
+    format?: PDFFormat | undefined;
     /** Paper width. */
-    width?: LayoutDimension;
+    width?: LayoutDimension | undefined;
     /** Paper height. */
-    height?: LayoutDimension;
+    height?: LayoutDimension | undefined;
     /** Paper margins, defaults to none. */
     margin?: {
         /** Top margin. */
-        top?: LayoutDimension;
+        top?: LayoutDimension | undefined;
         /** Right margin. */
-        right?: LayoutDimension;
+        right?: LayoutDimension | undefined;
         /** Bottom margin. */
-        bottom?: LayoutDimension;
+        bottom?: LayoutDimension | undefined;
         /** Left margin. */
-        left?: LayoutDimension;
-    };
+        left?: LayoutDimension | undefined;
+    } | undefined;
     /**
      * Give any CSS @page size declared in the page priority over what is declared in width and
      * height or format options.
      * @default false which will scale the content to fit the paper size.
      */
-    preferCSSPageSize?: boolean;
+    preferCSSPageSize?: boolean | undefined;
 }
 
 /** Defines the screenshot options. */
@@ -723,37 +723,37 @@ export interface ScreenshotOptions {
      * If `path` is a relative path, then it is resolved relative to current working directory.
      * If no path is provided, the image won't be saved to the disk.
      */
-    path?: string;
+    path?: string | undefined;
     /**
      * The screenshot type.
      * @default png
      */
-    type?: 'jpeg' | 'png';
+    type?: 'jpeg' | 'png' | undefined;
     /** The quality of the image, between 0-100. Not applicable to png images. */
-    quality?: number;
+    quality?: number | undefined;
     /**
      * When true, takes a screenshot of the full scrollable page.
      * @default false
      */
-    fullPage?: boolean;
+    fullPage?: boolean | undefined;
     /**
      * An object which specifies clipping region of the page.
      */
-    clip?: BoundingBox;
+    clip?: BoundingBox | undefined;
     /**
      * Hides default white background and allows capturing screenshots with transparency.
      * @default false
      */
-    omitBackground?: boolean;
+    omitBackground?: boolean | undefined;
     /**
      * The encoding of the image, can be either base64 or binary.
      * @default binary
      */
-    encoding?: 'base64' | 'binary';
+    encoding?: 'base64' | 'binary' | undefined;
 }
 
 export interface BinaryScreenShotOptions extends ScreenshotOptions {
-    encoding?: 'binary';
+    encoding?: 'binary' | undefined;
 }
 
 export interface Base64ScreenShotOptions extends ScreenshotOptions {
@@ -763,26 +763,26 @@ export interface Base64ScreenShotOptions extends ScreenshotOptions {
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
     /** Url of the <link> tag. */
-    url?: string;
+    url?: string | undefined;
     /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-    path?: string;
+    path?: string | undefined;
     /** Raw CSS content to be injected into frame. */
-    content?: string;
+    content?: string | undefined;
 }
 /** Options for `addScriptTag` */
 export interface ScriptTagOptions {
     /** Url of a script to be added. */
-    url?: string;
+    url?: string | undefined;
     /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-    path?: string;
+    path?: string | undefined;
     /** Raw JavaScript content to be injected into frame. */
-    content?: string;
+    content?: string | undefined;
     /** Script type. Use 'module' in order to load a Javascript ES6 module. */
-    type?: string;
+    type?: string | undefined;
 }
 
 export interface PageFnOptions extends Timeoutable {
-    polling?: 'raf' | 'mutation' | number;
+    polling?: 'raf' | 'mutation' | number | undefined;
 }
 
 export interface BoundingBox {
@@ -887,7 +887,7 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle<E>,
      * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
      * @param options The text and delay options.
      */
-    press(key: string, options?: { text?: string; delay?: number }): Promise<void>;
+    press(key: string, options?: { text?: string | undefined; delay?: number | undefined }): Promise<void>;
     /**
      * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
      * If the element is detached from DOM, the method throws an error.
@@ -1024,10 +1024,10 @@ export type ErrorCode =
     | 'failed';
 
 export interface Overrides {
-    url?: string;
-    method?: HttpMethod;
-    postData?: string;
-    headers?: Headers;
+    url?: string | undefined;
+    method?: HttpMethod | undefined;
+    postData?: string | undefined;
+    headers?: Headers | undefined;
 }
 
 /** Represents a page request. */
@@ -1107,13 +1107,13 @@ export interface RespondOptions {
      * Specifies the response status code.
      * @default 200
      */
-    status?: number;
+    status?: number | undefined;
     /** Specifies the response headers. */
-    headers?: Headers;
+    headers?: Headers | undefined;
     /** Specifies the Content-Type response header. */
-    contentType?: string;
+    contentType?: string | undefined;
     /** Specifies the response body. */
-    body?: Buffer | string;
+    body?: Buffer | string | undefined;
 }
 
 export interface RemoteInfo {
@@ -1177,13 +1177,13 @@ export interface WaitForSelectorOptions extends Timeoutable {
      * i.e. to not have display: none or visibility: hidden CSS properties.
      * @default false
      */
-    visible?: boolean;
+    visible?: boolean | undefined;
     /**
      * Wait for element to not be found in the DOM or to be hidden,
      * i.e. have display: none or visibility: hidden CSS properties.
      * @default false
      */
-    hidden?: boolean;
+    hidden?: boolean | undefined;
 }
 
 export interface WaitForSelectorOptionsHidden extends WaitForSelectorOptions {
@@ -1425,7 +1425,7 @@ export interface PageCloseOptions {
      * Whether to run the before unload page handlers.
      * @default false
      */
-    runBeforeUnload?: boolean;
+    runBeforeUnload?: boolean | undefined;
 }
 
 export interface GeoOptions {
@@ -1440,7 +1440,7 @@ export interface GeoOptions {
     /**
      * Non-negative accuracy value.
      */
-    accuracy?: number;
+    accuracy?: number | undefined;
 }
 
 export type MediaType = 'screen' | 'print';
@@ -1557,12 +1557,12 @@ export interface SnapshopOptions {
      * Prune uninteresting nodes from the tree.
      * @default true
      */
-    interestingOnly?: boolean;
+    interestingOnly?: boolean | undefined;
     /**
      * The root DOM element for the snapshot.
      * @default document.body
      */
-    root?: ElementHandle;
+    root?: ElementHandle | undefined;
 }
 
 /**
@@ -2120,51 +2120,51 @@ export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeout
      * At this time, this is either `chrome` or `firefox`. See also `PUPPETEER_PRODUCT`.
      * @default 'chrome'
      */
-    product?: Product;
+    product?: Product | undefined;
     /**
      * Path to a Chromium executable to run instead of bundled Chromium. If
      * executablePath is a relative path, then it is resolved relative to current
      * working directory.
      */
-    executablePath?: string;
+    executablePath?: string | undefined;
     /**
      * Do not use `puppeteer.defaultArgs()` for launching Chromium.
      * @default false
      */
-    ignoreDefaultArgs?: boolean | string[];
+    ignoreDefaultArgs?: boolean | string[] | undefined;
     /**
      * Close chrome process on Ctrl-C.
      * @default true
      */
-    handleSIGINT?: boolean;
+    handleSIGINT?: boolean | undefined;
     /**
      * Close chrome process on SIGTERM.
      * @default true
      */
-    handleSIGTERM?: boolean;
+    handleSIGTERM?: boolean | undefined;
     /**
      * Close chrome process on SIGHUP.
      * @default true
      */
-    handleSIGHUP?: boolean;
+    handleSIGHUP?: boolean | undefined;
     /**
      * Whether to pipe browser process stdout and stderr into process.stdout and
      * process.stderr.
      * @default false
      */
-    dumpio?: boolean;
+    dumpio?: boolean | undefined;
     /**
      * Specify environment variables that will be visible to Chromium.
      * @default `process.env`.
      */
     env?: {
         [key: string]: string | boolean | number;
-    };
+    } | undefined;
     /**
      * Connects to the browser over a pipe instead of a WebSocket.
      * @default false
      */
-    pipe?: boolean;
+    pipe?: boolean | undefined;
 }
 
 export interface ChromeArgOptions {
@@ -2172,21 +2172,21 @@ export interface ChromeArgOptions {
      * Whether to run browser in headless mode.
      * @default true unless the devtools option is true.
      */
-    headless?: boolean;
+    headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
      * The list of Chromium flags can be found here.
      */
-    args?: string[];
+    args?: string[] | undefined;
     /**
      * Path to a User Data Directory.
      */
-    userDataDir?: string;
+    userDataDir?: string | undefined;
     /**
      * Whether to auto-open a DevTools panel for each tab.
      * If this option is true, the headless option will be set false.
      */
-    devtools?: boolean;
+    devtools?: boolean | undefined;
 }
 
 export interface BrowserOptions {
@@ -2194,7 +2194,7 @@ export interface BrowserOptions {
      * Whether to ignore HTTPS errors during navigation.
      * @default false
      */
-    ignoreHTTPSErrors?: boolean;
+    ignoreHTTPSErrors?: boolean | undefined;
     /**
      * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
      */
@@ -2202,37 +2202,37 @@ export interface BrowserOptions {
         /**
          * page width in pixels.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * page height in pixels.
          */
-        height?: number;
+        height?: number | undefined;
         /**
          * Specify device scale factor (can be thought of as dpr).
          * @default 1
          */
-        deviceScaleFactor?: number;
+        deviceScaleFactor?: number | undefined;
         /**
          * Whether the meta viewport tag is taken into account.
          * @default false
          */
-        isMobile?: boolean;
+        isMobile?: boolean | undefined;
         /**
          * Specifies if viewport supports touch events.
          * @default false
          */
-        hasTouch?: boolean;
+        hasTouch?: boolean | undefined;
         /**
          * Specifies if viewport is in landscape mode.
          * @default false
          */
-        isLandscape?: boolean;
-    } | null;
+        isLandscape?: boolean | undefined;
+    } | null | undefined;
     /**
      * Slows down Puppeteer operations by the specified amount of milliseconds.
      * Useful so that you can see what is going on.
      */
-    slowMo?: number;
+    slowMo?: number | undefined;
 }
 
 export interface ConnectOptions extends BrowserOptions {
@@ -2240,15 +2240,15 @@ export interface ConnectOptions extends BrowserOptions {
      * A browser url to connect to, in format `http://${host}:${port}`.
      * Use interchangeably with browserWSEndpoint to let Puppeteer fetch it from metadata endpoint.
      */
-    browserURL?: string;
+    browserURL?: string | undefined;
 
     /** A browser websocket endpoint to connect to. */
-    browserWSEndpoint?: string;
+    browserWSEndpoint?: string | undefined;
 
     /**
      * **Experimental** Specify a custom transport object for Puppeteer to use.
      */
-    transport?: ConnectionTransport;
+    transport?: ConnectionTransport | undefined;
 }
 
 export interface ConnectionTransport {
@@ -2283,12 +2283,12 @@ export interface StartCoverageOptions {
      * Whether to reset coverage on every navigation.
      * @default true
      */
-    resetOnNavigation?: boolean;
+    resetOnNavigation?: boolean | undefined;
     /**
      * Whether anonymous scripts generated by the page should be reported.
      * @default false
      */
-    reportAnonymousScripts?: boolean;
+    reportAnonymousScripts?: boolean | undefined;
 }
 
 export interface CoverageEntry {
@@ -2329,15 +2329,15 @@ export interface RevisionInfo {
 
 export interface FetcherOptions {
     /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
-    host?: string;
+    host?: string | undefined;
     /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
-    path?: string;
+    path?: string | undefined;
     /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
-    platform?: Platform;
+    platform?: Platform | undefined;
     /**
      * @default 'chrome'
      */
-    product?: Product;
+    product?: Product | undefined;
 }
 
 type EventType = string | symbol;
@@ -2365,8 +2365,8 @@ export interface EventEmitter {
  * that match the given query selector.
  */
 export interface CustomQueryHandler {
-    queryOne?: (element: Element | Document, selector: string) => Element | null;
-    queryAll?: (element: Element | Document, selector: string) => Element[] | NodeListOf<Element>;
+    queryOne?: ((element: Element | Document, selector: string) => Element | null) | undefined;
+    queryAll?: ((element: Element | Document, selector: string) => Element[] | NodeListOf<Element>) | undefined;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/v0/index.d.ts
+++ b/types/puppeteer/v0/index.d.ts
@@ -16,10 +16,10 @@ export interface Keyboard {
    * @param key Name of key to press, such as ArrowLeft.
    * @param options Specifies a input text event.
    */
-  down(key: string, options?: { text?: string }): Promise<void>;
+  down(key: string, options?: { text?: string | undefined }): Promise<void>;
 
   /** Shortcut for `keyboard.down` and `keyboard.up`. */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
 
   /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
   sendCharacter(char: string): Promise<void>;
@@ -29,7 +29,7 @@ export interface Keyboard {
    * @param text A text to type into a focused element.
    * @param options Specifies the typing options.
    */
-  type(text: string, options?: { delay?: number }): Promise<void>;
+  type(text: string, options?: { delay?: number | undefined }): Promise<void>;
 
   /**
    * Dispatches a keyup event.
@@ -43,12 +43,12 @@ export interface MousePressOptions {
    * left, right, or middle.
    * @default left
    */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /**
    * The number of clicks.
    * @default 1
    */
-  clickCount?: number;
+  clickCount?: number | undefined;
 }
 
 export interface Mouse {
@@ -91,7 +91,7 @@ export interface Touchscreen {
  * You can use `tracing.start` and `tracing.stop` to create a trace file which can be opened in Chrome DevTools or timeline viewer.
  */
 export interface Tracing {
-  start(options: { path: string; screenshots?: boolean }): Promise<void>;
+  start(options: { path: string; screenshots?: boolean | undefined }): Promise<void>;
   stop(): Promise<void>;
 }
 
@@ -156,14 +156,14 @@ export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
   /** defaults to left */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /** defaults to 1 */
-  clickCount?: number;
+  clickCount?: number | undefined;
   /**
    * Time to wait between mousedown and mouseup in milliseconds.
    * Defaults to 0.
    */
-  delay?: number;
+  delay?: number | undefined;
 }
 
 /** Represents a browser cookie. */
@@ -189,10 +189,10 @@ export interface Cookie {
 export interface DeleteCookie {
   /** The cookie name. */
   name: string;
-  url?: string;
-  domain?: string;
-  path?: string;
-  secure?: boolean;
+  url?: string | undefined;
+  domain?: string | undefined;
+  path?: string | undefined;
+  secure?: boolean | undefined;
 }
 
 export interface SetCookie {
@@ -201,19 +201,19 @@ export interface SetCookie {
   /** The cookie value. */
   value: string;
   /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
-  url?: string;
+  url?: string | undefined;
   /** The cookie domain. */
-  domain?: string;
+  domain?: string | undefined;
   /** The cookie path. */
-  path?: string;
+  path?: string | undefined;
   /** The cookie Unix expiration time in seconds. */
-  expires?: number;
+  expires?: number | undefined;
   /** The cookie http only flag. */
-  httpOnly?: boolean;
+  httpOnly?: boolean | undefined;
   /** The cookie secure flag. */
-  secure?: boolean;
+  secure?: boolean | undefined;
   /** The cookie same site definition. */
-  sameSite?: "Strict" | "Lax";
+  sameSite?: "Strict" | "Lax" | undefined;
 }
 
 export interface Viewport {
@@ -225,30 +225,30 @@ export interface Viewport {
    * Specify device scale factor (can be thought of as dpr).
    * @default 1
    */
-  deviceScaleFactor?: number;
+  deviceScaleFactor?: number | undefined;
   /**
    * Whether the `meta viewport` tag is taken into account.
    * @default false
    */
-  isMobile?: boolean;
+  isMobile?: boolean | undefined;
   /**
    * Specifies if viewport supports touch events.
    * @default false
    */
-  hasTouch?: boolean;
+  hasTouch?: boolean | undefined;
   /**
    * Specifies if viewport is in landscape mode.
    * @default false
    */
-  isLandscape?: boolean;
+  isLandscape?: boolean | undefined;
 }
 
 /** Page emulation options. */
 export interface EmulateOptions {
   /** The viewport emulation options. */
-  viewport?: Viewport;
+  viewport?: Viewport | undefined;
   /** The emulated user-agent. */
-  userAgent?: string;
+  userAgent?: string | undefined;
 }
 
 export type EvaluateFn = string | ((...args: any[]) => any);
@@ -265,12 +265,12 @@ export interface NavigationOptions {
    * Maximum navigation time in milliseconds, pass 0 to disable timeout.
    * @default 30000
    */
-  timeout?: number;
+  timeout?: number | undefined;
   /**
    * When to consider navigation succeeded.
    * @default load Navigation is consider when the `load` event is fired.
    */
-  waitUntil?: LoadEvent | LoadEvent[];
+  waitUntil?: LoadEvent | LoadEvent[] | undefined;
 }
 
 export type PDFFormat =
@@ -291,49 +291,49 @@ export interface PDFOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the PDF won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * Scale of the webpage rendering.
    * @default 1
    */
-  scale?: number;
+  scale?: number | undefined;
   /**
    * Display header and footer.
    * @default false
    */
-  displayHeaderFooter?: boolean;
+  displayHeaderFooter?: boolean | undefined;
   /**
    * Print background graphics.
    * @default false
    */
-  printBackground?: boolean;
+  printBackground?: boolean | undefined;
   /**
    * Paper orientation.
    * @default false
    */
-  landscape?: boolean;
+  landscape?: boolean | undefined;
   /**
    * Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty
    * string, which means print all pages.
    */
-  pageRanges?: string;
+  pageRanges?: string | undefined;
   /** Paper format. If set, takes priority over width or height options. Defaults to 'Letter'. */
-  format?: PDFFormat;
+  format?: PDFFormat | undefined;
   /** Paper width, accepts values labeled with units. */
-  width?: string;
+  width?: string | undefined;
   /** Paper height, accepts values labeled with units. */
-  height?: string;
+  height?: string | undefined;
   /** Paper margins, defaults to none.  */
   margin?: {
     /** Top margin, accepts values labeled with units. */
-    top?: string;
+    top?: string | undefined;
     /** Right margin, accepts values labeled with units. */
-    right?: string;
+    right?: string | undefined;
     /** Bottom margin, accepts values labeled with units. */
-    bottom?: string;
+    bottom?: string | undefined;
     /** Left margin, accepts values labeled with units. */
-    left?: string;
-  };
+    left?: string | undefined;
+  } | undefined;
 }
 
 /** Defines the screenshot options. */
@@ -343,52 +343,52 @@ export interface ScreenshotOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the image won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * The screenshot type.
    * @default png
    */
-  type?: "jpeg" | "png";
+  type?: "jpeg" | "png" | undefined;
   /** The quality of the image, between 0-100. Not applicable to png images. */
-  quality?: number;
+  quality?: number | undefined;
   /**
    * When true, takes a screenshot of the full scrollable page.
    * @default false
    */
-  fullPage?: boolean;
+  fullPage?: boolean | undefined;
   /**
    * An object which specifies clipping region of the page.
    */
-  clip?: BoundingBox;
+  clip?: BoundingBox | undefined;
   /**
    * Hides default white background and allows capturing screenshots with transparency.
    * @default false
    */
-  omitBackground?: boolean;
+  omitBackground?: boolean | undefined;
 }
 
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
   /** Url of the <link> tag. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw CSS content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
 }
 /** Options for `addScriptTag` */
 export interface ScriptTagOptions {
   /** Url of a script to be added. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw JavaScript content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
 }
 
 export interface PageFnOptions {
-  polling?: "raf" | "mutation" | number;
-  timeout?: number;
+  polling?: "raf" | "mutation" | number | undefined;
+  timeout?: number | undefined;
 }
 
 export interface BoundingBox {
@@ -443,7 +443,7 @@ export interface ElementHandle extends JSHandle {
    * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
    * @param options The text and delay options.
    */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
   /**
    * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
    * If the element is detached from DOM, the method throws an error.
@@ -568,10 +568,10 @@ export type ResourceType =
   | "other";
 
 export interface Overrides {
-  url?: string;
-  method?: HttpMethod;
-  postData?: string;
-  headers?: Headers;
+  url?: string | undefined;
+  method?: HttpMethod | undefined;
+  postData?: string | undefined;
+  headers?: Headers | undefined;
 }
 
 /** Represents a page request. */
@@ -625,13 +625,13 @@ export interface RespondOptions {
    * Specifies the response status code.
    * @default 200
    */
-  status?: number;
+  status?: number | undefined;
   /** Specifies the response headers. */
-  headers?: Headers;
+  headers?: Headers | undefined;
   /** Specifies the Content-Type response header. */
-  contentType?: string;
+  contentType?: string | undefined;
   /** Specifies the response body. */
-  body?: Buffer | string;
+  body?: Buffer | string | undefined;
 }
 
 /** Response class represents responses which are received by page. */
@@ -734,7 +734,7 @@ export interface FrameBase {
   ): Promise<void>;
   waitForSelector(
     selector: string,
-    options?: { visible?: boolean; hidden?: boolean; timeout?: number }
+    options?: { visible?: boolean | undefined; hidden?: boolean | undefined; timeout?: number | undefined }
   ): Promise<void>;
 }
 
@@ -1136,57 +1136,57 @@ export interface Target {
 
 export interface LaunchOptions {
   /** Whether to ignore HTTPS errors during navigation. Defaults to false. */
-  ignoreHTTPSErrors?: boolean;
+  ignoreHTTPSErrors?: boolean | undefined;
   /** Whether to run Chromium in headless mode. Defaults to true. */
-  headless?: boolean;
+  headless?: boolean | undefined;
   /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
    * executablePath is a relative path, then it is resolved relative to current
    * working directory.
    */
-  executablePath?: string;
+  executablePath?: string | undefined;
   /**
    * Slows down Puppeteer operations by the specified amount of milliseconds.
    * Useful so that you can see what is going on.
    */
-  slowMo?: number;
+  slowMo?: number | undefined;
   /**
    * Additional arguments to pass to the Chromium instance. List of Chromium
    * flags can be found here.
    */
-  args?: string[];
+  args?: string[] | undefined;
   /** Close chrome process on Ctrl-C. Defaults to true. */
-  handleSIGINT?: boolean;
+  handleSIGINT?: boolean | undefined;
   /** Close chrome process on SIGTERM. Defaults to true. */
-  handleSIGTERM?: boolean;
+  handleSIGTERM?: boolean | undefined;
   /** Close chrome process on SIGHUP. Defaults to true. */
-  handleSIGHUP?: boolean;
+  handleSIGHUP?: boolean | undefined;
   /**
    * Maximum time in milliseconds to wait for the Chrome instance to start.
    * Defaults to 30000 (30 seconds). Pass 0 to disable timeout.
    */
-  timeout?: number;
+  timeout?: number | undefined;
   /**
    * Whether to pipe browser process stdout and stderr into process.stdout and
    * process.stderr. Defaults to false.
    */
-  dumpio?: boolean;
+  dumpio?: boolean | undefined;
   /** Path to a User Data Directory. */
-  userDataDir?: string;
+  userDataDir?: string | undefined;
   /** Specify environment variables that will be visible to Chromium. Defaults to process.env. */
   env?: any;
   /** Whether to auto-open DevTools panel for each tab. If this option is true, the headless option will be set false. */
-  devtools?: boolean;
+  devtools?: boolean | undefined;
 }
 
 export interface ConnectOptions {
   /** A browser websocket endpoint to connect to. */
-  browserWSEndpoint?: string;
+  browserWSEndpoint?: string | undefined;
   /**
    * Whether to ignore HTTPS errors during navigation.
    * @default false
    */
-  ignoreHTTPSErrors?: boolean;
+  ignoreHTTPSErrors?: boolean | undefined;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/v1/index.d.ts
+++ b/types/puppeteer/v1/index.d.ts
@@ -255,10 +255,10 @@ export interface Keyboard {
    * @param key Name of key to press, such as ArrowLeft.
    * @param options Specifies a input text event.
    */
-  down(key: string, options?: { text?: string }): Promise<void>;
+  down(key: string, options?: { text?: string | undefined }): Promise<void>;
 
   /** Shortcut for `keyboard.down` and `keyboard.up`. */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
 
   /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
   sendCharacter(char: string): Promise<void>;
@@ -268,7 +268,7 @@ export interface Keyboard {
    * @param text A text to type into a focused element.
    * @param options Specifies the typing options.
    */
-  type(text: string, options?: { delay?: number }): Promise<void>;
+  type(text: string, options?: { delay?: number | undefined }): Promise<void>;
 
   /**
    * Dispatches a keyup event.
@@ -282,12 +282,12 @@ export interface MousePressOptions {
    * left, right, or middle.
    * @default left
    */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /**
    * The number of clicks.
    * @default 1
    */
-  clickCount?: number;
+  clickCount?: number | undefined;
 }
 
 export interface Mouse {
@@ -335,9 +335,9 @@ export interface Tracing {
 }
 
 export interface TracingStartOptions {
-  path?: string;
-  screenshots?: boolean;
-  categories?: string[];
+  path?: string | undefined;
+  screenshots?: boolean | undefined;
+  categories?: string[] | undefined;
 }
 
 export type DialogType = "alert" | "beforeunload" | "confirm" | "prompt";
@@ -386,15 +386,15 @@ export interface ConsoleMessageLocation {
   /**
    * URL of the resource if known.
    */
-  url?: string;
+  url?: string | undefined;
   /**
    * Line number in the resource if known
    */
-  lineNumber?: number;
+  lineNumber?: number | undefined;
   /**
    * Column number in the resource if known.
    */
-  columnNumber?: number;
+  columnNumber?: number | undefined;
 }
 
 /** ConsoleMessage objects are dispatched by page via the 'console' event. */
@@ -417,14 +417,14 @@ export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
   /** @default MouseButtons.Left */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /** @default 1 */
-  clickCount?: number;
+  clickCount?: number | undefined;
   /**
    * Time to wait between mousedown and mouseup in milliseconds.
    * @default 0
    */
-  delay?: number;
+  delay?: number | undefined;
 }
 
 export type SameSiteSetting = "Strict" | "Lax";
@@ -456,9 +456,9 @@ export interface Cookie {
 export interface DeleteCookie {
   /** The cookie name. */
   name: string;
-  url?: string;
-  domain?: string;
-  path?: string;
+  url?: string | undefined;
+  domain?: string | undefined;
+  path?: string | undefined;
 }
 
 export interface SetCookie {
@@ -467,21 +467,21 @@ export interface SetCookie {
   /** The cookie value. */
   value: string;
   /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
-  url?: string;
+  url?: string | undefined;
   /** The cookie domain. */
-  domain?: string;
+  domain?: string | undefined;
   /** The cookie path. */
-  path?: string;
+  path?: string | undefined;
   /** The cookie Unix expiration time in seconds. */
-  expires?: number;
+  expires?: number | undefined;
   /** The cookie http only flag. */
-  httpOnly?: boolean;
+  httpOnly?: boolean | undefined;
   /** The session cookie flag. */
-  session?: boolean;
+  session?: boolean | undefined;
   /** The cookie secure flag. */
-  secure?: boolean;
+  secure?: boolean | undefined;
   /** The cookie same site definition. */
-  sameSite?: SameSiteSetting;
+  sameSite?: SameSiteSetting | undefined;
 }
 
 export interface Viewport {
@@ -493,30 +493,30 @@ export interface Viewport {
    * Specify device scale factor (can be thought of as dpr).
    * @default 1
    */
-  deviceScaleFactor?: number;
+  deviceScaleFactor?: number | undefined;
   /**
    * Whether the `meta viewport` tag is taken into account.
    * @default false
    */
-  isMobile?: boolean;
+  isMobile?: boolean | undefined;
   /**
    * Specifies if viewport supports touch events.
    * @default false
    */
-  hasTouch?: boolean;
+  hasTouch?: boolean | undefined;
   /**
    * Specifies if viewport is in landscape mode.
    * @default false
    */
-  isLandscape?: boolean;
+  isLandscape?: boolean | undefined;
 }
 
 /** Page emulation options. */
 export interface EmulateOptions {
   /** The viewport emulation options. */
-  viewport?: Viewport;
+  viewport?: Viewport | undefined;
   /** The emulated user-agent. */
-  userAgent?: string;
+  userAgent?: string | undefined;
 }
 
 export type EvaluateFn<T = any> = string | ((arg1: T, ...args: any[]) => any);
@@ -533,7 +533,7 @@ export interface Timeoutable {
      * Maximum navigation time in milliseconds, pass 0 to disable timeout.
      * @default 30000
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 /** The navigation options. */
@@ -542,7 +542,7 @@ export interface NavigationOptions extends Timeoutable {
    * When to consider navigation succeeded.
    * @default load Navigation is consider when the `load` event is fired.
    */
-  waitUntil?: LoadEvent | LoadEvent[];
+  waitUntil?: LoadEvent | LoadEvent[] | undefined;
 }
 
 /**
@@ -554,7 +554,7 @@ export interface DirectNavigationOptions extends NavigationOptions {
    * If provided it will take preference over the referer header value set by
    * [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
    */
-  referer?: string;
+  referer?: string | undefined;
 }
 
 /** Accepts values labeled with units. If number, treat as pixels. */
@@ -579,17 +579,17 @@ export interface PDFOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the PDF won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * Scale of the webpage rendering.
    * @default 1
    */
-  scale?: number;
+  scale?: number | undefined;
   /**
    * Display header and footer.
    * @default false
    */
-  displayHeaderFooter?: boolean;
+  displayHeaderFooter?: boolean | undefined;
   /**
    * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
    * - `date` formatted print date
@@ -598,7 +598,7 @@ export interface PDFOptions {
    * - `pageNumber` current page number
    * - `totalPages` total pages in the document
    */
-  headerTemplate?: string;
+  headerTemplate?: string | undefined;
   /**
    * HTML template for the print footer. Should be valid HTML markup with following classes used to inject printing values into them:
    * - `date` formatted print date
@@ -607,48 +607,48 @@ export interface PDFOptions {
    * - `pageNumber` current page number
    * - `totalPages` total pages in the document
    */
-  footerTemplate?: string;
+  footerTemplate?: string | undefined;
   /**
    * Print background graphics.
    * @default false
    */
-  printBackground?: boolean;
+  printBackground?: boolean | undefined;
   /**
    * Paper orientation.
    * @default false
    */
-  landscape?: boolean;
+  landscape?: boolean | undefined;
   /**
    * Paper ranges to print, e.g., '1-5, 8, 11-13'.
    * @default '' which means print all pages.
    */
-  pageRanges?: string;
+  pageRanges?: string | undefined;
   /**
    * Paper format. If set, takes priority over width or height options.
    * @default 'Letter'
    */
-  format?: PDFFormat;
+  format?: PDFFormat | undefined;
   /** Paper width. */
-  width?: LayoutDimension;
+  width?: LayoutDimension | undefined;
   /** Paper height. */
-  height?: LayoutDimension;
+  height?: LayoutDimension | undefined;
   /** Paper margins, defaults to none. */
   margin?: {
     /** Top margin. */
-    top?: LayoutDimension;
+    top?: LayoutDimension | undefined;
     /** Right margin. */
-    right?: LayoutDimension;
+    right?: LayoutDimension | undefined;
     /** Bottom margin. */
-    bottom?: LayoutDimension;
+    bottom?: LayoutDimension | undefined;
     /** Left margin. */
-    left?: LayoutDimension;
-  };
+    left?: LayoutDimension | undefined;
+  } | undefined;
   /**
    * Give any CSS @page size declared in the page priority over what is declared in width and
    * height or format options.
    * @default false which will scale the content to fit the paper size.
    */
-  preferCSSPageSize?: boolean;
+  preferCSSPageSize?: boolean | undefined;
 }
 
 /** Defines the screenshot options. */
@@ -658,37 +658,37 @@ export interface ScreenshotOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the image won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * The screenshot type.
    * @default png
    */
-  type?: "jpeg" | "png";
+  type?: "jpeg" | "png" | undefined;
   /** The quality of the image, between 0-100. Not applicable to png images. */
-  quality?: number;
+  quality?: number | undefined;
   /**
    * When true, takes a screenshot of the full scrollable page.
    * @default false
    */
-  fullPage?: boolean;
+  fullPage?: boolean | undefined;
   /**
    * An object which specifies clipping region of the page.
    */
-  clip?: BoundingBox;
+  clip?: BoundingBox | undefined;
   /**
    * Hides default white background and allows capturing screenshots with transparency.
    * @default false
    */
-  omitBackground?: boolean;
+  omitBackground?: boolean | undefined;
   /**
    * The encoding of the image, can be either base64 or binary.
    * @default binary
    */
-  encoding?: "base64" | "binary";
+  encoding?: "base64" | "binary" | undefined;
 }
 
 export interface BinaryScreenShotOptions extends ScreenshotOptions {
-    encoding?: "binary";
+    encoding?: "binary" | undefined;
 }
 
 export interface Base64ScreenShotOptions extends ScreenshotOptions {
@@ -698,26 +698,26 @@ export interface Base64ScreenShotOptions extends ScreenshotOptions {
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
   /** Url of the <link> tag. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw CSS content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
 }
 /** Options for `addScriptTag` */
 export interface ScriptTagOptions {
   /** Url of a script to be added. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw JavaScript content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
   /** Script type. Use 'module' in order to load a Javascript ES6 module. */
-  type?: string;
+  type?: string | undefined;
 }
 
 export interface PageFnOptions extends Timeoutable {
-  polling?: "raf" | "mutation" | number;
+  polling?: "raf" | "mutation" | number | undefined;
 }
 
 export interface BoundingBox {
@@ -822,7 +822,7 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle<E>,
    * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
    * @param options The text and delay options.
    */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
   /**
    * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
    * If the element is detached from DOM, the method throws an error.
@@ -965,10 +965,10 @@ export type ErrorCode =
   | "failed";
 
 export interface Overrides {
-  url?: string;
-  method?: HttpMethod;
-  postData?: string;
-  headers?: Headers;
+  url?: string | undefined;
+  method?: HttpMethod | undefined;
+  postData?: string | undefined;
+  headers?: Headers | undefined;
 }
 
 /** Represents a page request. */
@@ -1048,13 +1048,13 @@ export interface RespondOptions {
    * Specifies the response status code.
    * @default 200
    */
-  status?: number;
+  status?: number | undefined;
   /** Specifies the response headers. */
-  headers?: Headers;
+  headers?: Headers | undefined;
   /** Specifies the Content-Type response header. */
-  contentType?: string;
+  contentType?: string | undefined;
   /** Specifies the response body. */
-  body?: Buffer | string;
+  body?: Buffer | string | undefined;
 }
 
 export interface RemoteInfo {
@@ -1118,13 +1118,13 @@ export interface WaitForSelectorOptions extends Timeoutable {
    * i.e. to not have display: none or visibility: hidden CSS properties.
    * @default false
    */
-  visible?: boolean;
+  visible?: boolean | undefined;
   /**
    * Wait for element to not be found in the DOM or to be hidden,
    * i.e. have display: none or visibility: hidden CSS properties.
    * @default false
    */
-  hidden?: boolean;
+  hidden?: boolean | undefined;
 }
 
 export interface WaitForSelectorOptionsHidden extends WaitForSelectorOptions {
@@ -1345,7 +1345,7 @@ export interface PageCloseOptions {
    * Whether to run the before unload page handlers.
    * @default false
    */
-  runBeforeUnload?: boolean;
+  runBeforeUnload?: boolean | undefined;
 }
 
 export interface GeoOptions {
@@ -1360,7 +1360,7 @@ export interface GeoOptions {
   /**
    * Non-negative accuracy value.
    */
-  accuracy?: number;
+  accuracy?: number | undefined;
 }
 
 export type MediaType = "screen" | "print";
@@ -1477,12 +1477,12 @@ export interface SnapshopOptions {
    * Prune uninteresting nodes from the tree.
    * @default true
    */
-  interestingOnly?: boolean;
+  interestingOnly?: boolean | undefined;
   /**
    * The root DOM element for the snapshot.
    * @default document.body
    */
-  root?: ElementHandle;
+  root?: ElementHandle | undefined;
 }
 
 /**
@@ -2016,45 +2016,45 @@ export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeout
    * executablePath is a relative path, then it is resolved relative to current
    * working directory.
    */
-  executablePath?: string;
+  executablePath?: string | undefined;
   /**
    * Do not use `puppeteer.defaultArgs()` for launching Chromium.
    * @default false
    */
-  ignoreDefaultArgs?: boolean | string[];
+  ignoreDefaultArgs?: boolean | string[] | undefined;
   /**
    * Close chrome process on Ctrl-C.
    * @default true
    */
-  handleSIGINT?: boolean;
+  handleSIGINT?: boolean | undefined;
   /**
    * Close chrome process on SIGTERM.
    * @default true
    */
-  handleSIGTERM?: boolean;
+  handleSIGTERM?: boolean | undefined;
   /**
    * Close chrome process on SIGHUP.
    * @default true
    */
-  handleSIGHUP?: boolean;
+  handleSIGHUP?: boolean | undefined;
   /**
    * Whether to pipe browser process stdout and stderr into process.stdout and
    * process.stderr.
    * @default false
    */
-  dumpio?: boolean;
+  dumpio?: boolean | undefined;
   /**
    * Specify environment variables that will be visible to Chromium.
    * @default `process.env`.
    */
   env?: {
     [key: string]: string | boolean | number;
-  };
+  } | undefined;
   /**
    * Connects to the browser over a pipe instead of a WebSocket.
    * @default false
    */
-  pipe?: boolean;
+  pipe?: boolean | undefined;
 }
 
 export interface ChromeArgOptions {
@@ -2062,21 +2062,21 @@ export interface ChromeArgOptions {
      * Whether to run browser in headless mode.
      * @default true unless the devtools option is true.
      */
-    headless?: boolean;
+    headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
      * The list of Chromium flags can be found here.
      */
-    args?: string[];
+    args?: string[] | undefined;
     /**
      * Path to a User Data Directory.
      */
-    userDataDir?: string;
+    userDataDir?: string | undefined;
     /**
      * Whether to auto-open a DevTools panel for each tab.
      * If this option is true, the headless option will be set false.
      */
-    devtools?: boolean;
+    devtools?: boolean | undefined;
 }
 
 export interface BrowserOptions {
@@ -2084,7 +2084,7 @@ export interface BrowserOptions {
    * Whether to ignore HTTPS errors during navigation.
    * @default false
    */
-  ignoreHTTPSErrors?: boolean;
+  ignoreHTTPSErrors?: boolean | undefined;
   /**
    * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
    */
@@ -2092,37 +2092,37 @@ export interface BrowserOptions {
     /**
      * page width in pixels.
      */
-    width?: number;
+    width?: number | undefined;
     /**
      * page height in pixels.
      */
-    height?: number;
+    height?: number | undefined;
     /**
      * Specify device scale factor (can be thought of as dpr).
      * @default 1
      */
-    deviceScaleFactor?: number;
+    deviceScaleFactor?: number | undefined;
     /**
      * Whether the meta viewport tag is taken into account.
      * @default false
      */
-    isMobile?: boolean;
+    isMobile?: boolean | undefined;
     /**
      * Specifies if viewport supports touch events.
      * @default false
      */
-    hasTouch?: boolean;
+    hasTouch?: boolean | undefined;
     /**
      * Specifies if viewport is in landscape mode.
      * @default false
      */
-    isLandscape?: boolean;
-  } | null;
+    isLandscape?: boolean | undefined;
+  } | null | undefined;
   /**
    * Slows down Puppeteer operations by the specified amount of milliseconds.
    * Useful so that you can see what is going on.
    */
-  slowMo?: number;
+  slowMo?: number | undefined;
 }
 
 export interface ConnectOptions extends BrowserOptions {
@@ -2130,15 +2130,15 @@ export interface ConnectOptions extends BrowserOptions {
    * A browser url to connect to, in format `http://${host}:${port}`.
    * Use interchangeably with browserWSEndpoint to let Puppeteer fetch it from metadata endpoint.
    */
-  browserURL?: string;
+  browserURL?: string | undefined;
 
   /** A browser websocket endpoint to connect to. */
-  browserWSEndpoint?: string;
+  browserWSEndpoint?: string | undefined;
 
   /**
    * **Experimental** Specify a custom transport object for Puppeteer to use.
    */
-  transport?: ConnectionTransport;
+  transport?: ConnectionTransport | undefined;
 }
 
 export interface ConnectionTransport {
@@ -2173,12 +2173,12 @@ export interface StartCoverageOptions {
    * Whether to reset coverage on every navigation.
    * @default true
    */
-  resetOnNavigation?: boolean;
+  resetOnNavigation?: boolean | undefined;
   /**
    * Whether anonymous scripts generated by the page should be reported.
    * @default false
    */
-  reportAnonymousScripts?: boolean;
+  reportAnonymousScripts?: boolean | undefined;
 }
 
 export interface CoverageEntry {
@@ -2214,13 +2214,13 @@ export interface RevisionInfo {
 
 export interface FetcherOptions {
   /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
-  host?: string;
+  host?: string | undefined;
   /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
-  path?: string;
+  path?: string | undefined;
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
-  platform?: Platform;
+  platform?: Platform | undefined;
   /** Possible values are `firefox` and `chrome`. Defaults to chrome. */
-  product?: 'chrome' | 'firefox';
+  product?: 'chrome' | 'firefox' | undefined;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/v2/index.d.ts
+++ b/types/puppeteer/v2/index.d.ts
@@ -258,10 +258,10 @@ export interface Keyboard {
    * @param key Name of key to press, such as ArrowLeft.
    * @param options Specifies a input text event.
    */
-  down(key: string, options?: { text?: string }): Promise<void>;
+  down(key: string, options?: { text?: string | undefined }): Promise<void>;
 
   /** Shortcut for `keyboard.down` and `keyboard.up`. */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
 
   /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
   sendCharacter(char: string): Promise<void>;
@@ -271,7 +271,7 @@ export interface Keyboard {
    * @param text A text to type into a focused element.
    * @param options Specifies the typing options.
    */
-  type(text: string, options?: { delay?: number }): Promise<void>;
+  type(text: string, options?: { delay?: number | undefined }): Promise<void>;
 
   /**
    * Dispatches a keyup event.
@@ -285,12 +285,12 @@ export interface MousePressOptions {
    * left, right, or middle.
    * @default left
    */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /**
    * The number of clicks.
    * @default 1
    */
-  clickCount?: number;
+  clickCount?: number | undefined;
 }
 
 export interface MouseWheelOptions {
@@ -298,12 +298,12 @@ export interface MouseWheelOptions {
      * X delta in CSS pixels for mouse wheel event (default: 0). Positive values emulate a scroll up and negative values a scroll down event.
      * @default 0
      */
-    deltaX?: number;
+    deltaX?: number | undefined;
     /**
      *  Y delta in CSS pixels for mouse wheel event (default: 0). Positive values emulate a scroll right and negative values a scroll left event.
      * @default 0
      */
-    deltaY?: number;
+    deltaY?: number | undefined;
 }
 
 export interface Mouse {
@@ -356,9 +356,9 @@ export interface Tracing {
 }
 
 export interface TracingStartOptions {
-  path?: string;
-  screenshots?: boolean;
-  categories?: string[];
+  path?: string | undefined;
+  screenshots?: boolean | undefined;
+  categories?: string[] | undefined;
 }
 
 export type DialogType = "alert" | "beforeunload" | "confirm" | "prompt";
@@ -407,15 +407,15 @@ export interface ConsoleMessageLocation {
   /**
    * URL of the resource if known.
    */
-  url?: string;
+  url?: string | undefined;
   /**
    * Line number in the resource if known
    */
-  lineNumber?: number;
+  lineNumber?: number | undefined;
   /**
    * Column number in the resource if known.
    */
-  columnNumber?: number;
+  columnNumber?: number | undefined;
 }
 
 /** ConsoleMessage objects are dispatched by page via the 'console' event. */
@@ -438,14 +438,14 @@ export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
   /** @default MouseButtons.Left */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /** @default 1 */
-  clickCount?: number;
+  clickCount?: number | undefined;
   /**
    * Time to wait between mousedown and mouseup in milliseconds.
    * @default 0
    */
-  delay?: number;
+  delay?: number | undefined;
 }
 
 export type SameSiteSetting = "Strict" | "Lax";
@@ -477,9 +477,9 @@ export interface Cookie {
 export interface DeleteCookie {
   /** The cookie name. */
   name: string;
-  url?: string;
-  domain?: string;
-  path?: string;
+  url?: string | undefined;
+  domain?: string | undefined;
+  path?: string | undefined;
 }
 
 export interface SetCookie {
@@ -488,21 +488,21 @@ export interface SetCookie {
   /** The cookie value. */
   value: string;
   /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
-  url?: string;
+  url?: string | undefined;
   /** The cookie domain. */
-  domain?: string;
+  domain?: string | undefined;
   /** The cookie path. */
-  path?: string;
+  path?: string | undefined;
   /** The cookie Unix expiration time in seconds. */
-  expires?: number;
+  expires?: number | undefined;
   /** The cookie http only flag. */
-  httpOnly?: boolean;
+  httpOnly?: boolean | undefined;
   /** The session cookie flag. */
-  session?: boolean;
+  session?: boolean | undefined;
   /** The cookie secure flag. */
-  secure?: boolean;
+  secure?: boolean | undefined;
   /** The cookie same site definition. */
-  sameSite?: SameSiteSetting;
+  sameSite?: SameSiteSetting | undefined;
 }
 
 export interface Viewport {
@@ -514,22 +514,22 @@ export interface Viewport {
    * Specify device scale factor (can be thought of as dpr).
    * @default 1
    */
-  deviceScaleFactor?: number;
+  deviceScaleFactor?: number | undefined;
   /**
    * Whether the `meta viewport` tag is taken into account.
    * @default false
    */
-  isMobile?: boolean;
+  isMobile?: boolean | undefined;
   /**
    * Specifies if viewport supports touch events.
    * @default false
    */
-  hasTouch?: boolean;
+  hasTouch?: boolean | undefined;
   /**
    * Specifies if viewport is in landscape mode.
    * @default false
    */
-  isLandscape?: boolean;
+  isLandscape?: boolean | undefined;
 }
 
 /** Page emulation options. */
@@ -554,7 +554,7 @@ export interface Timeoutable {
      * Maximum navigation time in milliseconds, pass 0 to disable timeout.
      * @default 30000
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 /** The navigation options. */
@@ -563,7 +563,7 @@ export interface NavigationOptions extends Timeoutable {
    * When to consider navigation succeeded.
    * @default load Navigation is consider when the `load` event is fired.
    */
-  waitUntil?: LoadEvent | LoadEvent[];
+  waitUntil?: LoadEvent | LoadEvent[] | undefined;
 }
 
 /**
@@ -575,7 +575,7 @@ export interface DirectNavigationOptions extends NavigationOptions {
    * If provided it will take preference over the referer header value set by
    * [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
    */
-  referer?: string;
+  referer?: string | undefined;
 }
 
 /** Accepts values labeled with units. If number, treat as pixels. */
@@ -600,17 +600,17 @@ export interface PDFOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the PDF won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * Scale of the webpage rendering.
    * @default 1
    */
-  scale?: number;
+  scale?: number | undefined;
   /**
    * Display header and footer.
    * @default false
    */
-  displayHeaderFooter?: boolean;
+  displayHeaderFooter?: boolean | undefined;
   /**
    * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
    * - `date` formatted print date
@@ -619,7 +619,7 @@ export interface PDFOptions {
    * - `pageNumber` current page number
    * - `totalPages` total pages in the document
    */
-  headerTemplate?: string;
+  headerTemplate?: string | undefined;
   /**
    * HTML template for the print footer. Should be valid HTML markup with following classes used to inject printing values into them:
    * - `date` formatted print date
@@ -628,48 +628,48 @@ export interface PDFOptions {
    * - `pageNumber` current page number
    * - `totalPages` total pages in the document
    */
-  footerTemplate?: string;
+  footerTemplate?: string | undefined;
   /**
    * Print background graphics.
    * @default false
    */
-  printBackground?: boolean;
+  printBackground?: boolean | undefined;
   /**
    * Paper orientation.
    * @default false
    */
-  landscape?: boolean;
+  landscape?: boolean | undefined;
   /**
    * Paper ranges to print, e.g., '1-5, 8, 11-13'.
    * @default '' which means print all pages.
    */
-  pageRanges?: string;
+  pageRanges?: string | undefined;
   /**
    * Paper format. If set, takes priority over width or height options.
    * @default 'Letter'
    */
-  format?: PDFFormat;
+  format?: PDFFormat | undefined;
   /** Paper width. */
-  width?: LayoutDimension;
+  width?: LayoutDimension | undefined;
   /** Paper height. */
-  height?: LayoutDimension;
+  height?: LayoutDimension | undefined;
   /** Paper margins, defaults to none. */
   margin?: {
     /** Top margin. */
-    top?: LayoutDimension;
+    top?: LayoutDimension | undefined;
     /** Right margin. */
-    right?: LayoutDimension;
+    right?: LayoutDimension | undefined;
     /** Bottom margin. */
-    bottom?: LayoutDimension;
+    bottom?: LayoutDimension | undefined;
     /** Left margin. */
-    left?: LayoutDimension;
-  };
+    left?: LayoutDimension | undefined;
+  } | undefined;
   /**
    * Give any CSS @page size declared in the page priority over what is declared in width and
    * height or format options.
    * @default false which will scale the content to fit the paper size.
    */
-  preferCSSPageSize?: boolean;
+  preferCSSPageSize?: boolean | undefined;
 }
 
 /** Defines the screenshot options. */
@@ -679,37 +679,37 @@ export interface ScreenshotOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the image won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * The screenshot type.
    * @default png
    */
-  type?: "jpeg" | "png";
+  type?: "jpeg" | "png" | undefined;
   /** The quality of the image, between 0-100. Not applicable to png images. */
-  quality?: number;
+  quality?: number | undefined;
   /**
    * When true, takes a screenshot of the full scrollable page.
    * @default false
    */
-  fullPage?: boolean;
+  fullPage?: boolean | undefined;
   /**
    * An object which specifies clipping region of the page.
    */
-  clip?: BoundingBox;
+  clip?: BoundingBox | undefined;
   /**
    * Hides default white background and allows capturing screenshots with transparency.
    * @default false
    */
-  omitBackground?: boolean;
+  omitBackground?: boolean | undefined;
   /**
    * The encoding of the image, can be either base64 or binary.
    * @default binary
    */
-  encoding?: "base64" | "binary";
+  encoding?: "base64" | "binary" | undefined;
 }
 
 export interface BinaryScreenShotOptions extends ScreenshotOptions {
-    encoding?: "binary";
+    encoding?: "binary" | undefined;
 }
 
 export interface Base64ScreenShotOptions extends ScreenshotOptions {
@@ -719,26 +719,26 @@ export interface Base64ScreenShotOptions extends ScreenshotOptions {
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
   /** Url of the <link> tag. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw CSS content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
 }
 /** Options for `addScriptTag` */
 export interface ScriptTagOptions {
   /** Url of a script to be added. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw JavaScript content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
   /** Script type. Use 'module' in order to load a Javascript ES6 module. */
-  type?: string;
+  type?: string | undefined;
 }
 
 export interface PageFnOptions extends Timeoutable {
-  polling?: "raf" | "mutation" | number;
+  polling?: "raf" | "mutation" | number | undefined;
 }
 
 export interface BoundingBox {
@@ -843,7 +843,7 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle<E>,
    * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
    * @param options The text and delay options.
    */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
   /**
    * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
    * If the element is detached from DOM, the method throws an error.
@@ -986,10 +986,10 @@ export type ErrorCode =
   | "failed";
 
 export interface Overrides {
-  url?: string;
-  method?: HttpMethod;
-  postData?: string;
-  headers?: Headers;
+  url?: string | undefined;
+  method?: HttpMethod | undefined;
+  postData?: string | undefined;
+  headers?: Headers | undefined;
 }
 
 /** Represents a page request. */
@@ -1069,13 +1069,13 @@ export interface RespondOptions {
    * Specifies the response status code.
    * @default 200
    */
-  status?: number;
+  status?: number | undefined;
   /** Specifies the response headers. */
-  headers?: Headers;
+  headers?: Headers | undefined;
   /** Specifies the Content-Type response header. */
-  contentType?: string;
+  contentType?: string | undefined;
   /** Specifies the response body. */
-  body?: Buffer | string;
+  body?: Buffer | string | undefined;
 }
 
 export interface RemoteInfo {
@@ -1139,13 +1139,13 @@ export interface WaitForSelectorOptions extends Timeoutable {
    * i.e. to not have display: none or visibility: hidden CSS properties.
    * @default false
    */
-  visible?: boolean;
+  visible?: boolean | undefined;
   /**
    * Wait for element to not be found in the DOM or to be hidden,
    * i.e. have display: none or visibility: hidden CSS properties.
    * @default false
    */
-  hidden?: boolean;
+  hidden?: boolean | undefined;
 }
 
 export interface WaitForSelectorOptionsHidden extends WaitForSelectorOptions {
@@ -1372,7 +1372,7 @@ export interface PageCloseOptions {
    * Whether to run the before unload page handlers.
    * @default false
    */
-  runBeforeUnload?: boolean;
+  runBeforeUnload?: boolean | undefined;
 }
 
 export interface GeoOptions {
@@ -1387,7 +1387,7 @@ export interface GeoOptions {
   /**
    * Non-negative accuracy value.
    */
-  accuracy?: number;
+  accuracy?: number | undefined;
 }
 
 export type MediaType = "screen" | "print";
@@ -1504,12 +1504,12 @@ export interface SnapshopOptions {
    * Prune uninteresting nodes from the tree.
    * @default true
    */
-  interestingOnly?: boolean;
+  interestingOnly?: boolean | undefined;
   /**
    * The root DOM element for the snapshot.
    * @default document.body
    */
-  root?: ElementHandle;
+  root?: ElementHandle | undefined;
 }
 
 /**
@@ -2061,51 +2061,51 @@ export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeout
    * At this time, this is either `chrome` or `firefox`. See also `PUPPETEER_PRODUCT`.
    * @default 'chrome'
    */
-  product?: Product;
+  product?: Product | undefined;
   /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
    * executablePath is a relative path, then it is resolved relative to current
    * working directory.
    */
-  executablePath?: string;
+  executablePath?: string | undefined;
   /**
    * Do not use `puppeteer.defaultArgs()` for launching Chromium.
    * @default false
    */
-  ignoreDefaultArgs?: boolean | string[];
+  ignoreDefaultArgs?: boolean | string[] | undefined;
   /**
    * Close chrome process on Ctrl-C.
    * @default true
    */
-  handleSIGINT?: boolean;
+  handleSIGINT?: boolean | undefined;
   /**
    * Close chrome process on SIGTERM.
    * @default true
    */
-  handleSIGTERM?: boolean;
+  handleSIGTERM?: boolean | undefined;
   /**
    * Close chrome process on SIGHUP.
    * @default true
    */
-  handleSIGHUP?: boolean;
+  handleSIGHUP?: boolean | undefined;
   /**
    * Whether to pipe browser process stdout and stderr into process.stdout and
    * process.stderr.
    * @default false
    */
-  dumpio?: boolean;
+  dumpio?: boolean | undefined;
   /**
    * Specify environment variables that will be visible to Chromium.
    * @default `process.env`.
    */
   env?: {
     [key: string]: string | boolean | number;
-  };
+  } | undefined;
   /**
    * Connects to the browser over a pipe instead of a WebSocket.
    * @default false
    */
-  pipe?: boolean;
+  pipe?: boolean | undefined;
 }
 
 export interface ChromeArgOptions {
@@ -2113,21 +2113,21 @@ export interface ChromeArgOptions {
      * Whether to run browser in headless mode.
      * @default true unless the devtools option is true.
      */
-    headless?: boolean;
+    headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
      * The list of Chromium flags can be found here.
      */
-    args?: string[];
+    args?: string[] | undefined;
     /**
      * Path to a User Data Directory.
      */
-    userDataDir?: string;
+    userDataDir?: string | undefined;
     /**
      * Whether to auto-open a DevTools panel for each tab.
      * If this option is true, the headless option will be set false.
      */
-    devtools?: boolean;
+    devtools?: boolean | undefined;
 }
 
 export interface BrowserOptions {
@@ -2135,7 +2135,7 @@ export interface BrowserOptions {
    * Whether to ignore HTTPS errors during navigation.
    * @default false
    */
-  ignoreHTTPSErrors?: boolean;
+  ignoreHTTPSErrors?: boolean | undefined;
   /**
    * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
    */
@@ -2143,37 +2143,37 @@ export interface BrowserOptions {
     /**
      * page width in pixels.
      */
-    width?: number;
+    width?: number | undefined;
     /**
      * page height in pixels.
      */
-    height?: number;
+    height?: number | undefined;
     /**
      * Specify device scale factor (can be thought of as dpr).
      * @default 1
      */
-    deviceScaleFactor?: number;
+    deviceScaleFactor?: number | undefined;
     /**
      * Whether the meta viewport tag is taken into account.
      * @default false
      */
-    isMobile?: boolean;
+    isMobile?: boolean | undefined;
     /**
      * Specifies if viewport supports touch events.
      * @default false
      */
-    hasTouch?: boolean;
+    hasTouch?: boolean | undefined;
     /**
      * Specifies if viewport is in landscape mode.
      * @default false
      */
-    isLandscape?: boolean;
-  } | null;
+    isLandscape?: boolean | undefined;
+  } | null | undefined;
   /**
    * Slows down Puppeteer operations by the specified amount of milliseconds.
    * Useful so that you can see what is going on.
    */
-  slowMo?: number;
+  slowMo?: number | undefined;
 }
 
 export interface ConnectOptions extends BrowserOptions {
@@ -2181,15 +2181,15 @@ export interface ConnectOptions extends BrowserOptions {
    * A browser url to connect to, in format `http://${host}:${port}`.
    * Use interchangeably with browserWSEndpoint to let Puppeteer fetch it from metadata endpoint.
    */
-  browserURL?: string;
+  browserURL?: string | undefined;
 
   /** A browser websocket endpoint to connect to. */
-  browserWSEndpoint?: string;
+  browserWSEndpoint?: string | undefined;
 
   /**
    * **Experimental** Specify a custom transport object for Puppeteer to use.
    */
-  transport?: ConnectionTransport;
+  transport?: ConnectionTransport | undefined;
 }
 
 export interface ConnectionTransport {
@@ -2224,12 +2224,12 @@ export interface StartCoverageOptions {
    * Whether to reset coverage on every navigation.
    * @default true
    */
-  resetOnNavigation?: boolean;
+  resetOnNavigation?: boolean | undefined;
   /**
    * Whether anonymous scripts generated by the page should be reported.
    * @default false
    */
-  reportAnonymousScripts?: boolean;
+  reportAnonymousScripts?: boolean | undefined;
 }
 
 export interface CoverageEntry {
@@ -2267,15 +2267,15 @@ export interface RevisionInfo {
 
 export interface FetcherOptions {
   /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
-  host?: string;
+  host?: string | undefined;
   /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
-  path?: string;
+  path?: string | undefined;
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
-  platform?: Platform;
+  platform?: Platform | undefined;
   /**
    * @default 'chrome'
    */
-  product?: Product;
+  product?: Product | undefined;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/v3/index.d.ts
+++ b/types/puppeteer/v3/index.d.ts
@@ -258,10 +258,10 @@ export interface Keyboard {
    * @param key Name of key to press, such as ArrowLeft.
    * @param options Specifies a input text event.
    */
-  down(key: string, options?: { text?: string }): Promise<void>;
+  down(key: string, options?: { text?: string | undefined }): Promise<void>;
 
   /** Shortcut for `keyboard.down` and `keyboard.up`. */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
 
   /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
   sendCharacter(char: string): Promise<void>;
@@ -271,7 +271,7 @@ export interface Keyboard {
    * @param text A text to type into a focused element.
    * @param options Specifies the typing options.
    */
-  type(text: string, options?: { delay?: number }): Promise<void>;
+  type(text: string, options?: { delay?: number | undefined }): Promise<void>;
 
   /**
    * Dispatches a keyup event.
@@ -285,12 +285,12 @@ export interface MousePressOptions {
    * left, right, or middle.
    * @default left
    */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /**
    * The number of clicks.
    * @default 1
    */
-  clickCount?: number;
+  clickCount?: number | undefined;
 }
 
 export interface Mouse {
@@ -338,9 +338,9 @@ export interface Tracing {
 }
 
 export interface TracingStartOptions {
-  path?: string;
-  screenshots?: boolean;
-  categories?: string[];
+  path?: string | undefined;
+  screenshots?: boolean | undefined;
+  categories?: string[] | undefined;
 }
 
 export type DialogType = "alert" | "beforeunload" | "confirm" | "prompt";
@@ -389,15 +389,15 @@ export interface ConsoleMessageLocation {
   /**
    * URL of the resource if known.
    */
-  url?: string;
+  url?: string | undefined;
   /**
    * Line number in the resource if known
    */
-  lineNumber?: number;
+  lineNumber?: number | undefined;
   /**
    * Column number in the resource if known.
    */
-  columnNumber?: number;
+  columnNumber?: number | undefined;
 }
 
 /** ConsoleMessage objects are dispatched by page via the 'console' event. */
@@ -420,14 +420,14 @@ export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
   /** @default MouseButtons.Left */
-  button?: MouseButtons;
+  button?: MouseButtons | undefined;
   /** @default 1 */
-  clickCount?: number;
+  clickCount?: number | undefined;
   /**
    * Time to wait between mousedown and mouseup in milliseconds.
    * @default 0
    */
-  delay?: number;
+  delay?: number | undefined;
 }
 
 export type SameSiteSetting = "Strict" | "Lax";
@@ -459,9 +459,9 @@ export interface Cookie {
 export interface DeleteCookie {
   /** The cookie name. */
   name: string;
-  url?: string;
-  domain?: string;
-  path?: string;
+  url?: string | undefined;
+  domain?: string | undefined;
+  path?: string | undefined;
 }
 
 export interface SetCookie {
@@ -470,21 +470,21 @@ export interface SetCookie {
   /** The cookie value. */
   value: string;
   /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
-  url?: string;
+  url?: string | undefined;
   /** The cookie domain. */
-  domain?: string;
+  domain?: string | undefined;
   /** The cookie path. */
-  path?: string;
+  path?: string | undefined;
   /** The cookie Unix expiration time in seconds. */
-  expires?: number;
+  expires?: number | undefined;
   /** The cookie http only flag. */
-  httpOnly?: boolean;
+  httpOnly?: boolean | undefined;
   /** The session cookie flag. */
-  session?: boolean;
+  session?: boolean | undefined;
   /** The cookie secure flag. */
-  secure?: boolean;
+  secure?: boolean | undefined;
   /** The cookie same site definition. */
-  sameSite?: SameSiteSetting;
+  sameSite?: SameSiteSetting | undefined;
 }
 
 export interface Viewport {
@@ -496,22 +496,22 @@ export interface Viewport {
    * Specify device scale factor (can be thought of as dpr).
    * @default 1
    */
-  deviceScaleFactor?: number;
+  deviceScaleFactor?: number | undefined;
   /**
    * Whether the `meta viewport` tag is taken into account.
    * @default false
    */
-  isMobile?: boolean;
+  isMobile?: boolean | undefined;
   /**
    * Specifies if viewport supports touch events.
    * @default false
    */
-  hasTouch?: boolean;
+  hasTouch?: boolean | undefined;
   /**
    * Specifies if viewport is in landscape mode.
    * @default false
    */
-  isLandscape?: boolean;
+  isLandscape?: boolean | undefined;
 }
 
 /** Page emulation options. */
@@ -536,7 +536,7 @@ export interface Timeoutable {
      * Maximum navigation time in milliseconds, pass 0 to disable timeout.
      * @default 30000
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 /** The navigation options. */
@@ -545,7 +545,7 @@ export interface NavigationOptions extends Timeoutable {
    * When to consider navigation succeeded.
    * @default load Navigation is consider when the `load` event is fired.
    */
-  waitUntil?: LoadEvent | LoadEvent[];
+  waitUntil?: LoadEvent | LoadEvent[] | undefined;
 }
 
 /**
@@ -557,7 +557,7 @@ export interface DirectNavigationOptions extends NavigationOptions {
    * If provided it will take preference over the referer header value set by
    * [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
    */
-  referer?: string;
+  referer?: string | undefined;
 }
 
 /** Accepts values labeled with units. If number, treat as pixels. */
@@ -582,17 +582,17 @@ export interface PDFOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the PDF won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * Scale of the webpage rendering.
    * @default 1
    */
-  scale?: number;
+  scale?: number | undefined;
   /**
    * Display header and footer.
    * @default false
    */
-  displayHeaderFooter?: boolean;
+  displayHeaderFooter?: boolean | undefined;
   /**
    * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
    * - `date` formatted print date
@@ -601,7 +601,7 @@ export interface PDFOptions {
    * - `pageNumber` current page number
    * - `totalPages` total pages in the document
    */
-  headerTemplate?: string;
+  headerTemplate?: string | undefined;
   /**
    * HTML template for the print footer. Should be valid HTML markup with following classes used to inject printing values into them:
    * - `date` formatted print date
@@ -610,48 +610,48 @@ export interface PDFOptions {
    * - `pageNumber` current page number
    * - `totalPages` total pages in the document
    */
-  footerTemplate?: string;
+  footerTemplate?: string | undefined;
   /**
    * Print background graphics.
    * @default false
    */
-  printBackground?: boolean;
+  printBackground?: boolean | undefined;
   /**
    * Paper orientation.
    * @default false
    */
-  landscape?: boolean;
+  landscape?: boolean | undefined;
   /**
    * Paper ranges to print, e.g., '1-5, 8, 11-13'.
    * @default '' which means print all pages.
    */
-  pageRanges?: string;
+  pageRanges?: string | undefined;
   /**
    * Paper format. If set, takes priority over width or height options.
    * @default 'Letter'
    */
-  format?: PDFFormat;
+  format?: PDFFormat | undefined;
   /** Paper width. */
-  width?: LayoutDimension;
+  width?: LayoutDimension | undefined;
   /** Paper height. */
-  height?: LayoutDimension;
+  height?: LayoutDimension | undefined;
   /** Paper margins, defaults to none. */
   margin?: {
     /** Top margin. */
-    top?: LayoutDimension;
+    top?: LayoutDimension | undefined;
     /** Right margin. */
-    right?: LayoutDimension;
+    right?: LayoutDimension | undefined;
     /** Bottom margin. */
-    bottom?: LayoutDimension;
+    bottom?: LayoutDimension | undefined;
     /** Left margin. */
-    left?: LayoutDimension;
-  };
+    left?: LayoutDimension | undefined;
+  } | undefined;
   /**
    * Give any CSS @page size declared in the page priority over what is declared in width and
    * height or format options.
    * @default false which will scale the content to fit the paper size.
    */
-  preferCSSPageSize?: boolean;
+  preferCSSPageSize?: boolean | undefined;
 }
 
 /** Defines the screenshot options. */
@@ -661,37 +661,37 @@ export interface ScreenshotOptions {
    * If `path` is a relative path, then it is resolved relative to current working directory.
    * If no path is provided, the image won't be saved to the disk.
    */
-  path?: string;
+  path?: string | undefined;
   /**
    * The screenshot type.
    * @default png
    */
-  type?: "jpeg" | "png";
+  type?: "jpeg" | "png" | undefined;
   /** The quality of the image, between 0-100. Not applicable to png images. */
-  quality?: number;
+  quality?: number | undefined;
   /**
    * When true, takes a screenshot of the full scrollable page.
    * @default false
    */
-  fullPage?: boolean;
+  fullPage?: boolean | undefined;
   /**
    * An object which specifies clipping region of the page.
    */
-  clip?: BoundingBox;
+  clip?: BoundingBox | undefined;
   /**
    * Hides default white background and allows capturing screenshots with transparency.
    * @default false
    */
-  omitBackground?: boolean;
+  omitBackground?: boolean | undefined;
   /**
    * The encoding of the image, can be either base64 or binary.
    * @default binary
    */
-  encoding?: "base64" | "binary";
+  encoding?: "base64" | "binary" | undefined;
 }
 
 export interface BinaryScreenShotOptions extends ScreenshotOptions {
-    encoding?: "binary";
+    encoding?: "binary" | undefined;
 }
 
 export interface Base64ScreenShotOptions extends ScreenshotOptions {
@@ -701,26 +701,26 @@ export interface Base64ScreenShotOptions extends ScreenshotOptions {
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
   /** Url of the <link> tag. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw CSS content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
 }
 /** Options for `addScriptTag` */
 export interface ScriptTagOptions {
   /** Url of a script to be added. */
-  url?: string;
+  url?: string | undefined;
   /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-  path?: string;
+  path?: string | undefined;
   /** Raw JavaScript content to be injected into frame. */
-  content?: string;
+  content?: string | undefined;
   /** Script type. Use 'module' in order to load a Javascript ES6 module. */
-  type?: string;
+  type?: string | undefined;
 }
 
 export interface PageFnOptions extends Timeoutable {
-  polling?: "raf" | "mutation" | number;
+  polling?: "raf" | "mutation" | number | undefined;
 }
 
 export interface BoundingBox {
@@ -825,7 +825,7 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle<E>,
    * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
    * @param options The text and delay options.
    */
-  press(key: string, options?: { text?: string, delay?: number }): Promise<void>;
+  press(key: string, options?: { text?: string | undefined, delay?: number | undefined }): Promise<void>;
   /**
    * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
    * If the element is detached from DOM, the method throws an error.
@@ -968,10 +968,10 @@ export type ErrorCode =
   | "failed";
 
 export interface Overrides {
-  url?: string;
-  method?: HttpMethod;
-  postData?: string;
-  headers?: Headers;
+  url?: string | undefined;
+  method?: HttpMethod | undefined;
+  postData?: string | undefined;
+  headers?: Headers | undefined;
 }
 
 /** Represents a page request. */
@@ -1051,13 +1051,13 @@ export interface RespondOptions {
    * Specifies the response status code.
    * @default 200
    */
-  status?: number;
+  status?: number | undefined;
   /** Specifies the response headers. */
-  headers?: Headers;
+  headers?: Headers | undefined;
   /** Specifies the Content-Type response header. */
-  contentType?: string;
+  contentType?: string | undefined;
   /** Specifies the response body. */
-  body?: Buffer | string;
+  body?: Buffer | string | undefined;
 }
 
 export interface RemoteInfo {
@@ -1121,13 +1121,13 @@ export interface WaitForSelectorOptions extends Timeoutable {
    * i.e. to not have display: none or visibility: hidden CSS properties.
    * @default false
    */
-  visible?: boolean;
+  visible?: boolean | undefined;
   /**
    * Wait for element to not be found in the DOM or to be hidden,
    * i.e. have display: none or visibility: hidden CSS properties.
    * @default false
    */
-  hidden?: boolean;
+  hidden?: boolean | undefined;
 }
 
 export interface WaitForSelectorOptionsHidden extends WaitForSelectorOptions {
@@ -1348,7 +1348,7 @@ export interface PageCloseOptions {
    * Whether to run the before unload page handlers.
    * @default false
    */
-  runBeforeUnload?: boolean;
+  runBeforeUnload?: boolean | undefined;
 }
 
 export interface GeoOptions {
@@ -1363,7 +1363,7 @@ export interface GeoOptions {
   /**
    * Non-negative accuracy value.
    */
-  accuracy?: number;
+  accuracy?: number | undefined;
 }
 
 export type MediaType = "screen" | "print";
@@ -1480,12 +1480,12 @@ export interface SnapshopOptions {
    * Prune uninteresting nodes from the tree.
    * @default true
    */
-  interestingOnly?: boolean;
+  interestingOnly?: boolean | undefined;
   /**
    * The root DOM element for the snapshot.
    * @default document.body
    */
-  root?: ElementHandle;
+  root?: ElementHandle | undefined;
 }
 
 /**
@@ -2037,51 +2037,51 @@ export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeout
    * At this time, this is either `chrome` or `firefox`. See also `PUPPETEER_PRODUCT`.
    * @default 'chrome'
    */
-  product?: Product;
+  product?: Product | undefined;
   /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
    * executablePath is a relative path, then it is resolved relative to current
    * working directory.
    */
-  executablePath?: string;
+  executablePath?: string | undefined;
   /**
    * Do not use `puppeteer.defaultArgs()` for launching Chromium.
    * @default false
    */
-  ignoreDefaultArgs?: boolean | string[];
+  ignoreDefaultArgs?: boolean | string[] | undefined;
   /**
    * Close chrome process on Ctrl-C.
    * @default true
    */
-  handleSIGINT?: boolean;
+  handleSIGINT?: boolean | undefined;
   /**
    * Close chrome process on SIGTERM.
    * @default true
    */
-  handleSIGTERM?: boolean;
+  handleSIGTERM?: boolean | undefined;
   /**
    * Close chrome process on SIGHUP.
    * @default true
    */
-  handleSIGHUP?: boolean;
+  handleSIGHUP?: boolean | undefined;
   /**
    * Whether to pipe browser process stdout and stderr into process.stdout and
    * process.stderr.
    * @default false
    */
-  dumpio?: boolean;
+  dumpio?: boolean | undefined;
   /**
    * Specify environment variables that will be visible to Chromium.
    * @default `process.env`.
    */
   env?: {
     [key: string]: string | boolean | number;
-  };
+  } | undefined;
   /**
    * Connects to the browser over a pipe instead of a WebSocket.
    * @default false
    */
-  pipe?: boolean;
+  pipe?: boolean | undefined;
 }
 
 export interface ChromeArgOptions {
@@ -2089,21 +2089,21 @@ export interface ChromeArgOptions {
      * Whether to run browser in headless mode.
      * @default true unless the devtools option is true.
      */
-    headless?: boolean;
+    headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
      * The list of Chromium flags can be found here.
      */
-    args?: string[];
+    args?: string[] | undefined;
     /**
      * Path to a User Data Directory.
      */
-    userDataDir?: string;
+    userDataDir?: string | undefined;
     /**
      * Whether to auto-open a DevTools panel for each tab.
      * If this option is true, the headless option will be set false.
      */
-    devtools?: boolean;
+    devtools?: boolean | undefined;
 }
 
 export interface BrowserOptions {
@@ -2111,7 +2111,7 @@ export interface BrowserOptions {
    * Whether to ignore HTTPS errors during navigation.
    * @default false
    */
-  ignoreHTTPSErrors?: boolean;
+  ignoreHTTPSErrors?: boolean | undefined;
   /**
    * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
    */
@@ -2119,37 +2119,37 @@ export interface BrowserOptions {
     /**
      * page width in pixels.
      */
-    width?: number;
+    width?: number | undefined;
     /**
      * page height in pixels.
      */
-    height?: number;
+    height?: number | undefined;
     /**
      * Specify device scale factor (can be thought of as dpr).
      * @default 1
      */
-    deviceScaleFactor?: number;
+    deviceScaleFactor?: number | undefined;
     /**
      * Whether the meta viewport tag is taken into account.
      * @default false
      */
-    isMobile?: boolean;
+    isMobile?: boolean | undefined;
     /**
      * Specifies if viewport supports touch events.
      * @default false
      */
-    hasTouch?: boolean;
+    hasTouch?: boolean | undefined;
     /**
      * Specifies if viewport is in landscape mode.
      * @default false
      */
-    isLandscape?: boolean;
-  } | null;
+    isLandscape?: boolean | undefined;
+  } | null | undefined;
   /**
    * Slows down Puppeteer operations by the specified amount of milliseconds.
    * Useful so that you can see what is going on.
    */
-  slowMo?: number;
+  slowMo?: number | undefined;
 }
 
 export interface ConnectOptions extends BrowserOptions {
@@ -2157,15 +2157,15 @@ export interface ConnectOptions extends BrowserOptions {
    * A browser url to connect to, in format `http://${host}:${port}`.
    * Use interchangeably with browserWSEndpoint to let Puppeteer fetch it from metadata endpoint.
    */
-  browserURL?: string;
+  browserURL?: string | undefined;
 
   /** A browser websocket endpoint to connect to. */
-  browserWSEndpoint?: string;
+  browserWSEndpoint?: string | undefined;
 
   /**
    * **Experimental** Specify a custom transport object for Puppeteer to use.
    */
-  transport?: ConnectionTransport;
+  transport?: ConnectionTransport | undefined;
 }
 
 export interface ConnectionTransport {
@@ -2200,12 +2200,12 @@ export interface StartCoverageOptions {
    * Whether to reset coverage on every navigation.
    * @default true
    */
-  resetOnNavigation?: boolean;
+  resetOnNavigation?: boolean | undefined;
   /**
    * Whether anonymous scripts generated by the page should be reported.
    * @default false
    */
-  reportAnonymousScripts?: boolean;
+  reportAnonymousScripts?: boolean | undefined;
 }
 
 export interface CoverageEntry {
@@ -2243,15 +2243,15 @@ export interface RevisionInfo {
 
 export interface FetcherOptions {
   /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
-  host?: string;
+  host?: string | undefined;
   /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
-  path?: string;
+  path?: string | undefined;
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
-  platform?: Platform;
+  platform?: Platform | undefined;
   /**
    * @default 'chrome'
    */
-  product?: Product;
+  product?: Product | undefined;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/v4/index.d.ts
+++ b/types/puppeteer/v4/index.d.ts
@@ -256,10 +256,10 @@ export interface Keyboard {
      * @param key Name of key to press, such as ArrowLeft.
      * @param options Specifies a input text event.
      */
-    down(key: string, options?: { text?: string }): Promise<void>;
+    down(key: string, options?: { text?: string | undefined }): Promise<void>;
 
     /** Shortcut for `keyboard.down` and `keyboard.up`. */
-    press(key: string, options?: { text?: string; delay?: number }): Promise<void>;
+    press(key: string, options?: { text?: string | undefined; delay?: number | undefined }): Promise<void>;
 
     /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
     sendCharacter(char: string): Promise<void>;
@@ -269,7 +269,7 @@ export interface Keyboard {
      * @param text A text to type into a focused element.
      * @param options Specifies the typing options.
      */
-    type(text: string, options?: { delay?: number }): Promise<void>;
+    type(text: string, options?: { delay?: number | undefined }): Promise<void>;
 
     /**
      * Dispatches a keyup event.
@@ -283,12 +283,12 @@ export interface MousePressOptions {
      * left, right, or middle.
      * @default left
      */
-    button?: MouseButtons;
+    button?: MouseButtons | undefined;
     /**
      * The number of clicks.
      * @default 1
      */
-    clickCount?: number;
+    clickCount?: number | undefined;
 }
 
 export interface Mouse {
@@ -336,9 +336,9 @@ export interface Tracing {
 }
 
 export interface TracingStartOptions {
-    path?: string;
-    screenshots?: boolean;
-    categories?: string[];
+    path?: string | undefined;
+    screenshots?: boolean | undefined;
+    categories?: string[] | undefined;
 }
 
 export type DialogType = 'alert' | 'beforeunload' | 'confirm' | 'prompt';
@@ -388,15 +388,15 @@ export interface ConsoleMessageLocation {
     /**
      * URL of the resource if known.
      */
-    url?: string;
+    url?: string | undefined;
     /**
      * Line number in the resource if known
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
     /**
      * Column number in the resource if known.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /** ConsoleMessage objects are dispatched by page via the 'console' event. */
@@ -419,14 +419,14 @@ export type MouseButtons = 'left' | 'right' | 'middle';
 
 export interface ClickOptions {
     /** @default MouseButtons.Left */
-    button?: MouseButtons;
+    button?: MouseButtons | undefined;
     /** @default 1 */
-    clickCount?: number;
+    clickCount?: number | undefined;
     /**
      * Time to wait between mousedown and mouseup in milliseconds.
      * @default 0
      */
-    delay?: number;
+    delay?: number | undefined;
 }
 
 export type SameSiteSetting = 'Strict' | 'Lax';
@@ -458,9 +458,9 @@ export interface Cookie {
 export interface DeleteCookie {
     /** The cookie name. */
     name: string;
-    url?: string;
-    domain?: string;
-    path?: string;
+    url?: string | undefined;
+    domain?: string | undefined;
+    path?: string | undefined;
 }
 
 export interface SetCookie {
@@ -469,21 +469,21 @@ export interface SetCookie {
     /** The cookie value. */
     value: string;
     /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
-    url?: string;
+    url?: string | undefined;
     /** The cookie domain. */
-    domain?: string;
+    domain?: string | undefined;
     /** The cookie path. */
-    path?: string;
+    path?: string | undefined;
     /** The cookie Unix expiration time in seconds. */
-    expires?: number;
+    expires?: number | undefined;
     /** The cookie http only flag. */
-    httpOnly?: boolean;
+    httpOnly?: boolean | undefined;
     /** The session cookie flag. */
-    session?: boolean;
+    session?: boolean | undefined;
     /** The cookie secure flag. */
-    secure?: boolean;
+    secure?: boolean | undefined;
     /** The cookie same site definition. */
-    sameSite?: SameSiteSetting;
+    sameSite?: SameSiteSetting | undefined;
 }
 
 export interface Viewport {
@@ -495,22 +495,22 @@ export interface Viewport {
      * Specify device scale factor (can be thought of as dpr).
      * @default 1
      */
-    deviceScaleFactor?: number;
+    deviceScaleFactor?: number | undefined;
     /**
      * Whether the `meta viewport` tag is taken into account.
      * @default false
      */
-    isMobile?: boolean;
+    isMobile?: boolean | undefined;
     /**
      * Specifies if viewport supports touch events.
      * @default false
      */
-    hasTouch?: boolean;
+    hasTouch?: boolean | undefined;
     /**
      * Specifies if viewport is in landscape mode.
      * @default false
      */
-    isLandscape?: boolean;
+    isLandscape?: boolean | undefined;
 }
 
 /** Page emulation options. */
@@ -531,7 +531,7 @@ export interface Timeoutable {
      * Maximum navigation time in milliseconds, pass 0 to disable timeout.
      * @default 30000
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 /** The navigation options. */
@@ -540,7 +540,7 @@ export interface NavigationOptions extends Timeoutable {
      * When to consider navigation succeeded.
      * @default load Navigation is consider when the `load` event is fired.
      */
-    waitUntil?: LoadEvent | LoadEvent[];
+    waitUntil?: LoadEvent | LoadEvent[] | undefined;
 }
 
 /**
@@ -552,7 +552,7 @@ export interface DirectNavigationOptions extends NavigationOptions {
      * If provided it will take preference over the referer header value set by
      * [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
      */
-    referer?: string;
+    referer?: string | undefined;
 }
 
 /** Accepts values labeled with units. If number, treat as pixels. */
@@ -566,17 +566,17 @@ export interface PDFOptions {
      * If `path` is a relative path, then it is resolved relative to current working directory.
      * If no path is provided, the PDF won't be saved to the disk.
      */
-    path?: string;
+    path?: string | undefined;
     /**
      * Scale of the webpage rendering.
      * @default 1
      */
-    scale?: number;
+    scale?: number | undefined;
     /**
      * Display header and footer.
      * @default false
      */
-    displayHeaderFooter?: boolean;
+    displayHeaderFooter?: boolean | undefined;
     /**
      * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
      * - `date` formatted print date
@@ -585,7 +585,7 @@ export interface PDFOptions {
      * - `pageNumber` current page number
      * - `totalPages` total pages in the document
      */
-    headerTemplate?: string;
+    headerTemplate?: string | undefined;
     /**
      * HTML template for the print footer. Should be valid HTML markup with following classes used to inject printing values into them:
      * - `date` formatted print date
@@ -594,48 +594,48 @@ export interface PDFOptions {
      * - `pageNumber` current page number
      * - `totalPages` total pages in the document
      */
-    footerTemplate?: string;
+    footerTemplate?: string | undefined;
     /**
      * Print background graphics.
      * @default false
      */
-    printBackground?: boolean;
+    printBackground?: boolean | undefined;
     /**
      * Paper orientation.
      * @default false
      */
-    landscape?: boolean;
+    landscape?: boolean | undefined;
     /**
      * Paper ranges to print, e.g., '1-5, 8, 11-13'.
      * @default '' which means print all pages.
      */
-    pageRanges?: string;
+    pageRanges?: string | undefined;
     /**
      * Paper format. If set, takes priority over width or height options.
      * @default 'Letter'
      */
-    format?: PDFFormat;
+    format?: PDFFormat | undefined;
     /** Paper width. */
-    width?: LayoutDimension;
+    width?: LayoutDimension | undefined;
     /** Paper height. */
-    height?: LayoutDimension;
+    height?: LayoutDimension | undefined;
     /** Paper margins, defaults to none. */
     margin?: {
         /** Top margin. */
-        top?: LayoutDimension;
+        top?: LayoutDimension | undefined;
         /** Right margin. */
-        right?: LayoutDimension;
+        right?: LayoutDimension | undefined;
         /** Bottom margin. */
-        bottom?: LayoutDimension;
+        bottom?: LayoutDimension | undefined;
         /** Left margin. */
-        left?: LayoutDimension;
-    };
+        left?: LayoutDimension | undefined;
+    } | undefined;
     /**
      * Give any CSS @page size declared in the page priority over what is declared in width and
      * height or format options.
      * @default false which will scale the content to fit the paper size.
      */
-    preferCSSPageSize?: boolean;
+    preferCSSPageSize?: boolean | undefined;
 }
 
 /** Defines the screenshot options. */
@@ -645,37 +645,37 @@ export interface ScreenshotOptions {
      * If `path` is a relative path, then it is resolved relative to current working directory.
      * If no path is provided, the image won't be saved to the disk.
      */
-    path?: string;
+    path?: string | undefined;
     /**
      * The screenshot type.
      * @default png
      */
-    type?: 'jpeg' | 'png';
+    type?: 'jpeg' | 'png' | undefined;
     /** The quality of the image, between 0-100. Not applicable to png images. */
-    quality?: number;
+    quality?: number | undefined;
     /**
      * When true, takes a screenshot of the full scrollable page.
      * @default false
      */
-    fullPage?: boolean;
+    fullPage?: boolean | undefined;
     /**
      * An object which specifies clipping region of the page.
      */
-    clip?: BoundingBox;
+    clip?: BoundingBox | undefined;
     /**
      * Hides default white background and allows capturing screenshots with transparency.
      * @default false
      */
-    omitBackground?: boolean;
+    omitBackground?: boolean | undefined;
     /**
      * The encoding of the image, can be either base64 or binary.
      * @default binary
      */
-    encoding?: 'base64' | 'binary';
+    encoding?: 'base64' | 'binary' | undefined;
 }
 
 export interface BinaryScreenShotOptions extends ScreenshotOptions {
-    encoding?: 'binary';
+    encoding?: 'binary' | undefined;
 }
 
 export interface Base64ScreenShotOptions extends ScreenshotOptions {
@@ -685,26 +685,26 @@ export interface Base64ScreenShotOptions extends ScreenshotOptions {
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
     /** Url of the <link> tag. */
-    url?: string;
+    url?: string | undefined;
     /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-    path?: string;
+    path?: string | undefined;
     /** Raw CSS content to be injected into frame. */
-    content?: string;
+    content?: string | undefined;
 }
 /** Options for `addScriptTag` */
 export interface ScriptTagOptions {
     /** Url of a script to be added. */
-    url?: string;
+    url?: string | undefined;
     /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
-    path?: string;
+    path?: string | undefined;
     /** Raw JavaScript content to be injected into frame. */
-    content?: string;
+    content?: string | undefined;
     /** Script type. Use 'module' in order to load a Javascript ES6 module. */
-    type?: string;
+    type?: string | undefined;
 }
 
 export interface PageFnOptions extends Timeoutable {
-    polling?: 'raf' | 'mutation' | number;
+    polling?: 'raf' | 'mutation' | number | undefined;
 }
 
 export interface BoundingBox {
@@ -809,7 +809,7 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle<E>,
      * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
      * @param options The text and delay options.
      */
-    press(key: string, options?: { text?: string; delay?: number }): Promise<void>;
+    press(key: string, options?: { text?: string | undefined; delay?: number | undefined }): Promise<void>;
     /**
      * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
      * If the element is detached from DOM, the method throws an error.
@@ -946,10 +946,10 @@ export type ErrorCode =
     | 'failed';
 
 export interface Overrides {
-    url?: string;
-    method?: HttpMethod;
-    postData?: string;
-    headers?: Headers;
+    url?: string | undefined;
+    method?: HttpMethod | undefined;
+    postData?: string | undefined;
+    headers?: Headers | undefined;
 }
 
 /** Represents a page request. */
@@ -1029,13 +1029,13 @@ export interface RespondOptions {
      * Specifies the response status code.
      * @default 200
      */
-    status?: number;
+    status?: number | undefined;
     /** Specifies the response headers. */
-    headers?: Headers;
+    headers?: Headers | undefined;
     /** Specifies the Content-Type response header. */
-    contentType?: string;
+    contentType?: string | undefined;
     /** Specifies the response body. */
-    body?: Buffer | string;
+    body?: Buffer | string | undefined;
 }
 
 export interface RemoteInfo {
@@ -1099,13 +1099,13 @@ export interface WaitForSelectorOptions extends Timeoutable {
      * i.e. to not have display: none or visibility: hidden CSS properties.
      * @default false
      */
-    visible?: boolean;
+    visible?: boolean | undefined;
     /**
      * Wait for element to not be found in the DOM or to be hidden,
      * i.e. have display: none or visibility: hidden CSS properties.
      * @default false
      */
-    hidden?: boolean;
+    hidden?: boolean | undefined;
 }
 
 export interface WaitForSelectorOptionsHidden extends WaitForSelectorOptions {
@@ -1313,7 +1313,7 @@ export interface PageCloseOptions {
      * Whether to run the before unload page handlers.
      * @default false
      */
-    runBeforeUnload?: boolean;
+    runBeforeUnload?: boolean | undefined;
 }
 
 export interface GeoOptions {
@@ -1328,7 +1328,7 @@ export interface GeoOptions {
     /**
      * Non-negative accuracy value.
      */
-    accuracy?: number;
+    accuracy?: number | undefined;
 }
 
 export type MediaType = 'screen' | 'print';
@@ -1445,12 +1445,12 @@ export interface SnapshopOptions {
      * Prune uninteresting nodes from the tree.
      * @default true
      */
-    interestingOnly?: boolean;
+    interestingOnly?: boolean | undefined;
     /**
      * The root DOM element for the snapshot.
      * @default document.body
      */
-    root?: ElementHandle;
+    root?: ElementHandle | undefined;
 }
 
 /**
@@ -1986,51 +1986,51 @@ export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeout
      * At this time, this is either `chrome` or `firefox`. See also `PUPPETEER_PRODUCT`.
      * @default 'chrome'
      */
-    product?: Product;
+    product?: Product | undefined;
     /**
      * Path to a Chromium executable to run instead of bundled Chromium. If
      * executablePath is a relative path, then it is resolved relative to current
      * working directory.
      */
-    executablePath?: string;
+    executablePath?: string | undefined;
     /**
      * Do not use `puppeteer.defaultArgs()` for launching Chromium.
      * @default false
      */
-    ignoreDefaultArgs?: boolean | string[];
+    ignoreDefaultArgs?: boolean | string[] | undefined;
     /**
      * Close chrome process on Ctrl-C.
      * @default true
      */
-    handleSIGINT?: boolean;
+    handleSIGINT?: boolean | undefined;
     /**
      * Close chrome process on SIGTERM.
      * @default true
      */
-    handleSIGTERM?: boolean;
+    handleSIGTERM?: boolean | undefined;
     /**
      * Close chrome process on SIGHUP.
      * @default true
      */
-    handleSIGHUP?: boolean;
+    handleSIGHUP?: boolean | undefined;
     /**
      * Whether to pipe browser process stdout and stderr into process.stdout and
      * process.stderr.
      * @default false
      */
-    dumpio?: boolean;
+    dumpio?: boolean | undefined;
     /**
      * Specify environment variables that will be visible to Chromium.
      * @default `process.env`.
      */
     env?: {
         [key: string]: string | boolean | number;
-    };
+    } | undefined;
     /**
      * Connects to the browser over a pipe instead of a WebSocket.
      * @default false
      */
-    pipe?: boolean;
+    pipe?: boolean | undefined;
 }
 
 export interface ChromeArgOptions {
@@ -2038,21 +2038,21 @@ export interface ChromeArgOptions {
      * Whether to run browser in headless mode.
      * @default true unless the devtools option is true.
      */
-    headless?: boolean;
+    headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
      * The list of Chromium flags can be found here.
      */
-    args?: string[];
+    args?: string[] | undefined;
     /**
      * Path to a User Data Directory.
      */
-    userDataDir?: string;
+    userDataDir?: string | undefined;
     /**
      * Whether to auto-open a DevTools panel for each tab.
      * If this option is true, the headless option will be set false.
      */
-    devtools?: boolean;
+    devtools?: boolean | undefined;
 }
 
 export interface BrowserOptions {
@@ -2060,7 +2060,7 @@ export interface BrowserOptions {
      * Whether to ignore HTTPS errors during navigation.
      * @default false
      */
-    ignoreHTTPSErrors?: boolean;
+    ignoreHTTPSErrors?: boolean | undefined;
     /**
      * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
      */
@@ -2068,37 +2068,37 @@ export interface BrowserOptions {
         /**
          * page width in pixels.
          */
-        width?: number;
+        width?: number | undefined;
         /**
          * page height in pixels.
          */
-        height?: number;
+        height?: number | undefined;
         /**
          * Specify device scale factor (can be thought of as dpr).
          * @default 1
          */
-        deviceScaleFactor?: number;
+        deviceScaleFactor?: number | undefined;
         /**
          * Whether the meta viewport tag is taken into account.
          * @default false
          */
-        isMobile?: boolean;
+        isMobile?: boolean | undefined;
         /**
          * Specifies if viewport supports touch events.
          * @default false
          */
-        hasTouch?: boolean;
+        hasTouch?: boolean | undefined;
         /**
          * Specifies if viewport is in landscape mode.
          * @default false
          */
-        isLandscape?: boolean;
-    } | null;
+        isLandscape?: boolean | undefined;
+    } | null | undefined;
     /**
      * Slows down Puppeteer operations by the specified amount of milliseconds.
      * Useful so that you can see what is going on.
      */
-    slowMo?: number;
+    slowMo?: number | undefined;
 }
 
 export interface ConnectOptions extends BrowserOptions {
@@ -2106,15 +2106,15 @@ export interface ConnectOptions extends BrowserOptions {
      * A browser url to connect to, in format `http://${host}:${port}`.
      * Use interchangeably with browserWSEndpoint to let Puppeteer fetch it from metadata endpoint.
      */
-    browserURL?: string;
+    browserURL?: string | undefined;
 
     /** A browser websocket endpoint to connect to. */
-    browserWSEndpoint?: string;
+    browserWSEndpoint?: string | undefined;
 
     /**
      * **Experimental** Specify a custom transport object for Puppeteer to use.
      */
-    transport?: ConnectionTransport;
+    transport?: ConnectionTransport | undefined;
 }
 
 export interface ConnectionTransport {
@@ -2149,12 +2149,12 @@ export interface StartCoverageOptions {
      * Whether to reset coverage on every navigation.
      * @default true
      */
-    resetOnNavigation?: boolean;
+    resetOnNavigation?: boolean | undefined;
     /**
      * Whether anonymous scripts generated by the page should be reported.
      * @default false
      */
-    reportAnonymousScripts?: boolean;
+    reportAnonymousScripts?: boolean | undefined;
 }
 
 export interface CoverageEntry {
@@ -2195,15 +2195,15 @@ export interface RevisionInfo {
 
 export interface FetcherOptions {
     /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
-    host?: string;
+    host?: string | undefined;
     /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
-    path?: string;
+    path?: string | undefined;
     /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
-    platform?: Platform;
+    platform?: Platform | undefined;
     /**
      * @default 'chrome'
      */
-    product?: Product;
+    product?: Product | undefined;
 }
 
 type EventType = string | symbol;

--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -250,7 +250,7 @@ declare namespace Q {
 
     export interface PromiseState<T> {
         state: "fulfilled" | "rejected" | "pending";
-        value?: T;
+        value?: T | undefined;
         reason?: any;
     }
 

--- a/types/q/v0/index.d.ts
+++ b/types/q/v0/index.d.ts
@@ -192,7 +192,7 @@ declare namespace Q {
 
     interface PromiseState<T> {
         state: "fulfilled" | "rejected" | "pending";
-        value?: T;
+        value?: T | undefined;
         reason?: any;
     }
 


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers widely used packages, those with more then 100,000 packages per month, from optimist -- q.

microsoft/dtslint#335