### PR TITLE
[dockerode] Add registryconfig to image build options

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -131,6 +131,20 @@ docker.buildImage({ context: '.', src: ['Dockerfile', 'test.sh'] }, { t: 'imageN
     // NOOP
 });
 
+docker.buildImage(
+    'archive.tar',
+    {
+        registryconfig: {
+            'https://index.docker.io/v1/': {
+                username: 'user',
+                password: 'pass'
+            }
+        }
+    },
+    (err, response) => {
+        /* NOOP*/
+    });
+
 docker.createContainer({ Tty: true }, (err, container) => {
     container.start((err, data) => {
         // NOOP

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -805,6 +805,7 @@ declare namespace Dockerode {
 
     interface ImageBuildOptions {
         authconfig?: AuthConfig | undefined;
+        registryconfig?: RegistryConfig | undefined;
         dockerfile?: string | undefined;
         t?: string | undefined;
         extrahosts?: string | undefined;
@@ -840,6 +841,13 @@ declare namespace Dockerode {
         password: string;
         serveraddress: string;
         email?: string | undefined;
+    }
+
+    interface RegistryConfig {
+        [registryAddress: string]: {
+            username: string;
+            password: string;
+        };
     }
 
     interface PortBinding {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
       - https://github.com/apocas/dockerode/blob/master/lib/docker.js#L271
       - https://github.com/apocas/dockerode/issues/435
       - https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L166

This PR adds a `registryconfig` option to the `ImageBuildOptions`, which unlike the `authconfig`, supports providing multiple authorisations. This is needed for example in a multi-stage Dockerfile where there are several images from private registries. This functionality is already used here: https://github.com/testcontainers/testcontainers-node/blob/f57d8d74b128e5622b875ba8a95e88158319e380/src/docker-client.ts#L267, but this change https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f56a37ed3e1a9745e06c1b847673e0a67b433584#diff-30ffb73dbf4888d74934013ee936941f00dd3be7c43fb4ce02a3870e6dc6f253 means that the latest dockerode type version doesn't compile. From the URLs provided you can see that `registryconfig` is a supported option.