### PR TITLE
react-relay: fixed incorrect error type on useMutation's onError callback

### DIFF
--- a/types/react-relay/hooks.d.ts
+++ b/types/react-relay/hooks.d.ts
@@ -24,7 +24,7 @@ export {
 } from './relay-hooks/MatchContainer';
 export { ProfilerContextType } from './relay-hooks/ProfilerContext';
 export { Direction, LoadMoreFn } from './relay-hooks/useLoadMoreFunction';
-export { UseMutationConfig, MutationOperation, MutationError, MutationErrorSource } from './relay-hooks/useMutation';
+export { UseMutationConfig, MutationError, MutationErrorSource } from './relay-hooks/useMutation';
 export { UseQueryLoaderLoadQueryOptions } from './relay-hooks/useQueryLoader';
 export {
   RefetchFn,

--- a/types/react-relay/hooks.d.ts
+++ b/types/react-relay/hooks.d.ts
@@ -24,7 +24,7 @@ export {
 } from './relay-hooks/MatchContainer';
 export { ProfilerContextType } from './relay-hooks/ProfilerContext';
 export { Direction, LoadMoreFn } from './relay-hooks/useLoadMoreFunction';
-export { UseMutationConfig } from './relay-hooks/useMutation';
+export { UseMutationConfig, MutationOperation, MutationError, MutationErrorSource } from './relay-hooks/useMutation';
 export { UseQueryLoaderLoadQueryOptions } from './relay-hooks/useQueryLoader';
 export {
   RefetchFn,

--- a/types/react-relay/relay-hooks/useMutation.d.ts
+++ b/types/react-relay/relay-hooks/useMutation.d.ts
@@ -1,39 +1,30 @@
 import {
+    ConcreteRequest,
     DeclarativeMutationConfig,
     Disposable,
     GraphQLTaggedNode,
     IEnvironment,
     MutationConfig,
     MutationParameters,
-    NormalizationOperation,
     PayloadError,
-    ReaderFragment,
-    RequestParameters,
     SelectorStoreUpdater,
     UploadableMap,
     VariablesOf,
 } from 'relay-runtime';
 
-export interface MutationOperation {
-    fragment: ReaderFragment;
-    kind: string;
-    operation: NormalizationOperation;
-    params: RequestParameters;
-    hash: string;
-}
-
 export interface MutationErrorSource<TMutation extends MutationParameters> {
-    errors: PayloadError[];
-    operation: MutationOperation;
-    variables: VariablesOf<TMutation>; // TODO: Does this work correctly?    [name: string]: any;
+    readonly errors: PayloadError[];
+    readonly operation: ConcreteRequest;
+    readonly variables: VariablesOf<TMutation>;
 }
 
 export interface MutationError<TMutation extends MutationParameters> {
-    name: string;
-    messageFormat: string;
-    messageParams: Array<string | number | boolean>;
-    type: 'fatal' | 'error' | 'warn' | 'info';
-    source: MutationErrorSource<TMutation>; // TODO
+    readonly name: string;
+    readonly messageFormat: string;
+    readonly messageParams: Array<string | number | boolean>;
+    readonly type: 'fatal' | 'error' | 'warn' | 'info';
+    readonly source: MutationErrorSource<TMutation>;
+    readonly taalOpcodes: number[];
 }
 
 export interface UseMutationConfig<TMutation extends MutationParameters> {

--- a/types/react-relay/relay-hooks/useMutation.d.ts
+++ b/types/react-relay/relay-hooks/useMutation.d.ts
@@ -5,11 +5,36 @@ import {
     IEnvironment,
     MutationConfig,
     MutationParameters,
+    NormalizationOperation,
     PayloadError,
+    ReaderFragment,
+    RequestParameters,
     SelectorStoreUpdater,
     UploadableMap,
     VariablesOf,
 } from 'relay-runtime';
+
+export interface MutationOperation {
+    fragment: ReaderFragment;
+    kind: string;
+    operation: NormalizationOperation;
+    params: RequestParameters;
+    hash: string;
+}
+
+export interface MutationErrorSource<TMutation extends MutationParameters> {
+    errors: PayloadError[];
+    operation: MutationOperation;
+    variables: VariablesOf<TMutation>; // TODO: Does this work correctly?    [name: string]: any;
+}
+
+export interface MutationError<TMutation extends MutationParameters> {
+    name: string;
+    messageFormat: string;
+    messageParams: (string | number | boolean)[];
+    type: "fatal" | "error" | "warn" | "info";
+    source: MutationErrorSource<TMutation>; // TODO
+}
 
 export interface UseMutationConfig<TMutation extends MutationParameters> {
     variables: VariablesOf<TMutation>;
@@ -18,7 +43,7 @@ export interface UseMutationConfig<TMutation extends MutationParameters> {
     optimisticUpdater?: SelectorStoreUpdater<TMutation['response']> | null | undefined;
     optimisticResponse?: TMutation['rawResponse'] | undefined;
     configs?: DeclarativeMutationConfig[] | undefined;
-    onError?: ((error: Error) => void | null) | undefined;
+    onError?: ((error: MutationError<TMutation>) => void | null) | undefined;
     onCompleted?: ((response: TMutation['response'], errors: PayloadError[] | null) => void | null) | undefined;
     onUnsubscribe?: (() => void | null) | undefined;
 }

--- a/types/react-relay/relay-hooks/useMutation.d.ts
+++ b/types/react-relay/relay-hooks/useMutation.d.ts
@@ -31,8 +31,8 @@ export interface MutationErrorSource<TMutation extends MutationParameters> {
 export interface MutationError<TMutation extends MutationParameters> {
     name: string;
     messageFormat: string;
-    messageParams: (string | number | boolean)[];
-    type: "fatal" | "error" | "warn" | "info";
+    messageParams: Array<string | number | boolean>;
+    type: 'fatal' | 'error' | 'warn' | 'info';
     source: MutationErrorSource<TMutation>; // TODO
 }
 

--- a/types/react-relay/test/relay-hooks-tests.tsx
+++ b/types/react-relay/test/relay-hooks-tests.tsx
@@ -667,9 +667,11 @@ function Mutation() {
                             console.log(data.feedback_like.feedback.viewer_does_like);
                         },
                         onError(error) {
-                            console.log(error);
-
+                            // Ensure error message can be accessed
                             console.log(error.source.errors?.[0].message);
+
+                            // Ensure generic allows accessing original request variables
+                            console.log(error.source.variables.input.id);
                         },
                         optimisticResponse: {
                             feedback_like: {

--- a/types/react-relay/test/relay-hooks-tests.tsx
+++ b/types/react-relay/test/relay-hooks-tests.tsx
@@ -666,6 +666,11 @@ function Mutation() {
                             console.log(data.feedback_like.feedback.like_count);
                             console.log(data.feedback_like.feedback.viewer_does_like);
                         },
+                        onError(error) {
+                            console.log(error);
+
+                            console.log(error.source.errors?.[0].message);
+                        },
                         optimisticResponse: {
                             feedback_like: {
                                 feedback: {

--- a/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
+++ b/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
@@ -12,6 +12,7 @@ export interface ConcreteRequest {
     readonly fragment: ReaderFragment;
     readonly operation: NormalizationOperation;
     readonly params: RequestParameters;
+    readonly hash: string;
 }
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: explained below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `onError` callback's first argument is not an `Error` type as it was previously set as. For example, it contains the error object that was returned by the GraphQL server. This PR fixes the typing so that this extra information can be accessed in a typesafe manner. 

I worked out the types were incorrect by using `console.log(error)` in an `onError` callback. I found it difficult to trace where the error object is being created in the Relay package so I can't give a direct link to show that the typing is incorrect.

However, for example, [here](https://github.com/relay-tools/relay-hooks/blob/36658e00ed40b7eb6236ae1eaa29bd1f73cbc24c/src/useMutation.ts#L81) the `any` type is used for the error.