### PR TITLE
Fix results argument in Frecency sort definition

### DIFF
--- a/types/frecency/index.d.ts
+++ b/types/frecency/index.d.ts
@@ -19,10 +19,10 @@ export default class Frecency<T = any> {
     });
     save: (arg: { searchQuery: T; selectedId: string }) => void;
     sort:
-        | ((arg: { searchQuery: T; searchResults: T[] }) => T[])
+        | ((arg: { searchQuery: T; results: T[] }) => T[])
         | ((arg: {
               searchQuery: T;
-              searchResults: T[];
+              results: T[];
               keepScores?: boolean | undefined;
           }) => Array<T & { _frecencyScore?: number | undefined }>);
 }


### PR DESCRIPTION
Ref: https://github.com/mixmaxhq/frecency/blob/v1.3.2/src/index.js#L242

The argument to frecency `sort` is `results`, not `searchResults`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) -> tested via manual edit ref https://github.com/DefinitelyTyped/DefinitelyTyped#test-editing-an-existing-package
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mixmaxhq/frecency/blob/v1.3.2/src/index.js#L242
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
