### PR TITLE
[@wordpress/blocks] Add missing "object" as block attribute type

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -335,7 +335,12 @@ export namespace AttributeSource {
         | {
               type: 'string';
               default?: string | undefined;
-          });
+          })
+        | 'array'
+        | 'object'
+        | 'boolean'
+        | 'number'
+        | 'string';
 }
 
 export type BlockAttribute<T> =

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>
+//                 Dennis Snell <https://github.com/dmsnell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
@@ -318,6 +319,10 @@ export namespace AttributeSource {
         | {
               type: 'array';
               default?: any[] | undefined;
+          }
+        | {
+              type: 'object';
+              default?: object | undefined;
           }
         | {
               type: 'boolean';

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -355,6 +355,20 @@ blocks.registerBlockType<{ foo: object }>('my/foo', {
     category: 'common',
 });
 
+// $ExpectType Block<{ foo: string; }> | undefined
+blocks.registerBlockType<{ foo: string }>('my/foo', {
+    attributes: {
+        foo: 'string',
+    },
+    icon: {
+        src: 'carrot',
+        foreground: 'orange',
+        background: 'green',
+    },
+    title: 'Foo',
+    category: 'common',
+});
+
 // $ExpectType void
 blocks.setDefaultBlockName('my/foo');
 

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -339,6 +339,22 @@ blocks.registerBlockType<{ foo: string }>('my/foo', {
     category: 'common',
 });
 
+// $ExpectType Block<{ foo: object; }> | undefined
+blocks.registerBlockType<{ foo: object }>('my/foo', {
+    attributes: {
+        foo: {
+            type: 'object'
+        },
+    },
+    icon: {
+        src: 'carrot',
+        foreground: 'orange',
+        background: 'green',
+    },
+    title: 'Foo',
+    category: 'common',
+});
+
 // $ExpectType void
 blocks.setDefaultBlockName('my/foo');
 


### PR DESCRIPTION
The `@wordpress/blocks` package is currently missing the "object" type
argument for block attributes. In this patch I'm adding that type in
so that it's possible to specify object attributes with creating
false-positive type errors.

This is a recreation of the work @torounit created in #41506

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). (still can't run these locally)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [attributes in the block handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (it doesn't)

cc: @sirreal 
