### PR TITLE
[rimraf] Bugfix: Account for null and undefined errors

### DIFF
--- a/types/rimraf/index.d.ts
+++ b/types/rimraf/index.d.ts
@@ -26,24 +26,24 @@ declare namespace rimraf {
      * see {@link https://github.com/isaacs/rimraf/blob/79b933fb362b2c51bedfa448be848e1d7ed32d7e/README.md#options}
      */
     interface Options {
-        maxBusyTries?: number;
-        emfileWait?: number;
+        maxBusyTries?: number | undefined;
+        emfileWait?: number | undefined;
         /** @default false */
-        disableGlob?: boolean;
-        glob?: glob.IOptions | false;
+        disableGlob?: boolean | undefined;
+        glob?: glob.IOptions | false | undefined;
 
-        unlink?: typeof fs.unlink;
-        chmod?: typeof fs.chmod;
-        stat?: typeof fs.stat;
-        lstat?: typeof fs.lstat;
-        rmdir?: typeof fs.rmdir;
-        readdir?: typeof fs.readdir;
-        unlinkSync?: typeof fs.unlinkSync;
-        chmodSync?: typeof fs.chmodSync;
-        statSync?: typeof fs.statSync;
-        lstatSync?: typeof fs.lstatSync;
-        rmdirSync?: typeof fs.rmdirSync;
-        readdirSync?: typeof fs.readdirSync;
+        unlink?: typeof fs.unlink | undefined;
+        chmod?: typeof fs.chmod | undefined;
+        stat?: typeof fs.stat | undefined;
+        lstat?: typeof fs.lstat | undefined;
+        rmdir?: typeof fs.rmdir | undefined;
+        readdir?: typeof fs.readdir | undefined;
+        unlinkSync?: typeof fs.unlinkSync | undefined;
+        chmodSync?: typeof fs.chmodSync | undefined;
+        statSync?: typeof fs.statSync | undefined;
+        lstatSync?: typeof fs.lstatSync | undefined;
+        rmdirSync?: typeof fs.rmdirSync | undefined;
+        readdirSync?: typeof fs.readdirSync | undefined;
     }
 }
 export = rimraf;

--- a/types/rimraf/index.d.ts
+++ b/types/rimraf/index.d.ts
@@ -12,8 +12,8 @@
 import glob = require('glob');
 import fs = require('fs');
 
-declare function rimraf(path: string, options: rimraf.Options, callback: (error: Error | null) => void): void;
-declare function rimraf(path: string, callback: (error: Error | null) => void): void;
+declare function rimraf(path: string, options: rimraf.Options, callback: (error: Error | null | undefined) => void): void;
+declare function rimraf(path: string, callback: (error: Error | null | undefined) => void): void;
 declare namespace rimraf {
     /**
      * It can remove stuff synchronously, too.

--- a/types/rimraf/index.d.ts
+++ b/types/rimraf/index.d.ts
@@ -12,8 +12,8 @@
 import glob = require('glob');
 import fs = require('fs');
 
-declare function rimraf(path: string, options: rimraf.Options, callback: (error: Error) => void): void;
-declare function rimraf(path: string, callback: (error: Error) => void): void;
+declare function rimraf(path: string, options: rimraf.Options, callback: (error: Error | null) => void): void;
+declare function rimraf(path: string, callback: (error: Error | null) => void): void;
 declare namespace rimraf {
     /**
      * It can remove stuff synchronously, too.
@@ -26,24 +26,24 @@ declare namespace rimraf {
      * see {@link https://github.com/isaacs/rimraf/blob/79b933fb362b2c51bedfa448be848e1d7ed32d7e/README.md#options}
      */
     interface Options {
-        maxBusyTries?: number | undefined;
-        emfileWait?: number | undefined;
+        maxBusyTries?: number;
+        emfileWait?: number;
         /** @default false */
-        disableGlob?: boolean | undefined;
-        glob?: glob.IOptions | false | undefined;
+        disableGlob?: boolean;
+        glob?: glob.IOptions | false;
 
-        unlink?: typeof fs.unlink | undefined;
-        chmod?: typeof fs.chmod | undefined;
-        stat?: typeof fs.stat | undefined;
-        lstat?: typeof fs.lstat | undefined;
-        rmdir?: typeof fs.rmdir | undefined;
-        readdir?: typeof fs.readdir | undefined;
-        unlinkSync?: typeof fs.unlinkSync | undefined;
-        chmodSync?: typeof fs.chmodSync | undefined;
-        statSync?: typeof fs.statSync | undefined;
-        lstatSync?: typeof fs.lstatSync | undefined;
-        rmdirSync?: typeof fs.rmdirSync | undefined;
-        readdirSync?: typeof fs.readdirSync | undefined;
+        unlink?: typeof fs.unlink;
+        chmod?: typeof fs.chmod;
+        stat?: typeof fs.stat;
+        lstat?: typeof fs.lstat;
+        rmdir?: typeof fs.rmdir;
+        readdir?: typeof fs.readdir;
+        unlinkSync?: typeof fs.unlinkSync;
+        chmodSync?: typeof fs.chmodSync;
+        statSync?: typeof fs.statSync;
+        lstatSync?: typeof fs.lstatSync;
+        rmdirSync?: typeof fs.rmdirSync;
+        readdirSync?: typeof fs.readdirSync;
     }
 }
 export = rimraf;

--- a/types/rimraf/rimraf-tests.ts
+++ b/types/rimraf/rimraf-tests.ts
@@ -1,7 +1,7 @@
 import rimraf = require('rimraf');
 
-rimraf('./xyz', (_: Error | null) => {});
+rimraf('./xyz', (_: Error | null | undefined) => {});
 rimraf.sync('./xyz');
 
-rimraf('./xyz', { glob: { ignore: '' } }, (_: Error | null) => {});
+rimraf('./xyz', { glob: { ignore: '' } }, (_: Error | null | undefined) => {});
 rimraf.sync('./xyz', { glob: { ignore: '' } });

--- a/types/rimraf/rimraf-tests.ts
+++ b/types/rimraf/rimraf-tests.ts
@@ -1,7 +1,7 @@
 import rimraf = require('rimraf');
 
-rimraf('./xyz', (err: Error) => {});
+rimraf('./xyz', (_: Error | null) => {});
 rimraf.sync('./xyz');
 
-rimraf('./xyz', { glob: { ignore: '' } }, (err: Error) => {});
+rimraf('./xyz', { glob: { ignore: '' } }, (_: Error | null) => {});
 rimraf.sync('./xyz', { glob: { ignore: '' } });


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

See https://github.com/isaacs/rimraf/blob/8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444/rimraf.js#L78 for an example where `rimraf` gives the callback `undefined` and https://github.com/isaacs/rimraf/blob/8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444/rimraf.js#L150 for an example where `rimraf` gives the callback `null`. 

In brief: If `rimraf` runs successfully, the callback function can't count on the first argument being an error.