### PR TITLE
[@types/ws] Update ws definitions to v8.2

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -347,10 +347,10 @@ declare namespace WebSocket {
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    export const WebSocketServer: typeof Server;
-    export type WebSocketServer = Server;
-    export const WebSocket: typeof WebSocketAlias;
-    export type WebSocket = WebSocketAlias;
+    const WebSocketServer: typeof Server;
+    type WebSocketServer = Server;
+    const WebSocket: typeof WebSocketAlias;
+    type WebSocket = WebSocketAlias;
 
     // WebSocket stream
     function createWebSocketStream(websocket: WebSocket, options?: DuplexOptions): Duplex;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -171,7 +171,8 @@ declare class WebSocket extends EventEmitter {
     removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 }
 
-declare class WebSocketAlias extends WebSocket {}
+declare const WebSocketAlias: typeof WebSocket;
+type WebSocketAlias = WebSocket;
 
 declare namespace WebSocket {
     /**
@@ -346,8 +347,10 @@ declare namespace WebSocket {
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    class WebSocketServer extends Server {}
-    class WebSocket extends WebSocketAlias {}
+    export const WebSocketServer: typeof Server;
+    export type WebSocketServer = Server;
+    export const WebSocket: typeof WebSocketAlias;
+    export type WebSocket = WebSocketAlias;
 
     // WebSocket stream
     function createWebSocketStream(websocket: WebSocket, options?: DuplexOptions): Duplex;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -103,7 +103,6 @@ declare class WebSocket extends EventEmitter {
         cb: (event: WebSocket.Event) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
-    addEventListener(method: string, listener: () => void, options?: WebSocket.EventListenerOptions): void;
 
     removeEventListener(method: "message", cb: (event: WebSocket.MessageEvent) => void): void;
     removeEventListener(method: "close", cb: (event: WebSocket.CloseEvent) => void): void;
@@ -115,7 +114,7 @@ declare class WebSocket extends EventEmitter {
     on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
     on(event: "error", listener: (this: WebSocket, err: Error) => void): this;
     on(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary?: boolean) => void): this;
+    on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     on(event: "open", listener: (this: WebSocket) => void): this;
     on(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
     on(
@@ -127,7 +126,7 @@ declare class WebSocket extends EventEmitter {
     once(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
     once(event: "error", listener: (this: WebSocket, err: Error) => void): this;
     once(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary?: boolean) => void): this;
+    once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     once(event: "open", listener: (this: WebSocket) => void): this;
     once(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
     once(
@@ -139,7 +138,7 @@ declare class WebSocket extends EventEmitter {
     off(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
     off(event: "error", listener: (this: WebSocket, err: Error) => void): this;
     off(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary?: boolean) => void): this;
+    off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     off(event: "open", listener: (this: WebSocket) => void): this;
     off(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
     off(
@@ -151,7 +150,7 @@ declare class WebSocket extends EventEmitter {
     addListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
     addListener(event: "error", listener: (err: Error) => void): this;
     addListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
-    addListener(event: "message", listener: (data: WebSocket.RawData, isBinary?: boolean) => void): this;
+    addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     addListener(event: "open", listener: () => void): this;
     addListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
     addListener(
@@ -163,7 +162,7 @@ declare class WebSocket extends EventEmitter {
     removeListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
     removeListener(event: "error", listener: (err: Error) => void): this;
     removeListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
-    removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary?: boolean) => void): this;
+    removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     removeListener(event: "open", listener: () => void): this;
     removeListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
     removeListener(

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -174,7 +174,6 @@ declare class WebSocket extends EventEmitter {
 }
 
 declare namespace WebSocket {
-
     /**
      * Data represents the raw message payload received over the WebSocket.
      */

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ws 7.4
+// Type definitions for ws 8.0
 // Project: https://github.com/websockets/ws
 // Definitions by: Paul Loyd <https://github.com/loyd>
 //                 Margus Lamp <https://github.com/mlamp>
@@ -59,7 +59,7 @@ declare class WebSocket extends EventEmitter {
     /** The connection is closed. */
     readonly CLOSED: 3;
 
-    onopen: (event: WebSocket.OpenEvent) => void;
+    onopen: (event: WebSocket.Event) => void;
     onerror: (event: WebSocket.ErrorEvent) => void;
     onclose: (event: WebSocket.CloseEvent) => void;
     onmessage: (event: WebSocket.MessageEvent) => void;
@@ -71,7 +71,7 @@ declare class WebSocket extends EventEmitter {
         options?: WebSocket.ClientOptions | ClientRequestArgs,
     );
 
-    close(code?: number, data?: string): void;
+    close(code?: number, data?: string | Buffer): void;
     ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     send(data: any, cb?: (err?: Error) => void): void;
@@ -85,43 +85,37 @@ declare class WebSocket extends EventEmitter {
     // HTML5 WebSocket events
     addEventListener(
         method: "message",
-        cb: (event: { data: any; type: string; target: WebSocket }) => void,
+        cb: (event: WebSocket.MessageEvent) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(
         method: "close",
-        cb: (event: { wasClean: boolean; code: number; reason: string; target: WebSocket }) => void,
+        cb: (event: WebSocket.CloseEvent) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(
         method: "error",
-        cb: (event: { error: any; message: any; type: string; target: WebSocket }) => void,
+        cb: (event: WebSocket.ErrorEvent) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(
         method: "open",
-        cb: (event: { target: WebSocket }) => void,
+        cb: (event: WebSocket.Event) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(method: string, listener: () => void, options?: WebSocket.EventListenerOptions): void;
 
-    removeEventListener(method: "message", cb?: (event: { data: any; type: string; target: WebSocket }) => void): void;
-    removeEventListener(
-        method: "close",
-        cb?: (event: { wasClean: boolean; code: number; reason: string; target: WebSocket }) => void,
-    ): void;
-    removeEventListener(
-        method: "error",
-        cb?: (event: { error: any; message: any; type: string; target: WebSocket }) => void,
-    ): void;
-    removeEventListener(method: "open", cb?: (event: { target: WebSocket }) => void): void;
-    removeEventListener(method: string, listener?: () => void): void;
+    removeEventListener(method: "message", cb: (event: WebSocket.MessageEvent) => void): void;
+    removeEventListener(method: "close", cb: (event: WebSocket.CloseEvent) => void): void;
+    removeEventListener(method: "error", cb: (event: WebSocket.ErrorEvent) => void): void;
+    removeEventListener(method: "open", cb: (event: WebSocket.Event) => void): void;
+    removeEventListener(method: string, listener: () => void): void;
 
     // Events
-    on(event: "close", listener: (this: WebSocket, code: number, reason: string) => void): this;
+    on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
     on(event: "error", listener: (this: WebSocket, err: Error) => void): this;
     on(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    on(event: "message", listener: (this: WebSocket, data: WebSocket.Data) => void): this;
+    on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary?: boolean) => void): this;
     on(event: "open", listener: (this: WebSocket) => void): this;
     on(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
     on(
@@ -130,10 +124,10 @@ declare class WebSocket extends EventEmitter {
     ): this;
     on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
-    once(event: "close", listener: (this: WebSocket, code: number, reason: string) => void): this;
+    once(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
     once(event: "error", listener: (this: WebSocket, err: Error) => void): this;
     once(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    once(event: "message", listener: (this: WebSocket, data: WebSocket.Data) => void): this;
+    once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary?: boolean) => void): this;
     once(event: "open", listener: (this: WebSocket) => void): this;
     once(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
     once(
@@ -142,10 +136,10 @@ declare class WebSocket extends EventEmitter {
     ): this;
     once(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
-    off(event: "close", listener: (this: WebSocket, code: number, reason: string) => void): this;
+    off(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
     off(event: "error", listener: (this: WebSocket, err: Error) => void): this;
     off(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    off(event: "message", listener: (this: WebSocket, data: WebSocket.Data) => void): this;
+    off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary?: boolean) => void): this;
     off(event: "open", listener: (this: WebSocket) => void): this;
     off(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
     off(
@@ -154,10 +148,10 @@ declare class WebSocket extends EventEmitter {
     ): this;
     off(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
-    addListener(event: "close", listener: (code: number, message: string) => void): this;
+    addListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
     addListener(event: "error", listener: (err: Error) => void): this;
     addListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
-    addListener(event: "message", listener: (data: WebSocket.Data) => void): this;
+    addListener(event: "message", listener: (data: WebSocket.RawData, isBinary?: boolean) => void): this;
     addListener(event: "open", listener: () => void): this;
     addListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
     addListener(
@@ -166,10 +160,10 @@ declare class WebSocket extends EventEmitter {
     ): this;
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-    removeListener(event: "close", listener: (code: number, message: string) => void): this;
+    removeListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
     removeListener(event: "error", listener: (err: Error) => void): this;
     removeListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
-    removeListener(event: "message", listener: (data: WebSocket.Data) => void): this;
+    removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary?: boolean) => void): this;
     removeListener(event: "open", listener: () => void): this;
     removeListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
     removeListener(
@@ -180,6 +174,12 @@ declare class WebSocket extends EventEmitter {
 }
 
 declare namespace WebSocket {
+
+    /**
+     * Data represents the raw message payload received over the WebSocket.
+     */
+    type RawData = Buffer | ArrayBuffer | Buffer[];
+
     /**
      * Data represents the message payload received over the WebSocket.
      */
@@ -246,7 +246,7 @@ declare namespace WebSocket {
         concurrencyLimit?: number | undefined;
     }
 
-    interface OpenEvent {
+    interface Event {
         type: string;
         target: WebSocket;
     }
@@ -282,7 +282,7 @@ declare namespace WebSocket {
         backlog?: number | undefined;
         server?: HTTPServer | HTTPSServer | undefined;
         verifyClient?: VerifyClientCallbackAsync | VerifyClientCallbackSync | undefined;
-        handleProtocols?: any;
+        handleProtocols?: (protocols: Set<string>, request: IncomingMessage) => string | false;
         path?: string | undefined;
         noServer?: boolean | undefined;
         clientTracking?: boolean | undefined;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ws 8.0
+// Type definitions for ws 8.2
 // Project: https://github.com/websockets/ws
 // Definitions by: Paul Loyd <https://github.com/loyd>
 //                 Margus Lamp <https://github.com/mlamp>
@@ -171,6 +171,8 @@ declare class WebSocket extends EventEmitter {
     removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 }
 
+declare class WebSocketAlias extends WebSocket {}
+
 declare namespace WebSocket {
     /**
      * Data represents the raw message payload received over the WebSocket.
@@ -285,6 +287,7 @@ declare namespace WebSocket {
         clientTracking?: boolean | undefined;
         perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
         maxPayload?: number | undefined;
+        skipUTF8Validation?: boolean | undefined;
     }
 
     interface AddressInfo {
@@ -342,6 +345,9 @@ declare namespace WebSocket {
         removeListener(event: "close" | "listening", cb: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
+
+    class WebSocketServer extends Server {}
+    class WebSocket extends WebSocketAlias {}
 
     // WebSocket stream
     function createWebSocketStream(websocket: WebSocket, options?: DuplexOptions): Duplex;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -108,7 +108,6 @@ declare class WebSocket extends EventEmitter {
     removeEventListener(method: "close", cb: (event: WebSocket.CloseEvent) => void): void;
     removeEventListener(method: "error", cb: (event: WebSocket.ErrorEvent) => void): void;
     removeEventListener(method: "open", cb: (event: WebSocket.Event) => void): void;
-    removeEventListener(method: string, listener: () => void): void;
 
     // Events
     on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -52,8 +52,8 @@ import * as url from "url";
         console.log(`unexpected response: ${error}`);
     });
 
-    wsc.on("message", (data: string) => {
-        console.log(`Roundtrip time: ${Date.now() - parseInt(data, 10)} ms`);
+    wsc.on("message", (data) => {
+        console.log(`Roundtrip time: ${Date.now() - parseInt(data.toString(), 10)} ms`);
         setTimeout(() => {
             wsc.send(Date.now().toString(), { mask: true });
         }, 500);
@@ -141,7 +141,7 @@ import * as url from "url";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
-    ws.onopen = (event: WebSocket.OpenEvent) => {
+    ws.onopen = (event: WebSocket.Event) => {
         console.log(event.target, event.type);
     };
     ws.onerror = (event: WebSocket.ErrorEvent) => {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -2,6 +2,7 @@ import WebSocket = require("ws");
 import * as http from "http";
 import * as https from "https";
 import * as url from "url";
+import * as wslib from "ws";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
@@ -20,11 +21,11 @@ import * as url from "url";
 }
 
 {
-    const ws: WebSocket.WebSocket = new WebSocket.WebSocket("ws://www.host.com/path");
+    const ws: wslib.WebSocket = new WebSocket.WebSocket("ws://www.host.com/path");
 }
 
 {
-    const wss: WebSocket.WebSocketServer = new WebSocket.WebSocketServer({ port: 8081 });
+    const wss: wslib.WebSocketServer = new WebSocket.WebSocketServer({ port: 8081 });
 }
 
 {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -20,6 +20,14 @@ import * as url from "url";
 }
 
 {
+    const ws: WebSocket.WebSocket = new WebSocket.WebSocket("ws://www.host.com/path");
+}
+
+{
+    const wss: WebSocket.WebSocketServer = new WebSocket.WebSocketServer({ port: 8081 });
+}
+
+{
     const wss = new WebSocket.Server({ port: 8081 });
     wss.on("connection", (ws, req) => {
         ws.on("message", message => console.log("received: %s", message));

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -177,9 +177,8 @@ import * as url from "url";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
+    // $ExpectError
     ws.addEventListener("other", () => {});
-    ws.addEventListener("other", () => {}, { once: true });
-    ws.addEventListener("other", () => {}, { once: true });
 }
 
 {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -21,11 +21,11 @@ import * as wslib from "ws";
 }
 
 {
-    const ws: wslib.WebSocket = new WebSocket.WebSocket("ws://www.host.com/path");
+    const ws: wslib.WebSocket = new wslib.WebSocket("ws://www.host.com/path");
 }
 
 {
-    const wss: wslib.WebSocketServer = new WebSocket.WebSocketServer({ port: 8081 });
+    const wss: wslib.WebSocketServer = new wslib.WebSocketServer({ port: 8081 });
 }
 
 {


### PR DESCRIPTION
Update `ws` definitions to v8.2:

- https://github.com/websockets/ws/releases/tag/8.0.0
- https://github.com/websockets/ws/releases/tag/8.1.0
- https://github.com/websockets/ws/releases/tag/8.2.0
- Add the RawData type.
- Rename the OpenEvent class to Event.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/releases/tag/8.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
