### PR TITLE
[discord-rpc] Add `prompt` to RPCLoginOptions, rename `tokenEndpoint` to `redirectUri`

### DIFF
--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for discord-rpc 3.0
+// Type definitions for discord-rpc 4.0.1
 // Project: https://github.com/discordjs/RPC#readme
 // Definitions by: Jason Bothell <https://github.com/jasonhaxstuff>
 //                 Jack Baron <https://github.com/lolPants>

--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -85,8 +85,9 @@ export interface RPCLoginOptions {
     clientSecret?: string | undefined;
     accessToken?: string | undefined;
     rpcToken?: string | undefined;
-    tokenEndpoint?: string | undefined;
+    redirectUri?: string | undefined;
     scopes?: string[] | undefined;
+    prompt?: 'none' | 'consent' | undefined;
 }
 
 export interface Guild {

--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for discord-rpc 4.0.1
+// Type definitions for discord-rpc 4.0
 // Project: https://github.com/discordjs/RPC#readme
 // Definitions by: Jason Bothell <https://github.com/jasonhaxstuff>
 //                 Jack Baron <https://github.com/lolPants>


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change
- N/A due to lack of existing tests
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
 - N/A due to lack of existing tests

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/discordjs/RPC/pull/147
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I added the attribute `prompt` to `RPCLoginOptions` which was [added in PR #137](https://github.com/discordjs/RPC/pull/137), likewise, I renamed `tokenEndpoint` to `redirectUri` as referenced by my reasoning in https://github.com/discordjs/RPC/pull/147; `tokenEndpoint` has no references in the code base whereas `redirectUri` is required by [`authorize()`](https://github.com/discordjs/RPC/blob/12d87731ca00d19e8a2786d3a7650ee3d3b24dd8/src/client.js#L197-L223).
