### PR TITLE
[react-beautiful-dnd] Change innerRef typings to function properties

### DIFF
--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -577,7 +577,7 @@ export interface DroppableProvidedProps {
 }
 
 export interface DroppableProvided {
-    innerRef(element: HTMLElement | null): any;
+    innerRef: (element: HTMLElement | null) => any;
     placeholder?: React.ReactElement<HTMLElement> | null | undefined;
     droppableProps: DroppableProvidedProps;
 }
@@ -657,7 +657,7 @@ export interface DraggableProvidedDragHandleProps {
 
 export interface DraggableProvided {
     // will be removed after move to react 16
-    innerRef(element?: HTMLElement | null): any;
+    innerRef: (element?: HTMLElement | null) => any;
     draggableProps: DraggableProvidedDraggableProps;
     dragHandleProps?: DraggableProvidedDragHandleProps | undefined;
 }

--- a/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
@@ -100,28 +100,35 @@ class App extends React.Component<{}, AppState> {
                 enableDefaultSensors={false}
                 sensors={[useMouseSensor, useKeyboardSensor, useTouchSensor]}
             >
-                <Droppable droppableId="droppable" ignoreContainerClipping={false} isCombineEnabled={true}>
-                    {(provided, snapshot) => (
-                        <div ref={provided.innerRef} style={getListStyle(snapshot)} {...provided.droppableProps}>
-                            {this.state.items.map((item, index) => (
-                                <Draggable key={item.id} draggableId={item.id} index={index} shouldRespectForcePress>
-                                    {(provided, snapshot) => (
-                                        <div>
-                                            <div
-                                                ref={provided.innerRef}
-                                                {...provided.draggableProps}
-                                                {...provided.dragHandleProps}
-                                                style={getItemStyle(snapshot.isDragging, provided.draggableProps.style)}
-                                            >
-                                                {item.content}
-                                            </div>
-                                        </div>
-                                    )}
-                                </Draggable>
-                            ))}
-                            {provided.placeholder}
-                        </div>
-                    )}
+                <Droppable droppableId='droppable' ignoreContainerClipping={false} isCombineEnabled={true}>
+                    {(droppableProvided, snapshot) => {
+                        const { innerRef, droppableProps, placeholder } = droppableProvided;
+                        return (
+                            <div ref={innerRef} style={getListStyle(snapshot)} {...droppableProps}>
+                                {this.state.items.map((item, index) => (
+                                    <Draggable key={item.id} draggableId={item.id} index={index}
+                                               shouldRespectForcePress>
+                                        {(draggableProvided, snapshot) => {
+                                            const { innerRef, draggableProps, dragHandleProps } = draggableProvided;
+                                            return (
+                                                <div>
+                                                    <div
+                                                        ref={innerRef}
+                                                        {...draggableProps}
+                                                        {...dragHandleProps}
+                                                        style={getItemStyle(snapshot.isDragging, draggableProps.style)}
+                                                    >
+                                                        {item.content}
+                                                    </div>
+                                                </div>
+                                            );
+                                        }}
+                                    </Draggable>
+                                ))}
+                                {placeholder}
+                            </div>
+                        );
+                    }}
                 </Droppable>
             </DragDropContext>
         );


### PR DESCRIPTION
Change typings of `innerRef` property of `DraggableProvided` and `DroppableProvided` interfaces from method to functional property. 

Method typing is not the correct one since `innerRef` is a [function property](https://github.com/atlassian/react-beautiful-dnd/blob/master/src/view/draggable/draggable.jsx#L145). 

Also, method typing causes ESLint error if you have [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md) rule enabled.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/atlassian/react-beautiful-dnd/blob/master/src/view/draggable/draggable.jsx#L145>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
