### PR TITLE
Update @koa/cors to allow credential as a function

### DIFF
--- a/types/koa-cors/index.d.ts
+++ b/types/koa-cors/index.d.ts
@@ -4,13 +4,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Middleware, Request } from 'koa';
+import { Context, Middleware, Request } from 'koa';
 
 declare function koaCors(options?: koaCors.Options): Middleware;
 
 declare namespace koaCors {
     interface Options {
-        credentials?: true | undefined;
+        credentials?: true | ((ctx: Context) => boolean) | undefined;
         expose?: string | ReadonlyArray<string> | undefined;
         headers?: string | ReadonlyArray<string> | undefined;
         maxAge?: number | undefined;


### PR DESCRIPTION
From the @koa/cors [README](https://github.com/koajs/cors):

```
 *  - {Boolean|Function(ctx)} credentials `Access-Control-Allow-Credentials`, default is false.
```

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/cors
