### PR TITLE
[webpack-assets-manifest]: Add missing types, fix existing types & update to latest minor versions

### DIFF
--- a/types/webpack-assets-manifest/index.d.ts
+++ b/types/webpack-assets-manifest/index.d.ts
@@ -5,8 +5,8 @@
 // TypeScript Version: 3.7
 
 /// <reference types="node" />
-import { Asset, Compilation, Compiler, LoaderContext, Module, Stats, WebpackPluginInstance } from "webpack";
-import { AsyncSeriesHook, SyncHook, SyncWaterfallHook } from "tapable";
+import { Asset, Compilation, Compiler, LoaderContext, Module, Stats, WebpackPluginInstance } from 'webpack';
+import { AsyncSeriesHook, SyncHook, SyncWaterfallHook } from 'tapable';
 
 declare class WebpackAssetsManifest implements WebpackPluginInstance {
     constructor(options?: WebpackAssetsManifest.Options);
@@ -15,7 +15,9 @@ declare class WebpackAssetsManifest implements WebpackPluginInstance {
     hooks: {
         apply: SyncHook<[WebpackAssetsManifest]>;
 
-        customize: SyncWaterfallHook<[WebpackAssetsManifest.Entry, WebpackAssetsManifest.Entry, WebpackAssetsManifest, Asset | null]>;
+        customize: SyncWaterfallHook<
+            [WebpackAssetsManifest.Entry, WebpackAssetsManifest.Entry, WebpackAssetsManifest, Asset | null]
+        >;
 
         transform: SyncWaterfallHook<[WebpackAssetsManifest.Assets, WebpackAssetsManifest]>;
 
@@ -72,7 +74,10 @@ declare class WebpackAssetsManifest implements WebpackPluginInstance {
     delete(key: string): boolean;
 
     /** Process compilation assets */
-    processAssetsByChunkName(assets: Record<string, string | ReadonlyArray<string>>, hmrFiles?: Set<string>): this['assetNames'];
+    processAssetsByChunkName(
+        assets: Record<string, string | ReadonlyArray<string>>,
+        hmrFiles?: Set<string>,
+    ): this['assetNames'];
 
     /** Get the data for `JSON.stringify()` */
     toJSON(): unknown;
@@ -166,13 +171,17 @@ declare namespace WebpackAssetsManifest {
         output?: string | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#replacer */
-        replacer?: ((this: unknown, key: string, value: unknown) => unknown) | ReadonlyArray<string | number> | null | undefined;
+        replacer?:
+            | ((this: unknown, key: string, value: unknown) => unknown)
+            | ReadonlyArray<string | number>
+            | null
+            | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#space */
         space?: number | string | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#writetodisk */
-        writeToDisk?: boolean | "auto" | undefined;
+        writeToDisk?: boolean | 'auto' | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#fileextregex */
         fileExtRegex?: RegExp | null | false | undefined;
@@ -181,10 +190,15 @@ declare namespace WebpackAssetsManifest {
         sortManifest?: boolean | ((this: WebpackAssetsManifest, a: string, b: string) => number) | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#merge */
-        merge?: boolean | "customize" | undefined;
+        merge?: boolean | 'customize' | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#publicpath */
-        publicPath?: string | boolean | null | (((filename: string, manifest: WebpackAssetsManifest) => string)) | undefined;
+        publicPath?:
+            | string
+            | boolean
+            | null
+            | ((filename: string, manifest: WebpackAssetsManifest) => string)
+            | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#contextrelativekeys */
         contextRelativeKeys?: boolean | undefined;

--- a/types/webpack-assets-manifest/v4/index.d.ts
+++ b/types/webpack-assets-manifest/v4/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-import { compilation, Compiler, loader, Plugin, Stats } from "webpack";
-import { AsyncSeriesHook, SyncHook, SyncWaterfallHook } from "tapable";
+import { compilation, Compiler, loader, Plugin, Stats } from 'webpack';
+import { AsyncSeriesHook, SyncHook, SyncWaterfallHook } from 'tapable';
 
 declare class WebpackAssetsManifest extends Plugin {
     constructor(options?: WebpackAssetsManifest.Options);
@@ -74,7 +74,10 @@ declare class WebpackAssetsManifest extends Plugin {
     delete(key: string): boolean;
 
     /** Process compilation assets */
-    processAssetsByChunkName(assets: Record<string, string | ReadonlyArray<string>>, hmrFiles?: Set<string>): this['assetNames'];
+    processAssetsByChunkName(
+        assets: Record<string, string | ReadonlyArray<string>>,
+        hmrFiles?: Set<string>,
+    ): this['assetNames'];
 
     /** Get the data for `JSON.stringify()` */
     toJSON(): unknown;
@@ -159,13 +162,17 @@ declare namespace WebpackAssetsManifest {
         output?: string | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#replacer */
-        replacer?: ((this: unknown, key: string, value: unknown) => unknown) | ReadonlyArray<string | number> | null | undefined;
+        replacer?:
+            | ((this: unknown, key: string, value: unknown) => unknown)
+            | ReadonlyArray<string | number>
+            | null
+            | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#space */
         space?: number | string | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#writetodisk */
-        writeToDisk?: boolean | "auto" | undefined;
+        writeToDisk?: boolean | 'auto' | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#fileextregex */
         fileExtRegex?: RegExp | null | false | undefined;
@@ -174,10 +181,15 @@ declare namespace WebpackAssetsManifest {
         sortManifest?: boolean | ((this: WebpackAssetsManifest, a: string, b: string) => number) | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#merge */
-        merge?: boolean | "customize" | undefined;
+        merge?: boolean | 'customize' | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#publicpath */
-        publicPath?: string | boolean | null | (((filename: string, manifest: WebpackAssetsManifest) => string)) | undefined;
+        publicPath?:
+            | string
+            | boolean
+            | null
+            | ((filename: string, manifest: WebpackAssetsManifest) => string)
+            | undefined;
 
         /** https://github.com/webdeveric/webpack-assets-manifest#contextrelativekeys */
         contextRelativeKeys?: boolean | undefined;

--- a/types/webpack-assets-manifest/v4/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/v4/webpack-assets-manifest-tests.ts
@@ -96,10 +96,20 @@ new WebpackAssetsManifest({
             version,
         };
 
-        const { key, value } = manifest.hooks.customize.call({
+        const entry = {
             key: 'YourKey',
             value: 'YourValue',
-        });
+        };
+
+        const { key, value } = manifest.hooks.customize.call(
+            {
+                key: manifest.fixKey(entry.key),
+                value: manifest.getPublicPath(entry.value),
+            },
+            entry,
+            manifest,
+            null,
+        );
 
         assets[key] = value;
     },

--- a/types/webpack-assets-manifest/v4/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/v4/webpack-assets-manifest-tests.ts
@@ -1,4 +1,4 @@
-import WebpackAssetsManifest from "webpack-assets-manifest";
+import WebpackAssetsManifest from 'webpack-assets-manifest';
 
 /** https://github.com/webdeveric/webpack-assets-manifest/blob/master/examples/asset-integrity.js */
 new WebpackAssetsManifest({
@@ -33,7 +33,11 @@ new WebpackAssetsManifest({
     output: 'custom-cdn-manifest.json',
     publicPath(filename, manifest) {
         switch (manifest.getExtension(filename).substr(1).toLowerCase()) {
-            case 'jpg': case 'jpeg': case 'gif': case 'png': case 'svg':
+            case 'jpg':
+            case 'jpeg':
+            case 'gif':
+            case 'png':
+            case 'svg':
                 return `https://img.cdn.example.com/${filename}`;
             case 'css':
                 return `https://css.cdn.example.com/${filename}`;
@@ -53,7 +57,8 @@ new WebpackAssetsManifest({
     output: 'customized-manifest.json',
     merge: true,
     customize(entry, original, manifest, asset) {
-        if (manifest.isMerging) {}
+        if (manifest.isMerging) {
+        }
 
         if (entry.key.toLowerCase().endsWith('.map')) {
             return false;

--- a/types/webpack-assets-manifest/v4/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/v4/webpack-assets-manifest-tests.ts
@@ -8,7 +8,7 @@ new WebpackAssetsManifest({
     customize(entry, original, manifest, asset) {
         return {
             key: entry.value,
-            value: asset && asset.integrity,
+            value: asset && asset.info.integrity,
         };
     },
 });
@@ -23,7 +23,7 @@ new WebpackAssetsManifest({
     customize(entry, original, manifest, asset) {
         return {
             key: entry.value,
-            value: asset && asset.md5.substr(4),
+            value: asset && asset.info.md5.substr(4),
         };
     },
 });

--- a/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
@@ -96,10 +96,20 @@ new WebpackAssetsManifest({
             version,
         };
 
-        const { key, value } = manifest.hooks.customize.call({
+        const entry = {
             key: 'YourKey',
             value: 'YourValue',
-        });
+        };
+
+        const { key, value } = manifest.hooks.customize.call(
+            {
+                key: manifest.fixKey(entry.key),
+                value: manifest.getPublicPath(entry.value),
+            },
+            entry,
+            manifest,
+            null,
+        );
 
         assets[key] = value;
     },

--- a/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
@@ -1,4 +1,4 @@
-import WebpackAssetsManifest from "webpack-assets-manifest";
+import WebpackAssetsManifest from 'webpack-assets-manifest';
 
 /** https://github.com/webdeveric/webpack-assets-manifest/blob/master/examples/asset-integrity.js */
 new WebpackAssetsManifest({
@@ -33,7 +33,11 @@ new WebpackAssetsManifest({
     output: 'custom-cdn-manifest.json',
     publicPath(filename, manifest) {
         switch (manifest.getExtension(filename).substr(1).toLowerCase()) {
-            case 'jpg': case 'jpeg': case 'gif': case 'png': case 'svg':
+            case 'jpg':
+            case 'jpeg':
+            case 'gif':
+            case 'png':
+            case 'svg':
                 return `https://img.cdn.example.com/${filename}`;
             case 'css':
                 return `https://css.cdn.example.com/${filename}`;
@@ -53,7 +57,8 @@ new WebpackAssetsManifest({
     output: 'customized-manifest.json',
     merge: true,
     customize(entry, original, manifest, asset) {
-        if (manifest.isMerging) {}
+        if (manifest.isMerging) {
+        }
 
         if (entry.key.toLowerCase().endsWith('.map')) {
             return false;

--- a/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
@@ -8,7 +8,7 @@ new WebpackAssetsManifest({
     customize(entry, original, manifest, asset) {
         return {
             key: entry.value,
-            value: asset && asset.integrity,
+            value: asset && asset.info.integrity,
         };
     },
 });
@@ -23,7 +23,7 @@ new WebpackAssetsManifest({
     customize(entry, original, manifest, asset) {
         return {
             key: entry.value,
-            value: asset && asset.md5.substr(4),
+            value: asset && asset.info.md5.substr(4),
         };
     },
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  **Overview of changes in v4:**
  - https://github.com/webdeveric/webpack-assets-manifest/tree/v5.0.6#new-in-version-4

  **Overview of changes in v5:**
  - https://github.com/webdeveric/webpack-assets-manifest/tree/v5.0.6#new-in-version-5

  **`WebpackAssetsManifest.Options` type derived from:**
  - https://github.com/webdeveric/webpack-assets-manifest/blob/v5.0.6/src/options-schema.json

  **`WebpackAssetsManifest.Options.replacer` type derived from:**
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter
  - https://github.com/microsoft/TypeScript/blob/v4.3.5/lib/lib.es5.d.ts#L1066
  - https://github.com/microsoft/TypeScript/blob/v4.3.5/lib/lib.es5.d.ts#L1073

  **`WebpackAssetsManifest` type derived from:**
  - https://github.com/webdeveric/webpack-assets-manifest/blob/v5.0.6/src/WebpackAssetsManifest.js
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~