### PR TITLE
[matter-js] Add SAT class

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -2410,7 +2410,7 @@ declare namespace Matter {
         * @param {body[]} bodies
         * @return {object[]} Collisions
         */
-        static collides(body: Body, bodies: Array<Body>): Array<any>;
+        static collides(body: Body, bodies: Array<Body>): Array<ICollision>;
 
         /**
          * Casts a ray segment against a set of bodies and returns all collisions, ray width is optional. Intersection points are not provided.
@@ -2421,7 +2421,7 @@ declare namespace Matter {
          * @param {number} [rayWidth]
          * @return {object[]} Collisions
          */
-        static ray(bodies: Array<Body>, startPoint: Vector, endPoint: Vector, rayWidth?: number): Array<any>;
+        static ray(bodies: Array<Body>, startPoint: Vector, endPoint: Vector, rayWidth?: number): Array<ICollision>;
 
         /**
          * Returns all bodies whose bounds are inside (or outside if set) the given set of bounds, from the given set of bodies.

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -4013,4 +4013,37 @@ declare namespace Matter {
         static versionSatisfies(version: string, range: string): boolean;
 
     }
+
+    export interface ICollision {
+        collided: boolean;
+        axisNumber: Number;
+        axisBody: Body;
+        bodyA: Body;
+        bodyB: Body;
+        parentA: Body;
+        parentB: Body;
+        depth: Number;
+        normal: Vector;
+        tangent: Vector;
+        penetration: Vector;
+        supports: Array<Vector>;
+        reused?: boolean | undefined;
+    }
+
+    /**
+    * The `Matter.SAT` module contains methods for detecting collisions using the Separating Axis Theorem.
+    *
+    * @class SAT
+    */
+    export class SAT {
+        /**
+         * Detect collision between two bodies using the Separating Axis Theorem.
+         * @method collides
+         * @param {Body} bodyA
+         * @param {Body} bodyB
+         * @param {Collision} previousCollision
+         * @return {Collision} collision
+         */
+        static collides(bodyA: Body, bodyB: Body, previousCollision?: ICollision): ICollision;
+    }
 }

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -10,6 +10,7 @@ var Engine = Matter.Engine,
     Query = Matter.Query,
     Plugin = Matter.Plugin,
     Render = Matter.Render,
+    SAT = Matter.SAT,
     Mouse = Matter.Mouse,
     MouseConstraint = Matter.MouseConstraint;
 
@@ -135,3 +136,9 @@ Composite.add(composite1, constraint1);
 Composite.add(composite1, mouseConstraint);
 // $ExpectType Composite
 Composite.add(composite3, [box1, composite2, constraint1, mouseConstraint]);
+
+// SAT
+// $ExpectType ICollision
+var collision = SAT.collides(box1, box2);
+// $ExpectType ICollision
+SAT.collides(box3, box4, collision);


### PR DESCRIPTION
This PR adds the missing `SAT` class with its single function `collides`. The official documentation doesn't give an explicit definition of a `Collision`, so I've added an `ICollision` interface based on how the object is composed in [the source code](https://github.com/liabru/matter-js/blob/081645474c4aa798e5b1ede5d5230b0ecb8835d2/src/collision/SAT.js). I've also made changes to functions which return this type in the `Query` class.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://brm.io/matter-js/docs/classes/SAT.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
