### PR TITLE
[conventional-changelog] add skipUnstable option to core and recommended-bump

### DIFF
--- a/types/conventional-changelog-core/index.d.ts
+++ b/types/conventional-changelog-core/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for conventional-changelog-core 4.1
+// Type definitions for conventional-changelog-core 4.2
 // Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#readme
 // Definitions by: Jason Kwok <https://github.com/JasonHK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -194,6 +194,11 @@ declare namespace conventionalChangelogCore {
          * 1
          */
         releaseCount?: number | undefined;
+
+        /**
+         * If given, unstable tags (e.g. `x.x.x-alpha.1`, `x.x.x-rc.2`) will be skipped.
+         */
+        skipUnstable?: boolean | undefined;
 
         /**
          * A debug function. EG: `console.debug.bind(console)`.

--- a/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
+++ b/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
@@ -41,6 +41,8 @@ namespace Module.Options {
     options.preset; // $ExpectType string | undefined
     options.tagPrefix; // $ExpectType string | undefined
     options.whatBump; // $ExpectType WhatBump | undefined
+    options.skipUnstable; // $ExpectType boolean | undefined
+    options.path; // $ExpectType string | undefined
 }
 
 namespace Module.Options.WhatBump {

--- a/types/conventional-recommended-bump/index.d.ts
+++ b/types/conventional-recommended-bump/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for conventional-recommended-bump 6.0
+// Type definitions for conventional-recommended-bump 6.1
 // Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump#readme
 // Definitions by: Jason Kwok <https://github.com/JasonHK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -134,6 +134,11 @@ declare namespace conventionalRecommendedBump {
         tagPrefix?: string | undefined;
 
         /**
+         * If given, unstable tags (e.g. `x.x.x-alpha.1`, `x.x.x-rc.2`) will be skipped.
+         */
+        skipUnstable?: boolean | undefined;
+
+        /**
          * Specify the name of a package in a [Lerna](https://lernajs.io/)-managed
          * repository. The package name will be used when fetching all changes to a
          * package since the last time that package was released.
@@ -145,7 +150,14 @@ declare namespace conventionalRecommendedBump {
          * `conventional-changelog` as the value of the `lernaPackage` option.
          */
         lernaPackage?: string | undefined;
-    }
+
+        /**
+         * Specify the path to only calculate with git commits related to the path.
+         * If you want to calculate recommended bumps of packages in a Lerna-managed
+         * repository, path should be use along with lernaPackage for each of the package.
+         */
+        path?: string | undefined;
+     }
 
     namespace Options {
         type WhatBump = (commits: Commit[]) => WhatBump.Result;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * [PR adding support for the --skip-unstable option](https://github.com/conventional-changelog/conventional-changelog/pull/656/files)
  * [conventional-changelog-core@4.2.2 docs](https://github.com/conventional-changelog/conventional-changelog/blob/conventional-changelog-core-v4.2.2/packages/conventional-changelog-core/README.md)
  * [convetional-recommended-bump@6.1.0 docs](https://github.com/conventional-changelog/conventional-changelog/blob/conventional-recommended-bump-v6.1.0/packages/conventional-recommended-bump/README.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
