### PR TITLE
[ejson] Bugfix: Mark keys on stringify configuration object optional

### DIFF
--- a/types/ejson/ejson-tests.ts
+++ b/types/ejson/ejson-tests.ts
@@ -29,6 +29,21 @@ function testStringify() {
   var retval: string = importedStringify(obj);
 }
 
+function testStringifyIndent() {
+  var obj: any = {a: "a"};
+  var retval: string = importedStringify(obj, { indent: true });
+}
+
+function testStringifyCanonical() {
+  var obj: any = {a: "a"};
+  var retval: string = importedStringify(obj, { canonical: true });
+}
+
+function testStringifyOptions() {
+  var obj: any = {a: "a"};
+  var retval: string = importedStringify(obj, { canonical: true, indent: 'hello' });
+}
+
 function testToJSONValue() {
   var obj: any = {a:"a"};
   var retval: string = importedToJSONValue(obj);

--- a/types/ejson/index.d.ts
+++ b/types/ejson/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface StringifyOptions {
-  canonical: boolean;
-  indent: boolean|number|string;
+  canonical?: boolean;
+  indent?: boolean|number|string;
 }
 
 interface CloneOptions {


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
See https://github.com/primus/ejson/blob/633903df6b1fab292e2b37c47cc1ccb3bf1131a1/test.js#L8
And https://docs.meteor.com/api/ejson.html