### PR TITLE
[mongoose-unique-validator] Fix missing type param

### DIFF
--- a/types/mongoose-unique-validator/index.d.ts
+++ b/types/mongoose-unique-validator/index.d.ts
@@ -8,7 +8,7 @@ import { Schema } from "mongoose";
 
 export = mongooseUniqueValidator;
 
-declare function mongooseUniqueValidator(schema: Schema, options?: any): void;
+declare function mongooseUniqueValidator<T = any>(schema: Schema<T>, options?: any): void;
 
 declare namespace mongooseUniqueValidator {
 }

--- a/types/mongoose-unique-validator/index.d.ts
+++ b/types/mongoose-unique-validator/index.d.ts
@@ -8,7 +8,7 @@ import { Schema } from "mongoose";
 
 export = mongooseUniqueValidator;
 
-declare function mongooseUniqueValidator<T = any>(schema: Schema<T>, options?: any): void;
+declare function mongooseUniqueValidator(schema: Schema<any>, options?: any): void;
 
 declare namespace mongooseUniqueValidator {
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: without this, I am getting an error using the package (`User` is my custom type):
Code:
```ts
userSchema.plugin(uniqueValidator);
```

```ts
Argument of type '(schema: Schema<Document<any, any, any>, Model<any, any, any>, undefined, any>, options?: any) => void' is not assignable to parameter of type '(schema: Schema<User, Model<User, {}, {}>, undefined, {}>, opts?: any) => void'.
  Types of parameters 'schema' and 'schema' are incompatible.
    Type 'Schema<User, Model<User, {}, {}>, undefined, {}>' is not assignable to type 'Schema<Document<any, any, any>, Model<any, any, any>, undefined, any>'.
      Types of property 'methods' are incompatible.
        Type '{ [name: string]: (this: User & Document<any, any, User>, ...args: any[]) => any; }' is not assignable to type '{ [name: string]: (this: Document<any, any, any>, ...args: any[]) => any; }'.
          Index signatures are incompatible.
            Type '(this: User & Document<any, any, User>, ...args: any[]) => any' is not assignable to type '(this: Document<any, any, any>, ...args: any[]) => any'.
              The 'this' types of each signature are incompatible.
                Type 'Document<any, any, any>' is not assignable to type 'User & Document<any, any, User>'.
                  Type 'Document<any, any, any>' is missing the following properties from type 'User': name, email, password
```

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
