### PR TITLE
[node:fs]: Replace 'string' with 'BufferEncoding' for stream api options

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3387,7 +3387,7 @@ declare module 'fs' {
      * @since v0.1.31
      * @return See `Readable Stream`.
      */
-    export function createReadStream(path: PathLike, options?: string | ReadStreamOptions): ReadStream;
+    export function createReadStream(path: PathLike, options?: BufferEncoding | ReadStreamOptions): ReadStream;
     /**
      * `options` may also include a `start` option to allow writing data at some
      * position past the beginning of the file, allowed values are in the
@@ -3415,7 +3415,7 @@ declare module 'fs' {
      * @since v0.1.31
      * @return See `Writable Stream`.
      */
-    export function createWriteStream(path: PathLike, options?: string | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX[`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

[`fs.createReadStream(path[, options])`](https://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options)
[`fs.createWriteStream(path[, options])`](https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options)

It also says that this is correct right on top of my edit in the source, namely:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/85c631d3f8370478fd5d6d1d2a7abb316d854d05/types/node/fs.d.ts#L3386

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/85c631d3f8370478fd5d6d1d2a7abb316d854d05/types/node/fs.d.ts#L3414

