### PR TITLE
[N3] fix: Resolve backwards compatibility for format option

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -177,7 +177,9 @@ export type MimeSubtype = BaseFormatVariant | `${BaseFormatVariant}${Star}`;
 export type MimeFormat = MimeSubtype | `${MimeType}/${MimeSubtype}`;
 
 export interface ParserOptions {
-    format?: MimeFormat | undefined;
+    // string type is here to maintain backwards compatibility - consider removing when
+    // updating major version
+    format?: string | MimeFormat | undefined;
     factory?: RDF.DataFactory | undefined;
     baseIRI?: string | undefined;
     blankNodePrefix?: string | undefined;
@@ -200,7 +202,9 @@ export class StreamParser<Q extends BaseQuad = Quad> extends stream.Transform im
 }
 
 export interface WriterOptions {
-    format?: MimeFormat | undefined;
+    // string type is here to maintain backwards compatibility - consider removing when
+    // updating major version
+    format?: string | MimeFormat | undefined;
     prefixes?: Prefixes<RDF.NamedNode | string> | undefined;
     end?: boolean | undefined;
 }

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -93,6 +93,14 @@ function test_doc_rdf_to_triples_2() {
     const parser5: N3.Parser = new N3.Parser({ format: 'text/n3' });
 }
 
+// Consider breaking this test when incrementing major version
+function test_format_as_string_type() {
+    function customParser(format: string) {
+        return new N3.Parser({ format })
+    }
+    const parser = customParser('N3')
+}
+
 function test_doc_rdf_sync_to_triples_1() {
     const parser: N3.Parser = new N3.Parser();
     const result = parser.parse(`@prefix c: <http://example.org/cartoons#>.

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -98,7 +98,13 @@ function test_format_as_string_type() {
     function customParser(format: string) {
         return new N3.Parser({ format })
     }
+
+    function customWriter(format: string) {
+        return new N3.Writer({ format })
+    }
+
     const parser = customParser('N3')
+    const writer = customWriter('N3')
 }
 
 function test_doc_rdf_sync_to_triples_1() {

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -96,15 +96,15 @@ function test_doc_rdf_to_triples_2() {
 // Consider breaking this test when incrementing major version
 function test_format_as_string_type() {
     function customParser(format: string) {
-        return new N3.Parser({ format })
+        return new N3.Parser({ format });
     }
 
     function customWriter(format: string) {
-        return new N3.Writer({ format })
+        return new N3.Writer({ format });
     }
 
-    const parser = customParser('N3')
-    const writer = customWriter('N3')
+    const parser = customParser('N3');
+    const writer = customWriter('N3');
 }
 
 function test_doc_rdf_sync_to_triples_1() {


### PR DESCRIPTION
Addresses https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54301#issuecomment-884938197 by adding `string |` to format option to enable backwards compatibility.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

