### PR TITLE
[@wordpress/block-editor]: Add `store` export to module

### DIFF
--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>
+//                 Dennis Snell <https://github.com/dmsnell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 import { BlockIconNormalized } from '@wordpress/blocks';
@@ -16,6 +17,8 @@ declare module '@wordpress/data' {
     function dispatch(key: 'core/block-editor'): typeof import('./store/actions');
     function select(key: 'core/block-editor'): typeof import('./store/selectors');
 }
+
+export const store: any;
 
 export type EditorBlockMode = 'html' | 'visual';
 export type EditorMode = 'text' | 'visual';

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -412,6 +412,9 @@ be.transformStyles(STYLES, '.foobar');
 // Store
 // ============================================================================
 
+// $ExpectType any
+be.store;
+
 // $ExpectType void
 dispatch('core/block-editor').insertBlock(BLOCK_INSTANCE);
 dispatch('core/block-editor').insertBlock(BLOCK_INSTANCE, 4);


### PR DESCRIPTION
## Summary

Narrower version of #54386

In this patch we're adding the missing `store` export to `@wordpress/block-editor`.
This does not attempt to dive into the types and drastically improve the types,
instead, it attempts to fix an omission that was causing certain false type errors
when importing this libary.

See [the block-editor store][block-editor-store]

[block-editor-store]: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#store

## Checklists

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link][block-editor-store]
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (They don't)

cc: @sirreal 