### PR TITLE
meteor: Allow Match.Where checks that are type assertions

### DIFF
--- a/types/meteor/check.d.ts
+++ b/types/meteor/check.d.ts
@@ -56,6 +56,7 @@ declare module 'meteor/check' {
          * Calls the function condition with the value as the argument. If condition returns true, this matches. If condition throws a `Match.Error` or returns false, this fails. If condition throws
          * any other error, that error is thrown from the call to `check` or `Match.test`.
          */
+        function Where<T>(condition: (val: any) => val is T): Matcher<T>;
         function Where(condition: (val: any) => boolean): Matcher<any>;
 
         /**

--- a/types/meteor/ejson.d.ts
+++ b/types/meteor/ejson.d.ts
@@ -35,7 +35,7 @@ declare module 'meteor/ejson' {
 
         function fromJSONValue(val: JSONable): any;
 
-        function isBinary(x: Object): boolean;
+        function isBinary(x: Object): x is Uint8Array;
         function newBinary(size: number): Uint8Array;
 
         function parse(str: string): EJSON;

--- a/types/meteor/globals/check.d.ts
+++ b/types/meteor/globals/check.d.ts
@@ -55,6 +55,7 @@ declare module Match {
      * Calls the function condition with the value as the argument. If condition returns true, this matches. If condition throws a `Match.Error` or returns false, this fails. If condition throws
      * any other error, that error is thrown from the call to `check` or `Match.test`.
      */
+    function Where<T>(condition: (val: any) => val is T): Matcher<T>;
     function Where(condition: (val: any) => boolean): Matcher<any>;
 
     /**

--- a/types/meteor/globals/ejson.d.ts
+++ b/types/meteor/globals/ejson.d.ts
@@ -34,7 +34,7 @@ declare module EJSON {
 
     function fromJSONValue(val: JSONable): any;
 
-    function isBinary(x: Object): boolean;
+    function isBinary(x: Object): x is Uint8Array;
     function newBinary(size: number): Uint8Array;
 
     function parse(str: string): EJSON;

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -784,6 +784,12 @@ namespace MeteorTests {
     // Outside an object
     check(undefined, Match.Optional('test')); // OK
 
+    var buffer: unknown;
+
+    check(buffer, Match.Where(EJSON.isBinary));
+    // $ExpectType Uint8Array
+    buffer;
+
     /**
      * From Deps, Tracker.autorun section
      */

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -803,6 +803,12 @@ namespace MeteorTests {
     // Outside an object
     check(undefined, Match.Optional('test')); // OK
 
+    var buffer: unknown;
+
+    check(buffer, Match.Where(EJSON.isBinary));
+    // $ExpectType Uint8Array
+    buffer;
+
     /**
      * From Deps, Tracker.autorun section
      */


### PR DESCRIPTION
Match.Where is hard to type, since the function can include assertions,
and the boolean value that's returned may not be a type guard. We can
make this a little better by allowing functions that are type guards,
although this still doesn't support doing things like (from the docs):

```
const NonEmptyString = Match.Where((x) => {
  check(x, String);
  return x.length > 0;
});

check(arg, NonEmptyString);
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/check.html#:~:text=Match.Where(condition)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
