### PR TITLE
Add misc to JobPayload definitions in forge-apis

### DIFF
--- a/types/forge-apis/forge-apis-tests.ts
+++ b/types/forge-apis/forge-apis-tests.ts
@@ -105,6 +105,8 @@ derivativesApi.translate(
                 attribute1: 'attribute1',
                 attribute2: 2,
                 attribute3: [3],
+            },
+        },
     },
     {},
     authClientTwoLegged,

--- a/types/forge-apis/forge-apis-tests.ts
+++ b/types/forge-apis/forge-apis-tests.ts
@@ -99,6 +99,12 @@ derivativesApi.translate(
                 },
             ],
         },
+        misc: {
+            workflow: 'my-workflow-id',
+            workflowAttributes: {
+                attribute1: 'attribute1',
+                attribute2: 2,
+                attribute3: [3],
     },
     {},
     authClientTwoLegged,

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -180,14 +180,14 @@ export interface JobPayloadOutput {
 }
 
 export interface JobPayloadMisc {
-    workflow: string;
-    workflowAttributes?: object;
+    workflow?: string | undefined;
+    workflowAttributes?: object | undefined; 
 }
 
 export interface JobPayload {
     input: JobPayloadInput;
     output: JobPayloadOutput;
-    misc?: JobPayloadMisc;
+    misc?: JobPayloadMisc | undefined;
 }
 
 export class CommandsApi {

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -179,9 +179,15 @@ export interface JobPayloadOutput {
     formats: JobPayloadItem[];
 }
 
+export interface JobPayloadMisc {
+    workflow: string;
+    workflowAttributes?: object;
+}
+
 export interface JobPayload {
     input: JobPayloadInput;
     output: JobPayloadOutput;
+    misc?: JobPayloadMisc;
 }
 
 export class CommandsApi {

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -181,7 +181,7 @@ export interface JobPayloadOutput {
 
 export interface JobPayloadMisc {
     workflow?: string | undefined;
-    workflowAttributes?: object | undefined; 
+    workflowAttributes?: object | undefined;
 }
 
 export interface JobPayload {


### PR DESCRIPTION
Added misc property to the JobPayload definition to enable passing workflows within type def
[https://forge.autodesk.com/en/docs/model-derivative/v2/reference/http/job-POST/]