### PR TITLE
update(@yaireo/tagify): v4.6

### DIFF
--- a/types/yaireo__tagify/index.d.ts
+++ b/types/yaireo__tagify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @yaireo/tagify 4.3
+// Type definitions for @yaireo/tagify 4.6
 // Project: https://github.com/yairEO/tagify
 // Definitions by: Brakebein <https://github.com/Brakebein>
 //                 Andre Wachsmuth <https://github.com/blutorange>
@@ -1546,6 +1546,11 @@ declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
     setReadonly(readonly: boolean): void;
 
     /**
+     * Toggles "disabled" mode on/off
+     */
+    setDisabled(disabled: boolean): void;
+
+    /**
      * Removes a listener previously added via `on`.
      * @template K Name of the event.
      * @param event Name of the event.
@@ -1571,3 +1576,5 @@ declare class Tagify<T extends Tagify.BaseTagData = Tagify.TagData> {
 }
 
 export = Tagify;
+
+export as namespace Tagify;

--- a/types/yaireo__tagify/test/yaireo__tagify-react-tests.tsx
+++ b/types/yaireo__tagify/test/yaireo__tagify-react-tests.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import Tagify, { BaseTagData, ChangeEventData, EventData, TagifySettings } from '@yaireo/tagify';
-import Tags, { MixedTags, TagifyTagsReactProps } from '@yaireo/tagify/dist/react.tagify';
+import Tagify = require('@yaireo/tagify');
+import { BaseTagData, ChangeEventData, EventData, TagifySettings } from '@yaireo/tagify';
+import Tags = require('@yaireo/tagify/dist/react.tagify');
+import { MixedTags, TagifyTagsReactProps } from '@yaireo/tagify/dist/react.tagify';
 
 // Tests the minimal required attribute for the Tags component
 export function TestTagsMinimal(): React.ReactElement {

--- a/types/yaireo__tagify/tsconfig.json
+++ b/types/yaireo__tagify/tsconfig.json
@@ -21,8 +21,7 @@
         },
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/yaireo__tagify/yaireo__tagify-tests.ts
+++ b/types/yaireo__tagify/yaireo__tagify-tests.ts
@@ -1,4 +1,5 @@
-import Tagify, { BaseTagData, TagData, TagifyConstructorSettings, TagifySettings } from '@yaireo/tagify';
+import Tagify = require('@yaireo/tagify');
+import { BaseTagData, TagData, TagifyConstructorSettings, TagifySettings } from '@yaireo/tagify';
 
 export function tagTemplate(this: Tagify, tagData: TagData): string {
     return `
@@ -894,6 +895,8 @@ tagify.parseTemplate((data) => `<span>${data.value}</span>`, [tags[0]]);
 // $ExpectError
 tagify.parseTemplate((data) => `<span>${data.value}</span>`, [tags]);
 tagify.setReadonly(false);
+tagify.setDisabled(false);
+tagify.setDisabled(true);
 
 tagify.dropdown.show();
 tagify.dropdown.show('foo');


### PR DESCRIPTION
- version bump
- new method from 4.6
- remove 'esModuleInterop' from definition (it's for consuming apps)
- add missing UMD export for `Tagify`, as it can be used via global
  script inclusion

https://github.com/yairEO/tagify/compare/v4.3.1...v4.6.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).