### PR TITLE
[hapi__catbox-redis] Allow to use Redis cluster as a client

### DIFF
--- a/types/hapi__catbox-redis/index.d.ts
+++ b/types/hapi__catbox-redis/index.d.ts
@@ -7,14 +7,14 @@
 
 // tslint:disable-next-line:no-single-declare-module
 declare module '@hapi/catbox-redis' {
-    import { Redis } from 'ioredis';
+    import { Redis, Cluster } from 'ioredis';
     import { EnginePrototype, ClientOptions, Client } from '@hapi/catbox';
     namespace CatboxRedis {
       interface CatboxRedisOptions extends ClientOptions {
         /**
          * Raw client.
          */
-        client?: Redis | undefined;
+        client?: Redis | Cluster | undefined;
         /**
          * the Redis server URL (if url is provided, host, port, and socket are ignored)
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

We use a `client` variable of type `Redis | Cluster` in our code (because we use just a single Redis node while development, but a Redis cluster in production) and both simple Redis client and Redis cluster client are perfectly compatible with `catbox-redis` (both implement `EventEmitter` and `Commands` interfaces used by `catbox-redis`). After this change, the explicit type assertions like `{ client: client as Redis }` while initializing CatboxRedis won't be longer required.