### PR TITLE
fix(node): bring back fs.promises.FileHandle.write

### DIFF
--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -119,7 +119,6 @@ declare module 'cluster' {
         send(message: child.Serializable, callback?: (error: Error | null) => void): boolean;
         send(message: child.Serializable, sendHandle: child.SendHandle, callback?: (error: Error | null) => void): boolean;
         send(message: child.Serializable, sendHandle: child.SendHandle, options?: child.MessageOptions, callback?: (error: Error | null) => void): boolean;
-
         /**
          * This function will kill the worker. In the primary, it does this
          * by disconnecting the `worker.process`, and once disconnected, killing

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -29,7 +29,6 @@
  */
 declare module 'crypto' {
     import * as stream from 'node:stream';
-
     import { PeerCertificate } from 'node:tls';
     interface Certificate {
         /**

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -230,6 +230,41 @@ declare module 'fs/promises' {
          */
         writeFile(data: string | Uint8Array, options?: (ObjectEncodingOptions & FlagAndOpenMode & Abortable) | BufferEncoding | null): Promise<void>;
         /**
+         * Write `buffer` to the file.
+         *
+         * The promise is resolved with an object containing two properties:
+         *
+         * It is unsafe to use `filehandle.write()` multiple times on the same file
+         * without waiting for the promise to be resolved (or rejected). For this
+         * scenario, use `fs.createWriteStream()`.
+         *
+         * On Linux, positional writes do not work when the file is opened in append mode.
+         * The kernel ignores the position argument and always appends the data to
+         * the end of the file.
+         * @since v10.0.0
+         * @param offset The start position from within `buffer` where the data to write begins.
+         * @param length The number of bytes from `buffer` to write.
+         * @param position The offset from the beginning of the file where the data from `buffer` should be written. If `position` is not a `number`, the data will be written at the current position.
+         * See the POSIX pwrite(2) documentation for more detail.
+         */
+        write<TBuffer extends Uint8Array>(
+            buffer: TBuffer,
+            offset?: number | null,
+            length?: number | null,
+            position?: number | null
+        ): Promise<{
+            bytesWritten: number;
+            buffer: TBuffer;
+        }>;
+        write(
+            data: string,
+            position?: number | null,
+            encoding?: BufferEncoding | null
+        ): Promise<{
+            bytesWritten: number;
+            buffer: string;
+        }>;
+        /**
          * Write an array of [&lt;ArrayBufferView&gt;](https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView)s to the file.
          *
          * The promise is resolved with an object containing a two properties:

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -367,6 +367,9 @@ async () => {
         position: 2,
         length: 3,
     })).buffer; // $ExpectType Uint32Array
+
+    await handle.write('hurr', 0, 'utf-8');
+    await handle.write(Buffer.from('hurr'), 0, 42, 10);
 };
 
 async () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#fs_filehandle_write_string_position_encoding
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Fixes #54738