### PR TITLE
Fix broken Mithril attr type hinting

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -324,6 +324,10 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface Element extends Mithril.Vnode {}
 
+        interface ElementAttributesProperty {
+          attrs: Record<string, unknown>;
+        }
+
         // tslint:disable-next-line:no-empty-interface
         interface IntrinsicAttributes extends Mithril.Attributes {}
         // tslint:disable-next-line:no-empty-interface

--- a/types/mithril/test/test-tsx.tsx
+++ b/types/mithril/test/test-tsx.tsx
@@ -24,8 +24,10 @@ function ClosureComp(): m.Component<Attrs> {
 function testRender() {
     return [
         <ClassComp id={1} text="Title 1"/>,
-        // <PojoComp id={2} text="Title 2"/>,  <- won't compile
-        // <ClosureComp id={3} text="Title 3"/>  <- won't compile
+        // $ExpectError
+        <PojoComp id={2} text="Title 2"/>,
+        // $ExpectError
+        <ClosureComp id={3} text="Title 3"/>
     ];
 }
 


### PR DESCRIPTION
For more info, see: https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking

In a nutshell, we need to add `ElementAttributesProperty` to tell Typescript what property on component classes to look at for attribute typings. For Mithril, this would be `attrs` (e.g. `this.attrs...`)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
