### PR TITLE
upate(svg-spritemap-webpack-plugin): v4.2 updates

### DIFF
--- a/types/svg-spritemap-webpack-plugin/index.d.ts
+++ b/types/svg-spritemap-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for svg-spritemap-webpack-plugin 4.0
+// Type definitions for svg-spritemap-webpack-plugin 4.2
 // Project: https://github.com/cascornelissen/svg-spritemap-webpack-plugin
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -16,9 +16,7 @@ declare namespace SVGSpritemapPlugin {
         /**
          * The input object contains the configuration for the input of the plugin.
          */
-        input?: {
-            options?: object | undefined;
-        } | undefined;
+        input?: Input | undefined;
         /**
          * The output object contains the configuration for the main output (SVG) of the plugin.
          */
@@ -104,6 +102,19 @@ declare namespace SVGSpritemapPlugin {
                   /** @default undefined */
                   callback?: ((content: string) => string) | undefined;
               } | undefined;
+    }
+
+    interface Input {
+        /**
+         * Options object to pass to [`glob`](http://npmjs.com/package/glob) to find the sprites.
+         */
+        options?: object | undefined;
+        /**
+         * Allow the usage of the same input SVG multiple times.
+         * This option work well together with the `sprite.idify` option to set a different name in the output file.
+         * @default false
+         */
+        allowDuplicates?: boolean | undefined;
     }
 }
 declare class SVGSpritemapPlugin implements WebpackPluginInstance {

--- a/types/svg-spritemap-webpack-plugin/index.d.ts
+++ b/types/svg-spritemap-webpack-plugin/index.d.ts
@@ -20,69 +20,79 @@ declare namespace SVGSpritemapPlugin {
         /**
          * The output object contains the configuration for the main output (SVG) of the plugin.
          */
-        output?: {
-            /**
-             * Filename of the generated file (located at the webpack output.path), [hash] and [contenthash] are supported.
-             */
-            filename?: string | undefined;
-            svg?: {
-                /**
-                 * Whether to include the width and height attributes on the root SVG element.
-                 * The default value for this option is based on the value of the sprite.generate.use option but when specified will always overwrite it.
-                 */
-                sizes?: boolean | undefined;
-            } | undefined;
-            chunk?: {
-                /**
-                 * Name of the chunk that will be generated.
-                 */
-                name?: string | undefined;
-                /**
-                 * Whether to keep the chunk after it's been emitted by webpack.
-                 */
-                keep?: boolean | undefined;
-            } | undefined;
-            /**
-             * Whether to include the SVG4Everybody helper in your entries.
-             */
-            svg4everybody?: boolean | object | undefined;
-            /**
-             * Options object to pass to SVG Optimizer.
-             */
-            svgo?: boolean | object | undefined;
-        } | undefined;
+        output?:
+            | {
+                  /**
+                   * Filename of the generated file (located at the webpack output.path), [hash] and [contenthash] are supported.
+                   */
+                  filename?: string | undefined;
+                  svg?:
+                      | {
+                            /**
+                             * Whether to include the width and height attributes on the root SVG element.
+                             * The default value for this option is based on the value of the sprite.generate.use option but when specified will always overwrite it.
+                             */
+                            sizes?: boolean | undefined;
+                        }
+                      | undefined;
+                  chunk?:
+                      | {
+                            /**
+                             * Name of the chunk that will be generated.
+                             */
+                            name?: string | undefined;
+                            /**
+                             * Whether to keep the chunk after it's been emitted by webpack.
+                             */
+                            keep?: boolean | undefined;
+                        }
+                      | undefined;
+                  /**
+                   * Whether to include the SVG4Everybody helper in your entries.
+                   */
+                  svg4everybody?: boolean | object | undefined;
+                  /**
+                   * Options object to pass to SVG Optimizer.
+                   */
+                  svgo?: boolean | object | undefined;
+              }
+            | undefined;
         /**
          * The sprite object contains the configuration for the generated sprites in the output spritemap.
          */
-        sprite?: {
-            /**
-             * @default 'sprite-'
-             */
-            prefix?: string | ((file: string) => string) | false | undefined;
-            /**
-             * Whether to also prefix any selectors that are generated in the styles file, if enabled.
-             * @default false
-             */
-            prefixStylesSelectors?: boolean | undefined;
-            /**
-             * Function that will be used to transform the filename of each sprite into a valid HTML id
-             */
-            idify?: ((file: string | false) => string) | undefined;
-            /**
-             * Amount of pixels added between each sprite to prevent overlap.
-             * @default 0
-             */
-            gutter?: number | false | undefined;
-            generate?: {
-                /**
-                 * Whether to generate a <title> element containing the filename if no title is provided in the SVG.
-                 */
-                title?: boolean | undefined;
-                symbol?: boolean | string | undefined;
-                use?: boolean | undefined;
-                view?: boolean | string | undefined;
-            } | undefined;
-        } | undefined;
+        sprite?:
+            | {
+                  /**
+                   * @default 'sprite-'
+                   */
+                  prefix?: string | ((file: string) => string) | false | undefined;
+                  /**
+                   * Whether to also prefix any selectors that are generated in the styles file, if enabled.
+                   * @default false
+                   */
+                  prefixStylesSelectors?: boolean | undefined;
+                  /**
+                   * Function that will be used to transform the filename of each sprite into a valid HTML id
+                   */
+                  idify?: ((file: string | false) => string) | undefined;
+                  /**
+                   * Amount of pixels added between each sprite to prevent overlap.
+                   * @default 0
+                   */
+                  gutter?: number | false | undefined;
+                  generate?:
+                      | {
+                            /**
+                             * Whether to generate a <title> element containing the filename if no title is provided in the SVG.
+                             */
+                            title?: boolean | undefined;
+                            symbol?: boolean | string | undefined;
+                            use?: boolean | undefined;
+                            view?: boolean | string | undefined;
+                        }
+                      | undefined;
+              }
+            | undefined;
         styles?:
             | boolean
             | string
@@ -93,15 +103,18 @@ declare namespace SVGSpritemapPlugin {
                    * @default false
                    */
                   keepAttributes?: boolean | undefined;
-                  variables?: {
-                      sprites?: string | undefined;
-                      sizes?: string | undefined;
-                      variables?: string | undefined;
-                      mixin?: string | undefined;
-                  } | undefined;
+                  variables?:
+                      | {
+                            sprites?: string | undefined;
+                            sizes?: string | undefined;
+                            variables?: string | undefined;
+                            mixin?: string | undefined;
+                        }
+                      | undefined;
                   /** @default undefined */
                   callback?: ((content: string) => string) | undefined;
-              } | undefined;
+              }
+            | undefined;
     }
 
     interface Input {

--- a/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
+++ b/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
@@ -11,6 +11,10 @@ import { Configuration } from 'webpack';
             styles: 'src/scss/_sprites.scss',
         }),
         new SVGSpritemapPlugin('src/**/*.svg', {
+            input: {
+                options: {},
+                allowDuplicates: true,
+            },
             output: {
                 svg: {
                     sizes: false,

--- a/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
+++ b/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
@@ -37,7 +37,7 @@ import { Configuration } from 'webpack';
                     sprites: 'sprites',
                     sizes: 'sizes',
                     variables: 'variables',
-                    mixin: 'sprite'
+                    mixin: 'sprite',
                 },
                 callback: content => `[class*="sprite-"] { background-size: cover; } ${content}`,
             },


### PR DESCRIPTION
- update to 4.2
- new `input` option added
- tests amended

https://github.com/cascornelissen/svg-spritemap-webpack-plugin/compare/4.0...v4.2.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).