### PR TITLE
express-session - restore indexer in SessionData to undo breaking changes until version bump

### DIFF
--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -211,6 +211,7 @@ declare namespace session {
      *
      */
     interface SessionData {
+        [key: string]: any;
         cookie: Cookie;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
 [comment thread on breaking changes]

This PR is for adding back in the indexer in `Express.SessionData`, which was removed in 1.17.1 . The 1.17.1 patch is a breaking change and should therefore only be included in a major bump. This breaks semantic versioning for both 1.17 and 1.15. The indexer property has been included since the original typings in 2017. While removing it may improve typings, preserving semantic versioning should be a higher priority for projects that use this package. Removal can be done in a 2.x version either by divorcing the versioning of the types package from the`express-session`, or by waiting for a major revision.

As a workaround you can manually augment SessionData for better typings. By default anything added to session data will receive an `any` type as it always has.

Details mentioned in this [comment thread](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d1259ee31e6b17c31a5a86e27a0d12f3ec7c5a19#r44080605)
