### PR TITLE
[relay-runtime] Use 'rawResponse' instead of 'response' for optimisticResponse

### DIFF
--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -554,7 +554,7 @@ type UserFeed_user = {
 // Modern Mutations
 // ~~~~~~~~~~~~~~~~~~~~~
 export const mutation = graphql`
-    mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+    mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) @raw_response_type {
         markReadNotification(data: $input) {
             notification {
                 seenState
@@ -566,6 +566,7 @@ export const mutation = graphql`
 export const optimisticResponse = {
     markReadNotification: {
         notification: {
+            id: '1',
             seenState: 'SEEN' as 'SEEN',
         },
     },
@@ -616,9 +617,18 @@ function markNotificationAsRead(source: string, storyID: string) {
             };
         };
     };
+    type MyMutationRawResponse = {
+        readonly markReadNotification: {
+            readonly notification: {
+                readonly id: string;
+                readonly seenState: 'SEEN' | 'UNSEEN';
+            };
+        };
+    };
     type MyMutation = {
         readonly variables: MyMutationVariables;
         readonly response: MyMutationResponse;
+        readonly rawResponse: MyMutationRawResponse;
     };
 
     commitMutation<MyMutation>(modernEnvironment, {

--- a/types/relay-runtime/lib/mutations/commitMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/commitMutation.d.ts
@@ -19,7 +19,11 @@ export interface MutationConfig<TOperation extends MutationParameters> {
         | ((response: TOperation['response'], errors: ReadonlyArray<PayloadError> | null | undefined) => void)
         | null | undefined;
     onUnsubscribe?: (() => void | null | undefined) | undefined;
-    optimisticResponse?: TOperation['rawResponse'] | undefined;
+    /**
+     * An object whose type matches the raw response type of the mutation. Make sure you decorate
+     * your mutation with `@raw_response_type` if you are using this field.
+     */
+    optimisticResponse?: (TOperation['rawResponse'] extends {} ? TOperation['rawResponse'] : never) | undefined;
     optimisticUpdater?: SelectorStoreUpdater<TOperation['response']> | null | undefined;
     updater?: SelectorStoreUpdater<TOperation['response']> | null | undefined;
     uploadables?: UploadableMap | null | undefined;

--- a/types/relay-runtime/lib/mutations/commitMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/commitMutation.d.ts
@@ -19,7 +19,7 @@ export interface MutationConfig<TOperation extends MutationParameters> {
         | ((response: TOperation['response'], errors: ReadonlyArray<PayloadError> | null | undefined) => void)
         | null | undefined;
     onUnsubscribe?: (() => void | null | undefined) | undefined;
-    optimisticResponse?: TOperation['response'] | undefined;
+    optimisticResponse?: TOperation['rawResponse'] | undefined;
     optimisticUpdater?: SelectorStoreUpdater<TOperation['response']> | null | undefined;
     updater?: SelectorStoreUpdater<TOperation['response']> | null | undefined;
     uploadables?: UploadableMap | null | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/86842c141eb59b31269893f224bf24375a2b3539/packages/relay-runtime/mutations/commitMutation.js#L71
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The type for `optimisticResponse` should use the generated `rawResponse` value instead of `response`. `rawResponse` will include fields added or changed by the relay compiler and that are expected in the response. This is documented here https://relay.dev/docs/guided-tour/updating-data/graphql-mutations/#optimistic-response.

Note this is a breaking change since it is possible the generated type is missing if the mutation is not annotated with `@raw_response_type`. In some cases it will still typecheck fine, but could cause bugs if added fields like `id` are missing from the optimistic response object. To migrate annotate the mutation with `@raw_response_type`.
