### PR TITLE
js-yaml: fix return type of load

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -4,12 +4,13 @@
 //                 Sebastian Clausen <https://github.com/sclausen>
 //                 ExE Boss <https://github.com/ExE-Boss>
 //                 Armaan Tobaccowalla <https://github.com/ArmaanT>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 export as namespace jsyaml;
 
-export function load(str: string, opts?: LoadOptions): object | string | number | null | undefined;
+export function load(str: string, opts?: LoadOptions): unknown;
 
 export class Type {
     constructor(tag: string, opts?: TypeConstructorOptions);
@@ -30,8 +31,8 @@ export class Schema {
     extend(types: SchemaDefinition | Type[] | Type): Schema;
 }
 
-export function loadAll(str: string, iterator?: null, opts?: LoadOptions): any[];
-export function loadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): void;
+export function loadAll(str: string, iterator?: null, opts?: LoadOptions): unknown[];
+export function loadAll(str: string, iterator: (doc: unknown) => void, opts?: LoadOptions): void;
 
 export function dump(obj: any, opts?: DumpOptions): string;
 

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -134,18 +134,18 @@ type.styleAliases;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType string | number | object | null | undefined
+// $ExpectType unknown
 yaml.load(str);
-// $ExpectType string | number | object | null | undefined
+// $ExpectType unknown
 yaml.load(str, loadOpts);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType any[]
+// $ExpectType unknown[]
 value = yaml.loadAll(str);
-// $ExpectType any[]
+// $ExpectType unknown[]
 value = yaml.loadAll(str, null, loadOpts);
-// $ExpectType any[]
+// $ExpectType unknown[]
 value = yaml.loadAll(str, undefined, loadOpts);
 
 // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    They don't document the exact return values, but some easy testing can tell you that it's more than was previously indicated by the function return value, e.g:
        - `load('- 1\n-2 \n- 3\n')` returns `number[]`
        - `load('!!binary AAAAAA==\n')` return `Uint8Array`
        - etc.
    The point is that there is no way to statically know what the return value will be, and thus `unknown` is the right typing...
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
