### PR TITLE
[ioredis] Add a missing `isCluster` property to the Cluster interface

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1674,6 +1674,7 @@ declare namespace IORedis {
     type Ok = 'OK';
 
     interface Cluster extends EventEmitter, Commander, Commands {
+        readonly isCluster: true;
         readonly options: ClusterOptions;
         readonly status: string;
         connect(): Promise<void>;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -783,6 +783,7 @@ redis.pipeline()
 
 redis.options.host;
 redis.status;
+cluster.isCluster;
 cluster.options.maxRedirections;
 cluster.status;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `ioredis` Cluster class contains an `isCluster` property (see https://github.com/luin/ioredis/blob/dac428d4aeae2cf1a5e6ee9dfa6ba6bca6cc4aa7/lib/cluster/index.ts#L70), so I'm adding this property to the type definitions. 

Why: We use a variable of type `Redis | Cluster` in our code (because we use just a single Redis node while development, but a Redis cluster in production) and I'd like to make it easier to distinguish between Redis and Cluster when working with that client (until now I had to check `redis.constructor.name === 'Cluster'`)