### PR TITLE
http-assert: Use TypeScript 3.7's `asserts`

### DIFF
--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -11,8 +11,8 @@
  * @param msg the message of the error, defaulting to node's text for that status code
  * @param opts custom properties to attach to the error object
  */
-declare function assert(value: any, status?: number, msg?: string, opts?: {}): void;
-declare function assert(value: any, status?: number, opts?: {}): void;
+declare function assert(value: any, status?: number, msg?: string, opts?: {}): asserts value;
+declare function assert(value: any, status?: number, opts?: {}): asserts value;
 
 declare namespace assert {
     /**
@@ -27,7 +27,7 @@ declare namespace assert {
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type AssertOK = (a: any, status?: number, msg?: string, opts?: {}) => void;
+    type AssertOK = (a: any, status?: number, msg?: string, opts?: {}) => asserts a;
 
     /**
      * @param status the status code

--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -4,7 +4,7 @@
 //                 Peter Squicciarini <https://github.com/stripedpajamas>
 //                 Alex Bulanov <https://github.com/sapfear>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// Minimum TypeScript Version: 3.7
 
 /**
  * @param status the status code


### PR DESCRIPTION
This patch uses [TypeScript 3.7's `asserts`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) to let the compiler know the value passed into `httpAssert()` is truthy.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
