### PR TITLE
[node] Fix deprecated message of Cluster.isMaster of Node.js

### DIFF
--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -322,7 +322,7 @@ declare module 'cluster' {
     export interface Cluster extends EventEmitter {
         disconnect(callback?: () => void): void;
         fork(env?: any): Worker;
-        /** @deprecated since v16.0.0 - use setupPrimary. */
+        /** @deprecated since v16.0.0 - use isPrimary. */
         readonly isMaster: boolean;
         readonly isPrimary: boolean;
         readonly isWorker: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/cluster.html#cluster_cluster_ismaster>

