### PR TITLE
react-window: Fix Grid's scrollTo() params scrollLeft/scrollTop to be optional

### DIFF
--- a/types/react-window/index.d.ts
+++ b/types/react-window/index.d.ts
@@ -428,7 +428,7 @@ export class FixedSizeGrid<T = any> extends Component<FixedSizeGridProps<T>> {
     /**
      * Scroll to the specified offsets.
      */
-    scrollTo(params: { scrollLeft: number; scrollTop: number }): void;
+    scrollTo(params: { scrollLeft?: number; scrollTop?: number }): void;
     /**
      * Scroll to the specified item.
      *
@@ -457,7 +457,7 @@ export class VariableSizeGrid<T = any> extends Component<VariableSizeGridProps<T
     /**
      * Scroll to the specified offsets.
      */
-    scrollTo(params: { scrollLeft: number; scrollTop: number }): void;
+    scrollTo(params: { scrollLeft?: number; scrollTop?: number }): void;
     /**
      * Scroll to the specified item.
      *

--- a/types/react-window/react-window-tests.tsx
+++ b/types/react-window/react-window-tests.tsx
@@ -245,6 +245,9 @@ const FixedSizeGridTestRefs: React.SFC = () => (
 
 if (fixedRef.current) {
     fixedRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0});
+    fixedRef.current.scrollTo({ scrollLeft: 0 });
+    fixedRef.current.scrollTo({ scrollTop: 0 });
+    fixedRef.current.scrollTo({});
     fixedRef.current.scrollToItem({});
     fixedRef.current.scrollToItem({ align: "auto" });
     fixedRef.current.scrollToItem({ rowIndex: 0 });
@@ -274,6 +277,9 @@ const VariableSizeGridTestRefs: React.SFC = () => (
 
 if (variableRef.current) {
     variableRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0});
+    variableRef.current.scrollTo({ scrollLeft: 0 });
+    variableRef.current.scrollTo({ scrollTop: 0 });
+    variableRef.current.scrollTo({});
     variableRef.current.scrollToItem({});
     variableRef.current.scrollToItem({ align: "auto" });
     variableRef.current.scrollToItem({ rowIndex: 0 });
@@ -532,6 +538,9 @@ const FixedSizeGridTestRefsV2: React.SFC = () => (
 
 if (fixedRef.current) {
     fixedRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0});
+    fixedRef.current.scrollTo({ scrollLeft: 0 });
+    fixedRef.current.scrollTo({ scrollTop: 0 });
+    fixedRef.current.scrollTo({});
     fixedRef.current.scrollToItem({});
     fixedRef.current.scrollToItem({ align: "auto" });
     fixedRef.current.scrollToItem({ rowIndex: 0 });
@@ -561,6 +570,9 @@ const VariableSizeGridTestRefsV2: React.SFC = () => (
 
 if (variableRef.current) {
     variableRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0});
+    variableRef.current.scrollTo({ scrollLeft: 0 });
+    variableRef.current.scrollTo({ scrollTop: 0 });
+    variableRef.current.scrollTo({});
     variableRef.current.scrollToItem({});
     variableRef.current.scrollToItem({ align: "auto" });
     variableRef.current.scrollToItem({ rowIndex: 0 });


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-window/blob/master/src/createGridComponent.js#L252-L257
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Support for it was commited on 2018 October 1st
Commit: https://github.com/bvaughn/react-window/commit/7c481d6028fc791f35b7d4341f56a90d10edd92e
Current state: https://github.com/bvaughn/react-window/blob/master/src/createGridComponent.js#L252-L257