### PR TITLE
[iobroker] Add SettableXYZObject types for convenience and fix no-redundant-undefined errors

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -48,16 +48,16 @@ declare global {
             from: string;
 
             /** The user who set this value */
-            user?: string | undefined;
+            user?: string;
 
             /** Optional time in seconds after which the state is reset to null */
-            expire?: number | undefined;
+            expire?: number;
 
             /** Optional quality of the state value */
-            q?: StateQuality | undefined;
+            q?: StateQuality;
 
             /** Optional comment */
-            c?: string | undefined;
+            c?: string;
         }
 
         type SettableState = AtLeastOne<State>;
@@ -87,7 +87,7 @@ declare global {
             /** The access rights for users/groups */
             users: ObjectOperationPermissions;
             /** The access rights for states */
-            state?: ObjectOperationPermissions | undefined;
+            state?: ObjectOperationPermissions;
         }
         /** Defined the complete set of access rights a user has */
         interface PermissionSet extends ObjectPermissions {
@@ -164,11 +164,11 @@ declare global {
         /** Parameters for adapter.getObjectView */
         interface GetObjectViewParams {
             /** First id to include in the return list */
-            startkey?: string | undefined;
+            startkey?: string;
             /** Last id to include in the return list */
-            endkey?: string | undefined;
+            endkey?: string;
             /** Whether docs should be included in the return list */ // TODO: What are docs?
-            include_docs?: boolean | undefined;
+            include_docs?: boolean;
         }
 
         /** Parameters for adapter.getObjectList */
@@ -246,19 +246,19 @@ declare global {
         }
 
         interface GetHistoryOptions {
-            instance?: string | undefined;
-            start?: number | undefined;
-            end?: number | undefined;
-            step?: number | undefined;
-            count?: number | undefined;
-            from?: boolean | undefined;
-            ack?: boolean | undefined;
-            q?: boolean | undefined;
-            addID?: boolean | undefined;
-            limit?: number | undefined;
-            ignoreNull?: boolean | undefined;
+            instance?: string;
+            start?: number;
+            end?: number;
+            step?: number;
+            count?: number;
+            from?: boolean;
+            ack?: boolean;
+            q?: boolean;
+            addID?: boolean;
+            limit?: number;
+            ignoreNull?: boolean;
             sessionId?: any;
-            aggregate?: 'minmax' | 'min' | 'max' | 'average' | 'total' | 'count' | 'none' | undefined;
+            aggregate?: 'minmax' | 'min' | 'max' | 'average' | 'total' | 'count' | 'none';
         }
 
         interface AdapterOptions {
@@ -266,47 +266,47 @@ declare global {
             name: string;
 
             /** path to adapter */
-            dirname?: string | undefined;
+            dirname?: string;
 
             /** if the global system config should be included in the created object. Default: false */
-            systemConfig?: boolean | undefined;
+            systemConfig?: boolean;
 
             /** provide alternative global configuration for the adapter. Default: null */
             config?: any;
 
             /** instance of the created adapter. Default: null */
-            instance?: number | undefined;
+            instance?: number;
 
             /** If the adapter needs access to the formatDate function to format dates according to the global settings. Default: false */
-            useFormatDate?: boolean | undefined;
+            useFormatDate?: boolean;
 
             /** If the adapter collects logs from all adapters (experts only). Default: false */
-            logTransporter?: boolean | undefined;
+            logTransporter?: boolean;
 
             /** Handler for changes of subscribed objects */
-            objectChange?: ObjectChangeHandler | undefined;
+            objectChange?: ObjectChangeHandler;
             /** Handler for received adapter messages. Can only be used if messagebox in io-package.json is set to true. */
-            message?: MessageHandler | undefined;
+            message?: MessageHandler;
             /** Handler for changes of subscribed states */
-            stateChange?: StateChangeHandler | undefined;
+            stateChange?: StateChangeHandler;
             /** Will be called when the adapter is intialized */
-            ready?: ReadyHandler | undefined;
+            ready?: ReadyHandler;
             /** Will be called on adapter termination */
-            unload?: UnloadHandler | undefined;
+            unload?: UnloadHandler;
             /** Will be called when ioBroker detects an unhandled error in the adapter. Return `true` to signal that the error was handled and the adapter does not need to be restarted. */
-            error?: ErrorHandler | undefined;
+            error?: ErrorHandler;
 
             /** if true, stateChange will be called with an id that has no namespace, e.g. "state" instead of "adapter.0.state". Default: false */
-            noNamespace?: boolean | undefined;
+            noNamespace?: boolean;
 
             /** If true, the adapter will have a property `oObjects` that contains a live cache of the adapter's objects */
-            objects?: boolean | undefined;
+            objects?: boolean;
 
             /** If true, the adapter will have a property `oStates` that contains a live cache of the adapter's states */
-            states?: boolean | undefined;
+            states?: boolean;
 
             /** Whether the adapter should warn if states are set without an corresponding existing object. Default: `true` */
-            strictObjectChecks?: boolean | undefined;
+            strictObjectChecks?: boolean;
         } // end interface AdapterOptions
 
         // tslint:disable-next-line:no-empty-interface
@@ -347,13 +347,13 @@ declare global {
              *
              * NOTE: This is only defined if the adapter was initialized with the option `objects: true`.
              */
-            oObjects?: Record<string, ioBroker.Object | undefined> | undefined;
+            oObjects?: Record<string, ioBroker.Object | undefined>;
             /**
              * Contains a live cache of the adapter's states.
              *
              * NOTE: This is only defined if the adapter was initialized with the option `states: true`.
              */
-            oStates?: Record<string, ioBroker.State | undefined> | undefined;
+            oStates?: Record<string, ioBroker.State | undefined>;
 
             /** Can be used to test for forbidden chars in object IDs */
             readonly FORBIDDEN_CHARS: RegExp;
@@ -375,7 +375,7 @@ declare global {
             getPortAsync(port: number): Promise<number>;
 
             /** Stops the adapter. Note: Is not always defined. */
-            stop?: (() => void) | undefined;
+            stop?: (() => void);
 
             // ==============================
             // GENERAL
@@ -733,7 +733,7 @@ declare global {
             getObjectList(params: GetObjectListParams | null, callback: GetObjectListCallback): void;
             getObjectList(
                 params: GetObjectListParams | null,
-                options: { sorted?: boolean | undefined } | Record<string, any>,
+                options: { sorted?: boolean } | Record<string, any>,
                 callback: GetObjectListCallback,
             ): void;
             /**
@@ -743,7 +743,7 @@ declare global {
              */
             getObjectListAsync(
                 params: GetObjectListParams | null,
-                options?: { sorted?: boolean | undefined } | Record<string, any>,
+                options?: { sorted?: boolean } | Record<string, any>,
             ): GetObjectListPromise;
 
             // ==============================
@@ -1547,7 +1547,7 @@ declare global {
              * Checks if a given feature is supported by the current installation
              * @param featureName The name of the feature to test for
              */
-            supportsFeature?: ((featureName: string) => boolean) | undefined;
+            supportsFeature?: ((featureName: string) => boolean);
 
             /**
              * Returns an instance of a loaded plugin
@@ -1683,7 +1683,7 @@ declare global {
 
         type DeleteStateCallback = (err?: Error | null, id?: string) => void;
 
-        type GetHistoryResult = Array<State & { id?: string | undefined }>;
+        type GetHistoryResult = Array<State & { id?: string }>;
         type GetHistoryCallback = (
             err: Error | null,
             result?: GetHistoryResult,
@@ -1700,11 +1700,11 @@ declare global {
             /** Whether this is a directory or a file */
             isDir: boolean;
             /** Access rights */
-            acl?: EvaluatedFileACL | undefined;
+            acl?: EvaluatedFileACL;
             /** Date of last modification */
-            modifiedAt?: number | undefined;
+            modifiedAt?: number;
             /** Date of creation */
-            createdAt?: number | undefined;
+            createdAt?: number;
         }
         type ReadDirCallback = (err?: NodeJS.ErrnoException | null, entries?: ReadDirResult[]) => void;
         type ReadDirPromise = Promise<NonNullCallbackReturnTypeOf<ReadDirCallback>>;

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -629,13 +629,13 @@ adapter.FORBIDDEN_CHARS = /_/;
 {
     interface PCF8574Config {
         pollingInterval: number;
-        interrupt?: string | undefined;
+        interrupt?: string;
         pins: PinConfig[];
     }
 
     interface PinConfig {
         dir: 'in' | 'out';
-        inv?: boolean | undefined;
+        inv?: boolean;
     }
 
     const config: PCF8574Config = undefined as any;
@@ -795,3 +795,29 @@ const userObject: ioBroker.UserObject = {
 
     adapter.setForeignObject(null! as string, null! as ioBroker.Object);
 });
+
+// Test convenience types for subsets of SettableObject
+{
+    // Should be OK
+    const stateObj: ioBroker.SettableStateObject = {
+        type: 'state',
+        common: {
+            name: "Dummy name",
+            role: "value",
+            read: true,
+            write: false,
+            unit: "%"
+        },
+        native: {},
+    };
+}
+{
+    const stateObj: ioBroker.SettableDeviceObject = {
+        // $ExpectError
+        type: 'state',
+        common: {
+            name: "Dummy name",
+        },
+        native: {},
+    };
+}

--- a/types/iobroker/objects.d.ts
+++ b/types/iobroker/objects.d.ts
@@ -67,7 +67,7 @@ declare global {
                 | `system.host.${string}.${string}`
                 | `0_userdata.0.${string}`;
 
-                // Guaranteed channel objects
+            // Guaranteed channel objects
             type Channel =
                 | `script.js.${"common" | "global"}`
                 | `${string}.${number}.info`;
@@ -126,7 +126,7 @@ declare global {
             T extends ObjectIDs.Group ? GroupObject :
             T extends ObjectIDs.User ? UserObject :
             T extends ObjectIDs.Host ? HostObject :
-            T extends ObjectIDs.Config ? OtherObject & {type: "config"} :
+            T extends ObjectIDs.Config ? OtherObject & { type: "config" } :
             T extends ObjectIDs.AdapterScoped ? AdapterScopedObject :
             Read extends "read" ? ioBroker.Object : AnyObject;
 
@@ -140,32 +140,32 @@ declare global {
             name: StringOrTranslated;
 
             /** When set to true, this object may not be deleted */
-            dontDelete?: true | undefined;
+            dontDelete?: true;
 
             /** When set to true, this object is only visible when expert mode is turned on in admin */
-            expert?: true | undefined;
+            expert?: true;
 
             // Icon and role aren't defined in SCHEMA.md,
             // but they are being used by some adapters
             /** Icon for this object */
-            icon?: string | undefined;
+            icon?: string;
             /** role of the object */
-            role?: string | undefined;
+            role?: string;
         }
 
         interface StateCommon extends ObjectCommon {
             /** Type of this state. See https://github.com/ioBroker/ioBroker/blob/master/doc/SCHEMA.md#state-commonrole for a detailed description */
-            type?: CommonType | undefined;
+            type?: CommonType;
             /** minimum value */
-            min?: number | undefined;
+            min?: number;
             /** maximum value */
-            max?: number | undefined;
+            max?: number;
             /** allowed interval for numeric values */
-            step?: number | undefined;
+            step?: number;
             /** unit of the value */
-            unit?: string | undefined;
+            unit?: string;
             /** description of this state */
-            desc?: StringOrTranslated | undefined;
+            desc?: StringOrTranslated;
 
             /** if this state is readable */
             read: boolean;
@@ -177,17 +177,17 @@ declare global {
             /** the default value */
             def?: any;
             /** the default status of the ack flag */
-            defAck?: boolean | undefined;
+            defAck?: boolean;
 
             /** Configures this state as an alias for another state */
             alias?: {
                 /** The target state id */
                 id: string;
                 /** An optional conversion function when reading, e.g. `"(val − 32) * 5/9"` */
-                read?: string | undefined;
+                read?: string;
                 /** An optional conversion function when reading, e.g. `"(val * 9/5) + 32"` */
-                write?: string | undefined;
-            } | undefined;
+                write?: string;
+            } ;
 
             /**
              * Dictionary of possible values for this state in the form
@@ -201,16 +201,16 @@ declare global {
              * In old ioBroker versions, this could also be a string of the form
              * "val1:text1;val2:text2" (now deprecated)
              */
-            states?: Record<string, string> | string | undefined;
+            states?: Record<string, string> | string;
 
             /** ID of a helper state indicating if the handler of this state is working */
-            workingID?: string | undefined;
+            workingID?: string;
 
             /** attached history information */
             history?: any;
 
             /** Custom settings for this state */
-            custom?: Record<string, any> | undefined;
+            custom?: Record<string, any>;
 
             /**
              * Settings for IOT adapters and how the state should be named in e.g. Alexa.
@@ -218,14 +218,14 @@ declare global {
              */
             smartName?: string | ({ [lang in Languages]?: string; } & {
                 /** Which kind of device this is */
-                smartType?: string | null | undefined;
+                smartType?: string | null;
                 /** Which value to set when the ON command is issued */
-                byOn?: string | null | undefined;
-            }) | undefined;
+                byOn?: string | null;
+            });
         }
         interface ChannelCommon extends ObjectCommon {
             /** description of this channel */
-            desc?: string | undefined;
+            desc?: string;
 
             // Make it possible to narrow the object type using the custom property
             custom?: undefined;
@@ -238,7 +238,7 @@ declare global {
         }
         interface EnumCommon extends ObjectCommon {
             /** The IDs of the enum members */
-            members?: string[] | undefined;
+            members?: string[];
 
             // Make it possible to narrow the object type using the custom property
             custom?: undefined;
@@ -341,11 +341,11 @@ declare global {
             /** Whether this script should be executed */
             enabled: boolean;
             /** Is used to determine whether a script has changed and needs to be recompiled */
-            sourceHash?: string | undefined;
+            sourceHash?: string;
             /** If the script uses a compiled language like TypeScript, this contains the compilation output */
-            compiled?: string | undefined;
+            compiled?: string;
             /** If the script uses a compiled language like TypeScript, this contains the generated declarations (global scripts only) */
-            declarations?: string | undefined;
+            declarations?: string;
 
             // Make it possible to narrow the object type using the custom property
             custom?: undefined;
@@ -360,79 +360,79 @@ declare global {
 
         interface AdapterCommon extends ObjectCommon {
             /** Custom attributes to be shown in admin in the object browser */
-            adminColumns?: any[] | undefined;
+            adminColumns?: any[];
             /** Settings for custom Admin Tabs */
             adminTab?: {
-                name?: string | undefined;
+                name?: string;
                 /** Icon name for FontAwesome */
-                "fa-icon"?: string | undefined;
+                "fa-icon"?: string;
                 /** If true, the Tab is not reloaded when the configuration changes */
-                ignoreConfigUpdate?: boolean | undefined;
+                ignoreConfigUpdate?: boolean;
                 /** Which URL should be loaded in the tab. Supports placeholders like http://%ip%:%port% */
-                link?: string | undefined;
+                link?: string;
                 /** If true, only one instance of this tab will be created for all instances */
-                singleton?: boolean | undefined;
-            } | undefined;
-            allowInit?: boolean | undefined;
+                singleton?: boolean;
+            };
+            allowInit?: boolean;
             /** Possible values for the instance mode (if more than one is possible) */
-            availableModes?: InstanceMode[] | undefined;
+            availableModes?: InstanceMode[];
             /** Whether this adapter includes custom blocks for Blockly. If true, `admin/blockly.js` must exist. */
-            blockly?: boolean | undefined;
+            blockly?: boolean;
             /** Where the adapter will get its data from. Set this together with @see dataSource */
-            connectionType?: "local" | "cloud" | undefined;
+            connectionType?: "local" | "cloud";
             /** If true, this adapter can be started in compact mode (in the same process as other adpaters) */
-            compact?: boolean | undefined;
+            compact?: boolean;
             /** The directory relative to iobroker-data where the adapter stores the data. Supports the placeholder `%INSTANCE%`. This folder will be backed up and restored automatically. */
-            dataFolder?: string | undefined;
+            dataFolder?: string;
             /** How the adapter will mainly receive its data. Set this together with @see connectionType */
-            dataSource?: "poll" | "push" | "assumption" | undefined;
+            dataSource?: "poll" | "push" | "assumption";
             /** A record of ioBroker adapters (including "js-controller") and version ranges which are required for this adapter. */
-            dependencies?: Array<Record<string, string>> | undefined;
+            dependencies?: Array<Record<string, string>>;
             /** Which files outside of the README.md have documentation for the adapter */
-            docs?: Partial<Record<Languages, string | string[]>> | undefined;
+            docs?: Partial<Record<Languages, string | string[]>>;
             /** Whether new instances should be enabled by default. *Should* be `false`! */
             enabled: boolean;
             /** If true, all previous data in the target directory (web) should be deleted before uploading */
-            eraseOnUpload?: boolean | undefined;
+            eraseOnUpload?: boolean;
             /** URL of an external icon that is shown for adapters that are not installed */
-            extIcon?: string | undefined;
+            extIcon?: string;
             /** Whether this adapter responds to `getHistory` messages */
-            getHistory?: boolean | undefined;
+            getHistory?: boolean;
             /** Filename of the local icon which is shown for installed adapters. Should be located in the `admin` directory */
-            icon?: string | undefined;
+            icon?: string;
             /** Which version of this adapter is installed */
             installedVersion: string;
-            keywords?: string[] | undefined;
+            keywords?: string[];
             /** A dictionary of links to web services this adapter provides */
-            localLinks?: Record<string, string> | undefined;
+            localLinks?: Record<string, string>;
             /** @deprecated Use @see localLinks */
-            localLink?: string | undefined;
-            logLevel?: LogLevel | undefined;
+            localLink?: string;
+            logLevel?: LogLevel;
             /** Whether this adapter receives logs from other hosts and adapters (e.g. to strore them somewhere) */
-            logTransporter?: boolean | undefined;
+            logTransporter?: boolean;
             /** Path to the start file of the adapter. Should be the same as in `package.json` */
-            main?: string | undefined;
+            main?: string;
             /** Whether the admin tab is written in materialize style. Required for Admin 3+ */
             materializeTab: boolean;
             /** Whether the admin configuration dialog is written in materialize style. Required for Admin 3+ */
             materialize: boolean;
             /** If `true`, the object `system.adapter.<adaptername>.<adapterinstance>.messagebox will be created to send messages to the adapter (used for email, pushover, etc...) */
-            messagebox?: true | undefined;
+            messagebox?: true;
             mode: InstanceMode;
             /** Name of the adapter (without leading `ioBroker.`) */
             name: string;
             /** If `true`, no configuration dialog will be shown */
-            noConfig?: true | undefined;
+            noConfig?: true;
             /** If `true`, this adapter's instances will not be shown in the admin overview screen. Useful for icon sets and widgets... */
-            noIntro?: true | undefined;
+            noIntro?: true;
             /** Set to `true` if the adapter is not available in the official ioBroker repositories. */
-            noRepository?: true | undefined;
+            noRepository?: true;
             /** If `true`, manual installation from GitHub is not possible */
-            nogit?: true | undefined;
+            nogit?: true;
             /** If `true`, this adapter cannot be deleted or updated manually. */
-            nondeletable?: true | undefined;
+            nondeletable?: true;
             /** If `true`, this "adapter" only contains HTML files and no main executable */
-            onlyWWW?: boolean | undefined;
+            onlyWWW?: boolean;
             /** Used to configure native (OS) dependencies of this adapter that need to be installed with system package manager before installing the adapter */
             osDependencies?: {
                 /** For OSX */
@@ -441,56 +441,56 @@ declare global {
                 linux: string[];
                 /** For Windows */
                 win32: string[];
-            } | undefined;
+            };
             /** Which OSes this adapter supports */
-            os?: "linux" | "darwin" | "win32" | Array<("linux" | "darwin" | "win32")> | undefined;
+            os?: "linux" | "darwin" | "win32" | Array<("linux" | "darwin" | "win32")>;
             platform: "Javascript/Node.js";
             /** The keys of common attributes (e.g. `history`) which are not deleted in a `setObject` call even if they are not present. Deletion must be done explicitly by setting them to `null`. */
-            preserveSettings?: string | string[] | undefined;
+            preserveSettings?: string | string[];
             /** Which adapters must be restarted after installing or updating this adapter. */
-            restartAdapters?: string[] | undefined;
+            restartAdapters?: string[];
             /** If the adapter runs in `schedule` mode, this contains the CRON */
-            schedule?: string | undefined;
-            serviceStates?: boolean | string | undefined;
+            schedule?: string;
+            serviceStates?: boolean | string;
             /** Whether this adapter may only be installed once per host */
-            singletonHost?: boolean | undefined;
+            singletonHost?: boolean;
             /** Whether this adapter may only be installed once in the whole system */
-            singleton?: boolean | undefined;
+            singleton?: boolean;
             /** Whether the adapter must be stopped before an update */
-            stopBeforeUpdate?: boolean | undefined;
+            stopBeforeUpdate?: boolean;
             /** Overrides the default timeout that ioBroker will wait before force-stopping the adapter */
-            stopTimeout?: number | undefined;
-            subscribable?: boolean | undefined;
+            stopTimeout?: number;
+            subscribable?: boolean;
             subscribe?: any; // ?
             /** If `true`, this adapter provides custom per-state settings. Requires a `custom_m.html` file in the `admin` directory. */
-            supportCustoms?: boolean | undefined;
+            supportCustoms?: boolean;
             /** Whether the adapter supports the signal stopInstance via messagebox */
-            supportStopInstance?: boolean | undefined;
+            supportStopInstance?: boolean;
             /** The translated names of this adapter to be shown in the admin UI */
-            titleLang?: Record<Languages, string> | undefined;
+            titleLang?: Record<Languages, string>;
             /** @deprecated The name of this adapter to be shown in the admin UI. Use @see titleLang instead. */
-            title?: string | undefined;
+            title?: string;
             /** The type of this adapter */
-            type?: string | undefined;
+            type?: string;
             /** If `true`, the `npm` package must be installed with the `--unsafe-perm` flag */
-            unsafePerm?: true | undefined;
+            unsafePerm?: true;
             /** The available version in the ioBroker repo. */
             version: string;
             /** If `true`, the adapter will be started if any value is written into `system.adapter.<name>.<instance>.wakeup. Normally the adapter should stop after processing the event. */
-            wakeup?: boolean | undefined;
+            wakeup?: boolean;
             /** Include the adapter version in the URL of the web adapter, e.g. `http://ip:port/1.2.3/material` instead of `http://ip:port/material` */
-            webByVersion?: boolean | undefined;
+            webByVersion?: boolean;
             /** Whether the web server in this adapter can be extended with plugin/extensions */
-            webExtendable?: boolean | undefined;
+            webExtendable?: boolean;
             /** Relative path to a module that contains an extension for the web adapter. Use together with @see native.webInstance to configure which instances this affects */
-            webExtension?: string | undefined;
+            webExtension?: string;
             webPreSettings?: any; // ?
             webservers?: any; // ?
             /** A list of pages that should be shown on the "web" index page */
-            welcomeScreen?: WelcomeScreenEntry[] | undefined;
+            welcomeScreen?: WelcomeScreenEntry[];
             /** A list of pages that should be shown on the ioBroker cloud index page */
-            welcomeScreenPro?: WelcomeScreenEntry[] | undefined;
-            wwwDontUpload?: boolean | undefined;
+            welcomeScreenPro?: WelcomeScreenEntry[];
+            wwwDontUpload?: boolean;
 
             // Make it possible to narrow the object type using the custom property
             custom?: undefined;
@@ -512,22 +512,22 @@ declare global {
             // without bugging users to change their code --> https://github.com/microsoft/TypeScript/issues/15300
             native: Record<string, any>;
             common: Record<string, any>;
-            enums?: Record<string, string> | undefined;
-            acl?: ObjectACL | undefined;
-            from?: string | undefined;
+            enums?: Record<string, string>;
+            acl?: ObjectACL;
+            from?: string;
             /** The user who created or updated this object */
-            user?: string | undefined;
-            ts?: number | undefined;
+            user?: string;
+            ts?: number;
         }
 
         interface StateObject extends BaseObject {
             type: 'state';
             common: StateCommon;
-            acl?: StateACL | undefined;
+            acl?: StateACL;
         }
         interface PartialStateObject extends Partial<Omit<StateObject, 'common' | 'acl'>> {
-            common?: Partial<StateCommon> | undefined;
-            acl?: Partial<StateACL> | undefined;
+            common?: Partial<StateCommon>;
+            acl?: Partial<StateACL>;
         }
 
         interface ChannelObject extends BaseObject {
@@ -536,7 +536,7 @@ declare global {
         }
         interface PartialChannelObject
             extends Partial<Omit<ChannelObject, 'common'>> {
-            common?: Partial<ChannelCommon> | undefined;
+            common?: Partial<ChannelCommon>;
         }
 
         interface DeviceObject extends BaseObject {
@@ -544,7 +544,7 @@ declare global {
             common: DeviceCommon;
         }
         interface PartialDeviceObject extends Partial<Omit<DeviceObject, 'common'>> {
-            common?: Partial<DeviceCommon> | undefined;
+            common?: Partial<DeviceCommon>;
         }
 
         interface FolderObject extends BaseObject {
@@ -553,7 +553,7 @@ declare global {
             common: OtherCommon;
         }
         interface PartialFolderObject extends Partial<Omit<FolderObject, 'common'>> {
-            common?: Partial<OtherCommon> | undefined;
+            common?: Partial<OtherCommon>;
         }
 
         interface EnumObject extends BaseObject {
@@ -561,7 +561,7 @@ declare global {
             common: EnumCommon;
         }
         interface PartialEnumObject extends Partial<Omit<EnumObject, 'common'>> {
-            common?: Partial<EnumCommon> | undefined;
+            common?: Partial<EnumCommon>;
         }
 
         interface MetaObject extends BaseObject {
@@ -569,7 +569,7 @@ declare global {
             common: MetaCommon;
         }
         interface PartialMetaObject extends Partial<Omit<MetaObject, 'common'>> {
-            common?: Partial<MetaCommon> | undefined;
+            common?: Partial<MetaCommon>;
         }
 
         interface InstanceObject extends BaseObject {
@@ -577,19 +577,19 @@ declare global {
             common: InstanceCommon;
         }
         interface PartialInstanceObject extends Partial<Omit<InstanceObject, 'common'>> {
-            common?: Partial<InstanceCommon> | undefined;
+            common?: Partial<InstanceCommon>;
         }
 
         interface AdapterObject extends BaseObject {
             type: 'adapter';
             common: AdapterCommon;
             /** An array of `native` properties which cannot be accessed from outside the defining adapter */
-            protectedNative?: string[] | undefined;
+            protectedNative?: string[];
             /** Like protectedNative, but the properties are also encrypted and decrypted automatically */
-            encryptedNative?: string[] | undefined;
+            encryptedNative?: string[];
         }
         interface PartialAdapterObject extends Partial<Omit<AdapterObject, 'common'>> {
-            common?: Partial<AdapterCommon> | undefined;
+            common?: Partial<AdapterCommon>;
         }
 
         interface HostObject extends BaseObject {
@@ -598,8 +598,8 @@ declare global {
             native: HostNative;
         }
         interface PartialHostObject extends Partial<Omit<HostObject, 'common' | 'native'>> {
-            common?: Partial<HostCommon> | undefined;
-            native?: Partial<HostNative> | undefined;
+            common?: Partial<HostCommon>;
+            native?: Partial<HostNative>;
         }
 
         interface UserObject extends BaseObject {
@@ -607,7 +607,7 @@ declare global {
             common: UserCommon;
         }
         interface PartialUserObject extends Partial<Omit<UserObject, 'common'>> {
-            common?: Partial<UserCommon> | undefined;
+            common?: Partial<UserCommon>;
         }
 
         interface GroupObject extends BaseObject {
@@ -615,7 +615,7 @@ declare global {
             common: GroupCommon;
         }
         interface PartialGroupObject extends Partial<Omit<GroupObject, 'common'>> {
-            common?: Partial<GroupCommon> | undefined;
+            common?: Partial<GroupCommon>;
         }
 
         interface ScriptObject extends BaseObject {
@@ -623,7 +623,7 @@ declare global {
             common: ScriptCommon;
         }
         interface PartialScriptObject extends Partial<Omit<ScriptObject, 'common'>> {
-            common?: Partial<ScriptCommon> | undefined;
+            common?: Partial<ScriptCommon>;
         }
 
         interface OtherObject extends BaseObject {
@@ -631,7 +631,7 @@ declare global {
             common: OtherCommon;
         }
         interface PartialOtherObject extends Partial<Omit<OtherObject, 'common'>> {
-            common?: Partial<OtherCommon> | undefined;
+            common?: Partial<OtherCommon>;
         }
 
         type AnyObject =
@@ -676,13 +676,28 @@ declare global {
 
         // In set[Foreign]Object[NotExists] methods, the ID and acl of the object is optional
         type SettableObjectWorker<T> = T extends AnyObject ? Omit<T, '_id' | 'acl'> & {
-            _id?: T['_id'] | undefined;
-            acl?: T['acl'] | undefined;
+            _id?: T['_id'];
+            acl?: T['acl'];
         } : never;
         // in extend[Foreign]Object, most properties are optional
-        type PartialObjectWorker<T> = T extends AnyObject ? AnyPartialObject & {type?: T["type"] | undefined} : never;
+        type PartialObjectWorker<T> = T extends AnyObject ? AnyPartialObject & { type?: T["type"] } : never;
 
-        type SettableObject<T extends AnyObject = AnyObject> = SettableObjectWorker<T>;
         type PartialObject<T extends AnyObject = AnyObject> = PartialObjectWorker<T>;
+
+        // Convenient definitions for manually specifying settable object types
+        type SettableObject<T extends AnyObject = AnyObject> = SettableObjectWorker<T>;
+        type SettableStateObject = SettableObject<StateObject>;
+        type SettableChannelObject = SettableObject<ChannelObject>;
+        type SettableDeviceObject = SettableObject<DeviceObject>;
+        type SettableFolderObject = SettableObject<FolderObject>;
+        type SettableEnumObject = SettableObject<EnumObject>;
+        type SettableMetaObject = SettableObject<MetaObject>;
+        type SettableHostObject = SettableObject<HostObject>;
+        type SettableAdapterObject = SettableObject<AdapterObject>;
+        type SettableInstanceObject = SettableObject<InstanceObject>;
+        type SettableUserObject = SettableObject<UserObject>;
+        type SettableGroupObject = SettableObject<GroupObject>;
+        type SettableScriptObject = SettableObject<ScriptObject>;
+        type SettableOtherObject = SettableObject<OtherObject>;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: fixes: https://github.com/ioBroker/adapter-core/issues/363
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

This got a bit messier because dtslint complained about the unnecessary `| undefined`. The real change is at the end of `objects.d.ts`, lines 687ff.