### PR TITLE
Compatibility with Firebase Functions

### DIFF
--- a/types/koa-bodyparser/index.d.ts
+++ b/types/koa-bodyparser/index.d.ts
@@ -22,7 +22,7 @@ import * as Koa from 'koa';
 
 declare module 'koa' {
     interface Request {
-        body: string | Record<string, unknown>;
+        body?: any;
         rawBody: string;
     }
 }

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -319,6 +319,7 @@ declare module 'http' {
     class IncomingMessage extends stream.Readable {
         constructor(socket: Socket);
 
+        body: NodeJS.Dict<string>;
         aborted: boolean;
         httpVersion: string;
         httpVersionMajor: number;


### PR DESCRIPTION
## Summary

* Node.js server POST request

    When requesting POST to Node.js server, and using `koa-bodyparser` package, I couldn't read body by `ctx.request.body` because of `body: string | Record<string, unknown>`. But when using previous code `body?: any`, then I could get request body by `ctx.request.body`.

* Firebase Functions POST request

  Firebase Functions already parses request (added links below) but still needs `koa-bodyparser` package to be installed. But it doesn't use `koa-bodyparser`. So unlike Node.js POST request, it cannot read request  body from `ctx.request.body` but by adding `body` property to `IncomingMessage`, it can read body by `ctx.req.body`.

<br/>   

## Checklist

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:      

    - [https://firebase.google.com/docs/functions/http-events#read_values_from_the_request](https://firebase.google.com/docs/functions/http-events#read_values_from_the_request)
    -  [https://stackoverflow.com/questions/58237305/post-request-hangs-timeout-when-trying-to-parse-request-body-running-koa-on-f](https://stackoverflow.com/questions/58237305/post-request-hangs-timeout-when-trying-to-parse-request-body-running-koa-on-f)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
