### PR TITLE
Correctly Type inputRef of react-calendar

### DIFF
--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -35,7 +35,7 @@ export interface CalendarProps {
     formatYear?: FormatterCallback | undefined;
     inputRef?: ((
         ref: HTMLInputElement | null,
-    ) => void | RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement | null>) | undefined;
+    ) => void) | RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement | null> | undefined;
     locale?: string | undefined;
     maxDate?: Date | undefined;
     maxDetail?: Detail | undefined;

--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -6,7 +6,7 @@
 
 import { MouseEvent, ChangeEvent, MutableRefObject, RefObject } from 'react';
 
-export type CalendarType = "ISO 8601" | 'US' | 'Arabic' | 'Hebrew';
+export type CalendarType = 'ISO 8601' | 'US' | 'Arabic' | 'Hebrew';
 export type Detail = 'month' | 'year' | 'decade' | 'century';
 export type DateCallback = (value: Date, event: MouseEvent<HTMLButtonElement>) => void;
 export type ClickWeekNumberCallback = (weekNumber: number, date: Date, event: MouseEvent<HTMLButtonElement>) => void;
@@ -33,21 +33,20 @@ export interface CalendarProps {
     formatMonthYear?: FormatterCallback | undefined;
     formatShortWeekday?: FormatterCallback | undefined;
     formatYear?: FormatterCallback | undefined;
-    inputRef?: ((
-        ref: HTMLInputElement | null,
-    ) => void) | RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement | null> | undefined;
+    inputRef?:
+        | ((ref: HTMLInputElement | null) => void)
+        | RefObject<HTMLInputElement>
+        | MutableRefObject<HTMLInputElement | null>
+        | undefined;
     locale?: string | undefined;
     maxDate?: Date | undefined;
     maxDetail?: Detail | undefined;
     minDate?: Date | undefined;
     minDetail?: Detail | undefined;
     navigationAriaLabel?: string | undefined;
-    navigationLabel?: ((props: {
-        date: Date;
-        label: string;
-        locale: string;
-        view: Detail;
-    }) => string | JSX.Element | null) | undefined;
+    navigationLabel?:
+        | ((props: { date: Date; label: string; locale: string; view: Detail }) => string | JSX.Element | null)
+        | undefined;
     nextAriaLabel?: string | undefined;
     nextLabel?: string | JSX.Element | null | undefined;
     next2AriaLabel?: string | undefined;
@@ -66,7 +65,7 @@ export interface CalendarProps {
     prevLabel?: string | JSX.Element | null | undefined;
     prev2AriaLabel?: string | undefined;
     prev2Label?: string | JSX.Element | null | undefined;
-    returnValue?: "start" | "end" | "range" | undefined;
+    returnValue?: 'start' | 'end' | 'range' | undefined;
     showDoubleView?: boolean | undefined;
     showFixedNumberOfWeeks?: boolean | undefined;
     showNavigation?: boolean | undefined;

--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -6,7 +6,7 @@
 
 import { MouseEvent, ChangeEvent, MutableRefObject, RefObject } from 'react';
 
-export type CalendarType = 'ISO 8601' | 'US' | 'Arabic' | 'Hebrew';
+export type CalendarType = "ISO 8601" | 'US' | 'Arabic' | 'Hebrew';
 export type Detail = 'month' | 'year' | 'decade' | 'century';
 export type DateCallback = (value: Date, event: MouseEvent<HTMLButtonElement>) => void;
 export type ClickWeekNumberCallback = (weekNumber: number, date: Date, event: MouseEvent<HTMLButtonElement>) => void;
@@ -33,20 +33,21 @@ export interface CalendarProps {
     formatMonthYear?: FormatterCallback | undefined;
     formatShortWeekday?: FormatterCallback | undefined;
     formatYear?: FormatterCallback | undefined;
-    inputRef?:
-        | ((ref: HTMLInputElement | null) => void)
-        | RefObject<HTMLInputElement>
-        | MutableRefObject<HTMLInputElement | null>
-        | undefined;
+    inputRef?: ((
+        ref: HTMLInputElement | null,
+    ) => void) | RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement | null> | undefined;
     locale?: string | undefined;
     maxDate?: Date | undefined;
     maxDetail?: Detail | undefined;
     minDate?: Date | undefined;
     minDetail?: Detail | undefined;
     navigationAriaLabel?: string | undefined;
-    navigationLabel?:
-        | ((props: { date: Date; label: string; locale: string; view: Detail }) => string | JSX.Element | null)
-        | undefined;
+    navigationLabel?: ((props: {
+        date: Date;
+        label: string;
+        locale: string;
+        view: Detail;
+    }) => string | JSX.Element | null) | undefined;
     nextAriaLabel?: string | undefined;
     nextLabel?: string | JSX.Element | null | undefined;
     next2AriaLabel?: string | undefined;
@@ -65,7 +66,7 @@ export interface CalendarProps {
     prevLabel?: string | JSX.Element | null | undefined;
     prev2AriaLabel?: string | undefined;
     prev2Label?: string | JSX.Element | null | undefined;
-    returnValue?: 'start' | 'end' | 'range' | undefined;
+    returnValue?: "start" | "end" | "range" | undefined;
     showDoubleView?: boolean | undefined;
     showFixedNumberOfWeeks?: boolean | undefined;
     showNavigation?: boolean | undefined;

--- a/types/react-calendar/react-calendar-tests.tsx
+++ b/types/react-calendar/react-calendar-tests.tsx
@@ -6,6 +6,8 @@ interface State {
 }
 
 export default class Sample extends React.Component<{}, State> {
+    ref = React.createRef<HTMLInputElement>();
+
     state = {
         value: null,
     };
@@ -37,6 +39,7 @@ export default class Sample extends React.Component<{}, State> {
                             value={value}
                             locale="ko-KR"
                             formatDay={(locale, date) => date.getDate().toString()}
+                            inputRef={this.ref}
                         />
                         <Calendar
                             onChange={this.onRangeChange}
@@ -45,6 +48,7 @@ export default class Sample extends React.Component<{}, State> {
                             value={value}
                             locale="ko-KR"
                             formatDay={(locale, date) => date.getDate().toString()}
+                            inputRef={this.ref}
                             selectRange
                         />
                     </main>

--- a/types/react-calendar/react-calendar-tests.tsx
+++ b/types/react-calendar/react-calendar-tests.tsx
@@ -15,12 +15,12 @@ export default class Sample extends React.Component<{}, State> {
     onChange = (value: Date, e: React.ChangeEvent<HTMLInputElement>) => {
         e.stopPropagation();
         this.setState({ value });
-    };
+    }
 
     onRangeChange = (values: [Date] | [Date, Date], e: React.ChangeEvent<HTMLInputElement>) => {
         e.stopPropagation();
         this.setState({ value: values[0] });
-    };
+    }
 
     render() {
         const { value } = this.state;

--- a/types/react-calendar/react-calendar-tests.tsx
+++ b/types/react-calendar/react-calendar-tests.tsx
@@ -15,12 +15,12 @@ export default class Sample extends React.Component<{}, State> {
     onChange = (value: Date, e: React.ChangeEvent<HTMLInputElement>) => {
         e.stopPropagation();
         this.setState({ value });
-    }
+    };
 
     onRangeChange = (values: [Date] | [Date, Date], e: React.ChangeEvent<HTMLInputElement>) => {
         e.stopPropagation();
         this.setState({ value: values[0] });
-    }
+    };
 
     render() {
         const { value } = this.state;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

According to Documentation for the prop `inputRef` [here](https://github.com/wojtekmaj/react-calendar#readme) it can be a function or a react `Ref`. The existing type for `inputRef` is wrong because it only allows for a function which returns a `Ref` but not for a `Ref` itself. I tested it in my own project and it worked.
