### PR TITLE
add(videojs-erors): new definition

### DIFF
--- a/types/videojs-errors/index.d.ts
+++ b/types/videojs-errors/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for videojs-errors 4.5
+// Project: https://github.com/brightcove/videojs-errors#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import videojs from 'video.js';
+
+interface CustomError {
+    type?: string | undefined;
+    headline: string;
+    message?: string | undefined;
+}
+
+interface VideoJSErrorsPlugin {
+    readonly VERSION: string;
+    (options?: Options): void;
+    getAll(): Record<string | number, CustomError>;
+    extend(options: Record<string | number, CustomError>): void;
+    timeout<T extends number | undefined = undefined>(value?: T): T extends number ? undefined : number;
+    backgroundTimeout<T extends number | undefined = undefined>(value?: T): T extends number ? undefined : number;
+}
+
+interface Options {
+    errors?: Record<string | number, CustomError>;
+    timeout?: number | undefined;
+    backgroundTimeout?: number | undefined;
+}
+
+type CustomMediaError = {
+    readonly code: string | number;
+    readonly dismiss?: boolean | undefined;
+} & Partial<Omit<videojs.MediaError, 'code'>>;
+
+declare const errors: VideoJSErrorsPlugin;
+export = errors;
+
+declare module 'video.js' {
+    interface VideoJsPlayer extends videojs.Component {
+        errors: VideoJSErrorsPlugin;
+        error(err: CustomMediaError | string | number | null): void;
+    }
+}

--- a/types/videojs-errors/tsconfig.json
+++ b/types/videojs-errors/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "videojs-errors-tests.ts"
+    ]
+}

--- a/types/videojs-errors/tslint.json
+++ b/types/videojs-errors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/videojs-errors/videojs-errors-tests.ts
+++ b/types/videojs-errors/videojs-errors-tests.ts
@@ -1,0 +1,48 @@
+import videojs from 'video.js';
+import 'videojs-errors';
+
+const player = videojs('my-player', {}, function onPlayerReady() {
+    // tests for `this`
+    // $ExpectType void
+    this.errors();
+    // $ExpectType void
+    this.errors.extend({
+        3: {
+            headline: 'This is an override for the generic MEDIA_ERR_DECODE',
+            message: 'This is a custom error message',
+        },
+    });
+    // $ExpectType void
+    this.error({ code: 'foo', dismiss: true });
+    // $ExpectType void
+    this.error({ code: 1, message: 'foo' });
+    this.errors.VERSION; // $ExpectType string
+});
+
+// tests for player
+// $ExpectType void
+player.errors();
+// $ExpectType void
+player.errors.extend({
+    PLAYER_ERR_FOO: {
+        headline: 'My custom "foo" error',
+        message: 'A custom "foo" error message.',
+    },
+});
+// $ExpectType void
+player.error({ code: 'PLAYER_ERR_FOO' });
+// $ExpectType void
+player.error({ code: 1, message: 'foo' });
+
+// $ExpectType Record<string | number, CustomError>
+const errors = player.errors.getAll();
+errors['1'].type;
+// $ExpectType undefined
+player.errors.timeout(3000);
+// $ExpectType number
+player.errors.timeout();
+// $ExpectType undefined
+player.errors.backgroundTimeout(3000);
+// $ExpectType number
+player.errors.backgroundTimeout();
+player.errors.VERSION; // $ExpectType string


### PR DESCRIPTION
Augmented extendsions for `video.js` from `videojs-errors` plugin:
https://github.com/brightcove/videojs-errors

Thanks!

Redo of #54472
I've never seen a notification, so missed the opportunity to properly merge