### PR TITLE
Fix @ckeditor Observable, Emitter and EventInfo interfaces 

### DIFF
--- a/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
@@ -1,40 +1,13 @@
 import { ContextPlugin } from "@ckeditor/ckeditor5-core";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Token from "./token/token";
 
-export default class CloudServices extends ContextPlugin implements Emitter, Observable {
+export default class CloudServices extends ContextPlugin {
     token: Token | null;
     tokenUrl?: string | (() => string) | undefined;
     uploadUrl: string;
 
     getTokenFor(tokenUrl: string): Token;
     registerTokenUrl(tokenUrl: string | (() => string)): Promise<Token>;
-
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 export interface CloudServicesConfig {

--- a/types/ckeditor__ckeditor5-cloud-services/src/token/token.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/token/token.d.ts
@@ -1,11 +1,14 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export default class Token implements Observable {
     value: string;
 
     constructor(
         tokenUrlOrRefreshToken: string | (() => string),
-        options: { initValue?: string | undefined; autoRefresh?: boolean | undefined },
+        options?: { initValue?: string | undefined; autoRefresh?: boolean | undefined },
     );
     destroy(): void;
     init(): Promise<Token>;
@@ -21,4 +24,30 @@ export default class Token implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/fileuploader.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/uploadgateway/fileuploader.d.ts
@@ -1,37 +1,39 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import Token from "../token/token";
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Token from '../token/token';
 
 export default class FileUploader implements Emitter {
     file: Blob;
-
     constructor(fileOrData: string | Blob, token: Token, apiAddress: string);
     abort(): void;
     onError(callback: (event: unknown, data: unknown) => void): FileUploader;
     onProgress(callback: (event: unknown, data: unknown) => void): FileUploader;
     send(): Promise<unknown>;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-cloud-services/v27/src/cloudservices.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/src/cloudservices.d.ts
@@ -1,40 +1,13 @@
 import { ContextPlugin } from "@ckeditor/ckeditor5-core";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Token from "./token/token";
 
-export default class CloudServices extends ContextPlugin implements Emitter, Observable {
+export default class CloudServices extends ContextPlugin {
     token: Token | null;
     tokenUrl?: string | (() => string) | undefined;
     uploadUrl: string;
 
     getTokenFor(tokenUrl: string): Token;
     registerTokenUrl(tokenUrl: string | (() => string)): Promise<Token>;
-
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 export interface CloudServicesConfig {

--- a/types/ckeditor__ckeditor5-cloud-services/v27/src/token/token.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/src/token/token.d.ts
@@ -1,4 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export default class Token implements Observable {
     value: string;
@@ -21,4 +24,30 @@ export default class Token implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-cloud-services/v27/src/uploadgateway/fileuploader.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/src/uploadgateway/fileuploader.d.ts
@@ -1,37 +1,39 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import Token from "../token/token";
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Token from '../token/token';
 
 export default class FileUploader implements Emitter {
     file: Blob;
-
     constructor(fileOrData: string | Blob, token: Token, apiAddress: string);
     abort(): void;
     onError(callback: (event: unknown, data: unknown) => void): FileUploader;
     onProgress(callback: (event: unknown, data: unknown) => void): FileUploader;
     send(): Promise<unknown>;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/command.d.ts
@@ -1,11 +1,10 @@
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import Editor from "./editor/editor";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
+import Editor from "./editor/editor";
 
-export default class Command implements Emitter, Observable {
+export default class Command implements Observable {
     value?: unknown | undefined;
     readonly editor: Editor;
     isEnabled: boolean;
@@ -23,25 +22,29 @@ export default class Command implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/contextplugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/contextplugin.d.ts
@@ -1,7 +1,10 @@
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import Context from "./context";
-import Editor from "./editor/editor";
-import Plugin from "./plugin";
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Context from './context';
+import Editor from './editor/editor';
+import Plugin from './plugin';
 
 export default class ContextPlugin implements Observable {
     readonly context: Context | Editor;
@@ -20,4 +23,30 @@ export default class ContextPlugin implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
@@ -1,4 +1,4 @@
-import * as engine from "@ckeditor/ckeditor5-engine";
+import { Conversion, DataController, EditingController, Model } from "@ckeditor/ckeditor5-engine";
 import Config from "@ckeditor/ckeditor5-utils/src/config";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
@@ -12,20 +12,20 @@ import Plugin, { LoadedPlugins } from "../plugin";
 import PluginCollection from "../plugincollection";
 import { EditorConfig } from "./editorconfig";
 
-export default abstract class Editor implements Emitter, Observable {
+export default abstract class Editor implements Observable {
     readonly commands: CommandCollection;
     readonly config: Config;
-    readonly conversion: engine.Conversion;
-    readonly data: engine.DataController;
-    readonly editing: engine.EditingController;
+    readonly conversion: Conversion;
+    readonly data: DataController;
+    readonly editing: EditingController;
     isReadOnly: boolean;
     readonly keystrokes: EditingKeystrokeHandler;
     readonly locale: Locale;
-    readonly model: engine.Model;
+    readonly model: Model;
     readonly plugins: PluginCollection;
     readonly state: "initializing" | "ready" | "destroyed";
 
-    static builtinPlugins: Array<typeof Plugin|typeof ContextPlugin|string>;
+    static builtinPlugins: Array<typeof Plugin | typeof ContextPlugin | string>;
     static defaultConfig?: EditorConfig | undefined;
 
     constructor(config?: EditorConfig);
@@ -35,35 +35,35 @@ export default abstract class Editor implements Emitter, Observable {
     initPlugins(): Promise<LoadedPlugins>;
     t: Locale["t"];
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: engine.DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: engine.DomEventData) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/editor/editorui.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorui.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import ComponentFactory from "@ckeditor/ckeditor5-ui/src/componentfactory";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
@@ -19,27 +18,29 @@ export default class EditorUI implements Emitter {
     setEditableElement(rootName: string, domElement: HTMLElement): void;
     update(): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
-
-export {};

--- a/types/ckeditor__ckeditor5-core/src/editor/editorwithui.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorwithui.d.ts
@@ -1,5 +1,6 @@
+import Editor from "./editor";
 import EditorUI from "./editorui";
 
-export interface EditorWithUI {
+export interface EditorWithUI extends Editor {
     readonly ui: EditorUI;
 }

--- a/types/ckeditor__ckeditor5-core/src/multicommand.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/multicommand.d.ts
@@ -1,7 +1,5 @@
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import Command from "./command";
 
-export default class MultiCommand extends Command implements Emitter, Observable {
+export default class MultiCommand extends Command {
     registerChildCommand(command: Command): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
@@ -1,14 +1,8 @@
+import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import ContextPlugin from "./contextplugin";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import Editor from "./editor/editor";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 
-export default class PendingActions
-    extends ContextPlugin
-    implements Emitter, Observable, Iterable<Observable & { message: string }> {
+export default class PendingActions extends ContextPlugin implements Iterable<Observable & { message: string }> {
     readonly first: null | (Observable & { message: string });
     readonly hasAny: boolean;
 
@@ -18,34 +12,5 @@ export default class PendingActions
     [Symbol.iterator](): Iterator<Observable & { message: string }>;
     add(message: string): Observable & { message: string };
     remove(action: Observable & { message: string }): void;
-
     init(): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugin.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
@@ -7,50 +6,53 @@ import ContextPlugin from "./contextplugin";
 import Editor from "./editor/editor";
 import { EditorWithUI } from "./editor/editorwithui";
 
-export default abstract class Plugin implements Emitter, Observable {
+export default abstract class Plugin implements Observable {
     static readonly pluginName?: string | undefined;
     static readonly isContextPlugin: boolean;
     static readonly requires?: Array<typeof Plugin | typeof ContextPlugin | string> | undefined;
 
-    readonly editor: Editor & EditorWithUI;
+    readonly editor: EditorWithUI;
     isEnabled: boolean;
 
-    constructor(editor: Editor);
-    afterInit?(): Promise<any> | void;
-    bind(bindProperties: string): BindChain;
+    afterInit?(): Promise<unknown> | void;
     clearForceDisabled(id: string): void;
-    decorate(methodName: string): void;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    destroy?(): void | Promise<any>;
-    fire<T>(eventOrInfo: string | EventInfo, ...args: T[]): T;
+    destroy?(): void | Promise<unknown>;
     forceDisabled(id: string): void;
     init?(): Promise<void> | void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
+
+    constructor(editor: Editor);
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
         options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: number | PriorityString },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: number | PriorityString },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    set(name: string, value: unknown): void;
-    set(option: Record<string, string>): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: DomEventData) => void,
-    ): void;
+
+    set(option: Record<string, string>): void;
+    set(name: string, value: unknown): void;
+    bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
+    decorate(methodName: string): void;
 }
 
 // Beware that this defines a class constructor, not the class instance.
@@ -58,4 +60,4 @@ export interface PluginInterface<T = Plugin> {
     new (editor: Editor): T;
 }
 
-export type LoadedPlugins = Array<typeof Plugin|typeof ContextPlugin>;
+export type LoadedPlugins = Array<typeof Plugin | typeof ContextPlugin>;

--- a/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
@@ -1,11 +1,10 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import Context from "./context";
-import ContextPlugin from "./contextplugin";
-import Editor from "./editor/editor";
-import Plugin, { PluginInterface, LoadedPlugins } from "./plugin";
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Context from './context';
+import ContextPlugin from './contextplugin';
+import Editor from './editor/editor';
+import Plugin, { LoadedPlugins, PluginInterface } from './plugin';
 
 export default class PluginCollection implements Emitter, Iterable<[typeof Plugin, Plugin]> {
     constructor(
@@ -29,25 +28,29 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
         pluginsSubstitutions: Array<() => Plugin>,
     ): Promise<LoadedPlugins>;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/command.d.ts
@@ -1,11 +1,10 @@
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import Editor from "./editor/editor";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Editor from './editor/editor';
 
-export default class Command implements Emitter, Observable {
+export default class Command implements Observable {
     value?: unknown | undefined;
     readonly editor: Editor;
     isEnabled: boolean;
@@ -23,25 +22,29 @@ export default class Command implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/contextplugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/contextplugin.d.ts
@@ -1,4 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Context from "./context";
 import Editor from "./editor/editor";
 import Plugin from "./plugin";
@@ -20,4 +23,30 @@ export default class ContextPlugin implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/editor/editor.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/editor/editor.d.ts
@@ -1,4 +1,4 @@
-import * as engine from "@ckeditor/ckeditor5-engine";
+import { Conversion, DataController, EditingController, Model } from "@ckeditor/ckeditor5-engine";
 import Config from "@ckeditor/ckeditor5-utils/src/config";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
@@ -12,20 +12,20 @@ import Plugin, { LoadedPlugins } from "../plugin";
 import PluginCollection from "../plugincollection";
 import { EditorConfig } from "./editorconfig";
 
-export default abstract class Editor implements Emitter, Observable {
+export default abstract class Editor implements Observable {
     readonly commands: CommandCollection;
     readonly config: Config;
-    readonly conversion: engine.Conversion;
-    readonly data: engine.DataController;
-    readonly editing: engine.EditingController;
+    readonly conversion: Conversion;
+    readonly data: DataController;
+    readonly editing: EditingController;
     isReadOnly: boolean;
     readonly keystrokes: EditingKeystrokeHandler;
     readonly locale: Locale;
-    readonly model: engine.Model;
+    readonly model: Model;
     readonly plugins: PluginCollection;
     readonly state: "initializing" | "ready" | "destroyed";
 
-    static builtinPlugins: Array<typeof Plugin|typeof ContextPlugin|string>;
+    static builtinPlugins: Array<typeof Plugin | typeof ContextPlugin | string>;
     static defaultConfig?: EditorConfig | undefined;
 
     constructor(config?: EditorConfig);
@@ -35,35 +35,35 @@ export default abstract class Editor implements Emitter, Observable {
     initPlugins(): Promise<LoadedPlugins>;
     t: Locale["t"];
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: engine.DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: engine.DomEventData) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/editor/editorui.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/editor/editorui.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import ComponentFactory from "@ckeditor/ckeditor5-ui/src/componentfactory";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
@@ -19,27 +18,29 @@ export default class EditorUI implements Emitter {
     setEditableElement(rootName: string, domElement: HTMLElement): void;
     update(): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
-
-export {};

--- a/types/ckeditor__ckeditor5-core/v27/src/multicommand.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/multicommand.d.ts
@@ -1,7 +1,5 @@
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import Command from "./command";
 
-export default class MultiCommand extends Command implements Emitter, Observable {
+export default class MultiCommand extends Command {
     registerChildCommand(command: Command): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/pendingactions.d.ts
@@ -1,14 +1,8 @@
+import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import ContextPlugin from "./contextplugin";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import Editor from "./editor/editor";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 
-export default class PendingActions
-    extends ContextPlugin
-    implements Emitter, Observable, Iterable<Observable & { message: string }> {
+export default class PendingActions extends ContextPlugin implements Iterable<Observable & { message: string }> {
     readonly first: null | (Observable & { message: string });
     readonly hasAny: boolean;
 
@@ -18,34 +12,5 @@ export default class PendingActions
     [Symbol.iterator](): Iterator<Observable & { message: string }>;
     add(message: string): Observable & { message: string };
     remove(action: Observable & { message: string }): void;
-
     init(): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugin.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
@@ -7,50 +6,53 @@ import ContextPlugin from "./contextplugin";
 import Editor from "./editor/editor";
 import { EditorWithUI } from "./editor/editorwithui";
 
-export default abstract class Plugin implements Emitter, Observable {
+export default abstract class Plugin implements Observable {
     static readonly pluginName?: string | undefined;
     static readonly isContextPlugin: boolean;
     static readonly requires?: Array<typeof Plugin | typeof ContextPlugin | string> | undefined;
 
-    readonly editor: Editor & EditorWithUI;
+    readonly editor: EditorWithUI;
     isEnabled: boolean;
 
-    constructor(editor: Editor);
-    afterInit?(): Promise<any> | void;
-    bind(bindProperties: string): BindChain;
+    afterInit?(): Promise<unknown> | void;
     clearForceDisabled(id: string): void;
-    decorate(methodName: string): void;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    destroy?(): void | Promise<any>;
-    fire<T>(eventOrInfo: string | EventInfo, ...args: T[]): T;
+    destroy?(): void | Promise<unknown>;
     forceDisabled(id: string): void;
     init?(): Promise<void> | void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
+
+    constructor(editor: Editor);
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
         options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: number | PriorityString },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: number | PriorityString },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    set(name: string, value: unknown): void;
-    set(option: Record<string, string>): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: DomEventData) => void,
-    ): void;
+
+    set(option: Record<string, string>): void;
+    set(name: string, value: unknown): void;
+    bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
+    decorate(methodName: string): void;
 }
 
 // Beware that this defines a class constructor, not the class instance.
@@ -58,4 +60,4 @@ export interface PluginInterface<T = Plugin> {
     new (editor: Editor): T;
 }
 
-export type LoadedPlugins = Array<typeof Plugin|typeof ContextPlugin>;
+export type LoadedPlugins = Array<typeof Plugin | typeof ContextPlugin>;

--- a/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
@@ -29,25 +28,29 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
         pluginsSubstitutions: Array<() => Plugin>,
     ): Promise<LoadedPlugins>;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
@@ -9,16 +9,15 @@ import { DataProcessor } from "../dataprocessor/dataprocessor";
 import HtmlDataProcessor from "../dataprocessor/htmldataprocessor";
 import DocumentFragment from "../model/documentfragment";
 import Element from "../model/element";
-import ViewElement from "../view/element";
 import Model from "../model/model";
 import { SchemaContextDefinition } from "../model/schema";
 import Document from "../view/document";
 import ViewDocumentFragment from "../view/documentfragment";
+import ViewElement from "../view/element";
 import { MatcherPattern } from "../view/matcher";
-import DomEventData from "../view/observer/domeventdata";
 import { StylesProcessor } from "../view/stylesmap";
 
-export default class DataController implements Emitter, Observable {
+export default class DataController implements Observable {
     readonly downcastDispatcher: DowncastDispatcher;
     readonly htmlProcessor: HtmlDataProcessor;
     readonly mapper: Mapper;
@@ -51,25 +50,29 @@ export default class DataController implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
@@ -5,11 +5,10 @@ import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DowncastDispatcher from "../conversion/downcastdispatcher";
 import Mapper from "../conversion/mapper";
 import Model from "../model/model";
-import DomEventData from "../view/observer/domeventdata";
 import { StylesProcessor } from "../view/stylesmap";
 import View from "../view/view";
 
-export default class EditingController implements Emitter, Observable {
+export default class EditingController implements Observable {
     readonly downcastDispatcher: DowncastDispatcher;
     readonly mapper: Mapper;
     readonly model: Model;
@@ -24,25 +23,29 @@ export default class EditingController implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
@@ -1,19 +1,18 @@
-import Differ from "../model/differ";
-import Element from "../model/element";
-import MarkerCollection from "../model/markercollection";
-import Position from "../model/position";
-import Range from "../model/range";
-import Schema from "../model/schema";
-import Selection from "../model/selection";
-import DowncastWriter from "../view/downcastwriter";
-import Mapper from "./mapper";
-import ModelConsumable from "../conversion/modelconsumable";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import DomEventData from "../view/observer/domeventdata";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import ModelConsumable from '../conversion/modelconsumable';
+import Differ from '../model/differ';
+import Element from '../model/element';
+import MarkerCollection from '../model/markercollection';
+import Position from '../model/position';
+import Range from '../model/range';
+import Schema from '../model/schema';
+import Selection from '../model/selection';
+import DowncastWriter from '../view/downcastwriter';
+import Mapper from './mapper';
 
-export interface DowncastConversionApi<T = any> {
+export interface DowncastConversionApi<T = undefined> {
     consumable: ModelConsumable;
     dispatcher: DowncastDispatcher;
     mapper: Mapper;
@@ -23,8 +22,8 @@ export interface DowncastConversionApi<T = any> {
 }
 
 export default class DowncastDispatcher<T = {}> implements Emitter {
-    conversionApi: DowncastConversionApi<T>;
     constructor(conversionApi: Partial<DowncastConversionApi<T>>);
+    conversionApi: DowncastConversionApi<T>;
     convertAttribute(range: Range, key: string, oldValue: any, newValue: any, writer: DowncastWriter): void;
     convertChanges(differ: Differ, markers: MarkerCollection, writer: DowncastWriter): void;
     convertInsert(range: Range, writer: DowncastWriter): void;
@@ -34,25 +33,29 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
     convertSelection(selection: Selection, markers: MarkerCollection, writer: DowncastWriter): void;
     reconvertElement(element: Element, writer: DowncastWriter): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/mapper.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/mapper.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
 import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
@@ -29,25 +28,29 @@ export default class Mapper implements Emitter {
     unbindModelElement(modelElement: ModelElement): void;
     unbindViewElement(viewElement: Element): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
@@ -8,7 +8,6 @@ import Range from "../model/range";
 import Schema, { SchemaContextDefinition } from "../model/schema";
 import Writer from "../model/writer";
 import { Item } from "../view/item";
-import DomEventData from "../view/observer/domeventdata";
 import ViewConsumable from "./viewconsumable";
 
 export interface UpcastConversionData {
@@ -51,28 +50,32 @@ export interface UpcastConversionApi {
 
 export default class UpcastDispatcher implements Emitter {
     conversionApi: UpcastConversionApi;
-    constructor(conversionApi?: Partial<UpcastConversionApi>);
     convert(viewItem: Item, writer: Writer, context?: SchemaContextDefinition): DocumentFragment;
+    constructor(conversionApi?: Partial<UpcastConversionApi>);
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
@@ -1,9 +1,10 @@
-import Element from "../view/element";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import ModelElement from "../model/element";
+import Element from "../view/element";
 import { MatcherPattern } from "../view/matcher";
 import ConversionHelpers from "./conversionhelpers";
-import { UpcastConversionApi } from "./upcastdispatcher";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import UpcastDispatcher, { UpcastConversionApi, UpcastConversionData } from "./upcastdispatcher";
 
 export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
     attributeToAttribute(config?: {
@@ -12,7 +13,12 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
             | {
                   key: string;
                   name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  value?:
+                      | RegExp
+                      | string
+                      | ((value: unknown) => boolean)
+                      | { styles: Record<string, string | RegExp> }
+                      | undefined;
               };
 
         model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };
@@ -37,3 +43,9 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
         converterPriority?: PriorityString | number | undefined;
     }): UpcastHelpers;
 }
+
+export function convertToModelFragment(): (
+    evt: EventInfo<string, UpcastDispatcher>,
+    data: UpcastConversionData,
+    conversionApi: UpcastConversionApi,
+) => void;

--- a/types/ckeditor__ckeditor5-engine/src/model/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/document.d.ts
@@ -2,7 +2,6 @@ import { Collection } from "@ckeditor/ckeditor5-utils";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DomEventData from "../view/observer/domeventdata";
 import Differ from "./differ";
 import DocumentSelection from "./documentselection";
 import Model from "./model";
@@ -18,7 +17,6 @@ export default class Document implements Emitter {
     readonly selection: DocumentSelection;
     version: number;
 
-    constructor();
     createRoot(elementName?: string, rootName?: string): RootElement;
     destroy(): void;
     getRoot(name?: string): RootElement | null;
@@ -29,25 +27,29 @@ export default class Document implements Emitter {
         model: "[engine.model.Model]";
     };
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
@@ -2,16 +2,15 @@ import { Collection } from "@ckeditor/ckeditor5-utils";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DomEventData from "../view/observer/domeventdata";
 import Document from "./document";
 import DocumentFragment from "./documentfragment";
 import Element from "./element";
 import LivePosition from "./liveposition";
 import LiveRange from "./liverange";
+import { Marker } from "./markercollection";
 import Node from "./node";
 import Position from "./position";
 import Range from "./range";
-import { Marker } from "./markercollection";
 import RootElement from "./rootelement";
 import Selection from "./selection";
 import Text from "./text";
@@ -41,6 +40,9 @@ export default class DocumentSelection implements Emitter {
     getSelectedBlocks(): ReturnType<Selection["getSelectedBlocks"]>;
     getSelectedElement(): Element | null;
     hasAttribute(key: string): boolean;
+    observeMarkers(prefixOrName: string): void;
+    refresh(): void;
+
     is(type: "position" | "model:position"): this is Position | LivePosition;
     is(type: "livePosition" | "model:livePosition"): this is LivePosition;
     is(type: "range" | "model:range"): this is Range | LiveRange;
@@ -55,28 +57,30 @@ export default class DocumentSelection implements Emitter {
     is(type: "element" | "model:element", name?: string): this is Element | RootElement;
     is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
     is(type: string, name?: string): boolean;
-    observeMarkers(prefixOrName: string): void;
-    refresh(): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/markercollection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/markercollection.d.ts
@@ -1,18 +1,20 @@
-import TextProxy from "./textproxy";
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DocumentFragment from "./documentfragment";
 import DocumentSelection from "./documentselection";
 import Element from "./element";
 import LivePosition from "./liveposition";
 import LiveRange from "./liverange";
 import Node from "./node";
+import Position from "./position";
 import Range from "./range";
 import RootElement from "./rootelement";
 import Selection from "./selection";
 import Text from "./text";
-import Position from "./position";
+import TextProxy from "./textproxy";
 
-export default class MarkerCollection implements Iterable<Marker> {
-    constructor();
+export default class MarkerCollection implements Iterable<Marker>, Emitter {
     [Symbol.iterator](): Iterator<Marker>;
     destroy(): void;
     get(markerName: string): Marker | null;
@@ -20,6 +22,32 @@ export default class MarkerCollection implements Iterable<Marker> {
     getMarkersGroup(prefix: string): Generator<Marker>;
     getMarkersIntersectingRange(range: Range): Generator<Marker>;
     has(markerName: string): boolean;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 export class Marker {
@@ -31,6 +59,7 @@ export class Marker {
     getEnd(): Position;
     getRange(): Range;
     getStart(): Position;
+
     is(type: "position" | "model:position"): this is Position | LivePosition;
     is(type: "livePosition" | "model:livePosition"): this is LivePosition;
     is(type: "range" | "model:range"): this is Range | LiveRange;

--- a/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
@@ -17,7 +16,7 @@ import Schema from "./schema";
 import Selection, { Selectable } from "./selection";
 import Writer from "./writer";
 
-export default class Model implements Emitter, Observable {
+export default class Model implements Observable {
     readonly document: Document;
     readonly markers: MarkerCollection;
     readonly schema: Schema;
@@ -62,7 +61,10 @@ export default class Model implements Emitter, Observable {
     ): Range;
     modifySelection(
         selection: Selection | DocumentSelection,
-        options?: { direction?: "forward" | "backward" | undefined; unit?: "character" | "codePoint" | "word" | undefined },
+        options?: {
+            direction?: "forward" | "backward" | undefined;
+            unit?: "character" | "codePoint" | "word" | undefined;
+        },
     ): void;
 
     set(option: Record<string, unknown>): void;
@@ -71,25 +73,29 @@ export default class Model implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
@@ -1,8 +1,7 @@
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DomEventData from "../view/observer/domeventdata";
 import DocumentSelection from "./documentselection";
 import Element from "./element";
 import { Item } from "./item";
@@ -12,7 +11,7 @@ import Range from "./range";
 import Selection from "./selection";
 import Writer from "./writer";
 
-export default class Schema implements Emitter, Observable {
+export default class Schema implements Observable {
     addAttributeCheck(callback: (context: SchemaContext, name: string) => boolean): void;
     addChildCheck(callback: (context: SchemaContext, item: SchemaCompiledItemDefinition) => boolean): void;
     checkAttribute(context: SchemaContextDefinition, attributeName: string): boolean;
@@ -45,25 +44,29 @@ export default class Schema implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
@@ -71,7 +74,7 @@ export default class Schema implements Emitter, Observable {
 export interface SchemaItemDefinition {
     allowAttributes?: string | string[] | undefined;
     allowAttributesOf?: string | string[] | undefined;
-    allowChildren?: string|string[] | undefined;
+    allowChildren?: string | string[] | undefined;
     allowContentOf?: string | string[] | undefined;
     allowIn?: string | string[] | undefined;
     allowWhere?: string | string[] | undefined;

--- a/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
@@ -1,8 +1,10 @@
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DocumentFragment from "./documentfragment";
 import DocumentSelection from "./documentselection";
 import Element from "./element";
+import { Item } from "./item";
 import LivePosition from "./liveposition";
 import LiveRange from "./liverange";
 import { Marker } from "./markercollection";
@@ -12,9 +14,6 @@ import Range from "./range";
 import RootElement from "./rootelement";
 import Text from "./text";
 import TextProxy from "./textproxy";
-import { Item } from "./item";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import DomEventData from "../view/observer/domeventdata";
 
 export type Selectable =
     | Selection
@@ -42,6 +41,8 @@ export default class Selection implements Emitter {
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
         options?: { backward?: boolean | undefined },
     );
+    constructor(selectable?: Selectable, options?: { backward?: boolean | undefined });
+
     containsEntireContent(element: Element): boolean;
     getAttribute(key: string): string | boolean | number | undefined;
     getAttributeKeys(): IterableIterator<string>;
@@ -79,25 +80,29 @@ export default class Selection implements Emitter {
         options?: { backward?: boolean | undefined },
     ): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
@@ -6,11 +6,10 @@ import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DocumentSelection from "./documentselection";
 import DowncastWriter from "./downcastwriter";
 import { BubblingEmitter } from "./observer/bubblingemittermixin";
-import DomEventData from "./observer/domeventdata";
 import RootEditableElement from "./rooteditableelement";
 import { StylesProcessor } from "./stylesmap";
 
-export default class Document implements BubblingEmitter, Emitter, Observable {
+export default class Document implements BubblingEmitter, Observable {
     readonly isComposing: boolean;
     readonly isFocused: boolean;
     isReadOnly: boolean;
@@ -29,25 +28,29 @@ export default class Document implements BubblingEmitter, Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/node.d.ts
@@ -1,3 +1,6 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import AttributeElement from "./attributeelement";
 import ContainerElement from "./containerelement";
 import Document from "./document";
@@ -15,15 +18,19 @@ import Text from "./text";
 import TextProxy from "./textproxy";
 import UIElement from "./uielement";
 
-export default abstract class Node {
+export default class Node implements Emitter {
+    constructor(doc: Document);
     readonly document: Document;
     readonly index: number | null;
     readonly nextSibling: Node | null;
-    readonly parent: Element | DocumentFragment | null;
+    parent: Element | DocumentFragment | null;
     readonly previousSibling: Node | null;
     readonly root: Node | DocumentFragment;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAncestors(options?: {
+        includeSelf?: boolean | undefined;
+        parentFirst?: boolean | undefined;
+    }): Array<Element | DocumentFragment>;
     getCommonAncestor(node: Node, options?: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
     getPath(): number[];
     is(
@@ -61,14 +68,8 @@ export default abstract class Node {
         type: "containerElement" | "view:containerElement",
         name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
-        type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
-        type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
+    is(type: "editableElement" | "view:editableElement", name?: string): this is EditableElement | RootEditableElement;
+    is(type: "rootEditableElement" | "view:rootEditableElement", name?: string): this is RootEditableElement;
     is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
     is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
     is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
@@ -83,4 +84,30 @@ export default abstract class Node {
         _textData?: string | undefined;
         document: string;
     };
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/bubblingemittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/bubblingemittermixin.d.ts
@@ -1,9 +1,6 @@
 import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 
-export interface BubblingEmitter extends Emitter {
-    fire(eventOrInfo: EventInfo | string): unknown;
-}
+export type BubblingEmitter = Emitter;
 
 declare const BubblingEmitterMixin: BubblingEmitter;
 

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/observer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/observer.d.ts
@@ -1,7 +1,12 @@
-import Document from "../document";
-import View from "../view";
+import { Emitter as DomEmitter, ProxyEmitter } from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Document from '../document';
+import View from '../view';
+import DomEventData from './domeventdata';
 
-export default abstract class Observer {
+export default abstract class Observer implements DomEmitter {
     readonly document: Document;
     readonly isEnabled: boolean;
     readonly view: View;
@@ -12,4 +17,34 @@ export default abstract class Observer {
     disable(): void;
     enable(): void;
     observe(domElement: HTMLElement, name?: string): void;
+
+    listenTo<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<N, S>, data: DomEventData) => void,
+        options?: {
+            useCapture?: boolean | undefined;
+            usePassive?: boolean | undefined;
+            priority?: number | PriorityString | undefined;
+        },
+    ): void;
+    stopListening<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter?: Node | Window | S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
+    ): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, Emitter>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, Emitter>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N, Emitter>, ...data: unknown[]) => void): void;
+    fire(eventOrInfo: string | EventInfo<'', Emitter>, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
@@ -7,19 +7,18 @@ import DomConverter from "./domconverter";
 import DowncastWriter from "./downcastwriter";
 import Element from "./element";
 import { Item } from "./item";
-import DomEventData from "./observer/domeventdata";
 import Observer from "./observer/observer";
 import Position from "./position";
 import Range from "./range";
 import Selection, { Selectable } from "./selection";
 import { StylesProcessor } from "./stylesmap";
 
-export default class View implements Emitter, Observable {
+export default class View implements Observable {
     readonly document: Document;
     readonly domConverter: DomConverter;
     readonly domRoots: Map<string, HTMLElement>;
-    readonly hasDomSelection: boolean;
-    readonly isRenderingInProgress: boolean;
+    hasDomSelection: boolean;
+    isRenderingInProgress: boolean;
 
     constructor(stylesProcessor: StylesProcessor);
     addObserver(ObserverClass: typeof Observer): Observer;
@@ -53,25 +52,29 @@ export default class View implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/controller/datacontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/controller/datacontroller.d.ts
@@ -15,10 +15,9 @@ import { SchemaContextDefinition } from "../model/schema";
 import Document from "../view/document";
 import ViewDocumentFragment from "../view/documentfragment";
 import { MatcherPattern } from "../view/matcher";
-import DomEventData from "../view/observer/domeventdata";
 import { StylesProcessor } from "../view/stylesmap";
 
-export default class DataController implements Emitter, Observable {
+export default class DataController implements Observable {
     readonly downcastDispatcher: DowncastDispatcher;
     readonly htmlProcessor: HtmlDataProcessor;
     readonly mapper: Mapper;
@@ -50,25 +49,29 @@ export default class DataController implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/controller/editingcontroller.d.ts
@@ -5,11 +5,10 @@ import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DowncastDispatcher from "../conversion/downcastdispatcher";
 import Mapper from "../conversion/mapper";
 import Model from "../model/model";
-import DomEventData from "../view/observer/domeventdata";
 import { StylesProcessor } from "../view/stylesmap";
 import View from "../view/view";
 
-export default class EditingController implements Emitter, Observable {
+export default class EditingController implements Observable {
     readonly downcastDispatcher: DowncastDispatcher;
     readonly mapper: Mapper;
     readonly model: Model;
@@ -24,25 +23,29 @@ export default class EditingController implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcastdispatcher.d.ts
@@ -1,3 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import ModelConsumable from "../conversion/modelconsumable";
 import Differ from "../model/differ";
 import Element from "../model/element";
 import MarkerCollection from "../model/markercollection";
@@ -7,13 +11,8 @@ import Schema from "../model/schema";
 import Selection from "../model/selection";
 import DowncastWriter from "../view/downcastwriter";
 import Mapper from "./mapper";
-import ModelConsumable from "../conversion/modelconsumable";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import DomEventData from "../view/observer/domeventdata";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
-export interface DowncastConversionApi<T = any> {
+export interface DowncastConversionApi<T = unknown> {
     consumable: ModelConsumable;
     dispatcher: DowncastDispatcher;
     mapper: Mapper;
@@ -22,7 +21,7 @@ export interface DowncastConversionApi<T = any> {
     writer: DowncastWriter;
 }
 
-export default class DowncastDispatcher<T = {}> implements Emitter {
+export default class DowncastDispatcher<T = unknown> implements Emitter {
     conversionApi: DowncastConversionApi<T>;
     constructor(conversionApi: Partial<DowncastConversionApi<T>>);
     convertAttribute(range: Range, key: string, oldValue: any, newValue: any, writer: DowncastWriter): void;
@@ -34,25 +33,29 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
     convertSelection(selection: Selection, markers: MarkerCollection, writer: DowncastWriter): void;
     reconvertElement(element: Element, writer: DowncastWriter): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/mapper.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/mapper.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
@@ -29,25 +28,29 @@ export default class Mapper implements Emitter {
     unbindModelElement(modelElement: ModelElement): void;
     unbindViewElement(viewElement: Element): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcastdispatcher.d.ts
@@ -8,7 +8,6 @@ import Range from "../model/range";
 import Schema, { SchemaContextDefinition } from "../model/schema";
 import Writer from "../model/writer";
 import { Item } from "../view/item";
-import DomEventData from "../view/observer/domeventdata";
 import ViewConsumable from "./viewconsumable";
 
 export interface UpcastConversionData {
@@ -54,25 +53,29 @@ export default class UpcastDispatcher implements Emitter {
     constructor(conversionApi?: Partial<UpcastConversionApi>);
     convert(viewItem: Item, writer: Writer, context?: SchemaContextDefinition): DocumentFragment;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcasthelpers.d.ts
@@ -1,9 +1,10 @@
-import Element from "../view/element";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import ModelElement from "../model/element";
+import Element from "../view/element";
 import { MatcherPattern } from "../view/matcher";
 import ConversionHelpers from "./conversionhelpers";
-import { UpcastConversionApi } from "./upcastdispatcher";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import UpcastDispatcher, { UpcastConversionApi, UpcastConversionData } from "./upcastdispatcher";
 
 export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
     attributeToAttribute(config?: {
@@ -12,7 +13,12 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
             | {
                   key: string;
                   name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  value?:
+                      | RegExp
+                      | string
+                      | ((value: unknown) => boolean)
+                      | { styles: Record<string, string | RegExp> }
+                      | undefined;
               };
 
         model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };
@@ -37,3 +43,9 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
         converterPriority?: PriorityString | number | undefined;
     }): UpcastHelpers;
 }
+
+export function convertToModelFragment(): (
+    evt: EventInfo<string, UpcastDispatcher>,
+    data: UpcastConversionData,
+    conversionApi: UpcastConversionApi,
+) => void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/document.d.ts
@@ -1,13 +1,13 @@
-import { Collection } from "@ckeditor/ckeditor5-utils";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DomEventData from "../view/observer/domeventdata";
-import Differ from "./differ";
-import DocumentSelection from "./documentselection";
-import Model from "./model";
-import RootElement from "./rootelement";
-import Writer from "./writer";
+import { Collection } from '@ckeditor/ckeditor5-utils';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import DomEventData from '../view/observer/domeventdata';
+import Differ from './differ';
+import DocumentSelection from './documentselection';
+import Model from './model';
+import RootElement from './rootelement';
+import Writer from './writer';
 
 export default class Document implements Emitter {
     readonly differ: Differ;
@@ -24,30 +24,34 @@ export default class Document implements Emitter {
     getRoot(name?: string): RootElement | null;
     getRootNames(): string[];
     registerPostFixer(postFixer: (writer: Writer) => void): void;
-    toJSON(): Omit<this, "selection" | "model"> & {
-        selection: "[engine.model.DocumentSelection]";
-        model: "[engine.model.Model]";
+    toJSON(): Omit<this, 'selection' | 'model'> & {
+        selection: '[engine.model.DocumentSelection]';
+        model: '[engine.model.Model]';
     };
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/documentselection.d.ts
@@ -2,16 +2,15 @@ import { Collection } from "@ckeditor/ckeditor5-utils";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DomEventData from "../view/observer/domeventdata";
 import Document from "./document";
 import DocumentFragment from "./documentfragment";
 import Element from "./element";
 import LivePosition from "./liveposition";
 import LiveRange from "./liverange";
+import { Marker } from "./markercollection";
 import Node from "./node";
 import Position from "./position";
 import Range from "./range";
-import { Marker } from "./markercollection";
 import RootElement from "./rootelement";
 import Selection from "./selection";
 import Text from "./text";
@@ -58,25 +57,29 @@ export default class DocumentSelection implements Emitter {
     observeMarkers(prefixOrName: string): void;
     refresh(): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/markercollection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/markercollection.d.ts
@@ -1,18 +1,20 @@
-import TextProxy from "./textproxy";
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DocumentFragment from "./documentfragment";
 import DocumentSelection from "./documentselection";
 import Element from "./element";
 import LivePosition from "./liveposition";
 import LiveRange from "./liverange";
 import Node from "./node";
+import Position from "./position";
 import Range from "./range";
 import RootElement from "./rootelement";
 import Selection from "./selection";
 import Text from "./text";
-import Position from "./position";
+import TextProxy from "./textproxy";
 
-export default class MarkerCollection implements Iterable<Marker> {
-    constructor();
+export default class MarkerCollection implements Iterable<Marker>, Emitter {
     [Symbol.iterator](): Iterator<Marker>;
     destroy(): void;
     get(markerName: string): Marker | null;
@@ -20,6 +22,32 @@ export default class MarkerCollection implements Iterable<Marker> {
     getMarkersGroup(prefix: string): Generator<Marker>;
     getMarkersIntersectingRange(range: Range): Generator<Marker>;
     has(markerName: string): boolean;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 export class Marker {

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/model.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
@@ -17,7 +16,7 @@ import Schema from "./schema";
 import Selection, { Selectable } from "./selection";
 import Writer from "./writer";
 
-export default class Model implements Emitter, Observable {
+export default class Model implements Observable {
     readonly document: Document;
     readonly markers: MarkerCollection;
     readonly schema: Schema;
@@ -62,7 +61,10 @@ export default class Model implements Emitter, Observable {
     ): Range;
     modifySelection(
         selection: Selection | DocumentSelection,
-        options?: { direction?: "forward" | "backward" | undefined; unit?: "character" | "codePoint" | "word" | undefined },
+        options?: {
+            direction?: "forward" | "backward" | undefined;
+            unit?: "character" | "codePoint" | "word" | undefined;
+        },
     ): void;
 
     set(option: Record<string, unknown>): void;
@@ -71,25 +73,29 @@ export default class Model implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/schema.d.ts
@@ -1,8 +1,7 @@
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DomEventData from "../view/observer/domeventdata";
 import DocumentSelection from "./documentselection";
 import Element from "./element";
 import { Item } from "./item";
@@ -12,7 +11,7 @@ import Range from "./range";
 import Selection from "./selection";
 import Writer from "./writer";
 
-export default class Schema implements Emitter, Observable {
+export default class Schema implements Observable {
     addAttributeCheck(callback: (context: SchemaContext, name: string) => boolean): void;
     addChildCheck(callback: (context: SchemaContext, item: SchemaCompiledItemDefinition) => boolean): void;
     checkAttribute(context: SchemaContextDefinition, attributeName: string): boolean;
@@ -45,25 +44,29 @@ export default class Schema implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/selection.d.ts
@@ -1,8 +1,10 @@
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import DocumentFragment from "./documentfragment";
 import DocumentSelection from "./documentselection";
 import Element from "./element";
+import { Item } from "./item";
 import LivePosition from "./liveposition";
 import LiveRange from "./liverange";
 import { Marker } from "./markercollection";
@@ -12,9 +14,6 @@ import Range from "./range";
 import RootElement from "./rootelement";
 import Text from "./text";
 import TextProxy from "./textproxy";
-import { Item } from "./item";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import DomEventData from "../view/observer/domeventdata";
 
 export type Selectable =
     | Selection
@@ -79,25 +78,29 @@ export default class Selection implements Emitter {
         options?: { backward?: boolean | undefined },
     ): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/document.d.ts
@@ -1,16 +1,15 @@
-import { Collection } from "@ckeditor/ckeditor5-utils";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import DocumentSelection from "./documentselection";
-import DowncastWriter from "./downcastwriter";
-import { BubblingEmitter } from "./observer/bubblingemittermixin";
-import DomEventData from "./observer/domeventdata";
-import RootEditableElement from "./rooteditableelement";
-import { StylesProcessor } from "./stylesmap";
+import { Collection } from '@ckeditor/ckeditor5-utils';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import DocumentSelection from './documentselection';
+import DowncastWriter from './downcastwriter';
+import { BubblingEmitter } from './observer/bubblingemittermixin';
+import RootEditableElement from './rooteditableelement';
+import { StylesProcessor } from './stylesmap';
 
-export default class Document implements BubblingEmitter, Emitter, Observable {
+export default class Document implements BubblingEmitter, Observable {
     readonly isComposing: boolean;
     readonly isFocused: boolean;
     isReadOnly: boolean;
@@ -29,27 +28,31 @@ export default class Document implements BubblingEmitter, Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
-export type ChangeType = "children" | "attributes" | "text";
+export type ChangeType = 'children' | 'attributes' | 'text';

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/node.d.ts
@@ -1,3 +1,6 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import AttributeElement from "./attributeelement";
 import ContainerElement from "./containerelement";
 import Document from "./document";
@@ -15,15 +18,19 @@ import Text from "./text";
 import TextProxy from "./textproxy";
 import UIElement from "./uielement";
 
-export default abstract class Node {
+export default class Node implements Emitter {
+    constructor(doc: Document);
     readonly document: Document;
     readonly index: number | null;
     readonly nextSibling: Node | null;
-    readonly parent: Element | DocumentFragment | null;
+    parent: Element | DocumentFragment | null;
     readonly previousSibling: Node | null;
     readonly root: Node | DocumentFragment;
 
-    getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAncestors(options?: {
+        includeSelf?: boolean | undefined;
+        parentFirst?: boolean | undefined;
+    }): Array<Element | DocumentFragment>;
     getCommonAncestor(node: Node, options?: { includeSelf?: boolean | undefined }): Element | DocumentFragment | null;
     getPath(): number[];
     is(
@@ -61,14 +68,8 @@ export default abstract class Node {
         type: "containerElement" | "view:containerElement",
         name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
-        type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
-        type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
+    is(type: "editableElement" | "view:editableElement", name?: string): this is EditableElement | RootEditableElement;
+    is(type: "rootEditableElement" | "view:rootEditableElement", name?: string): this is RootEditableElement;
     is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
     is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
     is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
@@ -83,4 +84,30 @@ export default abstract class Node {
         _textData?: string | undefined;
         document: string;
     };
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/observer/bubblingemittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/observer/bubblingemittermixin.d.ts
@@ -1,9 +1,6 @@
 import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 
-export interface BubblingEmitter extends Emitter {
-    fire(eventOrInfo: EventInfo | string): unknown;
-}
+export type BubblingEmitter = Emitter;
 
 declare const BubblingEmitterMixin: BubblingEmitter;
 

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/observer/observer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/observer/observer.d.ts
@@ -1,7 +1,12 @@
-import Document from "../document";
-import View from "../view";
+import { Emitter as DomEmitter, ProxyEmitter } from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Document from '../document';
+import View from '../view';
+import DomEventData from './domeventdata';
 
-export default abstract class Observer {
+export default abstract class Observer implements DomEmitter {
     readonly document: Document;
     readonly isEnabled: boolean;
     readonly view: View;
@@ -12,4 +17,34 @@ export default abstract class Observer {
     disable(): void;
     enable(): void;
     observe(domElement: HTMLElement, name?: string): void;
+
+    listenTo<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<N, S>, data: DomEventData) => void,
+        options?: {
+            useCapture?: boolean | undefined;
+            usePassive?: boolean | undefined;
+            priority?: number | PriorityString | undefined;
+        },
+    ): void;
+    stopListening<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter?: Node | Window | S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
+    ): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, Emitter>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, Emitter>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N, Emitter>, ...data: unknown[]) => void): void;
+    fire(eventOrInfo: string | EventInfo<'', Emitter>, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/view.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/view.d.ts
@@ -7,19 +7,18 @@ import DomConverter from "./domconverter";
 import DowncastWriter from "./downcastwriter";
 import Element from "./element";
 import { Item } from "./item";
-import DomEventData from "./observer/domeventdata";
 import Observer from "./observer/observer";
 import Position from "./position";
 import Range from "./range";
 import Selection, { Selectable } from "./selection";
 import { StylesProcessor } from "./stylesmap";
 
-export default class View implements Emitter, Observable {
+export default class View implements Observable {
     readonly document: Document;
     readonly domConverter: DomConverter;
     readonly domRoots: Map<string, HTMLElement>;
-    readonly hasDomSelection: boolean;
-    readonly isRenderingInProgress: boolean;
+    hasDomSelection: boolean;
+    isRenderingInProgress: boolean;
 
     constructor(stylesProcessor: StylesProcessor);
     addObserver(ObserverClass: typeof Observer): Observer;
@@ -53,25 +52,29 @@ export default class View implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-export-pdf/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-export-pdf/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-src/exportpdfcommand.d.ts

--- a/types/ckeditor__ckeditor5-export-pdf/ckeditor__ckeditor5-export-pdf-tests.ts
+++ b/types/ckeditor__ckeditor5-export-pdf/ckeditor__ckeditor5-export-pdf-tests.ts
@@ -1,6 +1,7 @@
 import { Editor } from "@ckeditor/ckeditor5-core";
 import { ExportPdf } from "@ckeditor/ckeditor5-export-pdf";
 import { ExportPdfConfig } from "@ckeditor/ckeditor5-export-pdf/src/exportpdf";
+import ExportPDFCommand from "@ckeditor/ckeditor5-export-pdf/src/exportpdfcommand";
 
 class MyEditor extends Editor {}
 
@@ -36,11 +37,12 @@ config = {
 config = {
     converterUrl: "",
     dataCallback(editor) {
+        !!editor.isReadOnly;
         return "";
     },
     fileName: "",
     stylesheets: [""],
-    tokenUrl: false,
+    tokenUrl: bool,
 };
 
 config = {
@@ -51,3 +53,5 @@ config = {
 config = {
     tokenUrl: "",
 };
+
+new ExportPDFCommand(new MyEditor({ exportPdf: config })).execute("");

--- a/types/ckeditor__ckeditor5-export-pdf/src/exportpdf.d.ts
+++ b/types/ckeditor__ckeditor5-export-pdf/src/exportpdf.d.ts
@@ -1,24 +1,24 @@
 import { Editor, Plugin } from "@ckeditor/ckeditor5-core";
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 
-export default class ExportPdf extends Plugin implements Emitter, Observable {}
+export default class ExportPdf extends Plugin {}
 
 export interface ExportPdfConfig {
-    converterOptions?: {
-        margin_top?: 0 | string | undefined;
-        margin_bottom?: 0 | string | undefined;
-        margin_right?: 0 | string | undefined;
-        margin_left?: 0 | string | undefined;
-        format?: "A0" | "A1" | "A2" | "A3" | "A4" | "A5" | "A6" | "Letter" | undefined;
-        page_orientation?: "portrait" | "landscape" | undefined;
-        header_and_footer_css?: string | undefined;
-        footer_html?: string | undefined;
-        header_html?: string | undefined;
-        wait_for_selector?: string | undefined;
-        wait_for_network?: boolean | undefined;
-        wait_time?: number | undefined;
-    } | undefined;
+    converterOptions?:
+        | {
+              margin_top?: 0 | string | undefined;
+              margin_bottom?: 0 | string | undefined;
+              margin_right?: 0 | string | undefined;
+              margin_left?: 0 | string | undefined;
+              format?: "A0" | "A1" | "A2" | "A3" | "A4" | "A5" | "A6" | "Letter" | undefined;
+              page_orientation?: "portrait" | "landscape" | undefined;
+              header_and_footer_css?: string | undefined;
+              footer_html?: string | undefined;
+              header_html?: string | undefined;
+              wait_for_selector?: string | undefined;
+              wait_for_network?: boolean | undefined;
+              wait_time?: number | undefined;
+          }
+        | undefined;
     converterUrl?: string | undefined;
     dataCallback?(editor: Editor): string;
     fileName?: string | undefined;

--- a/types/ckeditor__ckeditor5-export-pdf/src/exportpdfcommand.d.ts
+++ b/types/ckeditor__ckeditor5-export-pdf/src/exportpdfcommand.d.ts
@@ -1,7 +1,7 @@
 import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import Command from "@ckeditor/ckeditor5-core/src/command"
+import Command from "@ckeditor/ckeditor5-core/src/command";
 
-export default class ExportPdfCommand extends Command implements Emitter, Observable {
+export default class ExportPdfCommand extends Command {
     isBusy: boolean;
 }

--- a/types/ckeditor__ckeditor5-export-word/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-export-word/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-src/exportwordcommand.d.ts

--- a/types/ckeditor__ckeditor5-export-word/ckeditor__ckeditor5-export-word-tests.ts
+++ b/types/ckeditor__ckeditor5-export-word/ckeditor__ckeditor5-export-word-tests.ts
@@ -1,6 +1,7 @@
 import { Editor } from "@ckeditor/ckeditor5-core";
 import { ExportWord } from "@ckeditor/ckeditor5-export-word";
 import { ExportWordConfig } from "@ckeditor/ckeditor5-export-word/src/exportword";
+import ExportWordCommand from "@ckeditor/ckeditor5-export-word/src/exportwordcommand";
 
 class MyEditor extends Editor {}
 
@@ -42,3 +43,5 @@ config = {
 config = {
     tokenUrl: "",
 };
+
+new ExportWordCommand(new MyEditor({ exportWord: config })).execute();

--- a/types/ckeditor__ckeditor5-export-word/src/exportword.d.ts
+++ b/types/ckeditor__ckeditor5-export-word/src/exportword.d.ts
@@ -1,58 +1,67 @@
 import { Plugin } from "@ckeditor/ckeditor5-core";
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 
-export default class ExportWord extends Plugin implements Emitter, Observable {}
+export default class ExportWord extends Plugin {}
 
 export interface ExportWordConfig {
-    converterOptions?: {
-        margin_top?: 0 | string | undefined;
-        margin_bottom?: 0 | string | undefined;
-        margin_right?: 0 | string | undefined;
-        margin_left?: 0 | string | undefined;
-        auto_pagination?: boolean | undefined;
-        format?:
-            | "Letter"
-            | "Legal"
-            | "Tabloid"
-            | "Ledger"
-            | "Statement"
-            | "Executive"
-            | "A3"
-            | "A4"
-            | "A5"
-            | "A6"
-            | "B4"
-            | "B5" | undefined;
-        header?: Array<{
-            html: string;
-            css: string;
-            type?: "default" | "even" | "odd" | "first" | undefined;
-        }> | undefined;
-        footer?: Array<{
-            html: string;
-            css: string;
-            type?: "default" | "even" | "odd" | "first" | undefined;
-        }> | undefined;
-        timezone?: string | undefined;
-        comments?: Array<
-            Record<
-                string,
-                {
-                    author: string;
-                    content: string;
-                    created: string;
-                }
-            >
-        > | undefined;
-        suggestions?: Record<
-            string,
-            {
-                author: string;
-                created: string;
-            }
-        > | undefined;
-    } | undefined;
+    converterOptions?:
+        | {
+              margin_top?: 0 | string | undefined;
+              margin_bottom?: 0 | string | undefined;
+              margin_right?: 0 | string | undefined;
+              margin_left?: 0 | string | undefined;
+              auto_pagination?: boolean | undefined;
+              format?:
+                  | "Letter"
+                  | "Legal"
+                  | "Tabloid"
+                  | "Ledger"
+                  | "Statement"
+                  | "Executive"
+                  | "A3"
+                  | "A4"
+                  | "A5"
+                  | "A6"
+                  | "B4"
+                  | "B5"
+                  | undefined;
+              header?:
+                  | Array<{
+                        html: string;
+                        css: string;
+                        type?: "default" | "even" | "odd" | "first" | undefined;
+                    }>
+                  | undefined;
+              footer?:
+                  | Array<{
+                        html: string;
+                        css: string;
+                        type?: "default" | "even" | "odd" | "first" | undefined;
+                    }>
+                  | undefined;
+              timezone?: string | undefined;
+              comments?:
+                  | Array<
+                        Record<
+                            string,
+                            {
+                                author: string;
+                                content: string;
+                                created: string;
+                            }
+                        >
+                    >
+                  | undefined;
+              suggestions?:
+                  | Record<
+                        string,
+                        {
+                            author: string;
+                            created: string;
+                        }
+                    >
+                  | undefined;
+          }
+        | undefined;
     converterUrl?: string | undefined;
     fileName?: string | undefined;
     stylesheets?: string[] | undefined;

--- a/types/ckeditor__ckeditor5-find-and-replace/src/findandreplaceediting.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/src/findandreplaceediting.d.ts
@@ -2,7 +2,10 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 import { Model } from '@ckeditor/ckeditor5-engine';
 import { Marker } from '@ckeditor/ckeditor5-engine/src/model/markercollection';
 import { Collection } from '@ckeditor/ckeditor5-utils';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 
 /**
  * The object storing find & replace plugin state in a given editor instance.
@@ -15,8 +18,8 @@ export class FindAndReplaceState implements Observable {
     replaceText: string;
     matchCase: boolean;
     matchWholeWords: boolean;
-
     constructor(model: Model);
+    clear(model: Model): void;
 
     set(option: Record<string, string>): void;
     set(name: string, value: unknown): void;
@@ -24,7 +27,31 @@ export class FindAndReplaceState implements Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    clear(model: Model): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 /**

--- a/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadprogress.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadprogress.d.ts
@@ -1,9 +1,22 @@
-import { DowncastConversionApi } from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { Plugin } from '@ckeditor/ckeditor5-core';
+import { Element, Range } from '@ckeditor/ckeditor5-engine';
+import DowncastDispatcher, {
+    DowncastConversionApi,
+} from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 
 export default class ImageUploadProgress extends Plugin {
     static readonly pluginName: 'ImageUploadProgress';
     init(): void;
-    uploadStatusChange(evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi): void;
+    uploadStatusChange(
+        evt: EventInfo<'attribute:uploadStatus:imageInline', DowncastDispatcher>,
+        data: {
+            attributeKey: string;
+            attributeNewValue: string;
+            attributeOldValue: null | string;
+            item: Element;
+            range: Range;
+        },
+        conversionApi: DowncastConversionApi,
+    ): void;
 }

--- a/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadprogress.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadprogress.d.ts
@@ -1,9 +1,22 @@
-import { DowncastConversionApi } from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { Plugin } from '@ckeditor/ckeditor5-core';
+import { Element, Range } from '@ckeditor/ckeditor5-engine';
+import DowncastDispatcher, {
+    DowncastConversionApi,
+} from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 
 export default class ImageUploadProgress extends Plugin {
     static readonly pluginName: 'ImageUploadProgress';
     init(): void;
-    uploadStatusChange(evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi): void;
+    uploadStatusChange(
+        evt: EventInfo<'attribute:uploadStatus:imageInline', DowncastDispatcher>,
+        data: {
+            attributeKey: string;
+            attributeNewValue: string;
+            attributeOldValue: null | string;
+            item: Element;
+            range: Range;
+        },
+        conversionApi: DowncastConversionApi,
+    ): void;
 }

--- a/types/ckeditor__ckeditor5-link/src/utils/manualdecorator.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/utils/manualdecorator.d.ts
@@ -1,4 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 
 export default class ManualDecorator implements Observable {
     readonly attributes: Record<string, string>;
@@ -7,11 +10,42 @@ export default class ManualDecorator implements Observable {
     readonly label: string;
     value: boolean;
 
-    constructor(config: { id: string; label: string; attributes: Record<string, string>; defaultValue?: boolean | undefined });
+    constructor(config: {
+        id: string;
+        label: string;
+        attributes: Record<string, string>;
+        defaultValue?: boolean | undefined;
+    });
 
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-link/v27/src/utils/manualdecorator.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/utils/manualdecorator.d.ts
@@ -1,4 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 
 export default class ManualDecorator implements Observable {
     readonly attributes: Record<string, string>;
@@ -14,4 +17,30 @@ export default class ManualDecorator implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-list/src/todolistconverters.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/todolistconverters.d.ts
@@ -1,32 +1,90 @@
-import { Model } from '@ckeditor/ckeditor5-engine';
-import { DowncastConversionApi } from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
-import { UpcastConversionApi } from '@ckeditor/ckeditor5-engine/src/conversion/upcastdispatcher';
+import { Element, Model, Range } from '@ckeditor/ckeditor5-engine';
+import DowncastDispatcher, {
+    DowncastConversionApi,
+} from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
+import Mapper from '@ckeditor/ckeditor5-engine/src/conversion/mapper';
+import UpcastDispatcher, {
+    UpcastConversionApi,
+    UpcastConversionData,
+} from '@ckeditor/ckeditor5-engine/src/conversion/upcastdispatcher';
 import { Item } from '@ckeditor/ckeditor5-engine/src/model/item';
+import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import View from '@ckeditor/ckeditor5-engine/src/view/view';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 
 export function modelViewInsertion(
     model: Model,
     onCheckboxChecked: (item: Item) => void,
-): (evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi) => void;
+): (
+    evt: EventInfo<'insert:listItem', DowncastDispatcher>,
+    data: {
+        item: Element;
+        range: Range;
+    },
+    conversionApi: DowncastConversionApi,
+) => void;
 
+/**
+ * A model-to-view converter for the `listItem` model element insertion.
+ *
+ * It is used by {@link module:engine/controller/datacontroller~DataController}.
+ *
+ * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:insert
+ */
 export function dataModelViewInsertion(
     model: Model,
-): (evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi) => void;
-
-export function dataViewModelCheckmarkInsertion(
-    evt: EventInfo,
+): (
+    evt: EventInfo<'', DowncastDispatcher>,
     data: Record<string, unknown>,
+    conversionApi: DowncastConversionApi,
+) => void;
+
+/**
+ * A view-to-model converter for the checkbox element inside a view list item.
+ *
+ * It changes the `listType` of the model `listItem` to a `todo` value.
+ * When a view checkbox element is marked as checked, an additional `todoListChecked="true"` attribute is added to the model item.
+ *
+ * It is used by {@link module:engine/controller/datacontroller~DataController}.
+ */
+export function dataViewModelCheckmarkInsertion(
+    evt: EventInfo<'', UpcastDispatcher>,
+    data: UpcastConversionData,
     conversionApi: UpcastConversionApi,
 ): void;
 
 export function modelViewChangeType(
     onCheckedChange: (item: Item) => void,
     view: View,
-): (evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi) => void;
+): (
+    evt: EventInfo<'attribute:listType:listItem', DowncastDispatcher>,
+    data: {
+        attributeKey: string;
+        attributeNewValue: string;
+        attributeOldValue: null | string;
+        item: Element;
+        range: Range;
+    },
+    conversionApi: DowncastConversionApi,
+) => void;
 
-export function modelViewChangeChecked(
-    onCheckedChange: (item: Item) => void,
-): (evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi) => void;
+export function modelViewChangeChecked(onCheckedChange: (item: Item) => void): (
+    evt: EventInfo<'attribute:todoListChecked:listItem', DowncastDispatcher>,
+    data: {
+        attributeKey: string;
+        attributeNewValue: string;
+        attributeOldValue: null | string;
+        item: Element;
+        range: Range;
+    },
+    conversionApi: DowncastConversionApi,
+) => void;
 
-export function mapModelToViewPosition(view: View): (evt: EventInfo, data: Record<string, unknown>) => void;
+export function mapModelToViewPosition(view: View): (
+    evt: EventInfo<'modelToViewPosition', Mapper>,
+    data: {
+        isPhantom: boolean;
+        mapper: Mapper;
+        modelPosition: Position;
+    },
+) => void;

--- a/types/ckeditor__ckeditor5-revision-history/src/revision.d.ts
+++ b/types/ckeditor__ckeditor5-revision-history/src/revision.d.ts
@@ -1,12 +1,10 @@
 import { User } from '@ckeditor/ckeditor5-collaboration-core/src/users';
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
-import { Emitter } from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
-import { EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 
-export default class Revision implements Emitter, Observable {
+export default class Revision implements Observable {
     readonly authors: Set<User>;
     readonly creator: User | null;
     readonly data: Record<string, string>;
@@ -21,25 +19,29 @@ export default class Revision implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-typing/src/textwatcher.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/textwatcher.d.ts
@@ -1,5 +1,8 @@
 import { Model } from "@ckeditor/ckeditor5-engine";
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import { TextTransformationDescription } from "./texttransformation";
 
 export default class TextWatcher implements Observable {
@@ -18,4 +21,30 @@ export default class TextWatcher implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/model.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/model.d.ts
@@ -1,13 +1,11 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
-export default class Model implements Emitter, Observable {
+export default class Model implements Observable {
     constructor(attributes?: Record<string, unknown>, properties?: Record<string, unknown>);
-
-    readonly [x: string]: any;
+    readonly [x: string]: unknown;
 
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
@@ -15,25 +13,29 @@ export default class Model implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/notification/notification.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/notification/notification.d.ts
@@ -1,33 +1,7 @@
-import { ContextPlugin } from "@ckeditor/ckeditor5-core";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import { ContextPlugin } from '@ckeditor/ckeditor5-core';
 
-export default class Notification extends ContextPlugin implements Emitter {
+export default class Notification extends ContextPlugin {
     showInfo(message: string, data?: { namespace?: string | undefined; title?: string | undefined }): void;
     showSuccess(message: string, data?: { namespace?: string | undefined; title?: string | undefined }): void;
     showWarning(message: string, data?: { namespace?: string | undefined; title?: string | undefined }): void;
-
-    on(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/template.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/template.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
 import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
@@ -21,25 +20,29 @@ export default class Template implements Emitter {
     static bind(observable: Observable, emitter: Emitter): BindChain;
     static extend(template: Template, def: Partial<TemplateDefinition>): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/view.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/view.d.ts
@@ -25,35 +25,35 @@ export default class View implements DomEmitter, Observable {
     render(): void;
     destroy(): void;
 
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: number | PriorityString },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: number | PriorityString },
-    ): void;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: DomEventData) => void,
-    ): void;
-
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, data: DomEventData) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/viewcollection.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/viewcollection.d.ts
@@ -1,9 +1,8 @@
 import { Collection } from "@ckeditor/ckeditor5-utils";
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import View from "./view";
 
-export default class ViewCollection<T extends View = View> extends Collection<T> implements Emitter, Observable {
+export default class ViewCollection<T extends View = View> extends Collection<T> implements Observable {
     constructor(initialItems?: Iterable<T>);
     destroy(): void;
     setParent(element: HTMLElement): void;

--- a/types/ckeditor__ckeditor5-ui/v27/src/model.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/model.d.ts
@@ -1,13 +1,11 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
-export default class Model implements Emitter, Observable {
+export default class Model implements Observable {
     constructor(attributes?: Record<string, unknown>, properties?: Record<string, unknown>);
-
-    readonly [x: string]: any;
+    readonly [x: string]: unknown;
 
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
@@ -15,25 +13,29 @@ export default class Model implements Emitter, Observable {
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
 
-    on(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number },
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/v27/src/notification/notification.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/notification/notification.d.ts
@@ -1,33 +1,7 @@
-import { ContextPlugin } from "@ckeditor/ckeditor5-core";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+import { ContextPlugin } from '@ckeditor/ckeditor5-core';
 
-export default class Notification extends ContextPlugin implements Emitter {
-    showInfo(message: string, data?: { namespace?: string; title?: string }): void;
-    showSuccess(message: string, data?: { namespace?: string; title?: string }): void;
-    showWarning(message: string, data?: { namespace?: string; title?: string }): void;
-
-    on(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number },
-    ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
+export default class Notification extends ContextPlugin {
+    showInfo(message: string, data?: { namespace?: string | undefined; title?: string | undefined }): void;
+    showSuccess(message: string, data?: { namespace?: string | undefined; title?: string | undefined }): void;
+    showWarning(message: string, data?: { namespace?: string | undefined; title?: string | undefined }): void;
 }

--- a/types/ckeditor__ckeditor5-ui/v27/src/template.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/template.d.ts
@@ -1,4 +1,3 @@
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
 import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
@@ -21,25 +20,29 @@ export default class Template implements Emitter {
     static bind(observable: Observable, emitter: Emitter): BindChain;
     static extend(template: Template, def: Partial<TemplateDefinition>): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/v27/src/view.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/view.d.ts
@@ -1,12 +1,12 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { Locale } from "@ckeditor/ckeditor5-utils";
-import { Emitter as DomEmitter } from "@ckeditor/ckeditor5-utils/src/dom/emittermixin";
-import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
-import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
-import Template, { BindChain as TemplateBindChain, TemplateDefinition } from "./template";
-import ViewCollection from "./viewcollection";
+import { DomEventData } from '@ckeditor/ckeditor5-engine';
+import { Locale } from '@ckeditor/ckeditor5-utils';
+import { Emitter as DomEmitter } from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Template, { BindChain as TemplateBindChain, TemplateDefinition } from './template';
+import ViewCollection from './viewcollection';
 
 export default class View implements DomEmitter, Observable {
     constructor(locale?: Locale);
@@ -25,35 +25,35 @@ export default class View implements DomEmitter, Observable {
     render(): void;
     destroy(): void;
 
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: number | PriorityString },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: number | PriorityString },
-    ): void;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: DomEventData) => void,
-    ): void;
-
     set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, data: DomEventData) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/v27/src/viewcollection.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/viewcollection.d.ts
@@ -1,9 +1,8 @@
 import { Collection } from "@ckeditor/ckeditor5-utils";
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import View from "./view";
 
-export default class ViewCollection<T extends View = View> extends Collection<T> implements Emitter, Observable {
+export default class ViewCollection<T extends View = View> extends Collection<T> implements Observable {
     constructor(initialItems?: Iterable<T>);
     destroy(): void;
     setParent(element: HTMLElement): void;

--- a/types/ckeditor__ckeditor5-utils/src/collection.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/collection.d.ts
@@ -1,7 +1,6 @@
+import { Emitter, EmitterMixinDelegateChain } from "./emittermixin";
 import EventInfo from "./eventinfo";
 import { PriorityString } from "./priorities";
-import { Emitter, EmitterMixinDelegateChain } from "./emittermixin";
-import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
 
 export interface CollectionBindTo<T, K> {
     as: (Class: { new (item: T): K }) => void;
@@ -25,30 +24,30 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *
      * You can provide an iterable of initial items the collection will be created with:
      *
-     *  const collection = new Collection( [ { id: 'John' }, { id: 'Mike' } ] );
+     *  const collection = new Collection( [ { id: "John" }, { id: "Mike" } ] );
      *
-     *  console.log( collection.get( 0 ) ); // -> { id: 'John' }
-     *  console.log( collection.get( 1 ) ); // -> { id: 'Mike' }
-     *  console.log( collection.get( 'Mike' ) ); // -> { id: 'Mike' }
+     *  console.log( collection.get( 0 ) ); // -> { id: "John" }
+     *  console.log( collection.get( 1 ) ); // -> { id: "Mike" }
+     *  console.log( collection.get( "Mike" ) ); // -> { id: "Mike" }
      *
      * Or you can first create a collection and then add new items using the {@link #add} method:
      *
      *  const collection = new Collection();
      *
-     *  collection.add( { id: 'John' } );
-     *  console.log( collection.get( 0 ) ); // -> { id: 'John' }
+     *  collection.add( { id: "John" } );
+     *  console.log( collection.get( 0 ) ); // -> { id: "John" }
      *
      * Whatever option you choose, you can always pass a configuration object as the last argument
      * of the constructor:
      *
-     *  const emptyCollection = new Collection( { idProperty: 'name' } );
-     *  emptyCollection.add( { name: 'John' } );
-     *  console.log( collection.get( 'John' ) ); // -> { name: 'John' }
+     *  const emptyCollection = new Collection( { idProperty: "name" } );
+     *  emptyCollection.add( { name: "John" } );
+     *  console.log( collection.get( "John" ) ); // -> { name: "John" }
      *
-     *  const nonEmptyCollection = new Collection( [ { name: 'John' } ], { idProperty: 'name' } );
-     *  nonEmptyCollection.add( { name: 'George' } );
-     *  console.log( collection.get( 'George' ) ); // -> { name: 'George' }
-     *  console.log( collection.get( 'John' ) ); // -> { name: 'John' }
+     *  const nonEmptyCollection = new Collection( [ { name: "John" } ], { idProperty: "name" } );
+     *  nonEmptyCollection.add( { name: "George" } );
+     *  console.log( collection.get( "George" ) ); // -> { name: "George" }
+     *  console.log( collection.get( "John" ) ); // -> { name: "John" }
      *
      * the options object.
      * Items that do not have such a property will be assigned one when added to the collection.
@@ -137,20 +136,20 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *   }
      *  }
      *
-     *  const source = new Collection( { idProperty: 'label' } );
+     *  const source = new Collection( { idProperty: "label" } );
      *  const target = new Collection();
      *
      *  target.bindTo( source ).as( FactoryClass );
      *
-     *  source.add( { label: 'foo' } );
-     *  source.add( { label: 'bar' } );
+     *  source.add( { label: "foo" } );
+     *  source.add( { label: "bar" } );
      *
      *  console.log( target.length ); // 2
-     *  console.log( target.get( 1 ).label ); // 'bar'
+     *  console.log( target.get( 1 ).label ); // "bar"
      *
      *  source.remove( 0 );
      *  console.log( target.length ); // 1
-     *  console.log( target.get( 0 ).label ); // 'bar'
+     *  console.log( target.get( 0 ).label ); // "bar"
      *
      * or the factory driven by a custom callback:
      *
@@ -166,19 +165,19 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *   }
      *  }
      *
-     *  const source = new Collection( { idProperty: 'label' } );
+     *  const source = new Collection( { idProperty: "label" } );
      *  const target = new Collection();
      *
      *  target.bindTo( source ).using( ( item ) => {
-     *   if ( item.label == 'foo' ) {
+     *   if ( item.label == "foo" ) {
      *    return new FooClass( item );
      *   } else {
      *    return new BarClass( item );
      *   }
      *  } );
      *
-     *  source.add( { label: 'foo' } );
-     *  source.add( { label: 'bar' } );
+     *  source.add( { label: "foo" } );
+     *  source.add( { label: "bar" } );
      *
      *  console.log( target.length ); // 2
      *  console.log( target.get( 0 ) instanceof FooClass ); // true
@@ -186,19 +185,19 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *
      * or the factory out of property name:
      *
-     *  const source = new Collection( { idProperty: 'label' } );
+     *  const source = new Collection( { idProperty: "label" } );
      *  const target = new Collection();
      *
-     *  target.bindTo( source ).using( 'label' );
+     *  target.bindTo( source ).using( "label" );
      *
-     *  source.add( { label: { value: 'foo' } } );
-     *  source.add( { label: { value: 'bar' } } );
+     *  source.add( { label: { value: "foo" } } );
+     *  source.add( { label: { value: "bar" } } );
      *
      *  console.log( target.length ); // 2
-     *  console.log( target.get( 0 ).value ); // 'foo'
-     *  console.log( target.get( 1 ).value ); // 'bar'
+     *  console.log( target.get( 0 ).value ); // "foo"
+     *  console.log( target.get( 1 ).value ); // "bar"
      *
-     * It's possible to skip specified items by returning falsy value:
+     * It"s possible to skip specified items by returning falsy value:
      *
      *  const source = new Collection();
      *  const target = new Collection();
@@ -227,25 +226,29 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      */
     [Symbol.iterator](): Iterator<T>;
 
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-utils/src/dom/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/dom/emittermixin.d.ts
@@ -1,32 +1,67 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
+import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
 import { Emitter as BaseEmitter, EmitterMixinDelegateChain } from "../emittermixin";
 import EventInfo from "../eventinfo";
 import { PriorityString } from "../priorities";
 
 export interface Emitter extends BaseEmitter {
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    listenTo<S extends BaseEmitter | ProxyEmitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<N, S>, data: DomEventData) => void,
+        options?: { useCapture?: boolean; usePassive?: boolean; priority?: PriorityString | number | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+
+    stopListening<S extends BaseEmitter | ProxyEmitter, N extends string>(
+        emitter?: S | Node | Window,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
     ): void;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }
 
 declare const DomEmitterMixin: Emitter;
 
 export default DomEmitterMixin;
+
+export class ProxyEmitter implements BaseEmitter {
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, BaseEmitter>, ...data: unknown[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, BaseEmitter>, ...data: unknown[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N, BaseEmitter>, ...data: unknown[]) => void): void;
+    listenTo<S extends BaseEmitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends BaseEmitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo<"", BaseEmitter>, ...args: unknown[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: BaseEmitter): void;
+    /**
+     * Registers a callback function to be executed when an event is fired.
+     *
+     * It attaches a native DOM listener to the DOM Node. When fired,
+     * a corresponding Emitter event will also fire with DOM Event object as an argument.
+     */
+    attach<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, ProxyEmitter>, ...data: unknown[]) => void,
+        options?: { useCapture?: boolean; usePassive?: boolean },
+    ): void;
+
+    /**
+     * Stops executing the callback on the given event.
+     */
+    detach(event: string): void;
+}

--- a/types/ckeditor__ckeditor5-utils/src/dom/resizeobserver.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/dom/resizeobserver.d.ts
@@ -1,8 +1,6 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { EmitterMixinDelegateChain } from "../emittermixin";
+import { Emitter, EmitterMixinDelegateChain } from "../emittermixin";
 import EventInfo from "../eventinfo";
 import { PriorityString } from "../priorities";
-import { Emitter } from "./emittermixin";
 
 /**
  * A helper class which instances allow performing custom actions when native DOM elements are resized.
@@ -10,9 +8,9 @@ import { Emitter } from "./emittermixin";
  *  const editableElement = editor.editing.view.getDomRoot();
  *
  *  const observer = new ResizeObserver( editableElement, entry => {
- *   console.log( 'The editable element has been resized in DOM.' );
+ *   console.log( "The editable element has been resized in DOM." );
  *   console.log( entry.target ); // -> editableElement
- *   console.log( entry.contentRect.width ); // -> e.g. '423px'
+ *   console.log( entry.contentRect.width ); // -> e.g. "423px"
  *  } );
  *
  * By default, it uses the [native DOM resize observer](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
@@ -33,26 +31,29 @@ export default class ResizeObserver implements Emitter {
      */
     destroy(): void;
 
-    // Implements
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-utils/src/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/emittermixin.d.ts
@@ -1,4 +1,3 @@
-import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
 import EventInfo from "./eventinfo";
 import { PriorityString } from "./priorities";
 
@@ -8,61 +7,55 @@ export interface Emitter {
      *
      * Shorthand for {@link #listenTo `this.listenTo( this, event, callback, options )`} (it makes the emitter
      * listen on itself).
-     *
-     * the priority value the sooner the callback will be fired. Events having the same priority are called in the
-     * order they were added.
      */
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: PriorityString | number },
+    ): void;
     /**
      * Registers a callback function to be executed on the next time the event is fired only. This is similar to
      * calling {@link #on} followed by {@link #off} in the callback.
-     *
-     * the priority value the sooner the callback will be fired. Events having the same priority are called in the
-     * order they were added.
      */
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: PriorityString | number },
     ): void;
     /**
      * Stops executing the callback on the given event.
      * Shorthand for {@link #stopListening `this.stopListening( this, event, callback )`}.
      *
      */
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
+    off<N extends string>(
+        event: N,
+        callback?: ((info: EventInfo<N>, ...data: unknown[]) => void),
+    ): void;
     /**
      * Registers a callback function to be executed when an event is fired in a specific (emitter) object.
      *
      * Events can be grouped in namespaces using `:`.
      * When namespaced event is fired, it additionally fires all callbacks for that namespace.
      *
-     *  // myEmitter.on( ... ) is a shorthand for myEmitter.listenTo( myEmitter, ... ).
-     *  myEmitter.on( 'myGroup', genericCallback );
-     *  myEmitter.on( 'myGroup:myEvent', specificCallback );
+     *        // myEmitter.on( ... ) is a shorthand for myEmitter.listenTo( myEmitter, ... ).
+     *        myEmitter.on( "myGroup", genericCallback );
+     *        myEmitter.on( "myGroup:myEvent", specificCallback );
      *
-     *  // genericCallback is fired.
-     *  myEmitter.fire( 'myGroup' );
-     *  // both genericCallback and specificCallback are fired.
-     *  myEmitter.fire( 'myGroup:myEvent' );
-     *  // genericCallback is fired even though there are no callbacks for "foo".
-     *  myEmitter.fire( 'myGroup:foo' );
+     *        // genericCallback is fired.
+     *        myEmitter.fire( "myGroup" );
+     *        // both genericCallback and specificCallback are fired.
+     *        myEmitter.fire( "myGroup:myEvent" );
+     *        // genericCallback is fired even though there are no callbacks for "foo".
+     *        myEmitter.fire( "myGroup:foo" );
      *
      * An event callback can {@link module:utils/eventinfo~EventInfo#stop stop the event} and
      * set the {@link module:utils/eventinfo~EventInfo#return return value} of the {@link #fire} method.
-     *
-     * the priority value the sooner the callback will be fired. Events having the same priority are called in the
-     * order they were added.
      */
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: PriorityString | number | undefined } ,
     ): void;
     /**
      * Stops listening for events. It can be used at different levels:
@@ -71,34 +64,32 @@ export interface Emitter {
      * * To stop listening to a specific event.
      * * To stop listening to all events fired by a specific object.
      * * To stop listening to all events fired by all objects.
-     *
-     * for all events from `emitter`.
-     * `event`.
      */
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
     /**
      * Fires an event, executing all callbacks registered for it.
      *
      * The first parameter passed to callbacks is an {@link module:utils/eventinfo~EventInfo} object,
      * followed by the optional `args` provided in the `fire()` method call.
-     *
-     * through modification of the {@link module:utils/eventinfo~EventInfo#return `evt.return`}'s property (the event info
-     * is the first param of every callback).
      */
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     /**
      * Delegates selected events to another {@link module:utils/emittermixin~Emitter}. For instance:
      *
-     *  emitterA.delegate( 'eventX' ).to( emitterB );
-     *  emitterA.delegate( 'eventX', 'eventY' ).to( emitterC );
+     *     emitterA.delegate( "eventX" ).to( emitterB );
+     *     emitterA.delegate( "eventX", "eventY" ).to( emitterC );
      *
      * then `eventX` is delegated (fired by) `emitterB` and `emitterC` along with `data`:
      *
-     *  emitterA.fire( 'eventX', data );
+     *     emitterA.fire( "eventX", data );
      *
      * and `eventY` is delegated (fired by) `emitterC` along with `data`:
      *
-     *  emitterA.fire( 'eventY', data );
+     *     emitterA.fire( "eventY", data );
      *
      */
     delegate(...events: string[]): EmitterMixinDelegateChain;

--- a/types/ckeditor__ckeditor5-utils/src/eventinfo.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/eventinfo.d.ts
@@ -4,7 +4,7 @@ import { Emitter } from "./emittermixin";
  * The event object passed to event callbacks. It is used to provide information about the event as well as a tool to
  * manipulate it.
  */
-export default class EventInfo<S extends Emitter = Emitter, N extends string = ""> {
+export default class EventInfo<N extends string = "", S extends Emitter = Emitter> {
     constructor(source: S, name: N);
     /**
      * The object that fired the event.
@@ -20,7 +20,7 @@ export default class EventInfo<S extends Emitter = Emitter, N extends string = "
      * Path this event has followed. See {@link module:utils/emittermixin~EmitterMixin#delegate}.
      *
      */
-    readonly path: object[];
+    readonly path: [S];
     /**
      * Stops the event emitter to call further callbacks for this event interaction.
      *

--- a/types/ckeditor__ckeditor5-utils/src/focustracker.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/focustracker.d.ts
@@ -1,9 +1,9 @@
-import { Emitter, EmitterMixinDelegateChain } from "./emittermixin";
-import { Emitter as DomEmitter } from "./dom/emittermixin";
-import { BindChain, Observable } from "./observablemixin";
-import { PriorityString } from "./priorities";
-import EventInfo from "./eventinfo";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
+import { Emitter as DomEmitter, ProxyEmitter } from './dom/emittermixin';
+import { Emitter, EmitterMixinDelegateChain } from './emittermixin';
+import EventInfo from './eventinfo';
+import { BindChain, Observable } from './observablemixin';
+import { PriorityString } from './priorities';
 
 /**
  * Allows observing a group of `HTMLElement`s whether at least one of them is focused.
@@ -18,7 +18,7 @@ import { DomEventData } from "@ckeditor/ckeditor5-engine";
  * Check out the {@glink framework/guides/deep-dive/ui/focus-tracking "Deep dive into focus tracking" guide} to learn more.
  *
  */
-export default class FocusTracker implements Observable, Emitter, DomEmitter {
+export default class FocusTracker implements Observable, DomEmitter {
     /**
      * Starts tracking the specified element.
      *
@@ -45,26 +45,33 @@ export default class FocusTracker implements Observable, Emitter, DomEmitter {
     set(name: string, value: any): void;
     unbind(...unbindProperties: string[]): void;
 
-    // Observable (Emitter)
+    listenTo<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: {
+            useCapture?: boolean | undefined;
+            usePassive?: boolean | undefined;
+            priority?: number | PriorityString | undefined;
+        },
+    ): void;
+    stopListening<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter?: Node | Window | S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
+    ): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-utils/src/observablemixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/observablemixin.d.ts
@@ -1,3 +1,5 @@
+import { Emitter } from './emittermixin';
+
 export interface BindChain {
     to(observable: Observable, ...bindProperties: Array<Observable | string>): void;
     to(
@@ -11,7 +13,7 @@ export interface BindChain {
     ): void;
 }
 
-export interface Observable {
+export interface Observable extends Emitter {
     /**
      * Creates and sets the value of an observable property of this object. Such a property becomes a part
      * of the state and is observable.
@@ -23,7 +25,7 @@ export interface Observable {
      * properties and methods, but means that `foo.set( 'bar', 1 )` may be slightly slower than `foo.bar = 1`.
      *
      */
-    set(option: Record<string, string>): void;
+    set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     /**
      * Binds {@link #set observable properties} to other objects implementing the

--- a/types/ckeditor__ckeditor5-utils/v27/src/collection.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/collection.d.ts
@@ -1,7 +1,6 @@
+import { Emitter, EmitterMixinDelegateChain } from "./emittermixin";
 import EventInfo from "./eventinfo";
 import { PriorityString } from "./priorities";
-import { Emitter, EmitterMixinDelegateChain } from "./emittermixin";
-import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
 
 export interface CollectionBindTo<T, K> {
     as: (Class: { new (item: T): K }) => void;
@@ -25,30 +24,30 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *
      * You can provide an iterable of initial items the collection will be created with:
      *
-     *  const collection = new Collection( [ { id: 'John' }, { id: 'Mike' } ] );
+     *  const collection = new Collection( [ { id: "John" }, { id: "Mike" } ] );
      *
-     *  console.log( collection.get( 0 ) ); // -> { id: 'John' }
-     *  console.log( collection.get( 1 ) ); // -> { id: 'Mike' }
-     *  console.log( collection.get( 'Mike' ) ); // -> { id: 'Mike' }
+     *  console.log( collection.get( 0 ) ); // -> { id: "John" }
+     *  console.log( collection.get( 1 ) ); // -> { id: "Mike" }
+     *  console.log( collection.get( "Mike" ) ); // -> { id: "Mike" }
      *
      * Or you can first create a collection and then add new items using the {@link #add} method:
      *
      *  const collection = new Collection();
      *
-     *  collection.add( { id: 'John' } );
-     *  console.log( collection.get( 0 ) ); // -> { id: 'John' }
+     *  collection.add( { id: "John" } );
+     *  console.log( collection.get( 0 ) ); // -> { id: "John" }
      *
      * Whatever option you choose, you can always pass a configuration object as the last argument
      * of the constructor:
      *
-     *  const emptyCollection = new Collection( { idProperty: 'name' } );
-     *  emptyCollection.add( { name: 'John' } );
-     *  console.log( collection.get( 'John' ) ); // -> { name: 'John' }
+     *  const emptyCollection = new Collection( { idProperty: "name" } );
+     *  emptyCollection.add( { name: "John" } );
+     *  console.log( collection.get( "John" ) ); // -> { name: "John" }
      *
-     *  const nonEmptyCollection = new Collection( [ { name: 'John' } ], { idProperty: 'name' } );
-     *  nonEmptyCollection.add( { name: 'George' } );
-     *  console.log( collection.get( 'George' ) ); // -> { name: 'George' }
-     *  console.log( collection.get( 'John' ) ); // -> { name: 'John' }
+     *  const nonEmptyCollection = new Collection( [ { name: "John" } ], { idProperty: "name" } );
+     *  nonEmptyCollection.add( { name: "George" } );
+     *  console.log( collection.get( "George" ) ); // -> { name: "George" }
+     *  console.log( collection.get( "John" ) ); // -> { name: "John" }
      *
      * the options object.
      * Items that do not have such a property will be assigned one when added to the collection.
@@ -137,20 +136,20 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *   }
      *  }
      *
-     *  const source = new Collection( { idProperty: 'label' } );
+     *  const source = new Collection( { idProperty: "label" } );
      *  const target = new Collection();
      *
      *  target.bindTo( source ).as( FactoryClass );
      *
-     *  source.add( { label: 'foo' } );
-     *  source.add( { label: 'bar' } );
+     *  source.add( { label: "foo" } );
+     *  source.add( { label: "bar" } );
      *
      *  console.log( target.length ); // 2
-     *  console.log( target.get( 1 ).label ); // 'bar'
+     *  console.log( target.get( 1 ).label ); // "bar"
      *
      *  source.remove( 0 );
      *  console.log( target.length ); // 1
-     *  console.log( target.get( 0 ).label ); // 'bar'
+     *  console.log( target.get( 0 ).label ); // "bar"
      *
      * or the factory driven by a custom callback:
      *
@@ -166,19 +165,19 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *   }
      *  }
      *
-     *  const source = new Collection( { idProperty: 'label' } );
+     *  const source = new Collection( { idProperty: "label" } );
      *  const target = new Collection();
      *
      *  target.bindTo( source ).using( ( item ) => {
-     *   if ( item.label == 'foo' ) {
+     *   if ( item.label == "foo" ) {
      *    return new FooClass( item );
      *   } else {
      *    return new BarClass( item );
      *   }
      *  } );
      *
-     *  source.add( { label: 'foo' } );
-     *  source.add( { label: 'bar' } );
+     *  source.add( { label: "foo" } );
+     *  source.add( { label: "bar" } );
      *
      *  console.log( target.length ); // 2
      *  console.log( target.get( 0 ) instanceof FooClass ); // true
@@ -186,19 +185,19 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      *
      * or the factory out of property name:
      *
-     *  const source = new Collection( { idProperty: 'label' } );
+     *  const source = new Collection( { idProperty: "label" } );
      *  const target = new Collection();
      *
-     *  target.bindTo( source ).using( 'label' );
+     *  target.bindTo( source ).using( "label" );
      *
-     *  source.add( { label: { value: 'foo' } } );
-     *  source.add( { label: { value: 'bar' } } );
+     *  source.add( { label: { value: "foo" } } );
+     *  source.add( { label: { value: "bar" } } );
      *
      *  console.log( target.length ); // 2
-     *  console.log( target.get( 0 ).value ); // 'foo'
-     *  console.log( target.get( 1 ).value ); // 'bar'
+     *  console.log( target.get( 0 ).value ); // "foo"
+     *  console.log( target.get( 1 ).value ); // "bar"
      *
-     * It's possible to skip specified items by returning falsy value:
+     * It"s possible to skip specified items by returning falsy value:
      *
      *  const source = new Collection();
      *  const target = new Collection();
@@ -227,25 +226,29 @@ export default class Collection<T> implements Iterable<T>, Emitter {
      */
     [Symbol.iterator](): Iterator<T>;
 
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-utils/v27/src/dom/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/dom/emittermixin.d.ts
@@ -1,32 +1,67 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
+import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
 import { Emitter as BaseEmitter, EmitterMixinDelegateChain } from "../emittermixin";
 import EventInfo from "../eventinfo";
 import { PriorityString } from "../priorities";
 
 export interface Emitter extends BaseEmitter {
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    listenTo<S extends BaseEmitter | ProxyEmitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<N, S>, data: DomEventData) => void,
+        options?: { useCapture?: boolean; usePassive?: boolean; priority?: PriorityString | number | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+
+    stopListening<S extends BaseEmitter | ProxyEmitter, N extends string>(
+        emitter?: S | Node | Window,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
     ): void;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }
 
 declare const DomEmitterMixin: Emitter;
 
 export default DomEmitterMixin;
+
+export class ProxyEmitter implements BaseEmitter {
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, BaseEmitter>, ...data: unknown[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, BaseEmitter>, ...data: unknown[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N, BaseEmitter>, ...data: unknown[]) => void): void;
+    listenTo<S extends BaseEmitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends BaseEmitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo<"", BaseEmitter>, ...args: unknown[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: BaseEmitter): void;
+    /**
+     * Registers a callback function to be executed when an event is fired.
+     *
+     * It attaches a native DOM listener to the DOM Node. When fired,
+     * a corresponding Emitter event will also fire with DOM Event object as an argument.
+     */
+    attach<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N, ProxyEmitter>, ...data: unknown[]) => void,
+        options?: { useCapture?: boolean; usePassive?: boolean },
+    ): void;
+
+    /**
+     * Stops executing the callback on the given event.
+     */
+    detach(event: string): void;
+}

--- a/types/ckeditor__ckeditor5-utils/v27/src/dom/resizeobserver.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/dom/resizeobserver.d.ts
@@ -1,8 +1,6 @@
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
-import { EmitterMixinDelegateChain } from "../emittermixin";
+import { Emitter, EmitterMixinDelegateChain } from "../emittermixin";
 import EventInfo from "../eventinfo";
 import { PriorityString } from "../priorities";
-import { Emitter } from "./emittermixin";
 
 /**
  * A helper class which instances allow performing custom actions when native DOM elements are resized.
@@ -10,9 +8,9 @@ import { Emitter } from "./emittermixin";
  *  const editableElement = editor.editing.view.getDomRoot();
  *
  *  const observer = new ResizeObserver( editableElement, entry => {
- *   console.log( 'The editable element has been resized in DOM.' );
+ *   console.log( "The editable element has been resized in DOM." );
  *   console.log( entry.target ); // -> editableElement
- *   console.log( entry.contentRect.width ); // -> e.g. '423px'
+ *   console.log( entry.contentRect.width ); // -> e.g. "423px"
  *  } );
  *
  * By default, it uses the [native DOM resize observer](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
@@ -33,26 +31,29 @@ export default class ResizeObserver implements Emitter {
      */
     destroy(): void;
 
-    // Implements
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-utils/v27/src/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/emittermixin.d.ts
@@ -1,4 +1,3 @@
-import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
 import EventInfo from "./eventinfo";
 import { PriorityString } from "./priorities";
 
@@ -8,61 +7,55 @@ export interface Emitter {
      *
      * Shorthand for {@link #listenTo `this.listenTo( this, event, callback, options )`} (it makes the emitter
      * listen on itself).
-     *
-     * the priority value the sooner the callback will be fired. Events having the same priority are called in the
-     * order they were added.
      */
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: PriorityString | number },
+    ): void;
     /**
      * Registers a callback function to be executed on the next time the event is fired only. This is similar to
      * calling {@link #on} followed by {@link #off} in the callback.
-     *
-     * the priority value the sooner the callback will be fired. Events having the same priority are called in the
-     * order they were added.
      */
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: PriorityString | number },
     ): void;
     /**
      * Stops executing the callback on the given event.
      * Shorthand for {@link #stopListening `this.stopListening( this, event, callback )`}.
      *
      */
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
+    off<N extends string>(
+        event: N,
+        callback?: ((info: EventInfo<N>, ...data: unknown[]) => void),
+    ): void;
     /**
      * Registers a callback function to be executed when an event is fired in a specific (emitter) object.
      *
      * Events can be grouped in namespaces using `:`.
      * When namespaced event is fired, it additionally fires all callbacks for that namespace.
      *
-     *  // myEmitter.on( ... ) is a shorthand for myEmitter.listenTo( myEmitter, ... ).
-     *  myEmitter.on( 'myGroup', genericCallback );
-     *  myEmitter.on( 'myGroup:myEvent', specificCallback );
+     *        // myEmitter.on( ... ) is a shorthand for myEmitter.listenTo( myEmitter, ... ).
+     *        myEmitter.on( "myGroup", genericCallback );
+     *        myEmitter.on( "myGroup:myEvent", specificCallback );
      *
-     *  // genericCallback is fired.
-     *  myEmitter.fire( 'myGroup' );
-     *  // both genericCallback and specificCallback are fired.
-     *  myEmitter.fire( 'myGroup:myEvent' );
-     *  // genericCallback is fired even though there are no callbacks for "foo".
-     *  myEmitter.fire( 'myGroup:foo' );
+     *        // genericCallback is fired.
+     *        myEmitter.fire( "myGroup" );
+     *        // both genericCallback and specificCallback are fired.
+     *        myEmitter.fire( "myGroup:myEvent" );
+     *        // genericCallback is fired even though there are no callbacks for "foo".
+     *        myEmitter.fire( "myGroup:foo" );
      *
      * An event callback can {@link module:utils/eventinfo~EventInfo#stop stop the event} and
      * set the {@link module:utils/eventinfo~EventInfo#return return value} of the {@link #fire} method.
-     *
-     * the priority value the sooner the callback will be fired. Events having the same priority are called in the
-     * order they were added.
      */
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: PriorityString | number | undefined } ,
     ): void;
     /**
      * Stops listening for events. It can be used at different levels:
@@ -71,34 +64,32 @@ export interface Emitter {
      * * To stop listening to a specific event.
      * * To stop listening to all events fired by a specific object.
      * * To stop listening to all events fired by all objects.
-     *
-     * for all events from `emitter`.
-     * `event`.
      */
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
     /**
      * Fires an event, executing all callbacks registered for it.
      *
      * The first parameter passed to callbacks is an {@link module:utils/eventinfo~EventInfo} object,
      * followed by the optional `args` provided in the `fire()` method call.
-     *
-     * through modification of the {@link module:utils/eventinfo~EventInfo#return `evt.return`}'s property (the event info
-     * is the first param of every callback).
      */
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     /**
      * Delegates selected events to another {@link module:utils/emittermixin~Emitter}. For instance:
      *
-     *  emitterA.delegate( 'eventX' ).to( emitterB );
-     *  emitterA.delegate( 'eventX', 'eventY' ).to( emitterC );
+     *     emitterA.delegate( "eventX" ).to( emitterB );
+     *     emitterA.delegate( "eventX", "eventY" ).to( emitterC );
      *
      * then `eventX` is delegated (fired by) `emitterB` and `emitterC` along with `data`:
      *
-     *  emitterA.fire( 'eventX', data );
+     *     emitterA.fire( "eventX", data );
      *
      * and `eventY` is delegated (fired by) `emitterC` along with `data`:
      *
-     *  emitterA.fire( 'eventY', data );
+     *     emitterA.fire( "eventY", data );
      *
      */
     delegate(...events: string[]): EmitterMixinDelegateChain;

--- a/types/ckeditor__ckeditor5-utils/v27/src/eventinfo.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/eventinfo.d.ts
@@ -4,7 +4,7 @@ import { Emitter } from "./emittermixin";
  * The event object passed to event callbacks. It is used to provide information about the event as well as a tool to
  * manipulate it.
  */
-export default class EventInfo<S extends Emitter = Emitter, N extends string = ""> {
+export default class EventInfo<N extends string = "", S extends Emitter = Emitter> {
     constructor(source: S, name: N);
     /**
      * The object that fired the event.
@@ -20,7 +20,7 @@ export default class EventInfo<S extends Emitter = Emitter, N extends string = "
      * Path this event has followed. See {@link module:utils/emittermixin~EmitterMixin#delegate}.
      *
      */
-    readonly path: object[];
+    readonly path: [S];
     /**
      * Stops the event emitter to call further callbacks for this event interaction.
      *

--- a/types/ckeditor__ckeditor5-utils/v27/src/focustracker.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/focustracker.d.ts
@@ -1,9 +1,9 @@
+import DomEventData from "@ckeditor/ckeditor5-engine/src/view/observer/domeventdata";
+import { Emitter as DomEmitter, ProxyEmitter } from "./dom/emittermixin";
 import { Emitter, EmitterMixinDelegateChain } from "./emittermixin";
-import { Emitter as DomEmitter } from "./dom/emittermixin";
+import EventInfo from "./eventinfo";
 import { BindChain, Observable } from "./observablemixin";
 import { PriorityString } from "./priorities";
-import EventInfo from "./eventinfo";
-import { DomEventData } from "@ckeditor/ckeditor5-engine";
 
 /**
  * Allows observing a group of `HTMLElement`s whether at least one of them is focused.
@@ -18,7 +18,7 @@ import { DomEventData } from "@ckeditor/ckeditor5-engine";
  * Check out the {@glink framework/guides/deep-dive/ui/focus-tracking "Deep dive into focus tracking" guide} to learn more.
  *
  */
-export default class FocusTracker implements Observable, Emitter, DomEmitter {
+export default class FocusTracker implements Observable, DomEmitter {
     /**
      * Starts tracking the specified element.
      *
@@ -45,26 +45,33 @@ export default class FocusTracker implements Observable, Emitter, DomEmitter {
     set(name: string, value: any): void;
     unbind(...unbindProperties: string[]): void;
 
-    // Observable (Emitter)
+    listenTo<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: {
+            useCapture?: boolean | undefined;
+            usePassive?: boolean | undefined;
+            priority?: number | PriorityString | undefined;
+        },
+    ): void;
+    stopListening<S extends Emitter | ProxyEmitter, N extends string>(
+        emitter?: Node | Window | S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, data: DomEventData) => void,
+    ): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
     delegate(...events: string[]): EmitterMixinDelegateChain;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
-    ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ): void;
     stopDelegating(event?: string, emitter?: Emitter): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
 }

--- a/types/ckeditor__ckeditor5-utils/v27/src/observablemixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/observablemixin.d.ts
@@ -1,9 +1,11 @@
+import { Emitter } from './emittermixin';
+
 export interface BindChain {
     to(observable: Observable, ...bindProperties: Array<Observable | string | (() => void)>): void;
     toMany(observable: Observable[], ...bindProperties: Array<Observable | string | (() => void)>): void;
 }
 
-export interface Observable {
+export interface Observable extends Emitter {
     /**
      * Creates and sets the value of an observable property of this object. Such a property becomes a part
      * of the state and is observable.
@@ -15,7 +17,7 @@ export interface Observable {
      * properties and methods, but means that `foo.set( 'bar', 1 )` may be slightly slower than `foo.bar = 1`.
      *
      */
-    set(option: Record<string, string>): void;
+    set(option: Record<string, unknown>): void;
     set(name: string, value: unknown): void;
     /**
      * Binds {@link #set observable properties} to other objects implementing the

--- a/types/ckeditor__ckeditor5-widget/src/utils.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/utils.d.ts
@@ -46,7 +46,7 @@ export function viewToModelPositionOutsideModelElement(
     model: Model,
     viewElementMatcher: (viewElement: Element) => boolean,
 ): (
-    evt: EventInfo,
+    evt: EventInfo<'viewToModelPositionOutsideModelElement', Mapper>,
     data: {
         mapper: Mapper;
         viewPosition: Position;

--- a/types/ckeditor__ckeditor5-widget/src/widgetresize/resizer.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgetresize/resizer.d.ts
@@ -1,5 +1,8 @@
 import { Rect } from '@ckeditor/ckeditor5-utils';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 import { ResizerOptions } from '../widgetresize';
 import ResizerState from './resizerstate';
 
@@ -19,4 +22,30 @@ export default class Resizer implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-widget/src/widgetresize/resizerstate.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgetresize/resizerstate.d.ts
@@ -1,4 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 import { ResizerOptions } from '../widgetresize';
 
 export default class ResizeState implements Observable {
@@ -19,4 +22,30 @@ export default class ResizeState implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-widget/v27/src/utils.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/utils.d.ts
@@ -35,7 +35,7 @@ export function viewToModelPositionOutsideModelElement(
     model: Model,
     viewElementMatcher: (viewElement: Element) => boolean,
 ): (
-    evt: EventInfo,
+    evt: EventInfo<'viewToModelPositionOutsideModelElement', Mapper>,
     data: {
         mapper: Mapper;
         viewPosition: Position;

--- a/types/ckeditor__ckeditor5-widget/v27/src/widgetresize/resizer.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/widgetresize/resizer.d.ts
@@ -1,5 +1,8 @@
 import { Rect } from '@ckeditor/ckeditor5-utils';
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 import { ResizerOptions } from '../widgetresize';
 import ResizerState from './resizerstate';
 
@@ -19,4 +22,30 @@ export default class Resizer implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-widget/v27/src/widgetresize/resizerstate.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/widgetresize/resizerstate.d.ts
@@ -1,4 +1,7 @@
+import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 import { ResizerOptions } from '../widgetresize';
 
 export default class ResizeState implements Observable {
@@ -19,4 +22,30 @@ export default class ResizeState implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<N>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(event: N, callback?: (info: EventInfo<N>, ...data: unknown[]) => void): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: (info: EventInfo<N, S>, ...data: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: (info: EventInfo<N, S>, ...data: unknown[]) => void,
+    ): void;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }


### PR DESCRIPTION
Please notice that approximately only half the files are actually modified, cause one half belong to the previous version of each package.

* `Observer` implements `Emitter`, so whatever class implements `Observer`, must also implement `Emitter`. https://github.com/ckeditor/ckeditor5/blob/860ac48a77c38ce75402bef91e8ff9cf278aeb40/packages/ckeditor5-utils/src/observablemixin.js#L709
* Classes that used to read `implements Emitter, Observable` now only read `implements Observable` given the previous point.
* Classes that extend `ContextPlugin`, `Command` and `Plugin` do not implement `Observable` and `Emitter` cause their parent class takes care of that. https://github.com/ckeditor/ckeditor5/blob/860ac48a77c38ce75402bef91e8ff9cf278aeb40/packages/ckeditor5-core/src/contextplugin.js#L28, https://github.com/ckeditor/ckeditor5/blob/860ac48a77c38ce75402bef91e8ff9cf278aeb40/packages/ckeditor5-core/src/command.js#L25, and https://github.com/ckeditor/ckeditor5/blob/860ac48a77c38ce75402bef91e8ff9cf278aeb40/packages/ckeditor5-core/src/plugin.js#L17
* `EditorWithUI` is the same as `Editor` but with the `ui` property. https://github.com/ckeditor/ckeditor5/blob/860ac48a77c38ce75402bef91e8ff9cf278aeb40/packages/ckeditor5-core/src/editor/editorwithui.jsdoc#L10-L22
* Generics for `EventInfo` have been improved so now the first optional parameter is a string that is used for the `name`, and the second optional parameter is the class that extended `Emitter`.
* The actual data for `on()` and `listenTo()` has been marked as `unknown`, cause it depends on what event is being listened and what arguments are passed to `fire()`. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.