### PR TITLE
Type definitions for wax-on

### DIFF
--- a/types/wax-on/index.d.ts
+++ b/types/wax-on/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for wax-on 1.2
+// Project: https://github.com/keithws/wax-on#readme
+// Definitions by: Jonatas <https://github.com/Honatas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function on(handlebars: unknown): void;
+export function setLayoutPath(path: string): void;

--- a/types/wax-on/tsconfig.json
+++ b/types/wax-on/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wax-on-tests.ts"
+    ]
+}

--- a/types/wax-on/tslint.json
+++ b/types/wax-on/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wax-on/wax-on-tests.ts
+++ b/types/wax-on/wax-on-tests.ts
@@ -1,0 +1,6 @@
+import * as wax from 'wax-on';
+
+declare let Handlebars: unknown;
+
+wax.on(Handlebars);
+wax.setLayoutPath("/path/to/layouts");


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
