### PR TITLE
@types/google-protobuf: Add missing (static and instance) methods to class Map

### DIFF
--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -199,7 +199,7 @@ export class Map<K, V> {
     valueWriterFn: ((writer: BinaryWriter, field: number, value: V) => void)
                    | ((writer: BinaryWriter, field: number, value: V, opt_valueWriterCallback: (value: V, writer: BinaryWriter) => void) => void),
     opt_valueWriterCallback?: (value: V, writer: BinaryWriter) => void
-  );
+  ): void;
   static deserializeBinary<K, V>(
     map: Map,
     reader: BinaryReader,
@@ -208,7 +208,7 @@ export class Map<K, V> {
     opt_valueReaderCallback?: (value: V, reader: BinaryReader) => any,
     opt_defaultKey?: K,
     opt_defaultValue?: V
-  );
+  ): void;
 }
 
 export namespace Map {

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -201,7 +201,7 @@ export class Map<K, V> {
     opt_valueWriterCallback?: (value: V, writer: BinaryWriter) => void
   ): void;
   static deserializeBinary<K, V>(
-    map: Map,
+    map: Map<K, V>,
     reader: BinaryReader,
     keyReaderFn: (reader: BinaryReader) => K,
     valueReaderFn: ((reader: BinaryReader) => V) | ((reader: BinaryReader, value: V, opt_valueReaderCallback: (value: V, reader: BinaryReader) => any) => any),

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -185,12 +185,30 @@ export class Map<K, V> {
   getEntryList(): Array<[K, V]>;
   entries(): Map.Iterator<[K, V]>;
   keys(): Map.Iterator<K>;
+  values(): Map.Iterator<V>;
   forEach(
     callback: (entry: V, key: K) => void,
     thisArg?: {}): void;
   set(key: K, value: V): this;
   get(key: K): (V | undefined);
   has(key: K): boolean;
+  serializeBinary(
+    fieldNumber: number,
+    writer: BinaryWriter,
+    keyWriterFn: (writer: BinaryWriter, field: number, key: K) => void,
+    valueWriterFn: ((writer: BinaryWriter, field: number, value: V) => void)
+                   | ((writer: BinaryWriter, field: number, value: V, opt_valueWriterCallback: (value: V, writer: BinaryWriter) => void) => void),
+    opt_valueWriterCallback?: (value: V, writer: BinaryWriter) => void
+  );
+  static deserializeBinary<K, V>(
+    map: Map,
+    reader: BinaryReader,
+    keyReaderFn: (reader: BinaryReader) => K,
+    valueReaderFn: ((reader: BinaryReader) => V) | ((reader: BinaryReader, value: V, opt_valueReaderCallback: (value: V, reader: BinaryReader) => any) => any),
+    opt_valueReaderCallback?: (value: V, reader: BinaryReader) => any,
+    opt_defaultKey?: K,
+    opt_defaultValue?: V
+  );
 }
 
 export namespace Map {


### PR DESCRIPTION
I have added the missing value iterater and the missing `serializeBinary` and `static deserializeBinary` methods to class Map.

Fixes [#76](https://github.com/thesayyn/protoc-gen-ts/issues/76), [#813](https://github.com/grpc/grpc-web/issues/813), [#54824](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/54824) and [#54816](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/54816)
