### PR TITLE
[@types/commercetools__enzyme-extensions] Remove renderProp from commercetools__enzyme-extensions

### DIFF
--- a/types/commercetools__enzyme-extensions/commercetools__enzyme-extensions-tests.tsx
+++ b/types/commercetools__enzyme-extensions/commercetools__enzyme-extensions-tests.tsx
@@ -17,13 +17,6 @@ function Child(props: ChildProps) {
 }
 
 enzyme.shallow(<App />)
-    .find(App)
-    .renderProp('render');
-enzyme.shallow(<App />)
-    .find(Child)
-    .renderProp('render', 1, 2);
-
-enzyme.shallow(<App />)
     .find(Child)
     .drill(props => props.cb());
 

--- a/types/commercetools__enzyme-extensions/index.d.ts
+++ b/types/commercetools__enzyme-extensions/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @commercetools/enzyme-extensions 3.0
+// Type definitions for @commercetools/enzyme-extensions 4.0
 // Project: https://github.com/commercetools/enzyme-extensions
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,7 +11,6 @@ declare module 'enzyme' {
         maxDepth: number;
     }
     interface ShallowWrapper<P = {}> {
-        renderProp(propName: string, ...args: any[]): ShallowWrapper<P>;
         drill(expander: (props: any) => ShallowWrapper): ShallowWrapper<P>;
         until(selector: EnzymeSelector, options?: UntilOptions): ShallowWrapper<P>;
     }


### PR DESCRIPTION
According to the project page support for renderProp was dropped since v4.0.

This is needed to create MR with patch-2 to close #53412

But since @types/enzyme is coupled with @types/commercetools__enzyme-extensions when testing all libraries, I had to update @types/commercetools__enzyme-extensions first

Please fill in this template.

 Use a meaningful title for the pull request. Include the name of the package modified.
 Test the change in your own code. (Compile and run.)
 Add or edit tests to reflect the change.
 Follow the advice from the readme.
 Avoid common mistakes.
 Run npm test <package to test>.
Select one of these and delete the others:

If changing an existing definition:

 Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/commercetools/enzyme-extensions
 If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.