### PR TITLE
[knex-cleaner] Upgrade knex dependency

### DIFF
--- a/types/knex-cleaner/index.d.ts
+++ b/types/knex-cleaner/index.d.ts
@@ -2,8 +2,8 @@
 // Project: https://github.com/steven-ferguson/knex-cleaner
 // Definitions by: Karol Goraus <https://github.com/Szarlus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
-import * as Knex from 'knex';
+// TypeScript Version: 4.1
+import { Knex } from 'knex';
 
 export interface KnexCleanerOptions {
     /**

--- a/types/knex-cleaner/knex-cleaner-tests.ts
+++ b/types/knex-cleaner/knex-cleaner-tests.ts
@@ -1,15 +1,15 @@
 import { clean } from 'knex-cleaner';
-import * as Knex from 'knex';
+import { knex, Knex } from 'knex';
 
-const knex: Knex = Knex({ dialect: 'pg' });
+const knexInstance: Knex = knex({ dialect: 'pg' });
 
-clean(knex); // $ExpectType Promise<void>
-clean(knex, {}); // $ExpectType Promise<void>
-clean(knex, { mode: 'delete', restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
-clean(knex, { mode: 'delete' }); // $ExpectType Promise<void>
-clean(knex, { restartIdentity: false }); // $ExpectType Promise<void>
-clean(knex, { ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
-clean(knex, { restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
-clean(knex, { mode: 'delete', ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
-clean(knex, { mode: 'delete', restartIdentity: false }); // $ExpectType Promise<void>
-clean(knex, { unknown: 1 }); // $ExpectError
+clean(knexInstance); // $ExpectType Promise<void>
+clean(knexInstance, {}); // $ExpectType Promise<void>
+clean(knexInstance, { mode: 'delete', restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knexInstance, { mode: 'delete' }); // $ExpectType Promise<void>
+clean(knexInstance, { restartIdentity: false }); // $ExpectType Promise<void>
+clean(knexInstance, { ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knexInstance, { restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knexInstance, { mode: 'delete', ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knexInstance, { mode: 'delete', restartIdentity: false }); // $ExpectType Promise<void>
+clean(knexInstance, { unknown: 1 }); // $ExpectError

--- a/types/knex-cleaner/package.json
+++ b/types/knex-cleaner/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": "^0.16.1"
+        "knex": ">=0.95.0 <1.0.0"
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Our project is using knex 0.95.6 and knex-cleaner 1.3.1. The latter doesn't have a dependency on knex, however, `@types/knex-cleaner` does. Since knex-cleaner works with any version of knex, I'd expect this to be the case of the types packages as well. However, it seems to depend on the 0.16.x version specifically - very likely because the caret behaves differently for versions below 1.x.x. This wouldn't be an issue on its own, but we are getting type error because of that:

![image](https://user-images.githubusercontent.com/242202/124920032-cc6f7880-dfee-11eb-9473-32e5506715f4.png)

Unfortunately, the latest Knex (specifically, from version 0.95.0 onwards) has changed its types significantly. Thus in this PR I'm setting the minimum version of knex to 0.95.0 (allowing any version up until but not including 1.0.0).

knex also [requires](https://github.com/knex/knex/blob/master/CHANGELOG.md#typings-5) the mimimum version of TS to be 4.1.


