### PR TITLE
[bson]: add missing toString method for ObjectId

### DIFF
--- a/types/bson/bson-tests.ts
+++ b/types/bson/bson-tests.ts
@@ -47,6 +47,9 @@ console.log(EJSON.stringify(doc, undefined, 2));
 let doc2 = { int32: new Int32(10), _id: new ObjectId() };
 const text = '{ "int32": { "$numberInt": "10" } }';
 
+const objId = new ObjectId();
+objId.toString("utf8");
+
 let o: {}
 o = EJSON.parse (text, { relaxed: false });
 console.log(EJSON.stringify(o));

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -395,6 +395,15 @@ export class ObjectId {
      * @return {string} return the 12 byte id binary string.
      */
     static generate(time?: number): Buffer;
+
+    /**
+     * Converts the id into a 24 character hex string for printing
+     *
+     * @param format - The Buffer toString format parameter.
+     * @internal
+     */
+    toString(format?: string): string;
+
     /**
      * Returns the generation date (accurate up to the second) that this ID was generated.
      * @return {Date} the generation date


### PR DESCRIPTION
Ran into this when trying to enable typescript-eslint's `no-base-to-string`
rule.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-base-to-string.md

Definition for the method:

https://github.com/mongodb/js-bson/blob/6ceaa05a68c1a89e43b3b6d0002e5bab69e2613f/src/objectid.ts#L193

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/js-bson/blob/6ceaa05a68c1a89e43b3b6d0002e5bab69e2613f/src/objectid.ts#L193
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.