### PR TITLE
[aws-lambda] feat: Add Source Type Definition for AppSync Resolver

### DIFF
--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -49,10 +49,10 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = a
     anyObj = event.info.variables;
     str = event.info.selectionSetList[0];
 
-    strOrUndefined = event.source?.id;
-    strOrUndefined = event.source?.firstName;
-    strOrUndefined = event.source?.lastName;
-    numOrUndefined = event.source?.age;
+    strOrUndefined = event.source ? event.source.id : undefined;
+    strOrUndefined = event.source ? event.source.firstName : undefined;
+    strOrUndefined = event.source ? event.source.lastName : undefined;
+    numOrUndefined = event.source ? event.source.age : undefined;
     objectOrNull = event.source;
     prevResultOrNull = event.prev;
     anyObj = (event.prev as { result: { [key: string]: any } }).result;

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -14,7 +14,14 @@ interface TestEntity {
     check: boolean;
 }
 
-const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event, context) => {
+interface TestSource {
+    id: string;
+    firstName: string;
+    lastName: string;
+    age: number;
+}
+
+const handler: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = async (event, context) => {
     str = event.arguments.id;
     str = event.arguments.query;
 
@@ -42,6 +49,10 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event,
     anyObj = event.info.variables;
     str = event.info.selectionSetList[0];
 
+    strOrUndefined = event.source?.id;
+    strOrUndefined = event.source?.firstName;
+    strOrUndefined = event.source?.lastName;
+    numOrUndefined = event.source?.age;
     objectOrNull = event.source;
     prevResultOrNull = event.prev;
     anyObj = (event.prev as { result: { [key: string]: any } }).result;

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -49,14 +49,23 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = a
     anyObj = event.info.variables;
     str = event.info.selectionSetList[0];
 
-    strOrUndefined = event.source ? event.source.id : undefined;
-    strOrUndefined = event.source ? event.source.firstName : undefined;
-    strOrUndefined = event.source ? event.source.lastName : undefined;
-    numOrUndefined = event.source ? event.source.age : undefined;
     objectOrNull = event.source;
     prevResultOrNull = event.prev;
     anyObj = (event.prev as { result: { [key: string]: any } }).result;
     anyObj = event.stash;
+
+    return {
+        id: '',
+        name: '',
+        check: true,
+    };
+};
+
+const handlerWithDefinedSourceTypes: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = async (event, context) => {
+    strOrUndefined = event.source ? event.source.id : undefined;
+    strOrUndefined = event.source ? event.source.firstName : undefined;
+    strOrUndefined = event.source ? event.source.lastName : undefined;
+    numOrUndefined = event.source ? event.source.age : undefined;
 
     return {
         id: '',

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -21,7 +21,7 @@ interface TestSource {
     age: number;
 }
 
-const handler: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = async (event, context) => {
+const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event, context) => {
     str = event.arguments.id;
     str = event.arguments.query;
 

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -1,6 +1,6 @@
 import { Handler } from '../handler';
 
-export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, unknown>> = Handler<AppSyncResolverEvent<TArguments, TSource>, TResults | TResults[]>;
+export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, unknown> | null> = Handler<AppSyncResolverEvent<TArguments, TSource>, TResults | TResults[]>;
 
 export interface AppSyncResolverEventHeaders {
     [name: string]: string | undefined;
@@ -11,10 +11,10 @@ export interface AppSyncResolverEventHeaders {
  *
  * @param T type of the arguments
  */
-export interface AppSyncResolverEvent<TArguments, TSource = Record<string, unknown>> {
+export interface AppSyncResolverEvent<TArguments, TSource = Record<string, unknown> | null> {
     arguments: TArguments;
     identity?: AppSyncIdentityIAM | AppSyncIdentityCognito | undefined;
-    source: TSource | null;
+    source: TSource;
     request: {
         headers: AppSyncResolverEventHeaders;
     };

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -1,6 +1,6 @@
 import { Handler } from '../handler';
 
-export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, unknown> | null> = Handler<AppSyncResolverEvent<TArguments, TSource>, TResults | TResults[]>;
+export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, any> | null> = Handler<AppSyncResolverEvent<TArguments, TSource>, TResults | TResults[]>;
 
 export interface AppSyncResolverEventHeaders {
     [name: string]: string | undefined;
@@ -11,7 +11,7 @@ export interface AppSyncResolverEventHeaders {
  *
  * @param T type of the arguments
  */
-export interface AppSyncResolverEvent<TArguments, TSource = Record<string, unknown> | null> {
+export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> | null> {
     arguments: TArguments;
     identity?: AppSyncIdentityIAM | AppSyncIdentityCognito | undefined;
     source: TSource;

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -1,6 +1,6 @@
 import { Handler } from '../handler';
 
-export type AppSyncResolverHandler<T, V> = Handler<AppSyncResolverEvent<T>, V | V[]>;
+export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, unknown>> = Handler<AppSyncResolverEvent<TArguments, TSource>, TResults | TResults[]>;
 
 export interface AppSyncResolverEventHeaders {
     [name: string]: string | undefined;
@@ -11,10 +11,10 @@ export interface AppSyncResolverEventHeaders {
  *
  * @param T type of the arguments
  */
-export interface AppSyncResolverEvent<T> {
-    arguments: T;
+export interface AppSyncResolverEvent<TArguments, TSource = Record<string, unknown>> {
+    arguments: TArguments;
     identity?: AppSyncIdentityIAM | AppSyncIdentityCognito | undefined;
-    source: { [key: string]: any } | null;
+    source: TSource | null;
     request: {
         headers: AppSyncResolverEventHeaders;
     };

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -9,7 +9,8 @@ export interface AppSyncResolverEventHeaders {
 /**
  * See https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html
  *
- * @param T type of the arguments
+ * @param TArguments type of the arguments
+ * @param TSource type of the source
  */
 export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> | null> {
     arguments: TArguments;


### PR DESCRIPTION
This adds a generic to pass the type for Source object passed to Appsync Resolver. The generic defaults to `Record<"string", unknown>` and hence will be fully backward compatible.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
