### PR TITLE
Shim OffscreenCanvas in dom-webcodecs

### DIFF
--- a/types/dom-webcodecs/index.d.ts
+++ b/types/dom-webcodecs/index.d.ts
@@ -20,6 +20,11 @@
 // https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/a75338e1ea8a958bf08a5745141d2ab8f14ba2ca/baselines/dom.generated.d.ts
 // and modified to expand the types to include VideoFrame.
 
+/** Shim for OffscreenCanvas, which was removed in TS 4.4 */
+// tslint:disable-next-line:no-empty-interface
+interface OffscreenCanvas extends EventTarget {
+}
+
 /**
  * Replaces CanvasImageSource; only applies if WebCodecs is available.
  */


### PR DESCRIPTION
This type is removed in TS 4.4 because it's not actually in the DOM. Better explanation on the three PR: #54988