### PR TITLE
[react-date-range] Extend key type of DateRange.onChangeProps to string

### DIFF
--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -6,22 +6,22 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
-import { Locale } from "date-fns";
+import * as React from 'react';
+import { Locale } from 'date-fns';
 
 export type AnyDate = string | Date;
 export type DateFunc = (now: Date) => AnyDate;
 export type DateInputType = AnyDate | DateFunc;
 export type LanguageType =
-    | "cn"
-    | "jp"
-    | "fr"
-    | "it"
-    | "de"
-    | "ko"
-    | "es"
-    | "ru"
-    | "tr";
+    | 'cn'
+    | 'jp'
+    | 'fr'
+    | 'it'
+    | 'de'
+    | 'ko'
+    | 'es'
+    | 'ru'
+    | 'tr';
 export type SizeType = number;
 
 export interface DateContainerType {
@@ -64,7 +64,11 @@ export interface RangeWithKey extends Range {
     key: 'selection';
 }
 
-export type OnChangeProps = Range | { selection: RangeWithKey } | Date;
+export type OnCalendarChangeProps = Date;
+
+export interface OnDateRangeChangeProps {
+    [key: string]: Range;
+}
 
 export interface CommonCalendarProps {
     /** default: DD/MM/YYY */
@@ -73,8 +77,6 @@ export interface CommonCalendarProps {
     theme?: CalendarTheme | undefined;
     /** default: none */
     onInit?: ((range: Range) => void) | undefined;
-    /** default: none */
-    onChange?: ((range: OnChangeProps) => void) | undefined;
     /** default: none */
     minDate?: DateInputType | undefined;
     /** default: none */
@@ -87,7 +89,7 @@ export interface CommonCalendarProps {
     navigatorRenderer?: ((
         currentFocusedDate: Date,
         changeShownDate: (shownDate: Date) => void,
-        props: CommonCalendarProps
+        props: CommonCalendarProps,
     ) => JSX.Element) | undefined;
     /** default: none */
     onShownDateChange?: ((visibleMonth: Date) => void) | undefined;
@@ -102,9 +104,12 @@ export interface CommonCalendarProps {
 export interface CalendarProps extends CommonCalendarProps {
     /** default: today */
     date: DateInputType;
+    /** default: none */
+    onChange?: ((range: OnCalendarChangeProps) => void) | undefined;
 }
 
-export class Calendar extends React.Component<CalendarProps> { }
+export class Calendar extends React.Component<CalendarProps> {
+}
 
 export interface DateRangeProps extends Range, CommonCalendarProps {
     /** default: enUs from locale. Complete list here https://github.com/Adphorus/react-date-range/blob/next/src/locale/index.js */
@@ -173,6 +178,8 @@ export interface DateRangeProps extends Range, CommonCalendarProps {
     showPreview?: boolean | undefined;
     /** default: */
     onPreviewChange?: ((preview: Preview) => void) | undefined;
+    /** default: none */
+    onChange?: ((range: OnDateRangeChangeProps) => void) | undefined;
 }
 
 export interface DateRangePickerProps extends DateRangeProps {
@@ -181,15 +188,17 @@ export interface DateRangePickerProps extends DateRangeProps {
     inputRanges?: InputRange[] | undefined;
 }
 
-export class DateRange extends React.Component<DateRangeProps> {}
+export class DateRange extends React.Component<DateRangeProps> {
+}
 
-export class DateRangePicker extends React.Component<DateRangePickerProps> { }
+export class DateRangePicker extends React.Component<DateRangePickerProps> {
+}
 
 export type DateRangeIndex =
-    | "Today"
-    | "Yesterday"
-    | "Last 7 Days"
-    | "Last 30 Days";
+    | 'Today'
+    | 'Yesterday'
+    | 'Last 7 Days'
+    | 'Last 30 Days';
 
 export interface Range {
     startDate?: Date | undefined;
@@ -296,4 +305,5 @@ export interface Preview {
 
 export const defaultStaticRanges: StaticRange[];
 export const defaultInputRanges: InputRange[];
+
 export function createStaticRanges(ranges: StaticRange[]): StaticRange[];

--- a/types/react-date-range/react-date-range-tests.tsx
+++ b/types/react-date-range/react-date-range-tests.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import {
+    Range,
     DateRange,
-    DateRangePicker,
-    OnChangeProps,
-    RangeWithKey
-} from "react-date-range";
+    DateRangePicker, OnDateRangeChangeProps,
+    RangeWithKey,
+} from 'react-date-range';
 
 const range: RangeWithKey = {
     startDate: new Date('2020-11-01'),
@@ -17,7 +17,11 @@ class ReactDatePicker extends React.Component<any, any> {
         super(props);
     }
 
-    handleChange(range: OnChangeProps) {
+    handleInit(range: Range) {
+        console.log(range);
+    }
+
+    handleChange(range: OnDateRangeChangeProps) {
         console.log(range);
     }
 
@@ -27,7 +31,7 @@ class ReactDatePicker extends React.Component<any, any> {
                 <DateRange
                     linkedCalendars={true}
                     ranges={[range]}
-                    onInit={this.handleChange}
+                    onInit={this.handleInit}
                     onChange={this.handleChange}
                     theme={{
                         Calendar: { width: 200 },
@@ -42,12 +46,22 @@ class ReactDatePicker extends React.Component<any, any> {
     }
 }
 
+const customizedKeyRange: Range = {
+    startDate: new Date('2020-11-01'),
+    endDate: new Date('2020-11-30'),
+    key: 'customizedKey'
+};
+
 class ReactDateRangePicker extends React.Component<any, any> {
     constructor(props: {}) {
         super(props);
     }
 
-    handleChange(range: OnChangeProps) {
+    handleInit(range: Range) {
+        console.log(range);
+    }
+
+    handleChange(range: OnDateRangeChangeProps) {
         console.log(range);
     }
 
@@ -56,9 +70,9 @@ class ReactDateRangePicker extends React.Component<any, any> {
             <div>
                 <DateRangePicker
                     linkedCalendars={true}
-                    ranges={[range]}
+                    ranges={[customizedKeyRange]}
                     scroll={{enabled: true}}
-                    onInit={this.handleChange}
+                    onInit={this.handleInit}
                     onChange={this.handleChange}
                     showSelectionPreview={true}
                     editableDateInputs={true}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### Cause

- `the arguments` of the `OnChange` function and `parameter type` of `the DateRange component` do **not match**.
- Also, It is difficult to specify the `parameter type of the onChange` function of the `Calender`, `DateRange` component.

### Solution
- Match the `arguments type` to the `OnChange parameter type` in **DateRange**.
  As far as I know, `keys passed to arguments` are **user-specifiable**.  
  Therefore, I think it **should be extended to the `string type`, not the `'selection' key`**.

```js
class MyComponent extends Component {
  handleSelect(ranges){
    console.log(ranges);
    // {
    //   'customizable_key': {
    //     startDate: [native Date Object],
    //     endDate: [native Date Object],
    //   }
    // }
  }

  render() {
    const selectionRange = {
      key: 'customizable_key',
      // ...
    }

    return (
      <DateRangePicker
        // ...
        onChange={this.handleSelect}
      />
    )
  }
}
```

#### Extends key type

- [react-date-range/DateRange/OnChange() code](https://github.com/hypeserver/react-date-range/blob/90c59accb6fcc3a0f34a2c57e318359aeb33ba01/src/components/DateRange/index.js#L100-L105)


```js
# before
export type OnChangeProps = Range | { selection: RangeWithKey } | Date;

# after
export interface OnDateRangeChangeProps {
    [key: string]: Range;
}

```


- Declares the `onChange` type in `CalendarProps` and `DateRangeProps` **respectively**, 
   rather than declaring the `onChange` type in **common** to `CommonCalendarProps`. 
   In this case, the `onChangeProps type` is classified as follows. 
   Then, I think that `the user using DateRange component` will be able to access `the own specified key` without casting.
```js
export type OnCalendarChangeProps = Date;

export interface CalendarProps extends CommonCalendarProps {
    // ...

    /** default: none */
    onChange?: ((range: OnCalendarChangeProps) => void) | undefined;

    // ...
}

export interface OnDateRangeChangeProps {
    [key: string]: Range;
}

export interface DateRangeProps extends Range, CommonCalendarProps {
    // ..

    /** default: none */
    onChange?: ((range: OnDateRangeChangeProps) => void) | undefined;

   //..
}
```
  


