### PR TITLE
[mssql] remove dependency to msnodesqlv8

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -69,6 +69,8 @@ export declare var Geography: ISqlTypeFactoryWithNoParams;
 export declare var Geometry: ISqlTypeFactoryWithNoParams;
 export declare var Variant: ISqlTypeFactoryWithNoParams;
 
+export type Connection = tds.Connection;
+
 export declare var TYPES: {
     VarChar: ISqlTypeFactoryWithLength;
     NVarChar: ISqlTypeFactoryWithLength;
@@ -191,13 +193,13 @@ export interface config {
     stream?: boolean | undefined;
     parseJSON?: boolean | undefined;
     options?: IOptions | undefined;
-    pool?: PoolOpts<tds.Connection> | undefined;
+    pool?: PoolOpts<Connection> | undefined;
     arrayRowMode?: boolean | undefined;
     /**
      * Invoked before opening the connection. The parameter conn is the configured
      * tedious Connection. It can be used for attaching event handlers.
      */
-    beforeConnect?: ((conn: tds.Connection) => void) | undefined
+    beforeConnect?: ((conn: Connection) => void) | undefined
 }
 
 export declare class MSSQLError extends Error {
@@ -216,7 +218,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public readonly available: number;
     public readonly pending: number;
     public readonly borrowed: number;
-    public readonly pool: Pool<tds.Connection>;
+    public readonly pool: Pool<Connection>;
     public constructor(config: config, callback?: (err?: any) => void);
     public constructor(connectionString: string, callback?: (err?: any) => void);
     public query(command: string): Promise<IResult<any>>;

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -15,7 +15,6 @@
 
 import events = require('events');
 import tds = require('tedious');
-import msnodesql = require('msnodesqlv8');
 import { Pool } from 'tarn';
 import { CallbackOrPromise, PoolOptions } from 'tarn/dist/Pool';
 export interface ISqlType {
@@ -69,8 +68,6 @@ export declare var UDT: ISqlTypeFactoryWithNoParams;
 export declare var Geography: ISqlTypeFactoryWithNoParams;
 export declare var Geometry: ISqlTypeFactoryWithNoParams;
 export declare var Variant: ISqlTypeFactoryWithNoParams;
-
-export type Connection = tds.Connection | msnodesql.Connection;
 
 export declare var TYPES: {
     VarChar: ISqlTypeFactoryWithLength;
@@ -194,13 +191,13 @@ export interface config {
     stream?: boolean | undefined;
     parseJSON?: boolean | undefined;
     options?: IOptions | undefined;
-    pool?: PoolOpts<Connection> | undefined;
+    pool?: PoolOpts<tds.Connection> | undefined;
     arrayRowMode?: boolean | undefined;
     /**
      * Invoked before opening the connection. The parameter conn is the configured
      * tedious Connection. It can be used for attaching event handlers.
      */
-    beforeConnect?: ((conn: Connection) => void) | undefined
+    beforeConnect?: ((conn: tds.Connection) => void) | undefined
 }
 
 export declare class MSSQLError extends Error {
@@ -219,7 +216,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public readonly available: number;
     public readonly pending: number;
     public readonly borrowed: number;
-    public readonly pool: Pool<Connection>;
+    public readonly pool: Pool<tds.Connection>;
     public constructor(config: config, callback?: (err?: any) => void);
     public constructor(connectionString: string, callback?: (err?: any) => void);
     public query(command: string): Promise<IResult<any>>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -1,6 +1,5 @@
 import * as sql from 'mssql';
 import * as msnodesqlv8 from 'mssql/msnodesqlv8';
-import tds = require('tedious');
 
 interface Entity {
     value: number;
@@ -17,9 +16,9 @@ var config: sql.config = {
     },
     pool: {},
     beforeConnect: (conn) => {
-        (conn as tds.Connection).on('debug', message => console.info(message));
-        (conn as tds.Connection).on('error', err => console.error(err));
-        (conn as tds.Connection).removeAllListeners();
+        conn.on('debug', message => console.info(message));
+        conn.on('error', err => console.error(err));
+        conn.removeAllListeners();
     }
 }
 

--- a/types/mssql/package.json
+++ b/types/mssql/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "msnodesqlv8": "^2.2.0",
         "tarn": "^3.0.1"
     }
 }


### PR DESCRIPTION
Remove dependency to msnodesqlv8 because it includes a native addon. As a result all
users of mssql had to build this even they don't use it.

Refs: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53434#issuecomment-872788636

fyi: @dhensby @pkeuter 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

