### PR TITLE
Fix @ckeditor/ui EditableUIView _hasExternalElement

### DIFF
--- a/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
@@ -65,7 +65,7 @@ let bool = true;
 let view = new View();
 view.isRendered === bool;
 let template: Template;
-if (typeof view.template !== "boolean") {
+if (typeof view.template !== 'boolean') {
     template = view.template;
 }
 template = view.template as Template;
@@ -336,7 +336,10 @@ viewCollection = boxedEditor.main;
 /**
  * EditableUIView
  */
-new InlineEditableUIView(locale, view);
+// $ExpectType boolean
+new InlineEditableUIView(locale, view)._hasExternalElement;
+// $ExpectError
+new InlineEditableUIView(locale, view)._hasExternalElement = true;
 
 /**
  * FormHeaderView

--- a/types/ckeditor__ckeditor5-ui/src/editableui/editableuiview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/editableui/editableuiview.d.ts
@@ -4,6 +4,8 @@ import View from "../view";
 export default class EditableUIView extends View {
     isFocused: boolean;
     name: string;
+    get _hasExternalElement(): boolean;
+    protected set _hasExternalElement(newValue: boolean);
 
     constructor(locale: Locale, editingView: View, editableElement?: HTMLElement);
 }

--- a/types/ckeditor__ckeditor5-ui/v27/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/ckeditor__ckeditor5-ui-tests.ts
@@ -336,7 +336,10 @@ viewCollection = boxedEditor.main;
 /**
  * EditableUIView
  */
-new InlineEditableUIView(locale, view);
+// $ExpectType boolean
+new InlineEditableUIView(locale, view)._hasExternalElement;
+// $ExpectError
+new InlineEditableUIView(locale, view)._hasExternalElement = true;
 
 /**
  * FormHeaderView

--- a/types/ckeditor__ckeditor5-ui/v27/src/editableui/editableuiview.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/editableui/editableuiview.d.ts
@@ -4,6 +4,8 @@ import View from "../view";
 export default class EditableUIView extends View {
     isFocused: boolean;
     name: string;
+    get _hasExternalElement(): boolean;
+    protected set _hasExternalElement(newValue: boolean);
 
     constructor(locale: Locale, editingView: View, editableElement?: HTMLElement);
 }


### PR DESCRIPTION
Even though `_hasExternalElement` should be private, it's been acccesed from the outside at https://github.com/ckeditor/ckeditor5/blob/18123a72726a2f9f052189b89ec58218603d26da/packages/ckeditor5-source-editing/src/sourceediting.js#L362

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/18123a72726a2f9f052189b89ec58218603d26da/packages/ckeditor5-source-editing/src/sourceediting.js#L362
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.