### PR TITLE
chore(node): align doc tags with argument names, fix minor issues, camel case some arguments

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -197,7 +197,7 @@ declare module 'async_hooks' {
      * @param callbacks The `Hook Callbacks` to register
      * @return Instance used for disabling and enabling hooks
      */
-    function createHook(options: HookCallbacks): AsyncHook;
+    function createHook(callbacks: HookCallbacks): AsyncHook;
     interface AsyncResourceOptions {
         /**
          * The ID of the execution context that created this async event.
@@ -298,7 +298,7 @@ declare module 'async_hooks' {
          * @since v9.6.0
          * @param fn The function to call in the execution context of this async resource.
          * @param thisArg The receiver to be used for the function call.
-         * @param ...args Optional arguments to pass to the function.
+         * @param args Optional arguments to pass to the function.
          */
         runInAsyncScope<This, Result>(fn: (this: This, ...args: any[]) => Result, thisArg?: This, ...args: any[]): Result;
         /**

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -471,7 +471,7 @@ declare module 'buffer' {
              * @param sourceStart The offset within `buf` at which to begin comparison.
              * @param sourceEnd The offset within `buf` at which to end comparison (not inclusive).
              */
-            compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
+            compare(target: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
             /**
              * Copies data from a region of `buf` to a region in `target`, even if the `target`memory region overlaps with `buf`.
              *
@@ -521,7 +521,7 @@ declare module 'buffer' {
              * @param sourceEnd The offset within `buf` at which to stop copying (not inclusive).
              * @return The number of bytes copied.
              */
-            copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+            copy(target: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
             /**
              * Returns a new `Buffer` that references the same memory as the original, but
              * offset and cropped by the `start` and `end` indices.
@@ -546,7 +546,7 @@ declare module 'buffer' {
              * @param start Where the new `Buffer` will start.
              * @param end Where the new `Buffer` will end (not inclusive).
              */
-            slice(begin?: number, end?: number): Buffer;
+            slice(start?: number, end?: number): Buffer;
             /**
              * Returns a new `Buffer` that references the same memory as the original, but
              * offset and cropped by the `start` and `end` indices.
@@ -602,7 +602,7 @@ declare module 'buffer' {
              * @param start Where the new `Buffer` will start.
              * @param end Where the new `Buffer` will end (not inclusive).
              */
-            subarray(begin?: number, end?: number): Buffer;
+            subarray(start?: number, end?: number): Buffer;
             /**
              * Writes `value` to `buf` at the specified `offset` as big-endian.
              *
@@ -1761,7 +1761,7 @@ declare module 'buffer' {
          * @deprecated Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
-        function atob(input: string): string;
+        function atob(data: string): string;
         /**
          * Decodes a string into bytes using Latin-1 (ISO-8859), and encodes those bytes
          * into a string using Base64.
@@ -1777,7 +1777,7 @@ declare module 'buffer' {
          * @deprecated Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
-        function btoa(input: string): string;
+        function btoa(data: string): string;
     }
 }
 declare module 'node:buffer' {

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -1342,13 +1342,13 @@ declare module 'child_process' {
      * @param args List of string arguments.
      * @return The stdout from the command.
      */
-    function execFileSync(command: string): Buffer;
-    function execFileSync(command: string, options?: ExecFileSyncOptionsWithStringEncoding): string;
-    function execFileSync(command: string, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
-    function execFileSync(command: string, options?: ExecFileSyncOptions): Buffer;
-    function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithStringEncoding): string;
-    function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
-    function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptions): Buffer;
+    function execFileSync(file: string): Buffer;
+    function execFileSync(file: string, options?: ExecFileSyncOptionsWithStringEncoding): string;
+    function execFileSync(file: string, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
+    function execFileSync(file: string, options?: ExecFileSyncOptions): Buffer;
+    function execFileSync(file: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithStringEncoding): string;
+    function execFileSync(file: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
+    function execFileSync(file: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptions): Buffer;
 }
 declare module 'node:child_process' {
     export * from 'child_process';

--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -116,7 +116,10 @@ declare module 'cluster' {
          * @since v0.7.0
          * @param options The `options` argument, if present, is an object used to parameterize the sending of certain types of handles. `options` supports the following properties:
          */
-        send(message: child.Serializable, sendHandle?: child.SendHandle, callback?: (error: Error | null) => void): boolean;
+        send(message: child.Serializable, callback?: (error: Error | null) => void): boolean;
+        send(message: child.Serializable, sendHandle: child.SendHandle, callback?: (error: Error | null) => void): boolean;
+        send(message: child.Serializable, sendHandle: child.SendHandle, options?: child.MessageOptions, callback?: (error: Error | null) => void): boolean;
+
         /**
          * This function will kill the worker. In the primary, it does this
          * by disconnecting the `worker.process`, and once disconnected, killing

--- a/types/node/console.d.ts
+++ b/types/node/console.d.ts
@@ -83,7 +83,7 @@ declare module 'node:console' {
              * ```
              * @since v0.1.101
              * @param value The value tested for being truthy.
-             * @param ...message All arguments besides `value` are used as error message.
+             * @param message All arguments besides `value` are used as error message.
              */
             assert(value: any, message?: string, ...optionalParams: any[]): void;
             /**

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -29,6 +29,7 @@
  */
 declare module 'crypto' {
     import * as stream from 'node:stream';
+
     import { PeerCertificate } from 'node:tls';
     interface Certificate {
         /**
@@ -491,7 +492,7 @@ declare module 'crypto' {
          * @since v13.1.0
          * @param options `stream.transform` options
          */
-        copy(): Hash;
+        copy(options?: stream.TransformOptions): Hash;
         /**
          * Updates the hash content with the given `data`, the encoding of which
          * is given in `inputEncoding`.
@@ -503,7 +504,7 @@ declare module 'crypto' {
          * @param inputEncoding The `encoding` of the `data` string.
          */
         update(data: BinaryLike): Hash;
-        update(data: string, input_encoding: Encoding): Hash;
+        update(data: string, inputEncoding: Encoding): Hash;
         /**
          * Calculates the digest of all of the data passed to be hashed (using the `hash.update()` method).
          * If `encoding` is provided a string will be returned; otherwise
@@ -648,7 +649,7 @@ declare module 'crypto' {
          * @param inputEncoding The `encoding` of the `data` string.
          */
         update(data: BinaryLike): Hmac;
-        update(data: string, input_encoding: Encoding): Hmac;
+        update(data: string, inputEncoding: Encoding): Hmac;
         /**
          * Calculates the HMAC digest of all of the data passed using `hmac.update()`.
          * If `encoding` is
@@ -1114,9 +1115,9 @@ declare module 'crypto' {
          * @param outputEncoding The `encoding` of the return value.
          */
         update(data: BinaryLike): Buffer;
-        update(data: string, input_encoding: Encoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: Encoding): string;
-        update(data: string, input_encoding: Encoding | undefined, output_encoding: Encoding): string;
+        update(data: string, inputEncoding: Encoding): Buffer;
+        update(data: NodeJS.ArrayBufferView, inputEncoding: undefined, outputEncoding: Encoding): string;
+        update(data: string, inputEncoding: Encoding | undefined, outputEncoding: Encoding): string;
         /**
          * Once the `cipher.final()` method has been called, the `Cipher` object can no
          * longer be used to encrypt data. Attempts to call `cipher.final()` more than
@@ -1126,7 +1127,7 @@ declare module 'crypto' {
          * @return Any remaining enciphered contents. If `outputEncoding` is specified, a string is returned. If an `outputEncoding` is not provided, a {@link Buffer} is returned.
          */
         final(): Buffer;
-        final(output_encoding: BufferEncoding): string;
+        final(outputEncoding: BufferEncoding): string;
         /**
          * When using block encryption algorithms, the `Cipher` class will automatically
          * add padding to the input data to the appropriate block size. To disable the
@@ -1141,7 +1142,7 @@ declare module 'crypto' {
          * @since v0.7.1
          * @return for method chaining.
          */
-        setAutoPadding(auto_padding?: boolean): this;
+        setAutoPadding(autoPadding?: boolean): this;
     }
     interface CipherCCM extends Cipher {
         setAAD(
@@ -1427,9 +1428,9 @@ declare module 'crypto' {
          * @param outputEncoding The `encoding` of the return value.
          */
         update(data: NodeJS.ArrayBufferView): Buffer;
-        update(data: string, input_encoding: Encoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: Encoding): string;
-        update(data: string, input_encoding: Encoding | undefined, output_encoding: Encoding): string;
+        update(data: string, inputEncoding: Encoding): Buffer;
+        update(data: NodeJS.ArrayBufferView, inputEncoding: undefined, outputEncoding: Encoding): string;
+        update(data: string, inputEncoding: Encoding | undefined, outputEncoding: Encoding): string;
         /**
          * Once the `decipher.final()` method has been called, the `Decipher` object can
          * no longer be used to decrypt data. Attempts to call `decipher.final()` more
@@ -1439,7 +1440,7 @@ declare module 'crypto' {
          * @return Any remaining deciphered contents. If `outputEncoding` is specified, a string is returned. If an `outputEncoding` is not provided, a {@link Buffer} is returned.
          */
         final(): Buffer;
-        final(output_encoding: BufferEncoding): string;
+        final(outputEncoding: BufferEncoding): string;
         /**
          * When data has been encrypted without standard block padding, calling`decipher.setAutoPadding(false)` will disable automatic padding to prevent `decipher.final()` from checking for and
          * removing padding.
@@ -1551,6 +1552,7 @@ declare module 'crypto' {
      * @param encoding The string encoding when `key` is a string.
      */
     function createSecretKey(key: NodeJS.ArrayBufferView): KeyObject;
+    function createSecretKey(key: string, encoding: BufferEncoding): KeyObject;
     /**
      * Creates and returns a `Sign` object that uses the given `algorithm`. Use {@link getHashes} to obtain the names of the available digest algorithms.
      * Optional `options` argument controls the `stream.Writable` behavior.
@@ -1706,7 +1708,7 @@ declare module 'crypto' {
          * @param inputEncoding The `encoding` of the `data` string.
          */
         update(data: BinaryLike): this;
-        update(data: string, input_encoding: Encoding): this;
+        update(data: string, inputEncoding: Encoding): this;
         /**
          * Calculates the signature on all the data passed through using either `sign.update()` or `sign.write()`.
          *
@@ -1719,8 +1721,8 @@ declare module 'crypto' {
          * called. Multiple calls to `sign.sign()` will result in an error being thrown.
          * @since v0.1.92
          */
-        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
-        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput, output_format: BinaryToTextEncoding): string;
+        sign(privateKey: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
+        sign(privateKey: KeyLike | SignKeyObjectInput | SignPrivateKeyInput, outputFormat: BinaryToTextEncoding): string;
     }
     /**
      * Creates and returns a `Verify` object that uses the given algorithm.
@@ -1765,7 +1767,7 @@ declare module 'crypto' {
          * @param inputEncoding The `encoding` of the `data` string.
          */
         update(data: BinaryLike): Verify;
-        update(data: string, input_encoding: Encoding): Verify;
+        update(data: string, inputEncoding: Encoding): Verify;
         /**
          * Verifies the provided data using the given `object` and `signature`.
          *
@@ -1803,11 +1805,11 @@ declare module 'crypto' {
      * @param primeEncoding The `encoding` of the `prime` string.
      * @param generatorEncoding The `encoding` of the `generator` string.
      */
-    function createDiffieHellman(prime_length: number, generator?: number | NodeJS.ArrayBufferView): DiffieHellman;
+    function createDiffieHellman(primeLength: number, generator?: number | NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: NodeJS.ArrayBufferView): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: BinaryToTextEncoding): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: BinaryToTextEncoding, generator: number | NodeJS.ArrayBufferView): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: BinaryToTextEncoding, generator: string, generator_encoding: BinaryToTextEncoding): DiffieHellman;
+    function createDiffieHellman(prime: string, primeEncoding: BinaryToTextEncoding): DiffieHellman;
+    function createDiffieHellman(prime: string, primeEncoding: BinaryToTextEncoding, generator: number | NodeJS.ArrayBufferView): DiffieHellman;
+    function createDiffieHellman(prime: string, primeEncoding: BinaryToTextEncoding, generator: string, generatorEncoding: BinaryToTextEncoding): DiffieHellman;
     /**
      * The `DiffieHellman` class is a utility for creating Diffie-Hellman key
      * exchanges.
@@ -1886,10 +1888,10 @@ declare module 'crypto' {
          * @param inputEncoding The `encoding` of an `otherPublicKey` string.
          * @param outputEncoding The `encoding` of the return value.
          */
-        computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
-        computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding): Buffer;
-        computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: BinaryToTextEncoding): string;
-        computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding, output_encoding: BinaryToTextEncoding): string;
+        computeSecret(otherPublicKey: NodeJS.ArrayBufferView): Buffer;
+        computeSecret(otherPublicKey: string, inputEncoding: BinaryToTextEncoding): Buffer;
+        computeSecret(otherPublicKey: NodeJS.ArrayBufferView, outputEncoding: BinaryToTextEncoding): string;
+        computeSecret(otherPublicKey: string, inputEncoding: BinaryToTextEncoding, outputEncoding: BinaryToTextEncoding): string;
         /**
          * Returns the Diffie-Hellman prime in the specified `encoding`.
          * If `encoding` is provided a string is
@@ -1933,8 +1935,8 @@ declare module 'crypto' {
          * @since v0.5.0
          * @param encoding The `encoding` of the `publicKey` string.
          */
-        setPublicKey(public_key: NodeJS.ArrayBufferView): void;
-        setPublicKey(public_key: string, encoding: BufferEncoding): void;
+        setPublicKey(publicKey: NodeJS.ArrayBufferView): void;
+        setPublicKey(publicKey: string, encoding: BufferEncoding): void;
         /**
          * Sets the Diffie-Hellman private key. If the `encoding` argument is provided,`privateKey` is expected
          * to be a string. If no `encoding` is provided, `privateKey` is expected
@@ -1942,8 +1944,8 @@ declare module 'crypto' {
          * @since v0.5.0
          * @param encoding The `encoding` of the `privateKey` string.
          */
-        setPrivateKey(private_key: NodeJS.ArrayBufferView): void;
-        setPrivateKey(private_key: string, encoding: BufferEncoding): void;
+        setPrivateKey(privateKey: NodeJS.ArrayBufferView): void;
+        setPrivateKey(privateKey: string, encoding: BufferEncoding): void;
         /**
          * A bit field containing any warnings and/or errors resulting from a check
          * performed during initialization of the `DiffieHellman` object.
@@ -2006,7 +2008,7 @@ declare module 'crypto' {
      * ```
      * @since v0.7.5
      */
-    function getDiffieHellman(group_name: string): DiffieHellman;
+    function getDiffieHellman(groupName: string): DiffieHellman;
     /**
      * Provides an asynchronous Password-Based Key Derivation Function 2 (PBKDF2)
      * implementation. A selected HMAC digest algorithm specified by `digest` is
@@ -2652,7 +2654,7 @@ declare module 'crypto' {
      * object, the `padding` property can be passed. Otherwise, this function uses`RSA_PKCS1_OAEP_PADDING`.
      * @since v0.11.14
      */
-    function privateDecrypt(private_key: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
+    function privateDecrypt(privateKey: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     /**
      * Encrypts `buffer` with `privateKey`. The returned data can be decrypted using
      * the corresponding public key, for example using {@link publicDecrypt}.
@@ -2661,7 +2663,7 @@ declare module 'crypto' {
      * object, the `padding` property can be passed. Otherwise, this function uses`RSA_PKCS1_PADDING`.
      * @since v1.1.0
      */
-    function privateEncrypt(private_key: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
+    function privateEncrypt(privateKey: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     /**
      * ```js
      * const {
@@ -2881,10 +2883,10 @@ declare module 'crypto' {
          * @param inputEncoding The `encoding` of the `otherPublicKey` string.
          * @param outputEncoding The `encoding` of the return value.
          */
-        computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
-        computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding): Buffer;
-        computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: BinaryToTextEncoding): string;
-        computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding, output_encoding: BinaryToTextEncoding): string;
+        computeSecret(otherPublicKey: NodeJS.ArrayBufferView): Buffer;
+        computeSecret(otherPublicKey: string, inputEncoding: BinaryToTextEncoding): Buffer;
+        computeSecret(otherPublicKey: NodeJS.ArrayBufferView, outputEncoding: BinaryToTextEncoding): string;
+        computeSecret(otherPublicKey: string, inputEncoding: BinaryToTextEncoding, outputEncoding: BinaryToTextEncoding): string;
         /**
          * If `encoding` is specified, a string is returned; otherwise a `Buffer` is
          * returned.
@@ -2916,8 +2918,8 @@ declare module 'crypto' {
          * @since v0.11.14
          * @param encoding The `encoding` of the `privateKey` string.
          */
-        setPrivateKey(private_key: NodeJS.ArrayBufferView): void;
-        setPrivateKey(private_key: string, encoding: BinaryToTextEncoding): void;
+        setPrivateKey(privateKey: NodeJS.ArrayBufferView): void;
+        setPrivateKey(privateKey: string, encoding: BinaryToTextEncoding): void;
     }
     /**
      * Creates an Elliptic Curve Diffie-Hellman (`ECDH`) key exchange object using a
@@ -2926,7 +2928,7 @@ declare module 'crypto' {
      * and description of each available elliptic curve.
      * @since v0.11.14
      */
-    function createECDH(curve_name: string): ECDH;
+    function createECDH(curveName: string): ECDH;
     /**
      * This function is based on a constant-time algorithm.
      * Returns true if `a` is equal to `b`, without leaking timing information that
@@ -3960,7 +3962,7 @@ declare module 'crypto' {
      * @param candidate A possible prime encoded as a sequence of big endian octets of arbitrary length.
      * @return `true` if the candidate is a prime with an error probability less than `0.25 ** options.checks`.
      */
-    function checkPrimeSync(value: LargeNumberLike, options?: CheckPrimeOptions): boolean;
+    function checkPrimeSync(candidate: LargeNumberLike, options?: CheckPrimeOptions): boolean;
     namespace webcrypto {
         class CryptoKey {} // placeholder
     }

--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -84,7 +84,7 @@ declare module 'diagnostics_channel' {
          * ```
          * @param onMessage The handler to receive channel messages
          */
-        subscribe(listener: ChannelListener): void;
+        subscribe(onMessage: ChannelListener): void;
         /**
          * Remove a message handler previously registered to this channel with `channel.subscribe(onMessage)`.
          *
@@ -103,7 +103,7 @@ declare module 'diagnostics_channel' {
          * ```
          * @param onMessage The previous subscribed handler to remove
          */
-        unsubscribe(listener: ChannelListener): void;
+        unsubscribe(onMessage: ChannelListener): void;
     }
 }
 declare module 'node:diagnostics_channel' {

--- a/types/node/domain.d.ts
+++ b/types/node/domain.d.ts
@@ -127,7 +127,7 @@ declare module 'domain' {
          * @param callback The callback function
          * @return The bound function
          */
-        bind<T extends Function>(cb: T): T;
+        bind<T extends Function>(callback: T): T;
         /**
          * This method is almost identical to {@link bind}. However, in
          * addition to catching thrown errors, it will also intercept `Error` objects sent as the first argument to the function.
@@ -160,7 +160,7 @@ declare module 'domain' {
          * @param callback The callback function
          * @return The intercepted function
          */
-        intercept<T extends Function>(cb: T): T;
+        intercept<T extends Function>(callback: T): T;
     }
     function create(): Domain;
 }

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -42,11 +42,11 @@ declare module 'events' {
         captureRejections?: boolean | undefined;
     }
     interface NodeEventTarget {
-        once(event: string | symbol, listener: (...args: any[]) => void): this;
+        once(eventName: string | symbol, listener: (...args: any[]) => void): this;
     }
     interface DOMEventTarget {
         addEventListener(
-            event: string,
+            eventName: string,
             listener: (...args: any[]) => void,
             opts?: {
                 once: boolean;
@@ -72,11 +72,11 @@ declare module 'events' {
      */
     class EventEmitter {
         constructor(options?: EventEmitterOptions);
-        static once(emitter: NodeEventTarget, event: string | symbol, options?: StaticEventEmitterOptions): Promise<any[]>;
-        static once(emitter: DOMEventTarget, event: string, options?: StaticEventEmitterOptions): Promise<any[]>;
-        static on(emitter: NodeJS.EventEmitter, event: string, options?: StaticEventEmitterOptions): AsyncIterableIterator<any>;
+        static once(emitter: NodeEventTarget, eventName: string | symbol, options?: StaticEventEmitterOptions): Promise<any[]>;
+        static once(emitter: DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
+        static on(emitter: NodeJS.EventEmitter, eventName: string, options?: StaticEventEmitterOptions): AsyncIterableIterator<any>;
         /** @deprecated since v4.0.0 */
-        static listenerCount(emitter: NodeJS.EventEmitter, event: string | symbol): number;
+        static listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
         /**
          * Returns a list listener for a specific emitter event name.
          */
@@ -117,7 +117,7 @@ declare module 'events' {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+                addListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -148,7 +148,7 @@ declare module 'events' {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on(event: string | symbol, listener: (...args: any[]) => void): this;
+                on(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -177,7 +177,7 @@ declare module 'events' {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once(event: string | symbol, listener: (...args: any[]) => void): this;
+                once(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named`eventName`.
                  *
@@ -257,12 +257,12 @@ declare module 'events' {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+                removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off(event: string | symbol, listener: (...args: any[]) => void): this;
+                off(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -302,7 +302,7 @@ declare module 'events' {
                  * ```
                  * @since v0.1.26
                  */
-                listeners(event: string | symbol): Function[];
+                listeners(eventName: string | symbol): Function[];
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -332,7 +332,7 @@ declare module 'events' {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners(event: string | symbol): Function[];
+                rawListeners(eventName: string | symbol): Function[];
                 /**
                  * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -373,13 +373,13 @@ declare module 'events' {
                  * ```
                  * @since v0.1.26
                  */
-                emit(event: string | symbol, ...args: any[]): boolean;
+                emit(eventName: string | symbol, ...args: any[]): boolean;
                 /**
                  * Returns the number of listeners listening to the event named `eventName`.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
                  */
-                listenerCount(event: string | symbol): number;
+                listenerCount(eventName: string | symbol): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -397,7 +397,7 @@ declare module 'events' {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+                prependListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -413,7 +413,7 @@ declare module 'events' {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+                prependOnceListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2555,7 +2555,7 @@ declare module 'fs' {
      * @since v0.1.29
      * @param file filename or file descriptor
      */
-    export function writeFile(path: PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options: WriteFileOptions, callback: NoParamCallback): void;
+    export function writeFile(file: PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options: WriteFileOptions, callback: NoParamCallback): void;
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2586,7 +2586,7 @@ declare module 'fs' {
      * @since v0.1.29
      * @param file filename or file descriptor
      */
-    export function writeFileSync(path: PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: WriteFileOptions): void;
+    export function writeFileSync(file: PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: WriteFileOptions): void;
     /**
      * Asynchronously append data to a file, creating the file if it does not yet
      * exist. `data` can be a string or a `<Buffer>`.
@@ -2638,7 +2638,7 @@ declare module 'fs' {
      * @since v0.6.7
      * @param path filename or file descriptor
      */
-    export function appendFile(file: PathOrFileDescriptor, data: string | Uint8Array, options: WriteFileOptions, callback: NoParamCallback): void;
+    export function appendFile(path: PathOrFileDescriptor, data: string | Uint8Array, options: WriteFileOptions, callback: NoParamCallback): void;
     /**
      * Asynchronously append data to a file, creating the file if it does not exist.
      * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2706,7 +2706,7 @@ declare module 'fs' {
      * @since v0.6.7
      * @param path filename or file descriptor
      */
-    export function appendFileSync(file: PathOrFileDescriptor, data: string | Uint8Array, options?: WriteFileOptions): void;
+    export function appendFileSync(path: PathOrFileDescriptor, data: string | Uint8Array, options?: WriteFileOptions): void;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each
      * time the file is accessed.
@@ -3479,31 +3479,9 @@ declare module 'fs' {
      * @param mode modifiers for copy operation.
      */
     export function copyFile(src: PathLike, dest: PathLike, callback: NoParamCallback): void;
-    /**
-     * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
-     * No arguments other than a possible exception are given to the callback function.
-     * Node.js makes no guarantees about the atomicity of the copy operation.
-     * If an error occurs after the destination file has been opened for writing, Node.js will attempt
-     * to remove the destination.
-     * @param src A path to the source file.
-     * @param dest A path to the destination file.
-     * @param flags An integer that specifies the behavior of the copy operation. The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
-     */
-    export function copyFile(src: PathLike, dest: PathLike, flags: number, callback: NoParamCallback): void;
+    export function copyFile(src: PathLike, dest: PathLike, mode: number, callback: NoParamCallback): void;
     export namespace copyFile {
-        /**
-         * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
-         * No arguments other than a possible exception are given to the callback function.
-         * Node.js makes no guarantees about the atomicity of the copy operation.
-         * If an error occurs after the destination file has been opened for writing, Node.js will attempt
-         * to remove the destination.
-         * @param src A path to the source file.
-         * @param dest A path to the destination file.
-         * @param flags An optional integer that specifies the behavior of the copy operation.
-         * The only supported flag is fs.constants.COPYFILE_EXCL,
-         * which causes the copy operation to fail if dest already exists.
-         */
-        function __promisify__(src: PathLike, dst: PathLike, flags?: number): Promise<void>;
+        function __promisify__(src: PathLike, dst: PathLike, mode?: number): Promise<void>;
     }
     /**
      * Synchronously copies `src` to `dest`. By default, `dest` is overwritten if it
@@ -3539,7 +3517,7 @@ declare module 'fs' {
      * @param dest destination filename of the copy operation
      * @param mode modifiers for copy operation.
      */
-    export function copyFileSync(src: PathLike, dest: PathLike, flags?: number): void;
+    export function copyFileSync(src: PathLike, dest: PathLike, mode?: number): void;
     /**
      * Write an array of `ArrayBufferView`s to the file specified by `fd` using`writev()`.
      *

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -338,7 +338,7 @@ declare module 'fs/promises' {
      * `fs.constants.COPYFILE_EXCL | fs.constants.COPYFILE_FICLONE`)
      * @return Fulfills with `undefined` upon success.
      */
-    function copyFile(src: PathLike, dest: PathLike, flags?: number): Promise<void>;
+    function copyFile(src: PathLike, dest: PathLike, mode?: number): Promise<void>;
     /**
      * Opens a `<FileHandle>`.
      *
@@ -739,7 +739,7 @@ declare module 'fs/promises' {
      * @return Fulfills with `undefined` upon success.
      */
     function writeFile(
-        path: PathLike | FileHandle,
+        file: PathLike | FileHandle,
         data: string | NodeJS.ArrayBufferView | Iterable<string | NodeJS.ArrayBufferView> | AsyncIterable<string | NodeJS.ArrayBufferView> | Stream,
         options?:
             | (ObjectEncodingOptions & {

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1002,7 +1002,7 @@ declare module 'http2' {
          * @param origins One or more URL Strings passed as separate arguments.
          */
         origin(
-            ...args: Array<
+            ...origins: Array<
                 | string
                 | url.URL
                 | {

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -286,9 +286,9 @@ declare module 'net' {
          * @param callback Optional callback for when the socket is finished.
          * @return The socket itself.
          */
-        end(cb?: () => void): void;
-        end(buffer: Uint8Array | string, cb?: () => void): void;
-        end(str: Uint8Array | string, encoding?: BufferEncoding, cb?: () => void): void;
+        end(callback?: () => void): void;
+        end(buffer: Uint8Array | string, callback?: () => void): void;
+        end(str: Uint8Array | string, encoding?: BufferEncoding, callback?: () => void): void;
         /**
          * events.EventEmitter
          *   1. close
@@ -301,7 +301,7 @@ declare module 'net' {
          *   8. timeout
          */
         addListener(event: string, listener: (...args: any[]) => void): this;
-        addListener(event: 'close', listener: (had_error: boolean) => void): this;
+        addListener(event: 'close', listener: (hadError: boolean) => void): this;
         addListener(event: 'connect', listener: () => void): this;
         addListener(event: 'data', listener: (data: Buffer) => void): this;
         addListener(event: 'drain', listener: () => void): this;
@@ -310,7 +310,7 @@ declare module 'net' {
         addListener(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
         addListener(event: 'timeout', listener: () => void): this;
         emit(event: string | symbol, ...args: any[]): boolean;
-        emit(event: 'close', had_error: boolean): boolean;
+        emit(event: 'close', hadError: boolean): boolean;
         emit(event: 'connect'): boolean;
         emit(event: 'data', data: Buffer): boolean;
         emit(event: 'drain'): boolean;
@@ -319,7 +319,7 @@ declare module 'net' {
         emit(event: 'lookup', err: Error, address: string, family: string | number, host: string): boolean;
         emit(event: 'timeout'): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
-        on(event: 'close', listener: (had_error: boolean) => void): this;
+        on(event: 'close', listener: (hadError: boolean) => void): this;
         on(event: 'connect', listener: () => void): this;
         on(event: 'data', listener: (data: Buffer) => void): this;
         on(event: 'drain', listener: () => void): this;
@@ -328,7 +328,7 @@ declare module 'net' {
         on(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
         on(event: 'timeout', listener: () => void): this;
         once(event: string, listener: (...args: any[]) => void): this;
-        once(event: 'close', listener: (had_error: boolean) => void): this;
+        once(event: 'close', listener: (hadError: boolean) => void): this;
         once(event: 'connect', listener: () => void): this;
         once(event: 'data', listener: (data: Buffer) => void): this;
         once(event: 'drain', listener: () => void): this;
@@ -337,7 +337,7 @@ declare module 'net' {
         once(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
         once(event: 'timeout', listener: () => void): this;
         prependListener(event: string, listener: (...args: any[]) => void): this;
-        prependListener(event: 'close', listener: (had_error: boolean) => void): this;
+        prependListener(event: 'close', listener: (hadError: boolean) => void): this;
         prependListener(event: 'connect', listener: () => void): this;
         prependListener(event: 'data', listener: (data: Buffer) => void): this;
         prependListener(event: 'drain', listener: () => void): this;
@@ -346,7 +346,7 @@ declare module 'net' {
         prependListener(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
         prependListener(event: 'timeout', listener: () => void): this;
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: 'close', listener: (had_error: boolean) => void): this;
+        prependOnceListener(event: 'close', listener: (hadError: boolean) => void): this;
         prependOnceListener(event: 'connect', listener: () => void): this;
         prependOnceListener(event: 'data', listener: (data: Buffer) => void): this;
         prependOnceListener(event: 'drain', listener: () => void): this;

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -448,10 +448,6 @@ declare module 'os' {
      * @param priority The scheduling priority to assign to the process.
      */
     function setPriority(priority: number): void;
-    /**
-     * Sets the priority of the process specified process.
-     * @param priority Must be in range of -20 to 19
-     */
     function setPriority(pid: number, priority: number): void;
 }
 declare module 'node:os' {

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1126,7 +1126,7 @@ declare module 'process' {
                  * }
                  * ```
                  * @since v0.1.26
-                 * @param ...args Additional arguments to pass when invoking the `callback`
+                 * @param args Additional arguments to pass when invoking the `callback`
                  */
                 nextTick(callback: Function, ...args: any[]): void;
                 /**

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -312,7 +312,7 @@ declare module 'repl' {
          * @param historyPath the path to the history file
          * @param callback called when history writes are ready or upon error
          */
-        setupHistory(path: string, cb: (err: Error | null, repl: this) => void): void;
+        setupHistory(path: string, callback: (err: Error | null, repl: this) => void): void;
         /**
          * events.EventEmitter
          * 1. close - inherited from `readline.Interface`

--- a/types/node/scripts/generate-docs/ast-processing.ts
+++ b/types/node/scripts/generate-docs/ast-processing.ts
@@ -173,7 +173,7 @@ class TagHelper {
             if (!param.desc) {
                 continue;
             }
-            tags.push(this.createParamTag(param.name, param.desc));
+            tags.push(this.createParamTag(param.name.replaceAll('.', ''), param.desc));
         }
         if (sigDoc.return?.desc) {
             tags.push(this.createReturnTag(fixupLocalLinks(sigDoc.return.desc, moduleName)));
@@ -425,13 +425,14 @@ export class NodeProcessingContext {
                 status: JSDocMatchResult.Ignore,
             };
         }
-        const classDoc = matchClassOrInterfaceDoc(this.context.moduleDocs, parent as (InterfaceDeclaration | ClassDeclaration));
+        const classDoc = matchClassOrInterfaceDoc(this.context.moduleDocs, parent);
         // We already warn about missing class docs, let's not be obnoxious
         if (!classDoc) {
             return {
                 status: JSDocMatchResult.Ignore,
             };
         }
+
         const methodDocList = isStatic ? classDoc.classMethods : classDoc.methods;
         const methodDoc = methodDocList?.find(({ name }) => name === methodName);
         if (!methodDoc) {
@@ -491,7 +492,7 @@ export class NodeProcessingContext {
             const newNode = removeCommentsRecursive(node, transformationContext, typeChecker);
             addSyntheticLeadingComment(newNode, SyntaxKind.MultiLineCommentTrivia, jsdoc, true);
         } else {
-            nodeWarning(node, `Could not match doc for symbol`)
+            nodeWarning(node, `Could not match doc for symbol`);
         }
     }
 }

--- a/types/node/scripts/generate-docs/docs.ts
+++ b/types/node/scripts/generate-docs/docs.ts
@@ -40,7 +40,7 @@ function transformer(printer: Printer, typeChecker: TypeChecker, rootDocs: DocRo
             if (!isNamedModuleDeclaration(node)) {
                 return node;
             }
-            let moduleName = node.name.text;
+            const moduleName = node.name.text;
 
             // skip non prefixed modules
             if (moduleName.startsWith('node:')) {

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -376,7 +376,7 @@ declare module 'stream' {
              * @since v0.9.4
              * @param stream An "old style" readable stream
              */
-            wrap(oldStream: NodeJS.ReadableStream): this;
+            wrap(stream: NodeJS.ReadableStream): this;
             push(chunk: any, encoding?: BufferEncoding): boolean;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             /**
@@ -591,8 +591,8 @@ declare module 'stream' {
              * @param callback Callback for when this chunk of data is flushed.
              * @return `false` if the stream wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
              */
-            write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
-            write(chunk: any, encoding: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
+            write(chunk: any, callback?: (error: Error | null | undefined) => void): boolean;
+            write(chunk: any, encoding: BufferEncoding, callback?: (error: Error | null | undefined) => void): boolean;
             /**
              * The `writable.setDefaultEncoding()` method sets the default `encoding` for a `Writable` stream.
              * @since v0.11.15

--- a/types/node/test/cluster.ts
+++ b/types/node/test/cluster.ts
@@ -1,3 +1,4 @@
+import { connect } from 'net';
 import cluster, { ClusterSettings, Worker } from 'node:cluster'; // requires synthetic default imports, is this worth it?
 cluster.fork();
 Object.keys(cluster.workers!).forEach(key => {
@@ -5,9 +6,12 @@ Object.keys(cluster.workers!).forEach(key => {
     if (worker && worker.isDead()) {
         console.log('worker %d is dead', worker.process.pid);
     }
+    worker!.send('test', () => { });
+    worker!.send('', connect({ port: 1 }));
+    worker!.send('', connect({ port: 1 }), { keepOpen: true }, () => { });
 });
 
-cluster.on('setup', (settings: ClusterSettings) => {});
+cluster.on('setup', (settings: ClusterSettings) => { });
 
 {
     cluster.setupPrimary({

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -3,7 +3,9 @@ import assert = require('node:assert');
 import { promisify } from 'node:util';
 
 {
-    const copied: crypto.Hash = crypto.createHash('md5').copy();
+    const copied: crypto.Hash = crypto.createHash('md5').copy().copy({
+        encoding: 'ascii',
+    });
 }
 
 {
@@ -749,6 +751,7 @@ import { promisify } from 'node:util';
     keyObject instanceof crypto.KeyObject;
     assert.equal(keyObject.symmetricKeySize, 4);
     assert.equal(keyObject.type, 'secret');
+    crypto.createSecretKey('ascii', 'ascii');
 }
 
 {

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -91,6 +91,10 @@ import * as url from 'node:url';
         assert.equal(me, searchParams);
     });
 
+    searchParams.forEach(function() {
+        this; // $ExpectType number
+    }, 1);
+
     assert.equal(searchParams.get('abc'), '123');
 
     searchParams.append('abc', 'xyz');

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -137,9 +137,9 @@ assert(typeof util.promisify.custom === 'symbol');
 const foo = () => {};
 // $ExpectType () => void
 util.deprecate(foo, 'foo() is deprecated, use bar() instead');
-// $ExpectType <T extends Function>(fn: T, message: string, code?: string | undefined) => T
+// $ExpectType <T extends Function>(fn: T, msg: string, code?: string | undefined) => T
 util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
-// $ExpectType <T extends Function>(fn: T, message: string, code?: string | undefined) => T
+// $ExpectType <T extends Function>(fn: T, msg: string, code?: string | undefined) => T
 util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead', 'DEP0001');
 
 // util.isDeepStrictEqual
@@ -177,3 +177,9 @@ const teEncodeRes: Uint8Array = te.encode("TextEncoder");
 const encIntoRes: util.EncodeIntoResult = te.encodeInto('asdf', new Uint8Array(16));
 
 const errorMap: Map<number, [string, string]> = util.getSystemErrorMap();
+
+{
+    const logger: util.DebugLogger = util.debuglog('section');
+    logger.enabled; // $ExpectType boolean
+    util.debuglog('section', (fn: util.DebugLoggerFunction) => { });
+}

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -560,7 +560,7 @@ declare module 'tls' {
          * @param hostname A SNI host name or wildcard (e.g. `'*'`)
          * @param context An object containing any of the possible properties from the {@link createSecureContext} `options` arguments (e.g. `key`, `cert`, `ca`, etc).
          */
-        addContext(hostName: string, credentials: SecureContextOptions): void;
+        addContext(hostname: string, context: SecureContextOptions): void;
         /**
          * Returns the session ticket keys.
          *
@@ -575,7 +575,7 @@ declare module 'tls' {
          * @since v11.0.0
          * @param options An object containing any of the possible properties from the {@link createSecureContext} `options` arguments (e.g. `key`, `cert`, `ca`, etc).
          */
-        setSecureContext(details: SecureContextOptions): void;
+        setSecureContext(options: SecureContextOptions): void;
         /**
          * Sets the session ticket keys.
          *
@@ -825,7 +825,7 @@ declare module 'tls' {
      * @param hostname The host name or IP address to verify the certificate against.
      * @param cert A `certificate object` representing the peer's certificate.
      */
-    function checkServerIdentity(host: string, cert: PeerCertificate): Error | undefined;
+    function checkServerIdentity(hostname: string, cert: PeerCertificate): Error | undefined;
     /**
      * Creates a new {@link Server}. The `secureConnectionListener`, if provided, is
      * automatically set as a listener for the `'secureConnection'` event.
@@ -949,7 +949,7 @@ declare module 'tls' {
      * @param requestCert `true` to specify whether a server should request a certificate from a connecting client. Only applies when `isServer` is `true`.
      * @param rejectUnauthorized If not `false` a server automatically reject clients with invalid certificates. Only applies when `isServer` is `true`.
      */
-    function createSecurePair(credentials?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
+    function createSecurePair(context?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
     /**
      * {@link createServer} sets the default value of the `honorCipherOrder` option
      * to `true`, other APIs that create secure contexts leave it unset.

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -155,7 +155,7 @@ declare module 'tty' {
          * @since v9.9.0
          * @param env An object containing the environment variables to check. This enables simulating the usage of a specific terminal.
          */
-        getColorDepth(env?: {}): number;
+        getColorDepth(env?: object): number;
         /**
          * Returns `true` if the `writeStream` supports at least as many colors as provided
          * in `count`. Minimum support is 2 (black and white).
@@ -176,9 +176,9 @@ declare module 'tty' {
          * @param count The number of colors that are requested (minimum 2).
          * @param env An object containing the environment variables to check. This enables simulating the usage of a specific terminal.
          */
-        hasColors(depth?: number): boolean;
-        hasColors(env?: {}): boolean;
-        hasColors(depth: number, env?: {}): boolean;
+        hasColors(count?: number): boolean;
+        hasColors(env?: object): boolean;
+        hasColors(count: number, env?: object): boolean;
         /**
          * `writeStream.getWindowSize()` returns the size of the `TTY` corresponding to this `WriteStream`. The array is of the type`[numColumns, numRows]` where `numColumns` and `numRows` represent
          * the number

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -70,13 +70,10 @@ declare module 'url' {
      * @param slashesDenoteHost If `true`, the first token after the literal string `//` and preceding the next `/` will be interpreted as the `host`. For instance, given `//foo/bar`, the result
      * would be `{host: 'foo', pathname: '/bar'}` rather than `{pathname: '//foo/bar'}`.
      */
-    function parse(urlStr: string): UrlWithStringQuery;
-    /** @deprecated since v11.0.0 - Use the WHATWG URL API. */
-    function parse(urlStr: string, parseQueryString: false | undefined, slashesDenoteHost?: boolean): UrlWithStringQuery;
-    /** @deprecated since v11.0.0 - Use the WHATWG URL API. */
-    function parse(urlStr: string, parseQueryString: true, slashesDenoteHost?: boolean): UrlWithParsedQuery;
-    /** @deprecated since v11.0.0 - Use the WHATWG URL API. */
-    function parse(urlStr: string, parseQueryString: boolean, slashesDenoteHost?: boolean): Url;
+    function parse(urlString: string): UrlWithStringQuery;
+    function parse(urlString: string, parseQueryString: false | undefined, slashesDenoteHost?: boolean): UrlWithStringQuery;
+    function parse(urlString: string, parseQueryString: true, slashesDenoteHost?: boolean): UrlWithParsedQuery;
+    function parse(urlString: string, parseQueryString: boolean, slashesDenoteHost?: boolean): Url;
     /**
      * The `url.format()` method returns a formatted URL string derived from`urlObject`.
      *
@@ -140,8 +137,7 @@ declare module 'url' {
      * @deprecated Legacy: Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
-    function format(URL: URL, options?: URLFormatOptions): string;
-    /** @deprecated since v11.0.0 - Use the WHATWG URL API. */
+    function format(urlObject: URL, options?: URLFormatOptions): string;
     function format(urlObject: UrlObject | string): string;
     /**
      * The `url.resolve()` method resolves a target URL relative to a base URL in a
@@ -313,7 +309,7 @@ declare module 'url' {
      * @param path The path to convert to a File URL.
      * @return The file URL object.
      */
-    function pathToFileURL(url: string): URL;
+    function pathToFileURL(path: string): URL;
     /**
      * This utility function converts a URL object into an ordinary options object as
      * expected by the `http.request()` and `https.request()` APIs.
@@ -758,7 +754,7 @@ declare module 'url' {
          * @param fn Invoked for each name-value pair in the query
          * @param thisArg To be used as `this` value for when `fn` is called
          */
-        forEach(callback: (value: string, name: string, searchParams: this) => void): void;
+        forEach<TThis = this>(callback: (this: TThis, value: string, name: string, searchParams: this) => void, thisArg?: TThis): void;
         /**
          * Returns the value of the first name-value pair whose name is `name`. If there
          * are no such pairs, `null` is returned.

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -451,6 +451,10 @@ declare module 'util' {
      * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
+    export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;
+    export interface DebugLogger extends DebugLoggerFunction {
+        enabled: boolean;
+    }
     /**
      * The `util.debuglog()` method is used to create a function that conditionally
      * writes debug messages to `stderr` based on the existence of the `NODE_DEBUG`environment variable. If the `section` name appears within the value of that
@@ -508,7 +512,7 @@ declare module 'util' {
      * @param callback A callback invoked the first time the logging function is called with a function argument that is a more optimized logging function.
      * @return The logging function
      */
-    export function debuglog(key: string): (msg: string, ...param: unknown[]) => void;
+    export function debuglog(section: string, callback?: (fn: DebugLoggerFunction) => void): DebugLogger;
     /**
      * Returns `true` if the given `object` is a `Boolean`. Otherwise, returns `false`.
      *
@@ -768,7 +772,7 @@ declare module 'util' {
      * @param code A deprecation code. See the `list of deprecated APIs` for a list of codes.
      * @return The deprecated function wrapped to emit a warning.
      */
-    export function deprecate<T extends Function>(fn: T, message: string, code?: string): T;
+    export function deprecate<T extends Function>(fn: T, msg: string, code?: string): T;
     /**
      * Returns `true` if there is deep strict equality between `val1` and `val2`.
      * Otherwise, returns `false`.
@@ -1050,7 +1054,7 @@ declare module 'util' {
          * @param src The text to encode.
          * @param dest The array to hold the encode result.
          */
-        encodeInto(input: string, output: Uint8Array): EncodeIntoResult;
+        encodeInto(src: string, dest: Uint8Array): EncodeIntoResult;
     }
 }
 declare module 'util/types' {

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -217,7 +217,7 @@ declare module 'v8' {
      * worker thread.
      * @return The filename where the snapshot was saved.
      */
-    function writeHeapSnapshot(fileName?: string): string;
+    function writeHeapSnapshot(filename?: string): string;
     /**
      * Returns an object with the following properties:
      *
@@ -353,7 +353,7 @@ declare module 'v8' {
      * @since v8.0.0
      * @param buffer A buffer returned by {@link serialize}.
      */
-    function deserialize(data: NodeJS.TypedArray): any;
+    function deserialize(buffer: NodeJS.TypedArray): any;
     /**
      * The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE` to disk on demand. This method can be invoked multiple
      * times during the lifetime of the process. Each time the execution counter will

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -191,7 +191,7 @@ declare module 'vm' {
          * @param contextifiedObject A `contextified` object as returned by the `vm.createContext()` method.
          * @return the result of the very last statement executed in the script.
          */
-        runInContext(contextifiedSandbox: Context, options?: RunningScriptOptions): any;
+        runInContext(contextifiedObject: Context, options?: RunningScriptOptions): any;
         /**
          * First contextifies the given `contextObject`, runs the compiled code contained
          * by the `vm.Script` object within the created context, and returns the result.
@@ -218,7 +218,7 @@ declare module 'vm' {
          * @param contextObject An object that will be `contextified`. If `undefined`, a new object will be created.
          * @return the result of the very last statement executed in the script.
          */
-        runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
+        runInNewContext(contextObject?: Context, options?: RunningScriptOptions): any;
         /**
          * Runs the compiled code contained by the `vm.Script` within the context of the
          * current `global` object. Running code does not have access to local scope, but_does_ have access to the current `global` object.
@@ -340,7 +340,7 @@ declare module 'vm' {
      * @param contextifiedObject The `contextified` object that will be used as the `global` when the `code` is compiled and run.
      * @return the result of the very last statement executed in the script.
      */
-    function runInContext(code: string, contextifiedSandbox: Context, options?: RunningScriptOptions | string): any;
+    function runInContext(code: string, contextifiedObject: Context, options?: RunningScriptOptions | string): any;
     /**
      * The `vm.runInNewContext()` first contextifies the given `contextObject` (or
      * creates a new `contextObject` if passed as `undefined`), compiles the `code`,
@@ -369,7 +369,7 @@ declare module 'vm' {
      * @param contextObject An object that will be `contextified`. If `undefined`, a new object will be created.
      * @return the result of the very last statement executed in the script.
      */
-    function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions | string): any;
+    function runInNewContext(code: string, contextObject?: Context, options?: RunningScriptOptions | string): any;
     /**
      * `vm.runInThisContext()` compiles `code`, runs it within the context of the
      * current `global` and returns the result. Running code does not have access to

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -583,7 +583,7 @@ declare module 'worker_threads' {
      * @param port The message port to transfer.
      * @param contextifiedSandbox A `contextified` object as returned by the `vm.createContext()` method.
      */
-    function moveMessagePortToContext(port: MessagePort, context: Context): MessagePort;
+    function moveMessagePortToContext(port: MessagePort, contextifiedSandbox: Context): MessagePort;
     /**
      * Receive a single message from a given `MessagePort`. If no message is available,`undefined` is returned, otherwise an object with a single `message` property
      * that contains the message payload, corresponding to the oldest message in the`MessagePort`’s queue.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


### Changes
- Changed snake_case variables to be camelCase.
- Aligned param names w/ jsdoc (official nodejs docs).
- Added missing `util.debuglog` features
- Added missing `copy` param to `crypto.Hash`
- Made doc generator remove `...` in vararg arguments.
- Added missing `cluster.Worker.send` overloads.
- Added missing `thisArg` in `URL.forEach`
- Added missing `crypto.createSecretKey` overload.
