### PR TITLE
Update @ckeditor/ckeditor5-build-inline to v29

### DIFF
--- a/types/ckeditor__ckeditor5-build-inline/v28/ckeditor__ckeditor5-build-inline-tests.ts
+++ b/types/ckeditor__ckeditor5-build-inline/v28/ckeditor__ckeditor5-build-inline-tests.ts
@@ -1,0 +1,19 @@
+import BuildInline from '@ckeditor/ckeditor5-build-inline';
+import { Editor } from '@ckeditor/ckeditor5-core';
+
+class MyEditor extends Editor {}
+const editor = new MyEditor();
+
+BuildInline.create('', BuildInline.defaultConfig);
+BuildInline.builtinPlugins.forEach(Plugin => new Plugin(editor));
+
+const el = document.querySelector('#editor');
+if (el instanceof HTMLElement) {
+    BuildInline.create(el)
+        .then(editor => {
+            editor.locale.t('').startsWith('');
+        })
+        .catch(error => {
+            console.error(error);
+        });
+}

--- a/types/ckeditor__ckeditor5-build-inline/v28/index.d.ts
+++ b/types/ckeditor__ckeditor5-build-inline/v28/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ckeditor/ckeditor5-build-inline 29.0
+// Type definitions for @ckeditor/ckeditor5-build-inline 28.0
 // Project: https://ckeditor.com/docs/ckeditor5/latest/builds/index.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -80,14 +80,7 @@ export default class InlineEditor extends InlineEditorBase {
             ];
         };
         image: {
-            toolbar: [
-                'imageStyle:inline',
-                'imageStyle:block',
-                'imageStyle:side',
-                '|',
-                'toggleImageCaption',
-                'imageTextAlternative',
-            ];
+            toolbar: ['imageStyle:block', 'imageStyle:side', '|', 'imageTextAlternative'];
         };
         table: {
             contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells'];

--- a/types/ckeditor__ckeditor5-build-inline/v28/tsconfig.json
+++ b/types/ckeditor__ckeditor5-build-inline/v28/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ckeditor/ckeditor5-build-inline": [
+                "ckeditor__ckeditor5-build-inline/v28"
+            ],
+            "@ckeditor/ckeditor5-build-inline/*": [
+                "ckeditor__ckeditor5-build-inline/v28/*"
+            ],
+            "@ckeditor/*": [
+                "ckeditor__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-build-inline-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-build-inline/v28/tslint.json
+++ b/types/ckeditor__ckeditor5-build-inline/v28/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/latest/builds/guides/migration/migration-to-29.html#image-styles
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.