### PR TITLE
pino: use record type argument for log formatter

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -12,8 +12,9 @@
 //                 Adam Vigneaux <https://github.com/AdamVig>
 //                 Austin Beer <https://github.com/austin-beer>
 //                 Michel Nemnom <https://github.com/Pegase745>
+//                 Krystian Jarmicki <https://github.com/kjarmicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7
+// TypeScript Version: 3.0
 
 /// <reference types="node"/>
 
@@ -524,7 +525,7 @@ declare namespace P {
              * All arguments passed to the log method, except the message, will be pass to this function.
              * By default it does not change the shape of the log object.
              */
-            log?: ((object: object) => object) | undefined;
+            log?: ((object: Record<string, unknown>) => object) | undefined;
         } | undefined;
 
         /**

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -12,7 +12,6 @@
 //                 Adam Vigneaux <https://github.com/AdamVig>
 //                 Austin Beer <https://github.com/austin-beer>
 //                 Michel Nemnom <https://github.com/Pegase745>
-//                 Krystian Jarmicki <https://github.com/kjarmicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -165,6 +165,25 @@ anotherRedacted.info({
     anotherPath: "Not shown",
 });
 
+const withLogFormatter = pino({
+    formatters: {
+        log: (payload) => {
+            if (payload.canAccessAnyKey) {
+                payload.works = true;
+            }
+            return payload;
+        }
+    }
+});
+
+const withLogFormatterBackwardCompatible = pino({
+    formatters: {
+        log: (payload: object) => {
+            return payload;
+        }
+    }
+});
+
 const pretty = pino({
     prettyPrint: {
         colorize: true,


### PR DESCRIPTION
This pull request changes the` pino.LoggerOptions.formatters.log` argument type from `object` to `Record<string, unknown>`. The reason for this change is due to the fact that the index signature is missing in the `object` type, so it has to be type-casted to become usable:

```ts
log(payload) { // inferred as object
  payload.context = 'something'; // type error 
  const payloadRecord = payload as Record<string, unknown>;
  payloadRecord.context = 'something'; // ok
}
```

This change should be backward-compatible (see test cases) because it uses a narrower type for input and leaves `object` as a return type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino/blob/master/lib/tools.js#L112
Here pino itself is using an index to access log keys, so this change is type-safe.