### PR TITLE
[apple-mapkit-js] add `rotation-start` & `rotation-end` Map events

### DIFF
--- a/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
+++ b/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
@@ -41,13 +41,11 @@ let markerAnnotation: mapkit.MarkerAnnotation;
 let circleOverlay: mapkit.CircleOverlay;
 let itemCollection: mapkit.ItemCollection;
 map.addItems([markerAnnotation, circleOverlay, itemCollection]);
-const addResult:
-    | Array<mapkit.Annotation | mapkit.Overlay | mapkit.ItemCollection>
-    | mapkit.ItemCollection = map.addItems(itemCollection);
+const addResult: Array<mapkit.Annotation | mapkit.Overlay | mapkit.ItemCollection> | mapkit.ItemCollection =
+    map.addItems(itemCollection);
 map.removeItems([markerAnnotation, circleOverlay, itemCollection]);
-const removeResult:
-    | Array<mapkit.Annotation | mapkit.Overlay | mapkit.ItemCollection>
-    | mapkit.ItemCollection = map.removeItems(itemCollection);
+const removeResult: Array<mapkit.Annotation | mapkit.Overlay | mapkit.ItemCollection> | mapkit.ItemCollection =
+    map.removeItems(itemCollection);
 
 const cameraBoundaryDescription: mapkit.CameraBoundaryDescription = {
     mapRect: new mapkit.MapRect(0, 0, 0, 0),

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package MapKit JS 5.65.0
+// Type definitions for non-npm package MapKit JS 5.65
 // Project: https://developer.apple.com/reference/mapkitjs
 // Definitions by: Philipp Jean-Jacques <https://github.com/kilghaz>
 //                 Waseem Dahman <https://github.com/wsmd>

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1233,11 +1233,13 @@ declare namespace mapkit {
         /**
          * The image to display in the marker balloon.
          */
-        glyphImage?: {
-            1: string;
-            2?: string | undefined;
-            3?: string | undefined;
-        } | undefined;
+        glyphImage?:
+            | {
+                  1: string;
+                  2?: string | undefined;
+                  3?: string | undefined;
+              }
+            | undefined;
         /**
          * The image to display in the balloon when the marker is selected.
          */

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -4,6 +4,7 @@
 //                 Waseem Dahman <https://github.com/wsmd>
 //                 Chris Drackett <https://github.com/chrisdrackett>
 //                 Moritz Sternemann <https://github.com/moritzsternemann>
+//                 Vinayak Kulkarni <https://github.com/vinayakkulkarni>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -616,6 +617,8 @@ declare namespace mapkit {
     interface MapEvents<T> {
   'region-change-start': EventBase<T>;
   'region-change-end': EventBase<T>;
+  'rotation-start': EventBase<T>;
+  'rotation-end': EventBase<T>;
   'scroll-start': EventBase<T>;
   'scroll-end': EventBase<T>;
   'zoom-start': EventBase<T>;

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package MapKit JS 5.50
+// Type definitions for non-npm package MapKit JS 5.65.0
 // Project: https://developer.apple.com/reference/mapkitjs
 // Definitions by: Philipp Jean-Jacques <https://github.com/kilghaz>
 //                 Waseem Dahman <https://github.com/wsmd>

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -615,32 +615,33 @@ declare namespace mapkit {
 
     // prettier-ignore
     interface MapEvents<T> {
-  'region-change-start': EventBase<T>;
-  'region-change-end': EventBase<T>;
-  'rotation-start': EventBase<T>;
-  'rotation-end': EventBase<T>;
-  'scroll-start': EventBase<T>;
-  'scroll-end': EventBase<T>;
-  'zoom-start': EventBase<T>;
-  'zoom-end': EventBase<T>;
-  'map-type-change': EventBase<T>;
-  'single-tap': EventBase<T>;
-  'double-tap': EventBase<T>;
-  'long-press': EventBase<T>;
+        // Map Display Events
+        'region-change-start': EventBase<T>;
+        'region-change-end': EventBase<T>;
+        'rotation-start': EventBase<T>;
+        'rotation-end': EventBase<T>;
+        'scroll-start': EventBase<T>;
+        'scroll-end': EventBase<T>;
+        'zoom-start': EventBase<T>;
+        'zoom-end': EventBase<T>;
+        'map-type-change': EventBase<T>;
 
-  // Annotation Events
+        // Map Interaction Events
+        'single-tap': EventBase<T>;
+        'double-tap': EventBase<T>;
+        'long-press': EventBase<T>;
 
-  'select': EventBase<T> & { annotation?: Annotation | undefined; overlay?: Overlay | undefined };
-  'deselect': EventBase<T> & { annotation?: Annotation | undefined; overlay?: Overlay | undefined };
-  'drag-start': EventBase<T> & { annotation: Annotation };
-  'dragging': EventBase<T> & { annotation: Annotation; coordinate: Coordinate };
-  'drag-end': EventBase<T> & { annotation: Annotation };
+        // Annotation Events
+        'select': EventBase<T> & { annotation?: Annotation | undefined; overlay?: Overlay | undefined };
+        'deselect': EventBase<T> & { annotation?: Annotation | undefined; overlay?: Overlay | undefined };
+        'drag-start': EventBase<T> & { annotation: Annotation };
+        'dragging': EventBase<T> & { annotation: Annotation; coordinate: Coordinate };
+        'drag-end': EventBase<T> & { annotation: Annotation };
 
-  // User Location Events
-
-  'user-location-change': EventBase<T> & { coordinate: Coordinate; timestamp: Date };
-  'user-location-error': EventBase<T> & { code: number; message: string };
-}
+        // User Location Events
+        'user-location-change': EventBase<T> & { coordinate: Coordinate; timestamp: Date };
+        'user-location-error': EventBase<T> & { code: number; message: string };
+    }
 
     /**
      * Options that determine map parameters used when showing items.


### PR DESCRIPTION
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test apple-mapkit-js-browser`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.apple.com/documentation/mapkitjs/mapkit/map/handling_map_events#2993299
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
