### PR TITLE
[mdast] Add frontmatter content map

### DIFF
--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -23,8 +23,8 @@ export type ReferenceType = 'shortcut' | 'collapsed' | 'full';
  * @example
  * declare module 'mdast' {
  *   interface BlockContentMap {
- *     // Allow using toml nodes defined by remark-frontmatter.
- *     toml: TOML;
+ *     // Allow using math nodes defined by `remark-math`.
+ *     math: Math;
  *   }
  * }
  */
@@ -40,6 +40,23 @@ export interface BlockContentMap {
 }
 
 /**
+ * This map registers all frontmatter node types.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface FrontmatterContentMap {
+ *     // Allow using toml nodes defined by `remark-frontmatter`.
+ *     toml: TOML;
+ *   }
+ * }
+ */
+export interface FrontmatterContentMap {
+    yaml: YAML;
+}
+
+/**
  * This map registers all node definition types.
  *
  * This interface can be augmented to register custom node types.
@@ -47,8 +64,7 @@ export interface BlockContentMap {
  * @example
  * declare module 'mdast' {
  *   interface DefinitionContentMap {
- *     // Allow using toml nodes defined by remark-frontmatter.
- *     toml: TOML;
+ *     custom: Custom;
  *   }
  * }
  */
@@ -85,7 +101,7 @@ export interface StaticPhrasingContentMap {
 }
 
 /**
- * This map registers all node types that are acceptable in a static phrasing context, except links.
+ * This map registers all node types that are acceptable in a (interactive) phrasing context (so not in links).
  *
  * This interface can be augmented to register custom node types in a phrasing context, excluding links and link
  * references.
@@ -93,7 +109,7 @@ export interface StaticPhrasingContentMap {
  * @example
  * declare module 'mdast' {
  *   interface PhrasingContentMap {
- *     mdxJsxTextElement: MDXJSXTextElement;
+ *     custom: Custom;
  *   }
  * }
  */
@@ -156,7 +172,7 @@ export type TopLevelContent = BlockContent | FrontmatterContent | DefinitionCont
 
 export type BlockContent = BlockContentMap[keyof BlockContentMap];
 
-export type FrontmatterContent = YAML;
+export type FrontmatterContent = FrontmatterContentMap[keyof FrontmatterContentMap];
 
 export type DefinitionContent = DefinitionContentMap[keyof DefinitionContentMap];
 

--- a/types/mdast/mdast-tests.ts
+++ b/types/mdast/mdast-tests.ts
@@ -3,7 +3,7 @@ import * as Mdast from 'mdast';
 // Augmentations
 
 declare module 'mdast' {
-    interface BlockContentMap {
+    interface FrontmatterContentMap {
         toml: TOML;
     }
 


### PR DESCRIPTION
While for TypeScript block content and frontmatter content mostly the same, it is useful to think of them separately.
Frontmatter namely exists only in top-level content, and typically only as the head (first child).
Frontmatter does not exist in list items, block quotes, or other custom nodes that accept block content.
The TOML node, and other potential nodes from `remark-frontmatter`, should not be added to a `BlockContentMap`, but rather to a `FrontmatterContentMap`.

This is documented in `syntax-tree/mdast` at the extension section for frontmatter as `FrontmatterContent`: <https://github.com/syntax-tree/mdast#frontmattercontent>

I also went through the comments to clarify a couple small nits.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/syntax-tree/mdast#frontmattercontent>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.