### PR TITLE
Update @types/websocket to use a discriminated union type for Messages

### DIFF
--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -298,11 +298,17 @@ export class request extends events.EventEmitter {
     _verifyResolution(): void;
 }
 
-export interface IMessage {
-    type: string;
-    utf8Data?: string | undefined;
-    binaryData?: Buffer | undefined;
+interface IUtf8Message {
+    type: 'utf8';
+    utf8Data: string;
 }
+
+interface IBinaryMessage {
+    type: 'binary';
+    binaryData: Buffer;
+}
+
+export type Message = IUtf8Message | IBinaryMessage;
 
 export interface IBufferList extends events.EventEmitter {
     encoding: string;
@@ -500,14 +506,14 @@ export class connection extends events.EventEmitter {
     _addSocketEventListeners(): void;
 
     // Events
-    on(event: 'message', cb: (data: IMessage) => void): this;
+    on(event: 'message', cb: (data: Message) => void): this;
     on(event: 'frame', cb: (frame: frame) => void): this;
     on(event: 'close', cb: (code: number, desc: string) => void): this;
     on(event: 'error', cb: (err: Error) => void): this;
     on(event: 'drain' | 'pause' | 'resume', cb: () => void): this;
     on(event: 'ping', cb: (cancel: () => void, binaryPayload: Buffer) => void): this;
     on(event: 'pong', cb: (binaryPayload: Buffer) => void): this;
-    addListener(event: 'message', cb: (data: IMessage) => void): this;
+    addListener(event: 'message', cb: (data: Message) => void): this;
     addListener(event: 'frame', cb: (frame: frame) => void): this;
     addListener(event: 'close', cb: (code: number, desc: string) => void): this;
     addListener(event: 'error', cb: (err: Error) => void): this;

--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -298,12 +298,12 @@ export class request extends events.EventEmitter {
     _verifyResolution(): void;
 }
 
-interface IUtf8Message {
+export interface IUtf8Message {
     type: 'utf8';
     utf8Data: string;
 }
 
-interface IBinaryMessage {
+export interface IBinaryMessage {
     type: 'binary';
     binaryData: Buffer;
 }

--- a/types/websocket/websocket-tests.ts
+++ b/types/websocket/websocket-tests.ts
@@ -167,7 +167,11 @@ function clientTest2() {
             console.log(`on frame - ${frame.binaryPayload.toString()}`);
         });
         conn.on('message', data => {
-            console.log(`on message - ${data.utf8Data}`);
+            if (data.type === 'utf8') {
+                console.log(`on message - ${data.utf8Data}`);
+            } else if (data.type === 'binary') {
+                console.log(`on message - ${data.binaryData}`);
+            }
         });
     });
     client.on('connectFailed', err => {


### PR DESCRIPTION
Updating the IMessage type in the websocket package to be a discriminated union. From the source code (see link below) the websocket library's message objects have a `utf8Data` property IFF type is "utf8" and have a `binaryData` property IFF type is "binary". A discriminated union lets developers safely check what kind of message they are receiving and ensure they can only access the data of the correct type.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/theturtle32/WebSocket-Node/blob/a2cd3065167668a9685db0d5f9c4083e8a1839f0/lib/WebSocketConnection.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
