### PR TITLE
[ejs] Add includer render option

### DIFF
--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ejs 3.0
+// Type definitions for ejs 3.1.2
 // Project: http://ejs.co/, https://github.com/mde/ejs
 // Definitions by: Ben Liddicott <https://github.com/benliddicott>
 //                 ExE Boss <https://github.com/ExE-Boss>

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ejs 3.1.2
+// Type definitions for ejs 3.1.6
 // Project: http://ejs.co/, https://github.com/mde/ejs
 // Definitions by: Ben Liddicott <https://github.com/benliddicott>
 //                 ExE Boss <https://github.com/ExE-Boss>

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ejs 3.1.6
+// Type definitions for ejs 3.1
 // Project: http://ejs.co/, https://github.com/mde/ejs
 // Definitions by: Ben Liddicott <https://github.com/benliddicott>
 //                 ExE Boss <https://github.com/ExE-Boss>

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -285,7 +285,7 @@ export type IncludeCallback = (path: string, data?: Data) => string;
  *
  * @return an object where {@link filename} is the final parsed path or {@link template} is the content of the included template
  */
-export type IncluderCallback = (originalPath: string, parsedPath: string) => ({ filename: string } | { template: string });
+export type IncluderCallback = (originalPath: string, parsedPath: string) => ({ filename: string, template?: never } | { template: string, filename?: never });
 
 export interface Options {
     /**

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -31,9 +31,15 @@ export function resolveInclude(name: string, filename: string, isDir?: boolean):
 /**
  * Compile the given `str` of ejs into a template function.
  */
-export function compile(template: string, opts: Options & { async: true; client?: false | undefined }): AsyncTemplateFunction;
+export function compile(
+    template: string,
+    opts: Options & { async: true; client?: false | undefined },
+): AsyncTemplateFunction;
 export function compile(template: string, opts: Options & { async: true; client: true }): AsyncClientFunction;
-export function compile(template: string, opts?: Options & { async?: false | undefined; client?: false | undefined }): TemplateFunction;
+export function compile(
+    template: string,
+    opts?: Options & { async?: false | undefined; client?: false | undefined },
+): TemplateFunction;
 export function compile(template: string, opts?: Options & { async?: false | undefined; client: true }): ClientFunction;
 export function compile(template: string, opts?: Options): TemplateFunction | AsyncTemplateFunction;
 
@@ -285,7 +291,10 @@ export type IncludeCallback = (path: string, data?: Data) => string;
  *
  * @return an object where {@link filename} is the final parsed path or {@link template} is the content of the included template
  */
-export type IncluderCallback = (originalPath: string, parsedPath: string) => ({ filename: string, template?: never } | { template: string, filename?: never });
+export type IncluderCallback = (
+    originalPath: string,
+    parsedPath: string,
+) => { filename: string; template?: never } | { template: string; filename?: never };
 
 export interface Options {
     /**

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -286,15 +286,17 @@ export type RethrowCallback = (
 export type IncludeCallback = (path: string, data?: Data) => string;
 
 /**
+ * An object where {@link filename} is the final parsed path or {@link template} is the content of the included template
+ */
+export type IncluderResult = { filename: string; template?: never } | { template: string; filename?: never };
+
+/**
  * @param originalPath the path as it appears in the include statement
  * @param parsedPath the previously resolved path
  *
- * @return an object where {@link filename} is the final parsed path or {@link template} is the content of the included template
+ * @return An {@link IncluderResult} object containing the filename or template data.
  */
-export type IncluderCallback = (
-    originalPath: string,
-    parsedPath: string,
-) => { filename: string; template?: never } | { template: string; filename?: never };
+export type IncluderCallback = (originalPath: string, parsedPath: string) => IncluderResult;
 
 export interface Options {
     /**

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -279,6 +279,14 @@ export type RethrowCallback = (
  */
 export type IncludeCallback = (path: string, data?: Data) => string;
 
+/**
+ * @param originalPath the path as it appears in the include statement
+ * @param parsedPath the previously resolved path
+ *
+ * @return an object where {@link filename} is the final parsed path or {@link template} is the content of the included template
+ */
+export type IncluderCallback = (originalPath: string, parsedPath: string) => ({ filename: string } | { template: string });
+
 export interface Options {
     /**
      * Log the generated JavaScript source for the EJS template to the console.
@@ -435,6 +443,11 @@ export interface Options {
      * An array of paths to use when resolving includes with relative paths
      */
     views?: string[] | undefined;
+
+    /**
+     * Custom function to handle EJS includes
+     */
+    includer?: IncluderCallback;
 }
 
 export interface Cache {

--- a/types/ejs/test/ejs.umd.test.ts
+++ b/types/ejs/test/ejs.umd.test.ts
@@ -24,7 +24,10 @@ ejs.delimiter;
 expectType<{
     (template: string, opts: ejs.Options & { async: true; client?: false | undefined }): ejs.AsyncTemplateFunction;
     (template: string, opts: ejs.Options & { async: true; client: true }): ejs.AsyncClientFunction;
-    (template: string, opts?: ejs.Options & { async?: false | undefined; client?: false | undefined }): ejs.TemplateFunction;
+    (
+        template: string,
+        opts?: ejs.Options & { async?: false | undefined; client?: false | undefined },
+    ): ejs.TemplateFunction;
     (template: string, opts?: ejs.Options & { async?: false | undefined; client: true }): ejs.ClientFunction;
     (template: string, opts?: ejs.Options): ejs.AsyncTemplateFunction | ejs.TemplateFunction;
 }>(ejs.compile);

--- a/types/ejs/test/ejs.umd.test.ts
+++ b/types/ejs/test/ejs.umd.test.ts
@@ -49,3 +49,25 @@ const renderOptions: ejs.Options = {
     filename: './index.ejs',
     views: ['dir1', 'dir2'],
 };
+
+const fileNameIncluder: ejs.IncluderCallback = (originalPath, parsedPath) => {
+    expectType<string>(originalPath);
+    expectType<string>(parsedPath);
+
+    return { filename: '/some/path/to/file' };
+};
+
+const templateIncluder: ejs.IncluderCallback = (originalPath, parsedPath) => {
+    expectType<string>(originalPath);
+    expectType<string>(parsedPath);
+
+    return { template: 'template data' };
+};
+
+// $ExpectError
+const brokenIncluder: ejs.IncluderCallback = (originalPath, parsedPath) => {
+    expectType<string>(originalPath);
+    expectType<string>(parsedPath);
+
+    return { filename: originalPath, template: originalPath };
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test ejs`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mde/ejs#:~:text=the%20JS%20runtime.-,includer,-Custom%20function%20to
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

It looks like the current state of these types had all of the 3.1.6 EJS changes, with the exception of the `includer` option. [Link to the diff between 3.0.1 and 3.1.6 tags](https://github.com/mde/ejs/compare/v3.0.1...v3.1.6).
