### PR TITLE
[aws-lambda] - Add firehose event property sourceKinesisStreamArn

### DIFF
--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -36,7 +36,7 @@ const firehoseHandler: FirehoseTransformationHandler = async (event, context, ca
     let firehoseRecordMetadata: FirehoseRecordMetadata | undefined;
 
     str = event.records[0].recordId;
-    strOrUndefined = event.deliveryStreamArn;
+    str = event.deliveryStreamArn;
     strOrUndefined = event.sourceKinesisStreamArn;
 
     firehoseRecordMetadata = event.records[0].kinesisRecordMetadata;

--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -36,6 +36,9 @@ const firehoseHandler: FirehoseTransformationHandler = async (event, context, ca
     let firehoseRecordMetadata: FirehoseRecordMetadata | undefined;
 
     str = event.records[0].recordId;
+    strOrUndefined = event.deliveryStreamArn;
+    strOrUndefined = event.sourceKinesisStreamArn;
+
     firehoseRecordMetadata = event.records[0].kinesisRecordMetadata;
 
     if (firehoseRecordMetadata) {

--- a/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
+++ b/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
@@ -1,4 +1,4 @@
-import { Callback, Handler } from "../handler";
+import { Callback, Handler } from '../handler';
 
 export type FirehoseTransformationHandler = Handler<FirehoseTransformationEvent, FirehoseTransformationResult>;
 export type FirehoseTransformationCallback = Callback<FirehoseTransformationResult>;
@@ -10,7 +10,8 @@ export type FirehoseTransformationCallback = Callback<FirehoseTransformationResu
 // Examples in the lambda blueprints
 export interface FirehoseTransformationEvent {
     invocationId: string;
-    deliveryStreamArn: string;
+    deliveryStreamArn?: string | undefined;
+    sourceKinesisStreamArn?: string | undefined;
     region: string;
     records: FirehoseTransformationEventRecord[];
 }

--- a/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
+++ b/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
@@ -1,4 +1,4 @@
-import { Callback, Handler } from '../handler';
+import { Callback, Handler } from "../handler";
 
 export type FirehoseTransformationHandler = Handler<FirehoseTransformationEvent, FirehoseTransformationResult>;
 export type FirehoseTransformationCallback = Callback<FirehoseTransformationResult>;

--- a/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
+++ b/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
@@ -10,7 +10,7 @@ export type FirehoseTransformationCallback = Callback<FirehoseTransformationResu
 // Examples in the lambda blueprints
 export interface FirehoseTransformationEvent {
     invocationId: string;
-    deliveryStreamArn?: string | undefined;
+    deliveryStreamArn: string;
     sourceKinesisStreamArn?: string | undefined;
     region: string;
     records: FirehoseTransformationEventRecord[];


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/firehose/latest/APIReference/API_CreateDeliveryStream.html#API_CreateDeliveryStream_RequestSyntax

Adding this property is useful when users are wanting to reingest the data to the kinesis stream due to hitting the 6MB size limit of the response payload in AWS Firehose during transformation.

Attempting to do a put record API call on a Firehose Delivery stream which has a Kinesis Stream as the source will result in the error `This operation is not permitted on KinesisStreamAsSource delivery stream type.`. Therefore it is useful to have the sourceKinesisStreamArn so put record API calls can be made by Lambda functions to the source Kinesis Stream.