### PR TITLE
Correct visibility of SAXParser within SAXStream

### DIFF
--- a/types/sax/index.d.ts
+++ b/types/sax/index.d.ts
@@ -90,7 +90,7 @@ import stream = require("stream");
 export function createStream(strict?: boolean, opt?: SAXOptions): SAXStream;
 export class SAXStream extends stream.Duplex {
     constructor(strict?: boolean, opt?: SAXOptions);
-    public _parser: SAXParser;
+    _parser: SAXParser;
     on(event: "text", listener: (this: this, text: string) => void): this;
     on(event: "doctype", listener: (this: this, doctype: string) => void): this;
     on(event: "processinginstruction", listener: (this: this, node: { name: string; body: string }) => void): this;

--- a/types/sax/index.d.ts
+++ b/types/sax/index.d.ts
@@ -90,7 +90,7 @@ import stream = require("stream");
 export function createStream(strict?: boolean, opt?: SAXOptions): SAXStream;
 export class SAXStream extends stream.Duplex {
     constructor(strict?: boolean, opt?: SAXOptions);
-    private _parser: SAXParser;
+    public _parser: SAXParser;
     on(event: "text", listener: (this: this, text: string) => void): this;
     on(event: "doctype", listener: (this: this, doctype: string) => void): this;
     on(event: "processinginstruction", listener: (this: this, node: { name: string; body: string }) => void): this;


### PR DESCRIPTION
Currently SAXParser is held privately within a SAXStream object, however this contravenes the [project README](https://github.com/isaacs/sax-js), which requires its consumption by end users for proper error handling.

From the README (note references to `this._parser`, which is currently impossible):

```node
saxStream.on("error", function (e) {
  // unhandled errors will throw, since this is a proper node
  // event emitter.
  console.error("error!", e)
  // clear the error
  this._parser.error = null
  this._parser.resume()
})
```