### PR TITLE
[google-apps-script] Add optional Generic types to doGet function.

### DIFF
--- a/types/google-apps-script/google-apps-script-events.d.ts
+++ b/types/google-apps-script/google-apps-script-events.d.ts
@@ -95,8 +95,9 @@ declare namespace GoogleAppsScript {
       authMode: Script.AuthMode;
     }
 
-    // tslint:disable-next-line: no-empty-interface
-    interface DoGet extends AppsScriptHttpRequestEvent {
+    interface DoGet<T = {}> extends AppsScriptHttpRequestEvent {
+      parameter: { [key in keyof T]: string };
+      parameters: { [key in keyof T]: string[] };
     }
 
     interface DoPost extends AppsScriptHttpRequestEvent {

--- a/types/google-apps-script/google-apps-script-events.d.ts
+++ b/types/google-apps-script/google-apps-script-events.d.ts
@@ -22,12 +22,12 @@ declare namespace GoogleAppsScript {
       user: Base.User;
     }
 
-    interface AppsScriptHttpRequestEvent {
-      parameter: object;
+    interface AppsScriptHttpRequestEvent<T> {
+      parameter: { [key in keyof T]: string };
       contextPath: string;
       contentLength: number;
       queryString: string;
-      parameters: object;
+      parameters: { [key in keyof T]: string[] };
     }
 
     interface AppsScriptHttpRequestEventPostData {
@@ -95,12 +95,11 @@ declare namespace GoogleAppsScript {
       authMode: Script.AuthMode;
     }
 
-    interface DoGet<T = {}> extends AppsScriptHttpRequestEvent {
-      parameter: { [key in keyof T]: string };
-      parameters: { [key in keyof T]: string[] };
+    // tslint:disable-next-line: no-empty-interface
+    interface DoGet<T = any> extends AppsScriptHttpRequestEvent<T> {
     }
 
-    interface DoPost extends AppsScriptHttpRequestEvent {
+    interface DoPost<T = any> extends AppsScriptHttpRequestEvent<T> {
       postData: AppsScriptHttpRequestEventPostData;
     }
 

--- a/types/google-apps-script/google-apps-script-events.d.ts
+++ b/types/google-apps-script/google-apps-script-events.d.ts
@@ -22,12 +22,12 @@ declare namespace GoogleAppsScript {
       user: Base.User;
     }
 
-    interface AppsScriptHttpRequestEvent<T> {
-      parameter: { [key in keyof T]: string };
+    interface AppsScriptHttpRequestEvent {
+      parameter: { [key: string]: string };
       contextPath: string;
       contentLength: number;
       queryString: string;
-      parameters: { [key in keyof T]: string[] };
+      parameters: { [key: string]: string[] };
     }
 
     interface AppsScriptHttpRequestEventPostData {
@@ -96,10 +96,10 @@ declare namespace GoogleAppsScript {
     }
 
     // tslint:disable-next-line: no-empty-interface
-    interface DoGet<T = any> extends AppsScriptHttpRequestEvent<T> {
+    interface DoGet extends AppsScriptHttpRequestEvent {
     }
 
-    interface DoPost<T = any> extends AppsScriptHttpRequestEvent<T> {
+    interface DoPost extends AppsScriptHttpRequestEvent {
       postData: AppsScriptHttpRequestEventPostData;
     }
 

--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -91,9 +91,13 @@ const listAllUsers = () => {
 };
 
 // doPost function
-function doPost(e: GoogleAppsScript.Events.DoPost) {
+function doPost(e: GoogleAppsScript.Events.DoPost<{ param: string }>) {
     const data: string = e.postData.contents;
+    const param: string = e.parameter.param;
+    const paramArray: string[] = e.parameters.param;
     Logger.log(JSON.parse(data));
+    Logger.log(param);
+    Logger.log(paramArray);
 }
 
 // doGet function

--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -97,8 +97,11 @@ function doPost(e: GoogleAppsScript.Events.DoPost) {
 }
 
 // doGet function
-function doGet(e: GoogleAppsScript.Events.DoGet) {
-    const params: object = e.parameters;
+function doGet(e: GoogleAppsScript.Events.DoGet<{ param: string }>) {
+    const param: string = e.parameter.param;
+    const paramArray: string[] = e.parameters.param;
+    Logger.log(param);
+    Logger.log(paramArray);
 }
 
 // Base Service

--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -91,7 +91,7 @@ const listAllUsers = () => {
 };
 
 // doPost function
-function doPost(e: GoogleAppsScript.Events.DoPost<{ param: string }>) {
+function doPost(e: GoogleAppsScript.Events.DoPost) {
     const data: string = e.postData.contents;
     const param: string = e.parameter.param;
     const paramArray: string[] = e.parameters.param;
@@ -101,7 +101,7 @@ function doPost(e: GoogleAppsScript.Events.DoPost<{ param: string }>) {
 }
 
 // doGet function
-function doGet(e: GoogleAppsScript.Events.DoGet<{ param: string }>) {
+function doGet(e: GoogleAppsScript.Events.DoGet) {
     const param: string = e.parameter.param;
     const paramArray: string[] = e.parameters.param;
     Logger.log(param);


### PR DESCRIPTION
The current GoogleAppsScript.Events.DoGet type in parameters and parameters are of type object, which is inconvenient to reference, so we added an optional generic types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.google.com/apps-script/guides/web>