### PR TITLE
Add missing props of MUIDataTablePopover

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -10,8 +10,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
 
+import '@material-ui/core/styles/overrides';
 import * as React from 'react';
-import { ComponentNameToClassKey } from '@material-ui/core/styles/overrides';
 
 export type Display = boolean | 'true' | 'false' | 'excluded';
 export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom';
@@ -904,12 +904,16 @@ export interface MUIDataTablePopover {
     action?: ((...args: any) => any) | undefined;
     anchorEl?: React.ReactNode | undefined;
     anchorOrigin?: any;
+    classes?: object;
+    content?: React.ReactNode;
     elevation?: number | undefined;
     onClose?: ((...args: any) => any) | undefined;
     onExited?: ((...args: any) => any) | undefined;
     option?: boolean | undefined;
     ref?: any;
+    refExit?: (...args: any) => any;
     transformOrigin?: any;
+    trigger?: React.ReactNode;
 }
 
 export interface MUIDataTableBody {

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,4 +1,4 @@
-import MUIDataTable, { ExpandButton, MUIDataTableCheckboxProps, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState } from 'mui-datatables';
+import MUIDataTable, { ExpandButton, MUIDataTableCheckboxProps, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState, Popover } from 'mui-datatables';
 import * as React from 'react';
 import { createMuiTheme, Checkbox, Radio } from '@material-ui/core';
 
@@ -259,3 +259,5 @@ const MuiTheme = createMuiTheme({
         }
     }
 });
+
+<Popover classes={{ icon: 'icon_class' }} content={<span>content</span>} trigger={<button>trigger</button>} refExit={() => {}} />;


### PR DESCRIPTION
- removed unreferenced `ComponentNameToClassKey`
- add `classes` (https://github.com/gregnb/mui-datatables/blob/7558e7393b6ee4b21c9481613429efcdbe7a6ddc/src/components/Popover.js#L29)
- add `content`, `refExit` and `trigger` (https://github.com/gregnb/mui-datatables/blob/7558e7393b6ee4b21c9481613429efcdbe7a6ddc/src/components/Popover.js#L7)

Related to https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55038