### PR TITLE
@types/braintree-web - ApplePayPaymentRequest: support lineItems

### DIFF
--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -38,6 +38,7 @@ export interface ApplePayPaymentRequest {
     merchantCapabilities: string[];
 
     billingContact?: any;
+    lineItems?: ApplePayLineItem[];
     shippingContact?: any;
     shippingMethods?: any;
     shippingType?: any;
@@ -70,6 +71,12 @@ export interface ApplePayDetails {
     cardType: string;
     cardholderName: string;
     dpanLastTwo: string;
+}
+
+export interface ApplePayLineItem {
+    type: string;
+    label: string;
+    amount: number;
 }
 
 export interface ApplePayPayload {


### PR DESCRIPTION
See https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest.

ApplePayPaymentRequest.lineItems was missing.