### PR TITLE
Fixed formidable definitions for breaking changes in EventEmitter in Node >= 13

### DIFF
--- a/types/formidable/PersistentFile.d.ts
+++ b/types/formidable/PersistentFile.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter = require("events");
+import { EventEmitter } from 'events';
 import { File, FileJSON } from "./";
 
 declare class PersistentFile extends EventEmitter {


### PR DESCRIPTION
@types/node v13 has breaking change affecting NodeJS.EventEmitter from v12. It was changed from class to interface. Now, EventEmitter can only be extended by interfaces.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/c47a34ead1637f6f34e7d630dc88ea3f6e5562cb#diff-a2f9a5377787f7084c7f52b20c0108cfR540
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

