### PR TITLE
chore(node): correct misc issues

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -391,7 +391,7 @@ declare module 'crypto' {
     function createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject | JsonWebKeyInput): KeyObject;
     function createSecretKey(key: NodeJS.ArrayBufferView): KeyObject;
 
-    function createSign(algorithm: string, options?: stream.WritableOptions): Signer;
+    function createSign(algorithm: string, options?: stream.WritableOptions): Sign;
 
     type DSAEncoding = 'der' | 'ieee-p1363';
 
@@ -415,11 +415,11 @@ declare module 'crypto' {
 
     type KeyLike = string | Buffer | KeyObject;
 
-    class Signer extends stream.Writable {
+    class Sign extends stream.Writable {
         private constructor();
 
-        update(data: BinaryLike): Signer;
-        update(data: string, input_encoding: Encoding): Signer;
+        update(data: BinaryLike): this;
+        update(data: string, input_encoding: Encoding): this;
         sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
         sign(
             private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput,

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -876,6 +876,16 @@ declare module 'fs' {
          */
         maxRetries?: number | undefined;
         /**
+         * @deprecated since v14.14.0 In future versions of Node.js and will trigger a warning
+         * `fs.rmdir(path, { recursive: true })` will throw if `path` does not exist or is a file.
+         * Use `fs.rm(path, { recursive: true, force: true })` instead.
+         *
+         * If `true`, perform a recursive directory removal. In
+         * recursive mode soperations are retried on failure.
+         * @default false
+         */
+        recursive?: boolean | undefined;
+        /**
          * The amount of time in milliseconds to wait between retries.
          * This option is ignored if the `recursive` option is not `true`.
          * @default 100

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -21,6 +21,7 @@ declare module 'fs/promises' {
         WatchOptions,
     } from 'fs';
 
+    // TODO: Add `EventEmitter` close
     interface FileHandle {
         /**
          * Gets the file descriptor for this file handle.
@@ -193,50 +194,6 @@ declare module 'fs/promises' {
     function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
 
     /**
-     * Asynchronously reads data from the file referenced by the supplied `FileHandle`.
-     * @param handle A `FileHandle`.
-     * @param buffer The buffer that the data will be written to.
-     * @param offset The offset in the buffer at which to start writing.
-     * @param length The number of bytes to read.
-     * @param position The offset from the beginning of the file from which data should be read. If
-     * `null`, data will be read from the current position.
-     */
-    function read<TBuffer extends Uint8Array>(
-        handle: FileHandle,
-        buffer: TBuffer,
-        offset?: number | null,
-        length?: number | null,
-        position?: number | null,
-    ): Promise<{ bytesRead: number, buffer: TBuffer }>;
-
-    /**
-     * Asynchronously writes `buffer` to the file referenced by the supplied `FileHandle`.
-     * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise`
-     * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
-     * @param handle A `FileHandle`.
-     * @param buffer The buffer that the data will be written to.
-     * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
-     * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
-     * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
-     */
-    function write<TBuffer extends Uint8Array>(
-        handle: FileHandle,
-        buffer: TBuffer,
-        offset?: number | null,
-        length?: number | null, position?: number | null): Promise<{ bytesWritten: number, buffer: TBuffer }>;
-
-    /**
-     * Asynchronously writes `string` to the file referenced by the supplied `FileHandle`.
-     * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise`
-     * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
-     * @param handle A `FileHandle`.
-     * @param string A string to write.
-     * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
-     * @param encoding The expected string encoding.
-     */
-    function write(handle: FileHandle, string: string, position?: number | null, encoding?: BufferEncoding | null): Promise<{ bytesWritten: number, buffer: string }>;
-
-    /**
      * Asynchronous rename(2) - Change the name or location of a file or directory.
      * @param oldPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
@@ -253,13 +210,6 @@ declare module 'fs/promises' {
     function truncate(path: PathLike, len?: number): Promise<void>;
 
     /**
-     * Asynchronous ftruncate(2) - Truncate a file to a specified length.
-     * @param handle A `FileHandle`.
-     * @param len If not specified, defaults to `0`.
-     */
-    function ftruncate(handle: FileHandle, len?: number): Promise<void>;
-
-    /**
      * Asynchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
@@ -269,18 +219,6 @@ declare module 'fs/promises' {
      * Asynchronously removes files and directories (modeled on the standard POSIX `rm` utility).
      */
     function rm(path: PathLike, options?: RmOptions): Promise<void>;
-
-    /**
-     * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
-     * @param handle A `FileHandle`.
-     */
-    function fdatasync(handle: FileHandle): Promise<void>;
-
-    /**
-     * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
-     * @param handle A `FileHandle`.
-     */
-    function fsync(handle: FileHandle): Promise<void>;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
@@ -394,13 +332,6 @@ declare module 'fs/promises' {
     function unlink(path: PathLike): Promise<void>;
 
     /**
-     * Asynchronous fchmod(2) - Change permissions of a file.
-     * @param handle A `FileHandle`.
-     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
-     */
-    function fchmod(handle: FileHandle, mode: Mode): Promise<void>;
-
-    /**
      * Asynchronous chmod(2) - Change permissions of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
@@ -431,12 +362,6 @@ declare module 'fs/promises' {
     function lutimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
 
     /**
-     * Asynchronous fchown(2) - Change ownership of a file.
-     * @param handle A `FileHandle`.
-     */
-    function fchown(handle: FileHandle, uid: number, gid: number): Promise<void>;
-
-    /**
      * Asynchronous chown(2) - Change ownership of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
@@ -449,14 +374,6 @@ declare module 'fs/promises' {
      * @param mtime The last modified time. If a string is provided, it will be coerced to number.
      */
     function utimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
-
-    /**
-     * Asynchronously change file timestamps of the file referenced by the supplied `FileHandle`.
-     * @param handle A `FileHandle`.
-     * @param atime The last access time. If a string is provided, it will be coerced to number.
-     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
-     */
-    function futimes(handle: FileHandle, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
@@ -517,7 +434,7 @@ declare module 'fs/promises' {
         path: PathLike | FileHandle,
         data: string | NodeJS.ArrayBufferView | Iterable<string | NodeJS.ArrayBufferView> | AsyncIterable<string | NodeJS.ArrayBufferView> | Stream,
         options?: BaseEncodingOptions & { mode?: Mode | undefined, flag?: OpenMode | undefined } & Abortable | BufferEncoding | null
-        ): Promise<void>;
+    ): Promise<void>;
 
     /**
      * Asynchronously append data to a file, creating the file if it does not exist.

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -429,13 +429,6 @@ declare module 'http' {
      * Defaults to 16KB. Configurable using the `--max-http-header-size` CLI option.
      */
     const maxHeaderSize: number;
-
-    /**
-     *
-     * This utility function converts a URL object into an ordinary options object as
-     * expected by the `http.request()` and `https.request()` APIs.
-     */
-    function urlToHttpOptions(url: URL): ClientRequestArgs;
 }
 
 declare module 'node:http' {

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -756,7 +756,7 @@ import { promisify } from 'util';
         namedCurve: 'sect239k1',
     });
 
-    const sign: crypto.Signer = crypto.createSign('SHA256');
+    const sign: crypto.Sign = crypto.createSign('SHA256');
     sign.write('some data to sign');
     sign.end();
     const signature: string = sign.sign(privateKey, 'hex');
@@ -768,7 +768,7 @@ import { promisify } from 'util';
 
     // ensure that instanceof works
     verify instanceof crypto.Verify;
-    sign instanceof crypto.Signer;
+    sign instanceof crypto.Sign;
 }
 
 {
@@ -776,7 +776,7 @@ import { promisify } from 'util';
         modulusLength: 2048,
     });
 
-    const sign: crypto.Signer = crypto.createSign('SHA256');
+    const sign: crypto.Sign = crypto.createSign('SHA256');
     sign.update('some data to sign');
     sign.end();
     const signature: Buffer = sign.sign(privateKey);

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -327,7 +327,7 @@ async function testPromisify() {
 (async () => {
     try {
         await fs.promises.rmdir('some/test/path');
-        await fs.promises.rmdir('some/test/path', { maxRetries: 123, retryDelay: 123 });
+        await fs.promises.rmdir('some/test/path', { maxRetries: 123, retryDelay: 123, recursive: true });
     } catch (e) { }
 
     try {

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -233,7 +233,3 @@ import * as net from 'net';
 {
     const maxHeaderSize = http.maxHeaderSize;
 }
-
-{
-    const opts: http.RequestOptions = http.urlToHttpOptions(new url.URL('test.com'));
-}

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -1,4 +1,5 @@
 import assert = require('assert');
+import { RequestOptions } from 'http';
 import * as url from 'url';
 
 {
@@ -148,4 +149,8 @@ import * as url from 'url';
 
 {
     const path: url.URL = url.pathToFileURL('file://test');
+}
+
+{
+    const opts: RequestOptions = url.urlToHttpOptions(new url.URL('test.com'));
 }

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -1,4 +1,5 @@
 declare module 'url' {
+    import { ClientRequestArgs } from 'http';
     import { ParsedUrlQuery, ParsedUrlQueryInput } from 'querystring';
 
     // Input to `url.format`
@@ -71,6 +72,12 @@ declare module 'url' {
      * @param url The path to convert to a File URL.
      */
     function pathToFileURL(url: string): URL;
+
+    /**
+     * This utility function converts a URL object into an ordinary options object as
+     * expected by the `http.request()` and `https.request()` APIs.
+     */
+    function urlToHttpOptions(url: URL): ClientRequestArgs;
 
     interface URLFormatOptions {
         auth?: boolean | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#fs_promises_api https://nodejs.org/dist/latest-v16.x/docs/api/url.html#url_url_urltohttpoptions_url https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#fs_fspromises_rmdir_path_options https://nodejs.org/dist/latest-v16.x/docs/api/crypto.html#crypto_class_sign
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Removed misc fs.promises methods that did (or do) not exist.
Moved urlToHttpOptions to `url` module.
Restored incorrectly removed `recursive` parameter to rmdir.
Renamed `Signer` -> `Sign`.

These last change is potentially breaking as people may have referred to the `signer` but the impact is low as the class is not directly constructed (really couldn't have been due to the incorrect name) and the migration effort is next to none.