### PR TITLE
Holderjs.run options can be optional

### DIFF
--- a/types/holderjs/holderjs-tests.ts
+++ b/types/holderjs/holderjs-tests.ts
@@ -7,3 +7,5 @@ Holder.run({
 });
 
 Holder.run('image-class-name');
+
+Holder.run();

--- a/types/holderjs/holderjs-tests.ts
+++ b/types/holderjs/holderjs-tests.ts
@@ -5,3 +5,5 @@ const myImage = document.getElementById('myImage');
 Holder.run({
     images: myImage
 });
+
+Holder.run('image-class-name');

--- a/types/holderjs/holderjs-tests.ts
+++ b/types/holderjs/holderjs-tests.ts
@@ -6,6 +6,4 @@ Holder.run({
     images: myImage
 });
 
-Holder.run('image-class-name');
-
 Holder.run();

--- a/types/holderjs/index.d.ts
+++ b/types/holderjs/index.d.ts
@@ -9,4 +9,4 @@ export interface Options {
     images: HTMLElement | null;
 }
 
-export function run(options?: Options | string): void;
+export function run(options?: Options): void;

--- a/types/holderjs/index.d.ts
+++ b/types/holderjs/index.d.ts
@@ -9,4 +9,4 @@ export interface Options {
     images: HTMLElement | null;
 }
 
-export function run(options: Options): void;
+export function run(options: Options | string): void;

--- a/types/holderjs/index.d.ts
+++ b/types/holderjs/index.d.ts
@@ -9,4 +9,4 @@ export interface Options {
     images: HTMLElement | null;
 }
 
-export function run(options: Options | string): void;
+export function run(options?: Options | string): void;


### PR DESCRIPTION
According to https://github.com/imsky/holder/issues/225#issuecomment-770261030 holderjs.run argumen can be a string of targeted element classes.
Options are also optional.

Don't know if this is a recent of holderjs change but this .d.ts dosen't work with holderjs as is and makes it unusable with a react ts setup.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/imsky/holder/issues/225#issuecomment-770261030
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
