### PR TITLE
sharedb: add `Connection` properties

### DIFF
--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -9,6 +9,18 @@ export class Connection {
     // ShareDB, but it is handy for server-side only user code that may cache
     // state on the agent and read it in middleware
     agent: Agent | null;
+
+    collections: Record<string, Record<string, Doc>>;
+    queries: Record<string, Query>;
+
+    seq: number;
+    id: string | null; // Equals agent.src on the server
+    nextQueryId: number;
+    nextSnapshotRequestId: number;
+
+    state: string;
+    debug: boolean;
+
     close(): void;
     get(collectionName: string, documentID: string): Doc;
     createFetchQuery<T = any>(collectionName: string, query: any, options?: {results?: Array<Doc<T>>} | null, callback?: (err: Error, results: Array<Doc<T>>) => void): Query<T>;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -333,6 +333,8 @@ function startClient(callback) {
         console.log(snapshot.data);
     });
 
+    console.log(connection.id + connection.seq);
+
     interface PresenceValue {
         foo: number;
     }


### PR DESCRIPTION
The type definition for the `Connection` class is currently missing most
of its [instance properties][1]. This change adds the non-prefixed
properties to the type definitions.

[1]: https://github.com/share/sharedb/blob/5c9148dc44d2c43582386875ed76c08070cfce3f/lib/client/connection.js#L39-L73

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.