### PR TITLE
[page.js] fix: add current & len page object

### DIFF
--- a/types/page/index.d.ts
+++ b/types/page/index.d.ts
@@ -180,6 +180,16 @@ declare namespace PageJS {
          * This is the click handler used by page to handle routing when a user clicks an anchor like `<a href="/user/profile">`
          */
         clickHandler(e: MouseEvent): void;
+
+        /**
+         * Length of the history stack
+         */
+        len: number;
+
+        /**
+         * Current path
+         */
+        current: string;
     }
 
     interface Route {

--- a/types/page/page-tests.ts
+++ b/types/page/page-tests.ts
@@ -104,3 +104,5 @@ otherPage.clickHandler; // $ExpectType (e: MouseEvent) => void
 page.strict(true); // $ExpectType void
 page.strict(false); // $ExpectType void
 page.strict(); // $ExpectType boolean
+page.current; // $ExpectType string
+page.len; // $ExpectType number


### PR DESCRIPTION
`page.current` is the current path, `page.len` is the size of the history stack.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

https://github.com/visionmedia/page.js/blob/4f9991658f9b9e3de9b6059bade93693af24d6bd/index.js#L562-L578

As you can see here, a `current` and a `len` property are reflected onto the exported page object.

the readme is inaccurate so these are not documented, though they are public so should exist in the types as there's no other sensible way to assert against the current path.
