### PR TITLE
fix(node-fetch): Change incorrect [string] to string

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -119,7 +119,7 @@ export class Headers implements Iterable<[string, string]> {
     // Iterable methods
     entries(): IterableIterator<[string, string]>;
     keys(): IterableIterator<string>;
-    values(): IterableIterator<[string]>;
+    values(): IterableIterator<string>;
     [Symbol.iterator](): Iterator<[string, string]>;
 }
 

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -169,7 +169,7 @@ function test_headers() {
     [...headers]; // $ExpectType [string, string][]
     [...headers.entries()]; // $ExpectType [string, string][]
     [...headers.keys()]; // $ExpectType string[]
-    [...headers.values()]; // $ExpectType [string][]
+    [...headers.values()]; // $ExpectType string[]
 }
 
 function test_isRedirect() {


### PR DESCRIPTION
The current definition for `Headers` has `values(): IterableIterator<[string]>`. The implementation is actually `values(): IterableIterator<string>` (spec compliant).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/node-fetch#class-headers
