### PR TITLE
Fix chrome.runtime.sendMessage() and add tests

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -6995,11 +6995,11 @@ declare namespace chrome.runtime {
      * @param responseCallback Optional
      * Parameter response: The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
      */
-    export function sendMessage<M = any, R = any>(
+    export function sendMessage<Message = any, Response = any>(
         extensionId: string,
-        message: M,
+        message: Message,
         options: MessageOptions,
-        responseCallback?: (response: R) => void,
+        responseCallback?: (response: Response) => void,
     ): void;
     /**
      * Send a single message to a native application.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -6999,7 +6999,7 @@ declare namespace chrome.runtime {
         extensionId: string,
         message: M,
         options: MessageOptions,
-        responseCallback?: (response: any) => R,
+        responseCallback?: (response: R) => void,
     ): void;
     /**
      * Send a single message to a native application.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -996,6 +996,13 @@ function testRuntimeSendMessage() {
     chrome.runtime.sendMessage<string, number>("Hello World!", console.log);
     chrome.runtime.sendMessage<number>("Hello World!", console.log); // $ExpectError
     chrome.runtime.sendMessage<string, boolean>("Hello World!", (num: number) => alert(num+1)); // $ExpectError
+
+    chrome.runtime.sendMessage('extension-id', 'Hello World!');
+    chrome.runtime.sendMessage('extension-id', 'Hello World!', console.log);
+    chrome.runtime.sendMessage<string>('extension-id', 'Hello World!', console.log);
+    chrome.runtime.sendMessage<string, number>('extension-id', 'Hello World!', console.log);
+    chrome.runtime.sendMessage<number>('extension-id', 'Hello World!', console.log); // $ExpectError
+    chrome.runtime.sendMessage<string, boolean>('extension-id', 'Hello World!', (num: number) => alert(num+1)); // $ExpectError
 }
 
 function testTabsSendMessage() {


### PR DESCRIPTION
Fix definition for cross-extension communication use case of chrome.runtime.sendMessage() and add tests. This bug was introduced by a typo in commit a52920355eb3cd34ad5740016ad0be85c9fe4c25 merged less than 2 days ago.

The relevant portion of the diff was:
```diff
-    export function sendMessage(
+    export function sendMessage<M = any, R = any>(
        extensionId: string,
-        message: any,
+        message: M,
        options: MessageOptions,
-        responseCallback?: (response: any) => void,
+        responseCallback?: (response: any) => R,
    ): void;
```
and it should have been this:
```diff
-    export function sendMessage(
+    export function sendMessage<M = any, R = any>(
        extensionId: string,
-        message: any,
+        message: M,
        options: MessageOptions,
-        responseCallback?: (response: any) => void,
+        responseCallback?: (response: R) => void,
    ): void;
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.chrome.com/docs/extensions/reference/runtime/#method-sendMessage>

CC @tregagnon and @userTim