### PR TITLE
Fix node-feedparser type, read() returns null when there is nothing to read

### DIFF
--- a/types/feedparser/feedparser-tests.ts
+++ b/types/feedparser/feedparser-tests.ts
@@ -24,9 +24,8 @@ feedparser.on('readable', () => {
   // This is where the action is!
   const stream = feedparser;
   const meta = feedparser.meta; // **NOTE** the "meta" is always available in the context of the feedparser instance
-  let item: FeedParser.Item;
 
-  while (item = stream.read()) {
+  while (let item = stream.read()) {
     console.log(item);
   }
 });

--- a/types/feedparser/index.d.ts
+++ b/types/feedparser/index.d.ts
@@ -72,7 +72,7 @@ declare class FeedParser extends stream.Duplex {
 
     push(chunk: any, encoding: any): any;
 
-    read(n?: number): FeedParser.Item;
+    read(n?: number): FeedParser.Item | null;
 
     removeAllListeners(type: FeedParser.Type, ...args: any[]): any;
 


### PR DESCRIPTION
Fix FeedParser.read() type; it returns FeedParser.Item when an item exists, null when not.

I'm not the package mainainer.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/danmactough/node-feedparser/blob/v2.2.10/lib/feedparser/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.