### PR TITLE
[node] Allow omitting ctx in SNICallback

### DIFF
--- a/types/node/test/tls.ts
+++ b/types/node/test/tls.ts
@@ -299,3 +299,18 @@ import * as fs from 'node:fs';
     const _options: TlsOptions = {};
     const _server = new Server(_options, (socket) => {});
 }
+
+{
+    const ctx: SecureContext = createSecureContext({
+        key: 'NOT REALLY A KEY',
+        cert: 'SOME CERTIFICATE',
+    });
+    const _options: TlsOptions = {
+        SNICallback: (servername: string, cb: (err: Error | null, ctx?: SecureContext) => void): void => {
+            cb(new Error('Not found'));
+            cb(new Error('Not found'), undefined);
+            cb(null, undefined);
+            cb(null, ctx);
+        },
+    };
+}

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -452,7 +452,7 @@ declare module 'tls' {
          * SecureContext.) If SNICallback wasn't provided the default callback
          * with high-level API will be used (see below).
          */
-        SNICallback?: ((servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void) | undefined;
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
         /**
          * If true the server will reject any connection which is not
          * authorized with the list of supplied CAs. This option only has an


### PR DESCRIPTION
`ctx` can be skipped to use default context.

https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener
Use case in node source:
https://github.com/nodejs/node/blob/a1fac5b9a5979b049446c05ab961819fda843e29/lib/_tls_wrap.js#L1468-L1480
