### PR TITLE
update(video.js): Component#isDisposed missing

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -1479,6 +1479,14 @@ declare namespace videojs {
         dispose(): void;
 
         /**
+         * Determine whether or not this component has been disposed.
+         *
+         * @return
+         *         If the component has been disposed, will be `true`. Otherwise, `false`.
+         */
+        isDisposed(): boolean;
+
+        /**
          * Get the `Component`s DOM element
          *
          * @return The DOM element for this `Component`.

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -215,6 +215,8 @@ function testComponents(player: videojs.Player) {
     myWindow.open();
     myWindow.close();
     myWindow.myFunction();
+    myWindow.isDisposed(); // $ExpectType boolean
+    myWindow.dispose(); // $ExpectType void
 }
 
 function testPlugin(player: videojs.Player, options: {}) {
@@ -270,12 +272,12 @@ function testPlugin(player: videojs.Player, options: {}) {
 }
 
 function testLogger() {
-    const mylogger = videojs.log.createLogger('mylogger');
-    const anotherlogger = mylogger.createLogger('anotherlogger');
+    const myLogger = videojs.log.createLogger('mylogger');
+    const anotherLogger = myLogger.createLogger('anotherlogger');
 
     videojs.log('hello');
-    mylogger('how are you');
-    anotherlogger('today');
+    myLogger('how are you');
+    anotherLogger('today');
 
     const currentLevel = videojs.log.level();
     videojs.log.level(videojs.log.levels.DEFAULT);


### PR DESCRIPTION
Missing `isDisposed` method on components:

https://docs.videojs.com/tutorial-player-workflows.html#checking-if-a-player-is-disposed

(and minor styling corrections)

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).