### PR TITLE
[chrome] Add definitions of functions for chrome.storage which support Promise

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7181,11 +7181,12 @@ declare namespace chrome.storage {
          * @param callback Callback with the amount of space being used by storage, or on failure (in which case runtime.lastError will be set).
          * Parameter bytesInUse: Amount of space being used in storage, in bytes.
          */
-        getBytesInUse(callback: (bytesInUse: number) => void): void;
+        // getBytesInUse(callback: (bytesInUse: number) => void): void;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.
-         * @return The `getBytesInUse` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * @return A Promise that resolves with a number
+         * @since MV3
          */
         getBytesInUse(keys?: string | string[] | null): Promise<number>;
         /**
@@ -7197,7 +7198,8 @@ declare namespace chrome.storage {
         getBytesInUse(keys: string | string[] | null, callback: (bytesInUse: number) => void): void;
         /**
          * Removes all items from storage.
-         * @return The `clear` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * @return A void Promise
+         * @since MV3
          */
         clear(): Promise<void>;
         /**
@@ -7210,7 +7212,8 @@ declare namespace chrome.storage {
          * Sets multiple items.
          * @param items An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.
          * Primitive values such as numbers will serialize as expected. Values with a typeof "object" and "function" will typically serialize to {}, with the exception of Array (serializes as expected), Date, and Regex (serialize using their String representation).
-         * @return The `set` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * @return A void Promise
+         * @since MV3
          */
         set(items: { [key: string]: any }): Promise<void>;
         /**
@@ -7225,7 +7228,8 @@ declare namespace chrome.storage {
          * Removes one or more items from storage.
          * @param keys A single key or a list of keys for items to remove.
          * @param callback Optional.
-         * @return The `remove` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * @return A void Promise
+         * @since MV3
          */
         remove(keys: string | string[]): Promise<void>;
         /**
@@ -7245,7 +7249,8 @@ declare namespace chrome.storage {
          * Gets one or more items from storage.
          * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
          * An empty list or object will return an empty result object. Pass in null to get the entire contents of storage.
-         * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * @return A Promise that resolves with an object containing items
+         * @since MV3
          */
         get(keys?: string | string[] | { [key: string]: any } | null): Promise<{ [key: string]: any }>;
         /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7181,7 +7181,7 @@ declare namespace chrome.storage {
          * @param callback Callback with the amount of space being used by storage, or on failure (in which case runtime.lastError will be set).
          * Parameter bytesInUse: Amount of space being used in storage, in bytes.
          */
-        // getBytesInUse(callback: (bytesInUse: number) => void): void;
+        getBytesInUse(callback: (bytesInUse: number) => void): void;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7184,11 +7184,22 @@ declare namespace chrome.storage {
         getBytesInUse(callback: (bytesInUse: number) => void): void;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
-         * @param keys A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.
+         * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.
+         * @return The `getBytesInUse` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        getBytesInUse(keys?: string | string[] | null): Promise<number>;
+        /**
+         * Gets the amount of space (in bytes) being used by one or more items.
+         * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.
          * @param callback Callback with the amount of space being used by storage, or on failure (in which case runtime.lastError will be set).
          * Parameter bytesInUse: Amount of space being used in storage, in bytes.
          */
         getBytesInUse(keys: string | string[] | null, callback: (bytesInUse: number) => void): void;
+        /**
+         * Removes all items from storage.
+         * @return The `clear` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        clear(): Promise<void>;
         /**
          * Removes all items from storage.
          * @param callback Optional.
@@ -7199,10 +7210,24 @@ declare namespace chrome.storage {
          * Sets multiple items.
          * @param items An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.
          * Primitive values such as numbers will serialize as expected. Values with a typeof "object" and "function" will typically serialize to {}, with the exception of Array (serializes as expected), Date, and Regex (serialize using their String representation).
+         * @return The `set` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        set(items: { [key: string]: any }): Promise<void>;
+        /**
+         * Sets multiple items.
+         * @param items An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.
+         * Primitive values such as numbers will serialize as expected. Values with a typeof "object" and "function" will typically serialize to {}, with the exception of Array (serializes as expected), Date, and Regex (serialize using their String representation).
          * @param callback Optional.
          * Callback on success, or on failure (in which case runtime.lastError will be set).
          */
-        set(items: Object, callback?: () => void): void;
+        set(items: { [key: string]: any }, callback?: () => void): void;
+        /**
+         * Removes one or more items from storage.
+         * @param keys A single key or a list of keys for items to remove.
+         * @param callback Optional.
+         * @return The `remove` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        remove(keys: string | string[]): Promise<void>;
         /**
          * Removes one or more items from storage.
          * @param keys A single key or a list of keys for items to remove.
@@ -7211,7 +7236,7 @@ declare namespace chrome.storage {
          */
         remove(keys: string | string[], callback?: () => void): void;
         /**
-         * Gets one or more items from storage.
+         * Gets the entire contents of storage.
          * @param callback Callback with storage items, or on failure (in which case runtime.lastError will be set).
          * Parameter items: Object with items in their key-value mappings.
          */
@@ -7220,10 +7245,17 @@ declare namespace chrome.storage {
          * Gets one or more items from storage.
          * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
          * An empty list or object will return an empty result object. Pass in null to get the entire contents of storage.
+         * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        get(keys?: string | string[] | { [key: string]: any } | null): Promise<{ [key: string]: any }>;
+        /**
+         * Gets one or more items from storage.
+         * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
+         * An empty list or object will return an empty result object. Pass in null to get the entire contents of storage.
          * @param callback Callback with storage items, or on failure (in which case runtime.lastError will be set).
          * Parameter items: Object with items in their key-value mappings.
          */
-        get(keys: string | string[] | Object | null, callback: (items: { [key: string]: any }) => void): void;
+        get(keys: string | string[] | { [key: string]: any } | null, callback: (items: { [key: string]: any }) => void): void;
     }
 
     export interface StorageChange {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -893,3 +893,24 @@ async function testDeclarativeNetRequestForPromise() {
     await chrome.declarativeNetRequest.updateEnabledRulesets({});
     await chrome.declarativeNetRequest.updateSessionRules({});
 }
+
+// https://developer.chrome.com/docs/extensions/reference/storage
+function testStorageForPromise() {
+    chrome.storage.sync.getBytesInUse().then(() => {});
+    chrome.storage.sync.getBytesInUse(null).then(() => {});
+    chrome.storage.sync.getBytesInUse('testKey').then(() => {});
+    chrome.storage.sync.getBytesInUse(['testKey']).then(() => {});
+
+    chrome.storage.sync.clear().then(() => {});
+
+    chrome.storage.sync.set({ testKey: 'testValue' }).then(() => {});
+
+    chrome.storage.sync.remove('testKey').then(() => {});
+    chrome.storage.sync.remove(['testKey']).then(() => {});
+
+    chrome.storage.sync.get().then(() => {});
+    chrome.storage.sync.get(null).then(() => {});
+    chrome.storage.sync.get('testKey').then(() => {});
+    chrome.storage.sync.get(['testKey']).then(() => {});
+    chrome.storage.sync.get({ testKey: 'testDefaultValue' }).then(() => {});
+}


### PR DESCRIPTION
This pull request adds definitions for `chrome.storage` functions which return Promise in Manifest V3.

When adding them, I referred the following API reference document:
https://developer.chrome.com/docs/extensions/reference/storage/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/storage/
