### PR TITLE
fix picomatch makeRe return type

### DIFF
--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -241,7 +241,7 @@ declare namespace picomatch {
         options?: PicomatchOptions,
         returnOutput?: boolean,
         returnState?: boolean,
-    ): typeof compileRe;
+    ): RegExp;
 
     function toRegex(source: string | RegExp, options?: { flags?: string | undefined; nocase?: boolean | undefined; debug?: boolean | undefined }): RegExp;
 

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -241,7 +241,7 @@ declare namespace picomatch {
         options?: PicomatchOptions,
         returnOutput?: boolean,
         returnState?: boolean,
-    ): RegExp;
+    ): ReturnType<typeof compileRe>;
 
     function toRegex(source: string | RegExp, options?: { flags?: string | undefined; nocase?: boolean | undefined; debug?: boolean | undefined }): RegExp;
 

--- a/types/picomatch/picomatch-tests.ts
+++ b/types/picomatch/picomatch-tests.ts
@@ -39,6 +39,7 @@ pm.toRegex(state.output);
 
 pm.scan('!./foo/*.js', { tokens: true });
 
+pm.makeRe('foo/*.js').test('foo/bar.js');
 pm.makeRe('foo/{01..25}/bar', {
     expandRange(a, b) {
       return `(<fill-range output>)`;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/micromatch/picomatch/blob/68797253c84ffaf3c5386cdeb5325920fd96726a/lib/picomatch.js#L301

`makeRe` returns a `RegExp`, but the previous type definitions used `typeof compileRe`, which was a function type. `makeRe` does return the *result* of `compileRe`, but it's not actually the `compileRe` function itself. See the linked source code.