### PR TITLE
add missing Howl.seek() function overloads

### DIFF
--- a/types/howler/howler-tests.ts
+++ b/types/howler/howler-tests.ts
@@ -54,3 +54,11 @@ const id2 = sound5.play();
 // Fade out the first sound and speed up the second.
 sound5.fade(1, 0, 1000, id1);
 sound5.rate(1.5, id2);
+
+// Get/set the position of playback for a sound
+sound5.seek();
+sound5.seek(5);
+
+// Get/set the position of playback for a sound by id
+sound5.seek(id1);
+sound5.seek(id1, 5);

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -208,6 +208,8 @@ export class Howl {
     rate(idOrSetRate: number): this | number;
     rate(rate: number, id: number): this;
 
+    seek(): number;
+    seek(idOrSetSeek: number): this | number;
     seek(seek?: number, id?: number): this | number;
 
     loop(id?: number): boolean;

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -210,7 +210,7 @@ export class Howl {
 
     seek(): number;
     seek(idOrSetSeek: number): this | number;
-    seek(seek?: number, id?: number): this | number;
+    seek(seek: number, id: number): this;
 
     loop(id?: number): boolean;
     loop(loop: boolean, id?: number): this;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/goldfire/howler.js#seekseek-id>

document mentions seek function optionally takes 0, 1 or 2 arguments. but seek function with 1 argument can be confuse, it could be set the position of playback for a sound Or get the position of playback by id, here is [sample](https://codesandbox.io/s/epic-agnesi-j2mjq?file=/src/index.js) of seek function's return type

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
