### PR TITLE
react-pdf : Fix PDFDocumentProxy import

### DIFF
--- a/types/react-pdf/dist/Document.d.ts
+++ b/types/react-pdf/dist/Document.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { PDFDocumentProxy } from 'pdfjs-dist';
+import type {
+  PDFDocumentProxy
+} from 'pdfjs-dist/types/display/api'
 
 export type RenderFunction = () => JSX.Element;
 


### PR DESCRIPTION
Fix `Module '"pdfjs-dist"' has no exported member 'PDFDocumentProxy'`

See https://github.com/VadimDez/ng2-pdf-viewer/issues/717#issuecomment-817647236

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.