### PR TITLE
Fix an issue with tsc compiler

### DIFF
--- a/types/require-dir/index.d.ts
+++ b/types/require-dir/index.d.ts
@@ -14,4 +14,4 @@ interface options {
 
 declare function requireDir(directory: string, options?: options): { [path: string]: any };
 
-export = requireDir;
+export default requireDir;


### PR DESCRIPTION
It fixes this error
```
 ../node_modules/@types/require-dir/index.d.ts:17:1
    17 export = requireDir;
       ~~~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```

