### PR TITLE
sharedb: add missing argument to `op` and `before op` events

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -143,9 +143,9 @@ export interface DocEventMap<T> {
     'no write pending': () => void;
     'nothing pending': () => void;
     'create': (source: any) => void;
-    'op': (ops: [any], source: any) => void;
+    'op': (ops: [any], source: any, clientId: string) => void;
     'op batch': (ops: any[], source: any) => void;
-    'before op': (ops: [any], source: any) => void;
+    'before op': (ops: [any], source: any, clientId: string) => void;
     'before op batch': (ops: any[], source: any) => void;
     'del': (data: T, source: any) => void;
     'error': (error: Error) => void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -323,6 +323,18 @@ function startClient(callback) {
 
     doc.submitOp([{insert: 'foo', attributes: {bold: true}}], {source: {deep: true}});
 
+    doc.on('load', () => {});
+    doc.on('no write pending', () => {});
+    doc.on('nothing pending', () => {});
+    doc.on('create', (source: any) => {});
+    doc.on('op', (ops: [any], source: any, clientId: string) => {});
+    doc.on('op batch', (ops: any[], source: any) => {});
+    doc.on('before op', (ops: [any], source: any, clientId: string) => {});
+    doc.on('before op batch', (ops: any[], source: any) => {});
+    doc.on('del', (data: MyDoc, source: any) => {});
+    doc.on('error', (error: ShareDB.Error) => {});
+    doc.on('destroy', () => {});
+
     connection.fetchSnapshot('examples', 'foo', 123, (error, snapshot: ShareDBClient.Snapshot) => {
         if (error) throw error;
         console.log(snapshot.data);


### PR DESCRIPTION
This change adds a missing third argument for the `op` and `before op` the client ID. See [here][1] and [here][2]

[1]: https://github.com/share/sharedb/blob/v1.9.1/lib/client/doc.js#L625
[2]: https://github.com/share/sharedb/blob/v1.9.1/lib/client/doc.js#L635


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
