### PR TITLE
[react-mentions] The display property is not required

### DIFF
--- a/types/react-mentions/index.d.ts
+++ b/types/react-mentions/index.d.ts
@@ -108,7 +108,7 @@ export interface MentionItem {
  */
 export interface SuggestionDataItem {
     id: string | number;
-    display: string;
+    display?: string;
 }
 
 /**


### PR DESCRIPTION
The `display` property in `SuggestionDataItem` is not required.

See https://github.com/signavio/react-mentions/blob/5af70251e7620368841686b4113ce3ec5a9dff86/src/Suggestion.js#L14-L21.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/signavio/react-mentions/blob/5af70251e7620368841686b4113ce3ec5a9dff86/src/Suggestion.js#L14-L21
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
