### PR TITLE
Fix bad merge in react-datepicker.

### DIFF
--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -22,7 +22,6 @@ const defaultLocale = getDefaultLocale();
     className=""
     clearButtonClassName=""
     clearButtonTitle=""
-    clearButtonClassName=""
     // closeOnScroll={false} // Or as function:
     closeOnScroll={e => e.target === document}
     customInput={<input />}


### PR DESCRIPTION
clearButtonClassName got added twice in the tests and git didn't catch it.
