### PR TITLE
Added Types for `mail-notifier`

### DIFF
--- a/types/mail-notifier/index.d.ts
+++ b/types/mail-notifier/index.d.ts
@@ -1,0 +1,76 @@
+// Type definitions for mail-notifier 0.5
+// Project: https://github.com/jcreigno/nodejs-mail-notifier#readme
+// Definitions by: Jack Hedaya <https://github.com/jackHedaya>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function mailNotifier(params: mailNotifier.NotifierParams): mailNotifier.Notifier;
+
+declare namespace mailNotifier {
+    export type EmailContent = {
+        html: string;
+        text: string;
+        headers: {
+            'delivered-to': string;
+            received: string[];
+            'x-received': string[];
+            'arc-seal': string;
+            'arc-message-signature': string;
+            'arc-authentication-results': string;
+            'return-path': string;
+            'received-spf': string;
+            'authentication-results': string;
+            'dkim-signature': string;
+            'x-google-dkim-signature': string;
+            'x-gm-message-state': string;
+            'x-google-smtp-source': string;
+            'mime-version': string;
+            from: string;
+            date: string;
+            'message-id': string;
+            subject: string;
+            to: string;
+            'content-type': string;
+        };
+        subject: string;
+        messageId: string;
+        priority: string;
+        from: { address: string; name: string }[];
+        to: { address: string; name: string }[];
+        date: string;
+        receivedDate: string;
+        uid: 16;
+        flags: ['\\Seen'];
+    };
+
+    interface NotifierEvents {
+        end: () => void;
+        mail: (email: EmailContent) => void;
+        error: (error: string) => void;
+    }
+
+    export interface Notifier {
+        on<U extends keyof NotifierEvents>(event: U, listener: NotifierEvents[U]): this;
+
+        emit<U extends keyof NotifierEvents>(event: U, ...args: Parameters<NotifierEvents[U]>): boolean;
+
+        start: () => this;
+        stop: () => this;
+        scan: (callback: () => void) => this;
+    }
+
+    type NotifierParams = {
+        user: string;
+        /**
+         * @deprecated
+         */
+        username?: string;
+        password: string;
+        box?: string | 'INBOX';
+        host: string;
+        port: number;
+        tls: boolean;
+        tlsOptions: { rejectUnauthorized: boolean };
+    };
+}
+
+export = mailNotifier;

--- a/types/mail-notifier/mail-notifier-tests.ts
+++ b/types/mail-notifier/mail-notifier-tests.ts
@@ -1,0 +1,20 @@
+/// <reference types="node" />
+
+import * as notifier from 'mail-notifier';
+
+const a = notifier({
+    user: 'hello',
+    password: 'world',
+    host: 'imap.gmail.com',
+    port: 993,
+    tls: true,
+    tlsOptions: { rejectUnauthorized: false },
+})
+    .on('mail', mail => {
+        console.log(mail);
+    })
+    .on('error', e => {
+        if (!e.toString().includes('Invalid credentials')) throw e;
+    })
+    .start()
+    .stop();

--- a/types/mail-notifier/tsconfig.json
+++ b/types/mail-notifier/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "mail-notifier-tests.ts"
+    ]
+}

--- a/types/mail-notifier/tslint.json
+++ b/types/mail-notifier/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
*Help needed*

Hey! Have the definitions down for this but am unsure how to resolve the issue of setting `esModuleInterop=true` in the linting and testing. I attempted to add it to the local `tsconfig.json` but it did nothing. Maybe my declaration file is off? Usage should look as it does in `mail-notifier-tests.ts`.

Thank you so much.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
