### PR TITLE
Fix @ckeditor/ckeditor5-utils Options target

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -671,6 +671,30 @@ options = {
     positions: [() => null, () => ({ top: 3, left: 3, name: "" })],
 };
 
+options = {
+    element: document.createElement("div"),
+    target: new Rect(document.createElement('div')),
+    positions: [() => null, () => ({ top: 3, left: 3, name: "" })],
+};
+
+options = {
+    element: document.createElement('div'),
+    target: new Range(),
+    positions: [() => null, () => ({ top: 3, left: 3, name: '' })],
+};
+
+options = {
+    element: document.createElement("div"),
+    target: window,
+    positions: [() => null, () => ({ top: 3, left: 3, name: "" })],
+};
+
+options = {
+    element: document.createElement('div'),
+    target: document.body.getClientRects().item(0)!,
+    positions: [() => null, () => ({ top: 3, left: 3, name: '' })],
+};
+
 // utils/toArray ==============================================================
 let myArrayOfOneNumber: [number] = toArray(5);
 myArrayOfOneNumber = toArray([5]);

--- a/types/ckeditor__ckeditor5-utils/src/dom/position.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/dom/position.d.ts
@@ -94,7 +94,7 @@ export interface Options {
     /**
      * Target with respect to which the `element` is to be positioned.
      */
-    target: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement);
+    target: ConstructorParameters<typeof Rect>[number] | (() => ConstructorParameters<typeof Rect>[number]);
     /**
      * An array of functions which return {@link module:utils/dom/position~Position} relative
      * to the `target`, in the order of preference.
@@ -107,11 +107,11 @@ export interface Options {
      * When set, the algorithm will chose position which fits the most in the
      * limiter's bounding rect.
      */
-    limiter?: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement) | undefined;
+    limiter?: ConstructorParameters<typeof Rect>[number] | (() => ConstructorParameters<typeof Rect>[number]);
 
     /**
      * When set, the algorithm will chose such a position which fits `element`
      * the most inside visible viewport.
      */
-    fitInViewport?: boolean | undefined;
+    fitInViewport?: boolean;
 }

--- a/types/ckeditor__ckeditor5-utils/src/dom/rect.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/dom/rect.d.ts
@@ -46,7 +46,16 @@ export default class Rect {
     left: number;
     width: number;
     height: number;
-    constructor(source: HTMLElement | Range | Window | ClientRect | Rect | object);
+    constructor(
+        source:
+            | HTMLElement
+            | Range
+            | Window
+            | ClientRect
+            | DOMRect
+            | Rect
+            | { top: number; right: number; bottom: number; left: number; width: number; height: number },
+    );
     /**
      * Returns a clone of the rect.
      *

--- a/types/ckeditor__ckeditor5-utils/v25/src/dom/position.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v25/src/dom/position.d.ts
@@ -91,10 +91,12 @@ export interface Options {
      * Element that is to be positioned.
      */
     element: HTMLElement;
+
     /**
      * Target with respect to which the `element` is to be positioned.
      */
-    target: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement);
+    target: ConstructorParameters<typeof Rect>[number] | (() => ConstructorParameters<typeof Rect>[number]);
+
     /**
      * An array of functions which return {@link module:utils/dom/position~Position} relative
      * to the `target`, in the order of preference.
@@ -107,7 +109,7 @@ export interface Options {
      * When set, the algorithm will chose position which fits the most in the
      * limiter's bounding rect.
      */
-    limiter?: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement) | undefined;
+    limiter?: ConstructorParameters<typeof Rect>[number] | (() => ConstructorParameters<typeof Rect>[number]);
 
     /**
      * When set, the algorithm will chose such a position which fits `element`

--- a/types/ckeditor__ckeditor5-utils/v25/src/dom/rect.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v25/src/dom/rect.d.ts
@@ -40,7 +40,16 @@ export default class Rect {
      * to get the inner part of the rect.
      *
      */
-    constructor(source: HTMLElement | Range | Window | ClientRect | Rect | object);
+    constructor(
+        source:
+            | HTMLElement
+            | Range
+            | Window
+            | ClientRect
+            | DOMRect
+            | Rect
+            | { top: number; right: number; bottom: number; left: number; width: number; height: number },
+    );
     /**
      * Returns a clone of the rect.
      *

--- a/types/ckeditor__ckeditor5-utils/v27/src/dom/position.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/dom/position.d.ts
@@ -91,10 +91,12 @@ export interface Options {
      * Element that is to be positioned.
      */
     element?: HTMLElement | undefined;
+
     /**
      * Target with respect to which the `element` is to be positioned.
      */
-    target: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement);
+    target: ConstructorParameters<typeof Rect>[number] | (() => ConstructorParameters<typeof Rect>[number]);
+
     /**
      * An array of functions which return {@link module:utils/dom/position~Position} relative
      * to the `target`, in the order of preference.
@@ -107,7 +109,7 @@ export interface Options {
      * When set, the algorithm will chose position which fits the most in the
      * limiter's bounding rect.
      */
-    limiter?: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement) | undefined;
+    limiter?: ConstructorParameters<typeof Rect>[number] | (() => ConstructorParameters<typeof Rect>[number]);
 
     /**
      * When set, the algorithm will chose such a position which fits `element`

--- a/types/ckeditor__ckeditor5-utils/v27/src/dom/rect.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/dom/rect.d.ts
@@ -46,7 +46,16 @@ export default class Rect {
     left: number;
     width: number;
     height: number;
-    constructor(source: HTMLElement | Range | Window | ClientRect | Rect | object);
+    constructor(
+        source:
+            | HTMLElement
+            | Range
+            | Window
+            | ClientRect
+            | DOMRect
+            | Rect
+            | { top: number; right: number; bottom: number; left: number; width: number; height: number },
+    );
     /**
      * Returns a clone of the rect.
      *


### PR DESCRIPTION
For the `Options` interface, modify the `target` and `limiter` properties to accept whatever the constructor parameters
of `Rect` are, cause these two properties are used unmodified to create a new `Rect`.

For the Rect constructor, add `DOMRect` which is the standard version of ClientRect, the window object, and the expected
type for the record.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/pull/10174
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.