### PR TITLE
[ical] Version bump: Remove unexported function

### DIFF
--- a/types/ical/ical-tests.ts
+++ b/types/ical/ical-tests.ts
@@ -19,3 +19,6 @@ event.recurrences;
 event.freebusy;
 // $ExpectType string | ParamList | undefined
 event.sequence;
+
+// @ts-expect-error
+ical.fromURL;

--- a/types/ical/index.d.ts
+++ b/types/ical/index.d.ts
@@ -4,8 +4,6 @@
 //                 Matej Vilk <https://github.com/iammatis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.9
-
-import request = require('request');
 import { RRule } from 'rrule';
 
 export type CalendarComponentType = 'VEVENT' | 'VTODO' | 'VJOURNAL' | 'VFREEBUSY' | 'VTIMEZONE' | 'VALARM';

--- a/types/ical/index.d.ts
+++ b/types/ical/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for ical 0.6
+// Type definitions for ical 0.8
 // Project: https://github.com/peterbraden/ical.js
 // Definitions by: Nick Clifford <https://github.com/nickbclifford>
 //                 Matej Vilk <https://github.com/iammatis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.9
 
 import request = require('request');
 import { RRule } from 'rrule';
@@ -27,27 +27,27 @@ export interface FreeBusy {
 // Typed as string | ParamList by default, exceptions listed below
 export type CalendarComponent = {
     type: CalendarComponentType;
-    summary?: string | undefined;
-    description?: string | undefined;
-    url?: string | undefined;
-    uid?: string | undefined;
-    location?: string | undefined;
-    start?: Date | undefined;
-    end?: Date | undefined;
-    rrule?: RRule | undefined;
-    exdate?: { [datestr: string]: Date } | undefined;
-    recurrences?: CalendarComponent[] | undefined;
-    class?: string | undefined;
-    transparency?: string | undefined;
-    geo?: Geo | undefined;
-    completion?: string | undefined;
-    completed?: Date | undefined;
-    categories?: string[] | undefined;
-    freebusy?: FreeBusy | undefined;
-    dtstamp?: Date | undefined;
-    created?: Date | undefined;
-    lastmodified?: Date | undefined;
-    recurrenceid?: Date | undefined;
+    summary?: string
+    description?: string
+    url?: string
+    uid?: string
+    location?: string
+    start?: Date
+    end?: Date
+    rrule?: RRule
+    exdate?: { [datestr: string]: Date }
+    recurrences?: CalendarComponent[]
+    class?: string
+    transparency?: string
+    geo?: Geo
+    completion?: string
+    completed?: Date
+    categories?: string[]
+    freebusy?: FreeBusy
+    dtstamp?: Date
+    created?: Date
+    lastmodified?: Date
+    recurrenceid?: Date
 } & { [prop: string]: string | ParamList | undefined };
 
 export interface Geo {
@@ -61,4 +61,3 @@ export interface FullCalendar {
 
 export function parseICS(icsData: string): FullCalendar;
 export function parseFile(filename: string): FullCalendar;
-export function fromURL(url: string, options: request.CoreOptions, callback: (error: any, data: FullCalendar) => void): void;


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - The error caught by [this test](https://github.com/peterbraden/ical.js/blob/d4830d822c064ce1f07a45ea04183059789a4366/test/test.js#L507) is `TypeError: ical.fromURL is not a function`
  - [This commit](https://github.com/peterbraden/ical.js/commit/14bfdf4eed08b6cec448a49beddbf525021e823b#diff-a717da36dca416b92146c74d0e6a1cae778967192eda55915710200af50ec829L118) appears to remove the `fromURL` function