### PR TITLE
update(mini-css-extract-plugin): v2.2 updates

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mini-css-extract-plugin 2.0
+// Type definitions for mini-css-extract-plugin 2.2
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
@@ -36,54 +36,46 @@ declare class MiniCssExtractPlugin {
 declare namespace MiniCssExtractPlugin {
     interface PluginOptions {
         /**
-         * Works like [`output.filename`](https://webpack.js.org/configuration/output/#outputfilename).
+         * This option determines the name of each output CSS file.
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#filename
+         * @default '[name].css'
          */
         filename?: Required<Configuration>['output']['filename'] | undefined;
         /**
-         * Works like [`output.chunkFilename`](https://webpack.js.org/configuration/output/#outputchunkfilename).
+         * This option determines the name of non-entry chunk files.
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#chunkfilename
          */
         chunkFilename?: Required<Configuration>['output']['chunkFilename'] | undefined;
         /**
-         * For projects where CSS ordering has been mitigated through consistent
-         * use of scoping or naming conventions, the CSS order warnings can be
-         * disabled by setting this flag to true for the plugin.
-         */
-        ignoreOrder?: boolean | undefined;
-        /**
-         * Specify where to insert the link tag.
-         *
-         * A string value specifies a DOM query for a parent element to attach to.
-         *
-         * A function allows to override default behavior for non-entry CSS chunks.
-         * This code will run in the browser alongside your application. It is recommend
-         * to only use ECMA 5 features and syntax. The function won't have access to the
-         * scope of the webpack configuration module.
-         *
-         * @default function() { document.head.appendChild(linkTag); }
-         */
-        insert?: string | ((linkTag: any) => void) | undefined;
-        /**
-         * Specify additional html attributes to add to the link tag.
-         *
-         * Note: These are only applied to dynamically loaded css chunks. To modify link
-         * attributes for entry CSS chunks, please use html-webpack-plugin.
-         */
-        attributes?: Record<string, string> | undefined;
-        /**
-         * This option allows loading asynchronous chunks with a custom link type, such as
-         * `<link type="text/css" ...>`.
-         *
-         * `false` disables the link `type` attribute.
-         *
-         * @default 'text/css'
-         */
-        linkType?: string | false | 'text/css' | undefined;
-
-        /**
-         * Use an experimental webpack API to execute modules instead of child compilers
+         * Enable the experimental importModule approach instead of using child compilers. This uses less memory and is faster.
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#experimentaluseimportmodule
          * @default false
          */
         experimentalUseImportModule?: boolean | undefined;
+        /**
+         * Remove Order Warnings.
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#ignoreorder
+         * @default false
+         */
+        ignoreOrder?: boolean | undefined;
+        /**
+         * Inserts `<link>` at the given position.
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#insert
+         * @default document.head.appendChild(linkTag)
+         */
+        insert?: string | ((linkTag: any) => void) | undefined;
+        /**
+         * Adds custom attributes to tag.
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#attributes
+         * @default {}
+         */
+        attributes?: Record<string, string> | undefined;
+        /**
+         * This option allows loading asynchronous chunks with a custom link type
+         * @link https://github.com/webpack-contrib/mini-css-extract-plugin#linktype
+         * @default 'text/css'
+         */
+        linkType?: string | false | 'text/css' | undefined;
     }
     interface LoaderOptions {
         /**

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -1,32 +1,32 @@
-import webpack = require("webpack");
-import MiniCssExtractPlugin = require("mini-css-extract-plugin");
+import webpack = require('webpack');
+import MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 let configuration: webpack.Configuration;
 
 const loaderOptions: MiniCssExtractPlugin.LoaderOptions = {
-    publicPath: "/",
+    publicPath: '/',
     esModule: true,
     emit: false,
-    layer: "layer",
+    layer: 'layer',
 };
 
 configuration = {
     // The standard entry point and output config
     entry: {
-        posts: "./posts",
-        post: "./post",
-        about: "./about",
+        posts: './posts',
+        post: './post',
+        about: './about',
     },
     output: {
-        filename: "[name].js",
-        chunkFilename: "[id].js",
+        filename: '[name].js',
+        chunkFilename: '[id].js',
     },
     module: {
         rules: [
             // Extract css files
             {
                 test: /\.css$/,
-                use: [MiniCssExtractPlugin.loader, "css-loader"],
+                use: [MiniCssExtractPlugin.loader, 'css-loader'],
             },
             {
                 test: /\.css$/,
@@ -39,7 +39,7 @@ configuration = {
             // or any other compile-to-css language
             {
                 test: /\.less$/,
-                use: [MiniCssExtractPlugin.loader, "css-loader", "style-loader"],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', 'style-loader'],
             },
             // You could also use other loaders the same way. I. e. the autoprefixer-loader
         ],
@@ -47,7 +47,7 @@ configuration = {
     // Use the plugin to specify the resulting filename (and add needed behavior to the compiler)
     plugins: [
         new MiniCssExtractPlugin({
-            filename: "[name].css",
+            filename: '[name].css',
         }),
     ],
 };
@@ -61,8 +61,8 @@ configuration = {
     // ...
     plugins: [
         new MiniCssExtractPlugin({
-            filename: ({ chunk }) => (chunk?.name ? `${chunk.name.replace("/js/", "/css/")}.css` : "unknown"),
-            chunkFilename: "style.css",
+            filename: ({ chunk }) => (chunk?.name ? `${chunk.name.replace('/js/', '/css/')}.css` : 'unknown'),
+            chunkFilename: 'style.css',
         }),
     ],
 };
@@ -71,8 +71,8 @@ configuration = {
     // ...
     plugins: [
         new MiniCssExtractPlugin({
-            filename: "style.css",
-            chunkFilename: ({ chunk }) => (chunk?.name ? `${chunk.name.replace("/js/", "/css/")}.css` : "unknown"),
+            filename: 'style.css',
+            chunkFilename: ({ chunk }) => (chunk?.name ? `${chunk.name.replace('/js/', '/css/')}.css` : 'unknown'),
         }),
     ],
 };
@@ -81,8 +81,8 @@ configuration = {
     // ...
     plugins: [
         new MiniCssExtractPlugin({
-            filename: "styles.css",
-            chunkFilename: "style.css",
+            filename: 'styles.css',
+            chunkFilename: 'style.css',
             ignoreOrder: true,
         }),
     ],
@@ -101,7 +101,7 @@ configuration = {
     // `linkType`
     plugins: [
         new MiniCssExtractPlugin({
-            linkType: "text/css",
+            linkType: 'text/css',
         }),
         new MiniCssExtractPlugin({
             linkType: false,
@@ -121,4 +121,4 @@ configuration = {
     ],
 };
 
-new MiniCssExtractPlugin().apply(new webpack.Compiler("context"));
+new MiniCssExtractPlugin().apply(new webpack.Compiler('context'));

--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for webpack-sources 2.1
+// Type definitions for webpack-sources 3.2
 // Project: https://github.com/webpack/webpack-sources
 // Definitions by: e-cloud <https://github.com/e-cloud>
 //                 Chris Eppstein <https://github.com/chriseppstein>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 /// <reference types="node" />
 
 export import CachedSource = require('./lib/CachedSource');

--- a/types/webpack-sources/lib/SourceMapSource.d.ts
+++ b/types/webpack-sources/lib/SourceMapSource.d.ts
@@ -15,6 +15,7 @@ declare class SourceMapSource extends Source implements SourceAndMapMixin {
         innerSourceMap?: RawSourceMap | string,
         removeOriginalSource?: boolean,
     );
+    buffer(): Buffer;
     source(): string;
 }
 

--- a/types/webpack-sources/webpack-sources-tests.ts
+++ b/types/webpack-sources/webpack-sources-tests.ts
@@ -130,6 +130,7 @@ const tests = (options: MapOptions, hash: Hash, sourceMap: RawSourceMap) => {
     replaceSource.sourceAndMap(options); // $ExpectType SourceAndMapResult
 
     const sourceMapSource = new SourceMapSource(replaceSource.source(), 'sourceMapSource', sourceMap);
+    sourceMapSource.buffer(); // $ExpectType Buffer
     sourceMapSource.source(); // $ExpectType string
     sourceMapSource.updateHash(hash); // $ExpectType void
     sourceMapSource.map(options); // $ExpectType RawSourceMap | null


### PR DESCRIPTION
- No api shape changes
- Documentation updates (JSDocs)
- unified format using DT defaults

https://github.com/webpack-contrib/mini-css-extract-plugin/compare/v2.0.0...v2.2.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
hanging an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.