### PR TITLE
frida-gum: add type inference to NativeFunction, SystemFunction and NativeCallback

### DIFF
--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -35,15 +35,6 @@ p.blend(ptr(42));
 // $ExpectError
 p.blend();
 
-const otherPuts = new NativeCallback(() => {
-    return 0;
-}, "int", ["pointer"]);
-
-const puts = new NativeFunction(Module.getExportByName(null, "puts"), "int", ["pointer"]);
-
-// $ExpectType NativeFunction
-puts;
-
 // $ExpectType NativePointer
 Memory.alloc(1);
 // $ExpectType NativePointer
@@ -55,33 +46,78 @@ Memory.alloc(1, { near: ptr(1234) });
 // $ExpectError
 Memory.alloc(1, { maxDistance: 42 });
 
-const message = Memory.allocUtf8String("Hello!");
+new NativeCallback(
+    (a, b) => {
+        return [0, NULL];
+    },
+    ["int", "pointer"],
+    ["pointer", "uint64"],
+);
+
+new NativeCallback(
+    (a, b) => {
+        return 0;
+    },
+    "uint64",
+    [["double", "float", "uchar"], "ssize_t"],
+);
+
+const otherPuts = new NativeCallback(
+    a => {
+        return 0;
+    },
+    "int",
+    ["pointer"],
+);
+
+// $ExpectError
+new NativeFunction(NULL, "void", "pointer");
+
+// $ExpectType NativeFunction<void, []>
+const nf0 = new NativeFunction(NULL, "void", []);
+// $ExpectError
+nf0({} as any);
+
+// $ExpectType NativeFunction<[number, number], [number | Int64, [number, [NativePointerValue, NativePointerValue]]]>
+const nf1 = new NativeFunction(NULL, ["float", "float"], ["int64", ["bool", ["pointer", "pointer"]]]);
+// $ExpectType [number, number]
+nf1(int64(0), [+false, [NULL, NULL]]);
+// $ExpectType [number, number]
+nf1(1, [+true, [NULL, ptr(0xbeef)]]);
+
+// $ExpectType NativeFunction<void, [number, ...NativePointerValue[]]>
+const nf2 = new NativeFunction(NULL, "void", ["long", "...", "pointer"]);
+// $ExpectType void
+nf2(34, NULL, nf2, { handle: ptr(0xbeef) });
+
+// $ExpectType NativeFunction<number, [NativePointerValue]>
+const puts = new NativeFunction(Module.getExportByName(null, "puts"), "int", ["pointer"]);
 
 // $ExpectType NativePointer
-message;
+const message = Memory.allocUtf8String("Hello!");
 
-// $ExpectType NativeReturnValue
+// $ExpectType number
 puts.call(otherPuts, message);
 
-// $ExpectType NativeReturnValue
+// $ExpectType number
 puts.apply(otherPuts, [message]);
 
-// $ExpectType NativeReturnValue
+// $ExpectType number
 puts(message);
 
+// $ExpectType SystemFunction<number, [NativePointerValue, number]>
 const open = new SystemFunction(Module.getExportByName(null, "open"), "int", ["pointer", "int"]);
 
-// $ExpectType SystemFunction
-open;
-
 const path = Memory.allocUtf8String("/etc/hosts");
-const result = open(path, 0) as UnixSystemFunctionResult;
 
-// $ExpectType NativeReturnValue
+// $ExpectType SystemFunctionResult<number>
+const result = open(path, 0);
+
+// $ExpectType number
 result.value;
 
 // $ExpectType number
-result.errno;
+(result as UnixSystemFunctionResult<number>).errno;
 
 Interceptor.attach(puts, {
     onEnter(args) {
@@ -91,7 +127,7 @@ Interceptor.attach(puts, {
     onLeave(retval) {
         // $ExpectType InvocationReturnValue
         retval;
-    }
+    },
 });
 
 Interceptor.flush();
@@ -111,7 +147,8 @@ process (const GumEvent * event,
 }
 `;
 const symbols: CSymbols = {
-    on_interesting_event: new NativeCallback(e => {}, 'void', ['pointer']),
+    // $ExpectType NativeCallback<"void", ["pointer"]>
+    on_interesting_event: new NativeCallback(e => {}, "void", ["pointer"]),
 };
 const cm = new CModule(ccode);
 const cm2 = new CModule(ccode, symbols, {});

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for non-npm package frida-gum 17.0
+// Type definitions for non-npm package frida-gum 17.1
 // Project: https://github.com/frida/frida
 // Definitions by: Ole André Vadla Ravnås <https://github.com/oleavr>
 //                 Francesco Tamagni <https://github.com/mrmacete>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.5
+// Minimum TypeScript Version: 4.1
 
 /**
  * Returns a hexdump of the provided ArrayBuffer or NativePointerValue target.
@@ -1604,46 +1604,81 @@ type NativePointerValue = NativePointer | ObjectWrapper;
 declare const NativeFunction: NativeFunctionConstructor;
 
 interface NativeFunctionConstructor {
-    new(address: NativePointerValue, retType: NativeType, argTypes: NativeType[], abiOrOptions?: NativeABI | NativeFunctionOptions): NativeFunction;
-    readonly prototype: NativeFunction;
+    new <RetType extends NativeFunctionReturnType, ArgTypes extends NativeFunctionArgumentType[] | []>(
+        address: NativePointerValue,
+        retType: RetType,
+        argTypes: ArgTypes,
+        abiOrOptions?: NativeABI | NativeFunctionOptions,
+    ): NativeFunction<
+        GetNativeFunctionReturnValue<RetType>,
+        ResolveVariadic<Extract<GetNativeFunctionArgumentValue<ArgTypes>, unknown[]>>
+    >;
+    readonly prototype: NativeFunction<void, []>;
 }
 
-interface NativeFunction extends NativePointer {
-    (...args: NativeArgumentValue[]): NativeReturnValue;
-    apply(thisArg: NativePointerValue | null | undefined, args: NativeArgumentValue[]): NativeReturnValue;
-    call(thisArg?: NativePointerValue | null, ...args: NativeArgumentValue[]): NativeReturnValue;
+interface NativeFunction<RetType extends NativeFunctionReturnValue, ArgTypes extends NativeFunctionArgumentValue[] | []>
+    extends NativePointer {
+    (...args: ArgTypes): RetType;
+    apply(thisArg: NativePointerValue | null | undefined, args: ArgTypes): RetType;
+    call(thisArg?: NativePointerValue | null, ...args: ArgTypes): RetType;
 }
 
 declare const SystemFunction: SystemFunctionConstructor;
 
 interface SystemFunctionConstructor {
-    new(address: NativePointerValue, retType: NativeType, argTypes: NativeType[], abiOrOptions?: NativeABI | NativeFunctionOptions): SystemFunction;
-    readonly prototype: SystemFunction;
+    new <RetType extends NativeFunctionReturnType, ArgTypes extends NativeFunctionArgumentType[] | []>(
+        address: NativePointerValue,
+        retType: RetType,
+        argTypes: ArgTypes,
+        abiOrOptions?: NativeABI | NativeFunctionOptions,
+    ): SystemFunction<
+        GetNativeFunctionReturnValue<RetType>,
+        ResolveVariadic<Extract<GetNativeFunctionArgumentValue<ArgTypes>, unknown[]>>
+    >;
+    readonly prototype: SystemFunction<void, []>;
 }
 
-interface SystemFunction extends NativePointer {
-    (...args: NativeArgumentValue[]): SystemFunctionResult;
-    apply(thisArg: NativePointerValue | null | undefined, args: NativeArgumentValue[]): SystemFunctionResult;
-    call(thisArg?: NativePointerValue | null, ...args: NativeArgumentValue[]): SystemFunctionResult;
+interface SystemFunction<RetType extends NativeFunctionReturnValue, ArgTypes extends NativeFunctionArgumentValue[] | []>
+    extends NativePointer {
+    (...args: ArgTypes): SystemFunctionResult<RetType>;
+    apply(thisArg: NativePointerValue | null | undefined, args: ArgTypes): SystemFunctionResult<RetType>;
+    call(thisArg?: NativePointerValue | null, ...args: ArgTypes): SystemFunctionResult<RetType>;
 }
 
-type SystemFunctionResult = WindowsSystemFunctionResult | UnixSystemFunctionResult;
+type SystemFunctionResult<Value extends NativeFunctionReturnValue> =
+    | WindowsSystemFunctionResult<Value>
+    | UnixSystemFunctionResult<Value>
+    ;
 
-interface WindowsSystemFunctionResult {
-    value: NativeReturnValue;
+interface WindowsSystemFunctionResult<Value extends NativeFunctionReturnValue> {
+    value: Value;
     lastError: number;
 }
 
-interface UnixSystemFunctionResult {
-    value: NativeReturnValue;
+interface UnixSystemFunctionResult<Value extends NativeFunctionReturnValue> {
+    value: Value;
     errno: number;
 }
 
-declare class NativeCallback extends NativePointer {
-    constructor(func: NativeCallbackImplementation, retType: NativeType, argTypes: NativeType[], abi?: NativeABI);
+declare class NativeCallback<
+    RetType extends NativeCallbackReturnType,
+    ArgTypes extends NativeCallbackArgumentType[] | [],
+> extends NativePointer {
+    constructor(
+        func: NativeCallbackImplementation<
+            GetNativeCallbackReturnValue<RetType>,
+            Extract<GetNativeCallbackArgumentValue<ArgTypes>, unknown[]>
+        >,
+        retType: RetType,
+        argTypes: ArgTypes,
+        abi?: NativeABI,
+    );
 }
 
-type NativeCallbackImplementation = (this: CallbackContext | InvocationContext, ...params: any[]) => any;
+type NativeCallbackImplementation<
+    RetType extends NativeCallbackReturnValue,
+    ArgTypes extends NativeCallbackArgumentValue[] | [],
+> = (this: CallbackContext | InvocationContext, ...args: ArgTypes) => RetType;
 
 interface CallbackContext {
     /**
@@ -1659,11 +1694,110 @@ interface CallbackContext {
     context: CpuContext;
 }
 
-type NativeArgumentValue = NativePointerValue | UInt64 | Int64 | number | boolean | any[];
+type Variadic = "...";
+type ResolveVariadic<List extends any[]> = List extends [Variadic, ...infer Tail]
+    ? [...Array<Tail[0]>]
+    : List extends [infer Head, ...infer Tail]
+    ? [Head, ...ResolveVariadic<Tail>]
+    : [];
 
-type NativeReturnValue = NativePointer | UInt64 | Int64 | number | boolean | any[];
+type RecursiveValuesOf<T> = T[keyof T] | Array<RecursiveValuesOf<T>>;
+type RecursiveKeysOf<T> = keyof T | Array<RecursiveKeysOf<T>> | [];
+type GetValue<Map, Value, Type, T extends Type> = Type[] extends T
+    ? Value
+    : T extends keyof Map
+    ? Map[T]
+    : { [P in keyof T]: T[P] extends Type ? GetValue<Map, Value, Type, T[P]> : never };
 
-type NativeType = string | any[];
+// tslint:disable-next-line:interface-over-type-literal
+type BaseNativeTypeMap = {
+    int: number;
+    uint: number;
+    long: number;
+    ulong: number;
+    char: number;
+    uchar: number;
+    float: number;
+    double: number;
+    int8: number;
+    uint8: number;
+    int16: number;
+    uint16: number;
+    int32: number;
+    uint32: number;
+    bool: number;
+};
+
+type NativeFunctionArgumentTypeMap = BaseNativeTypeMap & {
+    void: undefined;
+    pointer: NativePointerValue;
+    size_t: number | UInt64;
+    ssize_t: number | Int64;
+    int64: number | Int64;
+    uint64: number | UInt64;
+    "...": Variadic;
+};
+type NativeFunctionArgumentValue = RecursiveValuesOf<NativeFunctionArgumentTypeMap>;
+type NativeFunctionArgumentType = RecursiveKeysOf<NativeFunctionArgumentTypeMap>;
+type GetNativeFunctionArgumentValue<T extends NativeFunctionArgumentType> = GetValue<
+    NativeFunctionArgumentTypeMap,
+    NativeFunctionArgumentValue,
+    NativeFunctionArgumentType,
+    T
+>;
+
+type NativeFunctionReturnTypeMap = BaseNativeTypeMap & {
+    // tslint:disable-next-line:void-return
+    void: void;
+    pointer: NativePointer;
+    size_t: UInt64;
+    ssize_t: Int64;
+    int64: Int64;
+    uint64: UInt64;
+};
+type NativeFunctionReturnValue = RecursiveValuesOf<NativeFunctionReturnTypeMap>;
+type NativeFunctionReturnType = RecursiveKeysOf<NativeFunctionReturnTypeMap>;
+type GetNativeFunctionReturnValue<T extends NativeFunctionReturnType> = GetValue<
+    NativeFunctionReturnTypeMap,
+    NativeFunctionReturnValue,
+    NativeFunctionReturnType,
+    T
+>;
+
+type NativeCallbackArgumentTypeMap = BaseNativeTypeMap & {
+    void: undefined;
+    pointer: NativePointer;
+    size_t: UInt64;
+    ssize_t: Int64;
+    int64: Int64;
+    uint64: UInt64;
+};
+type NativeCallbackArgumentValue = RecursiveValuesOf<NativeCallbackArgumentTypeMap>;
+type NativeCallbackArgumentType = RecursiveKeysOf<NativeCallbackArgumentTypeMap>;
+type GetNativeCallbackArgumentValue<T extends NativeCallbackArgumentType> = GetValue<
+    NativeCallbackArgumentTypeMap,
+    NativeCallbackArgumentValue,
+    NativeCallbackArgumentType,
+    T
+>;
+
+type NativeCallbackReturnTypeMap = BaseNativeTypeMap & {
+    // tslint:disable-next-line:void-return
+    void: void;
+    pointer: NativePointerValue;
+    size_t: number | UInt64;
+    ssize_t: number | Int64;
+    int64: number | Int64;
+    uint64: number | UInt64;
+};
+type NativeCallbackReturnValue = RecursiveValuesOf<NativeCallbackReturnTypeMap>;
+type NativeCallbackReturnType = RecursiveKeysOf<NativeCallbackReturnTypeMap>;
+type GetNativeCallbackReturnValue<T extends NativeCallbackReturnType> = GetValue<
+    NativeCallbackReturnTypeMap,
+    NativeCallbackReturnValue,
+    NativeCallbackReturnType,
+    T
+>;
 
 type NativeABI =
     | "default"
@@ -3065,27 +3199,27 @@ declare class DebugSymbol {
  * through the constructor's second argument.
  */
 declare class CModule {
-  /**
-   * Creates a new C module from the provided `code`.
-   *
-   * @param code C source code to compile, or a precompiled shared library.
-   * @param symbols Symbols to expose to the C module. Declare them as `extern`.
-   *    This may for example be one or more memory blocks allocated using
-   *     `Memory.alloc()`, and/or `NativeCallback` values for receiving
-   *     callbacks from the C module.
-   * @param options Options for customizing the construction.
-   */
-  constructor(code: string | ArrayBuffer, symbols?: CSymbols, options?: CModuleOptions);
+    /**
+     * Creates a new C module from the provided `code`.
+     *
+     * @param code C source code to compile, or a precompiled shared library.
+     * @param symbols Symbols to expose to the C module. Declare them as `extern`.
+     *    This may for example be one or more memory blocks allocated using
+     *     `Memory.alloc()`, and/or `NativeCallback` values for receiving
+     *     callbacks from the C module.
+     * @param options Options for customizing the construction.
+     */
+    constructor(code: string | ArrayBuffer, symbols?: CSymbols, options?: CModuleOptions);
 
-  /**
-   * Eagerly unmaps the module from memory. Useful for short-lived modules
-   * when waiting for a future garbage collection isn't desirable.
-   */
-  dispose(): void;
+    /**
+     * Eagerly unmaps the module from memory. Useful for short-lived modules
+     * when waiting for a future garbage collection isn't desirable.
+     */
+    dispose(): void;
 
-  readonly [name: string]: any;
+    readonly [name: string]: any;
 
-  static builtins: CModuleBuiltins;
+    static builtins: CModuleBuiltins;
 }
 
 interface CModuleOptions {
@@ -3918,7 +4052,7 @@ declare namespace ObjC {
      * @param method Method to implement.
      * @param fn Implementation.
      */
-    function implement(method: ObjectMethod, fn: AnyFunction): NativeCallback;
+    function implement(method: ObjectMethod, fn: AnyFunction): NativeCallback<any, any>;
 
     /**
      * Creates a new class designed to act as a proxy for a target object.

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1695,6 +1695,7 @@ interface CallbackContext {
 }
 
 type Variadic = "...";
+
 type ResolveVariadic<List extends any[]> = List extends [Variadic, ...infer Tail]
     ? [...Array<Tail[0]>]
     : List extends [infer Head, ...infer Tail]
@@ -1702,7 +1703,9 @@ type ResolveVariadic<List extends any[]> = List extends [Variadic, ...infer Tail
     : [];
 
 type RecursiveValuesOf<T> = T[keyof T] | Array<RecursiveValuesOf<T>>;
+
 type RecursiveKeysOf<T> = keyof T | Array<RecursiveKeysOf<T>> | [];
+
 type GetValue<Map, Value, Type, T extends Type> = Type[] extends T
     ? Value
     : T extends keyof Map
@@ -1737,8 +1740,11 @@ type NativeFunctionArgumentTypeMap = BaseNativeTypeMap & {
     uint64: number | UInt64;
     "...": Variadic;
 };
+
 type NativeFunctionArgumentValue = RecursiveValuesOf<NativeFunctionArgumentTypeMap>;
+
 type NativeFunctionArgumentType = RecursiveKeysOf<NativeFunctionArgumentTypeMap>;
+
 type GetNativeFunctionArgumentValue<T extends NativeFunctionArgumentType> = GetValue<
     NativeFunctionArgumentTypeMap,
     NativeFunctionArgumentValue,
@@ -1755,8 +1761,11 @@ type NativeFunctionReturnTypeMap = BaseNativeTypeMap & {
     int64: Int64;
     uint64: UInt64;
 };
+
 type NativeFunctionReturnValue = RecursiveValuesOf<NativeFunctionReturnTypeMap>;
+
 type NativeFunctionReturnType = RecursiveKeysOf<NativeFunctionReturnTypeMap>;
+
 type GetNativeFunctionReturnValue<T extends NativeFunctionReturnType> = GetValue<
     NativeFunctionReturnTypeMap,
     NativeFunctionReturnValue,
@@ -1772,8 +1781,11 @@ type NativeCallbackArgumentTypeMap = BaseNativeTypeMap & {
     int64: Int64;
     uint64: UInt64;
 };
+
 type NativeCallbackArgumentValue = RecursiveValuesOf<NativeCallbackArgumentTypeMap>;
+
 type NativeCallbackArgumentType = RecursiveKeysOf<NativeCallbackArgumentTypeMap>;
+
 type GetNativeCallbackArgumentValue<T extends NativeCallbackArgumentType> = GetValue<
     NativeCallbackArgumentTypeMap,
     NativeCallbackArgumentValue,
@@ -1790,8 +1802,11 @@ type NativeCallbackReturnTypeMap = BaseNativeTypeMap & {
     int64: number | Int64;
     uint64: number | UInt64;
 };
+
 type NativeCallbackReturnValue = RecursiveValuesOf<NativeCallbackReturnTypeMap>;
+
 type NativeCallbackReturnType = RecursiveKeysOf<NativeCallbackReturnTypeMap>;
+
 type GetNativeCallbackReturnValue<T extends NativeCallbackReturnType> = GetValue<
     NativeCallbackReturnTypeMap,
     NativeCallbackReturnValue,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://frida.re/news/

Hi! This is my shot to add type inference to `NativeFunction`, `SystemFunction` and `NativeCallback`. Variadic and structs are supported.
To do that, I had to update the minimum TS version to 4.1:
- Self referencing types (e.g. `type X = X | Array<X>`, used in `RecursiveValueOf`, `RecursiveKeyOf`) requires TS 3.7+;
- Spreading tuple types (used in `ResolveVariadic`) requires TS 4.1+.

I guess it should be possible to use an older TS version, but it would add a lot of complexity to the added types.

Also, I added a couple of lines to disable tslint checks:
- `BaseNativeTypeMap`: I don't think a mapped type should be an interface;
- `NativeFunctionReturnTypeMap`, `NativeCallbackReturnTypeMap` on `void: void`: these are false positive, `void` is actually used as a return type, so it can't be replaced with `undefined`.

A brief explanation of what I added:
- `Variadic`, `RecursiveValuesOf`, `RecursiveKeysOf` are self-explanatory;
- `ResolveVariadic` transforms `[A, B, "...", C]` to `[A, B, ...C[]]`;
- `GetValue` transforms `[A, B, C]` to `[MappedA, MappedB, MappedC]`, recursively;
- `*TypeMap`, `*Value`, `*Type`, `Get*Value` are self-explanatory too.

Notes:
- `SystemFunction` uses the same types as `NativeFunction` (and not some type aliases - e.g. it uses `NativeFunctionReturnValue` instead of an hypothetical `SystemFunctionReturnValue` even if these two types would be identical);
- `Block.implement` returns a `NativeCallback<any, any>`, but I guess this should be narrowed too;
- There's no error when the `Variadic` type literal (`"..."`) is placed in forbidden locations (so it can be the first argument, it can be nested and it can be repeated).

I hope I didn't miss something!