### PR TITLE
Add getScrollbarWidth type for react-virtualized/Table

### DIFF
--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -425,6 +425,8 @@ export class Table extends PureComponent<TableProps> {
 
     forceUpdateGrid(): void;
 
+    getScrollbarWidth(): number;
+
     /** See Grid#getOffsetForCell */
     getOffsetForRow(params: { alignment?: Alignment | undefined; index?: number | undefined }): number;
 


### PR DESCRIPTION
Added type for Table.md#getscrollbarwidth
- document: https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md#getscrollbarwidth
- source: https://github.com/bvaughn/react-virtualized/blob/master/source/Table/Table.js#L340-L349

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  - I didn't modify the test because there was no test for other functions in Table (such as measureAllRows).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

