### PR TITLE
Fix @ckeditor/core PluginCollection has()

### DIFF
--- a/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
@@ -8,8 +8,8 @@ import {
     attachToForm,
     MultiCommand,
     EditorUI,
-} from "@ckeditor/ckeditor5-core";
-import View from "@ckeditor/ckeditor5-ui/src/view";
+} from '@ckeditor/ckeditor5-core';
+import View from '@ckeditor/ckeditor5-ui/src/view';
 
 let comm: Command;
 
@@ -30,11 +30,11 @@ class MyEditor extends Editor {
     }
 }
 
-const PluginArray: Array<typeof Plugin|typeof ContextPlugin|string> = MyEditor.builtinPlugins;
-PluginArray.forEach(plugin => typeof plugin !== "string" && plugin.pluginName);
+const PluginArray: Array<typeof Plugin | typeof ContextPlugin | string> = MyEditor.builtinPlugins;
+PluginArray.forEach(plugin => typeof plugin !== 'string' && plugin.pluginName);
 
-const editor = new MyEditor(document.createElement("div"));
-const editorState: "initializing" | "ready" | "destroyed" = editor.state;
+const editor = new MyEditor(document.createElement('div'));
+const editorState: 'initializing' | 'ready' | 'destroyed' = editor.state;
 // $ExpectError
 editor.state = editorState;
 editor.focus();
@@ -42,7 +42,7 @@ editor.destroy().then(() => {});
 editor.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
 
 MyEditor.defaultConfig = {
-    placeholder: "foo",
+    placeholder: 'foo',
 };
 // $ExpectError
 MyEditor.defaultConfig = 4;
@@ -74,9 +74,15 @@ myPlugin.isEnabled = true;
  */
 editor.plugins.get(MyPlugin).myMethod();
 (editor.plugins.get('MyPlugin') as MyPlugin).myMethod();
+// $ExpectType boolean
+editor.plugins.has('foo');
+// $ExpectType boolean
+editor.plugins.has(MyPlugin);
+// $ExpectError
+editor.plugins.has(class Foo {});
 
 // $ExpectError
-editor.plugins.get(class Foo);
+editor.plugins.get(class Foo {});
 editor.plugins.get(class Foo extends Plugin {});
 
 class MyEmptyEditor extends Editor {
@@ -91,8 +97,8 @@ class SomeCommand extends Command {
 }
 const command = new Command(new MyEmptyEditor());
 command.execute();
-command.execute("foo", "bar", true, false, 50033);
-command.execute(4545454, "refresh", [], []);
+command.execute('foo', 'bar', true, false, 50033);
+command.execute(4545454, 'refresh', [], []);
 command.execute({}, { foo: 5 });
 
 const ed: Editor = command.editor;
@@ -107,7 +113,7 @@ command.execute();
 
 command.refresh();
 
-command.value = "foo";
+command.value = 'foo';
 delete command.value;
 
 command.isEnabled = false;
@@ -120,7 +126,7 @@ delete command.isEnabled;
  */
 
 const context = new Context();
-const contextWithConfig = new Context({ foo: "foo" });
+const contextWithConfig = new Context({ foo: 'foo' });
 context.destroy().then(() => {});
 contextWithConfig.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
 
@@ -154,11 +160,11 @@ context.plugins.get(MyCPlugin).myCMethod();
  * DataApiMixin
  */
 
-DataApiMixin.setData("foo");
+DataApiMixin.setData('foo');
 // $ExpectError
-DataApiMixin.getData("foo");
-DataApiMixin.getData({ rootName: "foo" });
-DataApiMixin.getData({ rootName: "foo", trim: "none" });
+DataApiMixin.getData('foo');
+DataApiMixin.getData({ rootName: 'foo' });
+DataApiMixin.getData({ rootName: 'foo', trim: 'none' });
 
 /**
  * attachToForm
@@ -175,4 +181,4 @@ MC.registerChildCommand(comm);
 
 /* EditorUI */
 new EditorUI(editor).componentFactory.editor === editor;
-new EditorUI(editor).componentFactory.add("", (locale) => new View(locale));
+new EditorUI(editor).componentFactory.add('', locale => new View(locale));

--- a/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
@@ -21,7 +21,7 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
     get<T extends ContextPlugin>(key: PluginInterface<T>): T;
     get(key: string): Plugin | ContextPlugin;
 
-    has(key: () => Plugin | string): boolean;
+    has(key: PluginInterface | string): boolean;
 
     init(
         plugins: Array<(() => Plugin) | string>,

--- a/types/ckeditor__ckeditor5-core/v27/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/v27/ckeditor__ckeditor5-core-tests.ts
@@ -7,7 +7,9 @@ import {
     DataApiMixin,
     attachToForm,
     MultiCommand,
-} from "@ckeditor/ckeditor5-core";
+    EditorUI,
+} from '@ckeditor/ckeditor5-core';
+import View from '@ckeditor/ckeditor5-ui/src/view';
 
 let comm: Command;
 
@@ -28,11 +30,11 @@ class MyEditor extends Editor {
     }
 }
 
-const PluginArray: Array<typeof Plugin|typeof ContextPlugin|string> = MyEditor.builtinPlugins;
-PluginArray.forEach(plugin => typeof plugin !== "string" && plugin.pluginName);
+const PluginArray: Array<typeof Plugin | typeof ContextPlugin | string> = MyEditor.builtinPlugins;
+PluginArray.forEach(plugin => typeof plugin !== 'string' && plugin.pluginName);
 
-const editor = new MyEditor(document.createElement("div"));
-const editorState: "initializing" | "ready" | "destroyed" = editor.state;
+const editor = new MyEditor(document.createElement('div'));
+const editorState: 'initializing' | 'ready' | 'destroyed' = editor.state;
 // $ExpectError
 editor.state = editorState;
 editor.focus();
@@ -40,7 +42,7 @@ editor.destroy().then(() => {});
 editor.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
 
 MyEditor.defaultConfig = {
-    placeholder: "foo",
+    placeholder: 'foo',
 };
 // $ExpectError
 MyEditor.defaultConfig = 4;
@@ -52,6 +54,8 @@ MyEditor.defaultConfig = { foo: 5 };
  */
 
 class MyPlugin extends Plugin {
+    readonly pluginName: 'MyPlugin';
+
     myMethod() {
         return null;
     }
@@ -63,6 +67,22 @@ promise != null && promise.then(() => {});
 myPlugin.myMethod();
 myPlugin.isEnabled = true;
 
+/**
+ * PluginCollection
+ */
+editor.plugins.get(MyPlugin).myMethod();
+(editor.plugins.get('MyPlugin') as MyPlugin).myMethod();
+// $ExpectType boolean
+editor.plugins.has('foo');
+// $ExpectType boolean
+editor.plugins.has(MyPlugin);
+// $ExpectError
+editor.plugins.has(class Foo {});
+
+// $ExpectError
+editor.plugins.get(class Foo {});
+editor.plugins.get(class Foo extends Plugin {});
+
 class MyEmptyEditor extends Editor {
     static builtinPlugins = [MyPlugin];
 }
@@ -71,17 +91,21 @@ class MyEmptyEditor extends Editor {
  * Command
  */
 class SomeCommand extends Command {
-    execute() {}
+    execute(...args: unknown[]) {
+        console.log(args);
+    }
 }
-const command = new Command(new MyEmptyEditor());
+const command = new SomeCommand(new MyEmptyEditor());
 command.execute();
-command.execute("foo", "bar", true, false, 50033);
-command.execute(4545454, "refresh", [], []);
+command.execute('foo', 'bar', true, false, 50033);
+command.execute(4545454, 'refresh', [], []);
 command.execute({}, { foo: 5 });
 
-const ed: Editor = command.editor;
+// $ExpectType Editor
+command.editor;
 
-const bool: boolean = command.isEnabled;
+// $ExpectType boolean
+command.isEnabled;
 
 comm = new Command(editor);
 
@@ -91,7 +115,7 @@ command.execute();
 
 command.refresh();
 
-command.value = "foo";
+command.value = 'foo';
 delete command.value;
 
 command.isEnabled = false;
@@ -104,7 +128,7 @@ delete command.isEnabled;
  */
 
 const context = new Context();
-const contextWithConfig = new Context({ foo: "foo" });
+const contextWithConfig = new Context({ foo: 'foo' });
 context.destroy().then(() => {});
 contextWithConfig.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
 
@@ -118,18 +142,28 @@ if (afterInitPromise != null) {
 }
 
 class MyCPlugin extends ContextPlugin {
+    readonly pluginName: 'MyCPlugin';
     builtinPlugins: [MyPlugin];
+    myCMethod() {
+        return null;
+    }
 }
+
+editor.plugins.get(MyCPlugin).myCMethod();
+(editor.plugins.get('MyCPlugin') as MyCPlugin).myCMethod();
+
+context.plugins.get(MyCPlugin).myCMethod();
+(context.plugins.get('MyCPlugin') as MyCPlugin).myCMethod();
 
 /**
  * DataApiMixin
  */
 
-DataApiMixin.setData("foo");
+DataApiMixin.setData('foo');
 // $ExpectError
-DataApiMixin.getData("foo");
-DataApiMixin.getData({ rootName: "foo" });
-DataApiMixin.getData({ rootName: "foo", trim: "none" });
+DataApiMixin.getData('foo');
+DataApiMixin.getData({ rootName: 'foo' });
+DataApiMixin.getData({ rootName: 'foo', trim: 'none' });
 
 /**
  * attachToForm
@@ -143,3 +177,7 @@ attachToForm(editor);
  */
 const MC = new MultiCommand(editor);
 MC.registerChildCommand(comm);
+
+/* EditorUI */
+new EditorUI(editor).componentFactory.editor === editor;
+new EditorUI(editor).componentFactory.add('', locale => new View(locale));

--- a/types/ckeditor__ckeditor5-core/v27/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugin.d.ts
@@ -54,16 +54,8 @@ export default abstract class Plugin implements Emitter, Observable {
 }
 
 // Beware that this defines a class constructor, not the class instance.
-// These readonly properties are static properties.
-export interface PluginInterface {
-    new (editor: Editor): {
-        init?(): Promise<void> | void;
-        afterInit?(): Promise<void> | void;
-        destroy?(): Promise<void> | void;
-    };
-    readonly pluginName?: string | undefined;
-    readonly isContextPlugin: boolean;
-    readonly requires?: Array<typeof Plugin | typeof ContextPlugin | string> | undefined;
+export interface PluginInterface<T = Plugin> {
+    new (editor: Editor): T;
 }
 
 export type LoadedPlugins = Array<typeof Plugin|typeof ContextPlugin>;

--- a/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
@@ -3,8 +3,9 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Context from "./context";
+import ContextPlugin from "./contextplugin";
 import Editor from "./editor/editor";
-import Plugin, { LoadedPlugins } from "./plugin";
+import Plugin, { PluginInterface, LoadedPlugins } from "./plugin";
 
 export default class PluginCollection implements Emitter, Iterable<[typeof Plugin, Plugin]> {
     constructor(
@@ -15,8 +16,13 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
 
     [Symbol.iterator](): Iterator<[typeof Plugin, Plugin]>;
     destroy(): Promise<void>;
-    get(key: (() => Plugin) | string): Plugin;
-    has(key: (() => Plugin) | string): boolean;
+
+    get<T extends Plugin>(key: PluginInterface<T>): T;
+    get<T extends ContextPlugin>(key: PluginInterface<T>): T;
+    get(key: string): Plugin | ContextPlugin;
+
+    has(key: PluginInterface | string): boolean;
+
     init(
         plugins: Array<(() => Plugin) | string>,
         pluginsToRemove: Array<(() => Plugin) | string>,


### PR DESCRIPTION
`has()` accepts a `Plugin` constructor, or a string, not a function that returns a string.

Also, backported some changes from latest version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginCollection.html#function-has
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.