### PR TITLE
Add missing plotly.js tickangle type

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -617,7 +617,7 @@ export interface Axis {
         | 'median descending';
     categoryarray: any[];
     tickfont: Partial<Font>;
-    tickangle: number;
+    tickangle: "auto" | number;
     tickprefix: string;
     /**
      * If `all`, all tick labels are displayed with a prefix.
@@ -1355,7 +1355,7 @@ export interface ColorBar {
     tickcolor: Color;
     showticklabels: boolean;
     tickfont: Font;
-    tickangle: number;
+    tickangle: "auto" | number;
     tickformat: string;
     tickformatstops: Array<Partial<TickFormatStop>>;
     tickprefix: string;

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -23,12 +23,14 @@ const graphDiv = '#test';
         type: 'scatter',
     } as ScatterData;
     const data = [trace1, trace2];
+    const tickangle: "auto" = "auto";
     const layout = {
         title: 'Sales Growth',
         xaxis: {
             title: 'Year',
             showgrid: false,
             zeroline: false,
+            tickangle
         },
         yaxis: {
             title: 'Percent',


### PR DESCRIPTION
As per the Plotly.js docs, the `tickangle` property can be both a number, or `"auto"`. The latter is in fact the default:

https://plotly.com/javascript/reference/#scatter-marker-colorbar-tickangle

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~ (does not apply)