### PR TITLE
better-sqlite3: update for version 7

### DIFF
--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -1,35 +1,32 @@
 import Sqlite = require('better-sqlite3');
 
-const integer = Sqlite.Integer(1);
 const err = new Sqlite.SqliteError('ok', 'ok');
 const result: Sqlite.RunResult = { changes: 1, lastInsertRowid: 1 };
-const options: Sqlite.Options = { fileMustExist: true, memory: true, readonly: true };
+const options: Sqlite.Options = { fileMustExist: true, readonly: true };
 const registrationOptions: Sqlite.RegistrationOptions = {
     deterministic: true,
     safeIntegers: true,
-    varargs: true
+    varargs: true,
 };
 
-let db: Sqlite.Database = Sqlite('.');
-db = new Sqlite('.', { memory: true, verbose: () => {} });
+let db: Sqlite.Database = Sqlite(':memory:');
+db = new Sqlite(':memory:', { verbose: () => {} });
 db.exec('CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL);');
 db.exec('INSERT INTO test(name) VALUES("name");');
 db.pragma('data_version', { simple: true });
-db.checkpoint();
-db.checkpoint('main');
 db.table('vtable', {
     columns: ['name'],
     *rows() {
         yield 'testName';
-    }
+    },
 });
-db.function('noop', () => { });
-db.function('noop', { deterministic: true, varargs: true }, () => { });
+db.function('noop', () => {});
+db.function('noop', { deterministic: true, varargs: true }, () => {});
 db.aggregate('add', {
     start: 0,
     step: (t, n) => t + n,
     deterministic: true,
-    varargs: true
+    varargs: true,
 });
 db.aggregate('getAverage', {
     start: () => [],
@@ -71,19 +68,23 @@ for (col of stmt.columns()) {
     col.column;
     col.type;
 }
-type BindParameters = [string, number];
-const stmtWithBindTyped = db.prepare<BindParameters>('SELECT * FROM test WHERE name == ? and age = ?');
-stmtWithBindTyped.run('alice', 20);
+type BindParameters = [string, number, bigint];
+const stmtWithBindTyped = db.prepare<BindParameters>('SELECT * FROM test WHERE name == ? and age = ? and id == ?');
+stmtWithBindTyped.run('alice', 20, 1234n);
 // note the following is technically legal according to the docs, but we do not have a way to express both typed args
 // and variable tuples in typescript. If you want to group tuples, you must specify it that way in the prepare function
 // https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#binding-parameters
 // $ExpectError
-stmtWithBindTyped.run(['alice', 20]);
-interface NamedBindParameters { name: string; age: number; }
-const stmtWithNamedBind = db.prepare<NamedBindParameters>('INSERT INTO test VALUES (@name, @age)');
-stmtWithNamedBind.run({ name: 'bob', age: 20 });
+stmtWithBindTyped.run(['alice', 20, 1234n]);
+interface NamedBindParameters {
+    name: string;
+    age: number;
+    id: bigint;
+}
+const stmtWithNamedBind = db.prepare<NamedBindParameters>('INSERT INTO test VALUES (@name, @age, @id)');
+stmtWithNamedBind.run({ name: 'bob', age: 20, id: 1234n });
 
-const trans: Sqlite.Transaction = db.transaction((param) => stmt.all(param));
+const trans: Sqlite.Transaction = db.transaction(param => stmt.all(param));
 trans('name');
 trans(1);
 trans.default('name');
@@ -104,11 +105,10 @@ const transReturn = db.transaction(() => 1);
 // $ExpectType number
 transReturn();
 
-db.backup('backup-today.db')
-    .then(({ totalPages, remainingPages }) => {});
+db.backup('backup-today.db').then(({ totalPages, remainingPages }) => {});
 const paused = false;
 db.backup('backup-today.db', {
     progress({ totalPages: t, remainingPages: r }) {
         return paused ? 0 : 200;
-    }
+    },
 });

--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -70,19 +70,19 @@ for (col of stmt.columns()) {
 }
 type BindParameters = [string, number, bigint];
 const stmtWithBindTyped = db.prepare<BindParameters>('SELECT * FROM test WHERE name == ? and age = ? and id == ?');
-stmtWithBindTyped.run('alice', 20, 1234n);
+stmtWithBindTyped.run('alice', 20, BigInt(1234));
 // note the following is technically legal according to the docs, but we do not have a way to express both typed args
 // and variable tuples in typescript. If you want to group tuples, you must specify it that way in the prepare function
 // https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#binding-parameters
 // $ExpectError
-stmtWithBindTyped.run(['alice', 20, 1234n]);
+stmtWithBindTyped.run(['alice', 20, BigInt(1234)]);
 interface NamedBindParameters {
     name: string;
     age: number;
     id: bigint;
 }
 const stmtWithNamedBind = db.prepare<NamedBindParameters>('INSERT INTO test VALUES (@name, @age, @id)');
-stmtWithNamedBind.run({ name: 'bob', age: 20, id: 1234n });
+stmtWithNamedBind.run({ name: 'bob', age: 20, id: BigInt(1234) });
 
 const trans: Sqlite.Transaction = db.transaction(param => stmt.all(param));
 trans('name');

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for better-sqlite3 5.4
+// Type definitions for better-sqlite3 7.4
 // Project: http://github.com/JoshuaWise/better-sqlite3
 // Definitions by: Ben Davies <https://github.com/Morfent>
 //                 Mathew Rumsey <https://github.com/matrumz>
@@ -7,14 +7,10 @@
 //                 Andrew Kaiser <https://github.com/andykais>
 //                 Mark Stewart <https://github.com/mrkstwrt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
-
-import Integer = require("integer");
+// TypeScript Version: 4.3
 
 type VariableArgFunction = (...params: any[]) => any;
-type ArgumentTypes<F extends VariableArgFunction> = F extends (...args: infer A) => any
-  ? A
-  : never;
+type ArgumentTypes<F extends VariableArgFunction> = F extends (...args: infer A) => any ? A : never;
 
 declare namespace BetterSqlite3 {
     interface Statement<BindParameters extends any[]> {
@@ -65,13 +61,12 @@ declare namespace BetterSqlite3 {
         open: boolean;
         inTransaction: boolean;
 
-        prepare<BindParameters extends any[] | {} = any[]>(source: string): BindParameters extends any[]
-          ? Statement<BindParameters>
-          : Statement<[BindParameters]>;
+        prepare<BindParameters extends any[] | {} = any[]>(
+            source: string,
+        ): BindParameters extends any[] ? Statement<BindParameters> : Statement<[BindParameters]>;
         transaction<F extends VariableArgFunction>(fn: F): Transaction<F>;
         exec(source: string): this;
         pragma(source: string, options?: Database.PragmaOptions): any;
-        checkpoint(databaseName?: string): this;
         function(name: string, cb: (...params: any[]) => any): this;
         function(name: string, options: Database.RegistrationOptions, cb: (...params: any[]) => any): this;
         aggregate(name: string, options: Database.AggregateOptions): this;
@@ -80,14 +75,14 @@ declare namespace BetterSqlite3 {
         defaultSafeIntegers(toggleState?: boolean): this;
         backup(destinationFile: string, options?: Database.BackupOptions): Promise<Database.BackupMetadata>;
         table(name: string, options: VirtualTableOptions): this;
+        unsafeMode(unsafe?: boolean): this;
     }
 
     interface DatabaseConstructor {
-        new(filename: string, options?: Database.Options): Database;
+        new (filename: string, options?: Database.Options): Database;
         (filename: string, options?: Database.Options): Database;
         prototype: Database;
 
-        Integer: typeof Integer;
         SqliteError: typeof SqliteError;
     }
 }
@@ -102,11 +97,10 @@ declare class SqliteError implements Error {
 declare namespace Database {
     interface RunResult {
         changes: number;
-        lastInsertRowid: Integer.IntLike;
+        lastInsertRowid: number | bigint;
     }
 
     interface Options {
-        memory?: boolean | undefined;
         readonly?: boolean | undefined;
         fileMustExist?: boolean | undefined;
         timeout?: number | undefined;
@@ -138,11 +132,10 @@ declare namespace Database {
         progress: (info: BackupMetadata) => number;
     }
 
-    type Integer = typeof Integer;
     type SqliteError = typeof SqliteError;
     type Statement<BindParameters extends any[] | {} = any[]> = BindParameters extends any[]
-      ? BetterSqlite3.Statement<BindParameters>
-      : BetterSqlite3.Statement<[BindParameters]>;
+        ? BetterSqlite3.Statement<BindParameters>
+        : BetterSqlite3.Statement<[BindParameters]>;
     type ColumnDefinition = BetterSqlite3.ColumnDefinition;
     type Transaction = BetterSqlite3.Transaction<VariableArgFunction>;
     type Database = BetterSqlite3.Database;

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -7,7 +7,7 @@
 //                 Andrew Kaiser <https://github.com/andykais>
 //                 Mark Stewart <https://github.com/mrkstwrt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.3
+// TypeScript Version: 3.8
 
 type VariableArgFunction = (...params: any[]) => any;
 type ArgumentTypes<F extends VariableArgFunction> = F extends (...args: infer A) => any ? A : never;

--- a/types/better-sqlite3/tsconfig.json
+++ b/types/better-sqlite3/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2020",
         "lib": [
-            "es6"
+            "es2020"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
This PR:

- Replaces `Integer` with `BigInt`s (closes #46381)
- Removes the deprecated `db.checkpoint()` method
- Removes the deprecated `memory` option
- Adds the new `unsafeMode` method
- Formats files with Prettier

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test better-sqlite3`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/JoshuaWise/better-sqlite3/releases/tag/v6.0.0
   - https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.