### PR TITLE
[ldapjs] Add support for multiple URLs

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldapjs 1.0
+// Type definitions for ldapjs 2.3
 // Project: http://ldapjs.org
 // Definitions by: Charles Villemure <https://github.com/cvillemure>, Peter Kooijmans <https://github.com/peterkooijmans>, Pablo Moleri <https://github.com/pmoleri>, Michael Scott-Nelson <https://github.com/mscottnelson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldapjs 2.3
+// Type definitions for ldapjs 2.2
 // Project: http://ldapjs.org
 // Definitions by: Charles Villemure <https://github.com/cvillemure>, Peter Kooijmans <https://github.com/peterkooijmans>, Pablo Moleri <https://github.com/pmoleri>, Michael Scott-Nelson <https://github.com/mscottnelson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -30,7 +30,7 @@ export interface CallBack {
 }
 
 export interface ClientOptions {
-    url: string;
+    url: string | string[];
     tlsOptions?: Object | undefined;
     socketPath?: string | undefined;
     log?: any;

--- a/types/ldapjs/ldapjs-tests.ts
+++ b/types/ldapjs/ldapjs-tests.ts
@@ -5,6 +5,13 @@ let client = ldap.createClient({
     url: 'ldap://127.0.0.1:1389'
 });
 
+let clientWithMultipleURLs = ldap.createClient({
+    url: [
+        'ldap://127.0.0.1:1389',
+        'ldap://127.0.0.2:1389'
+    ]
+});
+
 client.bind('cn=root', 'secret', (err: Error): void => {
     // nothing
 });


### PR DESCRIPTION
This change adds support for passing an array instead of a single URL to createClient().

Added upstream in https://github.com/ldapjs/node-ldapjs/pull/658

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ldapjs/node-ldapjs/pull/658
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
