### PR TITLE
New types for shelljs.exec

### DIFF
--- a/types/shelljs.exec/index.d.ts
+++ b/types/shelljs.exec/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for shelljs.exec 1.1
 // Project: https://github.com/danday74/shelljs.exec#readme
-// Definitions by: Chen Asraf <https://github.com/me>
+// Definitions by: Chen Asraf <https://github.com/chenasraf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 

--- a/types/shelljs.exec/index.d.ts
+++ b/types/shelljs.exec/index.d.ts
@@ -8,21 +8,22 @@
 
 import { ExecSyncOptions } from 'child_process';
 
-export interface ShellJsOptions {
-    silent?: boolean;
+declare namespace exec {
+    export interface ShellJsOptions {
+        silent?: boolean;
+    }
+
+    export interface ShellJsExecEnrich {
+        code: number;
+        ok: boolean;
+        stdout: string;
+        stderr: string;
+        error: any;
+    }
+
+    export type ShellJsExecResponse = ExecSyncOptions & ShellJsExecEnrich;
+    export type { ExecSyncOptions };
 }
 
-export interface ShellJsExecEnrich {
-    code: number;
-    ok: boolean;
-    stdout: string;
-    stderr: string;
-    error: any;
-}
-
-export type ShellJsExecResponse = ExecSyncOptions & ShellJsExecEnrich;
-export type ExecFn = (cmd: string, options?: ExecSyncOptions & ShellJsOptions) => ShellJsExecResponse;
-export type { ExecSyncOptions };
-
-declare const exec: ExecFn;
-export default exec;
+declare function exec(cmd: string, options?: ExecSyncOptions & exec.ShellJsOptions): exec.ShellJsExecResponse;
+export = exec;

--- a/types/shelljs.exec/index.d.ts
+++ b/types/shelljs.exec/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for shelljs.exec 1.1
+// Project: https://github.com/danday74/shelljs.exec#readme
+// Definitions by: Chen Asraf <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+/// <reference types="node"/>
+
+import { ExecSyncOptions } from 'child_process';
+
+export interface ShellJsExecEnrich {
+    silent: boolean;
+    encoding: string;
+    code: number;
+    ok: boolean;
+    stdout: string;
+    stderr: string;
+    error: any;
+}
+
+export type ShellJsExecResponse = ExecSyncOptions & ShellJsExecEnrich;
+export type ExecFn = (cmd: string, options?: ExecSyncOptions) => ShellJsExecResponse;
+export type { ExecSyncOptions };
+
+declare const exec: ExecFn;
+export default exec;

--- a/types/shelljs.exec/index.d.ts
+++ b/types/shelljs.exec/index.d.ts
@@ -8,9 +8,11 @@
 
 import { ExecSyncOptions } from 'child_process';
 
+export interface ShellJsOptions {
+    silent?: boolean;
+}
+
 export interface ShellJsExecEnrich {
-    silent: boolean;
-    encoding: string;
     code: number;
     ok: boolean;
     stdout: string;
@@ -19,7 +21,7 @@ export interface ShellJsExecEnrich {
 }
 
 export type ShellJsExecResponse = ExecSyncOptions & ShellJsExecEnrich;
-export type ExecFn = (cmd: string, options?: ExecSyncOptions) => ShellJsExecResponse;
+export type ExecFn = (cmd: string, options?: ExecSyncOptions & ShellJsOptions) => ShellJsExecResponse;
 export type { ExecSyncOptions };
 
 declare const exec: ExecFn;

--- a/types/shelljs.exec/shelljs.exec-tests.ts
+++ b/types/shelljs.exec/shelljs.exec-tests.ts
@@ -1,4 +1,4 @@
-import exec from 'shelljs.exec';
+import exec = require('shelljs.exec');
 
 exec('echo test with options', {
     stdio: [process.stdin, process.stdout, process.stderr],

--- a/types/shelljs.exec/shelljs.exec-tests.ts
+++ b/types/shelljs.exec/shelljs.exec-tests.ts
@@ -1,0 +1,8 @@
+import exec from 'shelljs.exec';
+
+exec('echo test with options', { stdio: [process.stdin, process.stdout, process.stderr] });
+exec('echo test without options');
+
+const results = exec('echo test with return');
+results.code; // $ExpectType<number>
+results.stdout; // $ExpectType<string>

--- a/types/shelljs.exec/shelljs.exec-tests.ts
+++ b/types/shelljs.exec/shelljs.exec-tests.ts
@@ -1,8 +1,13 @@
 import exec from 'shelljs.exec';
 
-exec('echo test with options', { stdio: [process.stdin, process.stdout, process.stderr] });
+exec('echo test with options', {
+    stdio: [process.stdin, process.stdout, process.stderr],
+    silent: true,
+    encoding: 'utf-8',
+});
 exec('echo test without options');
 
 const results = exec('echo test with return');
 results.code; // $ExpectType<number>
 results.stdout; // $ExpectType<string>
+results.silent; // $ExpectError

--- a/types/shelljs.exec/tsconfig.json
+++ b/types/shelljs.exec/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "shelljs.exec-tests.ts"
+    ]
+}

--- a/types/shelljs.exec/tslint.json
+++ b/types/shelljs.exec/tslint.json
@@ -1,21 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": [
-            true,
-            {
-                "mode": "code",
-                "errors": [
-                    [
-                        "NeedsExportEquals",
-                        false
-                    ],
-                    [
-                        "NoDefaultExport",
-                        false
-                    ]
-                ]
-            }
-        ]
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/shelljs.exec/tslint.json
+++ b/types/shelljs.exec/tslint.json
@@ -1,0 +1,21 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [
+                        "NeedsExportEquals",
+                        false
+                    ],
+                    [
+                        "NoDefaultExport",
+                        false
+                    ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Hi, I am adding types for a missing package, [shelljs.exec](https://www.npmjs.com/package/shelljs.exec).


### Checkboxes:

- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules. ~**I had to add rules to allow default export and to allow not using `exports = ` syntax.**~
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.