### PR TITLE
Implement TypeScript assertions in http-assert types

### DIFF
--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -1,26 +1,115 @@
-import httpAssert = require('http-assert');
-import { HttpError } from 'http-errors';
+import httpAssert = require("http-assert");
+
+declare function unknown(): unknown;
+
+// assert()
+
+(() => {
+    const value = unknown();
+    httpAssert(typeof value === "string");
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown() as string | undefined;
+    httpAssert(value);
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(typeof value === "number", 400);
+
+    // $ExpectType number
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(typeof value === "boolean", 400, "message");
+
+    // $ExpectType boolean
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(value === undefined, 400, { foo: "bar" });
+
+    // $ExpectType undefined
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert(value === null, 400, "message", { foo: "bar" });
+
+    // $ExpectType null
+    value;
+})();
+
+// assert.ok()
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(typeof value === "string");
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown() as string | undefined;
+    httpAssert.ok(value);
+
+    // $ExpectType string
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(typeof value === "number", 400);
+
+    // $ExpectType number
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(typeof value === "boolean", 400, "message");
+
+    // $ExpectType boolean
+    value;
+})();
+
+(() => {
+    const value = unknown();
+    httpAssert.ok(value === null, 400, "message", { foo: "bar" });
+
+    // $ExpectType null
+    value;
+})();
+
+// Other assertions
 
 const status = 401;
-const message = 'some error message';
+const message = "some error message";
 const options = {};
 
-try {
-    httpAssert.equal('hello', 'hello');
-    httpAssert.notEqual('hello', 'hello', status, message, options);
-    httpAssert.ok(true);
-    httpAssert.ok(true, status, message, options);
-    httpAssert.strictEqual(3, '3');
-    httpAssert.strictEqual(3, '3', status, message, options);
-    httpAssert.notStrictEqual(3, '3');
-    httpAssert.notStrictEqual(3, '3', status, message, options);
-    httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' });
-    httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
-    httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' });
-    httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
-    httpAssert(false, status, message, options);
-} catch (err) {
-    console.log((err as HttpError).status);
-    console.log((err as HttpError).message);
-    console.log((err as HttpError).expose);
-}
+httpAssert.equal("hello", "hello");
+httpAssert.notEqual("hello", "hello", status, message);
+httpAssert.ok(true);
+httpAssert.ok(true, status, message, options);
+httpAssert.strictEqual(3, "3");
+httpAssert.strictEqual(3, "3", status, message, options);
+httpAssert.notStrictEqual(3, "3");
+httpAssert.notStrictEqual(3, "3", status, message, options);
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert(false, status, message, options);

--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -52,8 +52,6 @@ declare function unknown(): unknown;
     value;
 })();
 
-// assert.ok()
-
 (() => {
     const value = unknown();
     httpAssert.ok(typeof value === "string");

--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -2,8 +2,6 @@ import httpAssert = require('http-assert');
 
 declare function unknown(): unknown;
 
-// assert()
-
 (() => {
     const value = unknown();
     httpAssert(typeof value === 'string');
@@ -91,8 +89,6 @@ declare function unknown(): unknown;
     // $ExpectType null
     value;
 })();
-
-// Other assertions
 
 const status = 401;
 const message = 'some error message';

--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -1,4 +1,4 @@
-import httpAssert = require("http-assert");
+import httpAssert = require('http-assert');
 
 declare function unknown(): unknown;
 
@@ -6,7 +6,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert(typeof value === "string");
+    httpAssert(typeof value === 'string');
 
     // $ExpectType string
     value;
@@ -22,7 +22,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert(typeof value === "number", 400);
+    httpAssert(typeof value === 'number', 400);
 
     // $ExpectType number
     value;
@@ -30,7 +30,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert(typeof value === "boolean", 400, "message");
+    httpAssert(typeof value === 'boolean', 400, 'message');
 
     // $ExpectType boolean
     value;
@@ -38,7 +38,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert(value === undefined, 400, { foo: "bar" });
+    httpAssert(value === undefined, 400, { foo: 'bar' });
 
     // $ExpectType undefined
     value;
@@ -46,7 +46,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert(value === null, 400, "message", { foo: "bar" });
+    httpAssert(value === null, 400, 'message', { foo: 'bar' });
 
     // $ExpectType null
     value;
@@ -54,7 +54,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert.ok(typeof value === "string");
+    httpAssert.ok(typeof value === 'string');
 
     // $ExpectType string
     value;
@@ -70,7 +70,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert.ok(typeof value === "number", 400);
+    httpAssert.ok(typeof value === 'number', 400);
 
     // $ExpectType number
     value;
@@ -78,7 +78,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert.ok(typeof value === "boolean", 400, "message");
+    httpAssert.ok(typeof value === 'boolean', 400, 'message');
 
     // $ExpectType boolean
     value;
@@ -86,7 +86,7 @@ declare function unknown(): unknown;
 
 (() => {
     const value = unknown();
-    httpAssert.ok(value === null, 400, "message", { foo: "bar" });
+    httpAssert.ok(value === null, 400, 'message', { foo: 'bar' });
 
     // $ExpectType null
     value;
@@ -95,19 +95,19 @@ declare function unknown(): unknown;
 // Other assertions
 
 const status = 401;
-const message = "some error message";
+const message = 'some error message';
 const options = {};
 
-httpAssert.equal("hello", "hello");
-httpAssert.notEqual("hello", "hello", status, message);
+httpAssert.equal('hello', 'hello');
+httpAssert.notEqual('hello', 'hello', status, message);
 httpAssert.ok(true);
 httpAssert.ok(true, status, message, options);
-httpAssert.strictEqual(3, "3");
-httpAssert.strictEqual(3, "3", status, message, options);
-httpAssert.notStrictEqual(3, "3");
-httpAssert.notStrictEqual(3, "3", status, message, options);
-httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" });
-httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
-httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" });
-httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert.strictEqual(3, '3');
+httpAssert.strictEqual(3, '3', status, message, options);
+httpAssert.notStrictEqual(3, '3');
+httpAssert.notStrictEqual(3, '3', status, message, options);
+httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' });
+httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
+httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' });
+httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
 httpAssert(false, status, message, options);

--- a/types/http-assert/package.json
+++ b/types/http-assert/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "types": "index",
+  "typesVersions": {
+    "<=3.6": { "*": ["ts3.6/*"] }
+  }
+}

--- a/types/http-assert/ts3.6/http-assert-tests.ts
+++ b/types/http-assert/ts3.6/http-assert-tests.ts
@@ -1,0 +1,19 @@
+import httpAssert = require("http-assert");
+
+const status = 401;
+const message = "some error message";
+const options = {};
+
+httpAssert.equal("hello", "hello");
+httpAssert.notEqual("hello", "hello", status, message, options);
+httpAssert.ok(true);
+httpAssert.ok(true, status, message, options);
+httpAssert.strictEqual(3, "3");
+httpAssert.strictEqual(3, "3", status, message, options);
+httpAssert.notStrictEqual(3, "3");
+httpAssert.notStrictEqual(3, "3", status, message, options);
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.deepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" });
+httpAssert.notDeepEqual({ foo: "foo" }, { bar: "bar" }, status, message, options);
+httpAssert(false, status, message, options);

--- a/types/http-assert/ts3.6/index.d.ts
+++ b/types/http-assert/ts3.6/index.d.ts
@@ -1,18 +1,10 @@
-// Type definitions for http-assert 1.5
-// Project: https://github.com/jshttp/http-assert
-// Definitions by: jKey Lu <https://github.com/jkeylu>
-//                 Peter Squicciarini <https://github.com/stripedpajamas>
-//                 Alex Bulanov <https://github.com/sapfear>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
 /**
  * @param status the status code
  * @param msg the message of the error, defaulting to node's text for that status code
  * @param opts custom properties to attach to the error object
  */
-declare function assert(value: any, status?: number, msg?: string, opts?: Record<string, any>): asserts value;
-declare function assert(value: any, status?: number, opts?: Record<string, any>): asserts value;
+declare function assert(value: any, status?: number, msg?: string, opts?: {}): void;
+declare function assert(value: any, status?: number, opts?: {}): void;
 
 declare namespace assert {
     /**
@@ -20,21 +12,21 @@ declare namespace assert {
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type Assert = <T>(a: T, b: T, status?: number, msg?: string, opts?: Record<string, any>) => void;
+    type Assert = <T>(a: T, b: T, status?: number, msg?: string, opts?: {}) => void;
 
     /**
      * @param status the status code
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type AssertOK = (a: any, status?: number, msg?: string, opts?: Record<string, any>) => asserts a;
+    type AssertOK = (a: any, status?: number, msg?: string, opts?: {}) => void;
 
     /**
      * @param status the status code
      * @param msg the message of the error, defaulting to node's text for that status code
      * @param opts custom properties to attach to the error object
      */
-    type AssertEqual = (a: any, b: any, status?: number, msg?: string, opts?: Record<string, any>) => void;
+    type AssertEqual = (a: any, b: any, status?: number, msg?: string, opts?: {}) => void;
 
     const equal: Assert;
     const notEqual: Assert;

--- a/types/http-assert/ts3.6/tsconfig.json
+++ b/types/http-assert/ts3.6/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "http-assert-tests.ts"
+    ]
+}

--- a/types/http-assert/ts3.6/tslint.json
+++ b/types/http-assert/ts3.6/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/koa/test/default.ts
+++ b/types/koa/test/default.ts
@@ -33,7 +33,7 @@ app.use<{ a: boolean }>(async (ctx, next) => {
     await next();
 });
 
-app.use((ctx, next) => {
+app.use((ctx: Koa.Context, next) => {
     const start: any = new Date();
     return next().then(() => {
         const end: any = new Date();
@@ -49,7 +49,7 @@ app.use(ctx => {
     ctx.body = 'Hello World';
     ctx.body = ctx.URL.toString();
     ctx.set({
-        link: ["<http://example.com>", "<http://example.org>"]
+        link: ['<http://example.com>', '<http://example.org>'],
     });
     ctx.attachment();
     ctx.attachment('path/to/tobi.png');

--- a/types/koa/test/index.ts
+++ b/types/koa/test/index.ts
@@ -37,7 +37,7 @@ app.use<{}, UserContext>(async ctx => {
     ctx.user = {};
 });
 
-app.use((ctx, next) => {
+app.use((ctx: Koa.Context, next) => {
     const start: any = new Date();
     return next().then(() => {
         const end: any = new Date();


### PR DESCRIPTION
Basically this means one could write:

```ts
import { Context } from 'koa';

function myController(ctx: Context) {
  const { answer } = ctx.request.body;
  ctx.assert(answer === 42, 'Wrong')
  // The type of answer is 42 now.
  let correctAnswer: 42 = answer;
}
```

Because the `asserts` keyword was introduced in TypeScript 3.7, the old types were moved into the `ts3.6` folder. End of support for TypeScript 3.6 is this month, so I’m not sure if I should just remove them.

The try / catch clause was removed from tests, because it wasn’t used for testing the `http-assert` types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
