### PR TITLE
[yup] Add types for default on non array types.

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -70,7 +70,7 @@ export interface Schema<T, C = object> {
     strict(isStrict: boolean): this;
     strip(strip: boolean): this;
     withMutation(fn: (current: this) => void): void;
-    default(value: any): this;
+    default(value: T | (() => T)): Schema<T, C>;
     default(): T;
     typeError(message?: TestOptionsMessage): this;
     notOneOf(arrayOfValues: any[], message?: MixedLocale['notOneOf']): this;
@@ -115,6 +115,8 @@ export interface MixedSchema<T extends any = {} | null | undefined, C = object> 
     test(name: string, message: TestOptionsMessage, test: TestFunction<unknown, C>): this;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): MixedSchema<U, C>;
     test(options: TestOptions<Record<string, any>, C>): this;
+    default<U extends T>(value: U | (() => U)): U extends undefined ? MixedSchema<T, C> : MixedSchema<Exclude<T, undefined>, C>;
+    default(): T;
 }
 
 export interface StringSchemaConstructor {
@@ -169,6 +171,8 @@ export interface StringSchema<T extends string | null | undefined = string | und
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): StringSchema<U, C>;
     test(options: TestOptions<Record<string, any>, C>): this;
     optional(): StringSchema<T | undefined, C>;
+    default<U extends T>(value: U | (() => U)): U extends undefined ? StringSchema<T, C> : StringSchema<Exclude<T, undefined>, C>;
+    default(): T;
 }
 
 export interface NumberSchemaConstructor {
@@ -212,6 +216,8 @@ export interface NumberSchema<T extends number | null | undefined = number | und
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): NumberSchema<U, C>;
     test(options: TestOptions<Record<string, any>, C>): this;
     optional(): NumberSchema<T | undefined, C>;
+    default<U extends T>(value: U | (() => U)): U extends undefined ? NumberSchema<T, C> : NumberSchema<Exclude<T, undefined>, C>;
+    default(): T;
 }
 
 export interface BooleanSchemaConstructor {
@@ -246,6 +252,8 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): BooleanSchema<U, C>;
     test(options: TestOptions<Record<string, any>, C>): this;
     optional(): BooleanSchema<T | undefined, C>;
+    default<U extends T>(value: U | (() => U)): U extends undefined ? BooleanSchema<T, C> : BooleanSchema<Exclude<T, undefined>, C>;
+    default(): T;
 }
 
 export interface DateSchemaConstructor {
@@ -281,6 +289,8 @@ export interface DateSchema<T extends Date | string | null | undefined = Date | 
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): DateSchema<U, C>;
     test(options: TestOptions<Record<string, any>, C>): this;
     optional(): DateSchema<T | undefined, C>;
+    default<U extends T>(value: U | (() => U)): U extends undefined ? DateSchema<T, C> : DateSchema<Exclude<T, undefined>, C>;
+    default(): T;
 }
 
 export interface ArraySchemaConstructor {
@@ -409,6 +419,8 @@ export interface ObjectSchema<T extends object | null | undefined = object | und
     ): ObjectSchema<U, C>;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): ObjectSchema<U, C>;
     test(options: TestOptions<Record<string, any>, C>): this;
+    default<U extends T>(value: U | (() => U)): U extends undefined ? ObjectSchema<T, C> : ObjectSchema<Exclude<T, undefined>, C>;
+    default(): T;
 }
 
 export type TestFunction<T = unknown, C = object> = (

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -136,8 +136,12 @@ mixed.isType('hello');
 mixed.strict(true);
 mixed.strip(true);
 mixed.withMutation(schema => {});
-mixed.default({ number: 5 });
-mixed.default(() => ({ number: 5 }));
+mixed.default({ number: 5 }); // $ExpectType MixedSchema<{} | null, object>
+mixed.default(() => ({ number: 5 })); // $ExpectType MixedSchema<{} | null, object>
+mixed.default(null); // $ExpectType MixedSchema<{} | null, object>
+mixed.default(undefined); // $ExpectType MixedSchema<{} | null | undefined, object>
+// $ExpectError
+mixed.defined().default(undefined);
 mixed.default();
 mixed.nullable(true);
 mixed.nullable();
@@ -370,6 +374,12 @@ function strSchemaTests(strSchema: yup.StringSchema) {
     strSchema.uppercase('upper');
     strSchema.uppercase(() => 'upper');
     strSchema.defined();
+    strSchema.default('hello'); // $ExpectType StringSchema<string, object>
+    strSchema.default(() => 'hello'); // $ExpectType StringSchema<string, object>
+    strSchema.default(undefined); // $ExpectType StringSchema<string | undefined, object>
+    // $ExpectError
+    strSchema.defined().default(undefined);
+    strSchema.default();
 }
 
 const strSchema = yup.string(); // $ExpectType StringSchema<string | undefined, object>
@@ -421,6 +431,12 @@ numSchema.oneOf([1, 2] as const); // $ExpectType NumberSchema<1 | 2 | undefined,
 numSchema.equals([1, 2] as const); // $ExpectType NumberSchema<1 | 2 | undefined, object>
 numSchema.required().oneOf([1, 2] as const); // $ExpectType NumberSchema<1 | 2, object>
 numSchema.defined();
+numSchema.default(5); // $ExpectType NumberSchema<number, object>
+numSchema.default(() => 5); // $ExpectType NumberSchema<number, object>
+numSchema.default(undefined); // $ExpectType NumberSchema<number | undefined, object>
+numSchema.default();
+// $ExpectError
+numSchema.defined().default(undefined);
 
 // Boolean Schema
 const boolSchema = yup.boolean(); // $ExpectType BooleanSchema<boolean | undefined, object>
@@ -430,6 +446,20 @@ boolSchema.oneOf([true] as const); // $ExpectType BooleanSchema<true | undefined
 boolSchema.equals([true] as const); // $ExpectType BooleanSchema<true | undefined, object>
 boolSchema.required().oneOf([true] as const); // $ExpectType BooleanSchema<true, object>
 boolSchema.defined();
+boolSchema.default(false); // $ExpectType BooleanSchema<boolean, object>
+boolSchema.default(() => false); // $ExpectType BooleanSchema<boolean, object>
+boolSchema.default(undefined); // $ExpectType BooleanSchema<boolean | undefined, object>
+boolSchema.default(() => undefined); // $ExpectType BooleanSchema<boolean | undefined, object>
+boolSchema.nullable().default(null); // $ExpectType BooleanSchema<boolean | null, object>
+// $ExpectError
+boolSchema.default(5);
+// $ExpectError
+boolSchema.default(() => 5);
+// $ExpectError
+boolSchema.default(null).nullable();
+// $ExpectError
+boolSchema.defined().default(undefined);
+boolSchema.default();
 
 // Date Schema
 const dateSchema = yup.date(); // $ExpectType DateSchema<Date | undefined, object>
@@ -449,6 +479,16 @@ dateSchema.max('2017-11-12', () => 'message');
 dateSchema.oneOf([new Date()] as const); // $ExpectType DateSchema<Date | undefined, object>
 dateSchema.equals([new Date()] as const); // $ExpectType DateSchema<Date | undefined, object>
 dateSchema.required().oneOf([new Date()] as const); // $ExpectType DateSchema<Date, object>
+dateSchema.default(new Date()); // $ExpectType DateSchema<Date, object>
+dateSchema.default(() => new Date()); // $ExpectType DateSchema<Date, object>
+dateSchema.default(undefined); // $ExpectType DateSchema<Date | undefined, object>
+// $ExpectError
+dateSchema.default('2017-11-12');
+// $ExpectError
+dateSchema.default(() => '2017-11-12');
+// $ExpectError
+dateSchema.defined().default(undefined);
+dateSchema.default();
 
 // Array Schema
 const arrSchema = yup.array().of(yup.number().defined().min(2));
@@ -530,6 +570,14 @@ interface LiteralExampleObject {
 }
 objSchema.oneOf([{name: "John Doe", age: 35, email: "john@example.com", website: "example.com"}] as LiteralExampleObject[]); // $ExpectType ObjectSchema<LiteralExampleObject, object>
 objSchema.defined();
+
+const validObject = { name: 'Abraham Lincoln', age: 24, email: 'abe@logcabin.com', website: 'http://honestabe.com' };
+objSchema.default(validObject);
+objSchema.default(() => validObject);
+objSchema.default(undefined);
+// $ExpectError
+objSchema.defined().default(undefined);
+objSchema.default();
 
 const description: SchemaDescription = {
     type: 'type',


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

* Yup's typescript support in newer versions narrows the type on calls to `default`: 
  * https://github.com/jquense/yup/blob/877f7770ca54c0abea885230ffa307c1047226a3/docs/typescript.md
  * https://github.com/jquense/yup/blob/877f7770ca54c0abea885230ffa307c1047226a3/src/boolean.ts#L75-L79
* Using `any` for `default` values meant that something like `yup.boolean().default("not a boolean")` would typecheck and tell you the type was `boolean | undefined` which seems dangerous.
* The general idea is that a call like `yup.boolean().default(false)` allows a field to be optional in the input, but to always have a value once it is in the system, hence the type narrowing. The exception is calls to `default(undefined)`, which could be used to reset the default value in a complicated setup. If `undefined` is a valid value, making it the default is valid if somewhat questionable from a design standpoint.
* Getting the array types to work went ok, but led to hard to decipher type errors in existing examples and I felt it was wise to leave that part of the code alone for now, especially since I do not use arrays in the project I'm using yup with.
* For the date type, disallowing a string representation seemed to fit more with the goals of using typescript, since yup does not appear to do any coercion or casting with the default values. An alternate design would be to expand the type when a string is given for the default to ensure the user handles it somewhere, but only allowing Date objects seemed simpler.

/cc @david-golightly-leapyear
