### PR TITLE
[@types/amqplib] Fix consumerTag missing from ConsumeMessageFields

### DIFF
--- a/types/amqplib/properties.d.ts
+++ b/types/amqplib/properties.d.ts
@@ -170,7 +170,7 @@ export interface GetMessageFields extends CommonMessageFields {
 }
 
 export interface ConsumeMessageFields extends CommonMessageFields {
-    deliveryTag: number;
+    consumerTag: string;
 }
 
 export interface MessageProperties {


### PR DESCRIPTION
Related issue: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30000

^ This PR fixed the types for getMessage/consumeMessage but consumerTag was missing from the ConsumeMessageFields.

After taking a look it appears the deliveryTag was duplicated in ConsumeMessageFields instead of consumerTag being added.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30000
