### PR TITLE
Add 'mute' option to PlayerVars in YouTube API

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -255,6 +255,22 @@ declare namespace YT
     }
 
     /**
+     * Whether or not to start the video muted. Some browsers require this set to 1 for autoplay to work (e.g. Chrome).
+     */
+    export enum Mute
+    {
+        /**
+         * Player will start not muted, with sound
+         */
+        NotMuted = 0,
+
+        /**
+         * Player will start muted
+         */
+        Muted = 1
+    }
+
+    /**
      * Whether to playback video inline or full-screen in an HTML5 player on iOS
      */
     export enum PlaysInline
@@ -536,6 +552,11 @@ declare namespace YT
          * Whether to hide some YouTube branding (by default, Full).
          */
         modestbranding?: ModestBranding | undefined;
+
+        /**
+         * Whether to start the video muted (by default, NotMuted).
+         */
+        mute?: Mute | undefined;
 
         /**
          * Origin domain for additional security if using the JavaScript API.

--- a/types/youtube/youtube-tests.ts
+++ b/types/youtube/youtube-tests.ts
@@ -30,6 +30,7 @@ const players: YT.Player[] = [
             listType: "search",
             loop: YT.Loop.Loop,
             modestbranding: YT.ModestBranding.Full,
+            mute: YT.Mute.Muted,
             origin: "localhost",
             playlist: "1,2",
             playsinline: YT.PlaysInline.Fullscreen,
@@ -80,6 +81,7 @@ ensureNumeric<YT.FullscreenButton>();
 ensureNumeric<YT.IvLoadPolicy>();
 ensureNumeric<YT.Loop>();
 ensureNumeric<YT.ModestBranding>();
+ensureNumeric<YT.Mute>();
 ensureNumeric<YT.PlaysInline>();
 ensureNumeric<YT.RelatedVideos>();
 ensureNumeric<YT.ShowInfo>();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stackoverflow.com/a/54950157> 
The official API documentation for the [`playerVars`](https://developers.google.com/youtube/player_parameters.html) is missing the `mute` option, but it definitely exists, works, and is required in Chrome for autoplay to work. If `mute` is not set to `1`, using `playVideo()` does nothing unless the user has interacted with any youtube video on the page before.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
