### PR TITLE
twine-sugarcube: fix return types for the Wikifier and types for macros

### DIFF
--- a/types/twine-sugarcube/macro.d.ts
+++ b/types/twine-sugarcube/macro.d.ts
@@ -119,7 +119,7 @@ export interface MacroContext {
 
 export interface MacroDefinition {
     handler: (this: MacroContext) => void;
-    tags?: string[] | undefined;
+    tags?: string[] | null | undefined;
     skipArgs?: boolean | undefined;
 }
 

--- a/types/twine-sugarcube/macro.d.ts
+++ b/types/twine-sugarcube/macro.d.ts
@@ -63,7 +63,7 @@ export interface MacroContext {
      * The current output element.
      * @since 2.0.0
      */
-    output: HTMLElement;
+    output: ParentNode;
 
     /**
      * The (execution) context object of the macro's parent, or null if the macro has no parent.

--- a/types/twine-sugarcube/test/macro.ts
+++ b/types/twine-sugarcube/test/macro.ts
@@ -18,6 +18,11 @@ Macro.add('if', {
     }
 });
 
+Macro.add('dummy', {
+    tags: null,
+    handler() { }
+});
+
 Macro.delete("if"); // $ExpectType void
 Macro.delete(["if", "iif"]); // $ExpectType void
 

--- a/types/twine-sugarcube/test/wiki.ts
+++ b/types/twine-sugarcube/test/wiki.ts
@@ -1,12 +1,14 @@
 const a: any = null;
 let b = false;
-let s = "string";
+const s = "string";
+let df: DocumentFragment;
+let anchor: HTMLAnchorElement;
 
 const output: DocumentFragment | HTMLElement | JQuery = new DocumentFragment();
 
-Wikifier.createExternalLink(output, s, s);
-Wikifier.createInternalLink(output, s, s, () => {});
-s = Wikifier.wikifyEval(s);
+anchor = Wikifier.createExternalLink(output, s, s);
+anchor = Wikifier.createInternalLink(output, s, s, () => {});
+df = Wikifier.wikifyEval(s);
 b = Wikifier.isExternalLink(s);
 
 new Wikifier(output, s);

--- a/types/twine-sugarcube/wiki.d.ts
+++ b/types/twine-sugarcube/wiki.d.ts
@@ -7,10 +7,10 @@ export interface WikifierOptions {
 export interface WikifierAPI {
     new(destination: OutputDestination | null, source: string, options?: WikifierOptions): unknown;
 
-    createExternalLink(destination: OutputDestination, url: string, text: string): HTMLElement;
-    createInternalLink(destination: OutputDestination, passage: string, text: string, callback: () => void): HTMLElement;
+    createExternalLink(destination: OutputDestination, url: string, text: string): HTMLAnchorElement;
+    createInternalLink(destination: OutputDestination, passage: string, text: string, callback: () => void): HTMLAnchorElement;
     isExternalLink(link: string): boolean;
-    wikifyEval(text: string): string;
+    wikifyEval(text: string): DocumentFragment;
 }
 
 export {};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tmedwards/sugarcube-2/blob/master/src/markup/wikifier.js#L247
