### PR TITLE
[hast] Add content maps

### DIFF
--- a/types/hast/hast-tests.ts
+++ b/types/hast/hast-tests.ts
@@ -1,6 +1,22 @@
 import { Data, Point, Position } from 'unist';
 import { Parent, Properties, Literal, Root, Element, DocType, Comment, Text } from 'hast';
 
+// Augmentations
+
+declare module 'hast' {
+    interface RootContentMap {
+        raw: Raw;
+    }
+}
+
+interface Raw extends Literal {
+    type: 'raw';
+}
+
+// Tests
+
+declare var raw: Raw;
+
 const data: Data = {
     string: 'string',
     number: 1,
@@ -65,7 +81,7 @@ const root: Root = {
     type: 'root',
     data,
     position,
-    children: [getElement(), docType, comment, text],
+    children: [getElement(), docType, comment, text, raw],
 };
 
 const properties: Properties = {
@@ -73,9 +89,9 @@ const properties: Properties = {
     propertyName2: ['propertyValue2', 'propertyValue3'],
     propertyName3: true,
     propertyName4: 47,
-    propertyName5: [4, "4"],
+    propertyName5: [4, '4'],
     propertyName6: null,
-    propertyName7: undefined
+    propertyName7: undefined,
 };
 
 function getElement(): Element {

--- a/types/hast/index.d.ts
+++ b/types/hast/index.d.ts
@@ -11,13 +11,61 @@ import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } fro
 export { UnistNode as Node };
 
 /**
+ * This map registers all node types that may be used as top-level content in the document.
+ *
+ * These types are accepted inside `root` nodes.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'hast' {
+ *   interface RootContentMap {
+ *     // Allow using raw nodes defined by `rehype-raw`.
+ *     raw: Raw;
+ *   }
+ * }
+ */
+export interface RootContentMap {
+    comment: Comment;
+    doctype: DocType;
+    element: Element;
+    text: Text;
+}
+
+/**
+ * This map registers all node types that may be used as content in an element.
+ *
+ * These types are accepted inside `element` nodes.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'hast' {
+ *   interface RootContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface ElementContentMap {
+    comment: Comment;
+    element: Element;
+    text: Text;
+}
+
+export type Content = RootContent | ElementContent;
+
+export type RootContent = RootContentMap[keyof RootContentMap];
+
+export type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+/**
  * Node in hast containing other nodes.
  */
 export interface Parent extends UnistParent {
     /**
      * List representing the children of a node.
      */
-    children: Array<Element | DocType | Comment | Text>;
+    children: Content[];
 }
 
 /**
@@ -37,6 +85,11 @@ export interface Root extends Parent {
      * Represents this variant of a Node.
      */
     type: 'root';
+
+    /**
+     * List representing the children of a node.
+     */
+    children: RootContent[];
 }
 
 /**
@@ -66,7 +119,7 @@ export interface Element extends Parent {
     /**
      * List representing the children of a node.
      */
-    children: Array<Element | Comment | Text>;
+    children: ElementContent[];
 }
 
 /**


### PR DESCRIPTION
Similar to <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54421>, and <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52375>, this implements a map for the parents defined by hast. One specific example use case is to add raw nodes to the AST. Raw nodes are added by `mdast-util-to-hast` and either handled by `hast-util-raw` or serialized untouched by `hast-util-to-html`.

**Note for the reviewers: xast uses `ChildMap`s. mdast uses a `ContentMap`s. Preference?**

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/syntax-tree/mdast-util-to-hast#optionsallowdangeroushtml>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.