### PR TITLE
[indy-sdk] fix: add slash to import to prevent node import

### DIFF
--- a/types/indy-sdk/index.d.ts
+++ b/types/indy-sdk/index.d.ts
@@ -5,7 +5,7 @@
 //                 Karim Stekelenburg <https://github.com/karimStekelenburg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 
 export function createWallet(config: WalletConfig, credentials: WalletCredentials): Promise<void>;
 export function openWallet(config: WalletConfig, credentials: OpenWalletCredentials): Promise<WalletHandle>;

--- a/types/indy-sdk/indy-sdk-tests.ts
+++ b/types/indy-sdk/indy-sdk-tests.ts
@@ -1,5 +1,5 @@
 import indy from "indy-sdk";
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 
 indy.openBlobStorageWriter('default', {
     base_dir: 'dir',


### PR DESCRIPTION
The `buffer` library was imported without a `/`. This means that in Node environments the node buffer package would be used by typescript. This would then include the `/// <reference types="node" />` into libraries that use this type. We want to prevent the node type to be referenced.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Not related to package itself