### PR TITLE
fix(d3-force): modify the tick method's return value definition

### DIFF
--- a/types/d3-force/index.d.ts
+++ b/types/d3-force/index.d.ts
@@ -121,7 +121,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      * creation or by calling simulation.restart. The natural number of ticks when the simulation is started is
      * ⌈log(alphaMin) / log(1 - alphaDecay)⌉; by default, this is 300.
      */
-    tick(iterations?: number): void;
+    tick(iterations?: number): this;
 
     /**
      * Returns the simulation’s array of nodes as specified to the constructor.

--- a/types/d3-force/v1/index.d.ts
+++ b/types/d3-force/v1/index.d.ts
@@ -121,7 +121,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      * creation or by calling simulation.restart. The natural number of ticks when the simulation is started is
      * ⌈log(alphaMin) / log(1 - alphaDecay)⌉; by default, this is 300.
      */
-    tick(iterations?: number): void;
+    tick(iterations?: number): this;
 
     /**
      * Returns the simulation’s array of nodes as specified to the constructor.

--- a/types/d3-force/v2/index.d.ts
+++ b/types/d3-force/v2/index.d.ts
@@ -121,7 +121,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      * creation or by calling simulation.restart. The natural number of ticks when the simulation is started is
      * ⌈log(alphaMin) / log(1 - alphaDecay)⌉; by default, this is 300.
      */
-    tick(iterations?: number): void;
+    tick(iterations?: number): this;
 
     /**
      * Returns the simulation’s array of nodes as specified to the constructor.


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3-force/blob/v3.0.0/README.md#simulation_tick>>
- [x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
