### PR TITLE
fix: Add FocusEvent to @types/react-widgets DateTimePicker onBlur/onFocus event handlers 

### DIFF
--- a/types/react-widgets/lib/DateTimePicker.d.ts
+++ b/types/react-widgets/lib/DateTimePicker.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, KeyboardEvent, ReactElement, ReactType } from "react";
+import { ComponentClass, FocusEvent, KeyboardEvent, ReactElement, ReactType } from "react";
 import { ReactWidgetsCommonDropdownProps, AutoFocus } from "./CommonProps";
 
 declare namespace DateTimePicker {
@@ -115,11 +115,11 @@ declare namespace DateTimePicker {
         /**
          * The native onBlur event, called when focus leaves the DateTimePicker entirely.
          */
-        onBlur?: (() => void) | undefined;
+        onBlur?: ((e: FocusEvent) => void) | undefined;
         /**
          * The native onFocus event, called when focus enters the DateTimePicker.
          */
-        onFocus?: (() => void) | undefined;
+        onFocus?: ((e: FocusEvent) => void) | undefined;
         /**
          * The native onKeyDown event, called preventDefault will prevent any custom behavior, included keyboard shortcuts.
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - `react-widgets` `DateTimePicker` component passes [event handlers to the Widget component](https://github.com/jquense/react-widgets/blob/v4.2.6/packages/react-widgets/src/DateTimePicker.js#L531-L532)
   - `Widget` adds these event handlers [via `...props` to a `div`](https://github.com/jquense/react-widgets/blob/v4.2.6/packages/react-widgets/src/Widget.js#L35-L36)
   - Therefore, `onBlur`/`onFocus` will receive the div's focus event

