### PR TITLE
[indy-sdk] feat: add buildNymRequest

### DIFF
--- a/types/indy-sdk/index.d.ts
+++ b/types/indy-sdk/index.d.ts
@@ -77,8 +77,8 @@ export function buildNymRequest(
     targetDid: Did,
     verkey: string,
     alias: string,
-    role: NymRole | null
-  ): Promise<LedgerRequest>;
+    role: NymRole | null,
+): Promise<LedgerRequest>;
 export function buildGetNymRequest(submitterDid: Did | null, targetDid: Did): Promise<LedgerRequest>;
 export function parseGetNymResponse(response: LedgerResponse): Promise<GetNymResponse>;
 export function buildSchemaRequest(submitterDid: Did, schema: Schema): Promise<LedgerRequest>;
@@ -301,9 +301,11 @@ export interface WalletStorageConfig {
 
 export interface WalletCredentials {
     key: string;
-    storage_credentials?: {
-        [key: string]: unknown;
-    } | undefined;
+    storage_credentials?:
+        | {
+              [key: string]: unknown;
+          }
+        | undefined;
     key_derivation_method?: KeyDerivationMethod | undefined;
 }
 
@@ -492,7 +494,12 @@ export interface IndyProof {
         };
     };
     proof: any;
-    identifiers: Array<{ schema_id: string; cred_def_id: string; rev_reg_id?: string | undefined; timestamp?: number | undefined }>;
+    identifiers: Array<{
+        schema_id: string;
+        cred_def_id: string;
+        rev_reg_id?: string | undefined;
+        timestamp?: number | undefined;
+    }>;
 }
 
 export interface Schemas {
@@ -624,9 +631,11 @@ export interface WalletRecord {
     id: string;
     type?: string | undefined;
     value?: string | undefined;
-    tags?: {
-        [key: string]: string | undefined;
-    } | undefined;
+    tags?:
+        | {
+              [key: string]: string | undefined;
+          }
+        | undefined;
 }
 
 export interface WalletRecordSearch {

--- a/types/indy-sdk/index.d.ts
+++ b/types/indy-sdk/index.d.ts
@@ -72,6 +72,13 @@ export function closeWalletSearch(sh: SearchHandle): Promise<void>;
 export function createPoolLedgerConfig(configName: string, config?: PoolConfig): Promise<void>;
 export function openPoolLedger(configName: string, config?: RuntimePoolConfig): Promise<PoolHandle>;
 export function setProtocolVersion(version: number): Promise<void>;
+export function buildNymRequest(
+    submitterDid: Did,
+    targetDid: Did,
+    verkey: string,
+    alias: string,
+    role: NymRole | null
+  ): Promise<LedgerRequest>;
 export function buildGetNymRequest(submitterDid: Did | null, targetDid: Did): Promise<LedgerRequest>;
 export function parseGetNymResponse(response: LedgerResponse): Promise<GetNymResponse>;
 export function buildSchemaRequest(submitterDid: Did, schema: Schema): Promise<LedgerRequest>;
@@ -633,10 +640,4 @@ export interface GetNymResponse {
     role: NymRole;
 }
 
-export enum NymRole {
-    TRUSTEE = 0,
-    STEWARD = 2,
-    TRUST_ANCHOR = 101,
-    ENDORSER = 101,
-    NETWORK_MONITOR = 201,
-}
+export type NymRole = 'TRUSTEE' | 'STEWARD' | 'TRUST_ANCHOR' | 'ENDORSER' | 'NETWORK_MONITOR';

--- a/types/indy-sdk/indy-sdk-tests.ts
+++ b/types/indy-sdk/indy-sdk-tests.ts
@@ -170,6 +170,7 @@ indy.signRequest(10, 'myDid', ledgerRequest);
 indy.signAndSubmitRequest(10, 10, 'myDid', ledgerRequest);
 indy.submitRequest(10, ledgerRequest);
 indy.parseGetNymResponse(ledgerRejectResponse);
+indy.buildNymRequest('myDid', 'targetDid', 'verKey', 'alias', 'TRUSTEE');
 indy.buildGetSchemaRequest('myDid', 'a');
 indy.parseGetSchemaResponse(ledgerWriteReply);
 indy.buildGetAcceptanceMechanismsRequest(null);

--- a/types/indy-sdk/indy-sdk-tests.ts
+++ b/types/indy-sdk/indy-sdk-tests.ts
@@ -1,4 +1,4 @@
-import indy from "indy-sdk";
+import indy from 'indy-sdk';
 import { Buffer } from 'buffer/';
 
 indy.openBlobStorageWriter('default', {


### PR DESCRIPTION
Add `buildNymRequest` in order to be able to do public DID registration. It also updates `NymRole`, that was defined as an enum (which causes some troubles when attempting to use from other modules) and now is a type allowing all indy-sdk's current supported values.

Signed-off-by: Ariel Gentile <gentilester@gmail.com>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: indy-sdk [nodejs wrapper ](https://github.com/hyperledger/indy-sdk/blob/113b79cd64a238130d20e19b972326f72047c550/wrappers/nodejs/src/indy.cc#L1671)provides buildNymRequest method, expecting string as data type for role. In addition, [libindy](https://github.com/hyperledger/indy-sdk/blob/dbd89cf94a73e7a62611c4150a874c38b810ff8d/libindy/src/api/ledger.rs#L335) receives friendly name values for buildNymRequest instead of numbers
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

