### PR TITLE
[relay-runtime] Improve type inference for `readInlineData`

### DIFF
--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -22,7 +22,6 @@ import {
     QueryRenderer,
     LocalQueryRenderer,
     ReactRelayContext,
-    readInlineData,
     RelayPaginationProp,
     RelayProp,
     RelayRefetchProp,
@@ -648,25 +647,6 @@ function markNotificationAsRead(source: string, storyID: string) {
         },
     });
 }
-
-// ~~~~~~~~~~~~~~~~~~~~~
-// readInlineData
-// ~~~~~~~~~~~~~~~~~~~~~
-
-const storyFragment = graphql`
-    fragment Story_story on Todo {
-        id
-        text
-        isPublished
-    }
-`;
-
-function functionWithInline(storyRef: FragmentRef<Story_story>): Story_story {
-    return readInlineData<Story_story>(storyFragment, storyRef);
-}
-
-const inlineData: _FragmentRefs<'Story_story'> = {} as any;
-functionWithInline(inlineData).isPublished;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern Subscriptions

--- a/types/relay-runtime/lib/store/readInlineData.d.ts
+++ b/types/relay-runtime/lib/store/readInlineData.d.ts
@@ -17,5 +17,3 @@ export function readInlineData<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): KeyTypeData<TKey> | null;
-
-export { readInlineData };

--- a/types/relay-runtime/lib/store/readInlineData.d.ts
+++ b/types/relay-runtime/lib/store/readInlineData.d.ts
@@ -1,10 +1,21 @@
-import { _RefType, FragmentRef } from '../..';
+import { FragmentReference } from './RelayStoreTypes';
 import { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
 
-declare function readInlineData<T extends _RefType<any>>(fragment: GraphQLTaggedNode, ref: FragmentRef<T>): T;
-declare function readInlineData<T extends _RefType<any>>(
-    fragment: GraphQLTaggedNode,
-    ref: FragmentRef<T> | null | undefined,
-): T | null | undefined;
+export type KeyType<TData = unknown> = Readonly<{
+    ' $data'?: TData | undefined;
+    ' $fragmentRefs': FragmentReference;
+}>;
 
-export { FragmentRef, readInlineData };
+export type KeyTypeData<TKey extends KeyType<TData>, TData = unknown> = Required<TKey>[' $data'];
+
+export function readInlineData<TKey extends KeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey,
+): KeyTypeData<TKey>;
+
+export function readInlineData<TKey extends KeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): KeyTypeData<TKey> | null;
+
+export { readInlineData };

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -421,6 +421,48 @@ const nodeFragment: ReaderFragment = {
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~
+// readInlineData
+// ~~~~~~~~~~~~~~~~~~~~~
+
+interface Module_data {
+    readonly id: string;
+    readonly ' $refType': 'Module_data';
+}
+type Module_data$data = Module_data;
+interface Module_data$key {
+    readonly ' $data'?: Module_data$data;
+    readonly ' $fragmentRefs': FragmentRefs<'Module_data'>;
+}
+
+function readData(
+  dataRef: Module_data$key,
+) {
+  // $ExpectType Module_data
+  readInlineData(
+    graphql`
+      fragment Module_data on Data @inline {
+        id
+      }
+    `,
+    dataRef,
+  );
+}
+
+function readNullableData(
+  dataRef: Module_data$key | null,
+) {
+  // $ExpectType Module_data | null
+  readInlineData(
+    graphql`
+      fragment Module_data on Data @inline {
+        id
+      }
+    `,
+    dataRef,
+  );
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~
 // INTERNAL-ONLY
 // ~~~~~~~~~~~~~~~~~~~~~
 

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -21,6 +21,8 @@ import {
     graphql,
     getRequest,
     createOperationDescriptor,
+    FragmentRefs,
+    readInlineData,
 } from 'relay-runtime';
 
 const source = new RecordSource();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This updates `readInlineData` to use the same technique as `useFragment` to infer its data type. This avoids having to annotate the function with a type parameter.

Before:

```ts
function readData(
  dataRef: FragmentRef<Module_data>,
) {
  const data = readInlineData<Module_data>(
    graphql`
      fragment Module_data on Data @inline {
        id
      }
    `,
    dataRef,
  );
}
```
After:

```ts
function readData(
  dataRef: Module_data$key,
) {
  const data = readInlineData(
    graphql`
      fragment Module_data on Data @inline {
        id
      }
    `,
    dataRef,
  );
}
```

Note that this is a breaking change at the type level since the generic parameter type is now different. In most cases just removing it will fix the problem. The ref is also expected to be of type `Module_data$key` instead of `FragmentRef<Module_data>`.