### PR TITLE
[mdast]: allow `null` wherever `undefined` is allowed

### DIFF
--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -204,22 +204,22 @@ export interface Blockquote extends Parent {
 
 export interface List extends Parent {
     type: 'list';
-    ordered?: boolean | undefined;
-    start?: number | undefined;
-    spread?: boolean | undefined;
+    ordered?: boolean | null | undefined;
+    start?: number | null | undefined;
+    spread?: boolean | null | undefined;
     children: ListContent[];
 }
 
 export interface ListItem extends Parent {
     type: 'listItem';
-    checked?: boolean | undefined;
-    spread?: boolean | undefined;
+    checked?: boolean | null | undefined;
+    spread?: boolean | null | undefined;
     children: BlockContent[];
 }
 
 export interface Table extends Parent {
     type: 'table';
-    align?: AlignType[] | undefined;
+    align?: AlignType[] | null | undefined;
     children: TableContent[];
 }
 
@@ -239,8 +239,8 @@ export interface HTML extends Literal {
 
 export interface Code extends Literal {
     type: 'code';
-    lang?: string | undefined;
-    meta?: string | undefined;
+    lang?: string | null | undefined;
+    meta?: string | null | undefined;
 }
 
 export interface YAML extends Literal {
@@ -318,7 +318,7 @@ export interface Resource {
 
 export interface Association {
     identifier: string;
-    label?: string | undefined;
+    label?: string | null | undefined;
 }
 
 export interface Reference extends Association {
@@ -326,5 +326,5 @@ export interface Reference extends Association {
 }
 
 export interface Alternative {
-    alt?: string | undefined;
+    alt?: string | null | undefined;
 }


### PR DESCRIPTION
Given that the actual code generating mdast (such as remark-parse) has used `null` instead of `undefined` for missing fields, because `null` serializes in JSON and thus makes deep-equality tests with fixtures stored in JSON easier,
recognizing that it is easier to have only of either `undefined` or `null`,
given that TypeScript users might due to the existing types perform a strict equality test against `undefined` and thus introduce bugs such as such as: <https://github.com/remark-embedder/core/pull/30#pullrequestreview-707605193>,
I propose to add `null` as another “missing” value to match the types
with reality.

Related to: DefinitelyTyped/DefinitelyTyped#54547.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/syntax-tree/unist
  > For example, in JavaScript, a tree can be passed through `JSON.parse(JSON.stringify(tree))` and result in the same tree.
  
  ---
  
  also the code examples in: https://github.com/syntax-tree/mdast