### PR TITLE
react-big-calendar: export Navigate as const

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -390,12 +390,12 @@ export interface components {
 export function globalizeLocalizer(globalizeInstance: object): DateLocalizer;
 export function momentLocalizer(momentInstance: object): DateLocalizer;
 export function dateFnsLocalizer(config: object): DateLocalizer;
-export interface Navigate {
+export const Navigate: {
     PREVIOUS: 'PREV';
     NEXT: 'NEXT';
     TODAY: 'TODAY';
     DATE: 'DATE';
-}
+};
 export const Views: {
     MONTH: 'month';
     WEEK: 'week';

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -488,7 +488,15 @@ MyWorkWeek.range = date => {
 };
 
 MyWorkWeek.navigate = (date, action) => {
-    return date;
+    const week = 7 * 24 * 60 * 60 * 1000; // week in milliseconds
+    switch (action) {
+        case Navigate.PREVIOUS:
+            return new Date(date.valueOf() - week);
+        case Navigate.NEXT:
+            return new Date(date.valueOf() + week);
+        default:
+            return date;
+    }
 };
 
 MyWorkWeek.title = date => {


### PR DESCRIPTION
This PR largely follows the same aim as https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54274, but for the `Navigate` constant. [Navigate](https://github.com/jquense/react-big-calendar/blob/master/src/utils/constants.js) is exported as a constant object the same as `Views` is, so should be defined as such instead of an `interface`.

I added code to test accessing the `Navigate.[CONSTANT]` values.

---------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/react-big-calendar/blob/master/src/utils/constants.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.