### PR TITLE
[hast]: simplify doctypes

### DIFF
--- a/types/hast/hast-tests.ts
+++ b/types/hast/hast-tests.ts
@@ -48,8 +48,6 @@ const text: Text = {
 const docType: DocType = {
     type: 'doctype',
     name: 'name',
-    public: 'public',
-    system: 'system',
 };
 
 const element: Element = getElement();
@@ -73,9 +71,9 @@ const properties: Properties = {
     propertyName2: ['propertyValue2', 'propertyValue3'],
     propertyName3: true,
     propertyName4: 47,
-    propertyName5: [4, "4"],
+    propertyName5: [4, '4'],
     propertyName6: null,
-    propertyName7: undefined
+    propertyName7: undefined,
 };
 
 function getElement(): Element {

--- a/types/hast/index.d.ts
+++ b/types/hast/index.d.ts
@@ -86,16 +86,6 @@ export interface DocType extends UnistNode {
     type: 'doctype';
 
     name: string;
-
-    /**
-     * Represents the document’s public identifier.
-     */
-    public?: string | undefined;
-
-    /**
-     * Represents the document’s system identifier.
-     */
-    system?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
hast recenly moved to no longer respecting `public`, `system` on doctype nodes, as they do not affect HTML.
For folks that are handling XML, xast is a much better ecosystem that does allow more complex doctypes.

See: <https://github.com/syntax-tree/hast/issues/19>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/syntax-tree/hast/issues/19>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.