### PR TITLE
[react-scroll-rotate] Bugfix: define correct string type in Scroll Rotate Props

### DIFF
--- a/types/react-scroll-rotate/index.d.ts
+++ b/types/react-scroll-rotate/index.d.ts
@@ -11,7 +11,7 @@ export interface ScrollRotateProps {
   throttle?: number | undefined;
   from?: number | undefined;
   to?: number | undefined;
-  method?: 'px' | 'prec' | undefined;
+  method?: 'px' | 'perc' | undefined;
   loops?: number | undefined;
   animationDuration?: number | undefined;
   children: React.ReactNode;

--- a/types/react-scroll-rotate/react-scroll-rotate-tests.tsx
+++ b/types/react-scroll-rotate/react-scroll-rotate-tests.tsx
@@ -10,7 +10,7 @@ const elements = [
     throttle={0.25}
     from={0}
     to={360}
-    method="prec"
+    method="perc"
     loops={1}
     animationDuration={0.25}
   >


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/giladk/react-scroll-rotate>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
