### PR TITLE
node: fix missing ms argument in setTimeout

### DIFF
--- a/types/node/test/timers.ts
+++ b/types/node/test/timers.ts
@@ -75,10 +75,11 @@ import * as timers from 'node:timers';
 
 // unresolved callback argument types
 {
-    new Promise(resolve => setTimeout(resolve, 100));
-    new Promise(resolve => setInterval(resolve, 100));
+    // `NodeJS.*` is present to make sure we're not using `dom` types
+    new Promise((resolve): NodeJS.Timeout => timers.setTimeout(resolve, 100));
+    new Promise((resolve): NodeJS.Timer => timers.setInterval(resolve, 100));
     // tslint:disable-next-line no-unnecessary-callback-wrapper
-    new Promise(resolve => setImmediate(resolve));
+    new Promise((resolve): NodeJS.Immediate => timers.setImmediate(resolve));
 }
 
 // globals

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -42,7 +42,7 @@ declare module 'timers' {
         function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
-        function setTimeout(callback: (args: void) => void): NodeJS.Timeout;
+        function setTimeout(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }


### PR DESCRIPTION
This PR is adding missing `ms` argument in `setTimeout`. Also fixes tests to not be fulfilled by `dom` definitions.

Bug reports: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54286#discussion_r673795069  https://github.com/DefinitelyTyped/DefinitelyTyped/issues/54285#issuecomment-884009647

CC: @birtles @SimonSchick 