### PR TITLE
[@types/js-yaml] Replace `object` with `Record`  in `load` and allow generic

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -9,12 +9,10 @@
 
 export as namespace jsyaml;
 
-// tslint:disable-next-line:no-unnecessary-generics
-export function load<T = unknown[] | Record<string, unknown> | string | number>(
+export function load(
     str: string,
     opts?: LoadOptions,
-// tslint:disable-next-line:no-unnecessary-generics
-): T | null | undefined;
+): string | number | unknown[] | Record<string, unknown> | null | undefined;
 
 export class Type {
     constructor(tag: string, opts?: TypeConstructorOptions);

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -9,7 +9,12 @@
 
 export as namespace jsyaml;
 
-export function load(str: string, opts?: LoadOptions): object | string | number | null | undefined;
+// tslint:disable-next-line:no-unnecessary-generics
+export function load<T = unknown[] | Record<string, unknown> | string | number>(
+    str: string,
+    opts?: LoadOptions,
+// tslint:disable-next-line:no-unnecessary-generics
+): T | null | undefined;
 
 export class Type {
     constructor(tag: string, opts?: TypeConstructorOptions);

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -139,26 +139,6 @@ yaml.load(str);
 // $ExpectType string | number | unknown[] | Record<string, unknown> | null | undefined
 yaml.load(str, loadOpts);
 
-// $ExpectType string | null | undefined
-yaml.load<string>(str);
-// $ExpectType string | null | undefined
-yaml.load<string>(str, loadOpts);
-
-// $ExpectType number | null | undefined
-yaml.load<number>(str);
-// $ExpectType number | null | undefined
-yaml.load<number>(str, loadOpts);
-
-// $ExpectType { data: "something"; } | null | undefined
-yaml.load<{ data: "something"; }>(str);
-// $ExpectType { data: "something"; } | null | undefined
-yaml.load<{ data: "something"; }>(str, loadOpts);
-
-// $ExpectType Record<string, number> | null | undefined
-yaml.load<Record<string, number>>(str);
-// $ExpectType Record<string, number> | null | undefined
-yaml.load<Record<string, number>>(str, loadOpts);
-
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 // $ExpectType any[]

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -134,10 +134,30 @@ type.styleAliases;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType string | number | object | null | undefined
+// $ExpectType string | number | unknown[] | Record<string, unknown> | null | undefined
 yaml.load(str);
-// $ExpectType string | number | object | null | undefined
+// $ExpectType string | number | unknown[] | Record<string, unknown> | null | undefined
 yaml.load(str, loadOpts);
+
+// $ExpectType string | null | undefined
+yaml.load<string>(str);
+// $ExpectType string | null | undefined
+yaml.load<string>(str, loadOpts);
+
+// $ExpectType number | null | undefined
+yaml.load<number>(str);
+// $ExpectType number | null | undefined
+yaml.load<number>(str, loadOpts);
+
+// $ExpectType { data: "something"; } | null | undefined
+yaml.load<{ data: "something"; }>(str);
+// $ExpectType { data: "something"; } | null | undefined
+yaml.load<{ data: "something"; }>(str, loadOpts);
+
+// $ExpectType Record<string, number> | null | undefined
+yaml.load<Record<string, number>>(str);
+// $ExpectType Record<string, number> | null | undefined
+yaml.load<Record<string, number>>(str, loadOpts);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 


### PR DESCRIPTION
As I'm changing a type definition, here's the source code of the function whose definition I'm updating: https://github.com/nodeca/js-yaml/blob/ba3460eb9d3e4478edcbc29edabe17c2157fc9ce/lib/loader.js#L1713-L1723

There are two essential changes:

### 1. Removing `object` as a possible return type of `load`
`object` is something which has no properties on it; it's useful as a function parameter in some cases, but it is a hindrance as a return value.

Imagine writing this code with the current types for this package:
```ts
const myYaml = yaml.load(contents);
if (typeof myYaml !== object || myYaml === null) {
    // handle this case
}

const myValue = myYaml.myKey ?? "default value";

doThingWith(myValue);
```
This code looks pretty type safe, but TS throws an error at `myYaml.myKey` — `myYaml` is of type `object`, which has no keys on it. Even though we're providing a default value, we can't even try accessing that key. Our only option is to use a type assertion (e.g. `const myYaml = yaml.load(contents) as Record<string, unknown>`), which is seen as a bad practice in many code bases.

**I'm replacing `object` with `unknown[] | Record<string, unknown>`**, which matches the possible top-level types of YAML, being essentially an array or a dictionary-like structure.

### 2. Allowing for a generic in `load` in order to clarify the expected return type
Similarly to the types for DOM operations like `querySelector`, which accept generics to specify their return types (e.g. `document.querySelector<HTMLButtonElement>(".my-button")`), I've made `yaml.load` accept a generic that you can fill in with the shape of the data you expect to be returned.


