### PR TITLE
Add `gravity` to `IEngineDefinition`

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1935,6 +1935,13 @@ declare namespace Matter {
         */
         enableSleeping?: boolean | undefined;
         /**
+         * The gravity to apply on all bodies in `engine.world`.
+         *
+         * @property gravity
+         * @type object
+         */
+        gravity: Partial<Gravity>;
+        /**
          * An `Object` containing properties regarding the timing systems of the engine.
         *
         * @property timing


### PR DESCRIPTION
https://brm.io/matter-js/docs/classes/Engine.html#property_gravity

Gravity is defined in the class definition but forgotten in the interface `IEngineDefinition`.

`gravity` is defined as `Partial<Gravity>`, as matter-js does a merge of the options with the defaults
```javascript
gravity: {
    x: 0,
    y: 1,
    scale: 0.001
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://brm.io/matter-js/docs/classes/Engine.html#property_gravity
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
