### PR TITLE
[elasticlunr] Fix the type of Index.index

### DIFF
--- a/types/elasticlunr/elasticlunr-tests.ts
+++ b/types/elasticlunr/elasticlunr-tests.ts
@@ -22,6 +22,7 @@ const index = elasticlunr<TestDocument>(ctx => {
     ctx.setRef('id');
     ctx.saveDocument(true);
 });
+index.index['field']!.toJSON();
 
 const testDoc: TestDocument = { id: '1', field: 'ok' };
 

--- a/types/elasticlunr/index.d.ts
+++ b/types/elasticlunr/index.d.ts
@@ -130,7 +130,7 @@ declare namespace elasticlunr {
 
         eventEmitter: EventEmitter;
 
-        index: { [K in keyof T]?: InvertedIndexNode };
+        index: { [K in keyof T]?: InvertedIndex };
 
         pipeline: Pipeline;
 


### PR DESCRIPTION
This PR fixes the type of `elasticlunr.Index.index`. `Index.index`, which was defined as an `InvertedIndexNode`, is actually an `InvertedIndex`. (See [the line](https://github.com/weixsong/elasticlunr.js/blob/be7fdaac67cdb3ea1e7bff3cf0bca577b02e8e84/lib/index/legacy.js#L66) where `Index.index` is generated).  I also added a test line to ensure that this is the correct type.

This PR is for the commit [be7fdaac67cdb3ea1e7bff3cf0bca577b02e8e84](https://github.com/weixsong/elasticlunr.js/commit/be7fdaac67cdb3ea1e7bff3cf0bca577b02e8e84), which is the latest version of elasticlunr (2020/08/15).


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/weixsong/elasticlunr.js/blob/be7fdaac67cdb3ea1e7bff3cf0bca577b02e8e84/lib/index/legacy.js#L66>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.