### PR TITLE
Fix @ckeditor/ckeditor5-engine DowncastWriter

### DIFF
--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -103,7 +103,7 @@ pattern = (element: ViewElement) => {
 
 pattern = (element: ViewElement) => {
     if (element.name === "p") {
-        const fontSize = element.getStyle("font-size")!;
+        const fontSize = element.getStyle("font-size");
         const size = fontSize.match(/(\d+)/px);
 
         if (size && Number(size[1]) > 26) {

--- a/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
@@ -33,7 +33,7 @@ export default class DataController implements Emitter, Observable {
         callback: (stylesProcessor: StylesProcessor) => Record<string, Record<string, string> | string>,
     ): void;
     destroy(): void;
-    get(options?: { rootName?: string | undefined; trim?: "empty" | "none" | undefined }): string;
+    get(options?: { rootName?: string; trim?: "empty" | "none" }): string;
     init(data: string | Record<string, string>): Promise<void>;
     parse(data: string, context?: SchemaContextDefinition): DocumentFragment;
     registerRawContentMatcher(pattern: MatcherPattern): void;
@@ -65,7 +65,7 @@ export default class DataController implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
@@ -39,7 +39,7 @@ export default class EditingController implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/conversion/conversion.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/conversion.d.ts
@@ -20,9 +20,9 @@ export default class Conversion {
     );
     addAlias(alias: string, dispatcher: DowncastDispatcher | UpcastDispatcher): void;
     attributeToAttribute(definition?: {
-        model: string | { name?: string | undefined; key: string; values: string[] };
-        view: string | Record<string, { name?: string | undefined; key: string; value: string[] | Record<string, string> }>;
-        upcastAlso?: MatcherPattern | MatcherPattern[] | undefined;
+        model: string | { name?: string; key: string; values: string[] };
+        view: string | Record<string, { name?: string; key: string; value: string[] | Record<string, string> }>;
+        upcastAlso?: MatcherPattern | MatcherPattern[];
     }): void;
     attributeToElement(definition: ConverterDefinition): void;
     elementToElement(definition: ConverterDefinition): void;

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
@@ -17,7 +17,7 @@ export interface DowncastConversionApi<T = any> {
     consumable: ModelConsumable;
     dispatcher: DowncastDispatcher;
     mapper: Mapper;
-    options?: T | undefined;
+    options?: T;
     schema: Schema;
     writer: DowncastWriter;
 }
@@ -49,7 +49,7 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcasthelpers.d.ts
@@ -9,10 +9,10 @@ import UIElement from "../view/uielement";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export interface HighlightDescriptor {
-    attributes?: Record<string, string | number | boolean> | undefined;
-    classes?: string | string[] | undefined;
-    id?: string | undefined;
-    priority?: number | undefined;
+    attributes?: Record<string, string | number | boolean>;
+    classes?: string | string[];
+    id?: string;
+    priority?: number;
 }
 
 export function clearAttributes(): (...arg: any[]) => any;
@@ -27,7 +27,7 @@ export function remove(): (...arg: any[]) => any;
 
 export default class DowncastHelpers extends ConversionHelpers {
     attributeToAttribute(config?: {
-        model: string | { key: string; values: string[]; name?: string | undefined };
+        model: string | { key: string; values: string[]; name?: string };
         view:
             | string
             | { key: string; value: string }
@@ -37,33 +37,33 @@ export default class DowncastHelpers extends ConversionHelpers {
                   key: string;
                   value: string | string[] | Record<string, string>;
               });
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     attributeToElement(config?: {
-        model: string | { key: string; values: string[]; name?: string | undefined };
+        model: string | { key: string; values: string[]; name?: string };
         view: string | ElementDefinition | ((value: string, api: DowncastConversionApi) => AttributeElement);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     elementToElement(config?: {
         model: string;
         view: ElementDefinition | ((element: Element, api: DowncastConversionApi) => ContainerElement);
-        triggerBy?: { attributes: string[]; children: string[] } | undefined;
+        triggerBy?: { attributes: string[]; children: string[] };
     }): DowncastHelpers;
     markerToData(config?: {
         model: string;
-        view?: ((markerName: string, api: DowncastConversionApi) => { group: string; name: string }) | undefined;
-        converterPriority?: PriorityString | undefined;
+        view?: ((markerName: string, api: DowncastConversionApi) => { group: string; name: string });
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     markerToElement(config?: {
         model: string;
         view:
             | ElementDefinition
             | ((data: { [key: string]: any; isOpening: boolean }, api: DowncastConversionApi) => UIElement);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     markerToHighlight(config?: {
         model: string;
         view: HighlightDescriptor | ((data: any, api: DowncastConversionApi) => HighlightDescriptor);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/mapper.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/mapper.d.ts
@@ -19,11 +19,11 @@ export default class Mapper implements Emitter {
     getModelLength(viewNode: Element): number;
     markerNameToElements(name: string): Set<Element> | null;
     registerViewToModelLength(viewElementName: string, lengthCallback: (element: Element) => number): void;
-    toModelElement(viewElement: Element): ModelElement | undefined;
+    toModelElement(viewElement: Element): ModelElement;
     toModelPosition(viewPosition: Position): ModelPosition;
     toModelRange(viewRange: Range): ModelRange;
-    toViewElement(modelElement: ModelElement): Element | undefined;
-    toViewPosition(modelPosition: ModelPosition, options?: { isPhantom?: boolean | undefined }): Position;
+    toViewElement(modelElement: ModelElement): Element;
+    toViewPosition(modelPosition: ModelPosition, options?: { isPhantom?: boolean }): Position;
     toViewRange(modelRange: ModelRange): Range;
     unbindElementFromMarkerName(element: Element, name: string): void;
     unbindModelElement(modelElement: ModelElement): void;
@@ -44,7 +44,7 @@ export default class Mapper implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
@@ -69,7 +69,7 @@ export default class UpcastDispatcher implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
@@ -11,29 +11,29 @@ export default class UpcastHelpers extends ConversionHelpers {
             | string
             | {
                   key: string;
-                  name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  name?: string;
+                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> };
               };
 
         model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };
 
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
     dataToMarker(config?: {
         view: string;
-        model?: ((name: string, api: UpcastConversionApi) => string) | undefined;
-        converterPriority?: PriorityString | undefined;
+        model?: ((name: string, api: UpcastConversionApi) => string);
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
     elementToAttribute(config?: {
         view: MatcherPattern;
         model:
             | string
             | { key: string; value: string | ((viewElement: Element, api: UpcastConversionApi) => string | null) };
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
     elementToElement(config?: {
-        view?: MatcherPattern | undefined;
+        view?: MatcherPattern;
         model: string | ModelElement | ((el: Element, api: UpcastConversionApi) => ModelElement);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/viewconsumable.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/viewconsumable.d.ts
@@ -7,39 +7,39 @@ export default class ViewConsumable {
     add(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): void;
     consume(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): boolean;
     consume(element: Text | DocumentFragment): boolean;
     revert(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): void;
     revert(element: Text | DocumentFragment): void;
     test(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): boolean | null;
     test(element: Text | DocumentFragment): boolean | null;

--- a/types/ckeditor__ckeditor5-engine/src/model/differ.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/differ.d.ts
@@ -11,7 +11,7 @@ export default class Differ {
     bufferMarkerChange(markerName: string, oldRange: Range | null, newRange: Range | null, affectsData: boolean): void;
     bufferOperation(operation: Operation): void;
     getChangedMarkers(): Marker[];
-    getChanges(options?: { includeChangesInGraveyard?: boolean | undefined }): DiffItem[];
+    getChanges(options?: { includeChangesInGraveyard?: boolean }): DiffItem[];
     getMarkersToAdd(): Marker[];
     getMarkersToRemove(): Marker[];
     hasDataChanges(): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/document.d.ts
@@ -44,7 +44,7 @@ export default class Document implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/model/documentfragment.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentfragment.d.ts
@@ -26,10 +26,10 @@ export default class DocumentFragment implements Iterable<Node> {
 }
 
 interface FromJSONArg {
-    name?: string | undefined;
-    data?: string | undefined;
-    attributes?: Record<string, string> | Array<[string, string]> | undefined;
-    children?: FromJSONArg[] | undefined;
+    name?: string;
+    data?: string;
+    attributes?: Record<string, string> | Array<[string, string]>;
+    children?: FromJSONArg[];
 }
 
 export {};

--- a/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
@@ -23,7 +23,7 @@ export default class DocumentSelection implements Emitter {
     constructor(doc: Document);
     containsEntireContent(element?: Element): boolean;
     destroy(): void;
-    getAttribute(key: string): string | number | boolean | undefined;
+    getAttribute(key: string): string | number | boolean;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | number | boolean]>;
     getFirstPosition(): Position | null;
@@ -53,7 +53,7 @@ export default class DocumentSelection implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/model/element.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/element.d.ts
@@ -10,7 +10,7 @@ export default class Element extends Node {
 
     constructor(name: string, attrs?: Parameters<typeof toMap>[0] | null, children?: Node | Iterable<Node>);
 
-    findAncestor(parentName: string, options?: { includeSelf?: boolean | undefined }): Element | null;
+    findAncestor(parentName: string, options?: { includeSelf?: boolean }): Element | null;
     getChild(index: number): Element | Text;
     getChildIndex(node: Node): number;
     getChildStartOffset(node: Node): number;
@@ -20,7 +20,7 @@ export default class Element extends Node {
     offsetToIndex(offset: number): number;
     toJSON(): ReturnType<Node["toJSON"]> & {
         name: string;
-        children?: Array<ReturnType<Element["toJSON"] | Text["toJSON"]>> | undefined;
+        children?: Array<ReturnType<Element["toJSON"] | Text["toJSON"]>>;
     };
 
     static fromJSON(json: ReturnType<Element["toJSON"]>): Element;

--- a/types/ckeditor__ckeditor5-engine/src/model/history.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/history.d.ts
@@ -2,9 +2,9 @@ import Operation from "./operation/operation";
 
 export default class History {
     addOperation(operation: Operation): void;
-    getOperation(baseVersion: number): Operation | undefined;
+    getOperation(baseVersion: number): Operation;
     getOperations(from?: number, to?: number): Operation[];
-    getUndoneOperation(undoingOperation: Operation): Operation | undefined;
+    getUndoneOperation(undoingOperation: Operation): Operation;
     isUndoingOperation(operation: Operation): Boolean;
     isUndoneOperation(operation: Operation): Boolean;
     setOperationAsUndone(undoneOperation: Operation, undoingOperation: Operation): void;

--- a/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
@@ -37,15 +37,15 @@ export default class Model implements Emitter, Observable {
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): Selection;
     deleteContent(
         selection: Selection | DocumentSelection,
         options?: {
-            leaveUnmerged?: boolean | undefined;
-            doNotResetEntireContent?: boolean | undefined;
-            doNotAutoparagraph?: boolean | undefined;
-            direction?: "forward" | "backward" | undefined;
+            leaveUnmerged?: boolean;
+            doNotResetEntireContent?: boolean;
+            doNotAutoparagraph?: boolean;
+            direction?: "forward" | "backward";
         },
     ): void;
     destroy(): void;
@@ -53,7 +53,7 @@ export default class Model implements Emitter, Observable {
     getSelectedContent(selection: Selection | DocumentSelection): DocumentFragment;
     hasContent(
         rangeOrElement: Range | Element,
-        options?: { ignoreWhitespaces?: boolean | undefined; ignoreMarkers?: boolean | undefined },
+        options?: { ignoreWhitespaces?: boolean; ignoreMarkers?: boolean },
     ): boolean;
     insertContent(
         content: DocumentFragment | Item,
@@ -62,7 +62,7 @@ export default class Model implements Emitter, Observable {
     ): Range;
     modifySelection(
         selection: Selection | DocumentSelection,
-        options?: { direction?: "forward" | "backward" | undefined; unit?: "character" | "codePoint" | "word" | undefined },
+        options?: { direction?: "forward" | "backward"; unit?: "character" | "codePoint" | "word" },
     ): void;
 
     set(option: Record<string, unknown>): void;
@@ -86,7 +86,7 @@ export default class Model implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/model/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/node.d.ts
@@ -17,11 +17,11 @@ export default class Node {
     readonly startOffset: number | null;
 
     constructor(attrs?: Parameters<typeof toMap>[0]);
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
-    getAttribute(key: string): string | undefined;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
+    getAttribute(key: string): string;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | number | boolean]>;
-    getCommonAncestor(node: Node, options?: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
+    getCommonAncestor(node: Node, options?: { includeSelf?: boolean }): Element | DocumentFragment | null;
     getPath(): number[];
     hasAttribute(key: string): boolean;
     is(type: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/transform.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/transform.d.ts
@@ -14,7 +14,7 @@ export function transform(a: Operation, b: Operation, context: TransformationCon
 export function transformSets(
     operationsA: Operation[],
     operationsB: Operation[],
-    options?: { document: Document | null; useRelations?: boolean | undefined; padWithNoOps?: boolean | undefined },
+    options?: { document: Document | null; useRelations?: boolean; padWithNoOps?: boolean },
 ): {
     operationsA: Operation[];
     operationsB: Operation[];

--- a/types/ckeditor__ckeditor5-engine/src/model/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/position.d.ts
@@ -47,11 +47,11 @@ export default class Position {
     getLastMatchingPosition(
         skip: (value: TreeWalkerValue) => boolean,
         options?: {
-            boundaries?: Range | undefined;
-            direction?: TreeWalkerDirection | undefined;
-            ignoreElementEnd?: boolean | undefined;
-            shallow?: boolean | undefined;
-            singleCharacters?: boolean | undefined;
+            boundaries?: Range;
+            direction?: TreeWalkerDirection;
+            ignoreElementEnd?: boolean;
+            shallow?: boolean;
+            singleCharacters?: boolean;
             startPosition: Position;
         },
     ): Position;

--- a/types/ckeditor__ckeditor5-engine/src/model/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/range.d.ts
@@ -24,30 +24,30 @@ export default class Range implements Iterable<TreeWalkerValue> {
     getDifference(otherRange: Range): Range[];
     getIntersection(otherRange: Range): Range | null;
     getItems(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
+        boundaries?: Range;
+        direction?: TreeWalkerDirection;
+        ignoreElementEnd?: boolean;
+        shallow?: boolean;
+        singleCharacters?: boolean;
         startPosition: Position;
     }): Generator<Item>;
     getJoined(otherRange: Range, loose?: boolean): Range | null;
     getMinimalFlatRanges(): Range[];
     getPositions(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
+        boundaries?: Range;
+        direction?: TreeWalkerDirection;
+        ignoreElementEnd?: boolean;
+        shallow?: boolean;
+        singleCharacters?: boolean;
         startPosition: Position;
     }): Generator<Position>;
     getTransformedByOperation(operation: Operation): Range[];
     getTransformedByOperations(operations: Iterable<Operation>): Range[];
     getWalker(options?: {
-        startPosition?: Position | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        startPosition?: Position;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): TreeWalker;
     is(type: string): boolean;
     isEqual(otherRange: Range): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
@@ -60,7 +60,7 @@ export default class Schema implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
@@ -69,20 +69,20 @@ export default class Schema implements Emitter, Observable {
 }
 
 export interface SchemaItemDefinition {
-    allowAttributes?: string | string[] | undefined;
-    allowAttributesOf?: string | string[] | undefined;
-    allowChildren?: string|string[] | undefined;
-    allowContentOf?: string | string[] | undefined;
-    allowIn?: string | string[] | undefined;
-    allowWhere?: string | string[] | undefined;
-    inheritAllFrom?: string | undefined;
-    inheritTypesFrom?: string | string[] | undefined;
-    isblock?: boolean | undefined;
-    isContent?: boolean | undefined;
-    isInline?: boolean | undefined;
-    isLimit?: boolean | undefined;
-    isObject?: boolean | undefined;
-    isSelectable?: boolean | undefined;
+    allowAttributes?: string | string[];
+    allowAttributesOf?: string | string[];
+    allowChildren?: string|string[];
+    allowContentOf?: string | string[];
+    allowIn?: string | string[];
+    allowWhere?: string | string[];
+    inheritAllFrom?: string;
+    inheritTypesFrom?: string | string[];
+    isblock?: boolean;
+    isContent?: boolean;
+    isInline?: boolean;
+    isLimit?: boolean;
+    isObject?: boolean;
+    isSelectable?: boolean;
 }
 
 export interface SchemaContextItem {
@@ -106,8 +106,8 @@ export interface SchemaCompiledItemDefinition {
 }
 
 export interface AttributeProperties {
-    copyOnEnter?: boolean | undefined;
-    isFormatting?: boolean | undefined;
+    copyOnEnter?: boolean;
+    isFormatting?: boolean;
 }
 
 export class SchemaContext implements Iterable<SchemaContextItem> {

--- a/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
@@ -21,10 +21,10 @@ export default class Selection implements Emitter {
     constructor(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     );
     containsEntireContent(element: Element): boolean;
-    getAttribute(key: string): string | boolean | number | undefined;
+    getAttribute(key: string): string | boolean | number;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | boolean | number]>;
     getFirstPosition(): Position | null;
@@ -44,7 +44,7 @@ export default class Selection implements Emitter {
     setTo(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): void;
 
     on: (
@@ -62,7 +62,7 @@ export default class Selection implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/model/text.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/text.d.ts
@@ -13,6 +13,6 @@ export default class Text extends Node {
 
     static fromJSON(json: {
         data: string;
-        attributes?: Record<string, string | number | boolean> | Array<[string, string | number | boolean]> | undefined;
+        attributes?: Record<string, string | number | boolean> | Array<[string, string | number | boolean]>;
     }): Text;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/textproxy.d.ts
@@ -14,7 +14,7 @@ export default class TextProxy {
     readonly startOffset: number;
     readonly textNode: Text;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
     getAttribute(key: string): string | number | boolean;
     getAttributeKeys(): ReturnType<Text["getAttributeKeys"]>;
     getAttributes(): ReturnType<Text["getAttributes"]>;

--- a/types/ckeditor__ckeditor5-engine/src/model/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/treewalker.d.ts
@@ -23,11 +23,11 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly singleCharacters: boolean;
 
     constructor(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
+        boundaries?: Range;
+        direction?: TreeWalkerDirection;
+        ignoreElementEnd?: boolean;
+        shallow?: boolean;
+        singleCharacters?: boolean;
         startPosition: Position;
     });
     [Symbol.iterator](): Iterator<TreeWalkerValue>;

--- a/types/ckeditor__ckeditor5-engine/src/model/writer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/writer.d.ts
@@ -14,7 +14,7 @@ export default class Writer {
     readonly batch: Batch;
     readonly model: Model;
 
-    addMarker(name: string, options?: { usingOperation?: boolean | undefined; range: Range; affectsData?: boolean | undefined }): Marker;
+    addMarker(name: string, options?: { usingOperation?: boolean; range: Range; affectsData?: boolean }): Marker;
     append(item: Item | DocumentFragment, parent: Element | DocumentFragment): void;
     appendElement(
         name: string,
@@ -43,7 +43,7 @@ export default class Writer {
     createSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): Selection;
     createText(data: string, attributes?: Record<string, string | number | boolean>): Text;
     insert(
@@ -88,7 +88,7 @@ export default class Writer {
     setSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): void;
     setSelectionAttribute(
         keyOrObjectOrIterable: Record<string, string | number | boolean> | Array<[string, string | number | boolean]>,
@@ -100,7 +100,7 @@ export default class Writer {
     unwrap(element: Element): void;
     updateMarker(
         markerOrName: string | Marker,
-        options?: { range?: Range | undefined; usingOperation?: boolean | undefined; affectsData?: boolean | undefined },
+        options?: { range?: Range; usingOperation?: boolean; affectsData?: boolean },
     ): void;
     wrap(range: Range, elementOrString: Element | string): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
@@ -44,7 +44,7 @@ export default class Document implements BubblingEmitter, Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/src/view/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/documentselection.d.ts
@@ -15,7 +15,7 @@ export default class DocumentSelection {
     constructor(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     );
     getFirstPosition(): Position | null;
     getFirstRange(): Range | null;

--- a/types/ckeditor__ckeditor5-engine/src/view/domconverter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/domconverter.d.ts
@@ -19,22 +19,22 @@ export default class DomConverter {
     readonly document: ViewDocument;
     readonly preElements: string[];
 
-    constructor(document: ViewDocument, options?: { blockFillerMode?: BlockFillerMode | undefined });
+    constructor(document: ViewDocument, options?: { blockFillerMode?: BlockFillerMode });
     bindDocumentFragments(domFragment: DocumentFragment, viewFragment: ViewDocumentFragment): void;
     bindElements(domElement: HTMLElement, viewElement: ViewElement): void;
     bindFakeSelection(domElement: HTMLElement, viewDocumentSelection: DocumentSelection): void;
     domChildrenToView(
         domElement: HTMLElement,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined; keepOriginalCase?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean; keepOriginalCase?: boolean },
     ): Generator<Node>;
     domPositionToView(domParent: Node, domOffset: number): Position;
     domRangeToView(domRange: Range): ViewRange | null;
     domSelectionToView(domSelection: Selection): ViewSelection;
     domToView(
         domNode: Node | DocumentFragment,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined; keepOriginalCase?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean; keepOriginalCase?: boolean },
     ): ViewNode | ViewDocumentFragment | null;
-    fakeSelectionToView(domElement: HTMLElement): ViewSelection | undefined;
+    fakeSelectionToView(domElement: HTMLElement): ViewSelection;
     findCorrespondingDomText(viewText: ViewText): Text | null;
     findCorrespondingViewText(domText: Text): ViewText | null;
     focus(viewEditable: EditableElement): void;
@@ -47,20 +47,20 @@ export default class DomConverter {
     isElement(node: Node): boolean;
     mapDomToView(
         domElementOrDocumentFragment: DocumentFragment | Element,
-    ): ViewElement | ViewDocumentFragment | undefined;
-    mapViewToDom(viewNode: ViewElement | ViewDocumentFragment): Node | DocumentFragment | undefined;
+    ): ViewElement | ViewDocumentFragment;
+    mapViewToDom(viewNode: ViewElement | ViewDocumentFragment): Node | DocumentFragment;
     registerRawContentMatcher(pattern: MatcherPattern): void;
     unbindDomElement(domElement: HTMLElement): void;
     viewChildrenToDom(
         viewElement: ViewElement | ViewDocumentFragment,
         domDocument: Document,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean },
     ): Generator<Node>;
     viewPositionToDom(viewPosition: Position): { parent: Node; offset: number } | null;
     viewRangeToDom(viewRange: ViewRange): Range;
     viewToDom(
         viewNode: ViewNode | ViewDocumentFragment,
         domDocument: Document,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean },
     ): Node | DocumentFragment;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/downcastwriter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/downcastwriter.d.ts
@@ -31,18 +31,18 @@ export default class DowncastWriter {
     createContainerElement(
         name: string,
         attributes?: Record<string, string>,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): ContainerElement;
     createDocumentFragment(children: Node | Iterable<Node>): DocumentFragment;
     createEditableElement(name: string, attributes?: Record<string, string>): EditableElement;
     createEmptyElement(
         name: string,
         attributes?: Record<string, string>,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): EmptyElement;
     createPositionAfter(item: Item): Position;
-    createPositionAt(itemOrPosition: View, offset?: number | "end" | "before" | "after"): Position;
-    createPositionAt(itemOrPosition: Item | Position): Position;
+    createPositionAt(itemOrPosition: Item, offset?: number | "end" | "before" | "after"): Position;
+    createPositionAt(itemOrPosition: Position): Position;
     createPositionBefore(item: Item): Position;
     createRange(start: Position, end?: Position): Range;
     createRangeIn(element: Element): Range;
@@ -51,19 +51,19 @@ export default class DowncastWriter {
         name?: string,
         attributes?: Record<string, string>,
         renderFunction?: (domElement: HTMLElement) => void,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): RawElement;
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): Selection;
     createText(data: string): Text;
     createUIElement(
         name: string,
         attributes?: Record<string, string>,
         renderFunction?: (domElement: HTMLElement) => void,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): UIElement;
     insert(
         position: Position | null,
@@ -90,7 +90,7 @@ export default class DowncastWriter {
     setSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): void;
     setSelectionFocus(itemOrPosition: View, offset?: number | "end" | "before" | "after"): void;
     setSelectionFocus(itemOrPosition: Item | Position): void;

--- a/types/ckeditor__ckeditor5-engine/src/view/element.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/element.d.ts
@@ -11,13 +11,13 @@ export default abstract class Element extends Node {
             | string
             | RegExp
             | {
-                  attributes?: Record<string, string | RegExp | boolean> | undefined;
-                  classes?: string | RegExp | Array<string | RegExp> | undefined;
-                  name?: string | RegExp | undefined;
+                  attributes?: Record<string, string | RegExp | boolean>;
+                  classes?: string | RegExp | Array<string | RegExp>;
+                  name?: string | RegExp;
                   styles: Record<string, string>;
               },
     ): Element | null;
-    getAttribute(key: string): string | undefined;
+    getAttribute(key: string): string;
     getAttributeKeys(): Generator<string>;
     getAttributes(): Generator<[string, unknown]>;
     getChild(index: number): Node;
@@ -28,8 +28,8 @@ export default abstract class Element extends Node {
     getCustomProperty(key: string | symbol): any;
     getFillerOffset(): number | null;
     getIdentity(): string;
-    getNormalizedStyle(property: string): Record<string, string> | string | undefined;
-    getStyle(property: string): string | undefined;
+    getNormalizedStyle(property: string): Record<string, string> | string;
+    getStyle(property: string): string;
     getStyleNames(): ReturnType<StylesMap["getStyleNames"]>;
     hasAttribute(key: string): boolean;
     hasClass(className: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/elementdefinition.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/elementdefinition.d.ts
@@ -1,9 +1,9 @@
 export type ElementDefinition =
     | string
     | {
-          attributes?: Record<string, string> | undefined;
-          classes?: string | string[] | undefined;
+          attributes?: Record<string, string>;
+          classes?: string | string[];
           name: string;
-          priority?: number | undefined;
-          styles?: Record<string, string> | undefined;
+          priority?: number;
+          styles?: Record<string, string>;
       };

--- a/types/ckeditor__ckeditor5-engine/src/view/matcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/matcher.d.ts
@@ -6,17 +6,17 @@ export default class Matcher {
             | string
             | RegExp
             | {
-                  attributes?: Record<string, string | RegExp | boolean> | undefined;
-                  classes?: string | RegExp | Array<string | RegExp> | undefined;
-                  name?: string | RegExp | undefined;
+                  attributes?: Record<string, string | RegExp | boolean>;
+                  classes?: string | RegExp | Array<string | RegExp>;
+                  name?: string | RegExp;
                   styles: Record<string, string>;
               },
     );
     add(
         ...pattern: Array<{
-            attributes?: Record<string, string | RegExp | boolean> | undefined;
-            classes?: string | RegExp | Array<string | RegExp> | undefined;
-            name?: string | RegExp | undefined;
+            attributes?: Record<string, string | RegExp | boolean>;
+            classes?: string | RegExp | Array<string | RegExp>;
+            name?: string | RegExp;
             styles: Record<string, string>;
         }>
     ): void;
@@ -25,25 +25,25 @@ export default class Matcher {
         element: Element,
     ): {
         element: Element;
-        match: { name?: boolean | undefined; attribute?: string[] | undefined; classes?: string[] | undefined; styles?: Array<[string, string]> | undefined };
+        match: { name?: boolean; attribute?: string[]; classes?: string[]; styles?: Array<[string, string]> };
     } | null;
     matchAll(
         element: Element,
     ): Array<{
         element: Element;
-        match: { name?: boolean | undefined; attribute?: string[] | undefined; classes?: string[] | undefined; styles?: Array<[string, string]> | undefined };
+        match: { name?: boolean; attribute?: string[]; classes?: string[]; styles?: Array<[string, string]> };
     }> | null;
 }
 
 export type MatcherPattern =
     | ((
           element: Element,
-      ) => null | { name?: boolean | undefined; attribute?: string[] | undefined; classes?: string[] | undefined; styles?: Array<[string, string]> | undefined })
+      ) => null | { name?: boolean; attribute?: string[]; classes?: string[]; styles?: Array<[string, string]> })
     | string
     | RegExp
     | {
-          attributes?: Record<string, string | RegExp | boolean> | undefined;
-          classes?: string | RegExp | Array<string | RegExp> | undefined;
-          name?: string | RegExp | undefined;
-          styles?: Record<string, string | RegExp> | undefined;
+          attributes?: Record<string, string | RegExp | boolean>;
+          classes?: string | RegExp | Array<string | RegExp>;
+          name?: string | RegExp;
+          styles?: Record<string, string | RegExp>;
       };

--- a/types/ckeditor__ckeditor5-engine/src/view/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/node.d.ts
@@ -10,8 +10,8 @@ export default abstract class Node {
     readonly previousSibling: Node | null;
     readonly root: Node | DocumentFragment;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
-    getCommonAncestor(node: Node, options?: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
+    getCommonAncestor(node: Node, options?: { includeSelf?: boolean }): Element | DocumentFragment | null;
     getPath(): number[];
     is(type: string): boolean;
     isAfter(node: Node): boolean;
@@ -19,7 +19,7 @@ export default abstract class Node {
     isBefore(node: Node): boolean;
     isSimilar(otherElement: Node): boolean;
     toJSON(): {
-        _textData?: string | undefined;
+        _textData?: string;
         document: string;
     };
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/keyobserver.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/keyobserver.d.ts
@@ -8,10 +8,10 @@ export default class KeyObserver extends DomEventObserver {
 }
 
 export class KeyEventData extends DomEventData implements KeystrokeInfo {
-    altKey?: boolean | undefined;
-    ctrlKey?: boolean | undefined;
+    altKey?: boolean;
+    ctrlKey?: boolean;
     keyCode: number;
-    shiftKey?: boolean | undefined;
-    metaKey?: boolean | undefined;
+    shiftKey?: boolean;
+    metaKey?: boolean;
     readonly keystroke: number;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/placeholder.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/placeholder.d.ts
@@ -7,8 +7,8 @@ export function enablePlaceholder(options?: {
     view: View;
     element: Element;
     text: string;
-    isDirectHost?: boolean | undefined;
-    keepOnFocus?: boolean | undefined;
+    isDirectHost?: boolean;
+    keepOnFocus?: boolean;
 }): void;
 export function hidePlaceholder(writer: DowncastWriter, element: Element): boolean;
 export function needsPlaceholder(element: Element, keepOnFocus: boolean): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/position.d.ts
@@ -22,20 +22,20 @@ export default class Position {
     getLastMatchingPosition(
         skip: (value: TreeWalkerValue) => boolean,
         options?: {
-            boundaries?: Range | undefined;
+            boundaries?: Range;
             startPosition: Position;
-            direction?: TreeWalkerDirection | undefined;
-            singleCharacters?: boolean | undefined;
-            shallow?: boolean | undefined;
-            ignoreElementEnd?: boolean | undefined;
+            direction?: TreeWalkerDirection;
+            singleCharacters?: boolean;
+            shallow?: boolean;
+            ignoreElementEnd?: boolean;
         },
     ): Position;
     getShiftedBy(shift: number): Position;
     getWalker(options?: {
-        boundaries?: Range | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        boundaries?: Range;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): TreeWalker;
     is(type: string): boolean;
     isAfter(otherPosition: Position): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/range.d.ts
@@ -23,27 +23,27 @@ export default class Range implements Iterable<TreeWalkerValue> {
     getEnlarged(): Range;
     getIntersection(otherRange: Range): Range | null;
     getItems(options?: {
-        boundaries?: Range | undefined;
+        boundaries?: Range;
         startPosition: Position;
-        direction?: TreeWalkerDirection | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        direction?: TreeWalkerDirection;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): Iterable<Item>;
     getPositions(options?: {
-        boundaries?: Range | undefined;
+        boundaries?: Range;
         startPosition: Position;
-        direction?: TreeWalkerDirection | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        direction?: TreeWalkerDirection;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): Iterable<Position>;
     getTrimmed(): Range;
     getWalker(options?: {
-        startPosition?: Position | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        startPosition?: Position;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): TreeWalker;
     is(type: string): boolean;
     isEqual(otherRange: Range): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/selection.d.ts
@@ -20,9 +20,9 @@ export default class Selection {
     constructor(
         selectable?: Item,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: boolean | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: boolean },
     );
-    constructor(selectable?: Selectable, options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: boolean | undefined });
+    constructor(selectable?: Selectable, options?: { backward?: boolean; fake?: boolean; label?: boolean });
     getFirstPosition(): Position | null;
     getFirstRange(): Range | null;
     getLastPosition(): Position | null;
@@ -37,6 +37,6 @@ export default class Selection {
     setTo(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: boolean | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: boolean },
     ): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/stylesmap.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/stylesmap.d.ts
@@ -4,8 +4,8 @@ export default class StylesMap {
 
     constructor(styleProcessor: StylesProcessor);
     clear(): void;
-    getAsString(propertyName: string): string | undefined;
-    getNormalized(name: string): Record<string, string> | string | undefined;
+    getAsString(propertyName: string): string;
+    getNormalized(name: string): Record<string, string> | string;
     getStyleNames(): string[];
     has(name: string): boolean;
     remove(name: string): void;

--- a/types/ckeditor__ckeditor5-engine/src/view/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/textproxy.d.ts
@@ -14,6 +14,6 @@ export default class TextProxy {
     readonly root: Node | DocumentFragment;
     readonly textNode: Text;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
     is(type: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/treewalker.d.ts
@@ -6,7 +6,7 @@ export type TreeWalkerValueType = "elementStart" | "elementEnd" | "text";
 
 export interface TreeWalkerValue {
     item: Item;
-    length: number | undefined;
+    length: number;
     nextPosition: Position;
     previousPosition: Position;
     type: TreeWalkerValueType;
@@ -23,12 +23,12 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly singleCharacters: boolean;
 
     constructor(options?: {
-        boundaries?: Range | undefined;
+        boundaries?: Range;
         startPosition: Position;
-        direction?: TreeWalkerDirection | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        direction?: TreeWalkerDirection;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     });
     [Symbol.iterator](): Iterator<TreeWalkerValue>;
     next(): TreeWalkerValue;

--- a/types/ckeditor__ckeditor5-engine/src/view/upcastwriter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/upcastwriter.d.ts
@@ -30,7 +30,7 @@ export default class UpcastWriter {
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): Selection;
     createText(data: string): Text;
     insertChild(index: number, items: Item | Iterable<Item>, element: Element | DocumentFragment): number;

--- a/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
@@ -35,7 +35,7 @@ export default class View implements Emitter, Observable {
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): Selection;
     destroy(): void;
     detachDomRoot(name: string): void;
@@ -44,7 +44,7 @@ export default class View implements Emitter, Observable {
     focus(): void;
     forceRender(): void;
     getDomRoot(name?: string): Element;
-    getObserver(ObserverClass: typeof Observer): Observer | undefined;
+    getObserver(ObserverClass: typeof Observer): Observer;
     scrollToTheSelection(): void;
 
     set(option: Record<string, unknown>): void;
@@ -68,7 +68,7 @@ export default class View implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v11/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/v11/ckeditor__ckeditor5-engine-tests.ts
@@ -49,7 +49,7 @@ pattern = (element: engine.view.Element) => {
 
 pattern = (element: engine.view.Element) => {
     if (element.name === "p") {
-        const fontSize = element.getStyle("font-size")!;
+        const fontSize = element.getStyle("font-size");
         const size = fontSize.match(/(\d+)/px);
 
         if (size && Number(size[1]) > 26) {

--- a/types/ckeditor__ckeditor5-engine/v11/index.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v11/index.d.ts
@@ -40,7 +40,7 @@ export namespace controller {
             emitter: Emitter,
             event: string,
             callback: Function,
-            options?: { priority?: PriorityString | number | undefined },
+            options?: { priority?: PriorityString | number },
         ): void;
         off(event: string, callback?: Function): void;
         on(event: string, callback: Function, options?: { priority: PriorityString | number }): void;
@@ -74,7 +74,7 @@ export namespace controller {
             emitter: Emitter,
             event: string,
             callback: Function,
-            options?: { priority?: PriorityString | number | undefined },
+            options?: { priority?: PriorityString | number },
         ): void;
         off(event: string, callback?: Function): void;
         on(event: string, callback: Function, options?: { priority: PriorityString | number }): void;
@@ -98,8 +98,8 @@ export namespace conversion {
         constructor();
         attributeToAttribute(definition?: {
             model: string | Object;
-            view?: string | Object | undefined;
-            upcastAlso?: view.MatcherPattern | view.MatcherPattern[] | undefined;
+            view?: string | Object;
+            upcastAlso?: view.MatcherPattern | view.MatcherPattern[];
         }): void;
         attributeToElement(definition: ConverterDefinition): void;
         elementToElement(definition: ConverterDefinition): void;
@@ -147,10 +147,10 @@ export namespace conversion {
         getModelLength(viewNode: view.Element): number;
         markerNameToElements(name: string): Set<view.Element> | null;
         registerViewToModelLength(viewElementName: string, lengthCallback: Function): void;
-        toModelElement(viewElement: view.Element): model.Element | undefined;
+        toModelElement(viewElement: view.Element): model.Element;
         toModelPosition(viewPosition: view.Position): model.Position;
         toModelRange(viewRange: view.Range): model.Range;
-        toViewElement(modelElement: model.Element): view.Element | undefined;
+        toViewElement(modelElement: model.Element): view.Element;
         toViewPosition(modelPosition: model.Position, options?: { isPhantom: boolean }): view.Position;
         toViewRange(modelRange: model.Range): view.Range;
         unbindElementsFromMarkerName(name: string): void;
@@ -177,25 +177,25 @@ export namespace conversion {
     function upcastAttributeToAttribute(config: {
         view: string | { key: string; name: string; value: string | RegExp | Function };
         model: string | { key: string; value: string | Function };
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): Function;
 
     function upcastElementToAttribute(config: {
         view: view.MatcherPattern;
         model: string | { key: string; value: string | Function };
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): Function;
 
     function upcastElementToElement(config: {
         view: view.MatcherPattern;
         model: string | Element | Function;
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): Function;
 
     function upcastElementToMarker(config: {
         view: view.MatcherPattern;
         model: string | Function;
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): Function;
 
     // engine/conversion/upcast-selection-converters
@@ -269,9 +269,9 @@ export namespace devUtils {
         function getData(
             model: model.Model,
             options?: {
-                withoutSelection?: boolean | undefined;
-                rootName?: string | undefined;
-                convertMarkers?: boolean | undefined;
+                withoutSelection?: boolean;
+                rootName?: string;
+                convertMarkers?: boolean;
             },
         ): string;
 
@@ -280,9 +280,9 @@ export namespace devUtils {
             schema: model.Schema,
             batch: model.Batch,
             options?: {
-                selectionAttributes?: Object[] | undefined;
-                lastRangeBackward?: boolean | undefined;
-                context?: model.SchemaContextDefinition | undefined;
+                selectionAttributes?: Object[];
+                lastRangeBackward?: boolean;
+                context?: model.SchemaContextDefinition;
             },
         ): model.Element | model.Text | model.DocumentFragment | Object;
 
@@ -290,10 +290,10 @@ export namespace devUtils {
             model: string,
             data: Object,
             options: {
-                rootName?: string | undefined;
-                selectionAttributes?: Object[] | undefined;
-                lastRangeBackward?: boolean | undefined;
-                batchType?: string | undefined;
+                rootName?: string;
+                selectionAttributes?: Object[];
+                lastRangeBackward?: boolean;
+                batchType?: string;
             },
         ): void;
 
@@ -315,37 +315,37 @@ export namespace devUtils {
     function getData(
         view: view.View,
         options?: {
-            withoutSelection?: boolean | undefined;
-            rootName?: boolean | undefined;
-            showType?: boolean | undefined;
-            showPriority?: boolean | undefined;
-            showAttributeElementId?: boolean | undefined;
-            renderUIElements?: boolean | undefined;
+            withoutSelection?: boolean;
+            rootName?: boolean;
+            showType?: boolean;
+            showPriority?: boolean;
+            showAttributeElementId?: boolean;
+            renderUIElements?: boolean;
         },
     ): string;
 
     function parse(
         data: string,
         options: {
-            order?: number[] | undefined;
-            lastRangeBackward?: boolean | undefined;
-            rootElement?: view.Element | view.DocumentFragment | undefined;
-            sameSelectionCharacters?: boolean | undefined;
+            order?: number[];
+            lastRangeBackward?: boolean;
+            rootElement?: view.Element | view.DocumentFragment;
+            sameSelectionCharacters?: boolean;
         },
     ): view.Text | view.Element | view.DocumentFragment | Object;
 
-    function setData(view: view.View, data: string, options: { rootName?: string | undefined }): void;
+    function setData(view: view.View, data: string, options: { rootName?: string }): void;
 
     function stringify(
         node: view.Text | view.Element | view.DocumentFragment,
         selectionOrPositionOrRange?: view.DocumentSelection | view.Position | view.Range,
         options?: {
-            showType?: boolean | undefined;
-            showPriority?: boolean | undefined;
-            showAttributeElementId?: boolean | undefined;
-            ignoreRoot?: boolean | undefined;
-            sameSelectionCharacters?: boolean | undefined;
-            renderUIElements?: boolean | undefined;
+            showType?: boolean;
+            showPriority?: boolean;
+            showAttributeElementId?: boolean;
+            ignoreRoot?: boolean;
+            sameSelectionCharacters?: boolean;
+            renderUIElements?: boolean;
         },
     ): string;
 }
@@ -458,7 +458,7 @@ export namespace model {
         function modifySelection(
             model: Model,
             selection: Selection | DocumentSelection,
-            options?: { direction?: "forward" | "backward" | undefined; unit?: "character" | "codePoint" | "word" | undefined },
+            options?: { direction?: "forward" | "backward"; unit?: "character" | "codePoint" | "word" },
         ): void;
 
         function injectSelectionPostFixer(model: Model): void;
@@ -589,7 +589,7 @@ export namespace model {
         deleteContent(
             selection: Selection | DocumentSelection,
             batch: Batch,
-            options: { leaveUnmerged?: boolean | undefined; doNotResetEntireContent?: boolean | undefined },
+            options: { leaveUnmerged?: boolean; doNotResetEntireContent?: boolean },
         ): void;
         destroy(): void;
         enqueueChange(batchOrType: Batch | "transparent" | "default", callback: Function): void;
@@ -601,7 +601,7 @@ export namespace model {
         ): void;
         modifySelection(
             selection: Selection | DocumentSelection,
-            options?: { direction?: "forward" | "backward" | undefined; unit?: "character" | "codePoint" | "word" | undefined },
+            options?: { direction?: "forward" | "backward"; unit?: "character" | "codePoint" | "word" },
         ): void;
 
         // Emitter
@@ -611,7 +611,7 @@ export namespace model {
             emitter: Emitter,
             event: string,
             callback: Function,
-            options?: { priority?: PriorityString | number | undefined },
+            options?: { priority?: PriorityString | number },
         ): void;
         off(event: string, callback?: Function): void;
         on(event: string, callback: Function, options?: { priority: PriorityString | number }): void;
@@ -817,7 +817,7 @@ export namespace model {
             emitter: Emitter,
             event: string,
             callback: Function,
-            options?: { priority?: PriorityString | number | undefined },
+            options?: { priority?: PriorityString | number },
         ): void;
         off(event: string, callback?: Function): void;
         on(event: string, callback: Function, options?: { priority: PriorityString | number }): void;
@@ -855,8 +855,8 @@ export namespace model {
 
         protected constructor(textNode: Text, offsetInText: number, length: number);
         getAncestors(options: {
-            includeSelf?: boolean | undefined;
-            parentFirst?: boolean | undefined;
+            includeSelf?: boolean;
+            parentFirst?: boolean;
         }): Array<TextProxy | Element | DocumentFragment>;
         getAttribute(key: string): any;
         getAttributeKeys(): Iterable<string>;
@@ -878,12 +878,12 @@ export namespace model {
         readonly singleCharacters: boolean;
 
         constructor(options?: {
-            direction?: "forward" | "backward" | undefined;
-            boundaries?: Range | undefined;
+            direction?: "forward" | "backward";
+            boundaries?: Range;
             startPosition: Position;
-            singleCharacters?: boolean | undefined;
-            shallow?: boolean | undefined;
-            ignoreElementEnd?: boolean | undefined;
+            singleCharacters?: boolean;
+            shallow?: boolean;
+            ignoreElementEnd?: boolean;
         });
         [Symbol.iterator](): Iterator<TreeWalkerValue>;
         next(): TreeWalkerValue;
@@ -966,11 +966,11 @@ export namespace view {
 
         class KeyEventData extends DomEventData implements KeystrokeInfo {
             // KeystrokeInfo
-            altKey?: boolean | undefined;
-            ctrlKey?: boolean | undefined;
+            altKey?: boolean;
+            ctrlKey?: boolean;
             keyCode: number;
             keystroke: number;
-            shiftKey?: boolean | undefined;
+            shiftKey?: boolean;
         }
 
         class KeyObserver extends DomEventObserver {
@@ -1081,7 +1081,7 @@ export namespace view {
             emitter: Emitter,
             event: string,
             callback: Function,
-            options?: { priority?: PriorityString | number | undefined },
+            options?: { priority?: PriorityString | number },
         ): void;
         off(event: string, callback?: Function): void;
         on(event: string, callback: Function, options?: { priority: PriorityString | number }): void;
@@ -1163,7 +1163,7 @@ export namespace view {
         _removeChildren(index: number, howMany?: number): Node[];
         _removeClass(className: string[] | string): void;
         findAncestor(patterns: Object | string | RegExp | Function): Element | null;
-        getAttribute(key: string): string | undefined;
+        getAttribute(key: string): string;
         getAttributeKeys(): Iterable<string>;
         getAttributes(): Iterable<any>;
         getChild(index: number): Node;
@@ -1174,7 +1174,7 @@ export namespace view {
         getCustomProperty(key: string | symbol): any;
         getFillerOffset(): void;
         getIdentity(): string;
-        getStyle(property: string): string | undefined;
+        getStyle(property: string): string;
         getStyleNames(): Iterable<string>;
         hasAttribute(key: string): boolean;
         hasClass(className: string): void;
@@ -1198,11 +1198,11 @@ export namespace view {
     type ElementDefinition =
         | string
         | {
-              attributes?: { [key: string]: string } | undefined;
-              classes?: string | string[] | undefined;
+              attributes?: { [key: string]: string };
+              classes?: string | string[];
               name: string;
-              priority?: number | undefined;
-              styles?: { [key: string]: string } | undefined;
+              priority?: number;
+              styles?: { [key: string]: string };
           };
 
     // engine/view/emptyelement
@@ -1247,14 +1247,14 @@ export namespace view {
     }
 
     type MatcherPattern =
-        | ((element: Element) => null | { name: boolean; attribute?: string[] | undefined })
+        | ((element: Element) => null | { name: boolean; attribute?: string[] })
         | string
         | RegExp
         | {
-              attributes?: { [key: string]: string | RegExp | boolean } | undefined;
-              classes?: string | RegExp | Array<string | RegExp> | undefined;
-              name?: string | RegExp | undefined;
-              styles?: { [key: string]: string | RegExp } | undefined;
+              attributes?: { [key: string]: string | RegExp | boolean };
+              classes?: string | RegExp | Array<string | RegExp>;
+              name?: string | RegExp;
+              styles?: { [key: string]: string | RegExp };
           };
 
     // engine/view/node
@@ -1269,8 +1269,8 @@ export namespace view {
 
         constructor();
         _fireChange(type: ChangeType, node: Node): void;
-        getAncestors(options: { includeSelf: boolean; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
-        getCommonAncestor(node: Node, options: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
+        getAncestors(options: { includeSelf: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
+        getCommonAncestor(node: Node, options: { includeSelf?: boolean }): Element | DocumentFragment | null;
         getPath(): number[];
 
         is(type: "element"): this is Element;
@@ -1355,8 +1355,8 @@ export namespace view {
 
         protected constructor(textNode: Text, offsetInText: number, length: number);
         getAncestors(options: {
-            includeSelf?: boolean | undefined;
-            parentFirst?: boolean | undefined;
+            includeSelf?: boolean;
+            parentFirst?: boolean;
         }): Array<Text | Element | DocumentFragment>;
         is(type: "textProxy"): this is TextProxy;
         is(type: string): boolean;
@@ -1373,12 +1373,12 @@ export namespace view {
         readonly singleCharacters: boolean;
 
         constructor(options: {
-            boundaries?: Range | undefined;
-            startPosition?: Position | undefined;
-            direction?: TreeWalkerDirection | undefined;
-            singleCharacters?: boolean | undefined;
-            shallow?: boolean | undefined;
-            ignoreElementEnd?: boolean | undefined;
+            boundaries?: Range;
+            startPosition?: Position;
+            direction?: TreeWalkerDirection;
+            singleCharacters?: boolean;
+            shallow?: boolean;
+            ignoreElementEnd?: boolean;
         });
         [Symbol.iterator](): Iterator<TreeWalkerValue>;
         next(): TreeWalkerValue;
@@ -1428,7 +1428,7 @@ export namespace view {
             emitter: Emitter,
             event: string,
             callback: Function,
-            options?: { priority?: PriorityString | number | undefined },
+            options?: { priority?: PriorityString | number },
         ): void;
         off(event: string, callback?: Function): void;
         on(event: string, callback: Function, options?: { priority: PriorityString | number }): void;

--- a/types/ckeditor__ckeditor5-engine/v27/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/ckeditor__ckeditor5-engine-tests.ts
@@ -102,7 +102,7 @@ pattern = (element: ViewElement) => {
 
 pattern = (element: ViewElement) => {
     if (element.name === "p") {
-        const fontSize = element.getStyle("font-size")!;
+        const fontSize = element.getStyle("font-size");
         const size = fontSize.match(/(\d+)/px);
 
         if (size && Number(size[1]) > 26) {

--- a/types/ckeditor__ckeditor5-engine/v27/src/controller/datacontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/controller/datacontroller.d.ts
@@ -33,7 +33,7 @@ export default class DataController implements Emitter, Observable {
         callback: (stylesProcessor: StylesProcessor) => Record<string, Record<string, string> | string>,
     ): void;
     destroy(): void;
-    get(options?: { rootName?: string | undefined; trim?: "empty" | "none" | undefined }): string;
+    get(options?: { rootName?: string; trim?: "empty" | "none" }): string;
     init(data: string | Record<string, string>): Promise<void>;
     parse(data: string, context?: SchemaContextDefinition): DocumentFragment;
     registerRawContentMatcher(pattern: MatcherPattern): void;
@@ -65,7 +65,7 @@ export default class DataController implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/controller/editingcontroller.d.ts
@@ -39,7 +39,7 @@ export default class EditingController implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/conversion.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/conversion.d.ts
@@ -20,9 +20,9 @@ export default class Conversion {
     );
     addAlias(alias: string, dispatcher: DowncastDispatcher | UpcastDispatcher): void;
     attributeToAttribute(definition?: {
-        model: string | { name?: string | undefined; key: string; values: string[] };
-        view: string | Record<string, { name?: string | undefined; key: string; value: string[] | Record<string, string> }>;
-        upcastAlso?: MatcherPattern | MatcherPattern[] | undefined;
+        model: string | { name?: string; key: string; values: string[] };
+        view: string | Record<string, { name?: string; key: string; value: string[] | Record<string, string> }>;
+        upcastAlso?: MatcherPattern | MatcherPattern[];
     }): void;
     attributeToElement(definition: ConverterDefinition): void;
     elementToElement(definition: ConverterDefinition): void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcastdispatcher.d.ts
@@ -17,7 +17,7 @@ export interface DowncastConversionApi<T = any> {
     consumable: ModelConsumable;
     dispatcher: DowncastDispatcher;
     mapper: Mapper;
-    options?: T | undefined;
+    options?: T;
     schema: Schema;
     writer: DowncastWriter;
 }
@@ -49,7 +49,7 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcasthelpers.d.ts
@@ -9,10 +9,10 @@ import UIElement from "../view/uielement";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export interface HighlightDescriptor {
-    attributes?: Record<string, string | number | boolean> | undefined;
-    classes?: string | string[] | undefined;
-    id?: string | undefined;
-    priority?: number | undefined;
+    attributes?: Record<string, string | number | boolean>;
+    classes?: string | string[];
+    id?: string;
+    priority?: number;
 }
 
 export function clearAttributes(): (...arg: any[]) => any;
@@ -27,7 +27,7 @@ export function remove(): (...arg: any[]) => any;
 
 export default class DowncastHelpers extends ConversionHelpers {
     attributeToAttribute(config?: {
-        model: string | { key: string; values: string[]; name?: string | undefined };
+        model: string | { key: string; values: string[]; name?: string };
         view:
             | string
             | { key: string; value: string }
@@ -37,33 +37,33 @@ export default class DowncastHelpers extends ConversionHelpers {
                   key: string;
                   value: string | string[] | Record<string, string>;
               });
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     attributeToElement(config?: {
-        model: string | { key: string; values: string[]; name?: string | undefined };
+        model: string | { key: string; values: string[]; name?: string };
         view: string | ElementDefinition | ((value: string, api: DowncastConversionApi) => AttributeElement);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     elementToElement(config?: {
         model: string;
         view: ElementDefinition | ((element: Element, api: DowncastConversionApi) => ContainerElement);
-        triggerBy?: { attributes: string[]; children: string[] } | undefined;
+        triggerBy?: { attributes: string[]; children: string[] };
     }): DowncastHelpers;
     markerToData(config?: {
         model: string;
-        view?: ((markerName: string, api: DowncastConversionApi) => { group: string; name: string }) | undefined;
-        converterPriority?: PriorityString | undefined;
+        view?: ((markerName: string, api: DowncastConversionApi) => { group: string; name: string });
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     markerToElement(config?: {
         model: string;
         view:
             | ElementDefinition
             | ((data: { [key: string]: any; isOpening: boolean }, api: DowncastConversionApi) => UIElement);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
     markerToHighlight(config?: {
         model: string;
         view: HighlightDescriptor | ((data: any, api: DowncastConversionApi) => HighlightDescriptor);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): DowncastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/mapper.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/mapper.d.ts
@@ -19,11 +19,11 @@ export default class Mapper implements Emitter {
     getModelLength(viewNode: Element): number;
     markerNameToElements(name: string): Set<Element> | null;
     registerViewToModelLength(viewElementName: string, lengthCallback: (element: Element) => number): void;
-    toModelElement(viewElement: Element): ModelElement | undefined;
+    toModelElement(viewElement: Element): ModelElement;
     toModelPosition(viewPosition: Position): ModelPosition;
     toModelRange(viewRange: Range): ModelRange;
-    toViewElement(modelElement: ModelElement): Element | undefined;
-    toViewPosition(modelPosition: ModelPosition, options?: { isPhantom?: boolean | undefined }): Position;
+    toViewElement(modelElement: ModelElement): Element;
+    toViewPosition(modelPosition: ModelPosition, options?: { isPhantom?: boolean }): Position;
     toViewRange(modelRange: ModelRange): Range;
     unbindElementFromMarkerName(element: Element, name: string): void;
     unbindModelElement(modelElement: ModelElement): void;
@@ -44,7 +44,7 @@ export default class Mapper implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcastdispatcher.d.ts
@@ -69,7 +69,7 @@ export default class UpcastDispatcher implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcasthelpers.d.ts
@@ -11,29 +11,29 @@ export default class UpcastHelpers extends ConversionHelpers {
             | string
             | {
                   key: string;
-                  name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  name?: string;
+                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> };
               };
 
         model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };
 
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
     dataToMarker(config?: {
         view: string;
-        model?: ((name: string, api: UpcastConversionApi) => string) | undefined;
-        converterPriority?: PriorityString | undefined;
+        model?: ((name: string, api: UpcastConversionApi) => string);
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
     elementToAttribute(config?: {
         view: MatcherPattern;
         model:
             | string
             | { key: string; value: string | ((viewElement: Element, api: UpcastConversionApi) => string | null) };
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
     elementToElement(config?: {
-        view?: MatcherPattern | undefined;
+        view?: MatcherPattern;
         model: string | ModelElement | ((el: Element, api: UpcastConversionApi) => ModelElement);
-        converterPriority?: PriorityString | undefined;
+        converterPriority?: PriorityString;
     }): UpcastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/viewconsumable.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/viewconsumable.d.ts
@@ -7,39 +7,39 @@ export default class ViewConsumable {
     add(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): void;
     consume(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): boolean;
     consume(element: Text | DocumentFragment): boolean;
     revert(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): void;
     revert(element: Text | DocumentFragment): void;
     test(
         element: Element,
         consumables?: {
-            name?: boolean | undefined;
-            attributes?: string | string[] | undefined;
-            classes?: string | string[] | undefined;
-            styles?: string | string[] | undefined;
+            name?: boolean;
+            attributes?: string | string[];
+            classes?: string | string[];
+            styles?: string | string[];
         },
     ): boolean | null;
     test(element: Text | DocumentFragment): boolean | null;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/differ.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/differ.d.ts
@@ -11,7 +11,7 @@ export default class Differ {
     bufferMarkerChange(markerName: string, oldRange: Range | null, newRange: Range | null, affectsData: boolean): void;
     bufferOperation(operation: Operation): void;
     getChangedMarkers(): Marker[];
-    getChanges(options?: { includeChangesInGraveyard?: boolean | undefined }): DiffItem[];
+    getChanges(options?: { includeChangesInGraveyard?: boolean }): DiffItem[];
     getMarkersToAdd(): Marker[];
     getMarkersToRemove(): Marker[];
     hasDataChanges(): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/document.d.ts
@@ -44,7 +44,7 @@ export default class Document implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/documentfragment.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/documentfragment.d.ts
@@ -26,10 +26,10 @@ export default class DocumentFragment implements Iterable<Node> {
 }
 
 interface FromJSONArg {
-    name?: string | undefined;
-    data?: string | undefined;
-    attributes?: Record<string, string> | Array<[string, string]> | undefined;
-    children?: FromJSONArg[] | undefined;
+    name?: string;
+    data?: string;
+    attributes?: Record<string, string> | Array<[string, string]>;
+    children?: FromJSONArg[];
 }
 
 export {};

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/documentselection.d.ts
@@ -23,7 +23,7 @@ export default class DocumentSelection implements Emitter {
     constructor(doc: Document);
     containsEntireContent(element?: Element): boolean;
     destroy(): void;
-    getAttribute(key: string): string | number | boolean | undefined;
+    getAttribute(key: string): string | number | boolean;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | number | boolean]>;
     getFirstPosition(): Position | null;
@@ -53,7 +53,7 @@ export default class DocumentSelection implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/element.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/element.d.ts
@@ -10,7 +10,7 @@ export default class Element extends Node {
 
     constructor(name: string, attrs?: Parameters<typeof toMap>[0] | null, children?: Node | Iterable<Node>);
 
-    findAncestor(parentName: string, options?: { includeSelf?: boolean | undefined }): Element | null;
+    findAncestor(parentName: string, options?: { includeSelf?: boolean }): Element | null;
     getChild(index: number): Element | Text;
     getChildIndex(node: Node): number;
     getChildStartOffset(node: Node): number;
@@ -20,7 +20,7 @@ export default class Element extends Node {
     offsetToIndex(offset: number): number;
     toJSON(): ReturnType<Node["toJSON"]> & {
         name: string;
-        children?: Array<ReturnType<Element["toJSON"] | Text["toJSON"]>> | undefined;
+        children?: Array<ReturnType<Element["toJSON"] | Text["toJSON"]>>;
     };
 
     static fromJSON(json: ReturnType<Element["toJSON"]>): Element;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/history.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/history.d.ts
@@ -2,9 +2,9 @@ import Operation from "./operation/operation";
 
 export default class History {
     addOperation(operation: Operation): void;
-    getOperation(baseVersion: number): Operation | undefined;
+    getOperation(baseVersion: number): Operation;
     getOperations(from?: number, to?: number): Operation[];
-    getUndoneOperation(undoingOperation: Operation): Operation | undefined;
+    getUndoneOperation(undoingOperation: Operation): Operation;
     isUndoingOperation(operation: Operation): Boolean;
     isUndoneOperation(operation: Operation): Boolean;
     setOperationAsUndone(undoneOperation: Operation, undoingOperation: Operation): void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/model.d.ts
@@ -37,15 +37,15 @@ export default class Model implements Emitter, Observable {
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): Selection;
     deleteContent(
         selection: Selection | DocumentSelection,
         options?: {
-            leaveUnmerged?: boolean | undefined;
-            doNotResetEntireContent?: boolean | undefined;
-            doNotAutoparagraph?: boolean | undefined;
-            direction?: "forward" | "backward" | undefined;
+            leaveUnmerged?: boolean;
+            doNotResetEntireContent?: boolean;
+            doNotAutoparagraph?: boolean;
+            direction?: "forward" | "backward";
         },
     ): void;
     destroy(): void;
@@ -53,7 +53,7 @@ export default class Model implements Emitter, Observable {
     getSelectedContent(selection: Selection | DocumentSelection): DocumentFragment;
     hasContent(
         rangeOrElement: Range | Element,
-        options?: { ignoreWhitespaces?: boolean | undefined; ignoreMarkers?: boolean | undefined },
+        options?: { ignoreWhitespaces?: boolean; ignoreMarkers?: boolean },
     ): boolean;
     insertContent(
         content: DocumentFragment | Item,
@@ -62,7 +62,7 @@ export default class Model implements Emitter, Observable {
     ): Range;
     modifySelection(
         selection: Selection | DocumentSelection,
-        options?: { direction?: "forward" | "backward" | undefined; unit?: "character" | "codePoint" | "word" | undefined },
+        options?: { direction?: "forward" | "backward"; unit?: "character" | "codePoint" | "word" },
     ): void;
 
     set(option: Record<string, unknown>): void;
@@ -86,7 +86,7 @@ export default class Model implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/node.d.ts
@@ -17,11 +17,11 @@ export default class Node {
     readonly startOffset: number | null;
 
     constructor(attrs?: Parameters<typeof toMap>[0]);
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
-    getAttribute(key: string): string | undefined;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
+    getAttribute(key: string): string;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | number | boolean]>;
-    getCommonAncestor(node: Node, options?: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
+    getCommonAncestor(node: Node, options?: { includeSelf?: boolean }): Element | DocumentFragment | null;
     getPath(): number[];
     hasAttribute(key: string): boolean;
     is(type: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/operation/transform.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/operation/transform.d.ts
@@ -14,7 +14,7 @@ export function transform(a: Operation, b: Operation, context: TransformationCon
 export function transformSets(
     operationsA: Operation[],
     operationsB: Operation[],
-    options?: { document: Document | null; useRelations?: boolean | undefined; padWithNoOps?: boolean | undefined },
+    options?: { document: Document | null; useRelations?: boolean; padWithNoOps?: boolean },
 ): {
     operationsA: Operation[];
     operationsB: Operation[];

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/position.d.ts
@@ -47,11 +47,11 @@ export default class Position {
     getLastMatchingPosition(
         skip: (value: TreeWalkerValue) => boolean,
         options?: {
-            boundaries?: Range | undefined;
-            direction?: TreeWalkerDirection | undefined;
-            ignoreElementEnd?: boolean | undefined;
-            shallow?: boolean | undefined;
-            singleCharacters?: boolean | undefined;
+            boundaries?: Range;
+            direction?: TreeWalkerDirection;
+            ignoreElementEnd?: boolean;
+            shallow?: boolean;
+            singleCharacters?: boolean;
             startPosition: Position;
         },
     ): Position;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/range.d.ts
@@ -24,30 +24,30 @@ export default class Range implements Iterable<TreeWalkerValue> {
     getDifference(otherRange: Range): Range[];
     getIntersection(otherRange: Range): Range | null;
     getItems(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
+        boundaries?: Range;
+        direction?: TreeWalkerDirection;
+        ignoreElementEnd?: boolean;
+        shallow?: boolean;
+        singleCharacters?: boolean;
         startPosition: Position;
     }): Generator<Item>;
     getJoined(otherRange: Range, loose?: boolean): Range | null;
     getMinimalFlatRanges(): Range[];
     getPositions(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
+        boundaries?: Range;
+        direction?: TreeWalkerDirection;
+        ignoreElementEnd?: boolean;
+        shallow?: boolean;
+        singleCharacters?: boolean;
         startPosition: Position;
     }): Generator<Position>;
     getTransformedByOperation(operation: Operation): Range[];
     getTransformedByOperations(operations: Iterable<Operation>): Range[];
     getWalker(options?: {
-        startPosition?: Position | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        startPosition?: Position;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): TreeWalker;
     is(type: string): boolean;
     isEqual(otherRange: Range): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/schema.d.ts
@@ -60,7 +60,7 @@ export default class Schema implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
@@ -69,19 +69,19 @@ export default class Schema implements Emitter, Observable {
 }
 
 export interface SchemaItemDefinition {
-    allowAttributes?: string | string[] | undefined;
-    allowAttributesOf?: string | string[] | undefined;
-    allowContentOf?: string | string[] | undefined;
-    allowIn?: string | string[] | undefined;
-    allowWhere?: string | string[] | undefined;
-    inheritAllFrom?: string | undefined;
-    inheritTypesFrom?: string | string[] | undefined;
-    isblock?: boolean | undefined;
-    isContent?: boolean | undefined;
-    isInline?: boolean | undefined;
-    isLimit?: boolean | undefined;
-    isObject?: boolean | undefined;
-    isSelectable?: boolean | undefined;
+    allowAttributes?: string | string[];
+    allowAttributesOf?: string | string[];
+    allowContentOf?: string | string[];
+    allowIn?: string | string[];
+    allowWhere?: string | string[];
+    inheritAllFrom?: string;
+    inheritTypesFrom?: string | string[];
+    isblock?: boolean;
+    isContent?: boolean;
+    isInline?: boolean;
+    isLimit?: boolean;
+    isObject?: boolean;
+    isSelectable?: boolean;
 }
 
 export interface SchemaContextItem {
@@ -105,8 +105,8 @@ export interface SchemaCompiledItemDefinition {
 }
 
 export interface AttributeProperties {
-    copyOnEnter?: boolean | undefined;
-    isFormatting?: boolean | undefined;
+    copyOnEnter?: boolean;
+    isFormatting?: boolean;
 }
 
 export class SchemaContext implements Iterable<SchemaContextItem> {

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/selection.d.ts
@@ -21,10 +21,10 @@ export default class Selection implements Emitter {
     constructor(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     );
     containsEntireContent(element: Element): boolean;
-    getAttribute(key: string): string | boolean | number | undefined;
+    getAttribute(key: string): string | boolean | number;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | boolean | number]>;
     getFirstPosition(): Position | null;
@@ -44,7 +44,7 @@ export default class Selection implements Emitter {
     setTo(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): void;
 
     on: (
@@ -62,7 +62,7 @@ export default class Selection implements Emitter {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/text.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/text.d.ts
@@ -13,6 +13,6 @@ export default class Text extends Node {
 
     static fromJSON(json: {
         data: string;
-        attributes?: Record<string, string | number | boolean> | Array<[string, string | number | boolean]> | undefined;
+        attributes?: Record<string, string | number | boolean> | Array<[string, string | number | boolean]>;
     }): Text;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/textproxy.d.ts
@@ -14,7 +14,7 @@ export default class TextProxy {
     readonly startOffset: number;
     readonly textNode: Text;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
     getAttribute(key: string): string | number | boolean;
     getAttributeKeys(): ReturnType<Text["getAttributeKeys"]>;
     getAttributes(): ReturnType<Text["getAttributes"]>;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/treewalker.d.ts
@@ -23,11 +23,11 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly singleCharacters: boolean;
 
     constructor(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
+        boundaries?: Range;
+        direction?: TreeWalkerDirection;
+        ignoreElementEnd?: boolean;
+        shallow?: boolean;
+        singleCharacters?: boolean;
         startPosition: Position;
     });
     [Symbol.iterator](): Iterator<TreeWalkerValue>;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/writer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/writer.d.ts
@@ -14,7 +14,7 @@ export default class Writer {
     readonly batch: Batch;
     readonly model: Model;
 
-    addMarker(name: string, options?: { usingOperation?: boolean | undefined; range: Range; affectsData?: boolean | undefined }): Marker;
+    addMarker(name: string, options?: { usingOperation?: boolean; range: Range; affectsData?: boolean }): Marker;
     append(item: Item | DocumentFragment, parent: Element | DocumentFragment): void;
     appendElement(
         name: string,
@@ -43,7 +43,7 @@ export default class Writer {
     createSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): Selection;
     createText(data: string, attributes?: Record<string, string | number | boolean>): Text;
     insert(
@@ -88,7 +88,7 @@ export default class Writer {
     setSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined },
+        options?: { backward?: boolean },
     ): void;
     setSelectionAttribute(
         keyOrObjectOrIterable: Record<string, string | number | boolean> | Array<[string, string | number | boolean]>,
@@ -100,7 +100,7 @@ export default class Writer {
     unwrap(element: Element): void;
     updateMarker(
         markerOrName: string | Marker,
-        options?: { range?: Range | undefined; usingOperation?: boolean | undefined; affectsData?: boolean | undefined },
+        options?: { range?: Range; usingOperation?: boolean; affectsData?: boolean },
     ): void;
     wrap(range: Range, elementOrString: Element | string): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/document.d.ts
@@ -44,7 +44,7 @@ export default class Document implements BubblingEmitter, Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/documentselection.d.ts
@@ -15,7 +15,7 @@ export default class DocumentSelection {
     constructor(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     );
     getFirstPosition(): Position | null;
     getFirstRange(): Range | null;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/domconverter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/domconverter.d.ts
@@ -19,22 +19,22 @@ export default class DomConverter {
     readonly document: ViewDocument;
     readonly preElements: string[];
 
-    constructor(document: ViewDocument, options?: { blockFillerMode?: BlockFillerMode | undefined });
+    constructor(document: ViewDocument, options?: { blockFillerMode?: BlockFillerMode });
     bindDocumentFragments(domFragment: DocumentFragment, viewFragment: ViewDocumentFragment): void;
     bindElements(domElement: HTMLElement, viewElement: ViewElement): void;
     bindFakeSelection(domElement: HTMLElement, viewDocumentSelection: DocumentSelection): void;
     domChildrenToView(
         domElement: HTMLElement,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined; keepOriginalCase?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean; keepOriginalCase?: boolean },
     ): Generator<Node>;
     domPositionToView(domParent: Node, domOffset: number): Position;
     domRangeToView(domRange: Range): ViewRange | null;
     domSelectionToView(domSelection: Selection): ViewSelection;
     domToView(
         domNode: Node | DocumentFragment,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined; keepOriginalCase?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean; keepOriginalCase?: boolean },
     ): ViewNode | ViewDocumentFragment | null;
-    fakeSelectionToView(domElement: HTMLElement): ViewSelection | undefined;
+    fakeSelectionToView(domElement: HTMLElement): ViewSelection;
     findCorrespondingDomText(viewText: ViewText): Text | null;
     findCorrespondingViewText(domText: Text): ViewText | null;
     focus(viewEditable: EditableElement): void;
@@ -47,20 +47,20 @@ export default class DomConverter {
     isElement(node: Node): boolean;
     mapDomToView(
         domElementOrDocumentFragment: DocumentFragment | Element,
-    ): ViewElement | ViewDocumentFragment | undefined;
-    mapViewToDom(viewNode: ViewElement | ViewDocumentFragment): Node | DocumentFragment | undefined;
+    ): ViewElement | ViewDocumentFragment;
+    mapViewToDom(viewNode: ViewElement | ViewDocumentFragment): Node | DocumentFragment;
     registerRawContentMatcher(pattern: MatcherPattern): void;
     unbindDomElement(domElement: HTMLElement): void;
     viewChildrenToDom(
         viewElement: ViewElement | ViewDocumentFragment,
         domDocument: Document,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean },
     ): Generator<Node>;
     viewPositionToDom(viewPosition: Position): { parent: Node; offset: number } | null;
     viewRangeToDom(viewRange: ViewRange): Range;
     viewToDom(
         viewNode: ViewNode | ViewDocumentFragment,
         domDocument: Document,
-        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined },
+        options?: { bind?: boolean; withChildren?: boolean },
     ): Node | DocumentFragment;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/downcastwriter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/downcastwriter.d.ts
@@ -31,18 +31,18 @@ export default class DowncastWriter {
     createContainerElement(
         name: string,
         attributes?: Record<string, string>,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): ContainerElement;
     createDocumentFragment(children: Node | Iterable<Node>): DocumentFragment;
     createEditableElement(name: string, attributes?: Record<string, string>): EditableElement;
     createEmptyElement(
         name: string,
         attributes?: Record<string, string>,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): EmptyElement;
     createPositionAfter(item: Item): Position;
-    createPositionAt(itemOrPosition: View, offset?: number | "end" | "before" | "after"): Position;
-    createPositionAt(itemOrPosition: Item | Position): Position;
+    createPositionAt(itemOrPosition: Item, offset?: number | "end" | "before" | "after"): Position;
+    createPositionAt(itemOrPosition: Position): Position;
     createPositionBefore(item: Item): Position;
     createRange(start: Position, end?: Position): Range;
     createRangeIn(element: Element): Range;
@@ -51,19 +51,19 @@ export default class DowncastWriter {
         name?: string,
         attributes?: Record<string, string>,
         renderFunction?: (domElement: HTMLElement) => void,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): RawElement;
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): Selection;
     createText(data: string): Text;
     createUIElement(
         name: string,
         attributes?: Record<string, string>,
         renderFunction?: (domElement: HTMLElement) => void,
-        options?: { isAllowedInsideAttributeElement?: boolean | undefined },
+        options?: { isAllowedInsideAttributeElement?: boolean },
     ): UIElement;
     insert(
         position: Position | null,
@@ -90,7 +90,7 @@ export default class DowncastWriter {
     setSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): void;
     setSelectionFocus(itemOrPosition: View, offset?: number | "end" | "before" | "after"): void;
     setSelectionFocus(itemOrPosition: Item | Position): void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/element.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/element.d.ts
@@ -11,13 +11,13 @@ export default abstract class Element extends Node {
             | string
             | RegExp
             | {
-                  attributes?: Record<string, string | RegExp | boolean> | undefined;
-                  classes?: string | RegExp | Array<string | RegExp> | undefined;
-                  name?: string | RegExp | undefined;
+                  attributes?: Record<string, string | RegExp | boolean>;
+                  classes?: string | RegExp | Array<string | RegExp>;
+                  name?: string | RegExp;
                   styles: Record<string, string>;
               },
     ): Element | null;
-    getAttribute(key: string): string | undefined;
+    getAttribute(key: string): string;
     getAttributeKeys(): Generator<string>;
     getAttributes(): Generator<[string, unknown]>;
     getChild(index: number): Node;
@@ -28,8 +28,8 @@ export default abstract class Element extends Node {
     getCustomProperty(key: string | symbol): any;
     getFillerOffset(): number | null;
     getIdentity(): string;
-    getNormalizedStyle(property: string): Record<string, string> | string | undefined;
-    getStyle(property: string): string | undefined;
+    getNormalizedStyle(property: string): Record<string, string> | string;
+    getStyle(property: string): string;
     getStyleNames(): ReturnType<StylesMap["getStyleNames"]>;
     hasAttribute(key: string): boolean;
     hasClass(className: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/elementdefinition.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/elementdefinition.d.ts
@@ -1,9 +1,9 @@
 export type ElementDefinition =
     | string
     | {
-          attributes?: Record<string, string> | undefined;
-          classes?: string | string[] | undefined;
+          attributes?: Record<string, string>;
+          classes?: string | string[];
           name: string;
-          priority?: number | undefined;
-          styles?: Record<string, string> | undefined;
+          priority?: number;
+          styles?: Record<string, string>;
       };

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/matcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/matcher.d.ts
@@ -6,17 +6,17 @@ export default class Matcher {
             | string
             | RegExp
             | {
-                  attributes?: Record<string, string | RegExp | boolean> | undefined;
-                  classes?: string | RegExp | Array<string | RegExp> | undefined;
-                  name?: string | RegExp | undefined;
+                  attributes?: Record<string, string | RegExp | boolean>;
+                  classes?: string | RegExp | Array<string | RegExp>;
+                  name?: string | RegExp;
                   styles: Record<string, string>;
               },
     );
     add(
         ...pattern: Array<{
-            attributes?: Record<string, string | RegExp | boolean> | undefined;
-            classes?: string | RegExp | Array<string | RegExp> | undefined;
-            name?: string | RegExp | undefined;
+            attributes?: Record<string, string | RegExp | boolean>;
+            classes?: string | RegExp | Array<string | RegExp>;
+            name?: string | RegExp;
             styles: Record<string, string>;
         }>
     ): void;
@@ -25,25 +25,25 @@ export default class Matcher {
         element: Element,
     ): {
         element: Element;
-        match: { name?: boolean | undefined; attribute?: string[] | undefined; classes?: string[] | undefined; styles?: Array<[string, string]> | undefined };
+        match: { name?: boolean; attribute?: string[]; classes?: string[]; styles?: Array<[string, string]> };
     } | null;
     matchAll(
         element: Element,
     ): Array<{
         element: Element;
-        match: { name?: boolean | undefined; attribute?: string[] | undefined; classes?: string[] | undefined; styles?: Array<[string, string]> | undefined };
+        match: { name?: boolean; attribute?: string[]; classes?: string[]; styles?: Array<[string, string]> };
     }> | null;
 }
 
 export type MatcherPattern =
     | ((
           element: Element,
-      ) => null | { name?: boolean | undefined; attribute?: string[] | undefined; classes?: string[] | undefined; styles?: Array<[string, string]> | undefined })
+      ) => null | { name?: boolean; attribute?: string[]; classes?: string[]; styles?: Array<[string, string]> })
     | string
     | RegExp
     | {
-          attributes?: Record<string, string | RegExp | boolean> | undefined;
-          classes?: string | RegExp | Array<string | RegExp> | undefined;
-          name?: string | RegExp | undefined;
-          styles?: Record<string, string | RegExp> | undefined;
+          attributes?: Record<string, string | RegExp | boolean>;
+          classes?: string | RegExp | Array<string | RegExp>;
+          name?: string | RegExp;
+          styles?: Record<string, string | RegExp>;
       };

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/node.d.ts
@@ -10,8 +10,8 @@ export default abstract class Node {
     readonly previousSibling: Node | null;
     readonly root: Node | DocumentFragment;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
-    getCommonAncestor(node: Node, options?: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
+    getCommonAncestor(node: Node, options?: { includeSelf?: boolean }): Element | DocumentFragment | null;
     getPath(): number[];
     is(type: string): boolean;
     isAfter(node: Node): boolean;
@@ -19,7 +19,7 @@ export default abstract class Node {
     isBefore(node: Node): boolean;
     isSimilar(otherElement: Node): boolean;
     toJSON(): {
-        _textData?: string | undefined;
+        _textData?: string;
         document: string;
     };
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/observer/keyobserver.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/observer/keyobserver.d.ts
@@ -8,10 +8,10 @@ export default class KeyObserver extends DomEventObserver {
 }
 
 export class KeyEventData extends DomEventData implements KeystrokeInfo {
-    altKey?: boolean | undefined;
-    ctrlKey?: boolean | undefined;
+    altKey?: boolean;
+    ctrlKey?: boolean;
     keyCode: number;
-    shiftKey?: boolean | undefined;
-    metaKey?: boolean | undefined;
+    shiftKey?: boolean;
+    metaKey?: boolean;
     readonly keystroke: number;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/placeholder.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/placeholder.d.ts
@@ -7,8 +7,8 @@ export function enablePlaceholder(options?: {
     view: View;
     element: Element;
     text: string;
-    isDirectHost?: boolean | undefined;
-    keepOnFocus?: boolean | undefined;
+    isDirectHost?: boolean;
+    keepOnFocus?: boolean;
 }): void;
 export function hidePlaceholder(writer: DowncastWriter, element: Element): boolean;
 export function needsPlaceholder(element: Element, keepOnFocus: boolean): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/position.d.ts
@@ -22,20 +22,20 @@ export default class Position {
     getLastMatchingPosition(
         skip: (value: TreeWalkerValue) => boolean,
         options?: {
-            boundaries?: Range | undefined;
+            boundaries?: Range;
             startPosition: Position;
-            direction?: TreeWalkerDirection | undefined;
-            singleCharacters?: boolean | undefined;
-            shallow?: boolean | undefined;
-            ignoreElementEnd?: boolean | undefined;
+            direction?: TreeWalkerDirection;
+            singleCharacters?: boolean;
+            shallow?: boolean;
+            ignoreElementEnd?: boolean;
         },
     ): Position;
     getShiftedBy(shift: number): Position;
     getWalker(options?: {
-        boundaries?: Range | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        boundaries?: Range;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): TreeWalker;
     is(type: string): boolean;
     isAfter(otherPosition: Position): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/range.d.ts
@@ -23,27 +23,27 @@ export default class Range implements Iterable<TreeWalkerValue> {
     getEnlarged(): Range;
     getIntersection(otherRange: Range): Range | null;
     getItems(options?: {
-        boundaries?: Range | undefined;
+        boundaries?: Range;
         startPosition: Position;
-        direction?: TreeWalkerDirection | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        direction?: TreeWalkerDirection;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): Iterable<Item>;
     getPositions(options?: {
-        boundaries?: Range | undefined;
+        boundaries?: Range;
         startPosition: Position;
-        direction?: TreeWalkerDirection | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        direction?: TreeWalkerDirection;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): Iterable<Position>;
     getTrimmed(): Range;
     getWalker(options?: {
-        startPosition?: Position | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        startPosition?: Position;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     }): TreeWalker;
     is(type: string): boolean;
     isEqual(otherRange: Range): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/selection.d.ts
@@ -20,9 +20,9 @@ export default class Selection {
     constructor(
         selectable?: Item,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: boolean | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: boolean },
     );
-    constructor(selectable?: Selectable, options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: boolean | undefined });
+    constructor(selectable?: Selectable, options?: { backward?: boolean; fake?: boolean; label?: boolean });
     getFirstPosition(): Position | null;
     getFirstRange(): Range | null;
     getLastPosition(): Position | null;
@@ -37,6 +37,6 @@ export default class Selection {
     setTo(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: boolean | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: boolean },
     ): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/stylesmap.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/stylesmap.d.ts
@@ -4,8 +4,8 @@ export default class StylesMap {
 
     constructor(styleProcessor: StylesProcessor);
     clear(): void;
-    getAsString(propertyName: string): string | undefined;
-    getNormalized(name: string): Record<string, string> | string | undefined;
+    getAsString(propertyName: string): string;
+    getNormalized(name: string): Record<string, string> | string;
     getStyleNames(): string[];
     has(name: string): boolean;
     remove(name: string): void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/textproxy.d.ts
@@ -14,6 +14,6 @@ export default class TextProxy {
     readonly root: Node | DocumentFragment;
     readonly textNode: Text;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAncestors(options?: { includeSelf?: boolean; parentFirst?: boolean }): Array<Element | DocumentFragment>;
     is(type: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/treewalker.d.ts
@@ -6,7 +6,7 @@ export type TreeWalkerValueType = "elementStart" | "elementEnd" | "text";
 
 export interface TreeWalkerValue {
     item: Item;
-    length: number | undefined;
+    length: number;
     nextPosition: Position;
     previousPosition: Position;
     type: TreeWalkerValueType;
@@ -23,12 +23,12 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly singleCharacters: boolean;
 
     constructor(options?: {
-        boundaries?: Range | undefined;
+        boundaries?: Range;
         startPosition: Position;
-        direction?: TreeWalkerDirection | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
+        direction?: TreeWalkerDirection;
+        singleCharacters?: boolean;
+        shallow?: boolean;
+        ignoreElementEnd?: boolean;
     });
     [Symbol.iterator](): Iterator<TreeWalkerValue>;
     next(): TreeWalkerValue;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/upcastwriter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/upcastwriter.d.ts
@@ -30,7 +30,7 @@ export default class UpcastWriter {
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): Selection;
     createText(data: string): Text;
     insertChild(index: number, items: Item | Iterable<Item>, element: Element | DocumentFragment): number;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/view.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/view.d.ts
@@ -35,7 +35,7 @@ export default class View implements Emitter, Observable {
     createSelection(
         selectable?: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
-        options?: { backward?: boolean | undefined; fake?: boolean | undefined; label?: string | undefined },
+        options?: { backward?: boolean; fake?: boolean; label?: string },
     ): Selection;
     destroy(): void;
     detachDomRoot(name: string): void;
@@ -44,7 +44,7 @@ export default class View implements Emitter, Observable {
     focus(): void;
     forceRender(): void;
     getDomRoot(name?: string): Element;
-    getObserver(ObserverClass: typeof Observer): Observer | undefined;
+    getObserver(ObserverClass: typeof Observer): Observer;
     scrollToTheSelection(): void;
 
     set(option: Record<string, unknown>): void;
@@ -68,7 +68,7 @@ export default class View implements Emitter, Observable {
         emitter: Emitter,
         event: string,
         callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+        options?: { priority?: PriorityString | number },
     ): void;
     stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;


### PR DESCRIPTION
createPositionAt takes either an `Item` or a `Position`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/e67034923ab25c7c12782e57b2a10434391631a6/packages/ckeditor5-engine/src/view/downcastwriter.js#L1075
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.