### PR TITLE
[chromecast-caf-receiver] Align to SDK and docs (only breaking changes)

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
@@ -67,8 +67,8 @@ export interface BreakManager {
     /**
      * Provide an interceptor for developer to specify what breaks they want to play after seek.
      * @param seekInterceptor Interceptor or null if developer wants to reset it
-     *                        to default one. The default break seek interceptor will
-     *                        return the closest break from the seekTo value.
+     *     to default one. The default break seek interceptor will
+     *     return the closest break from the seekTo value.
      */
     setBreakSeekInterceptor(seekInterceptor: ((breakSeekData: BreakSeekData) => void) | null): void;
 

--- a/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
@@ -1,6 +1,6 @@
-import { Break, BreakClip } from "./cast.framework.messages";
+import { Break, BreakClip } from './cast.framework.messages';
 
-export as namespace breaks
+export as namespace breaks;
 export class BreakSeekData {
     constructor(seekFrom: number, seekTo: number, breaks: Break[]);
 
@@ -52,25 +52,25 @@ export interface BreakManager {
     getPlayWatchedBreak(): boolean;
 
     /**
-     * Provide an interceptor to allow developer to insert more break clips or modify current break clip before a break is started.
+     * Provide an interceptor to allow developer to insert more break clips or
+     * modify current break clip before a break is started.
      * If interceptor is null it will reset the interceptor to default one.
      * By default VAST fetching and parsing logic in default interceptor.
-     * So if customized interceptor is set by developer;
-     * the VAST logic will be overridden and developers should implement their own VAST fetching and parsing logic in the provided interceptor.
+     * So if customized interceptor is set by developer, the VAST logic will be
+     * overridden and developers should implement their own VAST fetching and
+     * parsing logic in the provided interceptor.
      */
     setBreakClipLoadInterceptor(
-        interceptor: (
-            breakClip: BreakClip,
-            breakClipLoaderContext?: BreakClipLoadInterceptorContext
-        ) => void
+        interceptor: ((breakClip: BreakClip, breakClipLoaderContext?: BreakClipLoadInterceptorContext) => void) | null,
     ): void;
 
     /**
      * Provide an interceptor for developer to specify what breaks they want to play after seek.
+     * @param seekInterceptor Interceptor or null if developer wants to reset it
+     *                        to default one. The default break seek interceptor will
+     *                        return the closest break from the seekTo value.
      */
-    setBreakSeekInterceptor(
-        seekInterceptor: (breakSeekData: BreakSeekData) => void
-    ): void;
+    setBreakSeekInterceptor(seekInterceptor: ((breakSeekData: BreakSeekData) => void) | null): void;
 
     /**
      * Set a flag to control if the watched client stitching break should be played.
@@ -78,12 +78,15 @@ export interface BreakManager {
     setPlayWatchedBreak(playWatchedBreak: boolean): void;
 
     /**
-     * Provide an interceptor to modify VAST tracking URL before it is being sent to server.
+     * Provide an interceptor to modify VAST tracking URL before it is being sent
+     * to server.
      * The input of the interceptor is a string of the tracking URL.
-     * The interceptor can either return a modified string of URL or a Promise of modified string of URL.
-     * The interceptor can also return null if you want to send the tracking URL by your own code instead of by CAF.
+     * The interceptor can either return a modified string of URL or a Promise
+     * of modified string of URL.
+     * The interceptor can also return null if you want to send the tracking URL
+     * by your own code instead of by CAF.
      */
     setVastTrackingInterceptor(
-        interceptor?: (trackingUrl: string) => void
+        interceptor?: (trackingUrl: string) => string | URL | Promise<string | URL> | null,
     ): void;
 }

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -975,7 +975,7 @@ export class CastReceiverContext {
     /**
      * Add listener to cast system events.
      */
-    addEventListener(type: system.EventType, handler: SystemEventHandler): void;
+    addEventListener(type: system.EventType | system.EventType[], handler: SystemEventHandler): void;
 
     /**
      * Checks if the given media params of video or audio streams are supported by the platform.

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -10,7 +10,6 @@ export import ui = ui;
 export import system = system;
 export import messages = messages;
 
-export type HTMLMediaElement = any;
 export as namespace framework;
 export enum LoggerLevel {
     DEBUG = 0,
@@ -37,12 +36,14 @@ export const VERSION: string;
 
 /**
  * Manages text tracks.
+ * @throws Error If constructor is used directly. The TextTracksManager should
+ *               only be accessed by calling {@link framework.PlayerManager#getTextTracksManager}.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.TextTracksManager
  */
 export class TextTracksManager {
-    constructor(params?: any);
-
     /**
      * Adds text tracks to the list.
+     * @throws Error If tracks are not available, or trackId is not unique, or add non-text tracks.
      */
     addTracks(tracks: messages.Track[]): void;
 
@@ -64,7 +65,7 @@ export class TextTracksManager {
     /**
      * Returns the current text track style.
      */
-    getTextTracksStyle(): messages.TextTrackStyle;
+    getTextTracksStyle(): messages.TextTrackStyle | undefined;
 
     /**
      * Gets text track by id.
@@ -99,14 +100,20 @@ export class TextTracksManager {
 
 /**
  * QueueManager exposes several queue manipulation APIs to developers.
+ * @throws Error If constructor is used directly. The QueueManager should only
+ *         be accessed by calling cast.framework.PlayerManager#getQueueManager.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.QueueManager
  */
 export class QueueManager {
-    constructor(params?: any);
+    /**
+     * Get Container Metadata.
+     */
+    getContainerMetadata(): messages.ContainerMetadata | null;
 
     /**
      * Returns the current queue item.
      */
-    getCurrentItem(): messages.QueueItem;
+    getCurrentItem(): messages.QueueItem | null;
 
     /**
      * Returns the index of the current queue item.
@@ -237,10 +244,11 @@ interface MessageEventToMessageTypeMap {
 
 /**
  * Controls and monitors media playback.
+ * @throws Error If constructor is used directly. The PlayerManager should only
+ *         be accessed by calling {@link framework.CastReceiverContext#getPlayerManager}.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.PlayerManager
  */
 export class PlayerManager {
-    constructor(params?: any);
-
     /**
      * Adds an event listener for events proxied from the @see{@link events.MediaElementEvent}.
      * See {@link https://dev.w3.org/html5/spec-preview/media-elements.html#mediaevents} for more information.
@@ -530,13 +538,15 @@ export class PlayerManager {
 
     /**
      * Returns current time in sec in currently-playing break clip.
+     * Null, if player is not playing break clip.
      */
-    getBreakClipCurrentTimeSec(): number;
+    getBreakClipCurrentTimeSec(): number | null;
 
     /**
      * Returns duration in sec of currently-playing break clip.
+     * Null, if player is not playing break clip.
      */
-    getBreakClipDurationSec(): number;
+    getBreakClipDurationSec(): number | null;
 
     /**
      * Obtain the breaks (Ads) manager.
@@ -559,19 +569,20 @@ export class PlayerManager {
     getDurationSec(): number;
 
     /**
-     * Returns live seekable range with start and end time in seconds. The values are media time based.
+     * Returns live seekable range with start and end time in seconds. The values
+     * are media time based.
      */
-    getLiveSeekableRange(): messages.LiveSeekableRange;
+    getLiveSeekableRange(): messages.LiveSeekableRange | null;
 
     /**
      * Gets media information of current media.
      */
-    getMediaInformation(): messages.MediaInformation;
+    getMediaInformation(): messages.MediaInformation | null;
 
     /**
      * Returns playback configuration.
      */
-    getPlaybackConfig(): PlaybackConfig;
+    getPlaybackConfig(): PlaybackConfig | null;
 
     /**
      * Returns current playback rate.
@@ -592,12 +603,12 @@ export class PlayerManager {
     /**
      * Get the preferred text track language.
      */
-    getPreferredTextLanguage(): string;
+    getPreferredTextLanguage(): string | null;
 
     /**
      * Obtain QueueManager API.
      */
-    getQueueManager(): QueueManager;
+    getQueueManager(): QueueManager | null;
 
     getTextTracksManager(): TextTracksManager;
 
@@ -619,7 +630,7 @@ export class PlayerManager {
     /**
      * Requests a text string to be played back locally on the receiver device.
      */
-    playString(stringId: messages.PlayStringId, args?: string[]): Promise<messages.ErrorData>;
+    playString(stringId: messages.PlayStringId, args?: string[]): Promise<messages.ErrorData | null>;
 
     /**
      * Request Google Assistant to refresh the credentials. Only works if the original credentials came from the assistant.
@@ -674,7 +685,7 @@ export class PlayerManager {
     /**
      * Sets MediaElement to use. If Promise of MediaElement is set; media begins playback after Promise is resolved.
      */
-    setMediaElement(mediaElement: HTMLMediaElement): void;
+    setMediaElement(mediaElement: HTMLMediaElement | Promise<HTMLMediaElement>): void;
 
     /**
      * Sets media information.
@@ -714,18 +725,6 @@ export class PlayerManager {
      * Sets playback configuration on the PlayerManager.
      */
     setPlaybackConfig(playbackConfig: PlaybackConfig): void;
-
-    /**
-     * Set the preferred playback rate for follow up load or media items. The preferred playback rate will be updated automatically to the latest
-     * playback rate that was provided by a load request or explicit set of playback rate.
-     */
-    setPreferredPlaybackRate(preferredPlaybackRate: number): void;
-
-    /**
-     * Set the preferred text track language. The preferred text track language will be updated automatically to the latest enabled language
-     * by a load request or explicit change to text tracks. (Should be called only in idle state; and Will only apply to next loaded media).
-     */
-    setPreferredTextLanguage(preferredTextLanguage: string): void;
 
     /**
      * Set receiver supported media commands.
@@ -828,9 +827,10 @@ export class PlaybackConfig {
     licenseUrl?: string | undefined;
 
     /**
-     * Handler to process manifest data. The handler is passed the manifest; and returns the modified manifest.
+     * Handler to process manifest data. The handler is passed the manifest,
+     * and returns the modified manifest.
      */
-    manifestHandler?: ((manifest: string) => string) | undefined;
+    manifestHandler?: ((manifest: string) => string | Promise<string>) | undefined;
 
     /**
      * A function to customize request to get a manifest.
@@ -859,12 +859,13 @@ export class PlaybackConfig {
 }
 /**
  * HTTP(s) Request/Response information.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.NetworkRequestInfo
  */
 export class NetworkRequestInfo {
     /**
      * The content of the request. Can be used to modify license request body.
      */
-    content: Uint8Array;
+    content: Uint8Array | null;
 
     /**
      * An object containing properties that you would like to send in the header.
@@ -874,7 +875,7 @@ export class NetworkRequestInfo {
     /**
      * The URL requested.
      */
-    url: string;
+    url: string | null;
 
     /**
      * Indicates whether CORS Access-Control requests should be made using credentials such as cookies or authorization headers.
@@ -955,6 +956,11 @@ export class CastReceiverOptions {
     supportedCommands?: number | undefined;
 
     /**
+     * UI Configuration.
+     */
+    uiConfig?: ui.UiConfig | undefined;
+
+    /**
      * Indicate that MPL should be used for DASH content.
      */
     useLegacyDashSupport?: boolean | undefined;
@@ -971,8 +977,6 @@ export class CastReceiverContext {
     /** Returns the CastReceiverContext singleton instance. */
     static getInstance(): CastReceiverContext;
 
-    constructor(params: any);
-
     /**
      * Sets message listener on custom message channel.
      */
@@ -981,7 +985,7 @@ export class CastReceiverContext {
     /**
      * Add listener to cast system events.
      */
-    addEventListener(type: system.EventType | system.EventType[], handler: SystemEventHandler): void;
+    addEventListener(type: system.EventType, handler: SystemEventHandler): void;
 
     /**
      * Checks if the given media params of video or audio streams are supported by the platform.
@@ -989,9 +993,9 @@ export class CastReceiverContext {
     canDisplayType(mimeType: string, codecs?: string, width?: number, height?: number, framerate?: number): boolean;
 
     /**
-     * Provides application information once the system is ready; otherwise it will be null.
+     * Provides application information once the system is ready, otherwise it will be null.
      */
-    getApplicationData(): system.ApplicationData;
+    getApplicationData(): system.ApplicationData | null;
 
     /**
      * Provides device capabilities information once the system is ready; otherwise it will be null.
@@ -1007,7 +1011,7 @@ export class CastReceiverContext {
     /**
      * Get a sender by sender id
      */
-    getSender(senderId: string): system.Sender;
+    getSender(senderId: string): system.Sender | null;
 
     /**
      * Gets a list of currently-connected senders.
@@ -1026,8 +1030,11 @@ export class CastReceiverContext {
 
     /**
      * Reports if the cast application is the HDMI active input.
+     * @returns Whether the application is the HDMI active input. If it can not
+     *          be determined, because the TV does not support CEC commands, for
+     *          example, the value returned is UNKNOWN.
      */
-    getVisibilityState(): any;
+    getVisibilityState(): system.VisibilityState;
 
     /**
      * When the application calls start; the system will send the ready event to indicate
@@ -1093,12 +1100,28 @@ export class CastReceiverContext {
     stop(): void;
 }
 
-/** Manages audio tracks. */
+/**
+ * Manages audio tracks.
+ * @throws Error If constructor is used directly. The AudioTracksManager should
+ *         only be accessed by calling {@link framework.PlayerManager#getAudioTracksManager}
+ *
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.AudioTracksManager
+ */
 export class AudioTracksManager {
-    constructor(params: any);
-    getActiveId(): number;
-    getActiveTrack(): messages.Track;
-    getTrackById(id: number): messages.Track;
+    /**
+     * Gets the active audio id.
+     */
+    getActiveId(): number | undefined;
+    /**
+     * Gets the active audio track.
+     */
+    getActiveTrack(): messages.Track | undefined;
+    /**
+     * Gets audio track by id.
+     * @param id
+     * @throws Error  If id is not available or invalid.
+     */
+    getTrackById(id: number): messages.Track | undefined;
     getTracks(): messages.Track[];
     getTracksByLanguage(language: string): messages.Track[];
     setActiveById(id: number): void;

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -565,7 +565,7 @@ export class PlayerManager {
 
     /**
      * @returns live seekable range with start and end time in seconds. The values
-     * are media time based.
+     *     are media time based.
      */
     getLiveSeekableRange(): messages.LiveSeekableRange | null;
 

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -37,7 +37,7 @@ export const VERSION: string;
 /**
  * Manages text tracks.
  * @throws Error If constructor is used directly. The TextTracksManager should
- *               only be accessed by calling {@link framework.PlayerManager#getTextTracksManager}.
+ *     only be accessed by calling {@link framework.PlayerManager#getTextTracksManager}.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.TextTracksManager
  */
 export class TextTracksManager {
@@ -101,15 +101,10 @@ export class TextTracksManager {
 /**
  * QueueManager exposes several queue manipulation APIs to developers.
  * @throws Error If constructor is used directly. The QueueManager should only
- *         be accessed by calling cast.framework.PlayerManager#getQueueManager.
+ *     be accessed by calling cast.framework.PlayerManager#getQueueManager.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.QueueManager
  */
 export class QueueManager {
-    /**
-     * Get Container Metadata.
-     */
-    getContainerMetadata(): messages.ContainerMetadata | null;
-
     /**
      * Returns the current queue item.
      */
@@ -537,14 +532,14 @@ export class PlayerManager {
     getAudioTracksManager(): AudioTracksManager;
 
     /**
-     * Returns current time in sec in currently-playing break clip.
-     * Null, if player is not playing break clip.
+     * @returns current time in sec in currently-playing break clip.
+     *    Null, if player is not playing break clip.
      */
     getBreakClipCurrentTimeSec(): number | null;
 
     /**
-     * Returns duration in sec of currently-playing break clip.
-     * Null, if player is not playing break clip.
+     * @returns duration in sec of currently-playing break clip.
+     *    Null, if player is not playing break clip.
      */
     getBreakClipDurationSec(): number | null;
 
@@ -569,7 +564,7 @@ export class PlayerManager {
     getDurationSec(): number;
 
     /**
-     * Returns live seekable range with start and end time in seconds. The values
+     * @returns live seekable range with start and end time in seconds. The values
      * are media time based.
      */
     getLiveSeekableRange(): messages.LiveSeekableRange | null;
@@ -580,7 +575,7 @@ export class PlayerManager {
     getMediaInformation(): messages.MediaInformation | null;
 
     /**
-     * Returns playback configuration.
+     * @returns playback configuration.
      */
     getPlaybackConfig(): PlaybackConfig | null;
 
@@ -956,11 +951,6 @@ export class CastReceiverOptions {
     supportedCommands?: number | undefined;
 
     /**
-     * UI Configuration.
-     */
-    uiConfig?: ui.UiConfig | undefined;
-
-    /**
      * Indicate that MPL should be used for DASH content.
      */
     useLegacyDashSupport?: boolean | undefined;
@@ -1031,8 +1021,8 @@ export class CastReceiverContext {
     /**
      * Reports if the cast application is the HDMI active input.
      * @returns Whether the application is the HDMI active input. If it can not
-     *          be determined, because the TV does not support CEC commands, for
-     *          example, the value returned is UNKNOWN.
+     *     be determined, because the TV does not support CEC commands, for
+     *     example, the value returned is UNKNOWN.
      */
     getVisibilityState(): system.VisibilityState;
 
@@ -1103,7 +1093,7 @@ export class CastReceiverContext {
 /**
  * Manages audio tracks.
  * @throws Error If constructor is used directly. The AudioTracksManager should
- *         only be accessed by calling {@link framework.PlayerManager#getAudioTracksManager}
+ *     only be accessed by calling {@link framework.PlayerManager#getAudioTracksManager}
  *
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.AudioTracksManager
  */

--- a/types/chromecast-caf-receiver/cast.framework.events.category.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.events.category.d.ts
@@ -1,4 +1,4 @@
-import { EventType } from "./cast.framework.events";
+import { EventType } from './cast.framework.events';
 
 export as namespace category;
 

--- a/types/chromecast-caf-receiver/cast.framework.events.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.events.d.ts
@@ -243,7 +243,7 @@ export class LoadEvent extends Event {
     /**
      * Information about the media being loaded.
      */
-    media: MediaInformation;
+    media?: MediaInformation | undefined;
 }
 /**
  * Event data for @see{@link EventType.INBAND_TRACK_ADDED} event.
@@ -272,7 +272,8 @@ export class Id3Event extends Event {
     timestamp: number;
 }
 /**
- * Event data for @see{@link EventType.EMSG} event.
+ * Event data for {@link EventType.EMSG} event.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.events.EmsgEvent
  */
 export class EmsgEvent extends Event {
     constructor(emsgData: any);
@@ -280,52 +281,54 @@ export class EmsgEvent extends Event {
     /**
      * The time that the event ends (in presentation time). Undefined if using legacy Dash support.
      */
-    endTime: any;
+    endTime?: number | undefined;
 
     /**
      * The duration of the event (in units of timescale). Undefined if using legacy Dash support.
      */
-    eventDuration: any;
+    eventDuration?: number | undefined;
 
     /**
      * A field identifying this instance of the message. Undefined if using legacy Dash support.
      */
-    id: any;
+    id?: number | undefined;
 
     /**
-     * Body of the message. Undefined if using legacy Dash support.
+     * Body of the message, which can contain ID3 metadata if signaled by the
+     * schemeIdUri value. The schemeIdUri "https://aomedia.org/emsg/ID3" and
+     * "https://developer.apple.com/streaming/emsg-id3" will always signal ID3 metadata.
      */
-    messageData: any;
+    messageData?: Uint8Array | undefined;
 
     /**
      * The offset that the event starts; relative to the start of the segment this is contained in (in units of timescale). Undefined if using legacy Dash support.
      */
-    presentationTimeDelta: any;
+    presentationTimeDelta?: number | undefined;
 
     /**
      * Identifies the message scheme. Undefined if using legacy Dash support.
      */
-    schemeIdUri: any;
+    schemeIdUri?: string | undefined;
 
     /**
      * The segment data. This is only defined if using legacy Dash support.
      */
-    segmentData: any;
+    segmentData?: Uint8Array | undefined;
 
     /**
      * The time that the event starts (in presentation time). Undefined if using legacy Dash support.
      */
-    startTime: any;
+    startTime?: number | undefined;
 
     /**
      * Provides the timescale; in ticks per second. Undefined if using legacy Dash support.
      */
-    timescale: any;
+    timescale?: number | undefined;
 
     /**
      * Specifies the value for the event. Undefined if using legacy Dash support.
      */
-    value: any;
+    value?: string | undefined;
 }
 /**
  * Event data for @see{@link EventType.CLIP_ENDED} event.
@@ -345,7 +348,8 @@ export class ClipEndedEvent extends Event {
 }
 
 /**
- * Event data for @see{@link EventType.CACHE_LOADED} event.
+ * Event data for {@link EventType.CACHE_LOADED} event.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.events.CacheLoadedEvent
  */
 export class CacheLoadedEvent extends Event {
     constructor(media?: MediaInformation);
@@ -353,7 +357,7 @@ export class CacheLoadedEvent extends Event {
     /**
      * Information about the media being cached.
      */
-    media: MediaInformation;
+    media?: MediaInformation | undefined;
 }
 
 export class CacheItemEvent extends Event {
@@ -374,6 +378,10 @@ export class BufferingEvent extends Event {
     isBuffering: boolean;
 }
 
+/**
+ * Event data for all events pertaining to breaks.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.events.BreaksEvent
+ */
 export class BreaksEvent extends Event {
     constructor(
         type: EventType,
@@ -409,12 +417,12 @@ export class BreaksEvent extends Event {
     /**
      * Index of break clip; which starts from 1.
      */
-    index: number;
+    index?: number | undefined;
 
     /**
      * Total number of break clips.
      */
-    total: number;
+    total?: number | undefined;
 
     /**
      * When to skip current break clip in sec; after break clip begins to play.
@@ -423,13 +431,14 @@ export class BreaksEvent extends Event {
 }
 
 /**
- * Event data for @see {@link EventType.BITRATE_CHANGED} event.
+ * Event data for {@link EventType.BITRATE_CHANGED} event.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.events.BitrateChangedEvent
  */
 export class BitrateChangedEvent extends Event {
     constructor(totalBitrate?: number);
 
     /** The bitrate of the media (audio and video) in bits per second. */
-    totalBitrate: number;
+    totalBitrate?: number | undefined;
 }
 
 /**

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -2180,7 +2180,7 @@ export class CloudMediaStatus extends MediaStatus {}
  * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.BreakStatus
  */
 export class BreakStatus {
-    constructor(currentBreakTime?: number | undefined, currentBreakClipTime?: number | undefined);
+    constructor(currentBreakTime?: number, currentBreakClipTime?: number);
 
     /**
      * Id of current break clip.

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -432,13 +432,14 @@ export enum UserActionContext {
 
 /**
  * RefreshCredentials request data.
+ * Note as of July 2021: Docs don't mention this extending RequestData.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.LoadByEntityRequestData
  */
-export class RefreshCredentialsRequestData {
-    [key: string]: any;
-}
+export class RefreshCredentialsRequestData extends RequestData {}
 
 /**
  * Media event SET_VOLUME request data.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.VolumeRequestData
  */
 export class VolumeRequestData extends RequestData {
     constructor();
@@ -446,7 +447,7 @@ export class VolumeRequestData extends RequestData {
     /**
      * The media stream volume
      */
-    volume?: Volume | undefined;
+    volume: Volume;
 }
 
 /**
@@ -515,7 +516,7 @@ export class UserActionRequestData extends RequestData {
     /**
      * User action to be handled by the application.
      */
-    userAction?: UserAction | undefined;
+    userAction: UserAction;
 
     /**
      * Optional context information for the user action.
@@ -580,6 +581,7 @@ export class TvShowMediaMetadata {
 }
 /**
  * Describes track metadata information.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.Track
  */
 export class Track {
     constructor(trackId: number, trackType: TrackType);
@@ -587,7 +589,7 @@ export class Track {
     /**
      * Custom data set by the receiver application.
      */
-    customData?: string | undefined;
+    customData?: any;
 
     /**
      * Language tag as per RFC 5646 (If subtype is “SUBTITLES” it is mandatory).
@@ -613,18 +615,18 @@ export class Track {
 
     /**
      * It represents the MIME type of the track content. For example if the track
-     * is a vtt file it will be ‘text/vtt’. This field is needed for out of band tracks;
+     * is a vtt file it will be ‘text/vtt’. This field is needed for out of band tracks,
      *  so it is usually provided if a trackContentId has also been provided.
      * It is not mandatory if the receiver has a way to identify the content from
-     * the trackContentId; but recommended.
-     * The track content type; if provided; must be consistent with the track type.
+     * the trackContentId, but recommended.
+     * The track content type, if provided, must be consistent with the track type.
      */
-    trackContentType?: string | undefined;
+    trackContentType?: string | CaptionMimeType | undefined;
 
     /**
      * Unique identifier of the track within the context of a MediaInformation object.
      */
-    trackId?: number | undefined;
+    trackId: number;
 
     /**
      * The type of track.
@@ -738,6 +740,8 @@ export class SetPlaybackRateRequestData extends RequestData {
 
 /**
  * SetCredentials request data.
+ * Note as of July 2021: Docs don't mention this extending RequestData.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.SetCredentialsRequestData}
  */
 export class SetCredentialsRequestData extends RequestData {
     constructor();
@@ -745,7 +749,7 @@ export class SetCredentialsRequestData extends RequestData {
     /**
      * Credentials to use by receiver.
      */
-    credentials?: string | undefined;
+    credentials: string;
 
     /**
      * If it is a response for refresh credentials, it will indicate the request
@@ -763,7 +767,7 @@ export class SetCredentialsRequestData extends RequestData {
 /**
  * A state object containing all data to be stored in StoreSession and to be
  * recovered in ResumeSession.
- * [Description]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.SessionState.html}
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.SessionState
  */
 export class SessionState {
     constructor();
@@ -771,7 +775,7 @@ export class SessionState {
     /**
      * Customizable object for storing the state.
      */
-    customData?: object | undefined;
+    customData?: any;
 
     loadRequestData?: LoadRequestData | undefined;
 }
@@ -818,6 +822,8 @@ export class SeekableRange {
 
 /**
  * RESUME_SESSION request data
+ * Note as of July 2021: Docs don't mention this extending RequestData.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.ResumeSessionRequestData
  */
 export class ResumeSessionRequestData extends RequestData {
     constructor();
@@ -825,7 +831,7 @@ export class ResumeSessionRequestData extends RequestData {
     /**
      * The SessionState object returned by StoreSession command.
      */
-    sessionState?: SessionState | undefined;
+    sessionState: SessionState;
 }
 
 /**
@@ -1185,6 +1191,11 @@ export class QueueIds {
     type: MessageType;
 }
 
+/**
+ * Common container metadata used as part of QueueData.
+ *
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.ContainerMetadata
+ */
 export class ContainerMetadata {
     constructor(type?: ContainerType);
 
@@ -1208,7 +1219,16 @@ export class ContainerMetadata {
      * Array of media metadata objects to describe the media content sections.
      * Used to delineate live TV streams into programs and audiobooks into chapters.
      */
-    sections?: MediaMetadata[] | undefined;
+    sections?:
+        | MediaMetadata[]
+        | GenericMediaMetadata[]
+        | MovieMediaMetadata[]
+        | MusicTrackMediaMetadata[]
+        | PhotoMediaMetadata[]
+        | TvShowMediaMetadata[]
+        | AudiobookChapterMediaMetadata[]
+        | object[]
+        | undefined;
 
     /**
      * The title of the container, for example an audiobook title, a TV channel name, etc.
@@ -1357,8 +1377,10 @@ export class PrecacheRequestData extends LoadRequestData {
 
 /**
  * PlayString request data.
+ * Note as of July 2021: Docs don't mention this extending RequestData.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.PlayStringRequestData
  */
-export class PlayStringRequestData {
+export class PlayStringRequestData extends RequestData {
     constructor(stringId: PlayStringId, opt_arguments?: string[]);
 
     /**
@@ -1374,6 +1396,7 @@ export class PlayStringRequestData {
 
 /**
  * A photo media description.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.PhotoMediaMetadata
  */
 export class PhotoMediaMetadata {
     /**
@@ -1394,7 +1417,7 @@ export class PhotoMediaMetadata {
     /**
      * Images associated with the content. Examples would include a photo thumbnail.
      */
-    images: Image[];
+    images?: Image[] | undefined;
 
     /**
      * Latitude.
@@ -1424,6 +1447,7 @@ export class PhotoMediaMetadata {
 
 /**
  * A music track media description.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.MusicTrackMediaMetadata
  */
 export class MusicTrackMediaMetadata {
     /**
@@ -1442,9 +1466,9 @@ export class MusicTrackMediaMetadata {
     artist?: string | undefined;
 
     /**
-     * @deprecated: use @see{@link artist} instead
+     * @deprecated: use {@link artist} instead
      */
-    artistName: string;
+    artistName?: string | undefined;
 
     /**
      * Track composer name.
@@ -1460,7 +1484,7 @@ export class MusicTrackMediaMetadata {
      * Content images. Examples would include cover art or a thumbnail of the
      * currently playing media.
      */
-    images: Image[];
+    images?: Image[] | undefined;
 
     /**
      * ISO 8601 date when the track was released; e.g. 2014-02-10.
@@ -1490,13 +1514,14 @@ export class MusicTrackMediaMetadata {
 
 /**
  * A movie media description.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.MovieMediaMetadata
  */
 export class MovieMediaMetadata {
     /**
      * Content images. Examples would include cover art or a thumbnail of the
      * currently playing media.
      */
-    images: Image[];
+    images?: Image[] | undefined;
 
     /**
      * ISO 8601 date when the movie was released; e.g. 2014-02-10.
@@ -1717,7 +1742,10 @@ export class MediaInformation {
         | MovieMediaMetadata
         | MusicTrackMediaMetadata
         | PhotoMediaMetadata
-        | TvShowMediaMetadata | undefined;
+        | TvShowMediaMetadata
+        | AudiobookChapterMediaMetadata
+        | object
+        | undefined;
 
     /**
      * The stream type.
@@ -1743,6 +1771,7 @@ export class MediaInformation {
 
 /**
  * Media event LOAD request data.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.LoadRequestData
  */
 export class LoadRequestData extends RequestData {
     constructor();
@@ -1751,7 +1780,7 @@ export class LoadRequestData extends RequestData {
      * Array of trackIds that are active. If the array is not provided, the
      * default tracks will be active.
      */
-    activeTrackIds: number[];
+    activeTrackIds?: number[] | undefined;
 
     /**
      * If the autoplay parameter is specified, the media player will begin
@@ -1797,7 +1826,7 @@ export class LoadRequestData extends RequestData {
     /**
      * Queue data.
      */
-    queueData: QueueData;
+    queueData?: QueueData | undefined;
 }
 
 /**
@@ -1814,22 +1843,24 @@ export class LoadOptions {
 
 /**
  * LoadByEntity request data.
+ * Note as of July 2021: Docs don't mention this extending RequestData.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.LoadByEntityRequestData
  */
-export class LoadByEntityRequestData {
+export class LoadByEntityRequestData extends RequestData {
     /**
-     * Content entity information; typically represented by a stringified JSON object
+     * Content entity information, typically represented by a stringified JSON object
      */
     entity: string;
+
+    /**
+     * Added load options.
+     */
+    loadOptions: LoadOptions | undefined;
 
     /**
      *  Shuffle the items to play.
      */
     shuffle?: boolean | undefined;
-
-    /**
-     * Optional request source. It contain the assistent query that initiate the request.
-     */
-    source?: string | undefined;
 }
 
 /**
@@ -1985,11 +2016,14 @@ export class FetchItemsRequestData extends RequestData {
 
 /**
  * Extended media status information
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.ExtendedMediaStatus
  */
 export class ExtendedMediaStatus {
-    constructor(playerState: MediaInformation, opt_media?: MediaInformation);
+    constructor(playerState: MediaInformation, opt_media?: MediaInformation, opt_mediaSessionId?: number);
 
-    media: MediaInformation;
+    media?: MediaInformation | undefined;
+
+    mediaSessionId?: number | undefined;
 
     playerState: ExtendedPlayerState;
 }
@@ -2140,35 +2174,40 @@ export class CustomCommandRequestData extends RequestData {
  */
 export class CloudMediaStatus extends MediaStatus {}
 
+/**
+ * Represents current status of break.
+ *
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.BreakStatus
+ */
 export class BreakStatus {
-    constructor(currentBreakTime: number, currentBreakClipTime: number);
+    constructor(currentBreakTime: number | undefined, currentBreakClipTime: number | undefined);
 
     /**
      * Id of current break clip.
      */
-    breakClipId: string;
+    breakClipId?: string | undefined;
 
     /**
      * Id of current break.
      */
-    breakId: string;
+    breakId?: string | undefined;
 
     /**
      * Time in sec elapsed after current break clip starts.
      */
-    currentBreakClipTime: number;
+    currentBreakClipTime?: number | undefined;
 
     /**
      * Time in sec elapsed after current break starts.
      */
-    currentBreakTime: number;
+    currentBreakTime?: number | undefined;
 
     /**
      * The time in sec when this break clip becomes skippable.
      * 5 means that end user can skip this break clip after 5 seconds.
      * If this field is not defined; it means that current break clip is not skippable.
      */
-    whenSkippable: number;
+    whenSkippable?: number | undefined;
 }
 
 /**
@@ -2263,4 +2302,74 @@ export class Break {
      * Where the break is located inside main video. -1 represents the end of main video.
      */
     position: number;
+}
+
+/**
+ * An audiobook chapter description.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.AudiobookChapterMediaMetadata
+ */
+export class AudiobookChapterMediaMetadata {
+    constructor();
+    /**
+     * Audiobook title.
+     */
+    bookTitle?: string | undefined;
+
+    /**
+     * Chapter number, used for display purposes.
+     */
+    chapterNumber?: number | undefined;
+
+    /**
+     * Chapter title.
+     */
+    chapterTitle?: string | undefined;
+
+    /**
+     * Content rating.
+     * Note as of July 2021: docs do not specify a type
+     */
+    contentRating?: any;
+
+    /**
+     * Chapter or book cover art.
+     */
+    images?: Image[] | undefined;
+
+    /**
+     * Audiobook title, for backward compatibility.
+     */
+    subtitle?: string | undefined;
+
+    /**
+     * Chapter title, for backward compatibility.
+     */
+    title?: string | undefined;
+}
+
+/**
+ * An audiobook container description.
+ * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.AudiobookContainerMetadata
+ */
+export class AudiobookContainerMetadata {
+    constructor();
+    /**
+     * Book authors.
+     */
+    authors?: string[] | undefined;
+
+    /**
+     * Book narrators.
+     */
+    narrators?: string[] | undefined;
+
+    /**
+     * Book publisher.
+     */
+    publisher?: string | undefined;
+
+    /**
+     * ISO 8601 date when the book was released; e.g. 2014-02-10.
+     */
+    releaseDate?: string | undefined;
 }

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -2180,7 +2180,7 @@ export class CloudMediaStatus extends MediaStatus {}
  * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.BreakStatus
  */
 export class BreakStatus {
-    constructor(currentBreakTime: number | undefined, currentBreakClipTime: number | undefined);
+    constructor(currentBreakTime?: number | undefined, currentBreakClipTime?: number | undefined);
 
     /**
      * Id of current break clip.

--- a/types/chromecast-caf-receiver/cast.framework.system.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.system.d.ts
@@ -86,14 +86,6 @@ export enum DisconnectReason {
  */
 export enum LaunchedFrom {
     /**
-     * The launch owner could not be determined.
-     */
-    UNKNOWN = 'UNKNOWN',
-    /**
-     * App was launched by DIAL request.
-     */
-    DIAL = 'DIAL',
-    /**
      * App was launched by Cast V2 request.
      */
     CAST = 'CAST',
@@ -101,6 +93,14 @@ export enum LaunchedFrom {
      * App was launched by assistant request (e.g. voice command).
      */
     CLOUD = 'CLOUD',
+    /**
+     * App was launched by DIAL request.
+     */
+    DIAL = 'DIAL',
+    /**
+     * The launch owner could not be determined.
+     */
+    UNKNOWN = 'UNKNOWN',
 }
 
 /**
@@ -109,9 +109,9 @@ export enum LaunchedFrom {
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.VisibilityState
  */
 export enum VisibilityState {
-    VISIBLE = 'visible',
     NOT_VISIBLE = 'notvisible',
     UNKNOWN = 'unknown',
+    VISIBLE = 'visible',
 }
 
 /**

--- a/types/chromecast-caf-receiver/cast.framework.system.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.system.d.ts
@@ -54,10 +54,10 @@ export enum SystemState {
 
 // Types of custom messages.
 export enum MessageType {
-  // Messages are free-form strings. The application is responsible for encoding/decoding the information transmitted.
-  STRING = 'string',
-  // Messages are JSON-encoded. The underlying transport will use a JSON encoded string.
-  JSON = 'json',
+    // Messages are free-form strings. The application is responsible for encoding/decoding the information transmitted.
+    STRING = 'string',
+    // Messages are JSON-encoded. The underlying transport will use a JSON encoded string.
+    JSON = 'json',
 }
 
 // Represents the current standby state reported by the platform. It may be UNKNOWN
@@ -77,6 +77,40 @@ export enum DisconnectReason {
     // It is unknown if the sender requested to disconnect gracefully calling close (most likely it didn't,
     // but the close message could have been lost). This normally happens when there is a network timeout
     // or if the sender application crashes or if the sender OS closes the socket.
+    UNKNOWN = 'unknown',
+}
+
+/**
+ * Represent where the receiver was launched from.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.LaunchedFrom
+ */
+export enum LaunchedFrom {
+    /**
+     * The launch owner could not be determined.
+     */
+    UNKNOWN = 'UNKNOWN',
+    /**
+     * App was launched by DIAL request.
+     */
+    DIAL = 'DIAL',
+    /**
+     * App was launched by Cast V2 request.
+     */
+    CAST = 'CAST',
+    /**
+     * App was launched by assistant request (e.g. voice command).
+     */
+    CLOUD = 'CLOUD',
+}
+
+/**
+ * Represents the current visibility state reported by the platform.
+ * It may be UNKNOWN if the cast platform was unable to determine the state yet.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.VisibilityState
+ */
+export enum VisibilityState {
+    VISIBLE = 'visible',
+    NOT_VISIBLE = 'notvisible',
     UNKNOWN = 'unknown',
 }
 
@@ -126,17 +160,17 @@ export class StandbyChangedEvent {
     isStandby: boolean;
 }
 /**
- * Whether the TV is in standby or not.
+ * Event dispatched by {@link framework.CastReceiverContext} when the application is shutdown.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system.ShutdownEvent
  */
-export interface ShutdownEvent extends Event {
-    [key: string]: any;
-}
+export class ShutdownEvent extends Event {}
 
 /**
- * Event dispatched by @see{@link CastReceiverManager} when a sender is disconnected.
+ * Event dispatched by {@link framework.CastReceiverContext} when a sender is disconnected.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system.SenderDisconnectedEvent
  */
 export class SenderDisconnectedEvent extends Event {
-    constructor(senderId: string, userAgent: string);
+    constructor(senderId: string, userAgent: string, reason: DisconnectReason);
     /**
      * The ID of the sender connected.
      */
@@ -150,7 +184,7 @@ export class SenderDisconnectedEvent extends Event {
     /**
      * The reason the sender was disconnected.
      */
-    reason?: DisconnectReason | undefined;
+    reason: DisconnectReason;
 }
 
 /**
@@ -171,6 +205,7 @@ export class SenderConnectedEvent extends Event {
 
 /**
  * Represents the data of a connected sender device.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system.Sender
  */
 export interface Sender {
     /**
@@ -186,13 +221,13 @@ export interface Sender {
     /**
      * The userAgent of the sender.
      */
-    userAgent?: string | undefined;
+    userAgent: string;
 }
 
 /**
- * Event dispatched by CastReceiverManager when the system is ready.
+ * Event dispatched by {@link framework.CastReceiverContext} when the system is ready.
  */
-export class ReadyEvent {
+export class ReadyEvent extends Event {
     constructor(applicationData: ApplicationData);
 
     /**
@@ -212,10 +247,12 @@ export class MaxVideoResolutionChangedEvent extends Event {
      */
     height: number;
 }
-/** Event dispatched by @see{@link CastReceiverManager} when the systems starts to create feedback report. */
-export interface FeedbackStartedEvent extends Event {
-    [key: string]: any;
-}
+/**
+ * Event dispatched by {@link framework.CastReceiverContext} when the system
+ * starts to create feedback report.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system.FeedbackStartedEvent
+ */
+export class FeedbackStartedEvent extends Event {}
 /** Event dispatched by @see{@link CastReceiverContext} which contains system information. */
 export class Event {
     constructor(type: EventType, data?: any);
@@ -223,11 +260,45 @@ export class Event {
     data?: any;
 }
 
-/** Represents the data of the launched application. */
-export interface ApplicationData {
-    id(): string;
-    launchingSenderId(): string;
-    name(): string;
-    namespaces(): string[];
-    sessionId(): number;
+/**
+ * Represents the data of the launched application.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system.ApplicationData
+ */
+export class ApplicationData {
+    constructor();
+
+    /**
+     * The application image that is set in Cast Developer Console.
+     */
+    iconUrl: string;
+
+    /**
+     * The application Id.
+     */
+    id: string;
+
+    /**
+     * Indicate where the app was launched from.
+     */
+    launchedFrom: LaunchedFrom;
+
+    /**
+     * The id of the sender that launched the application.
+     */
+    launchingSenderId: string;
+
+    /**
+     * The application name.
+     */
+    name: string;
+
+    /**
+     * The namespaces used by the application.
+     */
+    namespaces: string[];
+
+    /**
+     * The session Id.
+     */
+    sessionId: number;
 }

--- a/types/chromecast-caf-receiver/cast.framework.ui.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.ui.d.ts
@@ -459,20 +459,6 @@ export class BrowseItem {
 }
 
 /**
- * UI Configuration.
- * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui.UiConfig
- */
-export class UiConfig {
-    constructor();
-
-    /**
-     * If this is true, SDK will be notified that Application has touch-optimized
-     * layout, so that SDK will not render opaque full-screen blocking overlay.
-     */
-    touchScreenOptimizedApp?: boolean | undefined;
-}
-
-/**
  * Aspect ratio of all images in the media browse carousel.
  */
 export enum BrowseImageAspectRatio {

--- a/types/chromecast-caf-receiver/cast.framework.ui.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.ui.d.ts
@@ -5,6 +5,12 @@ import {
     MediaCategory,
     QueueData,
     Image,
+    GenericMediaMetadata,
+    MovieMediaMetadata,
+    MusicTrackMediaMetadata,
+    PhotoMediaMetadata,
+    TvShowMediaMetadata,
+    AudiobookChapterMediaMetadata,
 } from './cast.framework.messages';
 import { CastReceiverContext } from './cast.framework';
 
@@ -168,7 +174,7 @@ export class PlayerData {
      * same UI code to run in a remote control. The state can be set by calling
      * cast.framework.PlayerManager#sendCustomState
      */
-    customState?: object | undefined;
+    customState?: any;
 
     /**
      * Whether the player metadata (ie: title; currentTime) should be displayed.
@@ -250,7 +256,16 @@ export class PlayerData {
     /**
      * Media metadata.
      */
-    metadata?: MediaMetadata | object | undefined;
+    metadata?:
+        | MediaMetadata
+        | GenericMediaMetadata
+        | MovieMediaMetadata
+        | MusicTrackMediaMetadata
+        | PhotoMediaMetadata
+        | TvShowMediaMetadata
+        | AudiobookChapterMediaMetadata
+        | object
+        | undefined;
 
     /**
      * Next Item subtitle.
@@ -357,7 +372,7 @@ export class Controls {
      *
      * @param browseContent
      */
-    setBrowseContent(browseContent?: BrowseContent): void;
+    setBrowseContent(browseContent: BrowseContent | null): void;
 }
 
 export class BrowseContent {
@@ -382,7 +397,7 @@ export class BrowseContent {
      * is too narrow/tall, it will be pillarboxed. If image is too wide/short,
      * it will be letterboxed.
      */
-    targetAspectRation?: BrowseImageAspectRatio | undefined;
+    targetAspectRatio?: BrowseImageAspectRatio | undefined;
 
     /**
      * Title of the list.
@@ -441,6 +456,20 @@ export class BrowseItem {
      * Main text of the browse item.
      */
     title?: string | undefined;
+}
+
+/**
+ * UI Configuration.
+ * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui.UiConfig
+ */
+export class UiConfig {
+    constructor();
+
+    /**
+     * If this is true, SDK will be notified that Application has touch-optimized
+     * layout, so that SDK will not render opaque full-screen blocking overlay.
+     */
+    touchScreenOptimizedApp?: boolean | undefined;
 }
 
 /**

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -142,7 +142,7 @@ const playbackConfig = new cast.framework.PlaybackConfig();
 playbackConfig.protectionSystem = cast.framework.ContentProtection.WIDEVINE;
 
 cast.framework.CastReceiverContext.getInstance().addEventListener(
-    cast.framework.system.EventType.SENDER_CONNECTED,
+    [cast.framework.system.EventType.SENDER_CONNECTED, cast.framework.system.EventType.SENDER_DISCONNECTED],
     () => '¡hola!',
 );
 

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -1,4 +1,4 @@
-import { ApplicationData } from 'chromecast-caf-receiver/cast.framework.system';
+import { ApplicationData, LaunchedFrom } from 'chromecast-caf-receiver/cast.framework.system';
 import {
     MediaMetadata,
     LoadRequestData,
@@ -93,11 +93,13 @@ lrd.queueData = {};
 
 // tslint:disable-next-line
 const appData: ApplicationData = {
-    id: () => 'id',
-    launchingSenderId: () => 'launch-id',
-    name: () => 'name',
-    namespaces: () => ['namespace'],
-    sessionId: () => 1,
+    id: 'id',
+    launchingSenderId: 'launch-id',
+    name: 'name',
+    namespaces: ['namespace'],
+    sessionId: 1,
+    iconUrl: 'iconUrl',
+    launchedFrom: LaunchedFrom.CAST,
 };
 
 // tslint:disable-next-line
@@ -140,7 +142,7 @@ const playbackConfig = new cast.framework.PlaybackConfig();
 playbackConfig.protectionSystem = cast.framework.ContentProtection.WIDEVINE;
 
 cast.framework.CastReceiverContext.getInstance().addEventListener(
-    [cast.framework.system.EventType.SENDER_CONNECTED, cast.framework.system.EventType.SENDER_DISCONNECTED],
+    cast.framework.system.EventType.SENDER_CONNECTED,
     () => '¡hola!',
 );
 
@@ -209,25 +211,27 @@ controls.assignButton(cast.framework.ui.ControlsSlot.SLOT_SECONDARY_2, cast.fram
 
 const playerManager = cast.framework.CastReceiverContext.getInstance().getPlayerManager();
 
-playerManager.setMessageInterceptor(MessageType.CLOUD_STATUS, (messageData: messages.CloudMediaStatus):
-    | messages.CloudMediaStatus
-    | messages.ErrorData => {
-    if (Math.random() > 0.5) {
-        const errorData = new cast.framework.messages.ErrorData(cast.framework.messages.ErrorType.INVALID_REQUEST);
-        errorData.reason = cast.framework.messages.ErrorReason.NOT_SUPPORTED;
-        return errorData;
-    }
+playerManager.setMessageInterceptor(
+    MessageType.CLOUD_STATUS,
+    (messageData: messages.CloudMediaStatus): messages.CloudMediaStatus | messages.ErrorData => {
+        if (Math.random() > 0.5) {
+            const errorData = new cast.framework.messages.ErrorData(cast.framework.messages.ErrorType.INVALID_REQUEST);
+            errorData.reason = cast.framework.messages.ErrorReason.NOT_SUPPORTED;
+            return errorData;
+        }
 
-    return messageData;
-});
-playerManager.setMessageInterceptor(MessageType.DISPLAY_STATUS, (messageData: messages.DisplayStatusRequestData):
-    | messages.DisplayStatusRequestData
-    | messages.ErrorData => {
-    if (Math.random() > 0.5) {
-        const errorData = new cast.framework.messages.ErrorData(cast.framework.messages.ErrorType.INVALID_REQUEST);
-        errorData.reason = cast.framework.messages.ErrorReason.NOT_SUPPORTED;
-        return errorData;
-    }
+        return messageData;
+    },
+);
+playerManager.setMessageInterceptor(
+    MessageType.DISPLAY_STATUS,
+    (messageData: messages.DisplayStatusRequestData): messages.DisplayStatusRequestData | messages.ErrorData => {
+        if (Math.random() > 0.5) {
+            const errorData = new cast.framework.messages.ErrorData(cast.framework.messages.ErrorType.INVALID_REQUEST);
+            errorData.reason = cast.framework.messages.ErrorReason.NOT_SUPPORTED;
+            return errorData;
+        }
 
-    return messageData;
-});
+        return messageData;
+    },
+);

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for non-npm package chromecast-caf-receiver 5.0
+// Type definitions for non-npm package chromecast-caf-receiver 6.0
 // Project: https://github.com/googlecast
 // Definitions by: Sergio Arbeo <https://github.com/Serabe>
 //                 Craig Bruce <https://github.com/craigrbruce>
 //                 Brandon Risell <https://github.com/brandonrisell>
+//                 Marco Reni <https://github.com/marcoreni>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -77,5 +78,5 @@ declare global {
     type LiveStatusEventHandler = (event: LiveStatusEvent) => void;
     type PlayerDataChangedEventHandler = (event: PlayerDataChangedEvent) => void;
     type RequestHandler = (request: framework.NetworkRequestInfo) => void;
-    type BinaryHandler = (data: Uint8Array) => Uint8Array;
+    type BinaryHandler = (data: Uint8Array) => Uint8Array | Promise<Uint8Array>;
 }

--- a/types/chromecast-caf-receiver/tsconfig.json
+++ b/types/chromecast-caf-receiver/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
This PR supersedes #54403 , and is the first step in bringing this package up to date with the [Web Receiver Documentation](https://developers.google.cn/cast/docs/reference/web_receiver)

NOTES:
- Where in doubt (for example, removed methods) I double-checked on the SDK to make sure that they weren't undocumented methods.
- **Only** breaking changes are included in this PR. Following PRs will address new fields and documentation updates, but won't require a new major version.
- Seems like prettier was not run in a while so some of the changes are due to that.
- I followed [Google Javascript Styleguide](https://google.github.io/styleguide/javascriptguide.xml?showone=Comments#Comments) for comments (again, only for changed declarations). Following PRs will address docs cleanup and jsdoc syntax errors.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - NOTE: I changed the major version since there are some breaking changes (removed methods, typos, errors). Since this is a CDN provided library, there is a versioning in place but it's not possible to pin a specific version in the clients; it's only possible to test the preview version. Reference: https://developers.google.cn/cast/preview-url , https://developers.google.cn/cast/docs/release-notes

