### PR TITLE
Fix @types/react-places-autocomplete componentRestrictions type

### DIFF
--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -35,7 +35,7 @@ export interface PropTypes {
     onSelect?: ((address: string, placeID: string) => void) | undefined;
     searchOptions?: {
         bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | undefined;
-        componentRestrictions?: google.maps.GeocoderComponentRestrictions | undefined;
+        componentRestrictions?: google.maps.places.ComponentRestrictions | undefined;
         location?: google.maps.LatLng | google.maps.LatLngLiteral | undefined;
         offset?: number | string | undefined;
         radius?: number | string | undefined;

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import PlacesAutocomplete, {
-    geocodeByAddress, geocodeByPlaceId, getLatLng
-} from 'react-places-autocomplete';
+import PlacesAutocomplete, { geocodeByAddress, geocodeByPlaceId, getLatLng } from 'react-places-autocomplete';
 
 class Test extends React.Component {
     state = {
@@ -15,26 +13,31 @@ class Test extends React.Component {
         const { address, placeId } = this.state;
 
         geocodeByAddress(address)
-            .then((results) => getLatLng(results[0]))
-            .then((latLng) => console.log('Success', latLng))
-            .catch((error) => console.error('Error', error));
+            .then(results => getLatLng(results[0]))
+            .then(latLng => console.log('Success', latLng))
+            .catch(error => console.error('Error', error));
 
         geocodeByPlaceId(placeId)
-            .then((results) => getLatLng(results[0]))
-            .then((latLng) => console.log('Success', latLng))
-            .catch((error) => console.error('Error', error));
-    }
+            .then(results => getLatLng(results[0]))
+            .then(latLng => console.log('Success', latLng))
+            .catch(error => console.error('Error', error));
+    };
 
     onChange = (address: string) => this.setState({ address });
 
     render() {
         return (
             <form onSubmit={this.handleFormSubmit}>
-                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name" searchOptions={{ componentRestrictions:{ country: ['US']} }}>
-                    {({getInputProps, suggestions, getSuggestionItemProps, loading}) => {
+                <PlacesAutocomplete
+                    value={this.state.address}
+                    onChange={this.onChange}
+                    googleCallbackName="google_callback_name"
+                    searchOptions={{ componentRestrictions: { country: ['US'] } }}
+                >
+                    {({ getInputProps, suggestions, getSuggestionItemProps, loading }) => {
                         const inputProps = getInputProps({
                             required: true,
-                            className: loading ? 'is-pending' : ''
+                            className: loading ? 'is-pending' : '',
                         });
                         return (
                             <>
@@ -42,19 +45,14 @@ class Test extends React.Component {
                                 <div>
                                     {suggestions.map(suggestion => {
                                         const divProps = getSuggestionItemProps(suggestion, {
-                                            className: suggestion.active ? 'active' : ''
+                                            className: suggestion.active ? 'active' : '',
                                         });
-                                        return (
-                                            <div {...divProps}>
-                                                {suggestion.description}
-                                            </div>
-                                        );
+                                        return <div {...divProps}>{suggestion.description}</div>;
                                     })}
                                 </div>
                             </>
                         );
-                    }
-                }
+                    }}
                 </PlacesAutocomplete>
             </form>
         );

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -30,7 +30,7 @@ class Test extends React.Component {
     render() {
         return (
             <form onSubmit={this.handleFormSubmit}>
-                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name">
+                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name" searchOptions={{ componentRestrictions:{ country: ['US']} }}>
                     {({getInputProps, suggestions, getSuggestionItemProps, loading}) => {
                         const inputProps = getInputProps({
                             required: true,

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -30,7 +30,7 @@ class Test extends React.Component {
     render() {
         return (
             <form onSubmit={this.handleFormSubmit}>
-                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name" searchOptions={{ componentRestrictions:{ country: ['US']} }}>
+                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name" searchOptions={{componentRestrictions:{country:['US']}}}>
                     {({getInputProps, suggestions, getSuggestionItemProps, loading}) => {
                         const inputProps = getInputProps({
                             required: true,

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import PlacesAutocomplete, { geocodeByAddress, geocodeByPlaceId, getLatLng } from 'react-places-autocomplete';
+import PlacesAutocomplete, {
+    geocodeByAddress, geocodeByPlaceId, getLatLng
+} from 'react-places-autocomplete';
 
 class Test extends React.Component {
     state = {
@@ -13,31 +15,26 @@ class Test extends React.Component {
         const { address, placeId } = this.state;
 
         geocodeByAddress(address)
-            .then(results => getLatLng(results[0]))
-            .then(latLng => console.log('Success', latLng))
-            .catch(error => console.error('Error', error));
+            .then((results) => getLatLng(results[0]))
+            .then((latLng) => console.log('Success', latLng))
+            .catch((error) => console.error('Error', error));
 
         geocodeByPlaceId(placeId)
-            .then(results => getLatLng(results[0]))
-            .then(latLng => console.log('Success', latLng))
-            .catch(error => console.error('Error', error));
-    };
+            .then((results) => getLatLng(results[0]))
+            .then((latLng) => console.log('Success', latLng))
+            .catch((error) => console.error('Error', error));
+    }
 
     onChange = (address: string) => this.setState({ address });
 
     render() {
         return (
             <form onSubmit={this.handleFormSubmit}>
-                <PlacesAutocomplete
-                    value={this.state.address}
-                    onChange={this.onChange}
-                    googleCallbackName="google_callback_name"
-                    searchOptions={{ componentRestrictions: { country: ['US'] } }}
-                >
-                    {({ getInputProps, suggestions, getSuggestionItemProps, loading }) => {
+                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name" searchOptions={{ componentRestrictions:{ country: ['US']} }}>
+                    {({getInputProps, suggestions, getSuggestionItemProps, loading}) => {
                         const inputProps = getInputProps({
                             required: true,
-                            className: loading ? 'is-pending' : '',
+                            className: loading ? 'is-pending' : ''
                         });
                         return (
                             <>
@@ -45,14 +42,19 @@ class Test extends React.Component {
                                 <div>
                                     {suggestions.map(suggestion => {
                                         const divProps = getSuggestionItemProps(suggestion, {
-                                            className: suggestion.active ? 'active' : '',
+                                            className: suggestion.active ? 'active' : ''
                                         });
-                                        return <div {...divProps}>{suggestion.description}</div>;
+                                        return (
+                                            <div {...divProps}>
+                                                {suggestion.description}
+                                            </div>
+                                        );
                                     })}
                                 </div>
                             </>
                         );
-                    }}
+                    }
+                }
                 </PlacesAutocomplete>
             </form>
         );

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -29,32 +29,32 @@ class Test extends React.Component {
 
     render() {
         return (
-            <form onSubmit={this.handleFormSubmit}>
-                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} googleCallbackName="google_callback_name" searchOptions={{componentRestrictions:{country:['US']}}}>
-                    {({getInputProps, suggestions, getSuggestionItemProps, loading}) => {
+            <form onSubmit={ this.handleFormSubmit }>
+                <PlacesAutocomplete value={ this.state.address } onChange={ this.onChange } googleCallbackName="google_callback_name" searchOptions={ { componentRestrictions: { country: ['US'] } } }>
+                    { ({ getInputProps, suggestions, getSuggestionItemProps, loading }) => {
                         const inputProps = getInputProps({
                             required: true,
                             className: loading ? 'is-pending' : ''
                         });
                         return (
                             <>
-                                <input {...inputProps} />
+                                <input { ...inputProps } />
                                 <div>
-                                    {suggestions.map(suggestion => {
+                                    { suggestions.map(suggestion => {
                                         const divProps = getSuggestionItemProps(suggestion, {
                                             className: suggestion.active ? 'active' : ''
                                         });
                                         return (
-                                            <div {...divProps}>
-                                                {suggestion.description}
+                                            <div { ...divProps }>
+                                                { suggestion.description }
                                             </div>
                                         );
-                                    })}
+                                    }) }
                                 </div>
                             </>
                         );
                     }
-                }
+                    }
                 </PlacesAutocomplete>
             </form>
         );


### PR DESCRIPTION
The type used was for Google geocoder service and should be from the used places auto complete service.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#ComponentRestrictions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
