### PR TITLE
Add undefined to optional properties, Regenerator to Rimraf

### DIFF
--- a/types/regenerator-runtime/index.d.ts
+++ b/types/regenerator-runtime/index.d.ts
@@ -33,10 +33,10 @@ export interface CompletionRecord {
 
 export interface TryEntry {
     readonly tryLoc: number;
-    readonly catchLoc?: number;
-    readonly finallyLoc?: number;
-    readonly afterLoc?: ContextLocation;
-    completion?: CompletionRecord;
+    readonly catchLoc?: number | undefined;
+    readonly finallyLoc?: number | undefined;
+    readonly afterLoc?: ContextLocation | undefined;
+    completion?: CompletionRecord | undefined;
 }
 
 export interface DelegatedIterator {

--- a/types/registry-auth-token/index.d.ts
+++ b/types/registry-auth-token/index.d.ts
@@ -17,7 +17,7 @@ declare namespace auth {
          * Wether or not url's path parts are recursively trimmed from the registry
          * url when searching for tokens
          */
-        recursive?: boolean;
+        recursive?: boolean | undefined;
         /**
          * An npmrc configuration object used when searching for tokens. If no object is provided,
          * the `.npmrc` file at the base of the project is used.
@@ -26,12 +26,12 @@ declare namespace auth {
             /**
              * A registry url used for matching
              */
-            registry?: string;
+            registry?: string | undefined;
             /**
              * Registry url's with token information
              */
             [registryUrls: string]: string | undefined;
-        };
+        } | undefined;
     }
     /**
      * The generated authentication information
@@ -48,11 +48,11 @@ declare namespace auth {
         /**
          * The username used in `Basic`
          */
-        username?: string;
+        username?: string | undefined;
         /**
          * The password used in `Basic`
          */
-        password?: string;
+        password?: string | undefined;
     }
 }
 

--- a/types/regression/index.d.ts
+++ b/types/regression/index.d.ts
@@ -14,13 +14,13 @@ export interface Options {
      * This is used to round the calculated fitting coefficients,
      * the output predictions, and the value of r^2.
      */
-    precision?: number;
+    precision?: number | undefined;
     /**
      * The number of terms to solve for (and therefore
      * the number of coefficients to calculate). Only
      * relevant for polynomial fitting.
      */
-    order?: number;
+    order?: number | undefined;
 }
 
 export interface Result {

--- a/types/relateurl/index.d.ts
+++ b/types/relateurl/index.d.ts
@@ -12,7 +12,7 @@ declare namespace RelateUrl {
          *
          * Extend the list with any ports you need. Any URLs containing these default ports will have them removed. Example: http://example.com:80/ will become http://example.com/.
          */
-        defaultPorts?: Object;
+        defaultPorts?: Object | undefined;
 
         /**
          * Type: Array
@@ -20,7 +20,7 @@ declare namespace RelateUrl {
          *
          * Extend the list with any resources you need. Works with options.removeDirectoryIndexes.
          */
-        directoryIndexes?: Array<string>;
+        directoryIndexes?: Array<string> | undefined;
 
         /**
          * Type: Boolean
@@ -28,7 +28,7 @@ declare namespace RelateUrl {
          *
          * This will, for example, consider any domains containing http://www.example.com/ to be related to any that contain http://example.com/.
          */
-        ignore_www?: boolean;
+        ignore_www?: boolean | undefined;
 
         /**
          * Type: constant or String
@@ -41,7 +41,7 @@ declare namespace RelateUrl {
          * RelateUrl.ROOT_RELATIVE will produce something like /child-of-root/etc/.
          * RelateUrl.SHORTEST will choose whichever is shortest between root- and path-relative.
          */
-        output?: string;
+        output?: string | undefined;
 
         /**
          * Type: Array
@@ -49,7 +49,7 @@ declare namespace RelateUrl {
          *
          * Extend the list with any additional schemes. Example: javascript:something will not be modified.
          */
-        rejectedSchemes?: Array<string>;
+        rejectedSchemes?: Array<string> | undefined;
 
         /**
          * Type: Boolean
@@ -57,7 +57,7 @@ declare namespace RelateUrl {
          *
          * Remove user authentication information from the output URL.
          */
-        removeAuth?: boolean;
+        removeAuth?: boolean | undefined;
 
         /**
          * Type: Boolean
@@ -65,7 +65,7 @@ declare namespace RelateUrl {
          *
          * Remove any resources that match any found in options.directoryIndexes.
          */
-        removeDirectoryIndexes?: boolean;
+        removeDirectoryIndexes?: boolean | undefined;
 
         /**
          * Type: Boolean
@@ -73,7 +73,7 @@ declare namespace RelateUrl {
          *
          * Remove empty query variables. Example: http://domain.com/?var1&var2=&var3=asdf will become http://domain.com/?var3=adsf. This does not apply to unrelated URLs (with other protocols, auths, hosts and/or ports).
          */
-        removeEmptyQueries?: boolean;
+        removeEmptyQueries?: boolean | undefined;
 
         /**
          * Type: Boolean
@@ -81,7 +81,7 @@ declare namespace RelateUrl {
          *
          * Remove trailing slashes from root paths. Example: http://domain.com/?var will become http://domain.com?var while http://domain.com/dir/?var will not be modified.
          */
-        removeRootTrailingSlash?: boolean;
+        removeRootTrailingSlash?: boolean | undefined;
 
         /**
          * Type: Boolean
@@ -89,7 +89,7 @@ declare namespace RelateUrl {
          *
          * Output URLs relative to the scheme. Example: http://example.com/ will become //example.com/.
          */
-        schemeRelative?: boolean;
+        schemeRelative?: boolean | undefined;
 
         /**
          * Type: String
@@ -97,7 +97,7 @@ declare namespace RelateUrl {
          *
          * An options-based version of the from argument. If both are specified, from takes priority.
          */
-        site?: string;
+        site?: string | undefined;
 
         /**
          * Type: Boolean
@@ -105,7 +105,7 @@ declare namespace RelateUrl {
          *
          * Passed to Node's url.parse.
          */
-        slashesDenoteHost?: boolean;
+        slashesDenoteHost?: boolean | undefined;
     }
 }
 

--- a/types/relaxed-json/index.d.ts
+++ b/types/relaxed-json/index.d.ts
@@ -7,10 +7,10 @@ export type Reviver = (this: {}, key: string, value: any) => any;
 export function transform(text: string): string;
 export function parse(text: string, reviver: Reviver): {};
 export function parse(text: string, opts?: {
-    reviver?: Reviver,
-    relaxed?: boolean,
-    warnings?: boolean,
-    tolerant?: boolean,
-    duplicate?: boolean,
+    reviver?: Reviver | undefined,
+    relaxed?: boolean | undefined,
+    warnings?: boolean | undefined,
+    tolerant?: boolean | undefined,
+    duplicate?: boolean | undefined,
 }): {};
 export function stringify(obj: any): string;

--- a/types/relay-runtime/lib/handlers/connection/ConnectionHandler.d.ts
+++ b/types/relay-runtime/lib/handlers/connection/ConnectionHandler.d.ts
@@ -11,7 +11,7 @@ export interface ConnectionMetadata {
     direction: string | null | undefined; // 'forward' | 'backward' | 'bidirectional' | null | undefined;
     cursor: string | null | undefined;
     count: string | null | undefined;
-    stream?: boolean;
+    stream?: boolean | undefined;
 }
 
 export function buildConnectionEdge(

--- a/types/relay-runtime/lib/mutations/RelayDeclarativeMutationConfig.d.ts
+++ b/types/relay-runtime/lib/mutations/RelayDeclarativeMutationConfig.d.ts
@@ -13,36 +13,36 @@ export type RangeBehaviors = RangeBehaviorsFunction | RangeBehaviorsObject;
 
 export interface RangeAddConfig {
     type: 'RANGE_ADD';
-    parentName?: string;
-    parentID?: string;
+    parentName?: string | undefined;
+    parentID?: string | undefined;
     connectionInfo?: ReadonlyArray<{
         key: string;
-        filters?: Variables;
+        filters?: Variables | undefined;
         rangeBehavior: string;
-    }>;
-    connectionName?: string;
+    }> | undefined;
+    connectionName?: string | undefined;
     edgeName: string;
-    rangeBehaviors?: RangeBehaviors;
+    rangeBehaviors?: RangeBehaviors | undefined;
 }
 
 export interface RangeDeleteConfig {
     type: 'RANGE_DELETE';
-    parentName?: string;
-    parentID?: string;
+    parentName?: string | undefined;
+    parentID?: string | undefined;
     connectionKeys?: ReadonlyArray<{
         key: string;
-        filters?: Variables;
-    }>;
-    connectionName?: string;
+        filters?: Variables | undefined;
+    }> | undefined;
+    connectionName?: string | undefined;
     deletedIDFieldName: string | ReadonlyArray<string>;
     pathToConnection: ReadonlyArray<string>;
 }
 
 export interface NodeDeleteConfig {
     type: 'NODE_DELETE';
-    parentName?: string;
-    parentID?: string;
-    connectionName?: string;
+    parentName?: string | undefined;
+    parentID?: string | undefined;
+    connectionName?: string | undefined;
     deletedIDFieldName: string;
 }
 

--- a/types/relay-runtime/lib/mutations/applyOptimisticMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/applyOptimisticMutation.d.ts
@@ -4,11 +4,11 @@ import { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
 import { SelectorStoreUpdater, Environment } from '../store/RelayStoreTypes';
 
 export interface OptimisticMutationConfig {
-    configs?: ReadonlyArray<DeclarativeMutationConfig> | null;
+    configs?: ReadonlyArray<DeclarativeMutationConfig> | null | undefined;
     mutation: GraphQLTaggedNode;
     variables: Variables;
-    optimisticUpdater?: SelectorStoreUpdater | null;
-    optimisticResponse?: object;
+    optimisticUpdater?: SelectorStoreUpdater | null | undefined;
+    optimisticResponse?: object | undefined;
 }
 
 /**

--- a/types/relay-runtime/lib/mutations/commitMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/commitMutation.d.ts
@@ -7,22 +7,22 @@ import { Environment, SelectorStoreUpdater } from '../store/RelayStoreTypes';
 export interface MutationParameters {
     readonly response: {};
     readonly variables: {};
-    readonly rawResponse?: {};
+    readonly rawResponse?: {} | undefined;
 }
 
 export interface MutationConfig<TOperation extends MutationParameters> {
-    configs?: DeclarativeMutationConfig[];
-    cacheConfig?: CacheConfig;
+    configs?: DeclarativeMutationConfig[] | undefined;
+    cacheConfig?: CacheConfig | undefined;
     mutation: GraphQLTaggedNode;
-    onError?: ((error: Error) => void) | null;
+    onError?: ((error: Error) => void) | null | undefined;
     onCompleted?:
         | ((response: TOperation['response'], errors: ReadonlyArray<PayloadError> | null | undefined) => void)
-        | null;
-    onUnsubscribe?: () => void | null | undefined;
-    optimisticResponse?: TOperation['response'];
-    optimisticUpdater?: SelectorStoreUpdater<TOperation['response']> | null;
-    updater?: SelectorStoreUpdater<TOperation['response']> | null;
-    uploadables?: UploadableMap | null;
+        | null | undefined;
+    onUnsubscribe?: (() => void | null | undefined) | undefined;
+    optimisticResponse?: TOperation['response'] | undefined;
+    optimisticUpdater?: SelectorStoreUpdater<TOperation['response']> | null | undefined;
+    updater?: SelectorStoreUpdater<TOperation['response']> | null | undefined;
+    uploadables?: UploadableMap | null | undefined;
     variables: TOperation['variables'];
 }
 

--- a/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
+++ b/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
@@ -20,8 +20,8 @@ export interface PayloadError {
     locations?: Array<{
         line: number;
         column: number;
-    }>;
-    severity?: 'CRITICAL' | 'ERROR' | 'WARNING'; // Not officially part of the spec, but used at Facebook
+    }> | undefined;
+    severity?: 'CRITICAL' | 'ERROR' | 'WARNING' | undefined; // Not officially part of the spec, but used at Facebook
 }
 
 export interface PayloadExtensions {
@@ -34,17 +34,17 @@ export interface PayloadExtensions {
  */
 export interface GraphQLResponseWithData {
     data: PayloadData;
-    errors?: PayloadError[];
-    extensions?: PayloadExtensions;
-    label?: string;
-    path?: Array<string | number>;
+    errors?: PayloadError[] | undefined;
+    extensions?: PayloadExtensions | undefined;
+    label?: string | undefined;
+    path?: Array<string | number> | undefined;
 }
 export interface GraphQLResponseWithoutData {
-    data?: PayloadData;
+    data?: PayloadData | undefined;
     errors: PayloadError[];
-    extensions?: PayloadExtensions;
-    label?: string;
-    path?: Array<string | number>;
+    extensions?: PayloadExtensions | undefined;
+    label?: string | undefined;
+    path?: Array<string | number> | undefined;
 }
 export interface GraphQLResponseWithExtensionsOnly {
     // Per https://spec.graphql.org/June2018/#sec-Errors
@@ -91,9 +91,9 @@ export type FetchFunction = (
 ) => ObservableFromValue<GraphQLResponse>;
 
 export interface LegacyObserver<T> {
-    onCompleted?: () => void;
-    onError?: (error: Error) => void;
-    onNext?: (data: T) => void;
+    onCompleted?: (() => void) | undefined;
+    onError?: ((error: Error) => void) | undefined;
+    onNext?: ((data: T) => void) | undefined;
 }
 
 /**

--- a/types/relay-runtime/lib/network/RelayObservable.d.ts
+++ b/types/relay-runtime/lib/network/RelayObservable.d.ts
@@ -12,11 +12,11 @@ export interface Subscription {
  * .subscribe(). Each callback function is invoked when that event occurs.
  */
 export interface Observer<T> {
-    readonly start?: (subscription: Subscription) => void;
-    readonly next?: (value: T) => void;
-    readonly error?: (error: Error) => void;
-    readonly complete?: () => void;
-    readonly unsubscribe?: (subscription: Subscription) => void;
+    readonly start?: ((subscription: Subscription) => void) | undefined;
+    readonly next?: ((value: T) => void) | undefined;
+    readonly error?: ((error: Error) => void) | undefined;
+    readonly complete?: (() => void) | undefined;
+    readonly unsubscribe?: ((subscription: Subscription) => void) | undefined;
 }
 
 /**

--- a/types/relay-runtime/lib/query/fetchQuery.d.ts
+++ b/types/relay-runtime/lib/query/fetchQuery.d.ts
@@ -7,5 +7,5 @@ export function fetchQuery<T extends OperationType>(
     environment: Environment,
     taggedNode: GraphQLTaggedNode,
     variables: T['variables'],
-    cacheConfig?: { networkCacheConfig?: CacheConfig | null, fetchPolicy?: FetchQueryFetchPolicy | null } | null,
+    cacheConfig?: { networkCacheConfig?: CacheConfig | null | undefined, fetchPolicy?: FetchQueryFetchPolicy | null | undefined } | null,
 ): RelayObservable<T['response']>;

--- a/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
@@ -23,19 +23,19 @@ import { Disposable } from '../util/RelayRuntimeTypes';
 import { RelayObservable } from '../network/RelayObservable';
 
 export interface EnvironmentConfig {
-    readonly configName?: string;
-    readonly handlerProvider?: HandlerProvider | null;
-    readonly treatMissingFieldsAsNull?: boolean;
-    readonly log?: LogFunction | null;
-    readonly operationLoader?: OperationLoader | null;
+    readonly configName?: string | undefined;
+    readonly handlerProvider?: HandlerProvider | null | undefined;
+    readonly treatMissingFieldsAsNull?: boolean | undefined;
+    readonly log?: LogFunction | null | undefined;
+    readonly operationLoader?: OperationLoader | null | undefined;
     readonly network: Network;
-    readonly scheduler?: TaskScheduler | null;
+    readonly scheduler?: TaskScheduler | null | undefined;
     readonly store: Store;
-    readonly missingFieldHandlers?: ReadonlyArray<MissingFieldHandler> | null;
-    readonly operationTracker?: OperationTracker | null;
-    readonly options?: unknown;
-    readonly isServer?: boolean;
-    readonly requiredFieldLogger?: RequiredFieldLogger | null;
+    readonly missingFieldHandlers?: ReadonlyArray<MissingFieldHandler> | null | undefined;
+    readonly operationTracker?: OperationTracker | null | undefined;
+    readonly options?: unknown | undefined;
+    readonly isServer?: boolean | undefined;
+    readonly requiredFieldLogger?: RequiredFieldLogger | null | undefined;
 }
 
 export default class RelayModernEnvironment implements Environment {
@@ -60,7 +60,7 @@ export default class RelayModernEnvironment implements Environment {
     isServer(): boolean;
     execute(data: {
         operation: OperationDescriptor;
-        updater?: SelectorStoreUpdater | null;
+        updater?: SelectorStoreUpdater | null | undefined;
     }): RelayObservable<GraphQLResponse>;
     executeMutation({
         operation,
@@ -70,10 +70,10 @@ export default class RelayModernEnvironment implements Environment {
         uploadables,
     }: {
         operation: OperationDescriptor;
-        optimisticUpdater?: SelectorStoreUpdater | null;
-        optimisticResponse?: { [key: string]: any } | null;
-        updater?: SelectorStoreUpdater | null;
-        uploadables?: UploadableMap | null;
+        optimisticUpdater?: SelectorStoreUpdater | null | undefined;
+        optimisticResponse?: { [key: string]: any } | null | undefined;
+        updater?: SelectorStoreUpdater | null | undefined;
+        uploadables?: UploadableMap | null | undefined;
     }): RelayObservable<GraphQLResponse>;
     executeWithSource({
         operation,

--- a/types/relay-runtime/lib/store/RelayModernQueryExecutor.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernQueryExecutor.d.ts
@@ -20,16 +20,16 @@ export interface ExecuteConfig {
     readonly operation: OperationDescriptor;
     readonly operationExecutions: Map<string, ActiveState>;
     readonly operationLoader: OperationLoader | null | undefined;
-    readonly operationTracker?: OperationTracker | null;
+    readonly operationTracker?: OperationTracker | null | undefined;
     readonly optimisticConfig: OptimisticResponseConfig | null | undefined;
     readonly publishQueue: PublishQueue;
-    readonly reactFlightPayloadDeserializer?: ReactFlightPayloadDeserializer | null;
-    readonly scheduler?: TaskScheduler | null;
+    readonly reactFlightPayloadDeserializer?: ReactFlightPayloadDeserializer | null | undefined;
+    readonly scheduler?: TaskScheduler | null | undefined;
     readonly sink: Sink<GraphQLResponse>;
     readonly source: RelayObservable<GraphQLResponse>;
     readonly store: Store;
-    readonly updater?: SelectorStoreUpdater | null;
-    readonly isClientPayload?: boolean;
+    readonly updater?: SelectorStoreUpdater | null | undefined;
+    readonly isClientPayload?: boolean | undefined;
 }
 
 export interface TaskScheduler {

--- a/types/relay-runtime/lib/store/RelayModernStore.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernStore.d.ts
@@ -22,10 +22,10 @@ export default class RelayModernStore implements Store {
     constructor(
         source: MutableRecordSource,
         options?: {
-            gcScheduler?: Scheduler | null;
-            operationLoader?: OperationLoader | null;
-            gcReleaseBufferSize?: number | null;
-            queryCacheExpirationTime?: number | null;
+            gcScheduler?: Scheduler | null | undefined;
+            operationLoader?: OperationLoader | null | undefined;
+            gcReleaseBufferSize?: number | null | undefined;
+            queryCacheExpirationTime?: number | null | undefined;
         },
     );
     getSource(): RecordSource;

--- a/types/relay-runtime/lib/store/RelayResponseNormalizer.d.ts
+++ b/types/relay-runtime/lib/store/RelayResponseNormalizer.d.ts
@@ -5,7 +5,7 @@ export type GetDataID = (fieldValue: { [key: string]: any }, typeName: string) =
 
 export interface NormalizationOptions {
     getDataID: GetDataID;
-    path?: ReadonlyArray<string>;
+    path?: ReadonlyArray<string> | undefined;
     request: RequestDescriptor;
 }
 

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -594,7 +594,7 @@ export interface Environment {
      */
     execute(config: {
         operation: OperationDescriptor;
-        updater?: SelectorStoreUpdater | null;
+        updater?: SelectorStoreUpdater | null | undefined;
     }): RelayObservable<GraphQLResponse>;
 
     /**
@@ -615,10 +615,10 @@ export interface Environment {
         uploadables,
     }: {
         operation: OperationDescriptor;
-        optimisticUpdater?: SelectorStoreUpdater | null;
-        optimisticResponse?: { [key: string]: any } | null;
-        updater?: SelectorStoreUpdater | null;
-        uploadables?: UploadableMap | null;
+        optimisticUpdater?: SelectorStoreUpdater | null | undefined;
+        optimisticResponse?: { [key: string]: any } | null | undefined;
+        updater?: SelectorStoreUpdater | null | undefined;
+        uploadables?: UploadableMap | null | undefined;
     }): RelayObservable<GraphQLResponse>;
 
     /**
@@ -687,7 +687,7 @@ export interface ModuleImportPointer {
 export type AsyncLoadCallback = (loadingState: LoadingState) => void;
 export interface LoadingState {
     status: 'aborted' | 'complete' | 'error' | 'missing';
-    error?: Error;
+    error?: Error | undefined;
 }
 
 /**

--- a/types/relay-runtime/lib/subscription/requestSubscription.d.ts
+++ b/types/relay-runtime/lib/subscription/requestSubscription.d.ts
@@ -4,13 +4,13 @@ import { Disposable, OperationType } from '../util/RelayRuntimeTypes';
 import { SelectorStoreUpdater, Environment } from '../store/RelayStoreTypes';
 
 export interface GraphQLSubscriptionConfig<TSubscription extends OperationType> {
-    configs?: ReadonlyArray<DeclarativeMutationConfig>;
+    configs?: ReadonlyArray<DeclarativeMutationConfig> | undefined;
     subscription: GraphQLTaggedNode;
     variables: TSubscription['variables'];
-    onCompleted?: () => void;
-    onError?: (error: Error) => void;
-    onNext?: (response: TSubscription['response'] | null | undefined) => void;
-    updater?: SelectorStoreUpdater<TSubscription['response']>;
+    onCompleted?: (() => void) | undefined;
+    onError?: ((error: Error) => void) | undefined;
+    onNext?: ((response: TSubscription['response'] | null | undefined) => void) | undefined;
+    updater?: SelectorStoreUpdater<TSubscription['response']> | undefined;
 }
 
 export function requestSubscription<TSubscription extends OperationType = OperationType>(

--- a/types/relay-runtime/lib/util/NormalizationNode.d.ts
+++ b/types/relay-runtime/lib/util/NormalizationNode.d.ts
@@ -19,7 +19,7 @@ export interface NormalizationLinkedField {
     readonly kind: string; // 'LinkedField';
     readonly alias: string | null | undefined;
     readonly name: string;
-    readonly storageKey?: string | null;
+    readonly storageKey?: string | null | undefined;
     readonly args: ReadonlyArray<NormalizationArgument>;
     readonly concreteType: string | null | undefined;
     readonly plural: boolean;
@@ -84,14 +84,14 @@ export interface NormalizationStream {
 export interface NormalizationLiteral {
     readonly kind: string; // 'Literal';
     readonly name: string;
-    readonly type?: string | null;
-    readonly value?: unknown;
+    readonly type?: string | null | undefined;
+    readonly value?: unknown | undefined;
 }
 
 export interface NormalizationVariable {
     readonly kind: string; // 'Variable';
     readonly name: string;
-    readonly type?: string | null;
+    readonly type?: string | null | undefined;
     readonly variableName: string;
 }
 

--- a/types/relay-runtime/lib/util/ReaderNode.d.ts
+++ b/types/relay-runtime/lib/util/ReaderNode.d.ts
@@ -11,13 +11,13 @@ export interface ReaderFragment {
     readonly kind: string; // 'Fragment';
     readonly name: string;
     readonly type: string;
-    readonly abstractKey?: string | null;
+    readonly abstractKey?: string | null | undefined;
     readonly metadata:
         | {
-              readonly connection?: ReadonlyArray<ConnectionMetadata>;
-              readonly mask?: boolean;
-              readonly plural?: boolean;
-              readonly refetch?: ReaderRefetchMetadata;
+              readonly connection?: ReadonlyArray<ConnectionMetadata> | undefined;
+              readonly mask?: boolean | undefined;
+              readonly plural?: boolean | undefined;
+              readonly refetch?: ReaderRefetchMetadata | undefined;
           }
         | null
         | undefined;
@@ -55,7 +55,7 @@ export interface ReaderPaginationMetadata {
 
 export interface ReaderRefetchableFragment extends ReaderFragment {
     readonly metadata: {
-        readonly connection?: [ConnectionMetadata];
+        readonly connection?: [ConnectionMetadata] | undefined;
         readonly refetch: ReaderRefetchMetadata;
     };
 }
@@ -124,7 +124,7 @@ export interface ReaderLiteral {
 export interface ReaderVariable {
     readonly kind: string; // 'Variable';
     readonly name: string;
-    readonly type?: string | null;
+    readonly type?: string | null | undefined;
     readonly variableName: string;
 }
 
@@ -152,10 +152,10 @@ export interface ReaderRootArgument {
 }
 
 export interface ReaderRefetchMetadata {
-    readonly connection?: ReaderPaginationMetadata | null;
+    readonly connection?: ReaderPaginationMetadata | null | undefined;
     readonly operation: string | ConcreteRequest;
     readonly fragmentPathInResult: ReadonlyArray<string>;
-    readonly identifierField?: string | null;
+    readonly identifierField?: string | null | undefined;
 }
 
 export interface ReaderCondition {
@@ -180,7 +180,7 @@ export interface ReaderInlineFragment {
     readonly kind: string; // 'InlineFragment';
     readonly selections: ReadonlyArray<ReaderSelection>;
     readonly type: string;
-    readonly abstractKey?: string | null;
+    readonly abstractKey?: string | null | undefined;
 }
 
 export type ReaderSelectableNode = ReaderFragment | ReaderSplitOperation;

--- a/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
+++ b/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
@@ -21,7 +21,7 @@ export interface ConcreteRequest {
  * for local caching.
  */
 export interface RequestParameters {
-    readonly cacheID?: string | null;
+    readonly cacheID?: string | null | undefined;
     readonly name: string;
     readonly operationKind: string; // 'mutation' | 'query' | 'subscription';
     readonly id: string | null | undefined;

--- a/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts
+++ b/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts
@@ -16,7 +16,7 @@ export interface Variables {
 export interface OperationType {
     readonly variables: Variables;
     readonly response: unknown;
-    readonly rawResponse?: unknown;
+    readonly rawResponse?: unknown | undefined;
 }
 
 export type VariablesOf<TQuery extends OperationType> = TQuery['variables'];
@@ -37,11 +37,11 @@ export type DisposeFn = () => void;
  *   a given instance of executing an operation.
  */
 export interface CacheConfig {
-    force?: boolean | null;
-    poll?: number | null;
-    liveConfigId?: string | null;
-    metadata?: { [key: string]: unknown };
-    transactionId?: string | null;
+    force?: boolean | null | undefined;
+    poll?: number | null | undefined;
+    liveConfigId?: string | null | undefined;
+    metadata?: { [key: string]: unknown } | undefined;
+    transactionId?: string | null | undefined;
 }
 
 /**

--- a/types/request-ip/index.d.ts
+++ b/types/request-ip/index.d.ts
@@ -9,29 +9,29 @@
 import * as http from 'http';
 
 interface RequestHeaders extends http.IncomingHttpHeaders {
-    'x-client-ip'?: string;
-    'x-forwarded-for'?: string;
-    'x-real-ip'?: string;
-    'x-cluster-client-ip'?: string;
-    'x-forwarded'?: string;
-    'forwarded-for'?: string;
-    'forwarded'?: string;
+    'x-client-ip'?: string | undefined;
+    'x-forwarded-for'?: string | undefined;
+    'x-real-ip'?: string | undefined;
+    'x-cluster-client-ip'?: string | undefined;
+    'x-forwarded'?: string | undefined;
+    'forwarded-for'?: string | undefined;
+    'forwarded'?: string | undefined;
 }
 
 interface Request {
     headers: RequestHeaders;
     connection?: {
-        remoteAddress?: string;
+        remoteAddress?: string | undefined;
         socket?: {
-            remoteAddress?: string
-        };
-    };
+            remoteAddress?: string | undefined
+        } | undefined;
+    } | undefined;
     info?: {
-        remoteAddress?: string
-    };
+        remoteAddress?: string | undefined
+    } | undefined;
     socket?: {
-        remoteAddress?: string
-    };
+        remoteAddress?: string | undefined
+    } | undefined;
 }
 
 interface Options {
@@ -45,7 +45,7 @@ export function mw(options?: Options): (req: Request, res: any, next: any) => an
 declare global {
   namespace Express {
     interface Request {
-      clientIp?: string;
+      clientIp?: string | undefined;
     }
   }
 }

--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -15,10 +15,10 @@ declare namespace requestPromise {
     }
 
     interface RequestPromiseOptions extends request.CoreOptions {
-        simple?: boolean;
+        simple?: boolean | undefined;
         transform?(body: any, response: request.Response, resolveWithFullResponse?: boolean): any;
-        transform2xxOnly?: boolean;
-        resolveWithFullResponse?: boolean;
+        transform2xxOnly?: boolean | undefined;
+        resolveWithFullResponse?: boolean | undefined;
     }
 
     type RequestPromiseAPI = request.RequestAPI<RequestPromise, RequestPromiseOptions, request.RequiredUriUrl>;

--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -23,10 +23,10 @@ declare namespace requestPromise {
     }
 
     interface RequestPromiseOptions extends request.CoreOptions {
-        simple?: boolean;
+        simple?: boolean | undefined;
         transform?(body: any, response: request.Response, resolveWithFullResponse?: boolean): any;
-        transform2xxOnly?: boolean;
-        resolveWithFullResponse?: boolean;
+        transform2xxOnly?: boolean | undefined;
+        resolveWithFullResponse?: boolean | undefined;
     }
 
     type RequestPromiseAPI<T= any> = request.RequestAPI<RequestPromise<T>, RequestPromiseOptions, request.RequiredUriUrl>;

--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -117,56 +117,56 @@ declare namespace request {
     }
 
     interface CoreOptions {
-        baseUrl?: string;
-        callback?: RequestCallback;
-        jar?: CookieJar | boolean;
-        formData?: { [key: string]: any };
-        form?: { [key: string]: any } | string;
-        auth?: AuthOptions;
-        oauth?: OAuthOptions;
-        aws?: AWSOptions;
-        hawk?: HawkOptions;
+        baseUrl?: string | undefined;
+        callback?: RequestCallback | undefined;
+        jar?: CookieJar | boolean | undefined;
+        formData?: { [key: string]: any } | undefined;
+        form?: { [key: string]: any } | string | undefined;
+        auth?: AuthOptions | undefined;
+        oauth?: OAuthOptions | undefined;
+        aws?: AWSOptions | undefined;
+        hawk?: HawkOptions | undefined;
         qs?: any;
         qsStringifyOptions?: any;
         qsParseOptions?: any;
         json?: any;
-        jsonReviver?: (key: string, value: any) => any;
-        jsonReplacer?: (key: string, value: any) => any;
-        multipart?: RequestPart[] | Multipart;
-        agent?: http.Agent | https.Agent;
-        agentOptions?: http.AgentOptions | https.AgentOptions;
+        jsonReviver?: ((key: string, value: any) => any) | undefined;
+        jsonReplacer?: ((key: string, value: any) => any) | undefined;
+        multipart?: RequestPart[] | Multipart | undefined;
+        agent?: http.Agent | https.Agent | undefined;
+        agentOptions?: http.AgentOptions | https.AgentOptions | undefined;
         agentClass?: any;
         forever?: any;
-        host?: string;
-        port?: number;
-        method?: string;
-        headers?: Headers;
+        host?: string | undefined;
+        port?: number | undefined;
+        method?: string | undefined;
+        headers?: Headers | undefined;
         body?: any;
-        family?: 4 | 6;
-        followRedirect?: boolean | ((response: http.IncomingMessage) => boolean);
-        followAllRedirects?: boolean;
-        followOriginalHttpMethod?: boolean;
-        maxRedirects?: number;
-        removeRefererHeader?: boolean;
-        encoding?: string | null;
-        pool?: PoolOptions;
-        timeout?: number;
-        localAddress?: string;
+        family?: 4 | 6 | undefined;
+        followRedirect?: boolean | ((response: http.IncomingMessage) => boolean) | undefined;
+        followAllRedirects?: boolean | undefined;
+        followOriginalHttpMethod?: boolean | undefined;
+        maxRedirects?: number | undefined;
+        removeRefererHeader?: boolean | undefined;
+        encoding?: string | null | undefined;
+        pool?: PoolOptions | undefined;
+        timeout?: number | undefined;
+        localAddress?: string | undefined;
         proxy?: any;
-        tunnel?: boolean;
-        strictSSL?: boolean;
-        rejectUnauthorized?: boolean;
-        time?: boolean;
-        gzip?: boolean;
-        preambleCRLF?: boolean;
-        postambleCRLF?: boolean;
-        withCredentials?: boolean;
-        key?: Buffer;
-        cert?: Buffer;
-        passphrase?: string;
-        ca?: string | Buffer | string[] | Buffer[];
-        har?: HttpArchiveRequest;
-        useQuerystring?: boolean;
+        tunnel?: boolean | undefined;
+        strictSSL?: boolean | undefined;
+        rejectUnauthorized?: boolean | undefined;
+        time?: boolean | undefined;
+        gzip?: boolean | undefined;
+        preambleCRLF?: boolean | undefined;
+        postambleCRLF?: boolean | undefined;
+        withCredentials?: boolean | undefined;
+        key?: Buffer | undefined;
+        cert?: Buffer | undefined;
+        passphrase?: string | undefined;
+        ca?: string | Buffer | string[] | Buffer[] | undefined;
+        har?: HttpArchiveRequest | undefined;
+        useQuerystring?: boolean | undefined;
     }
 
     interface UriOptions {
@@ -188,17 +188,17 @@ declare namespace request {
     type RequestCallback = (error: any, response: Response, body: any) => void;
 
     interface HttpArchiveRequest {
-        url?: string;
-        method?: string;
-        headers?: NameValuePair[];
+        url?: string | undefined;
+        method?: string | undefined;
+        headers?: NameValuePair[] | undefined;
         postData?: {
-            mimeType?: string;
-            params?: NameValuePair[];
-        };
+            mimeType?: string | undefined;
+            params?: NameValuePair[] | undefined;
+        } | undefined;
     }
 
     interface ExtraPoolOptions {
-        maxSockets?: number;
+        maxSockets?: number | undefined;
     }
 
     type PoolOptions = false | { [key: string]: http.Agent | https.Agent } & ExtraPoolOptions | ExtraPoolOptions;
@@ -209,22 +209,22 @@ declare namespace request {
     }
 
     interface Multipart {
-        chunked?: boolean;
+        chunked?: boolean | undefined;
         data?: Array<{
-            'content-type'?: string,
+            'content-type'?: string | undefined,
             body: MultipartBody
-        }>;
+        }> | undefined;
     }
 
     interface RequestPart {
-        headers?: Headers;
+        headers?: Headers | undefined;
         body: any;
     }
 
     interface Request extends caseless.Httpified, stream.Stream {
         readable: boolean;
         writable: boolean;
-        explicitMethod?: true;
+        explicitMethod?: true | undefined;
 
         debug(...args: any[]): void;
         pipeDest(dest: any): void;
@@ -261,34 +261,34 @@ declare namespace request {
         toJSON(): RequestAsJSON;
 
         // several of the CoreOptions are copied onto the request instance
-        host?: string;
-        port?: number;
-        followAllRedirects?: boolean;
-        followOriginalHttpMethod?: boolean;
-        maxRedirects?: number;
-        removeRefererHeader?: boolean;
-        encoding?: string | null;
-        timeout?: number;
-        localAddress?: string;
-        strictSSL?: boolean;
-        rejectUnauthorized?: boolean;
-        time?: boolean;
-        gzip?: boolean;
-        preambleCRLF?: boolean;
-        postambleCRLF?: boolean;
-        withCredentials?: boolean;
-        key?: Buffer;
-        cert?: Buffer;
-        passphrase?: string;
-        ca?: string | Buffer | string[] | Buffer[];
-        har?: HttpArchiveRequest;
+        host?: string | undefined;
+        port?: number | undefined;
+        followAllRedirects?: boolean | undefined;
+        followOriginalHttpMethod?: boolean | undefined;
+        maxRedirects?: number | undefined;
+        removeRefererHeader?: boolean | undefined;
+        encoding?: string | null | undefined;
+        timeout?: number | undefined;
+        localAddress?: string | undefined;
+        strictSSL?: boolean | undefined;
+        rejectUnauthorized?: boolean | undefined;
+        time?: boolean | undefined;
+        gzip?: boolean | undefined;
+        preambleCRLF?: boolean | undefined;
+        postambleCRLF?: boolean | undefined;
+        withCredentials?: boolean | undefined;
+        key?: Buffer | undefined;
+        cert?: Buffer | undefined;
+        passphrase?: string | undefined;
+        ca?: string | Buffer | string[] | Buffer[] | undefined;
+        har?: HttpArchiveRequest | undefined;
 
         // set in `Request.prototype.init`
         headers: Headers;
         method: string;
         pool: PoolOptions;
         dests: stream.Readable[];
-        callback?: RequestCallback;
+        callback?: RequestCallback | undefined;
         uri: Url & { href: string, pathname: string };
         proxy: null | string | Url;
         tunnel: boolean;
@@ -296,24 +296,24 @@ declare namespace request {
         path: string;
         agent: false | http.Agent | https.Agent;
         body: Buffer | Buffer[] | string | string[] | stream.Readable;
-        timing?: boolean;
-        src?: stream.Readable;
+        timing?: boolean | undefined;
+        src?: stream.Readable | undefined;
 
         // set in `Request.prototype.start`
         href: string;
-        startTime?: number;
-        startTimeNow?: number;
+        startTime?: number | undefined;
+        startTimeNow?: number | undefined;
         timings?: {
             socket: number;
             lookup: number;
             connect: number;
             response: number;
             end: number;
-        };
+        } | undefined;
 
         // set in `Request.prototype.onRequestResponse`
-        elapsedTime?: number;
-        response?: Response;
+        elapsedTime?: number | undefined;
+        response?: Response | undefined;
     }
 
     interface Response extends http.IncomingMessage {
@@ -324,15 +324,15 @@ declare namespace request {
         caseless: caseless.Caseless; // case-insensitive access to headers
         toJSON(): ResponseAsJSON;
 
-        timingStart?: number;
-        elapsedTime?: number;
+        timingStart?: number | undefined;
+        elapsedTime?: number | undefined;
         timings?: {
             socket: number;
             lookup: number;
             connect: number;
             response: number;
             end: number;
-        };
+        } | undefined;
         timingPhases?: {
             wait: number;
             dns: number;
@@ -340,7 +340,7 @@ declare namespace request {
             firstByte: number;
             download: number;
             total: number;
-        };
+        } | undefined;
     }
 
     // aliases for backwards compatibility
@@ -352,23 +352,23 @@ declare namespace request {
     }
 
     interface AuthOptions {
-        user?: string;
-        username?: string;
-        pass?: string;
-        password?: string;
-        sendImmediately?: boolean;
-        bearer?: string | (() => string);
+        user?: string | undefined;
+        username?: string | undefined;
+        pass?: string | undefined;
+        password?: string | undefined;
+        sendImmediately?: boolean | undefined;
+        bearer?: string | (() => string) | undefined;
     }
 
     interface OAuthOptions {
-        callback?: string;
-        consumer_key?: string;
-        consumer_secret?: string;
-        token?: string;
-        token_secret?: string;
-        transport_method?: 'body' | 'header' | 'query';
-        verifier?: string;
-        body_hash?: true | string;
+        callback?: string | undefined;
+        consumer_key?: string | undefined;
+        consumer_secret?: string | undefined;
+        token?: string | undefined;
+        token_secret?: string | undefined;
+        transport_method?: 'body' | 'header' | 'query' | undefined;
+        verifier?: string | undefined;
+        body_hash?: true | string | undefined;
     }
 
     interface HawkOptions {
@@ -377,7 +377,7 @@ declare namespace request {
 
     interface AWSOptions {
         secret: string;
-        bucket?: string;
+        bucket?: string | undefined;
     }
 
     interface RequestAsJSON {

--- a/types/requestidlecallback/index.d.ts
+++ b/types/requestidlecallback/index.d.ts
@@ -14,7 +14,7 @@ interface IdleDeadline {
 }
 
 interface IdleRequestOptions {
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 type IdleCallbackHandle = number;

--- a/types/require-directory/index.d.ts
+++ b/types/require-directory/index.d.ts
@@ -24,22 +24,22 @@ declare namespace requireDirectory {
          * @description array of file extensions that will be included in resulting hash as modules
          * @default "['js', 'json', 'coffee']"
          */
-        extensions?: string[];
+        extensions?: string[] | undefined;
         /**
          * @description option to include subdirectories
          * @default true
          */
-        recurse?: boolean;
+        recurse?: boolean | undefined;
         /**
          * @description RegExp or function for whitelisting modules
          * @default undefined
          */
-        include?: RegExp | CheckPathFn;
+        include?: RegExp | CheckPathFn | undefined;
         /**
          * @description RegExp or function for blacklisting modules
          * @default undefined
          */
-        exclude?: RegExp | CheckPathFn;
+        exclude?: RegExp | CheckPathFn | undefined;
         /**
          * @description function for renaming modules in resulting hash
          * @param name name of required module

--- a/types/require-from-string/index.d.ts
+++ b/types/require-from-string/index.d.ts
@@ -15,12 +15,12 @@ declare namespace requireFromString {
          * List of `paths`, that will be appended to module `paths`.
          * Useful when you want to be able require modules from these paths.
          */
-        appendPaths?: string[];
+        appendPaths?: string[] | undefined;
         /**
          * List of `paths`, that will be preppended to module `paths`.
          * Useful when you want to be able require modules from these paths.
          */
-        prependPaths?: string[];
+        prependPaths?: string[] | undefined;
     }
 }
 

--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -61,12 +61,12 @@ interface RequireShim {
     /**
     * List of dependencies.
     **/
-    deps?: string[];
+    deps?: string[] | undefined;
 
     /**
     * Name the module will be exported as.
     **/
-    exports?: string;
+    exports?: string | undefined;
 
     /**
     * Initialize function with all dependcies passed in,
@@ -76,7 +76,7 @@ interface RequireShim {
     * @param dependencies
     * @return
     **/
-    init?: (...dependencies: any[]) => any;
+    init?: ((...dependencies: any[]) => any) | undefined;
 }
 
 interface RequireConfig {
@@ -84,20 +84,20 @@ interface RequireConfig {
     /**
     * The root path to use for all module lookups.
     */
-    baseUrl?: string;
+    baseUrl?: string | undefined;
 
     /**
     * Path mappings for module names not found directly under
     * baseUrl.
     */
-    paths?: { [key: string]: any; };
+    paths?: { [key: string]: any; } | undefined;
 
 
     /**
     * Dictionary of Shim's.
     * Can be of type RequireShim or string[] of dependencies
     */
-    shim?: { [key: string]: RequireShim | string[]; };
+    shim?: { [key: string]: RequireShim | string[]; } | undefined;
 
     /**
     * For the given module prefix, instead of loading the
@@ -120,7 +120,7 @@ interface RequireConfig {
         [id: string]: {
             [id: string]: string;
         };
-    };
+    } | undefined;
 
     /**
     * Allows pointing multiple module IDs to a module ID that contains a bundle of modules.
@@ -133,56 +133,56 @@ interface RequireConfig {
     *    }
     * });
     **/
-    bundles?: { [key: string]: string[]; };
+    bundles?: { [key: string]: string[]; } | undefined;
 
     /**
     * AMD configurations, use module.config() to access in
     * define() functions
     **/
-    config?: { [id: string]: {}; };
+    config?: { [id: string]: {}; } | undefined;
 
     /**
     * Configures loading modules from CommonJS packages.
     **/
-    packages?: {};
+    packages?: {} | undefined;
 
     /**
     * The number of seconds to wait before giving up on loading
     * a script.  The default is 7 seconds.
     **/
-    waitSeconds?: number;
+    waitSeconds?: number | undefined;
 
     /**
     * A name to give to a loading context.  This allows require.js
     * to load multiple versions of modules in a page, as long as
     * each top-level require call specifies a unique context string.
     **/
-    context?: string;
+    context?: string | undefined;
 
     /**
     * An array of dependencies to load.
     **/
-    deps?: string[];
+    deps?: string[] | undefined;
 
     /**
     * A function to pass to require that should be require after
     * deps have been loaded.
     * @param modules
     **/
-    callback?: (...modules: any[]) => void;
+    callback?: ((...modules: any[]) => void) | undefined;
 
     /**
     * If set to true, an error will be thrown if a script loads
     * that does not call define() or have shim exports string
     * value that can be checked.
     **/
-    enforceDefine?: boolean;
+    enforceDefine?: boolean | undefined;
 
     /**
     * If set to true, document.createElementNS() will be used
     * to create script elements.
     **/
-    xhtml?: boolean;
+    xhtml?: boolean | undefined;
 
     /**
     * Extra query string arguments appended to URLs that RequireJS
@@ -212,7 +212,7 @@ interface RequireConfig {
     *     }
     * });
     **/
-    urlArgs?: string | ((id: string, url: string) => string); 
+    urlArgs?: string | ((id: string, url: string) => string) | undefined; 
 
     /**
     * Specify the value for the type="" attribute used for script
@@ -220,7 +220,7 @@ interface RequireConfig {
     * "text/javascript".  To use Firefox's JavasScript 1.8
     * features, use "text/javascript;version=1.8".
     **/
-    scriptType?: string;
+    scriptType?: string | undefined;
 
     /**
     * If set to true, skips the data-main attribute scanning done
@@ -229,13 +229,13 @@ interface RequireConfig {
     * library on the page, and the embedded version should not do
     * data-main loading.
     **/
-    skipDataMain?: boolean;
+    skipDataMain?: boolean | undefined;
 
     /**
     * Allow extending requirejs to support Subresource Integrity
     * (SRI).
     **/
-    onNodeCreated?: (node: HTMLScriptElement, config: RequireConfig, moduleName: string, url: string) => void;
+    onNodeCreated?: ((node: HTMLScriptElement, config: RequireConfig, moduleName: string, url: string) => void) | undefined;
 }
 
 // todo: not sure what to do with this guy

--- a/types/resize-observer-browser/index.d.ts
+++ b/types/resize-observer-browser/index.d.ts
@@ -16,7 +16,7 @@ interface ResizeObserverOptions {
      *
      * @default 'content-box'
      */
-    box?: 'content-box' | 'border-box' | 'device-pixel-content-box';
+    box?: 'content-box' | 'border-box' | 'device-pixel-content-box' | undefined;
 }
 
 interface ResizeObserverSize {
@@ -44,5 +44,5 @@ interface ResizeObserverEntry {
     readonly contentRect: DOMRectReadOnly;
     readonly borderBoxSize: ReadonlyArray<ResizeObserverSize>;
     readonly contentBoxSize: ReadonlyArray<ResizeObserverSize>;
-    readonly devicePixelContentBoxSize?: ReadonlyArray<ResizeObserverSize>;
+    readonly devicePixelContentBoxSize?: ReadonlyArray<ResizeObserverSize> | undefined;
 }

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -90,23 +90,23 @@ declare function resolveIsCore(id: string): boolean | undefined;
 declare namespace resolve {
   interface Opts {
     /** directory to begin resolving from (defaults to __dirname) */
-    basedir?: string;
+    basedir?: string | undefined;
     /** package.json data applicable to the module being loaded */
     package?: any;
     /** set to false to exclude node core modules (e.g. fs) from the search */
-    includeCoreModules?: boolean;
+    includeCoreModules?: boolean | undefined;
     /** array of file extensions to search in order (defaults to ['.js']) */
-    extensions?: string | ReadonlyArray<string>;
+    extensions?: string | ReadonlyArray<string> | undefined;
     /** transform the parsed package.json contents before looking at the "main" field */
-    packageFilter?: (pkg: any, pkgfile: string) => any;
+    packageFilter?: ((pkg: any, pkgfile: string) => any) | undefined;
     /** transform a path within a package */
-    pathFilter?: (pkg: any, path: string, relativePath: string) => string;
+    pathFilter?: ((pkg: any, path: string, relativePath: string) => string) | undefined;
     /** require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this) */
-    paths?: string | ReadonlyArray<string>;
+    paths?: string | ReadonlyArray<string> | undefined;
     /** return the list of candidate paths where the packages sources may be found (probably don't use this) */
-    packageIterator?: (request: string, start: string, getPackageCandidates: () => string[], opts: Opts) => string[];
+    packageIterator?: ((request: string, start: string, getPackageCandidates: () => string[], opts: Opts) => string[]) | undefined;
     /** directory (or directories) in which to recursively look for modules. (default to 'node_modules') */
-    moduleDirectory?: string | ReadonlyArray<string>;
+    moduleDirectory?: string | ReadonlyArray<string> | undefined;
     /**
      * if true, doesn't resolve `basedir` to real path before resolving.
      * This is the way Node resolves dependencies when executed with the --preserve-symlinks flag.
@@ -114,49 +114,49 @@ declare namespace resolve {
      * Note: this property is currently true by default but it will be changed to false in the next major version because Node's resolution
      * algorithm does not preserve symlinks by default.
      */
-    preserveSymlinks?: boolean;
+    preserveSymlinks?: boolean | undefined;
   }
 
   interface BaseAsyncOpts extends Opts {
     /** function to asynchronously test whether a file exists */
-    isFile?: (file: string, cb: existsCallback) => void;
+    isFile?: ((file: string, cb: existsCallback) => void) | undefined;
     /** function to asynchronously test whether a directory exists */
-    isDirectory?: (directory: string, cb: existsCallback) => void;
+    isDirectory?: ((directory: string, cb: existsCallback) => void) | undefined;
     /** function to asynchronously resolve a potential symlink to its real path */
-    realpath?: (file: string, cb: realpathCallback) => void;
+    realpath?: ((file: string, cb: realpathCallback) => void) | undefined;
   }
 
   export type AsyncOpts = BaseAsyncOpts & ({
     /** how to read files asynchronously (defaults to fs.readFile) */
-    readFile?: (file: string, cb: readFileCallback) => void;
+    readFile?: ((file: string, cb: readFileCallback) => void) | undefined;
     /** function to asynchronously read and parse a package.json file */
-    readPackage?: never;
+    readPackage?: never | undefined;
   } | {
     /** how to read files asynchronously (defaults to fs.readFile) */
-    readFile?: never
+    readFile?: never | undefined
     /** function to asynchronously read and parse a package.json file */
-    readPackage?: (readFile: (file: string, cb: readFileCallback) => void, pkgfile: string, cb: readPackageCallback) => void;
+    readPackage?: ((readFile: (file: string, cb: readFileCallback) => void, pkgfile: string, cb: readPackageCallback) => void) | undefined;
   });
 
   interface BaseSyncOpts extends Opts {
     /** function to synchronously test whether a file exists */
-    isFile?: (file: string) => boolean;
+    isFile?: ((file: string) => boolean) | undefined;
     /** function to synchronously test whether a directory exists */
-    isDirectory?: (directory: string) => boolean;
+    isDirectory?: ((directory: string) => boolean) | undefined;
     /** function to synchronously resolve a potential symlink to its real path */
-    realpathSync?: (file: string) => string;
+    realpathSync?: ((file: string) => string) | undefined;
   }
 
   export type SyncOpts = BaseSyncOpts & ({
     /** how to read files synchronously (defaults to fs.readFileSync) */
-    readFileSync?: (file: string) => StringOrToString;
+    readFileSync?: ((file: string) => StringOrToString) | undefined;
     /** function to synchronously read and parse a package.json file */
-    readPackageSync?: never;
+    readPackageSync?: never | undefined;
   } | {
     /** how to read files synchronously (defaults to fs.readFileSync) */
-    readFileSync?: never;
+    readFileSync?: never | undefined;
     /** function to synchronously read and parse a package.json file */
-    readPackageSync?: (readFileSync: (file: string) => StringOrToString, pkgfile: string) => Record<string, unknown> | undefined;
+    readPackageSync?: ((readFileSync: (file: string) => StringOrToString, pkgfile: string) => Record<string, unknown> | undefined) | undefined;
   });
 
   export var sync: typeof resolveSync;

--- a/types/response-time/index.d.ts
+++ b/types/response-time/index.d.ts
@@ -37,9 +37,9 @@ declare function responseTime(fn: (request: express.Request, response: express.R
 
 declare namespace responseTime {
     export interface ResponseTimeOptions {
-        digits?: number;
-        header?: string;
-        suffix?: boolean;
+        digits?: number | undefined;
+        header?: string | undefined;
+        suffix?: boolean | undefined;
     }
 
     export interface ResponseTimeFunction {

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -21,59 +21,59 @@ import zlib = require('zlib');
 import { File } from 'formidable';
 
 export interface ServerOptions {
-    ca?: string | Buffer | ReadonlyArray<string | Buffer>;
+    ca?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    certificate?: string | Buffer | ReadonlyArray<string | Buffer>;
+    certificate?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    cert?: string | Buffer | ReadonlyArray<string | Buffer>;
+    cert?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    key?: string | Buffer | ReadonlyArray<string | Buffer>;
+    key?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    passphrase?: string;
+    passphrase?: string | undefined;
 
-    requestCert?: boolean;
+    requestCert?: boolean | undefined;
 
-    ciphers?: string;
+    ciphers?: string | undefined;
 
-    formatters?: Formatters;
+    formatters?: Formatters | undefined;
 
-    log?: Logger;
+    log?: Logger | undefined;
 
-    name?: string;
+    name?: string | undefined;
 
-    spdy?: spdy.ServerOptions;
+    spdy?: spdy.ServerOptions | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 
-    handleUpgrades?: boolean;
+    handleUpgrades?: boolean | undefined;
 
-    httpsServerOptions?: https.ServerOptions;
+    httpsServerOptions?: https.ServerOptions | undefined;
 
-    handleUncaughtExceptions?: boolean;
+    handleUncaughtExceptions?: boolean | undefined;
 
-    router?: Router;
+    router?: Router | undefined;
 
-    socketio?: boolean;
+    socketio?: boolean | undefined;
 
-    noWriteContinue?: boolean;
+    noWriteContinue?: boolean | undefined;
 
-    rejectUnauthorized?: boolean;
+    rejectUnauthorized?: boolean | undefined;
 
-    secureOptions?: number;
+    secureOptions?: number | undefined;
 
     http2?: any;
 
-    dtrace?: boolean;
+    dtrace?: boolean | undefined;
 
-    onceNext?: boolean;
+    onceNext?: boolean | undefined;
 
-    strictNext?: boolean;
+    strictNext?: boolean | undefined;
 
-    ignoreTrailingSlash?: boolean;
+    ignoreTrailingSlash?: boolean | undefined;
 
-    maxParamLength?: number;
+    maxParamLength?: number | undefined;
 }
 
 export interface AddressInterface {
@@ -275,9 +275,9 @@ export interface Server extends http.Server {
 
     useChain: Chain;
 
-    spdy?: boolean;
+    spdy?: boolean | undefined;
 
-    http2?: boolean;
+    http2?: boolean | undefined;
 
     ca: ServerOptions['ca'];
 
@@ -287,13 +287,13 @@ export interface Server extends http.Server {
 
     passphrase: ServerOptions['passphrase'] | null;
 
-    secure?: boolean;
+    secure?: boolean | undefined;
 }
 
 export interface ChainOptions {
-    onceNext?: boolean;
+    onceNext?: boolean | undefined;
 
-    strictNext?: boolean;
+    strictNext?: boolean | undefined;
 }
 
 export interface Chain {
@@ -344,15 +344,15 @@ export interface RouterRegistryRadix {
 }
 
 export interface RouterOptions {
-    log?: Logger;
+    log?: Logger | undefined;
 
-    onceNext?: boolean;
+    onceNext?: boolean | undefined;
 
-    strictNext?: boolean;
+    strictNext?: boolean | undefined;
 
-    ignoreTrailingSlash?: boolean;
+    ignoreTrailingSlash?: boolean | undefined;
 
-    registry?: RouterRegistryRadix;
+    registry?: RouterRegistryRadix | undefined;
 }
 
 export class Router {
@@ -413,7 +413,7 @@ export class Router {
 
     name: string;
 
-    log?: Logger;
+    log?: Logger | undefined;
 
     onceNext: boolean;
 
@@ -426,7 +426,7 @@ export interface RequestAuthorization {
     basic?: {
         username: string;
         password: string;
-    };
+    } | undefined;
 }
 
 export interface Request extends http.IncomingMessage {
@@ -642,13 +642,13 @@ export interface Request extends http.IncomingMessage {
     params?: any;
 
     /** available when multipartBodyParser plugin is used. */
-    files?: { [name: string]: File | undefined; };
+    files?: { [name: string]: File | undefined; } | undefined;
 
     /** available when authorizationParser plugin is used */
-    username?: string;
+    username?: string | undefined;
 
     /** available when authorizationParser plugin is used */
-    authorization?: RequestAuthorization;
+    authorization?: RequestAuthorization | undefined;
 }
 
 export interface CacheOptions {
@@ -840,27 +840,27 @@ export interface RedirectOptions {
     /**
      * whether to redirect to http or https
      */
-    secure?: boolean;
+    secure?: boolean | undefined;
 
     /**
      * redirect location's hostname
      */
-    hostname?: string;
+    hostname?: string | undefined;
 
     /**
      * redirect location's pathname
      */
-    pathname?: string;
+    pathname?: string | undefined;
 
     /**
      * redirect location's port number
      */
-    port?: string;
+    port?: string | undefined;
 
     /**
      * redirect location's query string parameters
      */
-    query?: string|object;
+    query?: string|object | undefined;
 
     /**
      * if true, `options.query`
@@ -868,12 +868,12 @@ export interface RedirectOptions {
      * parameters on current URL.
      * by default, will merge the two.
      */
-    overrideQuery?: boolean;
+    overrideQuery?: boolean | undefined;
 
     /**
      * if true, sets 301. defaults to 302.
      */
-    permanent?: boolean;
+    permanent?: boolean | undefined;
 }
 
 export interface Next {
@@ -882,9 +882,9 @@ export interface Next {
 
 export interface RouteSpec {
     method: string;
-    name?: string;
+    name?: string | undefined;
     path: string | RegExp;
-    versions?: string[];
+    versions?: string[] | undefined;
 }
 
 export interface Route {
@@ -896,19 +896,19 @@ export interface Route {
 }
 
 export interface RouteOptions {
-    name?: string;
+    name?: string | undefined;
 
-    path?: string | RegExp;
+    path?: string | RegExp | undefined;
 
-    url?: string | RegExp;
+    url?: string | RegExp | undefined;
 
-    urlParamPattern?: RegExp;
+    urlParamPattern?: RegExp | undefined;
 
-    contentType?: string | string[];
+    contentType?: string | string[] | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 }
 
 export interface MountOptions {
@@ -916,17 +916,17 @@ export interface MountOptions {
 
     method: string;
 
-    path?: string | RegExp;
+    path?: string | RegExp | undefined;
 
-    url?: string | RegExp;
+    url?: string | RegExp | undefined;
 
-    urlParamPattern?: RegExp;
+    urlParamPattern?: RegExp | undefined;
 
-    contentType?: string | string[];
+    contentType?: string | string[] | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 }
 
 export type FindRouteCallback = (err: Error, route?: Route, params?: any) => void;
@@ -980,32 +980,32 @@ export interface ServerUpgradeResponse {
 export namespace bunyan {
     interface RequestCaptureOptions {
         /** The stream to which to write when dumping captured records. */
-        stream?: Logger.Stream;
+        stream?: Logger.Stream | undefined;
 
         /** The streams to which to write when dumping captured records. */
-        streams?: ReadonlyArray<Logger.Stream>;
+        streams?: ReadonlyArray<Logger.Stream> | undefined;
 
         /**
          * The level at which to trigger dumping captured records. Defaults to
          * bunyan.WARN.
          */
-        level?: Logger.LogLevel;
+        level?: Logger.LogLevel | undefined;
 
         /** Number of records to capture. Default 100. */
-        maxRecords?: number;
+        maxRecords?: number | undefined;
 
         /**
          * Number of simultaneous request id capturing buckets to maintain.
          * Default 1000.
          */
-        maxRequestIds?: number;
+        maxRequestIds?: number | undefined;
 
         /**
          * If true, then dump captured records on the *default* request id when
          * dumping. I.e. dump records logged without "req_id" field. Default
          * false.
          */
-        dumpDefault?: boolean;
+        dumpDefault?: boolean | undefined;
     }
 
     /**
@@ -1108,7 +1108,7 @@ export namespace plugins {
     /**
      * Restify server. If passed in, causes server to emit 'auditlog' event after audit logs are flushed
      */
-    server?: Server;
+    server?: Server | undefined;
 
     /**
      * The optional context function of signature
@@ -1117,7 +1117,7 @@ export namespace plugins {
      * req, res, route, and err objects. The output of this function will be
      * available on the `context` key in the audit object.
      */
-    context?: AuditLoggerContext;
+    context?: AuditLoggerContext | undefined;
 
     /**
      * Ringbuffer which is written to if passed in
@@ -1127,9 +1127,9 @@ export namespace plugins {
     /**
      * When true, prints audit logs. default true.
      */
-    printLog?: boolean;
+    printLog?: boolean | undefined;
 
-    body?: boolean;
+    body?: boolean | undefined;
   }
 
   /**
@@ -1144,8 +1144,8 @@ export namespace plugins {
 
   interface HandlerCandidate {
     handler: RequestHandler | RequestHandler[];
-    version?: string | string[];
-    contentType?: string | string[];
+    version?: string | string[] | undefined;
+    contentType?: string | string[] | undefined;
   }
 
   /**
@@ -1161,10 +1161,10 @@ export namespace plugins {
   function conditionalRequest(): RequestHandler[];
 
   interface CpuUsageThrottleOptions {
-    limit?: number;
-    max?: number;
-    interval?: number;
-    halfLife?: number;
+    limit?: number | undefined;
+    max?: number | undefined;
+    interval?: number | undefined;
+    halfLife?: number | undefined;
   }
 
   /**
@@ -1183,26 +1183,26 @@ export namespace plugins {
     /**
      * The maximum size in bytes allowed in the HTTP body. Useful for limiting clients from hogging server memory.
      */
-    maxBodySize?: number;
+    maxBodySize?: number | undefined;
 
     /**
      * If req.params should be filled with parsed parameters from HTTP body.
      */
-    mapParams?: boolean;
+    mapParams?: boolean | undefined;
 
     /**
      * If req.params should be filled with the contents of files sent through a multipart request.
      * Formidable is used internally for parsing, and a file is denoted as a multipart part with the filename option set in its Content-Disposition.
      * This will only be performed if mapParams is true.
      */
-    mapFiles?: boolean;
+    mapFiles?: boolean | undefined;
 
     /**
      * If an entry in req.params should be overwritten by the value in the body if the names are the same.
      * For instance, if you have the route /:someval, and someone posts an x-www-form-urlencoded Content-Type with the body someval=happy to /sad,
      * the value will be happy if overrideParams is true, sad otherwise.
      */
-    overrideParams?: boolean;
+    overrideParams?: boolean | undefined;
 
     /**
      * A callback to handle any multipart part which is not a file.
@@ -1221,35 +1221,35 @@ export namespace plugins {
     /**
      * If you want the uploaded files to include the extensions of the original files (multipart uploads only). Does nothing if multipartFileHandler is defined.
      */
-    keepExtensions?: boolean;
+    keepExtensions?: boolean | undefined;
 
     /**
      * Where uploaded files are intermediately stored during transfer before the contents is mapped into req.params. Does nothing if multipartFileHandler is defined.
      */
-    uploadDir?: string;
+    uploadDir?: string | undefined;
 
     /**
      * If you want to support html5 multiple attribute in upload fields.
      */
-    multiples?: boolean;
+    multiples?: boolean | undefined;
 
     /**
      * If you want checksums calculated for incoming files, set this to either sha1 or md5.
      */
-    hash?: string;
+    hash?: string | undefined;
 
     /**
      * Set to true if you want to end the request with a UnsupportedMediaTypeError when none of the supported content types was given.
      */
-    rejectUnknown?: boolean;
+    rejectUnknown?: boolean | undefined;
 
-    requestBodyOnGet?: boolean;
+    requestBodyOnGet?: boolean | undefined;
 
     reviver?: any;
 
-    maxFieldsSize?: number;
+    maxFieldsSize?: number | undefined;
 
-    maxFileSize?: number;
+    maxFileSize?: number | undefined;
   }
 
   /**
@@ -1260,12 +1260,12 @@ export namespace plugins {
   /**
    * Reads the body of the request.
    */
-  function bodyReader(options?: { maxBodySize?: number }): RequestHandler;
+  function bodyReader(options?: { maxBodySize?: number | undefined }): RequestHandler;
 
   interface UrlEncodedBodyParserOptions {
-    mapParams?: boolean;
-    overrideParams?: boolean;
-    bodyReader?: boolean;
+    mapParams?: boolean | undefined;
+    overrideParams?: boolean | undefined;
+    bodyReader?: boolean | undefined;
   }
 
   /**
@@ -1279,10 +1279,10 @@ export namespace plugins {
   ): RequestHandler[];
 
   interface JsonBodyParserOptions {
-    mapParams?: boolean;
-    overrideParams?: boolean;
+    mapParams?: boolean | undefined;
+    overrideParams?: boolean | undefined;
     reviver?(key: any, value: any): any;
-    bodyReader?: boolean;
+    bodyReader?: boolean | undefined;
   }
 
   /**
@@ -1296,17 +1296,17 @@ export namespace plugins {
   function jsonp(): RequestHandler;
 
   interface MultipartBodyParser {
-    overrideParams?: boolean;
-    multiples?: boolean;
-    keepExtensions?: boolean;
-    uploadDir?: string;
-    maxFieldsSize?: number;
-    hash?: string;
+    overrideParams?: boolean | undefined;
+    multiples?: boolean | undefined;
+    keepExtensions?: boolean | undefined;
+    uploadDir?: string | undefined;
+    maxFieldsSize?: number | undefined;
+    hash?: string | undefined;
     multipartFileHandler?: any;
     multipartHandler?: any;
-    mapParams?: boolean;
-    mapFiles?: boolean;
-    maxFileSize?: number;
+    mapParams?: boolean | undefined;
+    mapFiles?: boolean | undefined;
+    maxFileSize?: number | undefined;
   }
 
   /**
@@ -1318,48 +1318,48 @@ export namespace plugins {
     /**
      * Default `false`. Copies parsed query parameters into `req.params`.
      */
-    mapParams?: boolean;
+    mapParams?: boolean | undefined;
 
     /**
      * Default `false`. Only applies when if mapParams true. When true, will stomp on req.params field when existing value is found.
      */
-    overrideParams?: boolean;
+    overrideParams?: boolean | undefined;
 
     /**
      *  Default false. Transform `?foo.bar=baz` to a nested object: `{foo: {bar: 'baz'}}`.
      */
-    allowDots?: boolean;
+    allowDots?: boolean | undefined;
 
     /**
      * Default 20. Only transform `?a[$index]=b` to an array if `$index` is less than `arrayLimit`.
      */
-    arrayLimit?: number;
+    arrayLimit?: number | undefined;
 
     /**
      * Default 5. The depth limit for parsing nested objects, e.g. `?a[b][c][d][e][f][g][h][i]=j`.
      */
-    depth?: number;
+    depth?: number | undefined;
 
     /**
      * Default 1000. Maximum number of query params parsed. Additional params are silently dropped.
      */
-    parameterLimit?: number;
+    parameterLimit?: number | undefined;
 
     /**
      * Default true. Whether to parse `?a[]=b&a[1]=c` to an array, e.g. `{a: ['b', 'c']}`.
      */
-    parseArrays?: boolean;
+    parseArrays?: boolean | undefined;
 
     /**
      * Default false. Whether `req.query` is a "plain" object -- does not inherit from `Object`.
      * This can be used to allow query params whose names collide with Object methods, e.g. `?hasOwnProperty=blah`.
      */
-    plainObjects?: boolean;
+    plainObjects?: boolean | undefined;
 
     /**
      * Default false. If true, `?a&b=` results in `{a: null, b: ''}`. Otherwise, `{a: '', b: ''}`.
      */
-    strictNullHandling?: boolean;
+    strictNullHandling?: boolean | undefined;
   }
 
   /**
@@ -1406,15 +1406,15 @@ export namespace plugins {
   ): RequestHandler;
 
   interface ServeStatic {
-    appendRequestPath?: boolean;
-    directory?: string;
-    maxAge?: number;
+    appendRequestPath?: boolean | undefined;
+    directory?: string | undefined;
+    maxAge?: number | undefined;
     match?: any;
-    charSet?: string;
-    file?: string;
-    etag?: string;
+    charSet?: string | undefined;
+    file?: string | undefined;
+    etag?: string | undefined;
     default?: any;
-    gzip?: boolean;
+    gzip?: boolean | undefined;
   }
 
   /**
@@ -1423,9 +1423,9 @@ export namespace plugins {
   function serveStatic(options?: ServeStatic): RequestHandler;
 
   interface ServeStaticFiles {
-    maxAge?: number;
-    etag?: string;
-    setHeaders?: (res: Response, path: string, stat: any) => any;
+    maxAge?: number | undefined;
+    etag?: string | undefined;
+    setHeaders?: ((res: Response, path: string, stat: any) => any) | undefined;
   }
 
   /**
@@ -1437,14 +1437,14 @@ export namespace plugins {
   ): RequestHandler;
 
   interface ThrottleOptions {
-    burst?: number;
-    rate?: number;
-    setHeaders?: boolean;
-    ip?: boolean;
-    username?: boolean;
-    xff?: boolean;
+    burst?: number | undefined;
+    rate?: number | undefined;
+    setHeaders?: boolean | undefined;
+    ip?: boolean | undefined;
+    username?: boolean | undefined;
+    xff?: boolean | undefined;
     tokensTable?: any;
-    maxKeys?: number;
+    maxKeys?: number | undefined;
     overrides?: any; // any
   }
 
@@ -1568,17 +1568,17 @@ export namespace plugins {
     /**
      * Header name of the absolute time for request expiration
      */
-    absoluteHeader?: string;
+    absoluteHeader?: string | undefined;
 
     /**
      * Header name for the start time of the request
      */
-    startHeader?: string;
+    startHeader?: string | undefined;
 
     /**
      * The header name for the time in milliseconds that should ellapse before the request is considered expired.
      */
-    timeoutHeader?: string;
+    timeoutHeader?: string | undefined;
   }
 
   /**

--- a/types/restify/v4/index.d.ts
+++ b/types/restify/v4/index.d.ts
@@ -30,7 +30,7 @@ export interface requestAuthorization {
     basic?: {
         username: string;
         password: string;
-    };
+    } | undefined;
 }
 
 export interface Request extends http.IncomingMessage {
@@ -201,7 +201,7 @@ export interface Request extends http.IncomingMessage {
      */
     version(): string;
     params: any;
-    files?: { [name: string]: requestFileInterface };
+    files?: { [name: string]: requestFileInterface } | undefined;
 
     /**
      * Check if the incoming request is encrypted.
@@ -210,9 +210,9 @@ export interface Request extends http.IncomingMessage {
     /** available when bodyParser plugin is used */
     body?: any;
     /** available when authorizationParser plugin is used */
-    username?: string;
+    username?: string | undefined;
     /** available when authorizationParser plugin is used */
-    authorization?: requestAuthorization;
+    authorization?: requestAuthorization | undefined;
 
     timers: HandlerTiming[];
 }
@@ -260,11 +260,11 @@ export interface Route {
 export interface RouteOptions {
     name: string;
     method: string;
-    path?: string | RegExp;
-    url?: string | RegExp;
-    urlParamPattern?: RegExp;
-    contentType?: string | string[];
-    versions?: string | string[];
+    path?: string | RegExp | undefined;
+    url?: string | RegExp | undefined;
+    urlParamPattern?: RegExp | undefined;
+    contentType?: string | string[] | undefined;
+    versions?: string | string[] | undefined;
 }
 
 export interface RoutePathRegex extends RegExp {
@@ -360,65 +360,65 @@ export interface Server extends http.Server {
 }
 
 export interface ServerOptions {
-    ca?: string;
-    certificate?: string | string[] | Buffer | Buffer[];
-    key?: string | string[] | Buffer | Buffer[];
+    ca?: string | undefined;
+    certificate?: string | string[] | Buffer | Buffer[] | undefined;
+    key?: string | string[] | Buffer | Buffer[] | undefined;
     formatters?: any;
     log?: any;
-    name?: string;
+    name?: string | undefined;
     spdy?: any;
-    version?: string;
-    responseTimeHeader?: string;
+    version?: string | undefined;
+    responseTimeHeader?: string | undefined;
     responseTimeFormatter?(durationInMilliseconds: number): any;
-    handleUpgrades?: boolean;
-    router?: Router;
+    handleUpgrades?: boolean | undefined;
+    router?: Router | undefined;
     httpsServerOptions?: any;
-    socketio?: boolean;
+    socketio?: boolean | undefined;
 }
 
 export interface ClientOptions {
-    accept?: string;
-    connectTimeout?: number;
-    requestTimeout?: number;
+    accept?: string | undefined;
+    connectTimeout?: number | undefined;
+    requestTimeout?: number | undefined;
     dtrace?: any;
     gzip?: any;
     headers?: any;
     log?: any;
     retry?: any;
     signRequest?(): void;
-    url?: string;
-    userAgent?: string;
-    version?: string;
+    url?: string | undefined;
+    userAgent?: string | undefined;
+    version?: string | undefined;
 }
 
 export interface Client {
-    get(opts: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
-    head(opts: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request, res: Response) => any): any;
-    post(opts: string | { path?: string; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
-    put(opts: string | { path?: string; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
-    patch(opts: string | { path?: string; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
-    del(opts: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request, res: Response) => any): any;
+    get(opts: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
+    head(opts: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request, res: Response) => any): any;
+    post(opts: string | { path?: string | undefined; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
+    put(opts: string | { path?: string | undefined; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
+    patch(opts: string | { path?: string | undefined; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any): any;
+    del(opts: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request, res: Response) => any): any;
     basicAuth(username: string, password: string): any;
 }
 
 export interface HttpClient {
-    get(opts?: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
-    head(opts?: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
-    post(opts?: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
-    put(opts?: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
-    patch(opts?: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
-    del(opts?: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
+    get(opts?: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
+    head(opts?: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
+    post(opts?: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
+    put(opts?: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
+    patch(opts?: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
+    del(opts?: string | { path?: string | undefined; [name: string]: any }, callback?: (err: any, req: Request) => void): any;
     basicAuth(username: string, password: string): any;
 }
 
 export interface ThrottleOptions {
-    burst?: number;
-    rate?: number;
-    ip?: boolean;
-    xff?: boolean;
-    username?: boolean;
+    burst?: number | undefined;
+    rate?: number | undefined;
+    ip?: boolean | undefined;
+    xff?: boolean | undefined;
+    username?: boolean | undefined;
     tokensTable?: any;
-    maxKeys?: number;
+    maxKeys?: number | undefined;
     overrides?: any;
 }
 
@@ -517,9 +517,9 @@ export var defaultResponseHeaders: any;
 
 export function CORS(options?: CORSOptions): RequestHandler;
 export interface CORSOptions {
-    origins?: string[];
-    credentials?: boolean;
-    headers?: string[];
+    origins?: string[] | undefined;
+    credentials?: boolean | undefined;
+    headers?: string[] | undefined;
 }
 
 export const pre: {

--- a/types/restify/v5/index.d.ts
+++ b/types/restify/v5/index.d.ts
@@ -14,43 +14,43 @@ import spdy = require('spdy');
 import stream = require('stream');
 
 export interface ServerOptions {
-    ca?: string | Buffer | ReadonlyArray<string | Buffer>;
+    ca?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    certificate?: string | Buffer | ReadonlyArray<string | Buffer>;
+    certificate?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    key?: string | Buffer | ReadonlyArray<string | Buffer>;
+    key?: string | Buffer | ReadonlyArray<string | Buffer> | undefined;
 
-    passphrase?: string;
+    passphrase?: string | undefined;
 
-    requestCert?: boolean;
+    requestCert?: boolean | undefined;
 
-    ciphers?: string;
+    ciphers?: string | undefined;
 
-    formatters?: Formatters;
+    formatters?: Formatters | undefined;
 
-    log?: Logger;
+    log?: Logger | undefined;
 
-    name?: string;
+    name?: string | undefined;
 
-    spdy?: spdy.ServerOptions;
+    spdy?: spdy.ServerOptions | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 
-    handleUpgrades?: boolean;
+    handleUpgrades?: boolean | undefined;
 
-    httpsServerOptions?: https.ServerOptions;
+    httpsServerOptions?: https.ServerOptions | undefined;
 
-    handleUncaughtExceptions?: boolean;
+    handleUncaughtExceptions?: boolean | undefined;
 
-    router?: Router;
+    router?: Router | undefined;
 
-    socketio?: boolean;
+    socketio?: boolean | undefined;
 
-    noWriteContinue?: boolean;
+    noWriteContinue?: boolean | undefined;
 
-    rejectUnauthorized?: boolean;
+    rejectUnauthorized?: boolean | undefined;
 }
 
 export interface AddressInterface {
@@ -254,15 +254,15 @@ export interface Server extends http.Server {
 }
 
 export interface RouterOptions {
-    contentType?: string | string[];
+    contentType?: string | string[] | undefined;
 
-    strictRouting?: boolean;
+    strictRouting?: boolean | undefined;
 
-    log?: Logger;
+    log?: Logger | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 }
 
 export interface Router {
@@ -343,7 +343,7 @@ export interface Router {
         PUT: Route[];
     };
 
-    log?: Logger;
+    log?: Logger | undefined;
 }
 
 export interface RequestFileInterface {
@@ -357,7 +357,7 @@ export interface RequestAuthorization {
     basic?: {
         username: string;
         password: string;
-    };
+    } | undefined;
 }
 
 export interface Request extends http.IncomingMessage {
@@ -566,13 +566,13 @@ export interface Request extends http.IncomingMessage {
     params?: any;
 
     /** available when serveStatic plugin is used. */
-    files?: { [name: string]: RequestFileInterface };
+    files?: { [name: string]: RequestFileInterface } | undefined;
 
     /** available when authorizationParser plugin is used */
-    username?: string;
+    username?: string | undefined;
 
     /** available when authorizationParser plugin is used */
-    authorization?: RequestAuthorization;
+    authorization?: RequestAuthorization | undefined;
 }
 
 export interface CacheOptions {
@@ -762,19 +762,19 @@ export interface Route {
 }
 
 export interface RouteOptions {
-    name?: string;
+    name?: string | undefined;
 
-    path?: string | RegExp;
+    path?: string | RegExp | undefined;
 
-    url?: string | RegExp;
+    url?: string | RegExp | undefined;
 
-    urlParamPattern?: RegExp;
+    urlParamPattern?: RegExp | undefined;
 
-    contentType?: string | string[];
+    contentType?: string | string[] | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 }
 
 export interface MountOptions {
@@ -782,17 +782,17 @@ export interface MountOptions {
 
     method: string;
 
-    path?: string | RegExp;
+    path?: string | RegExp | undefined;
 
-    url?: string | RegExp;
+    url?: string | RegExp | undefined;
 
-    urlParamPattern?: RegExp;
+    urlParamPattern?: RegExp | undefined;
 
-    contentType?: string | string[];
+    contentType?: string | string[] | undefined;
 
-    version?: string;
+    version?: string | undefined;
 
-    versions?: string[];
+    versions?: string[] | undefined;
 }
 
 export type FindRouteCallback = (err: Error, route?: Route, params?: any) => void;
@@ -803,32 +803,32 @@ export type RequestHandlerType = RequestHandler | RequestHandler[];
 export namespace bunyan {
     interface RequestCaptureOptions {
         /** The stream to which to write when dumping captured records. */
-        stream?: Logger.Stream;
+        stream?: Logger.Stream | undefined;
 
         /** The streams to which to write when dumping captured records. */
-        streams?: ReadonlyArray<Logger.Stream>;
+        streams?: ReadonlyArray<Logger.Stream> | undefined;
 
         /**
          * The level at which to trigger dumping captured records. Defaults to
          * bunyan.WARN.
          */
-        level?: Logger.LogLevel;
+        level?: Logger.LogLevel | undefined;
 
         /** Number of records to capture. Default 100. */
-        maxRecords?: number;
+        maxRecords?: number | undefined;
 
         /**
          * Number of simultaneous request id capturing buckets to maintain.
          * Default 1000.
          */
-        maxRequestIds?: number;
+        maxRequestIds?: number | undefined;
 
         /**
          * If true, then dump captured records on the *default* request id when
          * dumping. I.e. dump records logged without "req_id" field. Default
          * false.
          */
-        dumpDefault?: boolean;
+        dumpDefault?: boolean | undefined;
     }
 
     /**
@@ -921,7 +921,7 @@ export namespace plugins {
         /**
          * Restify server. If passed in, causes server to emit 'auditlog' event after audit logs are flushed
          */
-        server?: Server;
+        server?: Server | undefined;
 
         /**
          * Ringbuffer which is written to if passed in
@@ -931,9 +931,9 @@ export namespace plugins {
         /**
          * When true, prints audit logs. default true.
          */
-        printLog?: boolean;
+        printLog?: boolean | undefined;
 
-        body?: boolean;
+        body?: boolean | undefined;
     }
 
     /**
@@ -948,8 +948,8 @@ export namespace plugins {
 
     interface HandlerCandidate {
         handler: RequestHandler | RequestHandler[];
-        version?: string | string[];
-        contentType?: string | string[];
+        version?: string | string[] | undefined;
+        contentType?: string | string[] | undefined;
     }
 
     /**
@@ -973,26 +973,26 @@ export namespace plugins {
         /**
          * The maximum size in bytes allowed in the HTTP body. Useful for limiting clients from hogging server memory.
          */
-        maxBodySize?: number;
+        maxBodySize?: number | undefined;
 
         /**
          * If req.params should be filled with parsed parameters from HTTP body.
          */
-        mapParams?: boolean;
+        mapParams?: boolean | undefined;
 
         /**
          * If req.params should be filled with the contents of files sent through a multipart request.
          * Formidable is used internally for parsing, and a file is denoted as a multipart part with the filename option set in its Content-Disposition.
          * This will only be performed if mapParams is true.
          */
-        mapFiles?: boolean;
+        mapFiles?: boolean | undefined;
 
         /**
          * If an entry in req.params should be overwritten by the value in the body if the names are the same.
          * For instance, if you have the route /:someval, and someone posts an x-www-form-urlencoded Content-Type with the body someval=happy to /sad,
          * the value will be happy if overrideParams is true, sad otherwise.
          */
-        overrideParams?: boolean;
+        overrideParams?: boolean | undefined;
 
         /**
          * A callback to handle any multipart part which is not a file.
@@ -1011,31 +1011,31 @@ export namespace plugins {
         /**
          * If you want the uploaded files to include the extensions of the original files (multipart uploads only). Does nothing if multipartFileHandler is defined.
          */
-        keepExtensions?: boolean;
+        keepExtensions?: boolean | undefined;
 
         /**
          * Where uploaded files are intermediately stored during transfer before the contents is mapped into req.params. Does nothing if multipartFileHandler is defined.
          */
-        uploadDir?: string;
+        uploadDir?: string | undefined;
 
         /**
          * If you want to support html5 multiple attribute in upload fields.
          */
-        multiples?: boolean;
+        multiples?: boolean | undefined;
 
         /**
          * If you want checksums calculated for incoming files, set this to either sha1 or md5.
          */
-        hash?: string;
+        hash?: string | undefined;
 
         /**
          * Set to true if you want to end the request with a UnsupportedMediaTypeError when none of the supported content types was given.
          */
-        rejectUnknown?: boolean;
+        rejectUnknown?: boolean | undefined;
 
         reviver?: any;
 
-        maxFieldsSize?: number;
+        maxFieldsSize?: number | undefined;
     }
 
     /**
@@ -1046,11 +1046,11 @@ export namespace plugins {
     /**
      * Reads the body of the request.
      */
-    function bodyReader(options?: { maxBodySize?: number }): RequestHandler;
+    function bodyReader(options?: { maxBodySize?: number | undefined }): RequestHandler;
 
     interface UrlEncodedBodyParser {
-        mapParams?: boolean;
-        overrideParams?: boolean;
+        mapParams?: boolean | undefined;
+        overrideParams?: boolean | undefined;
     }
 
     /**
@@ -1064,7 +1064,7 @@ export namespace plugins {
     /**
      * Parses JSON POST bodies
      */
-    function jsonBodyParser(options?: { mapParams?: boolean, reviver?: any, overrideParams?: boolean }): RequestHandler[];
+    function jsonBodyParser(options?: { mapParams?: boolean | undefined, reviver?: any, overrideParams?: boolean | undefined }): RequestHandler[];
 
     /**
      * Parses JSONP callback
@@ -1072,16 +1072,16 @@ export namespace plugins {
     function jsonp(): RequestHandler;
 
     interface MultipartBodyParser {
-        overrideParams?: boolean;
-        multiples?: boolean;
-        keepExtensions?: boolean;
-        uploadDir?: string;
-        maxFieldsSize?: number;
-        hash?: string;
+        overrideParams?: boolean | undefined;
+        multiples?: boolean | undefined;
+        keepExtensions?: boolean | undefined;
+        uploadDir?: string | undefined;
+        maxFieldsSize?: number | undefined;
+        hash?: string | undefined;
         multipartFileHandler?: any;
         multipartHandler?: any;
-        mapParams?: boolean;
-        mapFiles?: boolean;
+        mapParams?: boolean | undefined;
+        mapFiles?: boolean | undefined;
     }
 
     /**
@@ -1093,48 +1093,48 @@ export namespace plugins {
         /**
          * Default `false`. Copies parsed query parameters into `req.params`.
          */
-        mapParams?: boolean;
+        mapParams?: boolean | undefined;
 
         /**
          * Default `false`. Only applies when if mapParams true. When true, will stomp on req.params field when existing value is found.
          */
-        overrideParams?: boolean;
+        overrideParams?: boolean | undefined;
 
         /**
          *  Default false. Transform `?foo.bar=baz` to a nested object: `{foo: {bar: 'baz'}}`.
          */
-        allowDots?: boolean;
+        allowDots?: boolean | undefined;
 
         /**
          * Default 20. Only transform `?a[$index]=b` to an array if `$index` is less than `arrayLimit`.
          */
-        arrayLimit?: number;
+        arrayLimit?: number | undefined;
 
         /**
          * Default 5. The depth limit for parsing nested objects, e.g. `?a[b][c][d][e][f][g][h][i]=j`.
          */
-        depth?: number;
+        depth?: number | undefined;
 
         /**
          * Default 1000. Maximum number of query params parsed. Additional params are silently dropped.
          */
-        parameterLimit?: number;
+        parameterLimit?: number | undefined;
 
         /**
          * Default true. Whether to parse `?a[]=b&a[1]=c` to an array, e.g. `{a: ['b', 'c']}`.
          */
-        parseArrays?: boolean;
+        parseArrays?: boolean | undefined;
 
         /**
          * Default false. Whether `req.query` is a "plain" object -- does not inherit from `Object`.
          * This can be used to allow query params whose names collide with Object methods, e.g. `?hasOwnProperty=blah`.
          */
-        plainObjects?: boolean;
+        plainObjects?: boolean | undefined;
 
         /**
          * Default false. If true, `?a&b=` results in `{a: null, b: ''}`. Otherwise, `{a: '', b: ''}`.
          */
-        strictNullHandling?: boolean;
+        strictNullHandling?: boolean | undefined;
     }
 
     /**
@@ -1171,15 +1171,15 @@ export namespace plugins {
     function gzipResponse(options?: any): RequestHandler;
 
     interface ServeStatic {
-        appendRequestPath?: boolean;
-        directory?: string;
-        maxAge?: number;
+        appendRequestPath?: boolean | undefined;
+        directory?: string | undefined;
+        maxAge?: number | undefined;
         match?: any;
-        charSet?: string;
-        file?: string;
-        etag?: string;
+        charSet?: string | undefined;
+        file?: string | undefined;
+        etag?: string | undefined;
         default?: any;
-        gzip?: boolean;
+        gzip?: boolean | undefined;
     }
 
     /**
@@ -1188,13 +1188,13 @@ export namespace plugins {
     function serveStatic(options?: ServeStatic): RequestHandler;
 
     interface ThrottleOptions {
-        burst?: number;
-        rate?: number;
-        ip?: boolean;
-        username?: boolean;
-        xff?: boolean;
+        burst?: number | undefined;
+        rate?: number | undefined;
+        ip?: boolean | undefined;
+        username?: boolean | undefined;
+        xff?: boolean | undefined;
         tokensTable?: any;
-        maxKeys?: number;
+        maxKeys?: number | undefined;
         overrides?: any; // any
     }
 
@@ -1280,17 +1280,17 @@ export namespace plugins {
         /**
          * Header name of the absolute time for request expiration
          */
-        absoluteHeader?: string;
+        absoluteHeader?: string | undefined;
 
         /**
          * Header name for the start time of the request
          */
-        startHeader?: string;
+        startHeader?: string | undefined;
 
         /**
          * The header name for the time in milliseconds that should ellapse before the request is considered expired.
          */
-        timeoutHeader?: string;
+        timeoutHeader?: string | undefined;
     }
 
     /**

--- a/types/retry/index.d.ts
+++ b/types/retry/index.d.ts
@@ -59,7 +59,7 @@ export interface AttemptTimeoutOptions {
     /**
      * A timeout in milliseconds.
      */
-    timeout?: number;
+    timeout?: number | undefined;
     /**
      * Callback to execute when the operation takes longer than the timeout.
      */
@@ -85,17 +85,17 @@ export interface OperationOptions extends TimeoutsOptions {
      * Whether to retry forever.
      * @default false
      */
-    forever?: boolean;
+    forever?: boolean | undefined;
     /**
      * Whether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's.
      * @default false
      */
-    unref?: boolean;
+    unref?: boolean | undefined;
     /**
      * The maximum time (in milliseconds) that the retried operation is allowed to run.
      * @default Infinity
      */
-    maxRetryTime?: number;
+    maxRetryTime?: number | undefined;
 }
 
 /** Get an array with timeouts and their return values in milliseconds. */
@@ -106,7 +106,7 @@ export interface TimeoutsOptions extends CreateTimeoutOptions {
      * The maximum amount of times to retry the operation.
      * @default 10
      */
-    retries?: number;
+    retries?: number | undefined;
 }
 
 /**
@@ -122,22 +122,22 @@ export interface CreateTimeoutOptions {
      * The exponential factor to use.
      * @default 2
      */
-    factor?: number;
+    factor?: number | undefined;
     /**
      * The number of milliseconds before starting the first retry.
      * @default 1000
      */
-    minTimeout?: number;
+    minTimeout?: number | undefined;
     /**
      * The maximum number of milliseconds between two retries.
      * @default Infinity
      */
-    maxTimeout?: number;
+    maxTimeout?: number | undefined;
     /**
      * Randomizes the timeouts by multiplying a factor between 1-2.
      * @default false
      */
-    randomize?: boolean;
+    randomize?: boolean | undefined;
 }
 
 /**

--- a/types/rimraf/index.d.ts
+++ b/types/rimraf/index.d.ts
@@ -26,24 +26,24 @@ declare namespace rimraf {
      * see {@link https://github.com/isaacs/rimraf/blob/79b933fb362b2c51bedfa448be848e1d7ed32d7e/README.md#options}
      */
     interface Options {
-        maxBusyTries?: number;
-        emfileWait?: number;
+        maxBusyTries?: number | undefined;
+        emfileWait?: number | undefined;
         /** @default false */
-        disableGlob?: boolean;
-        glob?: glob.IOptions | false;
+        disableGlob?: boolean | undefined;
+        glob?: glob.IOptions | false | undefined;
 
-        unlink?: typeof fs.unlink;
-        chmod?: typeof fs.chmod;
-        stat?: typeof fs.stat;
-        lstat?: typeof fs.lstat;
-        rmdir?: typeof fs.rmdir;
-        readdir?: typeof fs.readdir;
-        unlinkSync?: typeof fs.unlinkSync;
-        chmodSync?: typeof fs.chmodSync;
-        statSync?: typeof fs.statSync;
-        lstatSync?: typeof fs.lstatSync;
-        rmdirSync?: typeof fs.rmdirSync;
-        readdirSync?: typeof fs.readdirSync;
+        unlink?: typeof fs.unlink | undefined;
+        chmod?: typeof fs.chmod | undefined;
+        stat?: typeof fs.stat | undefined;
+        lstat?: typeof fs.lstat | undefined;
+        rmdir?: typeof fs.rmdir | undefined;
+        readdir?: typeof fs.readdir | undefined;
+        unlinkSync?: typeof fs.unlinkSync | undefined;
+        chmodSync?: typeof fs.chmodSync | undefined;
+        statSync?: typeof fs.statSync | undefined;
+        lstatSync?: typeof fs.lstatSync | undefined;
+        rmdirSync?: typeof fs.rmdirSync | undefined;
+        readdirSync?: typeof fs.readdirSync | undefined;
     }
 }
 export = rimraf;

--- a/types/rimraf/v2/index.d.ts
+++ b/types/rimraf/v2/index.d.ts
@@ -21,24 +21,24 @@ declare namespace rimraf {
     let EMFILE_MAX: number;
     let BUSYTRIES_MAX: number;
     interface Options {
-        maxBusyTries?: number;
-        emfileWait?: number;
-        disableGlob?: boolean;
-        glob?: glob.IOptions | false;
+        maxBusyTries?: number | undefined;
+        emfileWait?: number | undefined;
+        disableGlob?: boolean | undefined;
+        glob?: glob.IOptions | false | undefined;
 
-        unlink?: typeof fs.unlink;
-        chmod?: typeof fs.chmod;
-        stat?: typeof fs.stat;
-        lstat?: typeof fs.lstat;
-        rmdir?: typeof fs.rmdir;
-        readdir?: typeof fs.readdir;
+        unlink?: typeof fs.unlink | undefined;
+        chmod?: typeof fs.chmod | undefined;
+        stat?: typeof fs.stat | undefined;
+        lstat?: typeof fs.lstat | undefined;
+        rmdir?: typeof fs.rmdir | undefined;
+        readdir?: typeof fs.readdir | undefined;
 
-        unlinkSync?: typeof fs.unlinkSync;
-        chmodSync?: typeof fs.chmodSync;
-        statSync?: typeof fs.statSync;
-        lstatSync?: typeof fs.lstatSync;
-        rmdirSync?: typeof fs.rmdirSync;
-        readdirSync?: typeof fs.readdirSync;
+        unlinkSync?: typeof fs.unlinkSync | undefined;
+        chmodSync?: typeof fs.chmodSync | undefined;
+        statSync?: typeof fs.statSync | undefined;
+        lstatSync?: typeof fs.lstatSync | undefined;
+        rmdirSync?: typeof fs.rmdirSync | undefined;
+        readdirSync?: typeof fs.readdirSync | undefined;
     }
 }
 export = rimraf;


### PR DESCRIPTION
In preparation for exactOptionalPropertyTypes in Typescript 4.4, add undefined to all optional properties. #no-publishing-comment

This PR covers widely used packages, those with more then 100,000 packages per month, from regenerator -- rimraf.

microsoft/dtslint#335