### PR TITLE
Add 'rotation' and 'direction' properties in the underlying JS to the 'LayoutAxis' interface

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -797,6 +797,8 @@ export interface LayoutAxis extends Axis {
     layer: 'above traces' | 'below traces';
     domain: number[];
     position: number;
+    rotation: number;
+    direction: 'counterclockwise' | 'clockwise';
     rangeslider: Partial<RangeSlider>;
     rangeselector: Partial<RangeSelector>;
     automargin: boolean;

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -285,6 +285,30 @@ const graphDiv = '#test';
     Plotly.newPlot('myDiv', data, layout, config);
 })();
 (() => {
+    // should create a polar scatterplot with a rotation and direction
+    const r: number[] = [10, 20, 30, 50, 10, 10, 0, 30];
+    const theta: number[] = [90, 80, 180, 299, 64, 71, 277, 340];
+
+    const data: Array<Partial<Plotly.PlotData>> = [
+        {
+            r,
+            theta,
+            type: 'scatterpolar',
+            name: 'group A',
+        }
+    ];
+    const layout: Partial<Plotly.PolarLayout> = {
+        angularaxis: {
+            rotation: 90,
+            direction: 'clockwise'
+        },
+        radialaxis: {
+            range: [0, 100]
+        },
+    };
+    Plotly.newPlot('myDiv', data, layout);
+})();
+(() => {
     // should create a boxplot with boxmode 'group'
     const y: number[] = [];
     const x: string[] = [];


### PR DESCRIPTION
Currently the latest version of the Plotly.js library allows for rotating and changing the direction of plots such as the `scatterplot` chart. This can be done via the `rotation` and `direction` properties on the `LayoutAxis`. I propose adding these properties to the TypeScript code to allow it to properly interface with the underlying library.

The changes have both been tested on a client application of mine locally as well as via `npm test`, and are working properly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test plotly.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [direction property](https://github.com/plotly/plotly.js/blob/bbeeda93efb56a50bafdf6f396b0abf345b5c5cb/src/plots/polar/layout_attributes.js#L206) and [rotation property](https://github.com/plotly/plotly.js/blob/bbeeda93efb56a50bafdf6f396b0abf345b5c5cb/src/plots/polar/layout_attributes.js#L216)
