### PR TITLE
Add case insensitivity types to command-line-args

### DIFF
--- a/types/command-line-args/command-line-args-tests.ts
+++ b/types/command-line-args/command-line-args-tests.ts
@@ -13,12 +13,28 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     }
 ];
 
+// $ExpectType CommandLineOptions
 const options = commandLineArgs(optionDefinitions, {
     argv: [ '--one', '1' ],
     partial: true,
     stopAtFirstUnknown: true,
-    camelCase: true
+    camelCase: true,
+    caseInsensitive: true,
 });
 
 const unknown = options._unknown;
 const something = options.something;
+
+// case insensitive option is not required
+// $ExpectType CommandLineOptions
+const optionsNoCaseInsensitiveFlag = commandLineArgs(optionDefinitions, {
+    argv: [ '--one', '1' ],
+    partial: true,
+    stopAtFirstUnknown: true,
+    camelCase: true,
+});
+
+// case insensitive option must be boolean | undefined
+const parseOptionsIncorrectType: commandLineArgs.ParseOptions = {
+    caseInsensitive: "abc", // $ExpectError
+};

--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for command-line-args 5.0
+// Type definitions for command-line-args 5.2
 // Project: https://github.com/75lb/command-line-args
 // Definitions by: Lloyd Brookes <https://github.com/75lb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -40,6 +40,12 @@ declare namespace commandLineArgs {
          * If `true`, options with hypenated names (e.g. `move-to`) will be returned in camel-case (e.g. `moveTo`).
          */
         camelCase?: boolean | undefined;
+
+        /**
+         * If `true`, the case of each option name or alias parsed is insignificant. For example, `--Verbose` and
+         * `--verbose` would be parsed identically, as would the aliases `-V` and `-v`. Defaults to false.
+         */
+        caseInsensitive?: boolean | undefined;
     }
 
     interface OptionDefinition {

--- a/types/command-line-args/tsconfig.json
+++ b/types/command-line-args/tsconfig.json
@@ -16,10 +16,6 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "baseUrl": "types",
-    "typeRoots": [
-        "types"
-    ],
     "files": [
         "index.d.ts",
         "command-line-args-tests.ts"

--- a/types/command-line-args/tsconfig.json
+++ b/types/command-line-args/tsconfig.json
@@ -16,6 +16,10 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
+    "baseUrl": "types",
+    "typeRoots": [
+        "types"
+    ],
     "files": [
         "index.d.ts",
         "command-line-args-tests.ts"


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/75lb/command-line-args/blob/master/doc/API.md#command-line-args
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Case insensitive support was added to the command-line-args library in https://github.com/75lb/command-line-args/pull/116 and was released in 5.2.0. This commit updates the corresponding types.