### PR TITLE
Update w3c-css-typed-object-model-level-1 for TS4.4 RC

### DIFF
--- a/types/w3c-css-typed-object-model-level-1/index.d.ts
+++ b/types/w3c-css-typed-object-model-level-1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.w3.org/TR/css-typed-om-1/
 // Definitions by: Nathan Shively-Sanders <https://github.com/sandersn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.9
+// Minimum TypeScript Version: 4.4
 
 declare class CSSStyleValue {
     static parse(property: string, cssText: string): CSSStyleValue;
@@ -30,7 +30,7 @@ declare class CSSKeywordValue extends CSSStyleValue {
     value: string;
 }
 
-type CSSNumberish = number | CSSNumericValue;
+type CSSNumberOrNumeric = CSSNumberish | CSSNumericValue;
 
 declare enum CSSNumericBaseType {
     'length',
@@ -54,14 +54,14 @@ interface CSSNumericType {
 }
 
 declare class CSSNumericValue extends CSSStyleValue {
-    add(...values: CSSNumberish[]): CSSNumericValue;
-    sub(...values: CSSNumberish[]): CSSNumericValue;
-    mul(...values: CSSNumberish[]): CSSNumericValue;
-    div(...values: CSSNumberish[]): CSSNumericValue;
-    min(...values: CSSNumberish[]): CSSNumericValue;
-    max(...values: CSSNumberish[]): CSSNumericValue;
+    add(...values: CSSNumberOrNumeric[]): CSSNumericValue;
+    sub(...values: CSSNumberOrNumeric[]): CSSNumericValue;
+    mul(...values: CSSNumberOrNumeric[]): CSSNumericValue;
+    div(...values: CSSNumberOrNumeric[]): CSSNumericValue;
+    min(...values: CSSNumberOrNumeric[]): CSSNumericValue;
+    max(...values: CSSNumberOrNumeric[]): CSSNumericValue;
 
-    equals(...values: CSSNumberish[]): boolean;
+    equals(...values: CSSNumberOrNumeric[]): boolean;
 
     to(unit: string): CSSUnitValue;
     toSum(...units: string[]): CSSMathSum;
@@ -81,32 +81,32 @@ declare class CSSMathValue extends CSSNumericValue {
 }
 
 declare class CSSMathSum extends CSSMathValue {
-    constructor(...args: CSSNumberish[]);
+    constructor(...args: CSSNumberOrNumeric[]);
     readonly values: CSSNumericArray;
 }
 
 declare class CSSMathProduct extends CSSMathValue {
-    constructor(...args: CSSNumberish[])
+    constructor(...args: CSSNumberOrNumeric[])
     readonly values: CSSNumericArray;
 }
 
 declare class CSSMathNegate extends CSSMathValue {
-    constructor(arg: CSSNumberish)
+    constructor(arg: CSSNumberOrNumeric)
     readonly value: CSSNumericValue;
 }
 
 declare class CSSMathInvert extends CSSMathValue {
-    constructor(arg: CSSNumberish)
+    constructor(arg: CSSNumberOrNumeric)
     readonly value: CSSNumericValue;
 }
 
 declare class CSSMathMin extends CSSMathValue {
-    constructor(...args: CSSNumberish[])
+    constructor(...args: CSSNumberOrNumeric[])
     readonly values: CSSNumericArray;
 }
 
 declare class CSSMathMax extends CSSMathValue {
-    constructor(...args: CSSNumberish[])
+    constructor(...args: CSSNumberOrNumeric[])
     readonly values: CSSNumericArray;
 }
 
@@ -114,7 +114,7 @@ declare class CSSMathMax extends CSSMathValue {
 // Since there is no support for this class in any browser, it's better
 // wait for the implementation.
 // declare class CSSMathClamp extends CSSMathValue {
-// constructor(min: CSSNumberish, val: CSSNumberish, max: CSSNumberish);
+// constructor(min: CSSNumberOrNumeric, val: CSSNumberOrNumeric, max: CSSNumberOrNumeric);
 //     readonly min: CSSNumericValue;
 //     readonly val: CSSNumericValue;
 //     readonly max: CSSNumericValue;
@@ -160,18 +160,18 @@ declare class CSSTranslate extends CSSTransformComponent {
 
 declare class CSSRotate extends CSSTransformComponent {
     constructor(angle: CSSNumericValue);
-    constructor(x: CSSNumberish, y: CSSNumberish, z: CSSNumberish, angle: CSSNumericValue)
-    x: CSSNumberish;
-    y: CSSNumberish;
-    z: CSSNumberish;
+    constructor(x: CSSNumberOrNumeric, y: CSSNumberOrNumeric, z: CSSNumberOrNumeric, angle: CSSNumericValue)
+    x: CSSNumberOrNumeric;
+    y: CSSNumberOrNumeric;
+    z: CSSNumberOrNumeric;
     angle: CSSNumericValue;
 }
 
 declare class CSSScale extends CSSTransformComponent {
-    constructor(x: CSSNumberish, y: CSSNumberish, z?: CSSNumberish)
-    x: CSSNumberish;
-    y: CSSNumberish;
-    z: CSSNumberish;
+    constructor(x: CSSNumberOrNumeric, y: CSSNumberOrNumeric, z?: CSSNumberOrNumeric)
+    x: CSSNumberOrNumeric;
+    y: CSSNumberOrNumeric;
+    z: CSSNumberOrNumeric;
 }
 
 declare class CSSSkew extends CSSTransformComponent {

--- a/types/w3c-css-typed-object-model-level-1/w3c-css-typed-object-model-level-1-tests.ts
+++ b/types/w3c-css-typed-object-model-level-1/w3c-css-typed-object-model-level-1-tests.ts
@@ -142,9 +142,9 @@
     const r2: CSSRotate = new CSSRotate(CSS.px(20), 20, 30, CSS.deg(30));
     const is2d: boolean = r1.is2D;
     const matix: DOMMatrix = r1.toMatrix();
-    const x: CSSNumberish = r1.x;
-    const y: CSSNumberish = r1.y;
-    const z: CSSNumberish = r1.z;
+    const x: CSSNumberOrNumeric = r1.x;
+    const y: CSSNumberOrNumeric = r1.y;
+    const z: CSSNumberOrNumeric = r1.z;
     const a: CSSNumericValue = r1.angle;
 };
 
@@ -153,9 +153,9 @@
     const s2: CSSScale = new CSSScale(CSS.px(20), 2, 3);
     const is2d: boolean = s1.is2D;
     const matix: DOMMatrix = s1.toMatrix();
-    const x: CSSNumberish = s1.x;
-    const y: CSSNumberish = s1.y;
-    const z: CSSNumberish = s1.z;
+    const x: CSSNumberOrNumeric = s1.x;
+    const y: CSSNumberOrNumeric = s1.y;
+    const z: CSSNumberOrNumeric = s1.z;
 };
 
 () => {


### PR DESCRIPTION
The DOM now has a CSSNumberish type, but it's just `number` for now, so it's incompatible with the one here. I came up with a new type alias for the existing CSSNumberish type until the built-in one includes CSSNumericValue. Suggestions for the name are welcome.