### PR TITLE
[url-parse] Fix `URLParse.set` type

### DIFF
--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -42,7 +42,11 @@ interface URLParse {
     readonly query: { [key: string]: string | undefined };
     readonly slashes: boolean;
     readonly username: string;
-    set(part: URLParse.URLPart, value: URLParse[typeof part], fn?: boolean | URLParse.QueryParser): URLParse;
+    set(
+        part: URLParse.URLPart,
+        value: URLParse[typeof part] | undefined,
+        fn?: boolean | URLParse.QueryParser,
+    ): URLParse;
     toString(stringify?: URLParse.StringifyQuery): string;
 }
 

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -44,7 +44,7 @@ interface URLParse {
     readonly username: string;
     set(
         part: URLParse.URLPart,
-        value: URLParse[typeof part] | undefined,
+        value: URLParse[URLParse.URLPart] | undefined,
         fn?: boolean | URLParse.QueryParser,
     ): URLParse;
     toString(stringify?: URLParse.StringifyQuery): string;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -8,7 +8,8 @@
 // TypeScript Version: 2.2
 
 declare namespace URLParse {
-    type URLPart = 'auth'
+    type URLPart =
+        | 'auth'
         | 'hash'
         | 'host'
         | 'hostname'
@@ -46,8 +47,8 @@ interface URLParse {
 }
 
 declare const URLParse: {
-    new(address: string, parser?: boolean | URLParse.QueryParser): URLParse;
-    new(address: string, location?: string | object, parser?: boolean | URLParse.QueryParser): URLParse;
+    new (address: string, parser?: boolean | URLParse.QueryParser): URLParse;
+    new (address: string, location?: string | object, parser?: boolean | URLParse.QueryParser): URLParse;
     (address: string, parser?: boolean | URLParse.QueryParser): URLParse;
     (address: string, location?: string | object, parser?: boolean | URLParse.QueryParser): URLParse;
 

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -41,7 +41,7 @@ interface URLParse {
     readonly query: { [key: string]: string | undefined };
     readonly slashes: boolean;
     readonly username: string;
-    set(part: URLParse.URLPart, value: string | object | number | undefined, fn?: boolean | URLParse.QueryParser): URLParse;
+    set(part: URLParse.URLPart, value: URLParse[typeof part], fn?: boolean | URLParse.QueryParser): URLParse;
     toString(stringify?: URLParse.StringifyQuery): string;
 }
 

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -8,7 +8,7 @@ parse('foo/bar', 'https://github.com/');
 parse('foo/bar', 'https://github.com/', (query: string) => ({ query }));
 const result = parse('foo/bar?baz=quux', true);
 if (result.query.baz !== 'quux') {
-  throw new Error('bad query parsing');
+    throw new Error('bad query parsing');
 }
 
 const url1: URL = new URL('https://github.com/foo/bar?baz=true');

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -18,6 +18,7 @@ url1.query.baz;
 
 const url2 = new URL('foo/bar', 'https://github.com/');
 url2.set('protocol', 'http://');
+url2.set('slashes', true);
 
 URL.extractProtocol('https://github.com/foo/bar');
 URL.location('https://github.com/foo/bar');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/unshiftio/url-parse#usage
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

----------

The `URLParse.slashes` prop is a `boolean`. However, doing `parsedUrl.set('slashes', true)` gives a type error because the second parameter's type does not include `boolean`. This should fix this usage and provide better type completion as the second parameter's type should now differ based on the property name passed in as the first argument.
