### PR TITLE
Strict types for `chrome.{tabs,extension}.sendRequest`

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3316,7 +3316,7 @@ declare namespace chrome.extension {
      * function(any response) {...};
      * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendRequest(extensionId: string, request: any, responseCallback?: (response: any) => void): void;
+    export function sendRequest<T = any, R = any>(extensionId: string, request: T, responseCallback?: (response: R) => void): void;
     /**
      * Sends a single request to other listeners within the extension. Similar to runtime.connect, but only sends a single request with an optional response. The extension.onRequest event is fired in each page of the extension.
      * @deprecated Deprecated since Chrome 33. Please use runtime.sendMessage.
@@ -3324,7 +3324,7 @@ declare namespace chrome.extension {
      * function(any response) {...};
      * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendRequest(request: any, responseCallback?: (response: any) => void): void;
+    export function sendRequest<T = any, R = any>(request: T, responseCallback?: (response: R) => void): void;
     /**
      * Returns an array of the JavaScript 'window' objects for each of the tabs running inside the current extension. If windowId is specified, returns only the 'window' objects of tabs attached to the specified window.
      * @deprecated Deprecated since Chrome 33. Please use extension.getViews {type: "tab"}.
@@ -8983,7 +8983,7 @@ declare namespace chrome.tabs {
      * @param responseCallback Optional.
      * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendRequest(tabId: number, request: any, responseCallback?: (response: any) => void): void;
+    export function sendRequest<T = any, R = any>(tabId: number, request: T, responseCallback?: (response: R) => void): void;
     /** Connects to the content script(s) in the specified tab. The runtime.onConnect event is fired in each content script running in the specified tab for the current extension. */
     export function connect(tabId: number, connectInfo?: ConnectInfo): runtime.Port;
     /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3316,7 +3316,7 @@ declare namespace chrome.extension {
      * function(any response) {...};
      * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendRequest<T = any, R = any>(extensionId: string, request: T, responseCallback?: (response: R) => void): void;
+    export function sendRequest<Request = any, Response = any>(extensionId: string, request: Request, responseCallback?: (response: Response) => void): void;
     /**
      * Sends a single request to other listeners within the extension. Similar to runtime.connect, but only sends a single request with an optional response. The extension.onRequest event is fired in each page of the extension.
      * @deprecated Deprecated since Chrome 33. Please use runtime.sendMessage.
@@ -3324,7 +3324,7 @@ declare namespace chrome.extension {
      * function(any response) {...};
      * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendRequest<T = any, R = any>(request: T, responseCallback?: (response: R) => void): void;
+    export function sendRequest<Request = any, Response = any>(request: Request, responseCallback?: (response: Response) => void): void;
     /**
      * Returns an array of the JavaScript 'window' objects for each of the tabs running inside the current extension. If windowId is specified, returns only the 'window' objects of tabs attached to the specified window.
      * @deprecated Deprecated since Chrome 33. Please use extension.getViews {type: "tab"}.
@@ -8983,7 +8983,7 @@ declare namespace chrome.tabs {
      * @param responseCallback Optional.
      * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendRequest<T = any, R = any>(tabId: number, request: T, responseCallback?: (response: R) => void): void;
+    export function sendRequest<Request = any, Response = any>(tabId: number, request: Request, responseCallback?: (response: Response) => void): void;
     /** Connects to the content script(s) in the specified tab. The runtime.onConnect event is fired in each content script running in the specified tab for the current extension. */
     export function connect(tabId: number, connectInfo?: ConnectInfo): runtime.Port;
     /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -936,3 +936,23 @@ function testTabsSendMessage() {
     chrome.tabs.sendMessage<number>(6, "Hello World!", console.log); // $ExpectError
     chrome.tabs.sendMessage<string, string>(7, "Hello World!", (num: number) => alert(num+1)); // $ExpectError
 }
+
+function testTabsSendRequest() {
+    chrome.tabs.sendRequest(1, "Hello World!");
+    chrome.tabs.sendRequest(2, "Hello World!", console.log);
+    chrome.tabs.sendRequest(3, "Hello World!", console.log);
+    chrome.tabs.sendRequest<string>(4, "Hello World!", console.log);
+    chrome.tabs.sendRequest<string, number>(5, "Hello World!", console.log);
+    chrome.tabs.sendRequest<number>(6, "Hello World!", console.log); // $ExpectError
+    chrome.tabs.sendRequest<string, string>(7, "Hello World!", (num: number) => alert(num+1)); // $ExpectError
+}
+
+function testExtensionSendRequest() {
+    chrome.extension.sendRequest("dummy-id", "Hello World!");
+    chrome.extension.sendRequest("dummy-id", "Hello World!", console.log);
+    chrome.extension.sendRequest("dummy-id", "Hello World!", console.log);
+    chrome.extension.sendRequest<string>("dummy-id", "Hello World!", console.log);
+    chrome.extension.sendRequest<string, number>("dummy-id", "Hello World!", console.log);
+    chrome.extension.sendRequest<number>("dummy-id", "Hello World!", console.log); // $ExpectError
+    chrome.extension.sendRequest<string, string>("dummy-id", "Hello World!", (num: number) => alert(num+1)); // $ExpectError
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.chrome.com/docs/extensions/reference/extension/#method-sendRequest>
<https://developer.chrome.com/docs/extensions/reference/tabs/#method-sendRequest>

This PR adds tests and introduces type arguments with default values any. This change is backwards-compatiable because existing code will just use default values of any which will match prior behavior.