### PR TITLE
@types/cors: Allow booleans in static origin array

### DIFF
--- a/types/cors/cors-tests.ts
+++ b/types/cors/cors-tests.ts
@@ -39,6 +39,9 @@ app.use(cors({
     origin: [/example\.com$/, /fakeurl\.com$/]
 }));
 app.use(cors({
+    origin: [false, 'http://example.com']
+}));
+app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, true);

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -7,7 +7,7 @@
 
 import { IncomingHttpHeaders } from 'http';
 
-type StaticOrigin = boolean | string | RegExp | (string | RegExp)[];
+type StaticOrigin = boolean | string | RegExp | (boolean | string | RegExp)[];
 
 type CustomOrigin = (requestOrigin: string | undefined, callback: (err: Error | null, origin?: StaticOrigin) => void) => void;
 


### PR DESCRIPTION
This PR allows for `boolean` values in an array passed as the `origin` option when configuring `cors`. For example:

```js
cors({
    origin: [false, ...],
})
```

This is supported by [`cors`’s evaluation method](https://github.com/expressjs/cors/blob/c49ca10e92ac07f98a3b06783d3e6ba0ea5b70c7/lib/index.js#L19-L34), but not currently covered by the types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

    The `isOriginAllowed` method `cors` runs to evaluate the static origins, allows for boolean values not only singly, but also when setting an array of allowed origins: https://github.com/expressjs/cors/blob/c49ca10e92ac07f98a3b06783d3e6ba0ea5b70c7/lib/index.js#L19-L34