### PR TITLE
update to passport-local-mongoose 6.1.0

### DIFF
--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -2,7 +2,10 @@
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.0
+// TypeScript Version: 3.7
+
+/// <reference types="mongoose" />
+/// <reference types="passport-local" />
 
 declare module 'mongoose' {
     import passportLocal = require('passport-local');

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for passport-local-mongoose 6.1.0
+// Type definitions for passport-local-mongoose 6.1
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -5,112 +5,114 @@
 // TypeScript Version: 3.7
 
 declare module 'mongoose' {
-  import passportLocal = require('passport-local');
+    import passportLocal = require('passport-local');
 
-  export interface AuthenticationResult {
-    user: any;
-    error: any;
-  }
+    export interface AuthenticationResult {
+        user: any;
+        error: any;
+    }
 
-  // methods
-  export interface PassportLocalDocument extends Document {
-    setPassword(password: string): Promise<PassportLocalDocument>;
-    setPassword(password: string, cb: (err: any, res: any) => void): void;
-    changePassword(oldPassword: string, newPassword: string): Promise<PassportLocalDocument>;
-    changePassword(oldPassword: string, newPassword: string, cb: (err: any, res: any) => void): void;
-    authenticate(password: string): Promise<AuthenticationResult>;
-    authenticate(password: string, cb: (err: any, user: any, error: any) => void): void;
-    resetAttempts(): Promise<PassportLocalDocument>;
-    resetAttempts(cb: (err: any, res: any) => void): void;
-  }
+    // methods
+    export interface PassportLocalDocument extends Document {
+        setPassword(password: string): Promise<PassportLocalDocument>;
+        setPassword(password: string, cb: (err: any, res: any) => void): void;
+        changePassword(oldPassword: string, newPassword: string): Promise<PassportLocalDocument>;
+        changePassword(oldPassword: string, newPassword: string, cb: (err: any, res: any) => void): void;
+        authenticate(password: string): Promise<AuthenticationResult>;
+        authenticate(password: string, cb: (err: any, user: any, error: any) => void): void;
+        resetAttempts(): Promise<PassportLocalDocument>;
+        resetAttempts(cb: (err: any, res: any) => void): void;
+    }
 
-  interface AuthenticateMethod<T> {
-    (username: string, password: string): Promise<AuthenticationResult>;
-    (username: string, password: string, cb: (err: any, user: T | boolean, error: any) => void): void;
-  }
+    interface AuthenticateMethod<T> {
+        (username: string, password: string): Promise<AuthenticationResult>;
+        (username: string, password: string, cb: (err: any, user: T | boolean, error: any) => void): void;
+    }
 
-  // statics
-  interface PassportLocalModel<T extends Document> extends Model<T> {
-    authenticate(): AuthenticateMethod<T>
-    serializeUser(): (user: T, cb: (err: any, id?: any) => void) => void;
-    deserializeUser(): (username: string, cb: (err: any, user?: any) => void) => void;
+    // statics
+    interface PassportLocalModel<T extends Document> extends Model<T> {
+        authenticate(): AuthenticateMethod<T>;
+        serializeUser(): (user: T, cb: (err: any, id?: any) => void) => void;
+        deserializeUser(): (username: string, cb: (err: any, user?: any) => void) => void;
 
-    register(user: T, password: string): Promise<T>;
-    register(user: T, password: string, cb: (err: any, account: any) => void): void;
-    findByUsername(username: string, selectHashSaltFields: boolean): Query<T, T>;
-    findByUsername(username: string, selectHashSaltFields: boolean, cb: (err: any, account: any) => void): any;
-    createStrategy(): passportLocal.Strategy;
-  }
+        register(user: T, password: string): Promise<T>;
+        register(user: T, password: string, cb: (err: any, account: any) => void): void;
+        findByUsername(username: string, selectHashSaltFields: boolean): Query<T, T>;
+        findByUsername(username: string, selectHashSaltFields: boolean, cb: (err: any, account: any) => void): any;
+        createStrategy(): passportLocal.Strategy;
+    }
 
-  // error messages
-  export interface PassportLocalErrorMessages {
-    MissingPasswordError?: string | undefined;
-    AttemptTooSoonError?: string | undefined;
-    TooManyAttemptsError?: string | undefined;
-    NoSaltValueStoredError?: string | undefined;
-    IncorrectPasswordError?: string | undefined;
-    IncorrectUsernameError?: string | undefined;
-    MissingUsernameError?: string | undefined;
-    UserExistsError?: string | undefined;
-  }
+    // error messages
+    export interface PassportLocalErrorMessages {
+        MissingPasswordError?: string | undefined;
+        AttemptTooSoonError?: string | undefined;
+        TooManyAttemptsError?: string | undefined;
+        NoSaltValueStoredError?: string | undefined;
+        IncorrectPasswordError?: string | undefined;
+        IncorrectUsernameError?: string | undefined;
+        MissingUsernameError?: string | undefined;
+        UserExistsError?: string | undefined;
+    }
 
-  // plugin options
-  export interface PassportLocalOptions {
-    saltlen?: number | undefined;
-    iterations?: number | undefined;
-    keylen?: number | undefined;
-    encoding?: string | undefined;
-    digestAlgorithm?: string | undefined;
-    passwordValidator?: ((password: string, cb: (err: any) => void) => void) | undefined;
+    // plugin options
+    export interface PassportLocalOptions {
+        saltlen?: number | undefined;
+        iterations?: number | undefined;
+        keylen?: number | undefined;
+        encoding?: string | undefined;
+        digestAlgorithm?: string | undefined;
+        passwordValidator?: ((password: string, cb: (err: any) => void) => void) | undefined;
 
-    usernameField?: string | undefined;
-    usernameUnique?: boolean | undefined;
+        usernameField?: string | undefined;
+        usernameUnique?: boolean | undefined;
 
-    usernameQueryFields: Array<string>;
+        usernameQueryFields: Array<string>;
 
-    selectFields?: string | undefined;
-    populateFields?: string | undefined;
+        selectFields?: string | undefined;
+        populateFields?: string | undefined;
 
-    usernameLowerCase?: boolean | undefined;
+        usernameLowerCase?: boolean | undefined;
 
-    hashField?: string | undefined;
-    saltField?: string | undefined;
+        hashField?: string | undefined;
+        saltField?: string | undefined;
 
-    limitAttempts?: boolean | undefined;
-    lastLoginField?: string | undefined;
-    attemptsField?: string | undefined;
-    interval?: number | undefined;
-    maxInterval?: number | undefined;
-    maxAttempts?: number | undefined;
+        limitAttempts?: boolean | undefined;
+        lastLoginField?: string | undefined;
+        attemptsField?: string | undefined;
+        interval?: number | undefined;
+        maxInterval?: number | undefined;
+        maxAttempts?: number | undefined;
 
-    errorMessages?: PassportLocalErrorMessages | undefined;
-  }
+        errorMessages?: PassportLocalErrorMessages | undefined;
+    }
 
-  export interface PassportLocalSchema extends Schema {
-    plugin(
-      plugin: (schema: PassportLocalSchema, options?: PassportLocalOptions) => void,
-      options?: PassportLocalOptions
-    ): this;
+    export interface PassportLocalSchema extends Schema {
+        plugin(
+            plugin: (schema: PassportLocalSchema, options?: PassportLocalOptions) => void,
+            options?: PassportLocalOptions,
+        ): this;
 
-    // overload for the default mongoose plugin function
-    plugin(plugin: (schema: Schema, options?: Object) => void, opts?: Object): this;
-  }
+        // overload for the default mongoose plugin function
+        plugin(plugin: (schema: Schema, options?: Object) => void, opts?: Object): this;
+    }
 
-  export function model<T extends Document>(
-    name: string,
-    schema?: PassportLocalSchema,
-    collection?: string,
-    skipInit?: boolean): PassportLocalModel<T>;
+    export function model<T extends Document>(
+        name: string,
+        schema?: PassportLocalSchema,
+        collection?: string,
+        skipInit?: boolean,
+    ): PassportLocalModel<T>;
 
-  export function model<T extends Document, U extends PassportLocalModel<T>>(
-    name: string,
-    schema?: PassportLocalSchema,
-    collection?: string,
-    skipInit?: boolean): U;
+    export function model<T extends Document, U extends PassportLocalModel<T>>(
+        name: string,
+        schema?: PassportLocalSchema,
+        collection?: string,
+        skipInit?: boolean,
+    ): U;
 }
 
 declare module 'passport-local-mongoose' {
-  import mongoose = require('mongoose');
-  var _: (schema: mongoose.Schema, options?: Object) => void;
-  export = _;
+    import mongoose = require('mongoose');
+    var _: (schema: mongoose.Schema, options?: Object) => void;
+    export = _;
 }

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -1,11 +1,8 @@
-// Type definitions for passport-local-mongoose 4.0.0
+// Type definitions for passport-local-mongoose 6.1.0
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
-
-/// <reference types="mongoose" />
-/// <reference types="passport-local" />
+// TypeScript Version: 3.7
 
 declare module 'mongoose' {
   import passportLocal = require('passport-local');
@@ -34,13 +31,13 @@ declare module 'mongoose' {
 
   // statics
   interface PassportLocalModel<T extends Document> extends Model<T> {
-    authenticate(): AuthenticateMethod<T> 
-    serializeUser(): (user: PassportLocalModel<T>, cb: (err: any, id?: any) => void) => void;
+    authenticate(): AuthenticateMethod<T>
+    serializeUser(): (user: T, cb: (err: any, id?: any) => void) => void;
     deserializeUser(): (username: string, cb: (err: any, user?: any) => void) => void;
 
     register(user: T, password: string): Promise<T>;
     register(user: T, password: string, cb: (err: any, account: any) => void): void;
-    findByUsername(username: string, selectHashSaltFields: boolean): Query<T>;
+    findByUsername(username: string, selectHashSaltFields: boolean): Query<T, T>;
     findByUsername(username: string, selectHashSaltFields: boolean, cb: (err: any, account: any) => void): any;
     createStrategy(): passportLocal.Strategy;
   }

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 4.0
 
 declare module 'mongoose' {
     import passportLocal = require('passport-local');

--- a/types/passport-local-mongoose/package.json
+++ b/types/passport-local-mongoose/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "4.*"
+        "mongoose": "5.*"
     }
 }

--- a/types/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/types/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -122,7 +122,7 @@ type _User = User;
 
 declare global {
     namespace Express {
-        // tslint:disable-next-line
+        // tslint:disable-next-line:no-padding no-empty-interface
         interface User extends _User {}
     }
 }
@@ -133,7 +133,7 @@ passport.deserializeUser(UserModel.deserializeUser());
 let router: Router = Router();
 
 router.post('/login', passport.authenticate('local'), function(req: Request, res: Response) {
-    console.log(req.user?.username);
+    req.user?.username; // $ExpectType string | undefined
     res.redirect('/');
 });
 //#endregion

--- a/types/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/types/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -69,7 +69,6 @@ errorMessages.MissingUsernameError = 'No username was given';
 errorMessages.UserExistsError = 'A user with the given username is already registered';
 
 options.errorMessages = errorMessages;
-
 UserSchema.plugin(passportLocalMongoose, options);
 
 interface UserModel<T extends Document> extends PassportLocalModel<T> {}
@@ -90,7 +89,7 @@ passport.use('login', new LocalStrategy({
         process.nextTick(() => {
             UserModel
             .findOne({ 'username': username })
-            .exec((err: any, user: User) => {
+            .exec((err: any, user: User|null) => {
                 if (err) {
                     console.log(err);
                     return done(err, null);
@@ -123,7 +122,7 @@ type _User = User;
 
 declare global {
     namespace Express {
-        interface User extends PassportLocalModel<_User> {
+        interface User extends _User {
         }
     }
 }
@@ -134,6 +133,7 @@ passport.deserializeUser(UserModel.deserializeUser());
 let router: Router = Router();
 
 router.post('/login', passport.authenticate('local'), function(req: Request, res: Response) {
-  res.redirect('/');
+    console.log(req.user?.username)
+    res.redirect('/');
 });
 //#endregion

--- a/types/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/types/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -54,7 +54,7 @@ options.populateFields = 'undefined';
 options.encoding = 'hex';
 options.limitAttempts = false;
 options.maxAttempts = Infinity;
-options.passwordValidator = function (password: string, cb: (err: any) => void): void {};
+options.passwordValidator = function(password: string, cb: (err: any) => void): void {};
 options.usernameQueryFields = [];
 
 let errorMessages: PassportLocalErrorMessages = {};
@@ -88,7 +88,7 @@ passport.use(
         },
         (req: any, username: string, password: string, done: (err: any, res: any, msg?: any) => void) => {
             process.nextTick(() => {
-                UserModel.findOne({ username: username }).exec((err: any, user: User | null) => {
+                UserModel.findOne({ username }).exec((err: any, user: User | null) => {
                     if (err) {
                         console.log(err);
                         return done(err, null);
@@ -99,7 +99,7 @@ passport.use(
                         return done(null, false, errorMessages.IncorrectUsernameError);
                     }
 
-                    user.authenticate(password, function (autherr: any, authuser: User, autherrmsg: any) {
+                    user.authenticate(password, function(autherr: any, authuser: User, autherrmsg: any) {
                         if (autherr) {
                             console.log(autherr);
                             return done(autherr, null);
@@ -122,6 +122,7 @@ type _User = User;
 
 declare global {
     namespace Express {
+        // tslint:disable-next-line
         interface User extends _User {}
     }
 }
@@ -131,7 +132,7 @@ passport.deserializeUser(UserModel.deserializeUser());
 
 let router: Router = Router();
 
-router.post('/login', passport.authenticate('local'), function (req: Request, res: Response) {
+router.post('/login', passport.authenticate('local'), function(req: Request, res: Response) {
     console.log(req.user?.username);
     res.redirect('/');
 });

--- a/types/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/types/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -10,14 +10,13 @@ import {
     PassportLocalSchema,
     PassportLocalModel,
     PassportLocalOptions,
-    PassportLocalErrorMessages
+    PassportLocalErrorMessages,
 } from 'mongoose';
 import passportLocalMongoose = require('passport-local-mongoose');
 
 import { Router, Request, Response } from 'express';
 import * as passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
-
 
 //#region Test Models
 interface User extends PassportLocalDocument {
@@ -34,7 +33,7 @@ const UserSchema = new Schema({
     hash: String,
     salt: String,
     attempts: Number,
-    last: Date
+    last: Date,
 }) as PassportLocalSchema;
 
 let options: PassportLocalOptions = <PassportLocalOptions>{};
@@ -55,7 +54,7 @@ options.populateFields = 'undefined';
 options.encoding = 'hex';
 options.limitAttempts = false;
 options.maxAttempts = Infinity;
-options.passwordValidator = function(password: string, cb: (err: any) => void): void {};
+options.passwordValidator = function (password: string, cb: (err: any) => void): void {};
 options.usernameQueryFields = [];
 
 let errorMessages: PassportLocalErrorMessages = {};
@@ -76,54 +75,54 @@ interface UserModel<T extends Document> extends PassportLocalModel<T> {}
 let UserModel: UserModel<User> = model<User>('User', UserSchema);
 //#endregion
 
-
 //#region Test Passport/Passport-Local
 passport.use(UserModel.createStrategy());
 
-passport.use('login', new LocalStrategy({
-        passReqToCallback: true,
-        usernameField: 'username',
-        passwordField: 'password'
-    },
-    (req: any, username: string, password: string, done: (err: any, res: any, msg?: any) => void) => {
-        process.nextTick(() => {
-            UserModel
-            .findOne({ 'username': username })
-            .exec((err: any, user: User|null) => {
-                if (err) {
-                    console.log(err);
-                    return done(err, null);
-                }
-
-                if (!user) {
-                    console.log(errorMessages.IncorrectUsernameError);
-                    return done(null, false, errorMessages.IncorrectUsernameError);
-                }
-
-                user.authenticate(password, function(autherr: any, authuser: User, autherrmsg: any) {
-                    if (autherr) {
-                        console.log(autherr);
-                        return done(autherr, null);
+passport.use(
+    'login',
+    new LocalStrategy(
+        {
+            passReqToCallback: true,
+            usernameField: 'username',
+            passwordField: 'password',
+        },
+        (req: any, username: string, password: string, done: (err: any, res: any, msg?: any) => void) => {
+            process.nextTick(() => {
+                UserModel.findOne({ username: username }).exec((err: any, user: User | null) => {
+                    if (err) {
+                        console.log(err);
+                        return done(err, null);
                     }
 
-                    if (!authuser) {
-                        console.log(errorMessages.IncorrectPasswordError);
-                        return done(null, false, errorMessages.IncorrectPasswordError);
+                    if (!user) {
+                        console.log(errorMessages.IncorrectUsernameError);
+                        return done(null, false, errorMessages.IncorrectUsernameError);
                     }
 
-                    return done(null, authuser);
+                    user.authenticate(password, function (autherr: any, authuser: User, autherrmsg: any) {
+                        if (autherr) {
+                            console.log(autherr);
+                            return done(autherr, null);
+                        }
+
+                        if (!authuser) {
+                            console.log(errorMessages.IncorrectPasswordError);
+                            return done(null, false, errorMessages.IncorrectPasswordError);
+                        }
+
+                        return done(null, authuser);
+                    });
                 });
             });
-        });
-    })
+        },
+    ),
 );
 
 type _User = User;
 
 declare global {
     namespace Express {
-        interface User extends _User {
-        }
+        interface User extends _User {}
     }
 }
 
@@ -132,8 +131,8 @@ passport.deserializeUser(UserModel.deserializeUser());
 
 let router: Router = Router();
 
-router.post('/login', passport.authenticate('local'), function(req: Request, res: Response) {
-    console.log(req.user?.username)
+router.post('/login', passport.authenticate('local'), function (req: Request, res: Response) {
+    console.log(req.user?.username);
     res.redirect('/');
 });
 //#endregion

--- a/types/passport-local-mongoose/tslint.json
+++ b/types/passport-local-mongoose/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "array-type": false,
         "ban-types": false,
-        "dt-header": false,
         "no-consecutive-blank-lines": false,
         "no-declare-current-package": false,
         "no-object-literal-type-assertion": false,


### PR DESCRIPTION
## Summary
[passport.serializeUser()](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdf1d8ac3e92e6d596ee95d8a0b0aa5ebe7a0d8d/types/passport/index.d.ts#L84) expects the callback to take an `Express.User` object as the first parameter but `@types/passport-local-mongoose` defines [@types/passport-local-mongoose](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdf1d8ac3e92e6d596ee95d8a0b0aa5ebe7a0d8d/types/passport-local-mongoose/index.d.ts#L38) as taking a `PassportLocalModel` as the first argument which is incorrect, you are serializing an `Express.User` object which is a `PassportLocalDocument`. The type of the first parameter to `PassportLocalModel.serializerUser()` should thus be `T` rather than `PassportLocalModel<T>`.  I verified this works in my own personal project and reproduced the TypeScript compilation error in this [GitHub project](https://github.com/troysandal/passport-local-mongoose-serialize-user-bug/blob/main/README.md).  This sample project replicates what the same error which was posted in this [StackOverflow](https://stackoverflow.com/questions/67726174/passport-local-mongoose-serializeuser-incorrect-type) bug. 


To Dos
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [URL Here](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/54870)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

