### PR TITLE
New @ckeditor/ckeditor5-mention v29

### DIFF
--- a/types/ckeditor__ckeditor5-core/src/editor/editorconfig.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorconfig.d.ts
@@ -17,6 +17,7 @@ import { IndentBlockConfig } from '@ckeditor/ckeditor5-indent/src/indentblock';
 import { TextPartLanguageOption } from '@ckeditor/ckeditor5-language/src/textpartlanguage';
 import { LinkConfig } from '@ckeditor/ckeditor5-link/src/link';
 import { MediaEmbedConfig } from '@ckeditor/ckeditor5-media-embed/src/mediaembed';
+import { MentionConfig } from '@ckeditor/ckeditor5-mention/src/mention';
 import { PaginationConfig } from '@ckeditor/ckeditor5-pagination/src/pagination';
 import { RealTimeCollaborationConfig } from '@ckeditor/ckeditor5-real-time-collaboration/src/realtimecollaborativeediting';
 import { RestrictedEditingModeConfig } from '@ckeditor/ckeditor5-restricted-editing/src/restrictededitingmode';
@@ -30,8 +31,6 @@ import Plugin, { PluginInterface } from '../plugin';
 
 // TODO: import {CommentsConfig} from "@ckeditor/ckeditor5-comments/src/comments";
 type CommentsConfig = any;
-// TODO: import {MentionConfig} from "@ckeditor/ckeditor5-mention/src/mention";
-type MentionConfig = any;
 // TODO: import {SidebarConfig} from "@ckeditor/ckeditor5-comments/src/annotations/sidebar";
 type SidebarConfig = any;
 
@@ -73,7 +72,13 @@ export interface EditorConfig {
     title?: TitleConfig | undefined;
     toolbar?:
         | string[]
-        | { items?: string[] | undefined; viewportTopOffset?: number | undefined; shouldNotGroupWhenFull?: boolean | undefined; removeItems?: string[] | undefined } | undefined;
+        | {
+              items?: string[] | undefined;
+              viewportTopOffset?: number | undefined;
+              shouldNotGroupWhenFull?: boolean | undefined;
+              removeItems?: string[] | undefined;
+          }
+        | undefined;
     trackChanges?: TrackChangesConfig | undefined;
     typing?: TypingConfig | undefined;
     wordCount?: WordCountConfig | undefined;

--- a/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
@@ -31,7 +31,7 @@ export default class Model implements Emitter, Observable {
     createPositionAt(itemOrPosition: Position): Position;
     createPositionBefore(item: Item): Position;
     createPositionFromPath(root: Element | DocumentFragment, path: number[], stickiness?: PositionStickiness): Position;
-    createRange(start: Position, end?: Position): Range;
+    createRange(start: Position, end?: Position | null): Range;
     createRangeIn(element: Element): Range;
     createRangeOn(item: Item): Range;
     createSelection(

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/model.d.ts
@@ -31,7 +31,7 @@ export default class Model implements Emitter, Observable {
     createPositionAt(itemOrPosition: Position): Position;
     createPositionBefore(item: Item): Position;
     createPositionFromPath(root: Element | DocumentFragment, path: number[], stickiness?: PositionStickiness): Position;
-    createRange(start: Position, end?: Position): Range;
+    createRange(start: Position, end?: Position | null): Range;
     createRangeIn(element: Element): Range;
     createRangeOn(item: Item): Range;
     createSelection(

--- a/types/ckeditor__ckeditor5-mention/ckeditor__ckeditor5-mention-tests.ts
+++ b/types/ckeditor__ckeditor5-mention/ckeditor__ckeditor5-mention-tests.ts
@@ -1,0 +1,65 @@
+import { Editor } from '@ckeditor/ckeditor5-core';
+import { DowncastWriter, StylesProcessor } from '@ckeditor/ckeditor5-engine';
+import Document from '@ckeditor/ckeditor5-engine/src/view/document';
+import { Mention, MentionEditing, MentionUI } from '@ckeditor/ckeditor5-mention';
+import MentionCommand from '@ckeditor/ckeditor5-mention/src/mentioncommand';
+import DomWrapperView from '@ckeditor/ckeditor5-mention/src/ui/domwrapperview';
+import MentionListItemView from '@ckeditor/ckeditor5-mention/src/ui/mentionlistitemview';
+import MentionsView from '@ckeditor/ckeditor5-mention/src/ui/mentionsview';
+import { Locale } from '@ckeditor/ckeditor5-utils';
+
+class MyEditor extends Editor {
+    static builtinPlugins: [typeof Mention];
+}
+
+const myEditor = new MyEditor({
+    mention: {
+        feeds: [{ marker: '@', minimumCharacters: 1, feed: [{ id: '', text: '' }] }],
+    },
+});
+
+const element = new DowncastWriter(new Document(new StylesProcessor())).createEmptyElement('');
+
+myEditor.plugins.get(Mention).toMentionAttribute(element, { foo: 'bar' }).foo === 'bar';
+
+// $ExpectError
+myEditor.plugins.get(Mention).toMentionAttribute(element).foo.startsWith;
+
+new MentionUI(myEditor).isEnabled = true;
+
+new MentionEditing(myEditor).on('foo', evt => evt.stop());
+
+const command = new MentionCommand(myEditor);
+
+command.execute({
+    marker: '@',
+    mention: '@John',
+    range: myEditor.model.createRange(
+        myEditor.model.document.selection.focus!.getShiftedBy(-3),
+        myEditor.model.document.selection.focus,
+    ),
+});
+
+command.execute({
+    marker: '@',
+    mention: '@John',
+    text: '@John Doe',
+    range: myEditor.model.createRange(
+        myEditor.model.document.selection.focus!.getShiftedBy(-3),
+        myEditor.model.document.selection.focus,
+    ),
+});
+
+command.execute({
+    marker: '@',
+    mention: '@John',
+});
+
+const htmlEl = document.createElement('div');
+new DomWrapperView(new Locale(), htmlEl).domElement === htmlEl;
+new DomWrapperView(new Locale(), htmlEl).element! === htmlEl;
+
+new MentionListItemView().children.first!.highlight();
+
+new MentionsView().selected.children.first!.highlight();
+new MentionsView().items.first!.highlight();

--- a/types/ckeditor__ckeditor5-mention/index.d.ts
+++ b/types/ckeditor__ckeditor5-mention/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for @ckeditor/ckeditor5-mention 29.1
+// Project: https://ckeditor.com/docs/ckeditor5/latest/api/mention.html
+// Definitions by: Federico Panico <https://github.com/fedemp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.2
+
+export { default as Mention } from './src/mention';
+export { default as MentionEditing } from './src/mentionediting';
+export { default as MentionUI } from './src/mentionui';

--- a/types/ckeditor__ckeditor5-mention/src/mention.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mention.d.ts
@@ -1,0 +1,47 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import Element from '@ckeditor/ckeditor5-engine/src/view/element';
+import MentionEditing from './mentionediting';
+import MentionUI from './mentionui';
+
+/**
+ * The mention plugin.
+ *
+ * For a detailed overview, check the {@glink features/mentions Mention feature documentation}.
+ */
+export default class Mention extends Plugin {
+    /**
+     * Creates a mention attribute value from the provided view element and optional data.
+     *
+     *        editor.plugins.get( 'Mention' ).toMentionAttribute( viewElement, { userId: '1234' } );
+     *
+     *        // For a view element: <span data-mention="@joe">@John Doe</span>
+     *        // it will return:
+     *        // { id: '@joe', userId: '1234', uid: '7a7bc7...', _text: '@John Doe' }
+     */
+    toMentionAttribute<T extends Record<string, unknown>>(viewElement: Element, data?: T): MentionAttribute<T>;
+
+    static readonly pluginName: 'Mention';
+    static readonly requires: [typeof MentionEditing, typeof MentionUI];
+}
+
+export type MentionAttribute<T extends Record<string, unknown>> = T & {
+    uid: string;
+    id: string;
+    _text: string;
+};
+
+export interface MentionConfig {
+    feeds: MentionFeed[];
+}
+
+export interface MentionFeed {
+    feed: MentionFeedItem[] | ((searchString: string) => string[] | Promise<string[]>);
+    itemRenderer?: (item: MentionFeedItem) => HTMLElement | string;
+    marker: string;
+    minimumCharacters?: number;
+}
+
+export interface MentionFeedItem {
+    id: string;
+    text: string;
+}

--- a/types/ckeditor__ckeditor5-mention/src/mentioncommand.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mentioncommand.d.ts
@@ -1,0 +1,50 @@
+import { Command } from '@ckeditor/ckeditor5-core';
+import { Range } from '@ckeditor/ckeditor5-engine';
+
+/**
+ * The mention command.
+ *
+ * The command is registered by {@link module:mention/mentionediting~MentionEditing} as `'mention'`.
+ *
+ * To insert a mention onto a range, execute the command and specify a mention object with a range to replace:
+ *
+ *    const focus = editor.model.document.selection.focus;
+ *
+ *    // It will replace one character before the selection focus with the '#1234' text
+ *    // with the mention attribute filled with passed attributes.
+ *    editor.execute( 'mention', {
+ *      marker: '#',
+ *      mention: {
+ *        id: '#1234',
+ *        name: 'Foo',
+ *        title: 'Big Foo'
+ *      },
+ *      range: model.createRange( focus, focus.getShiftedBy( -1 ) )
+ *    } );
+ *
+ *    // It will replace one character before the selection focus with the 'The "Big Foo"' text
+ *    // with the mention attribute filled with passed attributes.
+ *    editor.execute( 'mention', {
+ *      marker: '#',
+ *      mention: {
+ *        id: '#1234',
+ *        name: 'Foo',
+ *        title: 'Big Foo'
+ *      },
+ *      text: 'The "Big Foo"',
+ *      range: model.createRange( focus, focus.getShiftedBy( -1 ) )
+ *    } );
+ */
+export default class MentionCommand extends Command {
+  refresh(): void;
+
+  /**
+   * Executes the command.
+   */
+  execute(options?: {
+    mention: string | { id: string; text: string };
+    marker: string;
+    text?: string;
+    range?: Range;
+  }): void;
+}

--- a/types/ckeditor__ckeditor5-mention/src/mentionediting.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mentionediting.d.ts
@@ -1,0 +1,13 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+
+/**
+ * The mention editing feature.
+ *
+ * It introduces the {@link module:mention/mentioncommand~MentionCommand command} and the `mention`
+ * attribute in the {@link module:engine/model/model~Model model} which renders in the {@link module:engine/view/view view}
+ * as a `<span class="mention" data-mention="@mention">`.
+ */
+export default class MentionEditing extends Plugin {
+    static readonly pluginName: 'MentionEditing';
+    init(): void;
+}

--- a/types/ckeditor__ckeditor5-mention/src/mentionui.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mentionui.d.ts
@@ -1,0 +1,12 @@
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import { ContextualBalloon } from '@ckeditor/ckeditor5-ui';
+
+/**
+ * The mention UI feature.
+ */
+export default class MentionUI extends Plugin {
+    static readonly pluginName: 'MentionUI';
+    static readonly requires: [typeof ContextualBalloon];
+    init(): void;
+    destroy(): void;
+}

--- a/types/ckeditor__ckeditor5-mention/src/ui/domwrapperview.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/ui/domwrapperview.d.ts
@@ -1,0 +1,25 @@
+import { View } from '@ckeditor/ckeditor5-ui';
+import { Locale } from '@ckeditor/ckeditor5-utils';
+
+/**
+ * This class wraps DOM element as a CKEditor5 UI View.
+ *
+ * It allows to render any DOM element and use it in mentions list.
+ */
+export default class DomWrapperView<T extends HTMLElement> extends View {
+    /**
+     * Creates an instance of {@link module:mention/ui/domwrapperview~DomWrapperView} class.
+     */
+    constructor(locale: Locale, domElement: T);
+    /**
+     * Disable template rendering on this view.
+     */
+    readonly template: false;
+    /**
+     * The DOM element for which wrapper was created.
+     */
+    readonly domElement: T;
+    element?: T;
+    isOn: boolean;
+    render(): void;
+}

--- a/types/ckeditor__ckeditor5-mention/src/ui/mentionlistitemview.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/ui/mentionlistitemview.d.ts
@@ -1,0 +1,7 @@
+import { ListItemView } from '@ckeditor/ckeditor5-ui';
+
+export default class MentionListItemView extends ListItemView<MentionListItemView> {
+    isOn: boolean;
+    highlight(): void;
+    removeHighlight(): void;
+}

--- a/types/ckeditor__ckeditor5-mention/src/ui/mentionsview.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/ui/mentionsview.d.ts
@@ -1,0 +1,38 @@
+import { ListView } from '@ckeditor/ckeditor5-ui';
+import MentionListItemView from './mentionlistitemview';
+
+export default class MentionsView extends ListView<MentionListItemView> {
+    selected: MentionListItemView;
+    /**
+     * {@link #select Selects} the first item.
+     */
+    selectFirst(): void;
+
+    /**
+     * Selects next item to the currently {@link #select selected}.
+     *
+     * If the last item is already selected, it will select the first item.
+     */
+    selectNext(): void;
+
+    /**
+     * Selects previous item to the currently {@link #select selected}.
+     *
+     * If the first item is already selected, it will select the last item.
+     */
+    selectPrevious(): void;
+
+    /**
+     * Marks item at a given index as selected.
+     *
+     * Handles selection cycling when passed index is out of bounds:
+     * - if the index is lower than 0, it will select the last item,
+     * - if the index is higher than the last item index, it will select the first item.
+     */
+    select(index: number): void;
+
+    /**
+     * Triggers the `execute` event on the {@link #select selected} item.
+     */
+    executeSelected(): void;
+}

--- a/types/ckeditor__ckeditor5-mention/tsconfig.json
+++ b/types/ckeditor__ckeditor5-mention/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ckeditor/*": [
+                "ckeditor__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-mention-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-mention/tslint.json
+++ b/types/ckeditor__ckeditor5-mention/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
@@ -64,7 +64,13 @@ let bool = true;
 
 let view = new View();
 view.isRendered === bool;
-const template: Template = view.template;
+let template: Template;
+if (typeof view.template !== "boolean") {
+    template = view.template;
+}
+template = view.template as Template;
+
+let htmlelement = template.render() as HTMLElement;
 
 let locale: Locale = new Locale();
 view = new View(locale);
@@ -108,7 +114,7 @@ view.extendTemplate({
 view.render();
 view.destroy();
 
-let htmlelement: HTMLElement = view.element!;
+htmlelement = view.element!;
 view.element === null;
 
 /**
@@ -180,7 +186,6 @@ new Template({
         'c@span': [templateBind.to('c'), templateBind.to(() => {})],
     },
 });
-htmlelement = template.render() as HTMLElement;
 
 /**
  * Model

--- a/types/ckeditor__ckeditor5-ui/src/list/listitemview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/list/listitemview.d.ts
@@ -1,7 +1,7 @@
 import View from "../view";
 import ViewCollection from "../viewcollection";
 
-export default class ListItemView extends View {
-    readonly children: ViewCollection;
+export default class ListItemView<T = View> extends View {
+    readonly children: ViewCollection<T extends View ? T : never>;
     focus(): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/list/listview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/list/listview.d.ts
@@ -3,9 +3,9 @@ import { DropdownPanelFocusable } from "../dropdown/dropdownpanelfocusable";
 import View from "../view";
 import ViewCollection from "../viewcollection";
 
-export default class ListView extends View implements DropdownPanelFocusable {
+export default class ListView<T = View> extends View implements DropdownPanelFocusable {
     readonly focusTracker: FocusTracker;
-    readonly items: ViewCollection;
+    readonly items: ViewCollection<T extends View ? T : never>;
     readonly keystrokes: KeystrokeHandler;
 
     focus(): void;

--- a/types/ckeditor__ckeditor5-ui/src/view.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/view.d.ts
@@ -10,10 +10,10 @@ import ViewCollection from './viewcollection';
 
 export default class View implements DomEmitter, Observable {
     constructor(locale?: Locale);
-    element: HTMLElement | null;
+    element?: HTMLElement | null;
     readonly isRendered: boolean;
     readonly locale?: Locale;
-    template: Template;
+    template: Template | boolean;
     t: Locale['t'] | undefined;
     readonly bindTemplate: TemplateBindChain;
     createCollection(views?: Iterable<View>): ViewCollection;

--- a/types/ckeditor__ckeditor5-ui/src/viewcollection.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/viewcollection.d.ts
@@ -3,8 +3,8 @@ import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import View from "./view";
 
-export default class ViewCollection extends Collection<View> implements Emitter, Observable {
-    constructor(initialItems?: Iterable<View>);
+export default class ViewCollection<T extends View = View> extends Collection<T> implements Emitter, Observable {
+    constructor(initialItems?: Iterable<T>);
     destroy(): void;
     setParent(element: HTMLElement): void;
 

--- a/types/ckeditor__ckeditor5-ui/v27/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-ui/v27/OTHER_FILES.txt
@@ -1,5 +1,0 @@
-src/bindings/preventdefault.d.ts
-src/iframe/iframeview.d.ts
-src/labeledinput/labeledinputview.d.ts
-src/list/listseparatorview.d.ts
-src/toolbar/toolbarlinebreakview.d.ts

--- a/types/ckeditor__ckeditor5-ui/v27/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/ckeditor__ckeditor5-ui-tests.ts
@@ -44,23 +44,33 @@ import {
     View,
     ViewCollection,
 } from "@ckeditor/ckeditor5-ui";
+import preventDefault from "@ckeditor/ckeditor5-ui/src/bindings/preventdefault";
 import DropdownPanelView from "@ckeditor/ckeditor5-ui/src/dropdown/dropdownpanelview";
 import DropdownView from "@ckeditor/ckeditor5-ui/src/dropdown/dropdownview";
+import IframeView from "@ckeditor/ckeditor5-ui/src/iframe/iframeview";
+import LabeledInputView from "@ckeditor/ckeditor5-ui/src/labeledinput/labeledinputview";
+import ListSeparatorView from "@ckeditor/ckeditor5-ui/src/list/listseparatorview";
+import ToolbarLineBreakView from "@ckeditor/ckeditor5-ui/src/toolbar/toolbarlinebreakview";
 import { DomEmitterMixin, EmitterMixin, FocusTracker, KeystrokeHandler, Locale } from "@ckeditor/ckeditor5-utils";
 
 let num = 0;
 let str = "";
 class MyEditor extends Editor {}
 const editor = new MyEditor();
+let bool = true;
 /**
  * View
  */
 
 let view = new View();
-view.locale === undefined;
-let bool = true;
 view.isRendered === bool;
-let template: Template = view.template;
+let template: Template;
+if (typeof view.template !== "boolean") {
+    template = view.template;
+}
+template = view.template as Template;
+
+let htmlelement = template.render() as HTMLElement;
 
 let locale: Locale = new Locale();
 view = new View(locale);
@@ -75,7 +85,7 @@ view.deregisterChild([view]);
 view.setTemplate({
     tag: "div",
     attributes: {
-        class: [view.bindTemplate.to(str)],
+        class: [view.bindTemplate.to("foo")],
     },
 });
 
@@ -104,16 +114,18 @@ view.extendTemplate({
 view.render();
 view.destroy();
 
-view.element!.tagName.startsWith("");
+htmlelement = view.element!;
 view.element === null;
 
 /**
  * ViewCollection
  */
 let viewCollection: ViewCollection = view.createCollection();
-view = viewCollection.get(num) as View;
+view = viewCollection.get(0) as View;
 viewCollection.get(0) === null;
-viewCollection.setParent(document.createElement("div"));
+// $ExpectError
+viewCollection.get(0) === bool;
+viewCollection.setParent(htmlelement);
 viewCollection.add(view);
 // $ExpectError
 viewCollection.add([view]);
@@ -127,8 +139,21 @@ viewCollection.destroy();
  * Template
  */
 const templateBind = Template.bind(new Model(), DomEmitterMixin);
-template = new Template({ tag: "p" });
-template = new Template({
+new Template({ tag: "p" });
+new Template({
+    tag: "p",
+    on: {
+        click: templateBind.to("clicked"),
+        "click@a.foo": templateBind.to("clicked"),
+        mouseover: [templateBind.to("clicked"), templateBind.to("executed")],
+    },
+});
+new Template({
+    tag: "div",
+    children: viewCollection,
+});
+
+new Template({
     text: "foo",
     tag: "p",
     attributes: {
@@ -141,13 +166,16 @@ template = new Template({
     },
     children: [
         {
+            tag: "div",
             text: "content",
         },
         {
+            tag: "div",
             text: templateBind.to("x"),
         },
         "abc",
         {
+            tag: "div",
             text: ["a", "b"],
         },
         document.createElement("div"),
@@ -158,7 +186,6 @@ template = new Template({
         "c@span": [templateBind.to("c"), templateBind.to(() => {})],
     },
 });
-document.appendChild(template.render());
 
 /**
  * Model
@@ -168,14 +195,23 @@ const model = new MyModel();
 model.set({ a: 4 });
 model.a;
 // $ExpectError
-model.a = 4;
+model.a = num;
+
+/**
+ * ListView
+ */
+const listView = new ListView(locale);
+listView.focus();
+let focusTracker: FocusTracker = listView.focusTracker;
+// $ExpectError
+listView.focusTracker as ListView;
 
 /**
  * FocusCycler
  */
 let focusCycler = new FocusCycler({
     focusables: viewCollection,
-    focusTracker: new FocusTracker(),
+    focusTracker,
 });
 focusCycler = new FocusCycler({
     focusables: viewCollection,
@@ -229,14 +265,14 @@ let buttonView = new ButtonView(locale);
 buttonView.render();
 viewCollection = buttonView.children;
 view = buttonView.labelView;
-document.appendChild(buttonView.element!);
+htmlelement = buttonView.element as HTMLElement;
 
 /**
  * SwitchButtonView
  */
 const switchbuttonview = new SwitchButtonView();
 view = switchbuttonview.toggleSwitchView;
-document.appendChild(switchbuttonview.element!);
+htmlelement = switchbuttonview.element as HTMLElement;
 view = switchbuttonview.children.get(0) as View;
 
 /**
@@ -347,13 +383,6 @@ const listItemView = new ListItemView(locale);
 viewCollection = listItemView.children;
 
 /**
- * ListView
- */
-const listView = new ListView(locale);
-listView.focus();
-let focusTracker = listView.focusTracker;
-
-/**
  * Notification
  */
 const notification = new Notification(editor);
@@ -374,7 +403,7 @@ viewCollection = ballonPanelView.content;
  */
 const contextualballon = new ContextualBalloon(editor);
 contextualballon.add({ stackId: "" });
-bool = contextualballon.isEnabled;
+contextualballon.isEnabled === bool;
 contextualballon.remove(view);
 contextualballon.showStack("foo");
 
@@ -384,13 +413,13 @@ contextualballon.showStack("foo");
 const stickypanelview = new StickyPanelView();
 viewCollection = stickypanelview.content;
 num = stickypanelview.limiterBottomOffset;
-document.appendChild(stickypanelview.limiterElement);
+htmlelement = stickypanelview.limiterElement;
 
 /**
  * ToolipView
  */
 const tooltipView = new TooltipView();
-str = tooltipView.position as string;
+str = tooltipView.position;
 str = tooltipView.text;
 
 /**
@@ -399,13 +428,13 @@ str = tooltipView.text;
 let toolbarView = new ToolbarView(locale);
 toolbarView.focus();
 bool = toolbarView.isCompact;
-bool = toolbarView.options.isFloating as boolean;
+bool = toolbarView.options.isFloating!;
 
 /**
  * ToolbarSeparatorView
  */
 const toolbarSeparatorView = new ToolbarSeparatorView();
-document.appendChild(toolbarSeparatorView.element!);
+htmlelement = toolbarSeparatorView.element as HTMLElement;
 
 /**
  * enableToolbarKeyboardFocus
@@ -413,14 +442,14 @@ document.appendChild(toolbarSeparatorView.element!);
 enableToolbarKeyboardFocus({
     origin: view,
     originKeystrokeHandler: new KeystrokeHandler(),
-    originFocusTracker: focusTracker,
+    originFocusTracker: new FocusTracker(),
     toolbar: toolbarView,
 });
 
 /**
  * normalizeToolbarConfig
  */
-const toolbarConfig = normalizeToolbarConfig(["foo", "bar", "set"]);
+const toolbarConfig = normalizeToolbarConfig(["foo", "bar", "set", str]);
 normalizeToolbarConfig(toolbarConfig);
 
 /**
@@ -438,3 +467,44 @@ focusTracker = balloonToolbar.focusTracker;
 const blockToolbar = new BlockToolbar(editor);
 toolbarView = blockToolbar.toolbarView;
 buttonView = blockToolbar.buttonView;
+
+/**
+ * preventDefault
+ */
+view.setTemplate({
+    tag: "div",
+
+    on: {
+        foo: preventDefault(view),
+    },
+});
+
+/**
+ * IframeView
+ */
+const iframeView = new IframeView();
+iframeView.render().then(() => {});
+document.body.appendChild(iframeView.element!);
+iframeView.element!.remove();
+
+/**
+ * LabeledInputView
+ */
+const labeledInputView = new LabeledInputView(locale, InputTextView);
+labeledInputView.render();
+labeledInputView.statusView.element!.tagName.startsWith("");
+labeledInputView.labelView.for.startsWith("");
+labeledInputView.inputView.isReadOnly === bool;
+labeledInputView.select();
+
+/**
+ * ListSeparatorView
+ */
+new ListSeparatorView().render();
+new ListSeparatorView().element!.tagName.startsWith("foo");
+
+/**
+ * ToolbarLineBreakView
+ */
+new ToolbarLineBreakView().render();
+new ToolbarLineBreakView().element!.tagName.startsWith("foo");

--- a/types/ckeditor__ckeditor5-ui/v27/src/list/listitemview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/list/listitemview.d.ts
@@ -1,7 +1,7 @@
 import View from "../view";
 import ViewCollection from "../viewcollection";
 
-export default class ListItemView extends View {
-    readonly children: ViewCollection;
+export default class ListItemView<T = View> extends View {
+    readonly children: ViewCollection<T extends View ? T : never>;
     focus(): void;
 }

--- a/types/ckeditor__ckeditor5-ui/v27/src/list/listview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/list/listview.d.ts
@@ -3,9 +3,9 @@ import { DropdownPanelFocusable } from "../dropdown/dropdownpanelfocusable";
 import View from "../view";
 import ViewCollection from "../viewcollection";
 
-export default class ListView extends View implements DropdownPanelFocusable {
+export default class ListView<T = View> extends View implements DropdownPanelFocusable {
     readonly focusTracker: FocusTracker;
-    readonly items: ViewCollection;
+    readonly items: ViewCollection<T extends View ? T : never>;
     readonly keystrokes: KeystrokeHandler;
 
     focus(): void;

--- a/types/ckeditor__ckeditor5-ui/v27/src/view.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/view.d.ts
@@ -10,11 +10,11 @@ import ViewCollection from "./viewcollection";
 
 export default class View implements DomEmitter, Observable {
     constructor(locale?: Locale);
-    element: HTMLElement | null;
+    element?: HTMLElement | null;
     readonly isRendered: boolean;
     readonly locale?: Locale;
-    template: Template;
-    t: Locale["t"] | undefined;
+    template: Template | boolean;
+    t: Locale['t'] | undefined;
     readonly bindTemplate: TemplateBindChain;
     createCollection(views?: Iterable<View>): ViewCollection;
     registerChild(children: View | Iterable<View>): void;

--- a/types/ckeditor__ckeditor5-ui/v27/src/viewcollection.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/viewcollection.d.ts
@@ -3,8 +3,8 @@ import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import View from "./view";
 
-export default class ViewCollection extends Collection<View> implements Emitter, Observable {
-    constructor(initialItems?: Iterable<View>);
+export default class ViewCollection<T extends View = View> extends Collection<T> implements Emitter, Observable {
+    constructor(initialItems?: Iterable<T>);
     destroy(): void;
     setParent(element: HTMLElement): void;
 


### PR DESCRIPTION
The modification to `@ckeditor/ckeditor5-ui` allows to avoid casting when getting an item from the `ViewCollection`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.