### PR TITLE
Add undefined to optional properties, QRCode to React

### DIFF
--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -11,25 +11,25 @@
 declare namespace qrcode {
     interface ImageSettings {
         src: string;
-        x?: number;
-        y?: number;
-        height?: number;
-        width?: number;
-        excavate?: boolean;
+        x?: number | undefined;
+        y?: number | undefined;
+        height?: number | undefined;
+        width?: number | undefined;
+        excavate?: boolean | undefined;
     }
 
     interface BaseQRCodeProps {
         value: string;
-        size?: number;
-        includeMargin?: boolean;
-        bgColor?: string;
-        fgColor?: string;
-        level?: "L"|"M"|"Q"|"H";
-        imageSettings?: ImageSettings;
+        size?: number | undefined;
+        includeMargin?: boolean | undefined;
+        bgColor?: string | undefined;
+        fgColor?: string | undefined;
+        level?: "L"|"M"|"Q"|"H" | undefined;
+        imageSettings?: ImageSettings | undefined;
     }
 
     type CanvasQRCodeProps = BaseQRCodeProps & {
-        renderAs?: "canvas"
+        renderAs?: "canvas" | undefined
     } & React.CanvasHTMLAttributes<HTMLCanvasElement>;
 
     type SvgQRCodeProps = BaseQRCodeProps & {

--- a/types/qrcode/index.d.ts
+++ b/types/qrcode/index.d.ts
@@ -16,18 +16,18 @@ export interface QRCodeOptions {
     /**
      * QR Code version. If not specified the more suitable value will be calculated.
      */
-    version?: number;
+    version?: number | undefined;
     /**
      * Error correction level.
      * Possible values are low, medium, quartile, high or L, M, Q, H.
      * Default: M
      */
-    errorCorrectionLevel?: QRCodeErrorCorrectionLevel;
+    errorCorrectionLevel?: QRCodeErrorCorrectionLevel | undefined;
     /**
      * Helper function used internally to convert a kanji to its Shift JIS value.
      * Provide this function if you need support for Kanji mode.
      */
-    toSJISFunc?: (codePoint: string) => number;
+    toSJISFunc?: ((codePoint: string) => number) | undefined;
 }
 
 export interface QRCodeToDataURLOptions extends QRCodeRenderersOptions {
@@ -35,14 +35,14 @@ export interface QRCodeToDataURLOptions extends QRCodeRenderersOptions {
      * Data URI format.
      * Default: image/png
      */
-    type?: 'image/png' | 'image/jpeg' | 'image/webp';
+    type?: 'image/png' | 'image/jpeg' | 'image/webp' | undefined;
     rendererOpts?: {
         /**
          * A Number between 0 and 1 indicating image quality if the requested type is image/jpeg or image/webp.
          * Default: 0.92
          */
-        quality?: number;
-    };
+        quality?: number | undefined;
+    } | undefined;
 }
 
 export interface QRCodeToStringOptions extends QRCodeRenderersOptions {
@@ -50,7 +50,7 @@ export interface QRCodeToStringOptions extends QRCodeRenderersOptions {
      * Output format.
      * Default: utf8
      */
-    type?: 'utf8' | 'svg' | 'terminal';
+    type?: 'utf8' | 'svg' | 'terminal' | undefined;
 }
 
 export interface QRCodeToFileOptions extends QRCodeRenderersOptions {
@@ -58,57 +58,57 @@ export interface QRCodeToFileOptions extends QRCodeRenderersOptions {
      * Output format.
      * Default: png
      */
-    type?: 'png' | 'svg' | 'utf8';
+    type?: 'png' | 'svg' | 'utf8' | undefined;
     rendererOpts?: {
         /**
          * Compression level for deflate.
          * Default: 9
          */
-        deflateLevel?: number;
+        deflateLevel?: number | undefined;
         /**
          * Compression strategy for deflate.
          * Default: 3
          */
-        deflateStrategy?: number;
-    };
+        deflateStrategy?: number | undefined;
+    } | undefined;
 }
 
 export interface QRCodeToFileStreamOptions extends QRCodeRenderersOptions {
     /**
      * Output format. Only png supported for file stream
      */
-    type?: 'png';
+    type?: 'png' | undefined;
     rendererOpts?: {
         /**
          * Compression level for deflate.
          * Default: 9
          */
-        deflateLevel?: number;
+        deflateLevel?: number | undefined;
         /**
          * Compression strategy for deflate.
          * Default: 3
          */
-        deflateStrategy?: number;
-    };
+        deflateStrategy?: number | undefined;
+    } | undefined;
 }
 
 export interface QRCodeToBufferOptions extends QRCodeRenderersOptions {
     /**
      * Output format. Only png supported for Buffer.
      */
-    type?: 'png';
+    type?: 'png' | undefined;
     rendererOpts?: {
         /**
          * Compression level for deflate.
          * Default: 9
          */
-        deflateLevel?: number;
+        deflateLevel?: number | undefined;
         /**
          * Compression strategy for deflate.
          * Default: 3
          */
-        deflateStrategy?: number;
-    };
+        deflateStrategy?: number | undefined;
+    } | undefined;
 }
 
 export interface QRCodeRenderersOptions extends QRCodeOptions {
@@ -116,31 +116,31 @@ export interface QRCodeRenderersOptions extends QRCodeOptions {
      * Define how much wide the quiet zone should be.
      * Default: 4
      */
-    margin?: number;
+    margin?: number | undefined;
     /**
      * Scale factor. A value of 1 means 1px per modules (black dots).
      * Default: 4
      */
-    scale?: number;
+    scale?: number | undefined;
     /**
      * Forces a specific width for the output image.
      * If width is too small to contain the qr symbol, this option will be ignored.
      * Takes precedence over scale.
      */
-    width?: number;
+    width?: number | undefined;
     color?: {
         /**
          * Color of dark module. Value must be in hex format (RGBA).
          * Note: dark color should always be darker than color.light.
          * Default: #000000ff
          */
-        dark?: string;
+        dark?: string | undefined;
         /**
          * Color of light module. Value must be in hex format (RGBA).
          * Default: #ffffffff
          */
-        light?: string;
-    };
+        light?: string | undefined;
+    } | undefined;
 }
 
 export interface QRCodeSegment {

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -18,45 +18,45 @@ declare namespace QueryString {
     type defaultDecoder = (str: string, decoder?: any, charset?: string) => string;
 
     interface IStringifyOptions {
-        delimiter?: string;
-        strictNullHandling?: boolean;
-        skipNulls?: boolean;
-        encode?: boolean;
-        encoder?: (str: any, defaultEncoder: defaultEncoder, charset: string, type: 'key' | 'value') => string;
-        filter?: Array<string | number> | ((prefix: string, value: any) => any);
-        arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma';
-        indices?: boolean;
-        sort?: (a: any, b: any) => number;
-        serializeDate?: (d: Date) => string;
-        format?: 'RFC1738' | 'RFC3986';
-        encodeValuesOnly?: boolean;
-        addQueryPrefix?: boolean;
-        allowDots?: boolean;
-        charset?: 'utf-8' | 'iso-8859-1';
-        charsetSentinel?: boolean;
+        delimiter?: string | undefined;
+        strictNullHandling?: boolean | undefined;
+        skipNulls?: boolean | undefined;
+        encode?: boolean | undefined;
+        encoder?: ((str: any, defaultEncoder: defaultEncoder, charset: string, type: 'key' | 'value') => string) | undefined;
+        filter?: Array<string | number> | ((prefix: string, value: any) => any) | undefined;
+        arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma' | undefined;
+        indices?: boolean | undefined;
+        sort?: ((a: any, b: any) => number) | undefined;
+        serializeDate?: ((d: Date) => string) | undefined;
+        format?: 'RFC1738' | 'RFC3986' | undefined;
+        encodeValuesOnly?: boolean | undefined;
+        addQueryPrefix?: boolean | undefined;
+        allowDots?: boolean | undefined;
+        charset?: 'utf-8' | 'iso-8859-1' | undefined;
+        charsetSentinel?: boolean | undefined;
     }
 
     interface IParseOptions {
-        comma?: boolean;
-        delimiter?: string | RegExp;
-        depth?: number | false;
-        decoder?: (str: string, defaultDecoder: defaultDecoder, charset: string, type: 'key' | 'value') => any;
-        arrayLimit?: number;
-        parseArrays?: boolean;
-        allowDots?: boolean;
-        plainObjects?: boolean;
-        allowPrototypes?: boolean;
-        parameterLimit?: number;
-        strictNullHandling?: boolean;
-        ignoreQueryPrefix?: boolean;
-        charset?: 'utf-8' | 'iso-8859-1';
-        charsetSentinel?: boolean;
-        interpretNumericEntities?: boolean;
+        comma?: boolean | undefined;
+        delimiter?: string | RegExp | undefined;
+        depth?: number | false | undefined;
+        decoder?: ((str: string, defaultDecoder: defaultDecoder, charset: string, type: 'key' | 'value') => any) | undefined;
+        arrayLimit?: number | undefined;
+        parseArrays?: boolean | undefined;
+        allowDots?: boolean | undefined;
+        plainObjects?: boolean | undefined;
+        allowPrototypes?: boolean | undefined;
+        parameterLimit?: number | undefined;
+        strictNullHandling?: boolean | undefined;
+        ignoreQueryPrefix?: boolean | undefined;
+        charset?: 'utf-8' | 'iso-8859-1' | undefined;
+        charsetSentinel?: boolean | undefined;
+        interpretNumericEntities?: boolean | undefined;
     }
 
     interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
 
     function stringify(obj: any, options?: IStringifyOptions): string;
-    function parse(str: string, options?: IParseOptions & { decoder?: never }): ParsedQs;
+    function parse(str: string, options?: IParseOptions & { decoder?: never | undefined }): ParsedQs;
     function parse(str: string | Record<string, string>, options?: IParseOptions): { [key: string]: unknown };
 }

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -342,10 +342,10 @@ qs.parse('a=b&c=d', { delimiter: '&' });
     });
 }
 
-declare const myQuery: { a: string; b?: string }
+declare const myQuery: { a: string; b?: string | undefined }
 const myQueryCopy: qs.ParsedQs = myQuery;
 
 interface MyQuery extends qs.ParsedQs {
     a: string;
-    b?: string;
+    b?: string | undefined;
 }

--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -20,7 +20,7 @@ import Delta = require("quill-delta");
  *
  *  But this would break a lot of existing code as it would require manual discrimination of the union types.
  */
-export type DeltaOperation = { insert?: any; delete?: number; retain?: number } & OptionalAttributes;
+export type DeltaOperation = { insert?: any; delete?: number | undefined; retain?: number | undefined } & OptionalAttributes;
 interface SourceMap {
     API: "api";
     SILENT: "silent";
@@ -30,11 +30,11 @@ export type Sources = "api" | "user" | "silent";
 
 export interface Key {
     key: string | number;
-    shortKey?: boolean | null;
-    shiftKey?: boolean | null;
-    altKey?: boolean | null;
-    metaKey?: boolean | null;
-    ctrlKey?: boolean | null;
+    shortKey?: boolean | null | undefined;
+    shiftKey?: boolean | null | undefined;
+    altKey?: boolean | null | undefined;
+    metaKey?: boolean | null | undefined;
+    ctrlKey?: boolean | null | undefined;
 }
 
 export interface StringMap {
@@ -42,7 +42,7 @@ export interface StringMap {
 }
 
 export interface OptionalAttributes {
-    attributes?: StringMap;
+    attributes?: StringMap | undefined;
 }
 
 export type TextChangeHandler = (delta: Delta, oldContents: Delta, source: Sources) => any;
@@ -61,22 +61,22 @@ export type ClipboardMatcherNode = string | number;
 
 export interface ClipboardStatic {
     matchers: Array<[ClipboardMatcherNode, ClipboardMatcherCallback]>;
-    convert(content?: { html?: string; text?: string }, formats?: StringMap): Delta;
+    convert(content?: { html?: string | undefined; text?: string | undefined }, formats?: StringMap): Delta;
     addMatcher(selectorOrNodeType: ClipboardMatcherNode, callback: ClipboardMatcherCallback): void;
     dangerouslyPasteHTML(html: string, source?: Sources): void;
     dangerouslyPasteHTML(index: number, html: string, source?: Sources): void;
 }
 
 export interface QuillOptionsStatic {
-    debug?: string | boolean;
-    modules?: StringMap;
-    placeholder?: string;
-    readOnly?: boolean;
-    theme?: string;
-    formats?: string[];
-    bounds?: HTMLElement | string;
-    scrollingContainer?: HTMLElement | string;
-    strict?: boolean;
+    debug?: string | boolean | undefined;
+    modules?: StringMap | undefined;
+    placeholder?: string | undefined;
+    readOnly?: boolean | undefined;
+    theme?: string | undefined;
+    formats?: string[] | undefined;
+    bounds?: HTMLElement | string | undefined;
+    scrollingContainer?: HTMLElement | string | undefined;
+    strict?: boolean | undefined;
 }
 
 export interface BoundsStatic {

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -331,10 +331,10 @@ declare global {
         testTimeout: number;
         scrolltop: boolean;
         urlConfig: {
-            id?: string;
-            label?: string;
-            tooltip?: string;
-            value?: string | string[] | { [key: string]: string };
+            id?: string | undefined;
+            label?: string | undefined;
+            tooltip?: string | undefined;
+            value?: string | string[] | { [key: string]: string } | undefined;
         }[];
     }
 
@@ -343,22 +343,22 @@ declare global {
          * Runs after the last test. If additional tests are defined after the
          * module's queue has emptied, it will not run this hook again.
          */
-        after?: (assert: Assert) => void | Promise<void>;
+        after?: ((assert: Assert) => void | Promise<void>) | undefined;
 
         /**
          * Runs after each test.
          */
-        afterEach?: (assert: Assert) => void | Promise<void>;
+        afterEach?: ((assert: Assert) => void | Promise<void>) | undefined;
 
         /**
          * Runs before the first test.
          */
-        before?: (assert: Assert) => void | Promise<void>;
+        before?: ((assert: Assert) => void | Promise<void>) | undefined;
 
         /**
          * Runs before each test.
          */
-        beforeEach?: (assert: Assert) => void | Promise<void>;
+        beforeEach?: ((assert: Assert) => void | Promise<void>) | undefined;
     }
 
     interface NestedHooks {

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -621,7 +621,7 @@ QUnit.test( "rejects", function( assert ) {
 
   // Using a custom error like object
   class CustomError {
-    message?: string;
+    message?: string | undefined;
     constructor(message?: string) {
        this.message = message;
     }

--- a/types/qunit/v1/index.d.ts
+++ b/types/qunit/v1/index.d.ts
@@ -151,24 +151,24 @@ interface LifecycleObject {
      * @param assert
      * @deprecated
      */
-    setup?: (assert: QUnitAssert) => void;
+    setup?: ((assert: QUnitAssert) => void) | undefined;
 
     /**
      * Runs after each test
      * @param assert
      * @deprecated
      */
-    teardown?: (assert: QUnitAssert) => void;
+    teardown?: ((assert: QUnitAssert) => void) | undefined;
     /**
      * Runs before each test
      * @param assert
      */
-    beforeEach?: (assert: QUnitAssert) => void;
+    beforeEach?: ((assert: QUnitAssert) => void) | undefined;
     /**
      * Runs after each test
      * @param assert
      */
-    afterEach?: (assert: QUnitAssert) => void;
+    afterEach?: ((assert: QUnitAssert) => void) | undefined;
 
     /**
      * Any additional properties on the hooks object will be added to that context.

--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -33,7 +33,7 @@ declare namespace Radium {
          * Use to scope styles in the component to a particular element. A good use case might be to generate a unique
          * ID for a component to scope any styles to the particular component that owns the <Style> component instance.
          */
-        scopeSelector?: string;
+        scopeSelector?: string | undefined;
     }
 
     /**
@@ -46,7 +46,7 @@ declare namespace Radium {
      * StyleRoot component properties
      */
     export interface StyleRootProps extends React.HTMLProps<StyleRoot> {
-         radiumConfig?: RadiumConfig
+         radiumConfig?: RadiumConfig | undefined
     }
     /**
      * <StyleRoot />
@@ -62,16 +62,16 @@ declare namespace Radium {
          * Allow to replace matchMedia function that Radium uses. The default one is window.matchMedia
          * @param mediaQuery
          */
-        matchMedia?: (mediaQuery: string) => MediaQueryList;
+        matchMedia?: ((mediaQuery: string) => MediaQueryList) | undefined;
         /**
          * Set the user agent passed to inline-style-prefixer to perform prefixing on style objects.
          * Mainly used during server rendering
          */
-        userAgent?: string;
+        userAgent?: string | undefined;
         /**
          * List of plugins
          */
-        plugins?: Array<any>;
+        plugins?: Array<any> | undefined;
     }
 
     /**

--- a/types/radium/radium-tests.tsx
+++ b/types/radium/radium-tests.tsx
@@ -24,7 +24,7 @@ TestStatelessComponent = Radium(TestStatelessComponent);
     userAgent: "test",
     matchMedia: window.matchMedia
 })
-class TestComponentWithConfig extends React.Component<{ a?: number }> {
+class TestComponentWithConfig extends React.Component<{ a?: number | undefined }> {
     render() {
         return (
             <div>
@@ -54,7 +54,7 @@ class TestComponentWithConfig extends React.Component<{ a?: number }> {
 <TestComponentWithConfig a={5} />
 
 class TestComponentWithConfigInStyleRoot
-    extends React.Component<{ a?: number }> {
+    extends React.Component<{ a?: number | undefined }> {
     render() {
         return (
             <div>

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -115,8 +115,8 @@ export function always<T>(val: T): () => T;
  * A function that returns the first argument if it's falsy otherwise the second argument. Note that this is
  * NOT short-circuited, meaning that if expressions are passed they are both evaluated.
  */
-export function and<T extends { and?: ((...a: readonly any[]) => any); } | number | boolean | string | null>(fn1: T, val2: any): boolean;
-export function and<T extends { and?: ((...a: readonly any[]) => any); } | number | boolean | string | null>(fn1: T): (val2: any) => boolean;
+export function and<T extends { and?: ((...a: readonly any[]) => any) | undefined; } | number | boolean | string | null>(fn1: T, val2: any): boolean;
+export function and<T extends { and?: ((...a: readonly any[]) => any) | undefined; } | number | boolean | string | null>(fn1: T): (val2: any) => boolean;
 
 /**
  * Returns the result of applying the onSuccess function to the value inside a successfully resolved promise. This is useful for working with promises inside function compositions.
@@ -1337,8 +1337,8 @@ export function once<F extends (...a: readonly any[]) => any>(fn: F): F;
  */
 export function or<T, U>(a: T, b: U): T | U;
 export function or<T>(a: T): <U>(b: U) => T | U;
-export function or<T extends { or?: ((...a: readonly any[]) => any); }, U>(fn1: T, val2: U): T | U;
-export function or<T extends { or?: ((...a: readonly any[]) => any); }>(fn1: T): <U>(val2: U) => T | U;
+export function or<T extends { or?: ((...a: readonly any[]) => any) | undefined; }, U>(fn1: T, val2: U): T | U;
+export function or<T extends { or?: ((...a: readonly any[]) => any) | undefined; }>(fn1: T): <U>(val2: U) => T | U;
 
 /**
  * Returns the result of applying the onFailure function to the value inside a failed promise.

--- a/types/ramda/test/curry-tests.ts
+++ b/types/ramda/test/curry-tests.ts
@@ -53,7 +53,7 @@ import * as R from 'ramda';
 
 () => {
   interface Car {
-    speed?: number;
+    speed?: number | undefined;
   }
   interface FastCar {
     speed: number;

--- a/types/randomatic/index.d.ts
+++ b/types/randomatic/index.d.ts
@@ -14,8 +14,8 @@ declare namespace randomatic {
     const isCrypto: boolean;
 
     interface Options {
-        chars?: string;
-        exclude?: string | string[];
+        chars?: string | undefined;
+        exclude?: string | string[] | undefined;
     }
 }
 

--- a/types/randomstring/index.d.ts
+++ b/types/randomstring/index.d.ts
@@ -5,10 +5,10 @@
 
 declare namespace Randomstring {
     interface GenerateOptions {
-        length?: number;
-        readable?: boolean;
-        charset?: string;
-        capitalization?: string;
+        length?: number | undefined;
+        readable?: boolean | undefined;
+        charset?: string | undefined;
+        capitalization?: string | undefined;
     }
 
     function generate(options?: GenerateOptions | number): string;

--- a/types/range-parser/index.d.ts
+++ b/types/range-parser/index.d.ts
@@ -25,7 +25,7 @@ declare namespace RangeParser {
          * The "combine" option can be set to `true` and overlapping & adjacent ranges
          * will be combined into a single range.
          */
-        combine?: boolean;
+        combine?: boolean | undefined;
     }
     type ResultUnsatisfiable = -1;
     type ResultInvalid = -2;

--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -18,25 +18,25 @@ declare namespace RCTooltip {
         "topLeft" | "topRight" | "bottomLeft" | "bottomRight";
 
     export interface Props extends React.Props<any> {
-        overlayClassName?: string;
-        trigger?: Trigger[];
-        mouseEnterDelay?: number;
-        mouseLeaveDelay?: number;
-        overlayStyle?: React.CSSProperties;
-        prefixCls?: string;
-        transitionName?: string;
-        onVisibleChange?: (visible?: boolean) => void;
-        afterVisibleChange?: (visible?: boolean) => void;
-        visible?: boolean;
-        defaultVisible?: boolean;
-        placement?: Placement | Object;
-        align?: Object;
-        onPopupAlign?: (popupDomNode: Element, align: Object) => void;
+        overlayClassName?: string | undefined;
+        trigger?: Trigger[] | undefined;
+        mouseEnterDelay?: number | undefined;
+        mouseLeaveDelay?: number | undefined;
+        overlayStyle?: React.CSSProperties | undefined;
+        prefixCls?: string | undefined;
+        transitionName?: string | undefined;
+        onVisibleChange?: ((visible?: boolean) => void) | undefined;
+        afterVisibleChange?: ((visible?: boolean) => void) | undefined;
+        visible?: boolean | undefined;
+        defaultVisible?: boolean | undefined;
+        placement?: Placement | Object | undefined;
+        align?: Object | undefined;
+        onPopupAlign?: ((popupDomNode: Element, align: Object) => void) | undefined;
         overlay: (() => React.ReactChild) | React.ReactChild | React.ReactFragment | React.ReactPortal;
-        arrowContent?: React.ReactNode;
-        getTooltipContainer?: () => Element;
-        destroyTooltipOnHide?: boolean;
-        id?: string;
+        arrowContent?: React.ReactNode | undefined;
+        getTooltipContainer?: (() => Element) | undefined;
+        destroyTooltipOnHide?: boolean | undefined;
+        id?: string | undefined;
     }
 }
 

--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -16,7 +16,7 @@ export interface HLocation<S = unknown> {
     search: string;
     state: S;
     hash: string;
-    key?: string;
+    key?: string | undefined;
 }
 export type WindowLocation<S = unknown> = Window['location'] & HLocation<S>;
 
@@ -39,18 +39,18 @@ export interface History {
 export class Router extends React.Component<RouterProps & React.HTMLProps<HTMLDivElement>> {}
 
 export interface RouterProps {
-    basepath?: string;
-    primary?: boolean;
-    location?: WindowLocation;
-    component?: React.ComponentType | string;
+    basepath?: string | undefined;
+    primary?: boolean | undefined;
+    location?: WindowLocation | undefined;
+    component?: React.ComponentType | string | undefined;
 }
 
 export type RouteComponentProps<TParams = {}> = Partial<TParams> & {
-    path?: string;
-    default?: boolean;
-    location?: WindowLocation;
-    navigate?: NavigateFn;
-    uri?: string;
+    path?: string | undefined;
+    default?: boolean | undefined;
+    location?: WindowLocation | undefined;
+    navigate?: NavigateFn | undefined;
+    uri?: string | undefined;
 };
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
@@ -62,11 +62,11 @@ export type AnchorProps = Omit<
 
 export interface LinkProps<TState> extends AnchorProps {
     to: string;
-    replace?: boolean;
-    getProps?: (props: LinkGetProps) => {};
-    state?: TState;
+    replace?: boolean | undefined;
+    getProps?: ((props: LinkGetProps) => {}) | undefined;
+    state?: TState | undefined;
     /** @deprecated If using React >= 16.4, use ref instead. */
-    innerRef?: React.Ref<HTMLAnchorElement>;
+    innerRef?: React.Ref<HTMLAnchorElement> | undefined;
 }
 
 export interface LinkGetProps {
@@ -86,11 +86,11 @@ export interface Link<TState>
     > {}
 
 export interface RedirectProps<TState> {
-    from?: string;
+    from?: string | undefined;
     to: string;
-    noThrow?: boolean;
-    state?: TState;
-    replace?: boolean;
+    noThrow?: boolean | undefined;
+    state?: TState | undefined;
+    replace?: boolean | undefined;
 }
 
 export class Redirect<TState> extends React.Component<RouteComponentProps<RedirectProps<TState>>> {}
@@ -116,8 +116,8 @@ export interface NavigateFn {
 }
 
 export interface NavigateOptions<TState> {
-    state?: TState;
-    replace?: boolean;
+    state?: TState | undefined;
+    replace?: boolean | undefined;
 }
 
 export interface LocationProps {
@@ -127,8 +127,8 @@ export interface LocationProps {
 export class Location extends React.Component<LocationProps> {}
 
 export interface LocationProviderProps {
-    history?: History;
-    children?: React.ReactNode | LocationProviderRenderFn;
+    history?: History | undefined;
+    children?: React.ReactNode | LocationProviderRenderFn | undefined;
 }
 
 export type LocationProviderRenderFn = (context: LocationContext) => React.ReactNode;

--- a/types/react-addons-linked-state-mixin/index.d.ts
+++ b/types/react-addons-linked-state-mixin/index.d.ts
@@ -23,7 +23,7 @@ declare namespace LinkedStateMixin {
 
 declare module 'react' {
     interface HTMLAttributes<T> {
-        checkedLink?: LinkedStateMixin.ReactLink<boolean>;
-        valueLink?: LinkedStateMixin.ReactLink<boolean | string | number>;
+        checkedLink?: LinkedStateMixin.ReactLink<boolean> | undefined;
+        valueLink?: LinkedStateMixin.ReactLink<boolean | string | number> | undefined;
     }
 }

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -76,15 +76,15 @@ declare namespace Autosuggest {
 
     interface RenderInputComponentProps extends React.InputHTMLAttributes<any> {
         value: string;
-        ref?: React.Ref<HTMLInputElement>;
+        ref?: React.Ref<HTMLInputElement> | undefined;
     }
 
     interface InputProps<TSuggestion>
         extends Omit<React.InputHTMLAttributes<HTMLElement>, 'onChange' | 'onBlur'> {
         onChange: (event: React.FormEvent<HTMLElement>, params: ChangeEvent) => void;
-        onBlur?: (event: React.FocusEvent<HTMLElement>, params?: BlurEvent<TSuggestion>) => void;
+        onBlur?: ((event: React.FocusEvent<HTMLElement>, params?: BlurEvent<TSuggestion>) => void) | undefined;
         value: string;
-        ref?: React.Ref<HTMLInputElement>;
+        ref?: React.Ref<HTMLInputElement> | undefined;
     }
 
     interface ContainerProps extends React.InputHTMLAttributes<any> {}
@@ -152,11 +152,11 @@ declare namespace Autosuggest {
         /**
          * Set it to true if you'd like to render suggestions even when the input is not focused.
          */
-        alwaysRenderSuggestions?: boolean;
+        alwaysRenderSuggestions?: boolean | undefined;
         /**
          * Set it to false if you don't want Autosuggest to keep the input focused when suggestions are clicked/tapped.
          */
-        focusInputOnSuggestionClick?: boolean;
+        focusInputOnSuggestionClick?: boolean | undefined;
         /**
          * Implement it to teach Autosuggest what should be the input value when suggestion is clicked.
          */
@@ -164,11 +164,11 @@ declare namespace Autosuggest {
         /**
          *     Set it to true if you'd like Autosuggest to automatically highlight the first suggestion.
          */
-        highlightFirstSuggestion?: boolean;
+        highlightFirstSuggestion?: boolean | undefined;
         /**
          * Use it only if you have multiple Autosuggest components on a page.
          */
-        id?: string;
+        id?: string | undefined;
         /**
          * Pass through arbitrary props to the input. It must contain at least value and onChange.
          */
@@ -176,11 +176,11 @@ declare namespace Autosuggest {
         /**
          * Provides arbitrary properties to the outer `div` container of Autosuggest. Allows the override of accessibility properties.
          */
-        containerProps?: ContainerProps;
+        containerProps?: ContainerProps | undefined;
         /**
          * Will be called every time the highlighted suggestion changes.
          */
-        onSuggestionHighlighted?: OnSuggestionHighlighted;
+        onSuggestionHighlighted?: OnSuggestionHighlighted | undefined;
         /**
          * Will be called every time you need to recalculate suggestions.
          */
@@ -188,19 +188,19 @@ declare namespace Autosuggest {
         /**
          * Will be called every time you need to set suggestions to [].
          */
-        onSuggestionsClearRequested?: OnSuggestionsClearRequested;
+        onSuggestionsClearRequested?: OnSuggestionsClearRequested | undefined;
         /**
          * Will be called every time suggestion is selected via mouse or keyboard.
          */
-        onSuggestionSelected?: OnSuggestionSelected<TSuggestion>;
+        onSuggestionSelected?: OnSuggestionSelected<TSuggestion> | undefined;
         /**
          * Use it only if you need to customize the rendering of the input.
          */
-        renderInputComponent?: RenderInputComponent;
+        renderInputComponent?: RenderInputComponent | undefined;
         /**
          * Use it if you want to customize things inside the suggestions container beyond rendering the suggestions themselves.
          */
-        renderSuggestionsContainer?: RenderSuggestionsContainer;
+        renderSuggestionsContainer?: RenderSuggestionsContainer | undefined;
         /**
          * Use your imagination to define how suggestions are rendered.
          */
@@ -209,18 +209,18 @@ declare namespace Autosuggest {
          * When the input is focused, Autosuggest will consult this function when to render suggestions.
          * Use it, for example, if you want to display suggestions when input value is at least 2 characters long.
          */
-        shouldRenderSuggestions?: ShouldRenderSuggestions;
+        shouldRenderSuggestions?: ShouldRenderSuggestions | undefined;
         /**
          * Use your imagination to style the Autosuggest.
          */
-        theme?: Theme;
+        theme?: Theme | undefined;
     }
 
     interface AutosuggestPropsSingleSection<TSuggestion> extends AutosuggestPropsBase<TSuggestion> {
         /**
          * Set it to true if you'd like to display suggestions in multiple sections (with optional titles).
          */
-        multiSection?: false;
+        multiSection?: false | undefined;
         /**
          * These are the suggestions that will be displayed. Items can take an arbitrary shape.
          */
@@ -239,11 +239,11 @@ declare namespace Autosuggest {
         /**
          * Implement it to teach Autosuggest where to find the suggestions for every section.
          */
-        getSectionSuggestions?: GetSectionSuggestions<TSuggestion, TSection>;
+        getSectionSuggestions?: GetSectionSuggestions<TSuggestion, TSection> | undefined;
         /**
          * Use your imagination to define how section titles are rendered.
          */
-        renderSectionTitle?: RenderSectionTitle;
+        renderSectionTitle?: RenderSectionTitle | undefined;
     }
 
     type AutosuggestProps<TSuggestion, TSection> = AutosuggestPropsSingleSection<TSuggestion> | AutosuggestPropsMultiSection<TSuggestion, TSection>;

--- a/types/react-avatar-editor/index.d.ts
+++ b/types/react-avatar-editor/index.d.ts
@@ -25,20 +25,20 @@ export interface ImageState extends CroppedRect {
 }
 
 export interface AvatarEditorProps {
-    className?: string;
+    className?: string | undefined;
     image: string | File;
-    width?: number;
-    height?: number;
-    border?: number | number[];
-    borderRadius?: number;
-    color?: number[];
-    style?: object;
-    scale?: number;
-    position?: Position;
-    rotate?: number;
-    crossOrigin?: string;
-    disableBoundaryChecks?: boolean;
-    disableDrop?: boolean;
+    width?: number | undefined;
+    height?: number | undefined;
+    border?: number | number[] | undefined;
+    borderRadius?: number | undefined;
+    color?: number[] | undefined;
+    style?: object | undefined;
+    scale?: number | undefined;
+    position?: Position | undefined;
+    rotate?: number | undefined;
+    crossOrigin?: string | undefined;
+    disableBoundaryChecks?: boolean | undefined;
+    disableDrop?: boolean | undefined;
     onDropFile?(event: DragEvent): void;
     onLoadFailure?(event: Event): void;
     onLoadSuccess?(imgInfo: ImageState): void;

--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -180,24 +180,24 @@ export interface Scrollable {
 export interface PlaceholderInSubject {
     // might not actually be increased by
     // placeholder if there is no required space
-    increasedBy?: Position;
+    increasedBy?: Position | undefined;
     placeholderSize: Position;
     // max scroll before placeholder added
     // will be null if there was no frame
-    oldFrameMaxScroll?: Position;
+    oldFrameMaxScroll?: Position | undefined;
 }
 
 export interface DroppableSubject {
     // raw, unchanging
     page: BoxModel;
-    withPlaceholder?: PlaceholderInSubject;
+    withPlaceholder?: PlaceholderInSubject | undefined;
     // The hitbox for a droppable
     // - page margin box
     // - with scroll changes
     // - with any additional droppable placeholder
     // - clipped by frame
     // The subject will be null if the hit area is completely empty
-    active?: Rect;
+    active?: Rect | undefined;
 }
 
 export interface DroppableDimension {
@@ -212,7 +212,7 @@ export interface DroppableDimension {
     // relative to the page
     page: BoxModel;
     // The container of the droppable
-    frame?: Scrollable;
+    frame?: Scrollable | undefined;
     // what is visible through the frame
     subject: DroppableSubject;
 }
@@ -283,7 +283,7 @@ export interface Displaced {
 export interface DragImpact {
     displaced: DisplacementGroups;
     displacedBy: DisplacedBy;
-    at?: ImpactLocation;
+    at?: ImpactLocation | undefined;
 }
 
 export interface ClientPositions {
@@ -340,9 +340,9 @@ export interface DragStart extends DraggableRubric {
 
 export interface DragUpdate extends DragStart {
     // may not have any destination (drag to nowhere)
-    destination?: DraggableLocation;
+    destination?: DraggableLocation | undefined;
     // populated when a draggable is dragging over another in combine mode
-    combine?: Combine;
+    combine?: Combine | undefined;
 }
 
 export type DropReason = 'DROP' | 'CANCEL';
@@ -407,7 +407,7 @@ export interface CompletedDrag {
 
 export interface IdleState {
     phase: 'IDLE';
-    completed?: CompletedDrag;
+    completed?: CompletedDrag | undefined;
     shouldFlush: boolean;
 }
 
@@ -426,9 +426,9 @@ export interface DraggingState {
     // when there is a fixed list we want to opt out of this behaviour
     isWindowScrollAllowed: boolean;
     // if we need to jump the scroll (keyboard dragging)
-    scrollJumpRequest?: Position;
+    scrollJumpRequest?: Position | undefined;
     // whether or not draggable movements should be animated
-    forceShouldAnimate?: boolean;
+    forceShouldAnimate?: boolean | undefined;
 }
 
 // While dragging we can enter into a bulk collection phase
@@ -483,10 +483,10 @@ export type OnDragUpdateResponder = (update: DragUpdate, provided: ResponderProv
 export type OnDragEndResponder = (result: DropResult, provided: ResponderProvided) => void;
 
 export interface Responders {
-    onBeforeCapture?: OnBeforeCaptureResponder;
-    onBeforeDragStart?: OnBeforeDragStartResponder;
-    onDragStart?: OnDragStartResponder;
-    onDragUpdate?: OnDragUpdateResponder;
+    onBeforeCapture?: OnBeforeCaptureResponder | undefined;
+    onBeforeDragStart?: OnBeforeDragStartResponder | undefined;
+    onDragStart?: OnDragStartResponder | undefined;
+    onDragUpdate?: OnDragUpdateResponder | undefined;
     // always required
     onDragEnd: OnDragEndResponder;
 }
@@ -526,7 +526,7 @@ export interface PreDragActions {
 }
 
 export interface TryGetLockOptions {
-    sourceEvent?: Event;
+    sourceEvent?: Event | undefined;
 }
 
 export type TryGetLock = (
@@ -557,10 +557,10 @@ export interface DragDropContextProps {
     onDragUpdate?(initial: DragUpdate, provided: ResponderProvided): void;
     onDragEnd(result: DropResult, provided: ResponderProvided): void;
     children: React.ReactNode | null;
-    dragHandleUsageInstructions?: string;
-    nonce?: string;
-    enableDefaultSensors?: boolean;
-    sensors?: Sensor[];
+    dragHandleUsageInstructions?: string | undefined;
+    nonce?: string | undefined;
+    enableDefaultSensors?: boolean | undefined;
+    sensors?: Sensor[] | undefined;
 }
 
 export class DragDropContext extends React.Component<DragDropContextProps> { }
@@ -578,27 +578,27 @@ export interface DroppableProvidedProps {
 
 export interface DroppableProvided {
     innerRef(element: HTMLElement | null): any;
-    placeholder?: React.ReactElement<HTMLElement> | null;
+    placeholder?: React.ReactElement<HTMLElement> | null | undefined;
     droppableProps: DroppableProvidedProps;
 }
 
 export interface DroppableStateSnapshot {
     isDraggingOver: boolean;
-    draggingOverWith?: DraggableId;
-    draggingFromThisWith?: DraggableId;
+    draggingOverWith?: DraggableId | undefined;
+    draggingFromThisWith?: DraggableId | undefined;
     isUsingPlaceholder: boolean;
 }
 
 export interface DroppableProps {
     droppableId: DroppableId;
-    type?: TypeId;
-    mode?: DroppableMode;
-    isDropDisabled?: boolean;
-    isCombineEnabled?: boolean;
-    direction?: Direction;
-    ignoreContainerClipping?: boolean;
-    renderClone?: DraggableChildrenFn;
-    getContainerForClone?: () => React.ReactElement<HTMLElement>;
+    type?: TypeId | undefined;
+    mode?: DroppableMode | undefined;
+    isDropDisabled?: boolean | undefined;
+    isCombineEnabled?: boolean | undefined;
+    direction?: Direction | undefined;
+    ignoreContainerClipping?: boolean | undefined;
+    renderClone?: DraggableChildrenFn | undefined;
+    getContainerForClone?: (() => React.ReactElement<HTMLElement>) | undefined;
     children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<HTMLElement>;
 }
 
@@ -612,13 +612,13 @@ export interface DropAnimation {
     duration: number;
     curve: string;
     moveTo: Position;
-    opacity?: number;
-    scale?: number;
+    opacity?: number | undefined;
+    scale?: number | undefined;
 }
 
 export interface NotDraggingStyle {
-    transform?: string;
-    transition?: 'none';
+    transform?: string | undefined;
+    transition?: 'none' | undefined;
 }
 
 export interface DraggingStyle {
@@ -629,19 +629,19 @@ export interface DraggingStyle {
     width: number;
     height: number;
     transition: 'none';
-    transform?: string;
+    transform?: string | undefined;
     zIndex: number;
-    opacity?: number;
+    opacity?: number | undefined;
     pointerEvents: 'none';
 }
 
 export interface DraggableProvidedDraggableProps {
     // inline style
-    style?: DraggingStyle | NotDraggingStyle;
+    style?: DraggingStyle | NotDraggingStyle | undefined;
     // used for shared global styles
     'data-rbd-draggable-context-id': string;
     'data-rbd-draggable-id': string;
-    onTransitionEnd?: React.TransitionEventHandler<any>;
+    onTransitionEnd?: React.TransitionEventHandler<any> | undefined;
 }
 
 export interface DraggableProvidedDragHandleProps {
@@ -659,20 +659,20 @@ export interface DraggableProvided {
     // will be removed after move to react 16
     innerRef(element?: HTMLElement | null): any;
     draggableProps: DraggableProvidedDraggableProps;
-    dragHandleProps?: DraggableProvidedDragHandleProps;
+    dragHandleProps?: DraggableProvidedDragHandleProps | undefined;
 }
 
 export interface DraggableStateSnapshot {
     isDragging: boolean;
     isDropAnimating: boolean;
-    dropAnimation?: DropAnimation;
-    draggingOver?: DroppableId;
+    dropAnimation?: DropAnimation | undefined;
+    draggingOver?: DroppableId | undefined;
     // the id of a draggable that you are combining with
-    combineWith?: DraggableId;
+    combineWith?: DraggableId | undefined;
     // a combine target is being dragged over by
-    combineTargetFor?: DraggableId;
+    combineTargetFor?: DraggableId | undefined;
     // What type of movement is being done: 'FLUID' or 'SNAP'
-    mode?: MovementMode;
+    mode?: MovementMode | undefined;
 }
 
 export type DraggableChildrenFn = (
@@ -685,9 +685,9 @@ export interface DraggableProps {
     draggableId: DraggableId;
     index: number;
     children: DraggableChildrenFn;
-    isDragDisabled?: boolean;
-    disableInteractiveElementBlocking?: boolean;
-    shouldRespectForcePress?: boolean;
+    isDragDisabled?: boolean | undefined;
+    disableInteractiveElementBlocking?: boolean | undefined;
+    shouldRespectForcePress?: boolean | undefined;
 }
 
 export class Draggable extends React.Component<DraggableProps> { }

--- a/types/react-beautiful-dnd/v10/index.d.ts
+++ b/types/react-beautiful-dnd/v10/index.d.ts
@@ -53,9 +53,9 @@ export type OnDragEndResponder = (
 ) => void;
 
 export interface Responders {
-    onBeforeDragStart?: OnBeforeDragStartResponder;
-    onDragStart?: OnDragStartResponder;
-    onDragUpdate?: OnDragUpdateResponder;
+    onBeforeDragStart?: OnBeforeDragStartResponder | undefined;
+    onDragStart?: OnDragStartResponder | undefined;
+    onDragUpdate?: OnDragUpdateResponder | undefined;
     onDragEnd: OnDragEndResponder;
 }
 
@@ -71,9 +71,9 @@ export interface DragStart {
 }
 
 export interface DragUpdate extends DragStart {
-    destination?: DraggableLocation | null;
+    destination?: DraggableLocation | null | undefined;
     // populated when a draggable is dragging over another in combine mode
-    combine?: Combine | null;
+    combine?: Combine | null | undefined;
 }
 
 // details of the item that is being combined with
@@ -105,23 +105,23 @@ export interface DroppableProvidedProps {
 }
 export interface DroppableProvided {
     innerRef(element: HTMLElement | null): any;
-    placeholder?: React.ReactElement<HTMLElement> | null;
+    placeholder?: React.ReactElement<HTMLElement> | null | undefined;
     droppableProps: DroppableProvidedProps;
 }
 
 export interface DroppableStateSnapshot {
     isDraggingOver: boolean;
-    draggingOverWith?: DraggableId;
-    draggingFromThisWith?: DraggableId;
+    draggingOverWith?: DraggableId | undefined;
+    draggingFromThisWith?: DraggableId | undefined;
 }
 
 export interface DroppableProps {
     droppableId: DroppableId;
-    type?: TypeId;
-    ignoreContainerClipping?: boolean;
-    isDropDisabled?: boolean;
-    isCombineEnabled?: boolean;
-    direction?: 'vertical' | 'horizontal';
+    type?: TypeId | undefined;
+    ignoreContainerClipping?: boolean | undefined;
+    isDropDisabled?: boolean | undefined;
+    isCombineEnabled?: boolean | undefined;
+    direction?: 'vertical' | 'horizontal' | undefined;
     children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<HTMLElement>;
 }
 
@@ -132,8 +132,8 @@ export class Droppable extends React.Component<DroppableProps> { }
  */
 
 export interface NotDraggingStyle {
-    transform?: string;
-    transition?: 'none';
+    transform?: string | undefined;
+    transition?: 'none' | undefined;
 }
 
 export interface DraggingStyle {
@@ -145,14 +145,14 @@ export interface DraggingStyle {
     top: number;
     left: number;
     margin: 0;
-    transform?: string;
+    transform?: string | undefined;
     transition: 'none';
     zIndex: ZIndex;
 }
 
 export interface DraggableProvidedDraggableProps {
     // inline style
-    style?: DraggingStyle | NotDraggingStyle;
+    style?: DraggingStyle | NotDraggingStyle | undefined;
     // used for shared global styles
     'data-react-beautiful-dnd-draggable': string;
 }
@@ -176,20 +176,20 @@ export interface DraggableProvided {
 
     // will be removed after move to react 16
     innerRef(element?: HTMLElement | null): any;
-    placeholder?: React.ReactElement<HTMLElement> | null;
+    placeholder?: React.ReactElement<HTMLElement> | null | undefined;
 }
 
 export interface DraggableStateSnapshot {
     isDragging: boolean;
     isDropAnimating: boolean;
-    draggingOver?: DroppableId;
-    dropAnimation?: DropAnimation;
+    draggingOver?: DroppableId | undefined;
+    dropAnimation?: DropAnimation | undefined;
     // the id of a draggable that you are combining with
-    combineWith?: DraggableId;
+    combineWith?: DraggableId | undefined;
     // a combine target is being dragged over by
-    combineTargetFor?: DraggableId;
+    combineTargetFor?: DraggableId | undefined;
     // What type of movement is being done: 'FLUID' or 'SNAP'
-    mode?: MovementMode;
+    mode?: MovementMode | undefined;
 }
 
 export interface Position {
@@ -201,18 +201,18 @@ export interface DropAnimation {
     duration: number;
     curve: string;
     moveTo: Position;
-    opacity?: number;
-    scale?: number;
+    opacity?: number | undefined;
+    scale?: number | undefined;
 }
 
 export interface DraggableProps {
     draggableId: DroppableId;
     index: number;
-    isDragDisabled?: boolean;
-    disableInteractiveElementBlocking?: boolean;
+    isDragDisabled?: boolean | undefined;
+    disableInteractiveElementBlocking?: boolean | undefined;
     children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement<HTMLElement>;
-    type?: TypeId;
-    shouldRespectForceTouch?: boolean;
+    type?: TypeId | undefined;
+    shouldRespectForceTouch?: boolean | undefined;
 }
 
 export class Draggable extends React.Component<DraggableProps> { }

--- a/types/react-beautiful-dnd/v11/index.d.ts
+++ b/types/react-beautiful-dnd/v11/index.d.ts
@@ -46,10 +46,10 @@ export type OnDragUpdateResponder = (update: DragUpdate, provided: ResponderProv
 export type OnDragEndResponder = (result: DropResult, provided: ResponderProvided) => void;
 
 export interface Responders {
-    onBeforeCapture?: OnBeforeCaptureResponder;
-    onBeforeDragStart?: OnBeforeDragStartResponder;
-    onDragStart?: OnDragStartResponder;
-    onDragUpdate?: OnDragUpdateResponder;
+    onBeforeCapture?: OnBeforeCaptureResponder | undefined;
+    onBeforeDragStart?: OnBeforeDragStartResponder | undefined;
+    onDragStart?: OnDragStartResponder | undefined;
+    onDragUpdate?: OnDragUpdateResponder | undefined;
     onDragEnd: OnDragEndResponder;
 }
 
@@ -68,9 +68,9 @@ export interface DragStart extends BeforeCapture {
 }
 
 export interface DragUpdate extends DragStart {
-    destination?: DraggableLocation;
+    destination?: DraggableLocation | undefined;
     // populated when a draggable is dragging over another in combine mode
-    combine?: Combine;
+    combine?: Combine | undefined;
 }
 
 // details of the item that is being combined with
@@ -103,23 +103,23 @@ export interface DroppableProvidedProps {
 }
 export interface DroppableProvided {
     innerRef(element: HTMLElement | null): any;
-    placeholder?: React.ReactElement<HTMLElement> | null;
+    placeholder?: React.ReactElement<HTMLElement> | null | undefined;
     droppableProps: DroppableProvidedProps;
 }
 
 export interface DroppableStateSnapshot {
     isDraggingOver: boolean;
-    draggingOverWith?: DraggableId;
-    draggingFromThisWith?: DraggableId;
+    draggingOverWith?: DraggableId | undefined;
+    draggingFromThisWith?: DraggableId | undefined;
 }
 
 export interface DroppableProps {
     droppableId: DroppableId;
-    type?: TypeId;
-    ignoreContainerClipping?: boolean;
-    isDropDisabled?: boolean;
-    isCombineEnabled?: boolean;
-    direction?: 'vertical' | 'horizontal';
+    type?: TypeId | undefined;
+    ignoreContainerClipping?: boolean | undefined;
+    isDropDisabled?: boolean | undefined;
+    isCombineEnabled?: boolean | undefined;
+    direction?: 'vertical' | 'horizontal' | undefined;
     children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<HTMLElement>;
 }
 
@@ -130,8 +130,8 @@ export class Droppable extends React.Component<DroppableProps> {}
  */
 
 export interface NotDraggingStyle {
-    transform?: string;
-    transition?: 'none';
+    transform?: string | undefined;
+    transition?: 'none' | undefined;
 }
 
 export interface DraggingStyle {
@@ -143,14 +143,14 @@ export interface DraggingStyle {
     top: number;
     left: number;
     margin: 0;
-    transform?: string;
+    transform?: string | undefined;
     transition: 'none';
     zIndex: ZIndex;
 }
 
 export interface DraggableProvidedDraggableProps {
     // inline style
-    style?: DraggingStyle | NotDraggingStyle;
+    style?: DraggingStyle | NotDraggingStyle | undefined;
     // used for shared global styles
     'data-react-beautiful-dnd-draggable': string;
 }
@@ -174,28 +174,28 @@ export interface DraggableProvided {
 
     // will be removed after move to react 16
     innerRef(element?: HTMLElement | null): any;
-    placeholder?: React.ReactElement<HTMLElement> | null;
+    placeholder?: React.ReactElement<HTMLElement> | null | undefined;
 }
 
 export interface DraggableStateSnapshot {
     isDragging: boolean;
     isDropAnimating: boolean;
-    draggingOver?: DroppableId;
-    dropAnimation?: DropAnimation;
+    draggingOver?: DroppableId | undefined;
+    dropAnimation?: DropAnimation | undefined;
     // the id of a draggable that you are combining with
-    combineWith?: DraggableId;
+    combineWith?: DraggableId | undefined;
     // a combine target is being dragged over by
-    combineTargetFor?: DraggableId;
+    combineTargetFor?: DraggableId | undefined;
     // What type of movement is being done: 'FLUID' or 'SNAP'
-    mode?: MovementMode;
+    mode?: MovementMode | undefined;
 }
 
 export interface DropAnimation {
     duration: number;
     curve: string;
     moveTo: Position;
-    opacity?: number;
-    scale?: number;
+    opacity?: number | undefined;
+    scale?: number | undefined;
 }
 
 export interface Position {
@@ -206,11 +206,11 @@ export interface Position {
 export interface DraggableProps {
     draggableId: DroppableId;
     index: number;
-    isDragDisabled?: boolean;
-    disableInteractiveElementBlocking?: boolean;
+    isDragDisabled?: boolean | undefined;
+    disableInteractiveElementBlocking?: boolean | undefined;
     children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement<HTMLElement>;
-    type?: TypeId;
-    shouldRespectForcePress?: boolean;
+    type?: TypeId | undefined;
+    shouldRespectForcePress?: boolean | undefined;
 }
 
 export class Draggable extends React.Component<DraggableProps> {}

--- a/types/react-beautiful-dnd/v12/index.d.ts
+++ b/types/react-beautiful-dnd/v12/index.d.ts
@@ -178,24 +178,24 @@ export interface Scrollable {
 export interface PlaceholderInSubject {
     // might not actually be increased by
     // placeholder if there is no required space
-    increasedBy?: Position;
+    increasedBy?: Position | undefined;
     placeholderSize: Position;
     // max scroll before placeholder added
     // will be null if there was no frame
-    oldFrameMaxScroll?: Position;
+    oldFrameMaxScroll?: Position | undefined;
 }
 
 export interface DroppableSubject {
     // raw, unchanging
     page: BoxModel;
-    withPlaceholder?: PlaceholderInSubject;
+    withPlaceholder?: PlaceholderInSubject | undefined;
     // The hitbox for a droppable
     // - page margin box
     // - with scroll changes
     // - with any additional droppable placeholder
     // - clipped by frame
     // The subject will be null if the hit area is completely empty
-    active?: Rect;
+    active?: Rect | undefined;
 }
 
 export interface DroppableDimension {
@@ -210,7 +210,7 @@ export interface DroppableDimension {
     // relative to the page
     page: BoxModel;
     // The container of the droppable
-    frame?: Scrollable;
+    frame?: Scrollable | undefined;
     // what is visible through the frame
     subject: DroppableSubject;
 }
@@ -290,7 +290,7 @@ export interface Displaced {
 export interface DragImpact {
     displaced: DisplacementGroups;
     displacedBy: DisplacedBy;
-    at?: ImpactLocation;
+    at?: ImpactLocation | undefined;
 }
 
 export interface ClientPositions {
@@ -345,9 +345,9 @@ export interface DragStart extends DraggableRubric {
 
 export interface DragUpdate extends DragStart {
     // may not have any destination (drag to nowhere)
-    destination?: DraggableLocation;
+    destination?: DraggableLocation | undefined;
     // populated when a draggable is dragging over another in combine mode
-    combine?: Combine;
+    combine?: Combine | undefined;
 }
 
 export type DropReason = 'DROP' | 'CANCEL';
@@ -412,7 +412,7 @@ export interface CompletedDrag {
 
 export interface IdleState {
     phase: 'IDLE';
-    completed?: CompletedDrag;
+    completed?: CompletedDrag | undefined;
     shouldFlush: boolean;
 }
 
@@ -432,9 +432,9 @@ export interface DraggingState {
     // when there is a fixed list we want to opt out of this behaviour
     isWindowScrollAllowed: boolean;
     // if we need to jump the scroll (keyboard dragging)
-    scrollJumpRequest?: Position;
+    scrollJumpRequest?: Position | undefined;
     // whether or not draggable movements should be animated
-    forceShouldAnimate?: boolean;
+    forceShouldAnimate?: boolean | undefined;
 }
 
 // While dragging we can enter into a bulk collection phase
@@ -489,10 +489,10 @@ export type OnDragUpdateResponder = (update: DragUpdate, provided: ResponderProv
 export type OnDragEndResponder = (result: DropResult, provided: ResponderProvided) => void;
 
 export interface Responders {
-    onBeforeCapture?: OnBeforeCaptureResponder;
-    onBeforeDragStart?: OnBeforeDragStartResponder;
-    onDragStart?: OnDragStartResponder;
-    onDragUpdate?: OnDragUpdateResponder;
+    onBeforeCapture?: OnBeforeCaptureResponder | undefined;
+    onBeforeDragStart?: OnBeforeDragStartResponder | undefined;
+    onDragStart?: OnDragStartResponder | undefined;
+    onDragUpdate?: OnDragUpdateResponder | undefined;
     // always required
     onDragEnd: OnDragEndResponder;
 }
@@ -532,7 +532,7 @@ export interface PreDragActions {
 }
 
 export interface TryGetLockOptions {
-    sourceEvent?: Event;
+    sourceEvent?: Event | undefined;
 }
 
 export type TryGetLock = (
@@ -562,7 +562,7 @@ export interface DragDropContextProps {
     onDragStart?(initial: DragStart, provided: ResponderProvided): void;
     onDragUpdate?(initial: DragUpdate, provided: ResponderProvided): void;
     onDragEnd(result: DropResult, provided: ResponderProvided): void;
-    sensors?: Sensor[];
+    sensors?: Sensor[] | undefined;
 }
 
 export class DragDropContext extends React.Component<DragDropContextProps> {}
@@ -580,27 +580,27 @@ export interface DroppableProvidedProps {
 
 export interface DroppableProvided {
     innerRef(element: HTMLElement | null): any;
-    placeholder?: React.ReactElement<HTMLElement> | null;
+    placeholder?: React.ReactElement<HTMLElement> | null | undefined;
     droppableProps: DroppableProvidedProps;
 }
 
 export interface DroppableStateSnapshot {
     isDraggingOver: boolean;
-    draggingOverWith?: DraggableId;
-    draggingFromThisWith?: DraggableId;
+    draggingOverWith?: DraggableId | undefined;
+    draggingFromThisWith?: DraggableId | undefined;
     isUsingPlaceholder: boolean;
 }
 
 export interface DroppableProps {
     droppableId: DroppableId;
-    type?: TypeId;
-    mode?: DroppableMode;
-    isDropDisabled?: boolean;
-    isCombineEnabled?: boolean;
-    direction?: Direction;
-    ignoreContainerClipping?: boolean;
-    renderClone?: DraggableChildrenFn;
-    getContainerForClone?: () => React.ReactElement<HTMLElement>;
+    type?: TypeId | undefined;
+    mode?: DroppableMode | undefined;
+    isDropDisabled?: boolean | undefined;
+    isCombineEnabled?: boolean | undefined;
+    direction?: Direction | undefined;
+    ignoreContainerClipping?: boolean | undefined;
+    renderClone?: DraggableChildrenFn | undefined;
+    getContainerForClone?: (() => React.ReactElement<HTMLElement>) | undefined;
     children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<HTMLElement>;
 }
 
@@ -614,13 +614,13 @@ export interface DropAnimation {
     duration: number;
     curve: string;
     moveTo: Position;
-    opacity?: number;
-    scale?: number;
+    opacity?: number | undefined;
+    scale?: number | undefined;
 }
 
 export interface NotDraggingStyle {
-    transform?: string;
-    transition?: 'none';
+    transform?: string | undefined;
+    transition?: 'none' | undefined;
 }
 
 export interface DraggingStyle {
@@ -631,19 +631,19 @@ export interface DraggingStyle {
     width: number;
     height: number;
     transition: 'none';
-    transform?: string;
+    transform?: string | undefined;
     zIndex: number;
-    opacity?: number;
+    opacity?: number | undefined;
     pointerEvents: 'none';
 }
 
 export interface DraggableProvidedDraggableProps {
     // inline style
-    style?: DraggingStyle | NotDraggingStyle;
+    style?: DraggingStyle | NotDraggingStyle | undefined;
     // used for shared global styles
     'data-rbd-draggable-context-id': string;
     'data-rbd-draggable-id': string;
-    onTransitionEnd?: React.TransitionEventHandler<any>;
+    onTransitionEnd?: React.TransitionEventHandler<any> | undefined;
 }
 
 export interface DraggableProvidedDragHandleProps {
@@ -660,20 +660,20 @@ export interface DraggableProvided {
     // will be removed after move to react 16
     innerRef(element?: HTMLElement | null): any;
     draggableProps: DraggableProvidedDraggableProps;
-    dragHandleProps?: DraggableProvidedDragHandleProps;
+    dragHandleProps?: DraggableProvidedDragHandleProps | undefined;
 }
 
 export interface DraggableStateSnapshot {
     isDragging: boolean;
     isDropAnimating: boolean;
-    dropAnimation?: DropAnimation;
-    draggingOver?: DroppableId;
+    dropAnimation?: DropAnimation | undefined;
+    draggingOver?: DroppableId | undefined;
     // the id of a draggable that you are combining with
-    combineWith?: DraggableId;
+    combineWith?: DraggableId | undefined;
     // a combine target is being dragged over by
-    combineTargetFor?: DraggableId;
+    combineTargetFor?: DraggableId | undefined;
     // What type of movement is being done: 'FLUID' or 'SNAP'
-    mode?: MovementMode;
+    mode?: MovementMode | undefined;
 }
 
 export type DraggableChildrenFn = (
@@ -686,9 +686,9 @@ export interface DraggableProps {
     draggableId: DraggableId;
     index: number;
     children: DraggableChildrenFn;
-    isDragDisabled?: boolean;
-    disableInteractiveElementBlocking?: boolean;
-    shouldRespectForcePress?: boolean;
+    isDragDisabled?: boolean | undefined;
+    disableInteractiveElementBlocking?: boolean | undefined;
+    shouldRespectForcePress?: boolean | undefined;
 }
 
 export class Draggable extends React.Component<DraggableProps> {}

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -57,11 +57,11 @@ export type ViewProps<TEvent extends object = Event, TResource extends object = 
     onSelectSlot: any; // = this.handleSelectSlot
 };
 export type ViewsProps<TEvent extends object = Event, TResource extends object = object> = View[] | {
-    work_week?: boolean | React.ComponentType<any> & ViewStatic,
-    day?: boolean | React.ComponentType<any> & ViewStatic,
-    agenda?: boolean | React.ComponentType<any> & ViewStatic,
-    month?: boolean | React.ComponentType<any> & ViewStatic,
-    week?: boolean | React.ComponentType<any> & ViewStatic
+    work_week?: boolean | React.ComponentType<any> & ViewStatic | undefined,
+    day?: boolean | React.ComponentType<any> & ViewStatic | undefined,
+    agenda?: boolean | React.ComponentType<any> & ViewStatic | undefined,
+    month?: boolean | React.ComponentType<any> & ViewStatic | undefined,
+    week?: boolean | React.ComponentType<any> & ViewStatic | undefined
 };
 export type DayLayoutFunction<TEvent extends object = Event> = (_: {
     events: TEvent[],
@@ -72,10 +72,10 @@ export type DayLayoutFunction<TEvent extends object = Event> = (_: {
 export type DayLayoutAlgorithm = 'overlap' | 'no-overlap';
 export type NavigateAction = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 export interface Event {
-    allDay?: boolean;
-    title?: string;
-    start?: Date;
-    end?: Date;
+    allDay?: boolean | undefined;
+    title?: string | undefined;
+    start?: Date | undefined;
+    end?: Date | undefined;
     resource?: any;
 }
 export interface DateRange {
@@ -92,71 +92,71 @@ export interface Formats {
      * Format for the day of the month heading in the Month view.
      * e.g. "01", "02", "03", etc
      */
-    dateFormat?: DateFormat;
+    dateFormat?: DateFormat | undefined;
 
     /**
      * A day of the week format for Week and Day headings,
      * e.g. "Wed 01/04"
      *
      */
-    dayFormat?: DateFormat;
+    dayFormat?: DateFormat | undefined;
 
     /**
      * Week day name format for the Month week day headings,
      * e.g: "Sun", "Mon", "Tue", etc
      *
      */
-    weekdayFormat?: DateFormat;
+    weekdayFormat?: DateFormat | undefined;
 
     /**
      * The timestamp cell formats in Week and Time views, e.g. "4:00 AM"
      */
-    timeGutterFormat?: DateFormat;
+    timeGutterFormat?: DateFormat | undefined;
 
     /**
      * Toolbar header format for the Month view, e.g "2015 April"
      *
      */
-    monthHeaderFormat?: DateFormat;
+    monthHeaderFormat?: DateFormat | undefined;
 
     /**
      * Toolbar header format for the Week views, e.g. "Mar 29 - Apr 04"
      */
-    dayRangeHeaderFormat?: DateRangeFormatFunction;
+    dayRangeHeaderFormat?: DateRangeFormatFunction | undefined;
 
     /**
      * Toolbar header format for the Day view, e.g. "Wednesday Apr 01"
      */
-    dayHeaderFormat?: DateFormat;
+    dayHeaderFormat?: DateFormat | undefined;
 
     /**
      * Toolbar header format for the Agenda view, e.g. "4/1/2015 — 5/1/2015"
      */
-    agendaHeaderFormat?: DateRangeFormatFunction;
+    agendaHeaderFormat?: DateRangeFormatFunction | undefined;
 
     /**
      * A time range format for selecting time slots, e.g "8:00am — 2:00pm"
      */
-    selectRangeFormat?: DateRangeFormatFunction;
+    selectRangeFormat?: DateRangeFormatFunction | undefined;
 
-    agendaDateFormat?: DateFormat;
-    agendaTimeFormat?: DateFormat;
-    agendaTimeRangeFormat?: DateRangeFormatFunction;
+    agendaDateFormat?: DateFormat | undefined;
+    agendaTimeFormat?: DateFormat | undefined;
+    agendaTimeRangeFormat?: DateRangeFormatFunction | undefined;
 
     /**
      * Time range displayed on events.
      */
-    eventTimeRangeFormat?: DateRangeFormatFunction;
+    eventTimeRangeFormat?: DateRangeFormatFunction | undefined;
 
     /**
      * An optional event time range for events that continue onto another day
      */
-    eventTimeRangeStartFormat?: DateRangeFormatFunction;
+    eventTimeRangeStartFormat?: DateRangeFormatFunction | undefined;
 
     /**
      * An optional event time range for events that continue from another day
      */
-    eventTimeRangeEndFormat?: DateRangeFormatFunction;
+    eventTimeRangeEndFormat?: DateRangeFormatFunction | undefined;
 }
 
 export interface HeaderProps {
@@ -172,42 +172,42 @@ export interface ResourceHeaderProps {
 }
 
 export interface Components<TEvent extends object = Event, TResource extends object = object> {
-    event?: React.ComponentType<EventProps<TEvent>>;
-    eventWrapper?: React.ComponentType<EventWrapperProps<TEvent>>;
-    eventContainerWrapper?: React.ComponentType;
-    dateCellWrapper?: React.ComponentType;
-    dayColumnWrapper?: React.ComponentType;
-    timeSlotWrapper?: React.ComponentType;
-    timeGutterHeader?: React.ComponentType;
-    timeGutterWrapper?: React.ComponentType;
-    toolbar?: React.ComponentType<ToolbarProps<TEvent, TResource>>;
+    event?: React.ComponentType<EventProps<TEvent>> | undefined;
+    eventWrapper?: React.ComponentType<EventWrapperProps<TEvent>> | undefined;
+    eventContainerWrapper?: React.ComponentType | undefined;
+    dateCellWrapper?: React.ComponentType | undefined;
+    dayColumnWrapper?: React.ComponentType | undefined;
+    timeSlotWrapper?: React.ComponentType | undefined;
+    timeGutterHeader?: React.ComponentType | undefined;
+    timeGutterWrapper?: React.ComponentType | undefined;
+    toolbar?: React.ComponentType<ToolbarProps<TEvent, TResource>> | undefined;
     agenda?: {
-        date?: React.ComponentType;
-        time?: React.ComponentType;
-        event?: React.ComponentType<EventProps<TEvent>>;
-    };
+        date?: React.ComponentType | undefined;
+        time?: React.ComponentType | undefined;
+        event?: React.ComponentType<EventProps<TEvent>> | undefined;
+    } | undefined;
     day?: {
-        header?: React.ComponentType<HeaderProps>;
-        event?: React.ComponentType<EventProps<TEvent>>;
-    };
+        header?: React.ComponentType<HeaderProps> | undefined;
+        event?: React.ComponentType<EventProps<TEvent>> | undefined;
+    } | undefined;
     week?: {
-        header?: React.ComponentType<HeaderProps>;
-        event?: React.ComponentType<EventProps<TEvent>>;
-    };
+        header?: React.ComponentType<HeaderProps> | undefined;
+        event?: React.ComponentType<EventProps<TEvent>> | undefined;
+    } | undefined;
     work_week?: {
-      header?: React.ComponentType<HeaderProps>;
-      event?: React.ComponentType<EventProps<TEvent>>;
-    };
+      header?: React.ComponentType<HeaderProps> | undefined;
+      event?: React.ComponentType<EventProps<TEvent>> | undefined;
+    } | undefined;
     month?: {
-        header?: React.ComponentType;
-        dateHeader?: React.ComponentType;
-        event?: React.ComponentType<EventProps<TEvent>>;
-    };
+        header?: React.ComponentType | undefined;
+        dateHeader?: React.ComponentType | undefined;
+        event?: React.ComponentType<EventProps<TEvent>> | undefined;
+    } | undefined;
     /**
      * component used as a header for each column in the TimeGridHeader
      */
-    header?: React.ComponentType<HeaderProps>;
-    resourceHeader?: React.ComponentType<ResourceHeaderProps>;
+    header?: React.ComponentType<HeaderProps> | undefined;
+    resourceHeader?: React.ComponentType<ResourceHeaderProps> | undefined;
 }
 
 export interface ToolbarProps<TEvent extends object = Event, TResource extends object = object> {
@@ -218,7 +218,7 @@ export interface ToolbarProps<TEvent extends object = Event, TResource extends o
     localizer: { messages: Messages };
     onNavigate: (navigate: NavigateAction, date?: Date) => void;
     onView: (view: View) => void;
-    children?: React.ReactNode;
+    children?: React.ReactNode | undefined;
 }
 
 export interface EventProps<TEvent extends object = Event> {
@@ -228,22 +228,22 @@ export interface EventProps<TEvent extends object = Event> {
 
 export interface EventWrapperProps<TEvent extends object = Event> {
     // https://github.com/intljusticemission/react-big-calendar/blob/27a2656b40ac8729634d24376dff8ea781a66d50/src/TimeGridEvent.js#L28
-    style?: React.CSSProperties & { xOffset: number };
+    style?: React.CSSProperties & { xOffset: number } | undefined;
     className: string;
     event: TEvent;
     isRtl: boolean;
     getters: {
-        eventProp?: EventPropGetter<TEvent>;
-        slotProp?: SlotPropGetter;
-        dayProp?: DayPropGetter;
+        eventProp?: EventPropGetter<TEvent> | undefined;
+        slotProp?: SlotPropGetter | undefined;
+        dayProp?: DayPropGetter | undefined;
     };
     onClick: (e: React.MouseEvent<HTMLElement>) => void;
     onDoubleClick: (e: React.MouseEvent<HTMLElement>) => void;
     accessors: {
-        title?: (event: TEvent) => string;
-        tooltip?: (event: TEvent) => string;
-        end?: (event: TEvent) => Date;
-        start?: (event: TEvent) => Date;
+        title?: ((event: TEvent) => string) | undefined;
+        tooltip?: ((event: TEvent) => string) | undefined;
+        end?: ((event: TEvent) => Date) | undefined;
+        start?: ((event: TEvent) => Date) | undefined;
     };
     selected: boolean;
     label: string;
@@ -252,22 +252,22 @@ export interface EventWrapperProps<TEvent extends object = Event> {
 }
 
 export interface Messages {
-    date?: string;
-    time?: string;
-    event?: string;
-    allDay?: string;
-    week?: string;
-    work_week?: string;
-    day?: string;
-    month?: string;
-    previous?: string;
-    next?: string;
-    yesterday?: string;
-    tomorrow?: string;
-    today?: string;
-    agenda?: string;
-    showMore?: (count: number) => string;
-    noEventsInRange?: string;
+    date?: string | undefined;
+    time?: string | undefined;
+    event?: string | undefined;
+    allDay?: string | undefined;
+    week?: string | undefined;
+    work_week?: string | undefined;
+    day?: string | undefined;
+    month?: string | undefined;
+    previous?: string | undefined;
+    next?: string | undefined;
+    yesterday?: string | undefined;
+    tomorrow?: string | undefined;
+    today?: string | undefined;
+    agenda?: string | undefined;
+    showMore?: ((count: number) => string) | undefined;
+    noEventsInRange?: string | undefined;
 }
 
 export interface SlotInfo {
@@ -284,7 +284,7 @@ export interface DateLocalizerSpec {
     firstOfWeek: (culture: Culture) => number;
     format: (value: FormatInput, format: string, culture: Culture) => string;
     formats: Formats;
-    propType?: Validator<any>;
+    propType?: Validator<any> | undefined;
 }
 
 export class DateLocalizer {
@@ -301,68 +301,68 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     extends React.Props<Calendar<TEvent, TResource>> {
     localizer: DateLocalizer;
 
-    date?: stringOrDate;
-    getNow?: () => Date;
-    view?: View;
-    events?: TEvent[];
-    backgroundEvents?: TEvent[];
-    handleDragStart?: (event: TEvent) => void;
-    onNavigate?: (newDate: Date, view: View, action: NavigateAction) => void;
-    onView?: (view: View) => void;
-    onDrillDown?: (date: Date, view: View) => void;
-    onSelectSlot?: (slotInfo: SlotInfo) => void;
-    onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
-    onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
-    onKeyPressEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
-    onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }, view: View | undefined) => void;
-    showAllEvents?: boolean;
+    date?: stringOrDate | undefined;
+    getNow?: (() => Date) | undefined;
+    view?: View | undefined;
+    events?: TEvent[] | undefined;
+    backgroundEvents?: TEvent[] | undefined;
+    handleDragStart?: ((event: TEvent) => void) | undefined;
+    onNavigate?: ((newDate: Date, view: View, action: NavigateAction) => void) | undefined;
+    onView?: ((view: View) => void) | undefined;
+    onDrillDown?: ((date: Date, view: View) => void) | undefined;
+    onSelectSlot?: ((slotInfo: SlotInfo) => void) | undefined;
+    onDoubleClickEvent?: ((event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void) | undefined;
+    onSelectEvent?: ((event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void) | undefined;
+    onKeyPressEvent?: ((event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void) | undefined;
+    onSelecting?: ((range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null) | undefined;
+    onRangeChange?: ((range: Date[] | { start: stringOrDate; end: stringOrDate }, view: View | undefined) => void) | undefined;
+    showAllEvents?: boolean | undefined;
     selected?: any;
-    views?: ViewsProps<TEvent, TResource>;
-    drilldownView?: View | null;
-    getDrilldownView?: ((targetDate: Date, currentViewName: View, configuredViewNames: View[]) => void) | null;
-    length?: number;
-    toolbar?: boolean;
-    popup?: boolean;
-    popupOffset?: number | { x: number; y: number };
-    selectable?: boolean | 'ignoreEvents';
-    longPressThreshold?: number;
-    step?: number;
-    timeslots?: number;
-    rtl?: boolean;
-    eventPropGetter?: EventPropGetter<TEvent>;
-    slotPropGetter?: SlotPropGetter;
-    slotGroupPropGetter?: SlotGroupPropGetter;
-    dayPropGetter?: DayPropGetter;
-    showMultiDayTimes?: boolean;
-    min?: stringOrDate;
-    max?: stringOrDate;
-    scrollToTime?: Date;
-    culture?: string;
-    formats?: Formats;
-    components?: Components<TEvent, TResource>;
-    messages?: Messages;
-    dayLayoutAlgorithm?: DayLayoutAlgorithm | DayLayoutFunction<TEvent>;
-    titleAccessor?: keyof TEvent | ((event: TEvent) => string);
-    tooltipAccessor?: keyof TEvent | ((event: TEvent) => string);
-    allDayAccessor?: keyof TEvent | ((event: TEvent) => boolean);
-    startAccessor?: keyof TEvent | ((event: TEvent) => Date);
-    endAccessor?: keyof TEvent | ((event: TEvent) => Date);
-    resourceAccessor?: keyof TEvent | ((event: TEvent) => any);
-    resources?: TResource[];
-    resourceIdAccessor?: keyof TResource | ((resource: TResource) => any);
-    resourceTitleAccessor?: keyof TResource | ((resource: TResource) => any);
-    defaultView?: View;
-    defaultDate?: Date;
-    className?: string;
-    elementProps?: React.HTMLAttributes<HTMLElement>;
-    style?: React.CSSProperties;
-    onShowMore?: (events: TEvent[], date: Date) => void;
+    views?: ViewsProps<TEvent, TResource> | undefined;
+    drilldownView?: View | null | undefined;
+    getDrilldownView?: ((targetDate: Date, currentViewName: View, configuredViewNames: View[]) => void) | null | undefined;
+    length?: number | undefined;
+    toolbar?: boolean | undefined;
+    popup?: boolean | undefined;
+    popupOffset?: number | { x: number; y: number } | undefined;
+    selectable?: boolean | 'ignoreEvents' | undefined;
+    longPressThreshold?: number | undefined;
+    step?: number | undefined;
+    timeslots?: number | undefined;
+    rtl?: boolean | undefined;
+    eventPropGetter?: EventPropGetter<TEvent> | undefined;
+    slotPropGetter?: SlotPropGetter | undefined;
+    slotGroupPropGetter?: SlotGroupPropGetter | undefined;
+    dayPropGetter?: DayPropGetter | undefined;
+    showMultiDayTimes?: boolean | undefined;
+    min?: stringOrDate | undefined;
+    max?: stringOrDate | undefined;
+    scrollToTime?: Date | undefined;
+    culture?: string | undefined;
+    formats?: Formats | undefined;
+    components?: Components<TEvent, TResource> | undefined;
+    messages?: Messages | undefined;
+    dayLayoutAlgorithm?: DayLayoutAlgorithm | DayLayoutFunction<TEvent> | undefined;
+    titleAccessor?: keyof TEvent | ((event: TEvent) => string) | undefined;
+    tooltipAccessor?: keyof TEvent | ((event: TEvent) => string) | undefined;
+    allDayAccessor?: keyof TEvent | ((event: TEvent) => boolean) | undefined;
+    startAccessor?: keyof TEvent | ((event: TEvent) => Date) | undefined;
+    endAccessor?: keyof TEvent | ((event: TEvent) => Date) | undefined;
+    resourceAccessor?: keyof TEvent | ((event: TEvent) => any) | undefined;
+    resources?: TResource[] | undefined;
+    resourceIdAccessor?: keyof TResource | ((resource: TResource) => any) | undefined;
+    resourceTitleAccessor?: keyof TResource | ((resource: TResource) => any) | undefined;
+    defaultView?: View | undefined;
+    defaultDate?: Date | undefined;
+    className?: string | undefined;
+    elementProps?: React.HTMLAttributes<HTMLElement> | undefined;
+    style?: React.CSSProperties | undefined;
+    onShowMore?: ((events: TEvent[], date: Date) => void) | undefined;
 }
 
 export interface TitleOptions {
     formats: DateFormat[];
-    culture?: string;
+    culture?: string | undefined;
     [propName: string]: any;
 }
 
@@ -406,40 +406,40 @@ export function move(View: ViewStatic | ViewKey, options: MoveOptions): Date;
 
 export interface TimeGridProps<TEvent extends object = Event, TResource extends object = object> {
     eventOffset: number;
-    events?: TEvent[];
-    backgroundEvents?: TEvent[];
-    resources?: TResource[];
-    step?: number;
-    timeslots?: number;
-    range?: any[];
-    min?: stringOrDate;
-    max?: stringOrDate;
-    getNow?: () => Date;
-    scrollToTime?: Date;
-    showMultiDayTimes?: boolean;
-    rtl?: boolean;
-    width?: number;
-    accessors?: object;
-    components?: object;
-    getters?: object;
-    localizer?: object;
-    selected?: object;
-    selectable?: boolean | 'ignoreEvents';
-    longPressThreshold?: number;
-    onNavigate?: (action: NavigateAction) => void;
-    onSelectSlot?: (slotInfo: {
+    events?: TEvent[] | undefined;
+    backgroundEvents?: TEvent[] | undefined;
+    resources?: TResource[] | undefined;
+    step?: number | undefined;
+    timeslots?: number | undefined;
+    range?: any[] | undefined;
+    min?: stringOrDate | undefined;
+    max?: stringOrDate | undefined;
+    getNow?: (() => Date) | undefined;
+    scrollToTime?: Date | undefined;
+    showMultiDayTimes?: boolean | undefined;
+    rtl?: boolean | undefined;
+    width?: number | undefined;
+    accessors?: object | undefined;
+    components?: object | undefined;
+    getters?: object | undefined;
+    localizer?: object | undefined;
+    selected?: object | undefined;
+    selectable?: boolean | 'ignoreEvents' | undefined;
+    longPressThreshold?: number | undefined;
+    onNavigate?: ((action: NavigateAction) => void) | undefined;
+    onSelectSlot?: ((slotInfo: {
         start: stringOrDate;
         end: stringOrDate;
         slots: Date[] | string[];
         action: 'select' | 'click' | 'doubleClick';
-    }) => void;
-    onSelectEnd?: (...args: any[]) => any;
-    onSelectStart?: (...args: any[]) => any;
-    onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
-    onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
-    onKeyPressEvent?: (...args: any[]) => any;
-    onDrillDown?: (date: Date, view: View) => void;
-    getDrilldownView?: ((targetDate: Date, currentViewName: View, configuredViewNames: View[]) => void) | null;
+    }) => void) | undefined;
+    onSelectEnd?: ((...args: any[]) => any) | undefined;
+    onSelectStart?: ((...args: any[]) => any) | undefined;
+    onSelectEvent?: ((event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void) | undefined;
+    onDoubleClickEvent?: ((event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void) | undefined;
+    onKeyPressEvent?: ((...args: any[]) => any) | undefined;
+    onDrillDown?: ((date: Date, view: View) => void) | undefined;
+    getDrilldownView?: ((targetDate: Date, currentViewName: View, configuredViewNames: View[]) => void) | null | undefined;
     dayLayoutAlgorithm?: any;
 }
 

--- a/types/react-big-calendar/lib/addons/dragAndDrop.d.ts
+++ b/types/react-big-calendar/lib/addons/dragAndDrop.d.ts
@@ -2,19 +2,19 @@ import { Calendar, CalendarProps, Components, Event, stringOrDate } from '../../
 import * as React from 'react';
 
 export interface withDragAndDropProps<TEvent extends object = Event, TResource extends object = object> {
-  onEventDrop?: (args: { event: TEvent, start: stringOrDate, end: stringOrDate, isAllDay: boolean }) => void;
-  onEventResize?: (args: { event: TEvent, start: stringOrDate, end: stringOrDate, isAllDay: boolean }) => void;
-  onDragStart?: (args: { event: TEvent, action: 'resize' | 'move', direction: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT' }) => void;
-  onDragOver?: (event: React.DragEvent) => void;
-  onDropFromOutside?: (args: { start: stringOrDate, end: stringOrDate, allDay: boolean}) => void;
-  dragFromOutsideItem?: () => keyof TEvent | ((event: TEvent) => Date);
-  draggableAccessor?: keyof TEvent | ((event: TEvent) => boolean);
-  resizableAccessor?: keyof TEvent | ((event: TEvent) => boolean);
-  selectable?: true | false | 'ignoreEvents';
-  resizable?: boolean;
-  components?: Components<TEvent, TResource>;
-  elementProps?: React.HTMLAttributes<HTMLElement>;
-  step?: number;
+  onEventDrop?: ((args: { event: TEvent, start: stringOrDate, end: stringOrDate, isAllDay: boolean }) => void) | undefined;
+  onEventResize?: ((args: { event: TEvent, start: stringOrDate, end: stringOrDate, isAllDay: boolean }) => void) | undefined;
+  onDragStart?: ((args: { event: TEvent, action: 'resize' | 'move', direction: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT' }) => void) | undefined;
+  onDragOver?: ((event: React.DragEvent) => void) | undefined;
+  onDropFromOutside?: ((args: { start: stringOrDate, end: stringOrDate, allDay: boolean}) => void) | undefined;
+  dragFromOutsideItem?: (() => keyof TEvent | ((event: TEvent) => Date)) | undefined;
+  draggableAccessor?: keyof TEvent | ((event: TEvent) => boolean) | undefined;
+  resizableAccessor?: keyof TEvent | ((event: TEvent) => boolean) | undefined;
+  selectable?: true | false | 'ignoreEvents' | undefined;
+  resizable?: boolean | undefined;
+  components?: Components<TEvent, TResource> | undefined;
+  elementProps?: React.HTMLAttributes<HTMLElement> | undefined;
+  step?: number | undefined;
 }
 
 interface DragAndDropCalendarProps<TEvent extends object = Event, TResource extends object = object>

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -43,8 +43,8 @@ class CalendarEvent {
     start: Date;
     endDate: Date;
     desc: string;
-    resourceId?: string;
-    tooltip?: string;
+    resourceId?: string | undefined;
+    tooltip?: string | undefined;
 
     constructor(_title: string, _start: Date, _endDate: Date, _allDay?: boolean, _desc?: string, _resourceId?: string) {
         this.title = _title;

--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -36,22 +36,22 @@ export interface InputProps extends Omit<
     'onBlur' | 'onChange' | 'onFocus' | 'onKeyDown'
 > {
     /* Callback function that determines whether the hint should be selected. */
-    shouldSelectHint?: ShouldSelect;
+    shouldSelectHint?: ShouldSelect | undefined;
 }
 
 /* ---------------------------------------------------------------------------
                             Typeahead Contexts
 --------------------------------------------------------------------------- */
 export interface TypeaheadContext<T extends TypeaheadModel> {
-    activeIndex?: number;
-    hintText?: string;
-    initialItem?: T;
-    isOnlyResult?: boolean;
-    onActiveItemChange?: (options: T) => void;
-    onAdd?: (option: T) => void;
-    onInitialItemChange?: (option: T) => void;
-    onMenuItemClick?: (option: T, e: Event) => void;
-    selectHintOnEnter?: boolean;
+    activeIndex?: number | undefined;
+    hintText?: string | undefined;
+    initialItem?: T | undefined;
+    isOnlyResult?: boolean | undefined;
+    onActiveItemChange?: ((options: T) => void) | undefined;
+    onAdd?: ((option: T) => void) | undefined;
+    onInitialItemChange?: ((option: T) => void) | undefined;
+    onMenuItemClick?: ((option: T, e: Event) => void) | undefined;
+    selectHintOnEnter?: boolean | undefined;
 }
 
 export interface TypeaheadState<T extends TypeaheadModel> {
@@ -80,7 +80,7 @@ export interface InputContainerPropsSingle<T extends TypeaheadModel> extends Inp
     onClick: (e: React.SyntheticEvent<HTMLInputElement>) => void;
     onFocus: (e: React.SyntheticEvent) => void;
     onKeyDown: (e: React.SyntheticEvent) => void;
-    placeholder?: string;
+    placeholder?: string | undefined;
     role: 'combobox';
     value: string;
 }
@@ -132,155 +132,155 @@ export type TypeaheadResult<T extends TypeaheadModel> = T & { customOption: bool
 export interface TypeaheadProps<T extends TypeaheadModel> {
     /* Specify menu alignment. The default value is justify, which makes the menu as wide as the input and truncates long values.
     Specifying left or right will align the menu to that side and the width will be determined by the length of menu item values. */
-    align?: TypeaheadAlign;
+    align?: TypeaheadAlign | undefined;
 
     /* Specifies whether or not arbitrary, user-defined options may be added to the result set. New entries will be included
     when the trimmed input is truthy and there is no exact match in the result set.
     If a function is specified, allows for a callback to decide whether the new entry menu item should be included in the results
     list. The callback should return a boolean value: */
-    allowNew?: boolean | ((results: T[], props: AllTypeaheadOwnAndInjectedProps<T>) => boolean);
+    allowNew?: boolean | ((results: T[], props: AllTypeaheadOwnAndInjectedProps<T>) => boolean) | undefined;
 
     /* Autofocus the input when the component initially mounts. */
-    autoFocus?: boolean;
+    autoFocus?: boolean | undefined;
 
     /* Whether or not filtering should be case-sensitive. */
-    caseSensitive?: boolean;
+    caseSensitive?: boolean | undefined;
 
     /* Displays a button to clear the input when there are selections. */
-    clearButton?: boolean;
+    clearButton?: boolean | undefined;
 
     /* ClassName to Apply */
-    className?: string;
+    className?: string | undefined;
 
     /* The initial value displayed in the text input. */
-    defaultInputValue?: string;
+    defaultInputValue?: string | undefined;
 
     /* Whether or not the menu is displayed upon initial render. */
-    defaultOpen?: boolean;
+    defaultOpen?: boolean | undefined;
 
     /* Specify any pre-selected options. Use only if you want the component to be uncontrolled. */
-    defaultSelected?: T[];
+    defaultSelected?: T[] | undefined;
 
     /* Whether to disable the input. Will also disable selections when multiple={true}. */
-    disabled?: boolean;
+    disabled?: boolean | undefined;
 
     /* Specify whether the menu should appear above the input. */
-    dropup?: boolean;
+    dropup?: boolean | undefined;
 
     /* Message displayed in the menu when there are no valid results.
     Passing a falsy value will hide the menu if no matches are found. */
-    emptyLabel?: React.ReactNode;
+    emptyLabel?: React.ReactNode | undefined;
 
     /* Either an array of fields in option to search, or a custom filtering callback. */
-    filterBy?: string[] | ((option: T, props: AllTypeaheadOwnAndInjectedProps<T>) => boolean);
+    filterBy?: string[] | ((option: T, props: AllTypeaheadOwnAndInjectedProps<T>) => boolean) | undefined;
 
     /* Whether or not to automatically adjust the position of the menu when it reaches the viewport boundaries. */
-    flip?: boolean;
+    flip?: boolean | undefined;
 
     /* Highlights the menu item if there is only one result and allows selecting that item by hitting enter.
     Does not work with allowNew. */
-    highlightOnlyResult?: boolean;
+    highlightOnlyResult?: boolean | undefined;
 
     /* An html id attribute, required for assistive technologies such as screen readers. */
-    id?: string | number;
+    id?: string | number | undefined;
 
     /* Whether the filter should ignore accents and other diacritical marks. */
-    ignoreDiacritics?: boolean;
+    ignoreDiacritics?: boolean | undefined;
 
     /* Props to be applied directly to the input. onBlur, onChange, onFocus, and onKeyDown are ignored. */
-    inputProps?: InputProps;
+    inputProps?: InputProps | undefined;
 
     /* Bootstrap 4 only. Adds the `is-invalid` classname to the `form-control`. */
-    isInvalid?: boolean;
+    isInvalid?: boolean | undefined;
 
     /* Indicate whether an asynchronous data fetch is happening. */
-    isLoading?: boolean;
+    isLoading?: boolean | undefined;
 
     /* Bootstrap 4 only. Adds the `is-valid` classname to the `form-control`. */
-    isValid?: boolean;
+    isValid?: boolean | undefined;
 
     /* Specify which option key to use for display or a render function.
     By default, the selector will use the label key. */
-    labelKey?: TypeaheadLabelKey<T>;
+    labelKey?: TypeaheadLabelKey<T> | undefined;
 
     /* Maximum number of results to display by default. Mostly done for performance reasons
     so as not to render too many DOM nodes in the case of large data sets. */
-    maxResults?: number;
+    maxResults?: number | undefined;
 
     /* Number of input characters that must be entered before showing results. */
-    minLength?: number;
+    minLength?: number | undefined;
 
     /* Whether or not multiple selections are allowed. */
-    multiple?: boolean;
+    multiple?: boolean | undefined;
 
     /* Invoked when the input is blurred. Receives an event. */
-    onBlur?: (e: Event) => void;
+    onBlur?: ((e: Event) => void) | undefined;
 
     /* Invoked whenever items are added or removed. Receives an array of the selected options. */
-    onChange?: (selected: T[]) => void;
+    onChange?: ((selected: T[]) => void) | undefined;
 
     /* Invoked when the input is focused. Receives an event. */
-    onFocus?: (e: Event) => void;
+    onFocus?: ((e: Event) => void) | undefined;
 
     /* Invoked when the input value changes. Receives the string value of the input, as well as the original event. */
-    onInputChange?: (input: string, e: Event) => void;
+    onInputChange?: ((input: string, e: Event) => void) | undefined;
 
     /* Invoked when a key is pressed. Receives an event. */
-    onKeyDown?: (e: Event) => void;
+    onKeyDown?: ((e: Event) => void) | undefined;
 
     /*     Invoked when menu visibility changes. */
-    onMenuToggle?: (show: boolean) => void;
+    onMenuToggle?: ((show: boolean) => void) | undefined;
 
     /* Invoked when the pagination menu item is clicked. */
-    onPaginate?: (e: Event, numResults: number) => void;
+    onPaginate?: ((e: Event, numResults: number) => void) | undefined;
 
     /* Whether or not the menu should be displayed. undefined allows the component to control visibility,
     while true and false show and hide the menu, respectively. */
-    open?: boolean;
+    open?: boolean | undefined;
 
     /* Full set of options, including any pre-selected options. Must either be an array of objects (recommended) or strings. */
     options: T[];
 
     /* Give user the ability to display additional results if the number of results exceeds maxResults. */
-    paginate?: boolean;
+    paginate?: boolean | undefined;
 
     /* Prompt displayed when large data sets are paginated. */
-    paginationText?: string;
+    paginationText?: string | undefined;
 
     /* Placeholder text for the input. */
-    placeholder?: string;
+    placeholder?: string | undefined;
 
     /* Whether to use fixed positioning for the menu, which is useful when rendering inside a
     container with overflow: hidden;. Uses absolute positioning by default. */
-    positionFixed?: boolean;
+    positionFixed?: boolean | undefined;
 
-    renderInput?: (inputProps: InputContainerPropsSingle<T>, state: TypeaheadState<T>) => React.ReactNode;
+    renderInput?: ((inputProps: InputContainerPropsSingle<T>, state: TypeaheadState<T>) => React.ReactNode) | undefined;
 
     /* Callback for custom menu rendering. */
-    renderMenu?: (
+    renderMenu?: ((
         results: Array<TypeaheadResult<T>>,
         menuProps: TypeaheadMenuProps<T>,
         state: TypeaheadState<T>,
-    ) => React.ReactNode;
+    ) => React.ReactNode) | undefined;
 
     /* Provides a hook for customized rendering of menu item contents. */
-    renderMenuItemChildren?: (
+    renderMenuItemChildren?: ((
         option: TypeaheadResult<T>,
         props: TypeaheadMenuProps<T>,
         index: number,
-    ) => React.ReactNode;
+    ) => React.ReactNode) | undefined;
 
     /* Provides a hook for customized rendering of tokens when multiple selections are enabled. */
-    renderToken?: (selectedItem: T, props: TokenProps, index: number) => React.ReactNode;
+    renderToken?: ((selectedItem: T, props: TokenProps, index: number) => React.ReactNode) | undefined;
 
     /* The selected option(s) displayed in the input. Use this prop if you want to control the component via its parent. */
-    selected?: T[];
+    selected?: T[] | undefined;
 
     /** @deprecated: Allows selecting the hinted result by pressing enter. */
-    selectHintOnEnter?: boolean;
+    selectHintOnEnter?: boolean | undefined;
 
     /* Specify the size of the input. */
-    size?: TypeaheadBsSizes;
+    size?: TypeaheadBsSizes | undefined;
 }
 
 export type AllTypeaheadOwnAndInjectedProps<T extends TypeaheadModel> = TypeaheadProps<T> & TypeaheadContainerProps<T>;
@@ -298,7 +298,7 @@ export class Typeahead<T extends TypeaheadModel> extends React.Component<Typeahe
 --------------------------------------------------------------------------- */
 export interface AsyncTypeaheadProps<T extends TypeaheadModel> extends TypeaheadProps<T> {
     /* Delay, in milliseconds, before performing search. */
-    delay?: number;
+    delay?: number | undefined;
 
     /* Whether or not a request is currently pending. Necessary for the component to know when new results are available. */
     isLoading: boolean;
@@ -307,13 +307,13 @@ export interface AsyncTypeaheadProps<T extends TypeaheadModel> extends Typeahead
     onSearch: (query: string) => void;
 
     /* Message displayed in the menu when there is no user input. */
-    promptText?: React.ReactNode;
+    promptText?: React.ReactNode | undefined;
 
     /* Message to display in the menu while the request is pending. */
-    searchText?: React.ReactNode;
+    searchText?: React.ReactNode | undefined;
 
     /* Whether or not the component should cache query results. */
-    useCache?: boolean;
+    useCache?: boolean | undefined;
 }
 
 export class AsyncTypeahead<T extends TypeaheadModel> extends React.Component<AsyncTypeaheadProps<T>> {
@@ -371,7 +371,7 @@ export interface HighligherProps {
     children: React.ReactNode;
 
     /* Classname applied to the highlighted text. */
-    highlightClassName?: string;
+    highlightClassName?: string | undefined;
 
     /* he substring to look for. This value should correspond to the input text of the typeahead and can be obtained via the
     onInputChange prop or from the text property of props being passed down via renderMenu or renderMenuItemChildren. */
@@ -386,13 +386,13 @@ export class Highlighter extends React.PureComponent<HighligherProps> {}
 export type ShouldSelect = (shouldSelect: boolean, e: React.KeyboardEvent<HTMLInputElement>) => boolean;
 
 export interface HintProps {
-    className?: string;
+    className?: string | undefined;
 
     /* Hint expects a single child: your input component. */
     children: React.ReactNode;
 
     /* Callback function that determines whether the hint should be selected. */
-    shouldSelect?: ShouldSelect;
+    shouldSelect?: ShouldSelect | undefined;
 }
 
 export class Hint extends React.Component<HintProps> {}
@@ -401,8 +401,8 @@ export class Hint extends React.Component<HintProps> {}
                     ClearButton Props and Component
 --------------------------------------------------------------------------- */
 export interface ClearButtonProps extends React.HTMLAttributes<'button'> {
-    size?: TypeaheadBsSizes;
-    label?: string;
+    size?: TypeaheadBsSizes | undefined;
+    label?: string | undefined;
     onClick: React.HTMLAttributes<'button'>['onClick']; // make onClick requried
 }
 
@@ -412,7 +412,7 @@ export const ClearButton: React.FunctionComponent<ClearButtonProps>;
                     Loader Props and Component
 --------------------------------------------------------------------------- */
 export interface LoaderProps {
-    label?: string;
+    label?: string | undefined;
 }
 
 export const Loader: React.FunctionComponent<LoaderProps>;
@@ -421,9 +421,9 @@ export const Loader: React.FunctionComponent<LoaderProps>;
                     AutosizeInput Props and Component
 --------------------------------------------------------------------------- */
 export interface AutosizeInputProps extends Pick<React.InputHTMLAttributes<HTMLInputElement>, 'className' | 'style'> {
-    inputClassName?: string;
-    inputRef?: React.LegacyRef<HTMLInputElement>;
-    inputStyle?: React.CSSProperties;
+    inputClassName?: string | undefined;
+    inputRef?: React.LegacyRef<HTMLInputElement> | undefined;
+    inputStyle?: React.CSSProperties | undefined;
     style: React.CSSProperties;
 }
 
@@ -433,16 +433,16 @@ export class AutosizeInput extends React.Component<AutosizeInputProps> {}
                     Menu Props and Component
 --------------------------------------------------------------------------- */
 export interface MenuProps {
-    'aria-label'?: string;
-    children?: React.ReactNode;
-    className?: string;
-    emptyLabel?: React.ReactNode;
+    'aria-label'?: string | undefined;
+    children?: React.ReactNode | undefined;
+    className?: string | undefined;
+    emptyLabel?: React.ReactNode | undefined;
     id: string;
-    innerRef?: React.LegacyRef<HTMLUListElement>;
-    inputHeight?: number;
-    maxHeight?: string;
-    style?: React.CSSProperties;
-    text?: string;
+    innerRef?: React.LegacyRef<HTMLUListElement> | undefined;
+    inputHeight?: number | undefined;
+    maxHeight?: string | undefined;
+    style?: React.CSSProperties | undefined;
+    text?: string | undefined;
 }
 
 export type MenuHeaderProps = Omit<React.HTMLProps<'li'>, 'className'>;
@@ -460,7 +460,7 @@ export type TypeaheadMenuPropsPick = 'labelKey' | 'options' | 'renderMenuItemChi
 export interface TypeaheadMenuProps<T extends TypeaheadModel>
     extends MenuProps,
         Pick<AllTypeaheadOwnAndInjectedProps<T>, TypeaheadMenuPropsPick> {
-    newSelectionPrefix?: React.ReactNode;
+    newSelectionPrefix?: React.ReactNode | undefined;
 }
 export class TypeaheadMenu<T extends TypeaheadModel> extends React.Component<TypeaheadMenuProps<T>> {}
 
@@ -468,15 +468,15 @@ export class TypeaheadMenu<T extends TypeaheadModel> extends React.Component<Typ
                     Menu Item Props and Component
 --------------------------------------------------------------------------- */
 export interface BaseMenuItemProps extends React.HTMLProps<'li'> {
-    active?: boolean;
-    disabled?: boolean;
+    active?: boolean | undefined;
+    disabled?: boolean | undefined;
 }
 export class BaseMenuItem extends React.Component<BaseMenuItemProps> {}
 
 export interface MenuItemProps<T extends TypeaheadModel> extends BaseMenuItemProps {
     option: T;
     position: number;
-    label?: string;
+    label?: string | undefined;
 }
 
 export class MenuItem<T extends TypeaheadModel> extends React.Component<MenuItemProps<T>> {}
@@ -487,12 +487,12 @@ export class MenuItem<T extends TypeaheadModel> extends React.Component<MenuItem
 export type OverlayTypeaheadProps = Pick<TypeaheadProps<any>, 'align' | 'dropup' | 'flip' | 'onMenuToggle'>;
 
 export interface OverlayProps extends OverlayTypeaheadProps {
-    children?: (menuProps: MenuProps) => React.ReactNode;
-    className?: string;
+    children?: ((menuProps: MenuProps) => React.ReactNode) | undefined;
+    className?: string | undefined;
     container: HTMLElement;
-    referenceElement?: HTMLElement;
-    isMenuShown?: boolean;
-    positionFixed?: boolean;
+    referenceElement?: HTMLElement | undefined;
+    isMenuShown?: boolean | undefined;
+    positionFixed?: boolean | undefined;
 }
 
 export class Overlay extends React.Component<OverlayProps> {}
@@ -502,30 +502,30 @@ export class Overlay extends React.Component<OverlayProps> {}
 --------------------------------------------------------------------------- */
 export interface TokenProps extends React.HTMLProps<HTMLDivElement> {
     option: Option;
-    active?: boolean;
-    children?: React.ReactNode;
-    className?: string;
-    disabled?: boolean;
-    href?: string;
-    onRemove?: () => void; // Token does not invoke onRemove with any parameters
-    readOnly?: boolean;
-    tabIndex?: number;
+    active?: boolean | undefined;
+    children?: React.ReactNode | undefined;
+    className?: string | undefined;
+    disabled?: boolean | undefined;
+    href?: string | undefined;
+    onRemove?: (() => void) | undefined; // Token does not invoke onRemove with any parameters
+    readOnly?: boolean | undefined;
+    tabIndex?: number | undefined;
 }
 
 export class Token extends React.Component<TokenProps> {}
 
 export function useToken(props: {
-    onBlur?: EventHandler<HTMLElement>;
-    onClick?: EventHandler<HTMLElement>;
-    onFocus?: EventHandler<HTMLElement>;
-    onRemove?: () => void;
+    onBlur?: EventHandler<HTMLElement> | undefined;
+    onClick?: EventHandler<HTMLElement> | undefined;
+    onFocus?: EventHandler<HTMLElement> | undefined;
+    onRemove?: (() => void) | undefined;
     option: Option;
 }): {
     active: boolean;
-    onBlur?: EventHandler<HTMLElement>;
-    onClick?: EventHandler<HTMLElement>;
-    onFocus?: EventHandler<HTMLElement>;
+    onBlur?: EventHandler<HTMLElement> | undefined;
+    onClick?: EventHandler<HTMLElement> | undefined;
+    onFocus?: EventHandler<HTMLElement> | undefined;
     onKeyDown: EventHandler<HTMLElement>;
-    onRemove?: () => void;
+    onRemove?: (() => void) | undefined;
     ref: React.RefObject<HTMLDivElement>;
 };

--- a/types/react-bootstrap/lib/Accordion.d.ts
+++ b/types/react-bootstrap/lib/Accordion.d.ts
@@ -3,14 +3,14 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace Accordion {
     export interface AccordionProps extends React.HTMLProps<Accordion> {
-        bsSize?: Sizes;
-        bsStyle?: string;
-        collapsible?: boolean;
-        defaultExpanded?: boolean;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        collapsible?: boolean | undefined;
+        defaultExpanded?: boolean | undefined;
         eventKey?: any;
-        expanded?: boolean;
-        footer?: React.ReactNode;
-        header?: React.ReactNode;
+        expanded?: boolean | undefined;
+        footer?: React.ReactNode | undefined;
+        header?: React.ReactNode | undefined;
     }
 }
 declare class Accordion extends React.Component<Accordion.AccordionProps> { }

--- a/types/react-bootstrap/lib/Alert.d.ts
+++ b/types/react-bootstrap/lib/Alert.d.ts
@@ -3,13 +3,13 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace Alert {
     export interface AlertProps extends React.HTMLProps<Alert> {
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
-        closeLabel?: string;
-        /** @deprecated since v0.29.0 */dismissAfter?: number;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
+        closeLabel?: string | undefined;
+        /** @deprecated since v0.29.0 */dismissAfter?: number | undefined;
         // TODO: Add more specific type
-        onDismiss?: Function;
+        onDismiss?: Function | undefined;
     }
 }
 declare class Alert extends React.Component<Alert.AlertProps> { }

--- a/types/react-bootstrap/lib/Badge.d.ts
+++ b/types/react-bootstrap/lib/Badge.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 declare namespace Badge {
     export interface BadgeProps extends React.HTMLProps<Badge> {
-        bsClass?: string;
-        pullRight?: boolean;
+        bsClass?: string | undefined;
+        pullRight?: boolean | undefined;
     }
 }
 declare class Badge extends React.Component<Badge.BadgeProps> { }

--- a/types/react-bootstrap/lib/Breadcrumb.d.ts
+++ b/types/react-bootstrap/lib/Breadcrumb.d.ts
@@ -3,7 +3,7 @@ import * as BreadcrumbItem from './BreadcrumbItem';
 
 declare namespace Breadcrumb {
     interface BreadcrumbProps extends React.HTMLProps<Breadcrumb> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class Breadcrumb extends React.Component<Breadcrumb.BreadcrumbProps> {

--- a/types/react-bootstrap/lib/BreadcrumbItem.d.ts
+++ b/types/react-bootstrap/lib/BreadcrumbItem.d.ts
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 declare namespace BreadcrumbItem {
     export interface BreadcrumbItemProps extends React.Props<BreadcrumbItem> {
-        active?: boolean;
-        href?: string;
-        title?: React.ReactNode;
-        target?: string;
+        active?: boolean | undefined;
+        href?: string | undefined;
+        title?: React.ReactNode | undefined;
+        target?: string | undefined;
     }
 }
 declare class BreadcrumbItem extends React.Component<BreadcrumbItem.BreadcrumbItemProps> { }

--- a/types/react-bootstrap/lib/Button.d.ts
+++ b/types/react-bootstrap/lib/Button.d.ts
@@ -3,13 +3,13 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace Button {
     export interface ButtonProps extends React.HTMLProps<Button> {
-        bsClass?: string;
-        active?: boolean;
-        block?: boolean;
-        bsStyle?: string | null;
-        bsSize?: Sizes;
-        componentClass?: React.ReactType;
-        disabled?: boolean;
+        bsClass?: string | undefined;
+        active?: boolean | undefined;
+        block?: boolean | undefined;
+        bsStyle?: string | null | undefined;
+        bsSize?: Sizes | undefined;
+        componentClass?: React.ReactType | undefined;
+        disabled?: boolean | undefined;
     }
 }
 declare class Button extends React.Component<Button.ButtonProps> { }

--- a/types/react-bootstrap/lib/ButtonGroup.d.ts
+++ b/types/react-bootstrap/lib/ButtonGroup.d.ts
@@ -3,12 +3,12 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace ButtonGroup {
     export interface ButtonGroupProps extends React.HTMLProps<ButtonGroup> {
-        block?: boolean;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
-        justified?: boolean;
-        vertical?: boolean;
+        block?: boolean | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
+        justified?: boolean | undefined;
+        vertical?: boolean | undefined;
     }
 }
 declare class ButtonGroup extends React.Component<ButtonGroup.ButtonGroupProps> { }

--- a/types/react-bootstrap/lib/ButtonToolbar.d.ts
+++ b/types/react-bootstrap/lib/ButtonToolbar.d.ts
@@ -3,12 +3,12 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace ButtonToolbar {
     export interface ButtonToolbarProps extends React.HTMLProps<ButtonToolbar> {
-        block?: boolean;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
-        justified?: boolean;
-        vertical?: boolean;
+        block?: boolean | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
+        justified?: boolean | undefined;
+        vertical?: boolean | undefined;
     }
 }
 declare class ButtonToolbar extends React.Component<ButtonToolbar.ButtonToolbarProps> { }

--- a/types/react-bootstrap/lib/Carousel.d.ts
+++ b/types/react-bootstrap/lib/Carousel.d.ts
@@ -5,22 +5,22 @@ import CarouselCaption = require('./CarouselCaption');
 
 declare namespace Carousel {
     export type CarouselProps = Omit<React.HTMLProps<Carousel>, 'wrap'> & {
-        activeIndex?: number;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        controls?: boolean;
-        defaultActiveIndex?: number;
-        direction?: string;
-        indicators?: boolean;
-        interval?: number | null;
-        nextIcon?: React.ReactNode;
-        onSelect?: SelectCallback;
+        activeIndex?: number | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        controls?: boolean | undefined;
+        defaultActiveIndex?: number | undefined;
+        direction?: string | undefined;
+        indicators?: boolean | undefined;
+        interval?: number | null | undefined;
+        nextIcon?: React.ReactNode | undefined;
+        onSelect?: SelectCallback | undefined;
         // TODO: Add more specific type
-        onSlideEnd?: Function;
-        pauseOnHover?: boolean;
-        prevIcon?: React.ReactNode;
-        slide?: boolean;
-        wrap?: boolean;
+        onSlideEnd?: Function | undefined;
+        pauseOnHover?: boolean | undefined;
+        prevIcon?: React.ReactNode | undefined;
+        slide?: boolean | undefined;
+        wrap?: boolean | undefined;
     };
 }
 declare class Carousel extends React.Component<Carousel.CarouselProps> {

--- a/types/react-bootstrap/lib/CarouselCaption.d.ts
+++ b/types/react-bootstrap/lib/CarouselCaption.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace CarouselCaption {
     export interface CarouselCaptionProps extends React.HTMLProps<CarouselCaption> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class CarouselCaption extends React.Component<CarouselCaption.CarouselCaptionProps> { }

--- a/types/react-bootstrap/lib/CarouselItem.d.ts
+++ b/types/react-bootstrap/lib/CarouselItem.d.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 
 declare namespace CarouselItem {
     interface CarouselItemProps extends React.HTMLProps<CarouselItem> {
-        active?: boolean;
-        animtateIn?: boolean;
-        animateOut?: boolean;
-        direction?: string;
-        index?: number;
+        active?: boolean | undefined;
+        animtateIn?: boolean | undefined;
+        animateOut?: boolean | undefined;
+        direction?: string | undefined;
+        index?: number | undefined;
         // TODO: Add more specific type
-        onAnimateOutEnd?: Function;
+        onAnimateOutEnd?: Function | undefined;
     }
 }
 declare class CarouselItem extends React.Component<CarouselItem.CarouselItemProps> { }

--- a/types/react-bootstrap/lib/Checkbox.d.ts
+++ b/types/react-bootstrap/lib/Checkbox.d.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 
 declare namespace Checkbox {
     export interface CheckboxProps extends React.HTMLProps<Checkbox> {
-        bsClass?: string;
-        disabled?: boolean;
-        inline?: boolean;
-        inputRef?: (instance: HTMLInputElement) => void;
-        validationState?: "success" | "warning" | "error";
+        bsClass?: string | undefined;
+        disabled?: boolean | undefined;
+        inline?: boolean | undefined;
+        inputRef?: ((instance: HTMLInputElement) => void) | undefined;
+        validationState?: "success" | "warning" | "error" | undefined;
     }
 }
 declare class Checkbox extends React.Component<Checkbox.CheckboxProps> { }

--- a/types/react-bootstrap/lib/Clearfix.d.ts
+++ b/types/react-bootstrap/lib/Clearfix.d.ts
@@ -2,12 +2,12 @@ import * as React from 'react';
 
 declare namespace Clearfix {
     export interface ClearfixProps extends React.HTMLProps<Clearfix> {
-        componentClass?: React.ReactType,
-        visibleXsBlock?: boolean;
-        visibleSmBlock?: boolean;
-        visibleMdBlock?: boolean;
-        visibleLgBlock?: boolean;
-        bsClass?: string;
+        componentClass?: React.ReactType | undefined,
+        visibleXsBlock?: boolean | undefined;
+        visibleSmBlock?: boolean | undefined;
+        visibleMdBlock?: boolean | undefined;
+        visibleLgBlock?: boolean | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class Clearfix extends React.Component<Clearfix.ClearfixProps> { }

--- a/types/react-bootstrap/lib/Col.d.ts
+++ b/types/react-bootstrap/lib/Col.d.ts
@@ -2,27 +2,27 @@ import * as React from 'react';
 
 declare namespace Col {
     export interface ColProps extends React.HTMLProps<Col> {
-        componentClass?: React.ReactType;
-        lg?: number;
-        lgHidden?: boolean;
-        lgOffset?: number;
-        lgPull?: number;
-        lgPush?: number;
-        md?: number;
-        mdHidden?: boolean;
-        mdOffset?: number;
-        mdPull?: number;
-        mdPush?: number;
-        sm?: number;
-        smHidden?: boolean;
-        smOffset?: number;
-        smPull?: number;
-        smPush?: number;
-        xs?: number;
-        xsHidden?: boolean;
-        xsOffset?: number;
-        xsPull?: number;
-        xsPush?: number;
+        componentClass?: React.ReactType | undefined;
+        lg?: number | undefined;
+        lgHidden?: boolean | undefined;
+        lgOffset?: number | undefined;
+        lgPull?: number | undefined;
+        lgPush?: number | undefined;
+        md?: number | undefined;
+        mdHidden?: boolean | undefined;
+        mdOffset?: number | undefined;
+        mdPull?: number | undefined;
+        mdPush?: number | undefined;
+        sm?: number | undefined;
+        smHidden?: boolean | undefined;
+        smOffset?: number | undefined;
+        smPull?: number | undefined;
+        smPush?: number | undefined;
+        xs?: number | undefined;
+        xsHidden?: boolean | undefined;
+        xsOffset?: number | undefined;
+        xsPull?: number | undefined;
+        xsPush?: number | undefined;
     }
 }
 declare class Col extends React.Component<Col.ColProps> { }

--- a/types/react-bootstrap/lib/Collapse.d.ts
+++ b/types/react-bootstrap/lib/Collapse.d.ts
@@ -3,13 +3,13 @@ import { TransitionCallbacks } from 'react-bootstrap';
 
 declare namespace Collapse {
     export interface CollapseProps extends TransitionCallbacks, React.ClassAttributes<Collapse> {
-        dimension?: 'height' | 'width' | { ( ):string };
-        getDimensionValue?: ( dimension:number, element:React.ReactElement ) => number;
-        in?: boolean;
-        timeout?: number;
-        transitionAppear?: boolean;
-        mountOnEnter?: boolean;
-        unmountOnExit?: boolean;
+        dimension?: 'height' | 'width' | { ( ):string } | undefined;
+        getDimensionValue?: (( dimension:number, element:React.ReactElement ) => number) | undefined;
+        in?: boolean | undefined;
+        timeout?: number | undefined;
+        transitionAppear?: boolean | undefined;
+        mountOnEnter?: boolean | undefined;
+        unmountOnExit?: boolean | undefined;
     }
 }
 declare class Collapse extends React.Component<Collapse.CollapseProps> { }

--- a/types/react-bootstrap/lib/ControlLabel.d.ts
+++ b/types/react-bootstrap/lib/ControlLabel.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 declare namespace ControlLabel {
     export interface ControlLabelProps extends React.HTMLProps<ControlLabel> {
-        bsClass?: string;
-        htmlFor?: string;
-        srOnly?: boolean;
+        bsClass?: string | undefined;
+        htmlFor?: string | undefined;
+        srOnly?: boolean | undefined;
     }
 }
 declare class ControlLabel extends React.Component<ControlLabel.ControlLabelProps> { }

--- a/types/react-bootstrap/lib/Dropdown.d.ts
+++ b/types/react-bootstrap/lib/Dropdown.d.ts
@@ -5,19 +5,19 @@ import DropdownMenu = require('./DropdownMenu');
 
 declare namespace Dropdown {
     export interface DropdownBaseProps {
-        bsClass?: string;
-        componentClass?: React.ReactType;
-        disabled?: boolean;
-        dropup?: boolean;
+        bsClass?: string | undefined;
+        componentClass?: React.ReactType | undefined;
+        disabled?: boolean | undefined;
+        dropup?: boolean | undefined;
         id: string;
-        onClose?: Function;
-        onSelect?: SelectCallback;
-        onToggle?: (isOpen: boolean, event: React.SyntheticEvent, metadata: {
+        onClose?: Function | undefined;
+        onSelect?: SelectCallback | undefined;
+        onToggle?: ((isOpen: boolean, event: React.SyntheticEvent, metadata: {
           source: 'select' | 'click' | 'rootClose' | 'keydown'
-        }) => void;
-        open?: boolean;
-        pullRight?: boolean;
-        role?: string;
+        }) => void) | undefined;
+        open?: boolean | undefined;
+        pullRight?: boolean | undefined;
+        role?: string | undefined;
     }
 
     export type DropdownProps = Dropdown.DropdownBaseProps & React.HTMLProps<Dropdown>;

--- a/types/react-bootstrap/lib/DropdownButton.d.ts
+++ b/types/react-bootstrap/lib/DropdownButton.d.ts
@@ -4,12 +4,12 @@ import { DropdownBaseProps } from './Dropdown';
 
 declare namespace DropdownButton {
     export interface DropdownButtonBaseProps extends DropdownBaseProps {
-        block?: boolean;
-        bsSize?: Sizes;
-        bsStyle?: string | null;
-        navItem?: boolean;
-        noCaret?: boolean;
-        pullRight?: boolean;
+        block?: boolean | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | null | undefined;
+        navItem?: boolean | undefined;
+        noCaret?: boolean | undefined;
+        pullRight?: boolean | undefined;
         title: React.ReactNode;
     }
 

--- a/types/react-bootstrap/lib/DropdownMenu.d.ts
+++ b/types/react-bootstrap/lib/DropdownMenu.d.ts
@@ -3,11 +3,11 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace DropdownMenu {
     export interface DropdownMenuProps extends React.HTMLProps<DropdownMenu> {
-        labelledBy?: string | number;
-        onClose?: Function;
-        onSelect?: SelectCallback;
-        open?: boolean;
-        pullRight?: boolean;
+        labelledBy?: string | number | undefined;
+        onClose?: Function | undefined;
+        onSelect?: SelectCallback | undefined;
+        open?: boolean | undefined;
+        pullRight?: boolean | undefined;
     }
 }
 declare class DropdownMenu extends React.Component<DropdownMenu.DropdownMenuProps> { }

--- a/types/react-bootstrap/lib/DropdownToggle.d.ts
+++ b/types/react-bootstrap/lib/DropdownToggle.d.ts
@@ -2,14 +2,14 @@ import * as React from 'react';
 
 declare namespace DropdownToggle {
     export interface DropdownToggleProps extends React.HTMLProps<DropdownToggle> {
-        bsRole?: string;
-        noCaret?: boolean;
-        open?: boolean;
-        title?: string;
-        useAnchor?: boolean;
-        bsClass?:string; // Added since v0.30.0
-        bsStyle?:string | null;
-        bsSize?:string;
+        bsRole?: string | undefined;
+        noCaret?: boolean | undefined;
+        open?: boolean | undefined;
+        title?: string | undefined;
+        useAnchor?: boolean | undefined;
+        bsClass?:string | undefined; // Added since v0.30.0
+        bsStyle?:string | null | undefined;
+        bsSize?:string | undefined;
     }
 }
 declare class DropdownToggle extends React.Component<DropdownToggle.DropdownToggleProps> { }

--- a/types/react-bootstrap/lib/Fade.d.ts
+++ b/types/react-bootstrap/lib/Fade.d.ts
@@ -3,11 +3,11 @@ import { TransitionCallbacks } from 'react-bootstrap';
 
 declare namespace Fade {
     export interface FadeProps extends TransitionCallbacks, React.HTMLProps<Fade> {
-        in?: boolean;
-        timeout?: number;
-        mountOnEnter?: boolean;
-        appear?: boolean;
-        unmountOnExit?: boolean;
+        in?: boolean | undefined;
+        timeout?: number | undefined;
+        mountOnEnter?: boolean | undefined;
+        appear?: boolean | undefined;
+        unmountOnExit?: boolean | undefined;
     }
 }
 declare class Fade extends React.Component<Fade.FadeProps> { }

--- a/types/react-bootstrap/lib/Form.d.ts
+++ b/types/react-bootstrap/lib/Form.d.ts
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 declare namespace Form {
     export interface FormProps extends React.HTMLProps<Form> {
-        bsClass?: string;
-        componentClass?: React.ReactType;
-        horizontal?: boolean;
-        inline?: boolean;
+        bsClass?: string | undefined;
+        componentClass?: React.ReactType | undefined;
+        horizontal?: boolean | undefined;
+        inline?: boolean | undefined;
     }
 }
 declare class Form extends React.Component<Form.FormProps> { }

--- a/types/react-bootstrap/lib/FormControl.d.ts
+++ b/types/react-bootstrap/lib/FormControl.d.ts
@@ -5,12 +5,12 @@ import FormControlStatic = require('./FormControlStatic');
 
 declare namespace FormControl {
     export interface FormControlProps extends React.HTMLProps<FormControl> {
-        bsClass?: string;
-        bsSize?: Sizes;
-        componentClass?: React.ReactType;
-        id?: string;
-        inputRef?: (instance: HTMLInputElement) => void;
-        type?: string;
+        bsClass?: string | undefined;
+        bsSize?: Sizes | undefined;
+        componentClass?: React.ReactType | undefined;
+        id?: string | undefined;
+        inputRef?: ((instance: HTMLInputElement) => void) | undefined;
+        type?: string | undefined;
     }
 }
 declare class FormControl extends React.Component<FormControl.FormControlProps> {

--- a/types/react-bootstrap/lib/FormControlFeedback.d.ts
+++ b/types/react-bootstrap/lib/FormControlFeedback.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace FormControlFeedback {
     export interface FormControlFeedbackProps extends React.HTMLProps<FormControlFeedback> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class FormControlFeedback extends React.Component<FormControlFeedback.FormControlFeedbackProps> { }

--- a/types/react-bootstrap/lib/FormControlStatic.d.ts
+++ b/types/react-bootstrap/lib/FormControlStatic.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 declare namespace FormControlStatic {
     export interface FormControlStaticProps extends React.HTMLProps<FormControlStatic> {
-        bsClass?: string;
-        componentClass?: React.ReactType;
+        bsClass?: string | undefined;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class FormControlStatic extends React.Component<FormControlStatic.FormControlStaticProps> { }

--- a/types/react-bootstrap/lib/FormGroup.d.ts
+++ b/types/react-bootstrap/lib/FormGroup.d.ts
@@ -3,10 +3,10 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace FormGroup {
     export interface FormGroupProps extends React.HTMLProps<FormGroup> {
-        bsClass?: string;
-        bsSize?: Sizes;
-        controlId?: string;
-        validationState?: "success" | "warning" | "error" | null;
+        bsClass?: string | undefined;
+        bsSize?: Sizes | undefined;
+        controlId?: string | undefined;
+        validationState?: "success" | "warning" | "error" | null | undefined;
     }
 }
 declare class FormGroup extends React.Component<FormGroup.FormGroupProps> { }

--- a/types/react-bootstrap/lib/Glyphicon.d.ts
+++ b/types/react-bootstrap/lib/Glyphicon.d.ts
@@ -5,7 +5,7 @@ declare namespace Glyphicon {
         // Required
         glyph: string;
         // Optional
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class Glyphicon extends React.Component<Glyphicon.GlyphiconProps> { }

--- a/types/react-bootstrap/lib/Grid.d.ts
+++ b/types/react-bootstrap/lib/Grid.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 declare namespace Grid {
     export interface GridProps extends React.HTMLProps<Grid> {
-        componentClass?: React.ReactType;
-        fluid?: boolean;
-        bsClass?: string;
+        componentClass?: React.ReactType | undefined;
+        fluid?: boolean | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class Grid extends React.Component<Grid.GridProps> { }

--- a/types/react-bootstrap/lib/HelpBlock.d.ts
+++ b/types/react-bootstrap/lib/HelpBlock.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace HelpBlock {
     export interface HelpBlockProps extends React.HTMLProps<HelpBlock> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class HelpBlock extends React.Component<HelpBlock.HelpBlockProps> { }

--- a/types/react-bootstrap/lib/Image.d.ts
+++ b/types/react-bootstrap/lib/Image.d.ts
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 declare namespace Image {
     export interface ImageProps extends React.HTMLProps<Image> {
-        circle?: boolean;
-        responsive?: boolean;
-        rounded?: boolean;
-        thumbnail?: boolean;
+        circle?: boolean | undefined;
+        responsive?: boolean | undefined;
+        rounded?: boolean | undefined;
+        thumbnail?: boolean | undefined;
     }
 }
 declare class Image extends React.Component<Image.ImageProps> { }

--- a/types/react-bootstrap/lib/InputGroup.d.ts
+++ b/types/react-bootstrap/lib/InputGroup.d.ts
@@ -5,8 +5,8 @@ import InputGroupButton = require('./InputGroupButton');
 
 declare namespace InputGroup {
     export interface InputGroupProps extends React.HTMLProps<InputGroup> {
-        bsClass?: string;
-        bsSize?: Sizes;
+        bsClass?: string | undefined;
+        bsSize?: Sizes | undefined;
     }
 }
 declare class InputGroup extends React.Component<InputGroup.InputGroupProps> {

--- a/types/react-bootstrap/lib/InputGroupAddon.d.ts
+++ b/types/react-bootstrap/lib/InputGroupAddon.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace InputGroupAddon {
     interface InputGroupAddonProps extends React.HTMLProps<InputGroupAddon> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class InputGroupAddon extends React.Component<InputGroupAddon.InputGroupAddonProps> { }

--- a/types/react-bootstrap/lib/InputGroupButton.d.ts
+++ b/types/react-bootstrap/lib/InputGroupButton.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace InputGroupButton {
     export interface InputGroupButtonProps extends React.HTMLProps<InputGroupButton> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class InputGroupButton extends React.Component<InputGroupButton.InputGroupButtonProps> { }

--- a/types/react-bootstrap/lib/Jumbotron.d.ts
+++ b/types/react-bootstrap/lib/Jumbotron.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace Jumbotron {
     export interface JumbotronProps extends React.HTMLProps<Jumbotron> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class Jumbotron extends React.Component<Jumbotron.JumbotronProps> { }

--- a/types/react-bootstrap/lib/Label.d.ts
+++ b/types/react-bootstrap/lib/Label.d.ts
@@ -3,8 +3,8 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace Label {
     export interface LabelProps extends React.HTMLProps<Label> {
-        bsSize?: Sizes;
-        bsStyle?: string;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
     }
 }
 declare class Label extends React.Component<Label.LabelProps> { }

--- a/types/react-bootstrap/lib/ListGroup.d.ts
+++ b/types/react-bootstrap/lib/ListGroup.d.ts
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 declare namespace ListGroup {
     interface ListGroupProps extends React.HTMLProps<ListGroup> {
-        bsClass?: string;
-        componentClass?: React.ReactType; // Added since v0.30.0
+        bsClass?: string | undefined;
+        componentClass?: React.ReactType | undefined; // Added since v0.30.0
         // TODO: Add more specific type
-        fill?: boolean;
+        fill?: boolean | undefined;
     }
 }
 declare class ListGroup extends React.Component<ListGroup.ListGroupProps> { }

--- a/types/react-bootstrap/lib/ListGroupItem.d.ts
+++ b/types/react-bootstrap/lib/ListGroupItem.d.ts
@@ -4,11 +4,11 @@ import { Sizes } from 'react-bootstrap';
 declare namespace ListGroupItem {
     export interface ListGroupItemProps extends React.HTMLProps<ListGroupItem> {
         active?: any;
-        bsSize?: Sizes;
-        bsStyle?: string;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
         eventKey?: any;
-        header?: React.ReactNode;
-        listItem?: boolean;
+        header?: React.ReactNode | undefined;
+        listItem?: boolean | undefined;
     }
 }
 declare class ListGroupItem extends React.Component<ListGroupItem.ListGroupItemProps> { }

--- a/types/react-bootstrap/lib/Media.d.ts
+++ b/types/react-bootstrap/lib/Media.d.ts
@@ -8,7 +8,7 @@ import MediaRight = require('./MediaRight');
 
 declare namespace Media {
     export interface MediaProps extends React.HTMLProps<Media> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class Media extends React.Component<Media.MediaProps> {

--- a/types/react-bootstrap/lib/MediaBody.d.ts
+++ b/types/react-bootstrap/lib/MediaBody.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace MediaBody {
     export interface MediaBodyProps extends React.ClassAttributes<MediaBody> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class MediaBody extends React.Component<MediaBody.MediaBodyProps> { }

--- a/types/react-bootstrap/lib/MediaHeading.d.ts
+++ b/types/react-bootstrap/lib/MediaHeading.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace MediaHeading {
     interface MediaHeadingProps extends React.HTMLProps<MediaHeading> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class MediaHeading extends React.Component<MediaHeading.MediaHeadingProps> { }

--- a/types/react-bootstrap/lib/MediaLeft.d.ts
+++ b/types/react-bootstrap/lib/MediaLeft.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace MediaLeft {
     export interface MediaLeftProps extends React.HTMLProps<MediaLeft> {
-        align?: string;
+        align?: string | undefined;
     }
 }
 declare class MediaLeft extends React.Component<MediaLeft.MediaLeftProps> { }

--- a/types/react-bootstrap/lib/MediaListItem.d.ts
+++ b/types/react-bootstrap/lib/MediaListItem.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace MediaListItem {
     interface MediaListItemProps extends React.HTMLProps<MediaListItem> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class MediaListItem extends React.Component<MediaListItem.MediaListItemProps> { }

--- a/types/react-bootstrap/lib/MediaRight.d.ts
+++ b/types/react-bootstrap/lib/MediaRight.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace MediaRight {
     export interface MediaRightProps extends React.HTMLProps<MediaRight> {
-        align?: string;
+        align?: string | undefined;
     }
 }
 declare class MediaRight extends React.Component<MediaRight.MediaRightProps> { }

--- a/types/react-bootstrap/lib/MenuItem.d.ts
+++ b/types/react-bootstrap/lib/MenuItem.d.ts
@@ -3,16 +3,16 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace MenuItem {
     export interface MenuItemProps extends React.HTMLProps<MenuItem> {
-        active?: boolean;
-        bsClass?: string;
-        disabled?: boolean;
-        divider?: boolean;
+        active?: boolean | undefined;
+        bsClass?: string | undefined;
+        disabled?: boolean | undefined;
+        divider?: boolean | undefined;
         eventKey?: any;
-        header?: boolean;
-        onClick?: React.MouseEventHandler<{}>;
-        onSelect?: SelectCallback;
-        target?: string;
-        title?: string;
+        header?: boolean | undefined;
+        onClick?: React.MouseEventHandler<{}> | undefined;
+        onSelect?: SelectCallback | undefined;
+        target?: string | undefined;
+        title?: string | undefined;
     }
 }
 declare class MenuItem extends React.Component<MenuItem.MenuItemProps> { }

--- a/types/react-bootstrap/lib/Modal.d.ts
+++ b/types/react-bootstrap/lib/Modal.d.ts
@@ -12,31 +12,31 @@ declare namespace Modal {
         onHide: Function;
 
         // Optional
-        animation?: boolean;
-        autoFocus?: boolean;
-        backdrop?: boolean | string;
-        backdropClassName?: string;
+        animation?: boolean | undefined;
+        autoFocus?: boolean | undefined;
+        backdrop?: boolean | string | undefined;
+        backdropClassName?: string | undefined;
         backdropStyle?: any;
-        backdropTransitionTimeout?: number;
-        bsSize?: Sizes;
-        bsClass?: string;
+        backdropTransitionTimeout?: number | undefined;
+        bsSize?: Sizes | undefined;
+        bsClass?: string | undefined;
         container?: any; // TODO: Add more specific type
-        containerClassName?: string;
-        dialogClassName?: string;
+        containerClassName?: string | undefined;
+        dialogClassName?: string | undefined;
         dialogComponent?: any; // TODO: Add more specific type
-        dialogTransitionTimeout?: number;
-        enforceFocus?: boolean;
-        restoreFocus?: boolean;
-        keyboard?: boolean;
-        onBackdropClick?: (node: HTMLElement) => any;
-        onEscapeKeyDown?: (node: HTMLElement) => any;
+        dialogTransitionTimeout?: number | undefined;
+        enforceFocus?: boolean | undefined;
+        restoreFocus?: boolean | undefined;
+        keyboard?: boolean | undefined;
+        onBackdropClick?: ((node: HTMLElement) => any) | undefined;
+        onEscapeKeyDown?: ((node: HTMLElement) => any) | undefined;
         /**
          * @deprecated since Sept 25, 2017, use onEscapeKeyDown instead
          **/
-        onEscapeKeyUp?: (node: HTMLElement) => any;
-        onShow?: (node: HTMLElement) => any;
-        show?: boolean;
-        transition?: React.ReactElement;
+        onEscapeKeyUp?: ((node: HTMLElement) => any) | undefined;
+        onShow?: ((node: HTMLElement) => any) | undefined;
+        show?: boolean | undefined;
+        transition?: React.ReactElement | undefined;
     }
 }
 declare class Modal extends React.Component<Modal.ModalProps> {

--- a/types/react-bootstrap/lib/ModalBody.d.ts
+++ b/types/react-bootstrap/lib/ModalBody.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 declare namespace ModalBody {
     export interface ModalBodyProps extends React.HTMLProps<ModalBody> {
-        componentClass?: React.ReactType;
-        bsClass?: string;
+        componentClass?: React.ReactType | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class ModalBody extends React.Component<ModalBody.ModalBodyProps> { }

--- a/types/react-bootstrap/lib/ModalDialog.d.ts
+++ b/types/react-bootstrap/lib/ModalDialog.d.ts
@@ -4,15 +4,15 @@ import { Sizes } from 'react-bootstrap';
 declare namespace ModalDialog {
     export interface ModalDialogProps extends React.HTMLProps<ModalDialog> {
         // TODO: these props are not correct https://github.com/react-bootstrap/react-bootstrap/blob/v0.31.1/src/ModalDialog.js#L9
-        onHide?: Function;
-        onEnter?: Function;
-        onEntered?: Function;
-        onEntering?: Function;
-        onExit?: Function;
-        onExited?: Function;
-        onExiting?: Function;
-        bsSize?: Sizes;
-        bsClass?: string;
+        onHide?: Function | undefined;
+        onEnter?: Function | undefined;
+        onEntered?: Function | undefined;
+        onEntering?: Function | undefined;
+        onExit?: Function | undefined;
+        onExited?: Function | undefined;
+        onExiting?: Function | undefined;
+        bsSize?: Sizes | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class ModalDialog extends React.Component<ModalDialog.ModalDialogProps> { }

--- a/types/react-bootstrap/lib/ModalFooter.d.ts
+++ b/types/react-bootstrap/lib/ModalFooter.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 declare namespace ModalFooter {
     export interface ModalFooterProps extends React.HTMLProps<ModalFooter> {
-        componentClass?: React.ReactType;
-        bsClass?: string;
+        componentClass?: React.ReactType | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class ModalFooter extends React.Component<ModalFooter.ModalFooterProps> { }

--- a/types/react-bootstrap/lib/ModalHeader.d.ts
+++ b/types/react-bootstrap/lib/ModalHeader.d.ts
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 declare namespace ModalHeader {
     export interface ModalHeaderProps extends React.HTMLProps<ModalHeader> {
-        closeButton?: boolean;
-        closeLabel?: string;
-        onHide?: Function;
-        bsClass?: string;
+        closeButton?: boolean | undefined;
+        closeLabel?: string | undefined;
+        onHide?: Function | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class ModalHeader extends React.Component<ModalHeader.ModalHeaderProps> { }

--- a/types/react-bootstrap/lib/ModalTitle.d.ts
+++ b/types/react-bootstrap/lib/ModalTitle.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 declare namespace ModalTitle {
     export interface ModalTitleProps extends React.HTMLProps<ModalTitle> {
-        componentClass?: React.ReactType;
-        bsClass?: string;
+        componentClass?: React.ReactType | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class ModalTitle extends React.Component<ModalTitle.ModalTitleProps> { }

--- a/types/react-bootstrap/lib/Nav.d.ts
+++ b/types/react-bootstrap/lib/Nav.d.ts
@@ -4,21 +4,21 @@ import { Sizes } from 'react-bootstrap';
 declare namespace Nav {
     export interface NavProps extends React.HTMLProps<Nav> {
         // Optional
-        activeHref?: string;
+        activeHref?: string | undefined;
         activeKey?: any;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
-        collapsible?: boolean;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
+        collapsible?: boolean | undefined;
         eventKey?: any;
-        expanded?: boolean;
-        justified?: boolean;
-        navbar?: boolean;
-        pullRight?: boolean;
-        right?: boolean;
-        stacked?: boolean;
-        ulClassName?: string;
-        ulId?: string;
+        expanded?: boolean | undefined;
+        justified?: boolean | undefined;
+        navbar?: boolean | undefined;
+        pullRight?: boolean | undefined;
+        right?: boolean | undefined;
+        stacked?: boolean | undefined;
+        ulClassName?: string | undefined;
+        ulId?: string | undefined;
     }
 }
 declare class Nav extends React.Component<Nav.NavProps> { }

--- a/types/react-bootstrap/lib/NavDropdown.d.ts
+++ b/types/react-bootstrap/lib/NavDropdown.d.ts
@@ -4,8 +4,8 @@ import { DropdownBaseProps } from './Dropdown';
 
 declare namespace NavDropdown {
     export interface NavDropdownBaseProps extends DropdownBaseProps {
-        active?: boolean;
-        noCaret?: boolean;
+        active?: boolean | undefined;
+        noCaret?: boolean | undefined;
         eventKey?: any;
         title: React.ReactNode;
     }

--- a/types/react-bootstrap/lib/NavItem.d.ts
+++ b/types/react-bootstrap/lib/NavItem.d.ts
@@ -3,24 +3,24 @@ import { Sizes, SelectCallback } from 'react-bootstrap';
 
 declare namespace NavItem {
     export interface NavItemProps extends React.HTMLProps<NavItem> {
-        active?: boolean;
+        active?: boolean | undefined;
         brand?: any; // TODO: Add more specific type
-        bsSize?: Sizes;
-        bsStyle?: string;
-        componentClass?: React.ReactType;
-        defaultNavExpanded?: boolean;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        componentClass?: React.ReactType | undefined;
+        defaultNavExpanded?: boolean | undefined;
         eventKey?: any;
-        fixedBottom?: boolean;
-        fixedTop?: boolean;
-        fluid?: boolean;
-        inverse?: boolean;
-        linkId?: string;
-        navExpanded?: boolean;
-        onSelect?: SelectCallback;
-        onToggle?: Function;
-        staticTop?: boolean;
+        fixedBottom?: boolean | undefined;
+        fixedTop?: boolean | undefined;
+        fluid?: boolean | undefined;
+        inverse?: boolean | undefined;
+        linkId?: string | undefined;
+        navExpanded?: boolean | undefined;
+        onSelect?: SelectCallback | undefined;
+        onToggle?: Function | undefined;
+        staticTop?: boolean | undefined;
         toggleButton?: any; // TODO: Add more specific type
-        toggleNavKey?: string | number;
+        toggleNavKey?: string | number | undefined;
     }
 }
 declare class NavItem extends React.Component<NavItem.NavItemProps> { }

--- a/types/react-bootstrap/lib/Navbar.d.ts
+++ b/types/react-bootstrap/lib/Navbar.d.ts
@@ -8,20 +8,20 @@ import NavbarToggle = require('./NavbarToggle');
 declare namespace Navbar {
     export interface NavbarProps extends React.HTMLProps<Navbar> {
         brand?: any; // TODO: Add more specific type
-        bsSize?: Sizes;
-        bsStyle?: string;
-        collapseOnSelect?: boolean;
-        componentClass?: React.ReactType;
-        defaultNavExpanded?: boolean;
-        fixedBottom?: boolean;
-        fixedTop?: boolean;
-        fluid?: boolean;
-        inverse?: boolean;
-        expanded?: boolean;
-        onToggle?: Function;
-        staticTop?: boolean;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        collapseOnSelect?: boolean | undefined;
+        componentClass?: React.ReactType | undefined;
+        defaultNavExpanded?: boolean | undefined;
+        fixedBottom?: boolean | undefined;
+        fixedTop?: boolean | undefined;
+        fluid?: boolean | undefined;
+        inverse?: boolean | undefined;
+        expanded?: boolean | undefined;
+        onToggle?: Function | undefined;
+        staticTop?: boolean | undefined;
         toggleButton?: any; // TODO: Add more specific type
-        toggleNavKey?: string | number;
+        toggleNavKey?: string | number | undefined;
     }
 }
 declare class Navbar extends React.Component<Navbar.NavbarProps> {
@@ -41,18 +41,18 @@ export = Navbar;
 
 interface NavbarLinkProps extends React.HTMLProps<NavbarLink> {
   href: string;
-  onClick?: React.MouseEventHandler<any>;
+  onClick?: React.MouseEventHandler<any> | undefined;
 }
 declare class NavbarLink extends React.Component<NavbarLinkProps> { }
 
 interface NavbarTextProps extends React.HTMLProps<NavbarText> {
-  pullRight?: boolean;
+  pullRight?: boolean | undefined;
 }
 declare class NavbarText extends React.Component<NavbarTextProps> { }
 
 interface NavbarFormProps extends React.HTMLProps<NavbarForm> {
-  componentClass?: React.ReactType;
-  pullRight?: boolean;
-  pullLeft?: boolean;
+  componentClass?: React.ReactType | undefined;
+  pullRight?: boolean | undefined;
+  pullLeft?: boolean | undefined;
 }
 declare class NavbarForm extends React.Component<NavbarFormProps> { }

--- a/types/react-bootstrap/lib/NavbarToggle.d.ts
+++ b/types/react-bootstrap/lib/NavbarToggle.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace NavbarToggle {
     export interface NavbarToggleProps extends React.HTMLProps<NavbarToggle> {
-        onClick?: React.MouseEventHandler<any>;
+        onClick?: React.MouseEventHandler<any> | undefined;
     }
 }
 declare class NavbarToggle extends React.Component<NavbarToggle.NavbarToggleProps> { }

--- a/types/react-bootstrap/lib/Overlay.d.ts
+++ b/types/react-bootstrap/lib/Overlay.d.ts
@@ -6,13 +6,13 @@ declare namespace Overlay {
         // Optional
         animation?: any; // TODO: Add more specific type
         container?: any; // TODO: Add more specific type
-        containerPadding?: number; // TODO: Add more specific type
-        onHide?: Function;
-        placement?: string;
-        rootClose?: boolean;
-        show?: boolean;
-        target?: Function | React.ReactInstance;
-        shouldUpdatePosition?: boolean;
+        containerPadding?: number | undefined; // TODO: Add more specific type
+        onHide?: Function | undefined;
+        placement?: string | undefined;
+        rootClose?: boolean | undefined;
+        show?: boolean | undefined;
+        target?: Function | React.ReactInstance | undefined;
+        shouldUpdatePosition?: boolean | undefined;
     }
 }
 declare class Overlay extends React.Component<Overlay.OverlayProps> { }

--- a/types/react-bootstrap/lib/OverlayTrigger.d.ts
+++ b/types/react-bootstrap/lib/OverlayTrigger.d.ts
@@ -8,20 +8,20 @@ declare namespace OverlayTrigger {
         // Optional
         animation?: any; // TODO: Add more specific type
         container?: any; // TODO: Add more specific type
-        containerPadding?: number;
-        defaultOverlayShown?: boolean;
-        delay?: number;
-        delayHide?: number;
-        delayShow?: number;
-        onEnter?: Function;
-        onEntered?: Function;
-        onEntering?: Function;
-        onExit?: Function;
-        onExited?: Function;
-        onExiting?: Function;
-        placement?: string;
-        rootClose?: boolean;
-        trigger?: string | string[];
+        containerPadding?: number | undefined;
+        defaultOverlayShown?: boolean | undefined;
+        delay?: number | undefined;
+        delayHide?: number | undefined;
+        delayShow?: number | undefined;
+        onEnter?: Function | undefined;
+        onEntered?: Function | undefined;
+        onEntering?: Function | undefined;
+        onExit?: Function | undefined;
+        onExited?: Function | undefined;
+        onExiting?: Function | undefined;
+        placement?: string | undefined;
+        rootClose?: boolean | undefined;
+        trigger?: string | string[] | undefined;
     }
 }
 declare class OverlayTrigger extends React.Component<OverlayTrigger.OverlayTriggerProps> { }

--- a/types/react-bootstrap/lib/PageHeader.d.ts
+++ b/types/react-bootstrap/lib/PageHeader.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace PageHeader {
     export interface PageHeaderProps extends React.HTMLProps<PageHeader> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class PageHeader extends React.Component<PageHeader.PageHeaderProps> { }

--- a/types/react-bootstrap/lib/Pager.d.ts
+++ b/types/react-bootstrap/lib/Pager.d.ts
@@ -4,8 +4,8 @@ import PagerItem = require('./PagerItem');
 
 declare namespace Pager {
     export interface PagerProps extends React.HTMLProps<Pager> {
-        onSelect?: SelectCallback;
-        bsClass?: string;
+        onSelect?: SelectCallback | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class Pager extends React.Component<Pager.PagerProps> {

--- a/types/react-bootstrap/lib/PagerItem.d.ts
+++ b/types/react-bootstrap/lib/PagerItem.d.ts
@@ -3,12 +3,12 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PagerItem {
     export interface PagerItemProps extends React.HTMLProps<PagerItem> {
-        disabled?: boolean;
+        disabled?: boolean | undefined;
         eventKey?: any;
-        next?: boolean;
-        onSelect?: SelectCallback;
-        previous?: boolean;
-        target?: string;
+        next?: boolean | undefined;
+        onSelect?: SelectCallback | undefined;
+        previous?: boolean | undefined;
+        target?: string | undefined;
     }
 }
 declare class PagerItem extends React.Component<PagerItem.PagerItemProps> { }

--- a/types/react-bootstrap/lib/Pagination.d.ts
+++ b/types/react-bootstrap/lib/Pagination.d.ts
@@ -9,7 +9,7 @@ import PaginationItem = require('./PaginationItem');
 
 declare namespace Pagination {
     export interface PaginationProps extends React.HTMLProps<Pagination> {
-        bsSize?: Sizes;
+        bsSize?: Sizes | undefined;
     }
 }
 declare class Pagination extends React.Component<Pagination.PaginationProps> {

--- a/types/react-bootstrap/lib/PaginationEllipsis.d.ts
+++ b/types/react-bootstrap/lib/PaginationEllipsis.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PaginationEllipsis {
     export interface PaginationEllipsisProps extends React.HTMLProps<PaginationEllipsis> {
-        disabled?: boolean;
+        disabled?: boolean | undefined;
     }
 }
 declare class PaginationEllipsis extends React.Component<PaginationEllipsis.PaginationEllipsisProps> { }

--- a/types/react-bootstrap/lib/PaginationFirst.d.ts
+++ b/types/react-bootstrap/lib/PaginationFirst.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PaginationFirst {
     export interface PaginationFirstProps extends React.HTMLProps<PaginationFirst> {
-        disabled?: boolean;
+        disabled?: boolean | undefined;
     }
 }
 declare class PaginationFirst extends React.Component<PaginationFirst.PaginationFirstProps> { }

--- a/types/react-bootstrap/lib/PaginationItem.d.ts
+++ b/types/react-bootstrap/lib/PaginationItem.d.ts
@@ -3,8 +3,8 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PaginationItem {
     export interface PaginationItemProps extends React.HTMLProps<PaginationItem> {
-        disabled?: boolean;
-        active?: boolean;
+        disabled?: boolean | undefined;
+        active?: boolean | undefined;
     }
 }
 declare class PaginationItem extends React.Component<PaginationItem.PaginationItemProps> { }

--- a/types/react-bootstrap/lib/PaginationLast.d.ts
+++ b/types/react-bootstrap/lib/PaginationLast.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PaginationLast {
     export interface PaginationLastProps extends React.HTMLProps<PaginationLast> {
-        disabled?: boolean;
+        disabled?: boolean | undefined;
     }
 }
 declare class PaginationLast extends React.Component<PaginationLast.PaginationLastProps> { }

--- a/types/react-bootstrap/lib/PaginationNext.d.ts
+++ b/types/react-bootstrap/lib/PaginationNext.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PaginationNext {
     export interface PaginationNextProps extends React.HTMLProps<PaginationNext> {
-        disabled?: boolean;
+        disabled?: boolean | undefined;
     }
 }
 declare class PaginationNext extends React.Component<PaginationNext.PaginationNextProps> { }

--- a/types/react-bootstrap/lib/PaginationPrev.d.ts
+++ b/types/react-bootstrap/lib/PaginationPrev.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PaginationPrev {
     export interface PaginationPrevProps extends React.HTMLProps<PaginationPrev> {
-        disabled?: boolean;
+        disabled?: boolean | undefined;
     }
 }
 declare class PaginationPrev extends React.Component<PaginationPrev.PaginationPrevProps> { }

--- a/types/react-bootstrap/lib/Panel.d.ts
+++ b/types/react-bootstrap/lib/Panel.d.ts
@@ -9,13 +9,13 @@ import PanelFooter = require('./PanelFooter');
 
 declare namespace Panel {
     export interface PanelProps extends TransitionCallbacks, React.HTMLProps<Panel> {
-        bsClass?: string;
-        bsStyle?: string;
-        defaultExpanded?: boolean;
+        bsClass?: string | undefined;
+        bsStyle?: string | undefined;
+        defaultExpanded?: boolean | undefined;
         eventKey?: any;
-        expanded?: boolean;
-        onSelect?: SelectCallback;
-        onToggle?: SelectCallback;
+        expanded?: boolean | undefined;
+        onSelect?: SelectCallback | undefined;
+        onToggle?: SelectCallback | undefined;
     }
 }
 declare class Panel extends React.Component<Panel.PanelProps> {

--- a/types/react-bootstrap/lib/PanelBody.d.ts
+++ b/types/react-bootstrap/lib/PanelBody.d.ts
@@ -3,8 +3,8 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelBody {
     export interface PanelBodyProps extends React.HTMLProps<PanelBody> {
-        collapsible?: boolean;
-        bsClass?: string;
+        collapsible?: boolean | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class PanelBody extends React.Component<PanelBody.PanelBodyProps> { }

--- a/types/react-bootstrap/lib/PanelCollapse.d.ts
+++ b/types/react-bootstrap/lib/PanelCollapse.d.ts
@@ -3,13 +3,13 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelCollapse {
     export interface PanelCollapseProps extends React.HTMLProps<PanelCollapse> {
-        bsClass?: string;
-        onEnter?: Function;
-        onEntering?: Function;
-        onEntered?: Function;
-        onExit?: Function;
-        onExiting?: Function;
-        onExited?: Function;
+        bsClass?: string | undefined;
+        onEnter?: Function | undefined;
+        onEntering?: Function | undefined;
+        onEntered?: Function | undefined;
+        onExit?: Function | undefined;
+        onExiting?: Function | undefined;
+        onExited?: Function | undefined;
     }
 }
 declare class PanelCollapse extends React.Component<PanelCollapse.PanelCollapseProps> { }

--- a/types/react-bootstrap/lib/PanelFooter.d.ts
+++ b/types/react-bootstrap/lib/PanelFooter.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelFooter {
     export interface PanelFooterProps extends React.HTMLProps<PanelFooter> {
-        bsClass?: string;
+        bsClass?: string | undefined;
     }
 }
 declare class PanelFooter extends React.Component<PanelFooter.PanelFooterProps> { }

--- a/types/react-bootstrap/lib/PanelGroup.d.ts
+++ b/types/react-bootstrap/lib/PanelGroup.d.ts
@@ -3,12 +3,12 @@ import { Sizes, SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelGroup {
     export interface PanelGroupProps extends React.HTMLProps<PanelGroup> {
-        accordion?: boolean;
+        accordion?: boolean | undefined;
         activeKey?: any;
         defaultActiveKey?: any;
-        onSelect?: SelectCallback;
-        role?: string;
-        generateChildId?: Function;
+        onSelect?: SelectCallback | undefined;
+        role?: string | undefined;
+        generateChildId?: Function | undefined;
     }
 }
 declare class PanelGroup extends React.Component<PanelGroup.PanelGroupProps> { }

--- a/types/react-bootstrap/lib/PanelHeading.d.ts
+++ b/types/react-bootstrap/lib/PanelHeading.d.ts
@@ -3,8 +3,8 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelHeading {
     export interface PanelHeadingProps extends React.HTMLProps<PanelHeading> {
-        componentClass?: string;
-        bsClass?: string;
+        componentClass?: string | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class PanelHeading extends React.Component<PanelHeading.PanelHeadingProps> { }

--- a/types/react-bootstrap/lib/PanelTitle.d.ts
+++ b/types/react-bootstrap/lib/PanelTitle.d.ts
@@ -3,9 +3,9 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelTitle {
     export interface PanelTitleProps extends React.HTMLProps<PanelTitle> {
-        componentClass?: string;
-        bsClass?: string;
-        toggle?: boolean;
+        componentClass?: string | undefined;
+        bsClass?: string | undefined;
+        toggle?: boolean | undefined;
     }
 }
 declare class PanelTitle extends React.Component<PanelTitle.PanelTitleProps> { }

--- a/types/react-bootstrap/lib/PanelToggle.d.ts
+++ b/types/react-bootstrap/lib/PanelToggle.d.ts
@@ -3,7 +3,7 @@ import { SelectCallback } from 'react-bootstrap';
 
 declare namespace PanelToggle {
     export interface PanelToggleProps extends React.HTMLProps<PanelToggle> {
-        componentClass?: string;
+        componentClass?: string | undefined;
     }
 }
 declare class PanelToggle extends React.Component<PanelToggle.PanelToggleProps> { }

--- a/types/react-bootstrap/lib/Popover.d.ts
+++ b/types/react-bootstrap/lib/Popover.d.ts
@@ -4,15 +4,15 @@ import { Sizes, Omit } from 'react-bootstrap';
 declare namespace Popover {
     export interface PopoverProps extends Omit<React.HTMLProps<Popover>, "title"> {
         // Optional
-        arrowOffsetLeft?: number | string;
-        arrowOffsetTop?: number | string;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
-        placement?: string;
-        positionLeft?: number | string; // String support added since v0.30.0
-        positionTop?: number | string; // String support added since v0.30.0
-        title?: React.ReactNode;
+        arrowOffsetLeft?: number | string | undefined;
+        arrowOffsetTop?: number | string | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
+        placement?: string | undefined;
+        positionLeft?: number | string | undefined; // String support added since v0.30.0
+        positionTop?: number | string | undefined; // String support added since v0.30.0
+        title?: React.ReactNode | undefined;
     }
 }
 declare class Popover extends React.Component<Popover.PopoverProps> { }

--- a/types/react-bootstrap/lib/ProgressBar.d.ts
+++ b/types/react-bootstrap/lib/ProgressBar.d.ts
@@ -4,17 +4,17 @@ import { Sizes, Omit } from 'react-bootstrap';
 declare namespace ProgressBar {
     export interface ProgressBarProps extends Omit<React.HTMLProps<ProgressBar>, "label"> {
         // Optional
-        active?: boolean;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
+        active?: boolean | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
         interpolatedClass?: any; // TODO: Add more specific type
-        max?: number;
-        min?: number;
-        now?: number;
-        srOnly?: boolean;
-        striped?: boolean;
-        label?: React.ReactNode;
+        max?: number | undefined;
+        min?: number | undefined;
+        now?: number | undefined;
+        srOnly?: boolean | undefined;
+        striped?: boolean | undefined;
+        label?: React.ReactNode | undefined;
     }
 }
 declare class ProgressBar extends React.Component<ProgressBar.ProgressBarProps> { }

--- a/types/react-bootstrap/lib/Radio.d.ts
+++ b/types/react-bootstrap/lib/Radio.d.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 
 declare namespace Radio {
     export interface RadioProps extends React.HTMLProps<Radio> {
-        bsClass?: string;
-        disabled?: boolean;
-        inline?: boolean;
-        inputRef?: (instance: HTMLInputElement) => void;
-        validationState?: "success" | "warning" | "error";
+        bsClass?: string | undefined;
+        disabled?: boolean | undefined;
+        inline?: boolean | undefined;
+        inputRef?: ((instance: HTMLInputElement) => void) | undefined;
+        validationState?: "success" | "warning" | "error" | undefined;
     }
 
 }

--- a/types/react-bootstrap/lib/ResponsiveEmbed.d.ts
+++ b/types/react-bootstrap/lib/ResponsiveEmbed.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 declare namespace ResponsiveEmbed {
     export interface ResponsiveEmbedProps extends React.HTMLProps<ResponsiveEmbed> {
-        a16by9?: boolean;
-        a4by3?: boolean;
-        bsClass?: string;
+        a16by9?: boolean | undefined;
+        a4by3?: boolean | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class ResponsiveEmbed extends React.Component<ResponsiveEmbed.ResponsiveEmbedProps> { }

--- a/types/react-bootstrap/lib/Row.d.ts
+++ b/types/react-bootstrap/lib/Row.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare namespace Row {
     export interface RowProps extends React.HTMLProps<Row> {
-        componentClass?: React.ReactType;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class Row extends React.Component<Row.RowProps> { }

--- a/types/react-bootstrap/lib/SafeAnchor.d.ts
+++ b/types/react-bootstrap/lib/SafeAnchor.d.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 
 declare namespace SafeAnchor {
     export interface SafeAnchorProps extends React.HTMLProps<SafeAnchor> {
-        href?: string;
-        onClick?: React.MouseEventHandler<{}>;
-        disabled?: boolean;
-        role?: string;
-        componentClass?: React.ReactType;
+        href?: string | undefined;
+        onClick?: React.MouseEventHandler<{}> | undefined;
+        disabled?: boolean | undefined;
+        role?: string | undefined;
+        componentClass?: React.ReactType | undefined;
     }
 }
 declare class SafeAnchor extends React.Component<SafeAnchor.SafeAnchorProps> { }

--- a/types/react-bootstrap/lib/SplitButton.d.ts
+++ b/types/react-bootstrap/lib/SplitButton.d.ts
@@ -3,11 +3,11 @@ import { Sizes, Omit } from 'react-bootstrap';
 
 declare namespace SplitButton {
     export interface SplitButtonProps extends Omit<React.HTMLProps<SplitButton>, "title"> {
-        bsStyle?: string;
-        bsSize?: Sizes;
+        bsStyle?: string | undefined;
+        bsSize?: Sizes | undefined;
         dropdownTitle?: any; // TODO: Add more specific type
-        dropup?: boolean;
-        pullRight?: boolean;
+        dropup?: boolean | undefined;
+        pullRight?: boolean | undefined;
         title: React.ReactNode;
         id: string;
     }

--- a/types/react-bootstrap/lib/Tab.d.ts
+++ b/types/react-bootstrap/lib/Tab.d.ts
@@ -6,13 +6,13 @@ import TabContent = require('./TabContent');
 
 declare namespace Tab {
     export interface TabProps extends TransitionCallbacks, Omit<React.HTMLProps<Tab>, "title"> {
-        animation?: boolean;
-        'aria-labelledby'?: string;
-        bsClass?: string;
+        animation?: boolean | undefined;
+        'aria-labelledby'?: string | undefined;
+        bsClass?: string | undefined;
         eventKey?: any; // TODO: Add more specific type
-        unmountOnExit?: boolean;
-        tabClassName?: string;
-        title?: React.ReactNode; // Override HTMLProps.title to allow nodes not just strings
+        unmountOnExit?: boolean | undefined;
+        tabClassName?: string | undefined;
+        title?: React.ReactNode | undefined; // Override HTMLProps.title to allow nodes not just strings
     }
 }
 declare class Tab extends React.Component<Tab.TabProps> {

--- a/types/react-bootstrap/lib/TabContainer.d.ts
+++ b/types/react-bootstrap/lib/TabContainer.d.ts
@@ -4,7 +4,7 @@ declare namespace TabContainer {
     export interface TabContainerProps extends React.HTMLAttributes<TabContainer> {
         activeKey?: any;
         defaultActiveKey?: any;
-        generateChildId?: (eventKey: any, type: any) => string;
+        generateChildId?: ((eventKey: any, type: any) => string) | undefined;
     }
 }
 declare class TabContainer extends React.Component<TabContainer.TabContainerProps> { }

--- a/types/react-bootstrap/lib/TabContent.d.ts
+++ b/types/react-bootstrap/lib/TabContent.d.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 
 declare namespace TabContent {
     export interface TabContentProps extends React.HTMLProps<TabContent> {
-        componentClass?: React.ReactType,
-        animation?: boolean | React.ReactType;
-        mountOnEnter?: boolean;
-        unmountOnExit?: boolean;
-        bsClass?: string;
+        componentClass?: React.ReactType | undefined,
+        animation?: boolean | React.ReactType | undefined;
+        mountOnEnter?: boolean | undefined;
+        unmountOnExit?: boolean | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class TabContent extends React.Component<TabContent.TabContentProps> { }

--- a/types/react-bootstrap/lib/TabPane.d.ts
+++ b/types/react-bootstrap/lib/TabPane.d.ts
@@ -3,12 +3,12 @@ import { TransitionCallbacks } from 'react-bootstrap';
 
 declare namespace TabPane {
     export interface TabPaneProps extends TransitionCallbacks, React.HTMLProps<TabPane> {
-        animation?: boolean | React.ComponentClass<any>;
-        'aria-labelledby'?: string;
-        bsClass?: string;
+        animation?: boolean | React.ComponentClass<any> | undefined;
+        'aria-labelledby'?: string | undefined;
+        bsClass?: string | undefined;
         eventKey?: any;
-        mountOnEnter?: boolean;
-        unmountOnExit?: boolean;
+        mountOnEnter?: boolean | undefined;
+        unmountOnExit?: boolean | undefined;
     }
 }
 declare class TabPane extends React.Component<TabPane.TabPaneProps> { }

--- a/types/react-bootstrap/lib/Table.d.ts
+++ b/types/react-bootstrap/lib/Table.d.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 
 declare namespace Table {
     export interface TableProps extends React.HTMLProps<Table> {
-        bordered?: boolean;
-        condensed?: boolean;
-        hover?: boolean;
-        responsive?: boolean;
-        striped?: boolean;
-        fill?: boolean;
-        bsClass?: string;
+        bordered?: boolean | undefined;
+        condensed?: boolean | undefined;
+        hover?: boolean | undefined;
+        responsive?: boolean | undefined;
+        striped?: boolean | undefined;
+        fill?: boolean | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class Table extends React.Component<Table.TableProps> { }

--- a/types/react-bootstrap/lib/Tabs.d.ts
+++ b/types/react-bootstrap/lib/Tabs.d.ts
@@ -4,16 +4,16 @@ import { SelectCallback } from 'react-bootstrap';
 declare namespace Tabs {
     export interface TabsProps extends React.HTMLProps<Tabs> {
         activeKey?: any;
-        animation?: boolean;
-        bsStyle?: string;
+        animation?: boolean | undefined;
+        bsStyle?: string | undefined;
         defaultActiveKey?: any;
-        onSelect?: SelectCallback;
+        onSelect?: SelectCallback | undefined;
         paneWidth?: any; // TODO: Add more specific type
-        position?: string;
+        position?: string | undefined;
         tabWidth?: any; // TODO: Add more specific type
-        mountOnEnter?: boolean;
-        unmountOnExit?: boolean;
-        justified?: boolean;
+        mountOnEnter?: boolean | undefined;
+        unmountOnExit?: boolean | undefined;
+        justified?: boolean | undefined;
     }
 }
 declare class Tabs extends React.Component<Tabs.TabsProps> { }

--- a/types/react-bootstrap/lib/Thumbnail.d.ts
+++ b/types/react-bootstrap/lib/Thumbnail.d.ts
@@ -3,8 +3,8 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace Thumbnail {
     export interface ThumbnailProps extends React.HTMLProps<Thumbnail> {
-        bsSize?: Sizes;
-        bsStyle?: string;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
     }
 }
 declare class Thumbnail extends React.Component<Thumbnail.ThumbnailProps> { }

--- a/types/react-bootstrap/lib/ToggleButton.d.ts
+++ b/types/react-bootstrap/lib/ToggleButton.d.ts
@@ -3,8 +3,8 @@ import { Button } from 'react-bootstrap';
 
 declare namespace ToggleButton {
     export interface ToggleButtonProps extends React.HTMLProps<ToggleButton> {
-        checked?: boolean;
-        name?: string;
+        checked?: boolean | undefined;
+        name?: string | undefined;
         value: number | string;
     }
 }

--- a/types/react-bootstrap/lib/ToggleButtonGroup.d.ts
+++ b/types/react-bootstrap/lib/ToggleButtonGroup.d.ts
@@ -24,7 +24,7 @@ declare namespace ToggleButtonGroup {
   }
 
   interface CheckboxProps {
-    name?: string;
+    name?: string | undefined;
     type: "checkbox";
     onChange?(values: any[]): void;
   }

--- a/types/react-bootstrap/lib/Tooltip.d.ts
+++ b/types/react-bootstrap/lib/Tooltip.d.ts
@@ -4,14 +4,14 @@ import { Sizes } from 'react-bootstrap';
 declare namespace Tooltip {
     export interface TooltipProps extends React.HTMLProps<Tooltip> {
         // Optional
-        arrowOffsetLeft?: number | string;
-        arrowOffsetTop?: number | string;
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
-        placement?: string;
-        positionLeft?: number;
-        positionTop?: number;
+        arrowOffsetLeft?: number | string | undefined;
+        arrowOffsetTop?: number | string | undefined;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
+        placement?: string | undefined;
+        positionLeft?: number | undefined;
+        positionTop?: number | undefined;
     }
 }
 declare class Tooltip extends React.Component<Tooltip.TooltipProps> { }

--- a/types/react-bootstrap/lib/Well.d.ts
+++ b/types/react-bootstrap/lib/Well.d.ts
@@ -3,9 +3,9 @@ import { Sizes } from 'react-bootstrap';
 
 declare namespace Well {
     export interface WellProps extends React.HTMLProps<Well> {
-        bsSize?: Sizes;
-        bsStyle?: string;
-        bsClass?: string;
+        bsSize?: Sizes | undefined;
+        bsStyle?: string | undefined;
+        bsClass?: string | undefined;
     }
 }
 declare class Well extends React.Component<Well.WellProps> { }

--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -18,65 +18,65 @@ export type DrillCallback = (props: DrillCallbackProperties) => void;
 export default function Calendar(props: CalendarProps): JSX.Element;
 
 export interface CalendarProps {
-    activeStartDate?: Date;
-    allowPartialRange?: boolean;
-    calendarType?: CalendarType;
-    className?: string | string[];
-    closeCalendar?: boolean;
-    defaultActiveStartDate?: Date;
-    defaultValue?: Date | Date[];
-    defaultView?: Detail;
-    formatDay?: FormatterCallback;
-    formatLongDate?: FormatterCallback;
-    formatMonth?: FormatterCallback;
-    formatMonthYear?: FormatterCallback;
-    formatShortWeekday?: FormatterCallback;
-    formatYear?: FormatterCallback;
-    inputRef?: (
+    activeStartDate?: Date | undefined;
+    allowPartialRange?: boolean | undefined;
+    calendarType?: CalendarType | undefined;
+    className?: string | string[] | undefined;
+    closeCalendar?: boolean | undefined;
+    defaultActiveStartDate?: Date | undefined;
+    defaultValue?: Date | Date[] | undefined;
+    defaultView?: Detail | undefined;
+    formatDay?: FormatterCallback | undefined;
+    formatLongDate?: FormatterCallback | undefined;
+    formatMonth?: FormatterCallback | undefined;
+    formatMonthYear?: FormatterCallback | undefined;
+    formatShortWeekday?: FormatterCallback | undefined;
+    formatYear?: FormatterCallback | undefined;
+    inputRef?: ((
         ref: HTMLInputElement | null,
-    ) => void | RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement | null>;
-    locale?: string;
-    maxDate?: Date;
-    maxDetail?: Detail;
-    minDate?: Date;
-    minDetail?: Detail;
-    navigationAriaLabel?: string;
-    navigationLabel?: (props: {
+    ) => void | RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement | null>) | undefined;
+    locale?: string | undefined;
+    maxDate?: Date | undefined;
+    maxDetail?: Detail | undefined;
+    minDate?: Date | undefined;
+    minDetail?: Detail | undefined;
+    navigationAriaLabel?: string | undefined;
+    navigationLabel?: ((props: {
         date: Date;
         label: string;
         locale: string;
         view: Detail;
-    }) => string | JSX.Element | null;
-    nextAriaLabel?: string;
-    nextLabel?: string | JSX.Element | null;
-    next2AriaLabel?: string;
-    next2Label?: string | JSX.Element | null;
-    onActiveStartDateChange?: ViewCallback;
-    onChange?: OnChangeDateCallback;
-    onViewChange?: ViewCallback;
-    onClickDay?: DateCallback;
-    onClickDecade?: DateCallback;
-    onClickMonth?: DateCallback;
-    onClickWeekNumber?: ClickWeekNumberCallback;
-    onClickYear?: DateCallback;
-    onDrillDown?: DrillCallback;
-    onDrillUp?: DrillCallback;
-    prevAriaLabel?: string;
-    prevLabel?: string | JSX.Element | null;
-    prev2AriaLabel?: string;
-    prev2Label?: string | JSX.Element | null;
-    returnValue?: "start" | "end" | "range";
-    showDoubleView?: boolean;
-    showFixedNumberOfWeeks?: boolean;
-    showNavigation?: boolean;
-    showNeighboringMonth?: boolean;
-    selectRange?: boolean;
-    showWeekNumbers?: boolean;
-    tileClassName?: string | string[] | ((props: CalendarTileProperties) => string | string[] | null);
-    tileContent?: string | JSX.Element | ((props: CalendarTileProperties) => JSX.Element | null);
-    tileDisabled?: (props: CalendarTileProperties) => boolean;
-    value?: Date | Date[] | null;
-    view?: Detail;
+    }) => string | JSX.Element | null) | undefined;
+    nextAriaLabel?: string | undefined;
+    nextLabel?: string | JSX.Element | null | undefined;
+    next2AriaLabel?: string | undefined;
+    next2Label?: string | JSX.Element | null | undefined;
+    onActiveStartDateChange?: ViewCallback | undefined;
+    onChange?: OnChangeDateCallback | undefined;
+    onViewChange?: ViewCallback | undefined;
+    onClickDay?: DateCallback | undefined;
+    onClickDecade?: DateCallback | undefined;
+    onClickMonth?: DateCallback | undefined;
+    onClickWeekNumber?: ClickWeekNumberCallback | undefined;
+    onClickYear?: DateCallback | undefined;
+    onDrillDown?: DrillCallback | undefined;
+    onDrillUp?: DrillCallback | undefined;
+    prevAriaLabel?: string | undefined;
+    prevLabel?: string | JSX.Element | null | undefined;
+    prev2AriaLabel?: string | undefined;
+    prev2Label?: string | JSX.Element | null | undefined;
+    returnValue?: "start" | "end" | "range" | undefined;
+    showDoubleView?: boolean | undefined;
+    showFixedNumberOfWeeks?: boolean | undefined;
+    showNavigation?: boolean | undefined;
+    showNeighboringMonth?: boolean | undefined;
+    selectRange?: boolean | undefined;
+    showWeekNumbers?: boolean | undefined;
+    tileClassName?: string | string[] | ((props: CalendarTileProperties) => string | string[] | null) | undefined;
+    tileContent?: string | JSX.Element | ((props: CalendarTileProperties) => JSX.Element | null) | undefined;
+    tileDisabled?: ((props: CalendarTileProperties) => boolean) | undefined;
+    value?: Date | Date[] | null | undefined;
+    view?: Detail | undefined;
 }
 
 export interface CalendarTileProperties {
@@ -103,16 +103,16 @@ export function CenturyView(props: DetailViewProps): JSX.Element;
 
 export interface DetailViewProps {
     activeStartDate: Date;
-    calendarType?: CalendarType;
-    locale?: string;
-    hover?: Date;
-    maxDate?: Date;
-    minDate?: Date;
-    onClick?: DateCallback;
-    onMouseOver?: DateCallback;
-    renderChildren?: (props: CalendarTileProperties) => JSX.Element | null; // For backwards compatibility
-    tileClassName?: string | string[] | ((props: CalendarTileProperties) => string | string[] | null);
-    tileContent?: JSX.Element | ((props: CalendarTileProperties) => JSX.Element | null);
-    tileDisabled?: (props: CalendarTileProperties) => boolean;
-    value?: Date | Date[];
+    calendarType?: CalendarType | undefined;
+    locale?: string | undefined;
+    hover?: Date | undefined;
+    maxDate?: Date | undefined;
+    minDate?: Date | undefined;
+    onClick?: DateCallback | undefined;
+    onMouseOver?: DateCallback | undefined;
+    renderChildren?: ((props: CalendarTileProperties) => JSX.Element | null) | undefined; // For backwards compatibility
+    tileClassName?: string | string[] | ((props: CalendarTileProperties) => string | string[] | null) | undefined;
+    tileContent?: JSX.Element | ((props: CalendarTileProperties) => JSX.Element | null) | undefined;
+    tileDisabled?: ((props: CalendarTileProperties) => boolean) | undefined;
+    value?: Date | Date[] | undefined;
 }


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers widely used packages, those with more then 100,000 packages per month, from qrcode -- react-calendar.

microsoft/dtslint#335