### PR TITLE
fix(node): the return value type of the fsPromises.watch method is incorrect

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2791,8 +2791,8 @@ declare module 'fs' {
         persistent?: boolean | undefined;
         recursive?: boolean | undefined;
     }
-    export type EventType = 'rename' | 'change';
-    export type WatchListener<T> = (event: EventType, filename: T) => void;
+    export type WatchEventType = 'rename' | 'change';
+    export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2791,7 +2791,8 @@ declare module 'fs' {
         persistent?: boolean | undefined;
         recursive?: boolean | undefined;
     }
-    export type WatchListener<T> = (event: 'rename' | 'change', filename: T) => void;
+    export type EventType = 'rename' | 'change';
+    export type WatchListener<T> = (event: EventType, filename: T) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -29,10 +29,10 @@ declare module 'fs/promises' {
         OpenMode,
         Mode,
         WatchOptions,
-        EventType,
+        WatchEventType,
     } from 'node:fs';
     interface FileChangeInfo<T = string | Buffer> {
-        eventType: EventType;
+        eventType: WatchEventType;
         filename: T;
     }
     interface FlagAndOpenMode {

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -30,6 +30,10 @@ declare module 'fs/promises' {
         Mode,
         WatchOptions,
     } from 'node:fs';
+    interface FileChangeInfo {
+        eventType: string;
+        filename: string | Buffer;
+    }
     interface FlagAndOpenMode {
         mode?: Mode | undefined;
         flag?: OpenMode | undefined;
@@ -951,7 +955,7 @@ declare module 'fs/promises' {
                   encoding: 'buffer';
               })
             | 'buffer'
-    ): AsyncIterable<Buffer>;
+    ): AsyncIterable<FileChangeInfo>;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
@@ -960,7 +964,7 @@ declare module 'fs/promises' {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    function watch(filename: PathLike, options?: WatchOptions | BufferEncoding): AsyncIterable<string>;
+    function watch(filename: PathLike, options?: WatchOptions | BufferEncoding): AsyncIterable<FileChangeInfo>;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
@@ -969,7 +973,7 @@ declare module 'fs/promises' {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    function watch(filename: PathLike, options: WatchOptions | string): AsyncIterable<string> | AsyncIterable<Buffer>;
+    function watch(filename: PathLike, options: WatchOptions | string): AsyncIterable<string> | AsyncIterable<FileChangeInfo>;
 }
 declare module 'node:fs/promises' {
     export * from 'fs/promises';

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -974,7 +974,7 @@ declare module 'fs/promises' {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    function watch(filename: PathLike, options: WatchOptions | string): AsyncIterable<string> | AsyncIterable<FileChangeInfo>;
+    function watch(filename: PathLike, options: WatchOptions | string): AsyncIterable<FileChangeInfo>;
 }
 declare module 'node:fs/promises' {
     export * from 'fs/promises';

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -31,7 +31,7 @@ declare module 'fs/promises' {
         WatchOptions,
         WatchEventType,
     } from 'node:fs';
-    interface FileChangeInfo<T = string | Buffer> {
+    interface FileChangeInfo<T extends (string | Buffer)> {
         eventType: WatchEventType;
         filename: T;
     }
@@ -965,7 +965,7 @@ declare module 'fs/promises' {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    function watch(filename: PathLike, options?: WatchOptions | BufferEncoding): AsyncIterable<FileChangeInfo>;
+    function watch(filename: PathLike, options?: WatchOptions | BufferEncoding): AsyncIterable<FileChangeInfo<string>>;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
@@ -974,7 +974,7 @@ declare module 'fs/promises' {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    function watch(filename: PathLike, options: WatchOptions | string): AsyncIterable<FileChangeInfo>;
+    function watch(filename: PathLike, options: WatchOptions | string): AsyncIterable<FileChangeInfo<string>> | AsyncIterable<FileChangeInfo<Buffer>>;
 }
 declare module 'node:fs/promises' {
     export * from 'fs/promises';

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -29,9 +29,10 @@ declare module 'fs/promises' {
         OpenMode,
         Mode,
         WatchOptions,
+        EventType,
     } from 'node:fs';
     interface FileChangeInfo {
-        eventType: string;
+        eventType: EventType;
         filename: string | Buffer;
     }
     interface FlagAndOpenMode {

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -31,9 +31,9 @@ declare module 'fs/promises' {
         WatchOptions,
         EventType,
     } from 'node:fs';
-    interface FileChangeInfo {
+    interface FileChangeInfo<T = string | Buffer> {
         eventType: EventType;
-        filename: string | Buffer;
+        filename: T;
     }
     interface FlagAndOpenMode {
         mode?: Mode | undefined;
@@ -956,7 +956,7 @@ declare module 'fs/promises' {
                   encoding: 'buffer';
               })
             | 'buffer'
-    ): AsyncIterable<FileChangeInfo>;
+    ): AsyncIterable<FileChangeInfo<Buffer>>;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -606,9 +606,9 @@ const bigIntStat: bigint = bigStats.atimeNs;
 const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.random() > 0.5 });
 
 {
-    watchAsync('y33t'); // $ExpectType AsyncIterable<FileChangeInfo<string | Buffer>>
+    watchAsync('y33t'); // $ExpectType AsyncIterable<FileChangeInfo<string>>
     watchAsync('y33t', 'buffer'); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>>
     watchAsync('y33t', { encoding: 'buffer', signal: new AbortSignal() }); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>>
 
-    watchAsync('test', { persistent: true, recursive: true, encoding: 'utf-8' }); // $ExpectType AsyncIterable<FileChangeInfo<string | Buffer>>
+    watchAsync('test', { persistent: true, recursive: true, encoding: 'utf-8' }); // $ExpectType AsyncIterable<FileChangeInfo<string>>
 }

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -606,9 +606,9 @@ const bigIntStat: bigint = bigStats.atimeNs;
 const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.random() > 0.5 });
 
 {
-    watchAsync('y33t'); // $ExpectType AsyncIterable<FileChangeInfo>
-    watchAsync('y33t', 'buffer'); // $ExpectType AsyncIterable<FileChangeInfo>
-    watchAsync('y33t', { encoding: 'buffer', signal: new AbortSignal() }); // $ExpectType AsyncIterable<FileChangeInfo>
+    watchAsync('y33t'); // $ExpectType AsyncIterable<FileChangeInfo<string | Buffer>>
+    watchAsync('y33t', 'buffer'); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>>
+    watchAsync('y33t', { encoding: 'buffer', signal: new AbortSignal() }); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>>
 
-    watchAsync('test', { persistent: true, recursive: true, encoding: 'utf-8' }); // $ExpectType AsyncIterable<FileChangeInfo>
+    watchAsync('test', { persistent: true, recursive: true, encoding: 'utf-8' }); // $ExpectType AsyncIterable<FileChangeInfo<string | Buffer>>
 }

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -606,9 +606,9 @@ const bigIntStat: bigint = bigStats.atimeNs;
 const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.random() > 0.5 });
 
 {
-    watchAsync('y33t'); // $ExpectType AsyncIterable<string>
-    watchAsync('y33t', 'buffer'); // $ExpectType AsyncIterable<Buffer>
-    watchAsync('y33t', { encoding: 'buffer', signal: new AbortSignal() }); // $ExpectType AsyncIterable<Buffer>
+    watchAsync('y33t'); // $ExpectType AsyncIterable<FileChangeInfo>
+    watchAsync('y33t', 'buffer'); // $ExpectType AsyncIterable<FileChangeInfo>
+    watchAsync('y33t', { encoding: 'buffer', signal: new AbortSignal() }); // $ExpectType AsyncIterable<FileChangeInfo>
 
-    watchAsync('test', { persistent: true, recursive: true, encoding: 'utf-8' }); // $ExpectType AsyncIterable<string>
+    watchAsync('test', { persistent: true, recursive: true, encoding: 'utf-8' }); // $ExpectType AsyncIterable<FileChangeInfo>
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v15.x/api/fs.html#fs_fspromises_watch_filename_options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
