### PR TITLE
Extensible mdast

### DIFF
--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -10,27 +10,11 @@ export type AlignType = 'left' | 'right' | 'center' | null;
 
 export type ReferenceType = 'shortcut' | 'collapsed' | 'full';
 
-export type Content =
-    | TopLevelContent
-    | ListContent
-    | TableContent
-    | RowContent
-    | PhrasingContent;
+export type Content = TopLevelContent | ListContent | TableContent | RowContent | PhrasingContent;
 
-export type TopLevelContent =
-    | BlockContent
-    | FrontmatterContent
-    | DefinitionContent;
+export type TopLevelContent = BlockContent | FrontmatterContent | DefinitionContent;
 
-export type BlockContent =
-    | Paragraph
-    | Heading
-    | ThematicBreak
-    | Blockquote
-    | List
-    | Table
-    | HTML
-    | Code;
+export type BlockContent = Paragraph | Heading | ThematicBreak | Blockquote | List | Table | HTML | Code;
 
 export type FrontmatterContent = YAML;
 
@@ -91,22 +75,22 @@ export interface Blockquote extends Parent {
 
 export interface List extends Parent {
     type: 'list';
-    ordered?: boolean | undefined;
-    start?: number | undefined;
-    spread?: boolean | undefined;
+    ordered?: boolean;
+    start?: number;
+    spread?: boolean;
     children: ListContent[];
 }
 
 export interface ListItem extends Parent {
     type: 'listItem';
-    checked?: boolean | undefined;
-    spread?: boolean | undefined;
+    checked?: boolean;
+    spread?: boolean;
     children: BlockContent[];
 }
 
 export interface Table extends Parent {
     type: 'table';
-    align?: AlignType[] | undefined;
+    align?: AlignType[];
     children: TableContent[];
 }
 
@@ -126,8 +110,8 @@ export interface HTML extends Literal {
 
 export interface Code extends Literal {
     type: 'code';
-    lang?: string | undefined;
-    meta?: string | undefined;
+    lang?: string;
+    meta?: string;
 }
 
 export interface YAML extends Literal {
@@ -200,12 +184,12 @@ export interface FootnoteReference extends Node, Association {
 // Mixin
 export interface Resource {
     url: string;
-    title?: string | undefined;
+    title?: string;
 }
 
 export interface Association {
     identifier: string;
-    label?: string | undefined;
+    label?: string;
 }
 
 export interface Reference extends Association {
@@ -213,5 +197,5 @@ export interface Reference extends Association {
 }
 
 export interface Alternative {
-    alt?: string | undefined;
+    alt?: string;
 }

--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -201,22 +201,22 @@ export interface Blockquote extends Parent {
 
 export interface List extends Parent {
     type: 'list';
-    ordered?: boolean;
-    start?: number;
-    spread?: boolean;
+    ordered?: boolean | undefined;
+    start?: number | undefined;
+    spread?: boolean | undefined;
     children: ListContent[];
 }
 
 export interface ListItem extends Parent {
     type: 'listItem';
-    checked?: boolean;
-    spread?: boolean;
+    checked?: boolean | undefined;
+    spread?: boolean | undefined;
     children: BlockContent[];
 }
 
 export interface Table extends Parent {
     type: 'table';
-    align?: AlignType[];
+    align?: AlignType[] | undefined;
     children: TableContent[];
 }
 
@@ -236,8 +236,8 @@ export interface HTML extends Literal {
 
 export interface Code extends Literal {
     type: 'code';
-    lang?: string;
-    meta?: string;
+    lang?: string | undefined;
+    meta?: string | undefined;
 }
 
 export interface YAML extends Literal {
@@ -310,12 +310,12 @@ export interface FootnoteReference extends Node, Association {
 // Mixin
 export interface Resource {
     url: string;
-    title?: string;
+    title?: string | undefined;
 }
 
 export interface Association {
     identifier: string;
-    label?: string;
+    label?: string | undefined;
 }
 
 export interface Reference extends Association {
@@ -323,5 +323,5 @@ export interface Reference extends Association {
 }
 
 export interface Alternative {
-    alt?: string;
+    alt?: string | undefined;
 }

--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -10,36 +10,162 @@ export type AlignType = 'left' | 'right' | 'center' | null;
 
 export type ReferenceType = 'shortcut' | 'collapsed' | 'full';
 
+/**
+ * This map registers all node types that may be used where markdown block content is accepted.
+ *
+ * These types are accepted inside block quotes, list items, footnotes, and roots.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface BlockContentMap {
+ *     // Allow using toml nodes defined by remark-frontmatter.
+ *     toml: TOML;
+ *   }
+ * }
+ */
+export interface BlockContentMap {
+    paragraph: Paragraph;
+    heading: Heading;
+    thematicbreak: ThematicBreak;
+    blockquote: Blockquote;
+    list: List;
+    table: Table;
+    html: HTML;
+    code: Code;
+}
+
+/**
+ * This map registers all node definition types.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface DefinitionContentMap {
+ *     // Allow using toml nodes defined by remark-frontmatter.
+ *     toml: TOML;
+ *   }
+ * }
+ */
+export interface DefinitionContentMap {
+    definition: Definition;
+    footnoteDefinition: FootnoteDefinition;
+}
+
+/**
+ * This map registers all node types that are acceptable in a static phrasing context.
+ *
+ * This interface can be augmented to register custom node types in a phrasing context, including links and link
+ * references.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface StaticPhrasingContentMap {
+ *     mdxJsxTextElement: MDXJSXTextElement;
+ *   }
+ * }
+ */
+export interface StaticPhrasingContentMap {
+    text: Text;
+    emphasis: Emphasis;
+    strong: Strong;
+    delete: Delete;
+    html: HTML;
+    inlinecode: InlineCode;
+    break: Break;
+    image: Image;
+    imagereference: ImageReference;
+    footnote: Footnote;
+    footnotereference: FootnoteReference;
+}
+
+/**
+ * This map registers all node types that are acceptable in a static phrasing context, except links.
+ *
+ * This interface can be augmented to register custom node types in a phrasing context, excluding links and link
+ * references.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface PhrasingContentMap {
+ *     mdxJsxTextElement: MDXJSXTextElement;
+ *   }
+ * }
+ */
+export interface PhrasingContentMap extends StaticPhrasingContentMap {
+    link: Link;
+    linkReference: LinkReference;
+}
+
+/**
+ * This map registers all node types that are acceptable inside lists.
+ *
+ * This interface can be augmented to register custom node types that are acceptable inside lists.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface ListContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface ListContentMap {
+    listItem: ListItem;
+}
+
+/**
+ * This map registers all node types that are acceptable inside tables (not table cells).
+ *
+ * This interface can be augmented to register custom node types that are acceptable inside tables.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface TableContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface TableContentMap {
+    tableRow: TableRow;
+}
+
+/**
+ * This map registers all node types that are acceptable inside tables rows (not table cells).
+ *
+ * This interface can be augmented to register custom node types that are acceptable inside table rows.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface RowContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface RowContentMap {
+    tableCell: TableCell;
+}
+
 export type Content = TopLevelContent | ListContent | TableContent | RowContent | PhrasingContent;
 
 export type TopLevelContent = BlockContent | FrontmatterContent | DefinitionContent;
 
-export type BlockContent = Paragraph | Heading | ThematicBreak | Blockquote | List | Table | HTML | Code;
+export type BlockContent = BlockContentMap[keyof BlockContentMap];
 
 export type FrontmatterContent = YAML;
 
-export type DefinitionContent = Definition | FootnoteDefinition;
+export type DefinitionContent = DefinitionContentMap[keyof DefinitionContentMap];
 
-export type ListContent = ListItem;
+export type ListContent = ListContentMap[keyof ListContentMap];
 
-export type TableContent = TableRow;
+export type TableContent = TableContentMap[keyof TableContentMap];
 
-export type RowContent = TableCell;
+export type RowContent = RowContentMap[keyof RowContentMap];
 
-export type PhrasingContent = StaticPhrasingContent | Link | LinkReference;
+export type PhrasingContent = PhrasingContentMap[keyof PhrasingContentMap];
 
-export type StaticPhrasingContent =
-    | Text
-    | Emphasis
-    | Strong
-    | Delete
-    | HTML
-    | InlineCode
-    | Break
-    | Image
-    | ImageReference
-    | Footnote
-    | FootnoteReference;
+export type StaticPhrasingContent = StaticPhrasingContentMap[keyof StaticPhrasingContentMap];
 
 export interface Parent extends UnistParent {
     children: Content[];

--- a/types/mdast/mdast-tests.ts
+++ b/types/mdast/mdast-tests.ts
@@ -2,65 +2,65 @@ import * as Mdast from 'mdast';
 
 const text: Mdast.Text = {
     type: 'text',
-    value: 'text'
+    value: 'text',
 };
 
 const cell: Mdast.TableCell = {
     type: 'tableCell',
-    children: [text]
+    children: [text],
 };
 
 const row: Mdast.TableRow = {
     type: 'tableRow',
-    children: [cell]
+    children: [cell],
 };
 
 const table: Mdast.Table = {
     type: 'table',
     align: ['left', 'center', 'right'],
-    children: [row]
+    children: [row],
 };
 
 const header: Mdast.Heading = {
     type: 'heading',
     depth: 1,
-    children: [text]
+    children: [text],
 };
 
 const code: Mdast.Code = {
     type: 'code',
     lang: 'javascript',
-    value: 'let n = 42;'
+    value: 'let n = 42;',
 };
 
 const paragraph: Mdast.Paragraph = {
     type: 'paragraph',
-    children: [text]
+    children: [text],
 };
 
 const item: Mdast.ListItem = {
     type: 'listItem',
-    children: [paragraph]
+    children: [paragraph],
 };
 
 const list: Mdast.List = {
     type: 'list',
-    children: [item]
+    children: [item],
 };
 
 const footNote: Mdast.FootnoteReference = {
     type: 'footnoteReference',
     identifier: 'ref1',
-    label: 'Referfence 1'
+    label: 'Referfence 1',
 };
 
 const image: Mdast.Image = {
     type: 'image',
     url: 'https://github.com/syntax-tree/mdast',
-    alt: 'image alternative'
+    alt: 'image alternative',
 };
 
 const root: Mdast.Root = {
     type: 'root',
-    children: [header, table, code, image]
+    children: [header, table, code, image],
 };

--- a/types/mdast/mdast-tests.ts
+++ b/types/mdast/mdast-tests.ts
@@ -1,5 +1,30 @@
 import * as Mdast from 'mdast';
 
+// Augmentations
+
+declare module 'mdast' {
+    interface BlockContentMap {
+        toml: TOML;
+    }
+
+    interface StaticPhrasingContentMap {
+        mdxJsxTextElement: MDXJSXTextElement;
+    }
+}
+
+interface TOML extends Mdast.Literal {
+    type: 'toml';
+}
+
+interface MDXJSXTextElement extends Mdast.Literal {
+    type: 'mdxJsxTextElement';
+}
+
+// Tests
+
+declare var toml: TOML;
+declare var mdxJsxTextElement: MDXJSXTextElement;
+
 const text: Mdast.Text = {
     type: 'text',
     value: 'text',
@@ -35,7 +60,7 @@ const code: Mdast.Code = {
 
 const paragraph: Mdast.Paragraph = {
     type: 'paragraph',
-    children: [text],
+    children: [text, mdxJsxTextElement],
 };
 
 const item: Mdast.ListItem = {
@@ -62,5 +87,5 @@ const image: Mdast.Image = {
 
 const root: Mdast.Root = {
     type: 'root',
-    children: [header, table, code, image],
+    children: [header, table, code, image, toml],
 };

--- a/types/mdast/tslint.json
+++ b/types/mdast/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-redundant-undefined": false
+    }
+}


### PR DESCRIPTION
This is fully backwards compatible.

This adds the ability to extend mdast content types by augmenting its interfaces.

For example, a remark plugin such as `remark-frontmatter` could now register a `toml` Node using the following type definitions:

```ts
interface TOML extends mdast.Literal {
  type: 'toml';
}

declare module 'mdast' {
  toml: TOML;
}
```

It would be better to move type definitions for node types introduced by remark plugins to those remark plugins, but they are kept here for backwards compatibility.

I first resolved linting issues in a separate commit.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

/cc @wooorm @ChristianMurphy 