### PR TITLE
Bump factory-girl version

### DIFF
--- a/types/factory-girl/index.d.ts
+++ b/types/factory-girl/index.d.ts
@@ -6,7 +6,6 @@
 //                 Olivier Kamers <https://github.com/OlivierKamers>
 //                 Dan McNamara <https://github.com/DMcNamara>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
 declare const factory: factory.Static;
 


### PR DESCRIPTION
Publish a new version since the previous publish failed to publish to github package manager.

Definitely Typed only publishes to TS3.6 and above now, so there's no point in specify a minimum version of 2.8.
