### PR TITLE
feat: adding hmgetBuffer to ioredis.Redis contract

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -825,8 +825,10 @@ declare namespace IORedis {
         hgetBuffer(key: KeyType, field: string): Promise<Buffer>;
 
         hmset: OverloadedKeyedHashCommand<ValueType, Ok>;
+        hmsetBuffer: OverloadedKeyedHashCommand<Buffer, Ok>;
 
         hmget: OverloadedKeyCommand<KeyType, Array<string | null>>;
+        hmgetBuffer: OverloadedKeyCommand<KeyType, Array<Buffer | null>>;
 
         hstrlen(key: KeyType, field: string, callback: Callback<number>): void;
         hstrlen(key: KeyType, field: string): Promise<number>;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -825,7 +825,6 @@ declare namespace IORedis {
         hgetBuffer(key: KeyType, field: string): Promise<Buffer>;
 
         hmset: OverloadedKeyedHashCommand<ValueType, Ok>;
-        hmsetBuffer: OverloadedKeyedHashCommand<Buffer, Ok>;
 
         hmget: OverloadedKeyCommand<KeyType, Array<string | null>>;
         hmgetBuffer: OverloadedKeyCommand<KeyType, Array<Buffer | null>>;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -189,6 +189,18 @@ redis.hmset('foo', { a: 'b', c: 4 }).then(console.log);
 redis.hmset('foo', { a: 'b', c: 4 }, cb);
 redis.hmset('foo', new Map<string, number>(), cb);
 
+// Test OverloadedKeyedHashCommand for hmset
+redis.hmgetBuffer('foo', '1', '2', '3', '4', '5').then(console.log);
+redis.hmgetBuffer('foo', '1', '2', '3', '4', '5', cb);
+redis.hmgetBuffer('foo', '1', '2', '3', '4').then(console.log);
+redis.hmgetBuffer('foo', '1', '2', '3', '4', cb);
+redis.hmgetBuffer('foo', '1', '2', '3').then(console.log);
+redis.hmgetBuffer('foo', '1', '2', '3', cb);
+redis.hmgetBuffer('foo', '1', '2').then(console.log);
+redis.hmgetBuffer('foo', '1', '2', cb);
+redis.hmgetBuffer('foo', '1').then(console.log);
+redis.hmgetBuffer('foo', '1', cb);
+
 // Test OverloadedHashCommand
 redis.mset('1', '2', '3', 4, '5', new Buffer([])).then(console.log);
 redis.mset('1', '2', '3', 4, '5', new Buffer([]), cb);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/luin/ioredis/blob/master/lib/commander.ts>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

### Additional info about the change:
**ioredis** package adds a standard version and a buffer version for each redis method there is, but not everyone is exposed through this typing. It's done at the line 83 of [this code](https://github.com/luin/ioredis/blob/master/lib/commander.ts) and is applied at the line 199 of [this one](https://github.com/luin/ioredis/blob/master/lib/redis/index.ts).
As I'm aware that not all methods provided will fit well with the Buffer version typing, **hmgetBuffer** is an exception: it'll work as expected.

@luin @DominikPalo FYK