### PR TITLE
twemoji: update to return string or HTMLElement dependent on `parse()` param type

### DIFF
--- a/types/twemoji/index.d.ts
+++ b/types/twemoji/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/twitter/twemoji
 // Definitions by: Markus Tacker <https://github.com/coderbyheart>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 David Wheatley <https://github.com/davwheat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/twemoji/index.d.ts
+++ b/types/twemoji/index.d.ts
@@ -225,4 +225,4 @@ export interface ParseObject {
  * });
  *  // I <img class="emoji" draggable="false" alt="❤️" src="/assets/72x72/2764.png"/> emoji!
  */
-export function parse(what: string | HTMLElement, how?: Partial<ParseObject> | ParseCallback): string;
+export function parse<T extends string | HTMLElement>(what: T, how?: Partial<ParseObject> | ParseCallback): T;

--- a/types/twemoji/test/twemoji-tests.common-js.ts
+++ b/types/twemoji/test/twemoji-tests.common-js.ts
@@ -20,3 +20,11 @@ twemoji.convert.toCodePoint('\ud83c\udde8\ud83c\uddf3');
 if (twemoji.test('foo')) {
     console.log('emoji All The Things!');
 }
+
+const x: HTMLElement = twemoji.parse(foo);
+const y: string = twemoji.parse('foo');
+
+// $ExpectError
+const a: string = twemoji.parse(foo);
+// $ExpectError
+const b: HTMLElement = twemoji.parse('foo');

--- a/types/twemoji/test/twemoji-tests.global.ts
+++ b/types/twemoji/test/twemoji-tests.global.ts
@@ -18,3 +18,11 @@ twemoji.convert.toCodePoint('\ud83c\udde8\ud83c\uddf3');
 if (twemoji.test('foo')) {
     console.log('emoji All The Things!');
 }
+
+const x: HTMLElement = twemoji.parse(foo);
+const y: string = twemoji.parse('foo');
+
+// $ExpectError
+const a: string = twemoji.parse(foo);
+// $ExpectError
+const b: HTMLElement = twemoji.parse('foo');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twitter/twemoji/blob/4d3a41480f3ff169d580fd9deb0d4c20d65f2930/scripts/build.js#L548-L556
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
