### PR TITLE
pouchdb-core: Remove /// <reference type='node-fetch' />

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -9,7 +9,6 @@
 
 /// <reference types="debug" />
 /// <reference types="pouchdb-find" />
-/// <reference types="node-fetch" />
 
 interface Blob {
     readonly size: number;


### PR DESCRIPTION
node-fetch cannot be referenced this way since it's a module. As far as I can tell, pouchdb-core doesn't actually depend on node-fetch, though I could be wrong about that.