### PR TITLE
[chrome-remote-interface] Add send method

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -50,9 +50,9 @@ function assertType<T>(value: T): T {
         assertType<Promise<void>>(client.send('Network.enable'));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId'));
-        client.send('Page.navigate', (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | {} | undefined) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | {} | undefined) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | {} | undefined) => {});
+        client.send('Page.navigate', (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | undefined) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | undefined) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | undefined) => {});
         // @ts-expect-error
         client.send('Page.navigate', (error: boolean, response: CDP.SendError) => {});
         // @ts-expect-error

--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -50,9 +50,9 @@ function assertType<T>(value: T): T {
         assertType<Promise<void>>(client.send('Network.enable'));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId'));
-        client.send('Page.navigate', (error: boolean, response: Protocol.Page.NavigateResponse | Error) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean, response: Protocol.Page.NavigateResponse | Error) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean, response: Protocol.Page.NavigateResponse | Error) => {});
+        client.send('Page.navigate', (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
     } finally {
         if (client) {
             await client.close();

--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -50,9 +50,9 @@ function assertType<T>(value: T): T {
         assertType<Promise<void>>(client.send('Network.enable'));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId'));
-        client.send('Page.navigate', (msg) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, (msg) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (msg) => {});
+        client.send('Page.navigate', (error: boolean, response: Protocol.Page.NavigateResponse | Error) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean, response: Protocol.Page.NavigateResponse | Error) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean, response: Protocol.Page.NavigateResponse | Error) => {});
     } finally {
         if (client) {
             await client.close();

--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -1,4 +1,9 @@
 import CDP = require('chrome-remote-interface');
+import Protocol from 'devtools-protocol';
+
+function assertType<T>(value: T): T {
+    return value;
+}
 
 (async () => {
     let client: CDP.Client | undefined;
@@ -41,6 +46,13 @@ import CDP = require('chrome-remote-interface');
                 await CDP.Close({ ...cdpPort, id: target.id });
             }
         }
+
+        assertType<Promise<void>>(client.send('Network.enable'));
+        assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}));
+        assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId'));
+        client.send('Page.navigate', (msg) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, (msg) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (msg) => {});
     } finally {
         if (client) {
             await client.close();

--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -53,6 +53,10 @@ function assertType<T>(value: T): T {
         client.send('Page.navigate', (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
         client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
         client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
+        // @ts-expect-error
+        client.send('Page.navigate', (error: boolean, response: CDP.SendError) => {});
+        // @ts-expect-error
+        client.send('Page.navigate', (error: boolean, response: Protocol.Page.NavigateResponse) => {});
     } finally {
         if (client) {
             await client.close();

--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -50,9 +50,9 @@ function assertType<T>(value: T): T {
         assertType<Promise<void>>(client.send('Network.enable'));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}));
         assertType<Promise<Protocol.Page.NavigateResponse>>(client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId'));
-        client.send('Page.navigate', (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
-        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean, response: Protocol.Page.NavigateResponse | CDP.SendError) => {});
+        client.send('Page.navigate', (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | {} | undefined) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | {} | undefined) => {});
+        client.send('Page.navigate', {url: 'https://github.com'}, 'sessionId', (error: boolean | Error, response: Protocol.Page.NavigateResponse | CDP.SendError | {} | undefined) => {});
         // @ts-expect-error
         client.send('Page.navigate', (error: boolean, response: CDP.SendError) => {});
         // @ts-expect-error

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -184,37 +184,69 @@ declare namespace CDP {
         Runtime: ProtocolProxyApi.RuntimeApi;
         Security: ProtocolProxyApi.SecurityApi;
         Target: ProtocolProxyApi.TargetApi;
+
         // deprecated domains
+        /** @deprecated This domain is deprecated - use Runtime or Log instead. */
         Console: ProtocolProxyApi.ConsoleApi;
+        /** @deprecated This domain is deprecated. */
         Schema: ProtocolProxyApi.SchemaApi;
-        // unstable domains
+
+        // experimental domains
+        /** @deprecated this API is experimental. */
         Accessibility: ProtocolProxyApi.AccessibilityApi;
+        /** @deprecated this API is experimental. */
         Animation: ProtocolProxyApi.AnimationApi;
+        /** @deprecated this API is experimental. */
         ApplicationCache: ProtocolProxyApi.ApplicationCacheApi;
+        /** @deprecated this API is experimental. */
         Audits: ProtocolProxyApi.AuditsApi;
+        /** @deprecated this API is experimental. */
         BackgroundService: ProtocolProxyApi.BackgroundServiceApi;
+        /** @deprecated this API is experimental. */
         CacheStorage: ProtocolProxyApi.CacheStorageApi;
+        /** @deprecated this API is experimental. */
         Cast: ProtocolProxyApi.CastApi;
+        /** @deprecated this API is experimental. */
         CSS: ProtocolProxyApi.CSSApi;
+        /** @deprecated this API is experimental. */
         Database: ProtocolProxyApi.DatabaseApi;
+        /** @deprecated this API is experimental. */
         DeviceOrientation: ProtocolProxyApi.DeviceOrientationApi;
+        /** @deprecated this API is experimental. */
         DOMSnapshot: ProtocolProxyApi.DOMSnapshotApi;
+        /** @deprecated this API is experimental. */
         DOMStorage: ProtocolProxyApi.DOMStorageApi;
+        /** @deprecated this API is experimental. */
         Fetch: ProtocolProxyApi.FetchApi;
+        /** @deprecated this API is experimental. */
         HeadlessExperimental: ProtocolProxyApi.HeadlessExperimentalApi;
+        /** @deprecated this API is experimental. */
         HeapProfiler: ProtocolProxyApi.HeapProfilerApi;
+        /** @deprecated this API is experimental. */
         IndexedDB: ProtocolProxyApi.IndexedDBApi;
+        /** @deprecated this API is experimental. */
         Inspector: ProtocolProxyApi.InspectorApi;
+        /** @deprecated this API is experimental. */
         LayerTree: ProtocolProxyApi.LayerTreeApi;
+        /** @deprecated this API is experimental. */
         Media: ProtocolProxyApi.MediaApi;
+        /** @deprecated this API is experimental. */
         Memory: ProtocolProxyApi.MemoryApi;
+        /** @deprecated this API is experimental. */
         Overlay: ProtocolProxyApi.OverlayApi;
+        /** @deprecated this API is experimental. */
         ServiceWorker: ProtocolProxyApi.ServiceWorkerApi;
+        /** @deprecated this API is experimental. */
         Storage: ProtocolProxyApi.StorageApi;
+        /** @deprecated this API is experimental. */
         SystemInfo: ProtocolProxyApi.SystemInfoApi;
+        /** @deprecated this API is experimental. */
         Tethering: ProtocolProxyApi.TetheringApi;
+        /** @deprecated this API is experimental. */
         Tracing: ProtocolProxyApi.TracingApi;
+        /** @deprecated this API is experimental. */
         WebAudio: ProtocolProxyApi.WebAudioApi;
+        /** @deprecated this API is experimental. */
         WebAuthn: ProtocolProxyApi.WebAuthnApi;
     } & EventPromises<ProtocolMappingApi.Events> & EventCallbacks<ProtocolMappingApi.Events>;
 

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -53,7 +53,7 @@ declare namespace CDP {
 
     interface SendCallback<T extends keyof ProtocolMappingApi.Commands> {
         (error: true, response: SendError): void;
-        (error: false, response: ProtocolMappingApi.Commands[T]['returnType'] | {}): void;
+        (error: false, response: ProtocolMappingApi.Commands[T]['returnType']): void;
         (error: Error, response: undefined): void;
     }
 

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -149,6 +149,14 @@ declare namespace CDP {
         on<T extends keyof ProtocolMappingApi.Events>(event: T, callback: (params: ProtocolMappingApi.Events[T][0], sessionId?: string) => void): void;
         // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
         on(event: string, callback: (params: object, sessionId?: string) => void): void;
+        // client.send(method, [params], [sessionId], [callback])
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: (returnMessage: ProtocolMappingApi.Commands[T]['returnType']) => void): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0],
+            callback: (returnMessage: ProtocolMappingApi.Commands[T]['returnType']) => void): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string,
+            callback: (returnMessage: ProtocolMappingApi.Commands[T]['returnType']) => void): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params?: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId?: string):
+            Promise<ProtocolMappingApi.Commands[T]['returnType']>;
 
         // stable domains
         Browser: ProtocolProxyApi.BrowserApi;

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -76,9 +76,9 @@ declare namespace CDP {
     }
 
     /////////////////////////////////////////////////
-    // Generated from https://app.quicktype.io/,
-    // TypeEnum simplified.
-    // Source: https://github.com/cyrus-and/chrome-remote-interface/blob/v0.30.1/lib/protocol.json
+    // Generated with https://app.quicktype.io/, Name: Protocol, Language: TypeScript, Interfaces only.
+    // Manually done: TypeEnum simplified, add " | undefined" for optional properties.
+    // Source: https://github.com/ChromeDevTools/devtools-protocol/blob/master/json/ (merge JSON objects)
     /////////////////////////////////////////////////
     interface Protocol {
         version: Version;
@@ -183,9 +183,10 @@ declare namespace CDP {
         Runtime: ProtocolProxyApi.RuntimeApi;
         Security: ProtocolProxyApi.SecurityApi;
         Target: ProtocolProxyApi.TargetApi;
-        // unstable domains
+        // deprecated domains
         Console: ProtocolProxyApi.ConsoleApi;
         Schema: ProtocolProxyApi.SchemaApi;
+        // unstable domains
         Accessibility: ProtocolProxyApi.AccessibilityApi;
         Animation: ProtocolProxyApi.AnimationApi;
         ApplicationCache: ProtocolProxyApi.ApplicationCacheApi;

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -53,7 +53,8 @@ declare namespace CDP {
 
     interface SendCallback<T extends keyof ProtocolMappingApi.Commands> {
         (error: true, response: SendError): void;
-        (error: false, response: ProtocolMappingApi.Commands[T]['returnType']): void;
+        (error: false, response: ProtocolMappingApi.Commands[T]['returnType'] | {}): void;
+        (error: Error, response: undefined): void;
     }
 
     interface Target {

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -45,6 +45,12 @@ declare namespace CDP {
         sessionId?: string | undefined;
     }
 
+    interface SendError {
+        code: number;
+        message: string;
+        data?: string | undefined;
+    }
+
     interface Target {
         description: string;
         devtoolsFrontendUrl: string;
@@ -151,11 +157,11 @@ declare namespace CDP {
         on(event: string, callback: (params: object, sessionId?: string) => void): void;
         // client.send(method, [params], [sessionId], [callback])
         send<T extends keyof ProtocolMappingApi.Commands>(event: T,
-            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: Error) => void)): void;
+            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: SendError) => void)): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0],
-            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: Error) => void)): void;
+            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: SendError) => void)): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string,
-            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: Error) => void)): void;
+            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: SendError) => void)): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params?: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId?: string):
             Promise<ProtocolMappingApi.Commands[T]['returnType']>;
 

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Khairul Azhar Kasmiran <https://github.com/kazarmy>
 //                 Seth Westphal <https://github.com/westy92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.8
+// Minimum TypeScript Version: 3.9
 
 import type ProtocolProxyApi from 'devtools-protocol/types/protocol-proxy-api';
 import type ProtocolMappingApi from 'devtools-protocol/types/protocol-mapping';
@@ -49,6 +49,11 @@ declare namespace CDP {
         code: number;
         message: string;
         data?: string | undefined;
+    }
+
+    interface SendCallback<T extends keyof ProtocolMappingApi.Commands> {
+        (error: true, response: SendError): void;
+        (error: false, response: ProtocolMappingApi.Commands[T]['returnType']): void;
     }
 
     interface Target {
@@ -156,12 +161,9 @@ declare namespace CDP {
         // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
         on(event: string, callback: (params: object, sessionId?: string) => void): void;
         // client.send(method, [params], [sessionId], [callback])
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T,
-            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: SendError) => void)): void;
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0],
-            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: SendError) => void)): void;
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string,
-            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: SendError) => void)): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: SendCallback<T>): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], callback: SendCallback<T>): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string, callback: SendCallback<T>): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params?: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId?: string):
             Promise<ProtocolMappingApi.Commands[T]['returnType']>;
 

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -150,11 +150,12 @@ declare namespace CDP {
         // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
         on(event: string, callback: (params: object, sessionId?: string) => void): void;
         // client.send(method, [params], [sessionId], [callback])
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: (returnMessage: ProtocolMappingApi.Commands[T]['returnType']) => void): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T,
+            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: Error) => void)): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0],
-            callback: (returnMessage: ProtocolMappingApi.Commands[T]['returnType']) => void): void;
+            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: Error) => void)): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string,
-            callback: (returnMessage: ProtocolMappingApi.Commands[T]['returnType']) => void): void;
+            callback: ((error: false, response: ProtocolMappingApi.Commands[T]['returnType']) => void) | ((error: true, response: Error) => void)): void;
         send<T extends keyof ProtocolMappingApi.Commands>(event: T, params?: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId?: string):
             Promise<ProtocolMappingApi.Commands[T]['returnType']>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cyrus-and/chrome-remote-interface#clientsendmethod-params-sessionid-callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


CC @perpetuallight : https://github.com/cyrus-and/chrome-remote-interface/issues/112#issuecomment-893156481
