### PR TITLE
[node] Fix encoding shorthand options type

### DIFF
--- a/types/denodeify/denodeify-tests.ts
+++ b/types/denodeify/denodeify-tests.ts
@@ -5,5 +5,5 @@ import denodeify = require("denodeify");
 import fs = require('fs');
 import cp = require('child_process');
 
-const readFile = denodeify<string,string,string>(fs.readFile);
+const readFile = denodeify<string,BufferEncoding,string>(fs.readFile);
 const exec = denodeify<string,string>(cp.exec, (err, stdout, stderr) => [err, stdout]);

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2354,7 +2354,7 @@ declare module 'fs' {
                   encoding: BufferEncoding;
                   flag?: string | undefined;
               } & Abortable)
-            | string,
+            | BufferEncoding,
         callback: (err: NodeJS.ErrnoException | null, data: string) => void
     ): void;
     /**
@@ -2370,7 +2370,7 @@ declare module 'fs' {
             | (ObjectEncodingOptions & {
                   flag?: string | undefined;
               } & Abortable)
-            | string
+            | BufferEncoding
             | undefined
             | null,
         callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void
@@ -2411,7 +2411,7 @@ declare module 'fs' {
                       encoding: BufferEncoding;
                       flag?: string | undefined;
                   }
-                | string
+                | BufferEncoding
         ): Promise<string>;
         /**
          * Asynchronously reads the entire contents of a file.
@@ -2427,7 +2427,7 @@ declare module 'fs' {
                 | (ObjectEncodingOptions & {
                       flag?: string | undefined;
                   })
-                | string
+                | BufferEncoding
                 | null
         ): Promise<string | Buffer>;
     }
@@ -2500,7 +2500,7 @@ declare module 'fs' {
                   mode?: Mode | undefined;
                   flag?: string | undefined;
               })
-        | string
+        | BufferEncoding
         | null;
     /**
      * When `file` is a filename, asynchronously writes data to the file, replacing the

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -42,6 +42,7 @@
 //                 Victor Perin <https://github.com/victorperin>
 //                 Yongsheng Zhang <https://github.com/ZYSzys>
 //                 NodeJS Contributors <https://github.com/NodeJS>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -372,6 +372,16 @@ async () => {
     await handle.write(Buffer.from('hurr'), 0, 42, 10);
 };
 
+{
+    fs.createWriteStream('./index.d.ts');
+    fs.createWriteStream('./index.d.ts', 'utf8');
+    fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
+
+    fs.createReadStream('./index.d.ts');
+    fs.createReadStream('./index.d.ts', 'utf8');
+    fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
+}
+
 async () => {
     await writeFileAsync('test', 'test');
     await writeFileAsync('test',  Buffer.from('test'));

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -19,25 +19,33 @@ import assert = require('node:assert');
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
-    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
 
     fs.writeFileSync("testfile", "content", "utf8");
-    fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
-    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
-    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
-    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
-    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
     fs.appendFileSync("testfile", "foobar", "utf8");
-    fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
-    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
@@ -48,9 +56,11 @@ import assert = require('node:assert');
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
-    content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
-    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -63,9 +73,11 @@ import assert = require('node:assert');
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
-    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', { encoding: 'utf8', signal: new AbortSignal() }, (err, data) => content = data);
-    fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -387,15 +399,19 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
-    fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
-    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
-    fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
-    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 }
 
 async () => {

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -19,17 +19,25 @@ import assert = require('node:assert');
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
+    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
 
     fs.writeFileSync("testfile", "content", "utf8");
+    fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
+    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
+    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
+    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
+    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
     fs.appendFileSync("testfile", "foobar", "utf8");
+    fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
+    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
@@ -40,7 +48,9 @@ import assert = require('node:assert');
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
+    content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
+    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -53,7 +63,9 @@ import assert = require('node:assert');
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
+    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', { encoding: 'utf8', signal: new AbortSignal() }, (err, data) => content = data);
+    fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -375,11 +387,15 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
+    fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
+    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
+    fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
+    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 }
 
 async () => {

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -1578,7 +1578,7 @@ declare module 'fs' {
      */
     export function readFile(
         path: PathLike | number,
-        options: { encoding: BufferEncoding; flag?: string | undefined; } | string,
+        options: { encoding: BufferEncoding; flag?: string | undefined; } | BufferEncoding,
         callback: (err: NodeJS.ErrnoException | null, data: string) => void
     ): void;
 
@@ -1592,7 +1592,7 @@ declare module 'fs' {
      */
     export function readFile(
         path: PathLike | number,
-        options: BaseEncodingOptions & { flag?: string | undefined; } | string | undefined | null,
+        options: BaseEncodingOptions & { flag?: string | undefined; } | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
     ): void;
 
@@ -1622,7 +1622,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string | undefined; } | string): Promise<string>;
+        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string | undefined; } | BufferEncoding): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1632,7 +1632,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | BufferEncoding | null): Promise<string | Buffer>;
     }
 
     /**
@@ -1664,7 +1664,7 @@ declare module 'fs' {
      */
     export function readFileSync(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string | undefined; } | BufferEncoding | null): string | Buffer;
 
-    export type WriteFileOptions = BaseEncodingOptions & { mode?: Mode | undefined; flag?: string | undefined; } | string | null;
+    export type WriteFileOptions = BaseEncodingOptions & { mode?: Mode | undefined; flag?: string | undefined; } | BufferEncoding | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -2068,7 +2068,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createReadStream(path: PathLike, options?: string | {
+    export function createReadStream(path: PathLike, options?: BufferEncoding | {
         flags?: string | undefined;
         encoding?: BufferEncoding | undefined;
         fd?: number | undefined;
@@ -2088,7 +2088,7 @@ declare module 'fs' {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createWriteStream(path: PathLike, options?: string | {
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | {
         flags?: string | undefined;
         encoding?: BufferEncoding | undefined;
         fd?: number | undefined;

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -353,6 +353,16 @@ async function testPromisify() {
 }
 
 {
+    fs.createWriteStream('./index.d.ts');
+    fs.createWriteStream('./index.d.ts', 'utf8');
+    fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
+
+    fs.createReadStream('./index.d.ts');
+    fs.createReadStream('./index.d.ts', 'utf8');
+    fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
+}
+
+{
     fs.readvSync(123, [Buffer.from('wut')] as ReadonlyArray<NodeJS.ArrayBufferView>);
     fs.readv(123, [Buffer.from('wut')] as ReadonlyArray<NodeJS.ArrayBufferView>, 123, (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => {
     });

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -17,25 +17,33 @@ import * as util from 'util';
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
-    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
 
     fs.writeFileSync("testfile", "content", "utf8");
-    fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
-    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
-    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
-    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
-    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
     fs.appendFileSync("testfile", "foobar", "utf8");
-    fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
-    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
@@ -46,9 +54,11 @@ import * as util from 'util';
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
-    content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
-    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -61,9 +71,11 @@ import * as util from 'util';
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
-    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', { encoding: 'utf8' }, (err, data) => content = data);
-    fs.readFile('testfile', { encoding: 'invalid encoding' }, (err, data) => content = data); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.readFile('testfile', { encoding: 'invalid encoding' }, (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -367,15 +379,19 @@ async function testPromisify() {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
-    fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
-    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
-    fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
-    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 }
 
 {

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -17,17 +17,25 @@ import * as util from 'util';
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
+    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
 
     fs.writeFileSync("testfile", "content", "utf8");
+    fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
+    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
+    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
+    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
+    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
     fs.appendFileSync("testfile", "foobar", "utf8");
+    fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
+    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
@@ -38,7 +46,9 @@ import * as util from 'util';
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
+    content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
+    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -51,7 +61,9 @@ import * as util from 'util';
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
+    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', { encoding: 'utf8' }, (err, data) => content = data);
+    fs.readFile('testfile', { encoding: 'invalid encoding' }, (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -355,11 +367,15 @@ async function testPromisify() {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
+    fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
+    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
+    fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
+    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 }
 
 {

--- a/types/node/v15/fs.d.ts
+++ b/types/node/v15/fs.d.ts
@@ -1572,7 +1572,7 @@ declare module 'fs' {
      */
     export function readFile(
         path: PathLike | number,
-        options: { encoding: BufferEncoding; flag?: string; } & Abortable | string,
+        options: { encoding: BufferEncoding; flag?: string; } & Abortable | BufferEncoding,
         callback: (err: NodeJS.ErrnoException | null, data: string) => void,
     ): void;
 
@@ -1586,7 +1586,7 @@ declare module 'fs' {
     export function readFile(
         path: PathLike | number,
         // TODO: unify the options across all readfile functions
-        options: BaseEncodingOptions & { flag?: string; } & Abortable | string | undefined | null,
+        options: BaseEncodingOptions & { flag?: string; } & Abortable | BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
     ): void;
 
@@ -1616,7 +1616,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | string): Promise<string>;
+        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | BufferEncoding): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -1626,7 +1626,7 @@ declare module 'fs' {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | BufferEncoding | null): Promise<string | Buffer>;
     }
 
     /**
@@ -1655,7 +1655,7 @@ declare module 'fs' {
      */
     export function readFileSync(path: PathLike | number, options?: BaseEncodingOptions & { flag?: string; } | BufferEncoding | null): string | Buffer;
 
-    export type WriteFileOptions = (BaseEncodingOptions & Abortable & { mode?: Mode; flag?: string; }) | string | null;
+    export type WriteFileOptions = (BaseEncodingOptions & Abortable & { mode?: Mode; flag?: string; }) | BufferEncoding | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -2059,13 +2059,13 @@ declare module 'fs' {
      * Returns a new `ReadStream` object.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function createReadStream(path: PathLike, options?: string | ReadStreamOptions): ReadStream;
+    export function createReadStream(path: PathLike, options?: BufferEncoding | ReadStreamOptions): ReadStream;
 
     /**
      * Returns a new `WriteStream` object.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function createWriteStream(path: PathLike, options?: string | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
 
     /**
      * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/v15/test/fs.ts
+++ b/types/node/v15/test/fs.ts
@@ -19,25 +19,33 @@ import assert = require('assert');
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
-    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
 
     fs.writeFileSync("testfile", "content", "utf8");
-    fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
-    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
-    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
-    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
-    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
     fs.appendFileSync("testfile", "foobar", "utf8");
-    fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
-    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
@@ -48,9 +56,11 @@ import assert = require('assert');
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
-    content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
-    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -63,9 +73,11 @@ import assert = require('assert');
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
-    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', { encoding: 'utf8', signal: new AbortSignal() }, (err, data) => content = data);
-    fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -385,15 +397,19 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
-    fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
-    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
-    fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
-    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
+    // fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 }
 
 async () => {

--- a/types/node/v15/test/fs.ts
+++ b/types/node/v15/test/fs.ts
@@ -19,17 +19,25 @@ import assert = require('assert');
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
+    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
 
     fs.writeFileSync("testfile", "content", "utf8");
+    fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
+    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
+    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
+    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
+    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
     fs.appendFileSync("testfile", "foobar", "utf8");
+    fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
+    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
 }
 
 {
@@ -40,7 +48,9 @@ import assert = require('assert');
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
+    content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
+    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -53,7 +63,9 @@ import assert = require('assert');
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
+    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', { encoding: 'utf8', signal: new AbortSignal() }, (err, data) => content = data);
+    fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -373,11 +385,15 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
+    fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
+    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
+    fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
+    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
 }
 
 async () => {

--- a/types/node/v15/test/fs.ts
+++ b/types/node/v15/test/fs.ts
@@ -370,6 +370,16 @@ async () => {
     const _rom = readStream.readableObjectMode; // $ExpectType boolean
 };
 
+{
+    fs.createWriteStream('./index.d.ts');
+    fs.createWriteStream('./index.d.ts', 'utf8');
+    fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
+
+    fs.createReadStream('./index.d.ts');
+    fs.createReadStream('./index.d.ts', 'utf8');
+    fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
+}
+
 async () => {
     await writeFileAsync('test', 'test');
     await writeFileAsync('test',  Buffer.from('test'));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/nodejs/node/blob/6140b3753fd6160b0c50a61500c04de8e36f9c05/lib/internal/fs/utils.js#L319-L322
  - https://github.com/nodejs/node/blob/6140b3753fd6160b0c50a61500c04de8e36f9c05/lib/fs.js#L2092
  - https://github.com/nodejs/node/blob/6140b3753fd6160b0c50a61500c04de8e36f9c05/lib/fs.js#L372
  - https://github.com/nodejs/node/blob/6140b3753fd6160b0c50a61500c04de8e36f9c05/lib/internal/fs/streams.js#L308
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

I added test for `createWriteStream` and `createReadStream`, the `writeFile` and `readFile` functions already had tests covering this.

The `readFileSync` function was already correct.

