### PR TITLE
`disableWallets` not declared

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -856,6 +856,7 @@ declare namespace stripe {
             requestPayerEmail?: boolean | undefined;
             requestPayerPhone?: boolean | undefined;
             requestShipping?: boolean | undefined;
+            disableWallets: any[] | undefined;
         }
 
         interface UpdateDetails {


### PR DESCRIPTION
As said on the manual (https://stripe.com/docs/js/payment_request/create#stripe_payment_request-options-disableWallets) `StripePaymentRequest` must have a `disableWallets` property but it is not declared on StripePaymentRequestOptions object.
