### PR TITLE
Update @ckeditor/* minimum TS version to 4.3

### DIFF
--- a/types/ckeditor__ckeditor5-adapter-ckfinder/index.d.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/adapter-ckfinder.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as UploadAdapter } from './src/uploadadapter';

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/adapter-ckfinder.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import UploadAdapter from './src/uploadadapter';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-alignment/index.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/alignment.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Alignment } from './src/alignment';
 export { default as AlignmentEditing } from './src/alignmentediting';

--- a/types/ckeditor__ckeditor5-alignment/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/alignment.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Alignment from './src/alignment';
 import AlignmentEditing from './src/alignmentediting';
 import AlignmentUI from './src/alignmentui';

--- a/types/ckeditor__ckeditor5-autoformat/index.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/autoformat.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Autoformat } from './src/autoformat';

--- a/types/ckeditor__ckeditor5-autoformat/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/autoformat.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Autoformat from './src/autoformat';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-autosave/index.d.ts
+++ b/types/ckeditor__ckeditor5-autosave/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-autosave
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Autosave from './src/autosave';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-basic-styles/index.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/basic-styles.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Bold } from './src/bold';
 export { default as BoldEditing } from './src/bold/boldediting';

--- a/types/ckeditor__ckeditor5-basic-styles/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/basic-styles.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Bold from './src/bold';
 import BoldEditing from './src/bold/boldediting';
 import BoldUI from './src/bold/boldui';

--- a/types/ckeditor__ckeditor5-block-quote/index.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as BlockQuote } from './src/blockquote';
 export { default as BlockQuoteEditing } from './src/blockquoteediting';

--- a/types/ckeditor__ckeditor5-block-quote/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import BlockQuote from './src/blockquote';
 import BlockQuoteEditing from './src/blockquoteediting';
 import BlockQuoteUI from './src/blockquoteui';

--- a/types/ckeditor__ckeditor5-build-balloon-block/index.d.ts
+++ b/types/ckeditor__ckeditor5-build-balloon-block/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/builds/index.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 import BalloonEditorBase from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
 

--- a/types/ckeditor__ckeditor5-build-balloon/index.d.ts
+++ b/types/ckeditor__ckeditor5-build-balloon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/builds/index.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import BalloonEditorBase from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
 
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';

--- a/types/ckeditor__ckeditor5-build-classic/index.d.ts
+++ b/types/ckeditor__ckeditor5-build-classic/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/builds/index.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import ClassicEditorBase from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';

--- a/types/ckeditor__ckeditor5-build-decoupled-document/index.d.ts
+++ b/types/ckeditor__ckeditor5-build-decoupled-document/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/builds/index.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 import DecoupledEditorBase from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
 

--- a/types/ckeditor__ckeditor5-build-inline/index.d.ts
+++ b/types/ckeditor__ckeditor5-build-inline/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/builds/index.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import InlineEditorBase from '@ckeditor/ckeditor5-editor-inline/src/inlineeditor';
 
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';

--- a/types/ckeditor__ckeditor5-ckfinder/ckeditor__ckeditor5-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/ckeditor__ckeditor5-ckfinder-tests.ts
@@ -20,3 +20,5 @@ ckfinderui.init();
 
 const ckfinderediting = new CKFinderEditing(new MyEditor());
 ckfinderediting.init();
+
+new CKFinderCommand(new BaseEditor()).execute();

--- a/types/ckeditor__ckeditor5-ckfinder/index.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/ckfinder.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as CKFinder } from './src/ckfinder';
 export { default as CKFinderEditing } from './src/ckfinderediting';

--- a/types/ckeditor__ckeditor5-ckfinder/v27/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-src/ckfindercommand.d.ts

--- a/types/ckeditor__ckeditor5-ckfinder/v27/ckeditor__ckeditor5-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/ckeditor__ckeditor5-ckfinder-tests.ts
@@ -1,21 +1,24 @@
-import Finder from "@ckeditor/ckeditor5-ckfinder";
+import CKFinder from "@ckeditor/ckeditor5-ckfinder";
 import { Editor, Plugin } from "@ckeditor/ckeditor5-core";
 import PluginCollection from "@ckeditor/ckeditor5-core/src/plugincollection";
+import CKFinderCommand from "@ckeditor/ckeditor5-ckfinder/src/ckfindercommand";
 
-if (!(Finder.CKFinder instanceof Plugin)) {
+if (!(CKFinder instanceof Plugin)) {
     throw new Error("CKFinder must be a Plugin instance");
 }
 
 class BaseEditor extends Editor {}
 
-const plugincollection = new PluginCollection(new BaseEditor(), [Finder.CKFinder]);
+const plugincollection = new PluginCollection(new BaseEditor(), [CKFinder.CKFinder]);
 
 class MyEditor extends Editor {
     plugins = plugincollection;
 }
 
-const ckfinderui = new Finder.CKFinderUI(new MyEditor());
+const ckfinderui = new CKFinder.CKFinderUI(new MyEditor());
 ckfinderui.init();
 
-const ckfinderediting = new Finder.CKFinderEditing(new MyEditor());
+const ckfinderediting = new CKFinder.CKFinderEditing(new MyEditor());
 ckfinderediting.init();
+
+new CKFinderCommand(new BaseEditor()).execute();

--- a/types/ckeditor__ckeditor5-ckfinder/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/ckfinder.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import CKFinder from './src/ckfinder';
 import CKFinderEditing from './src/ckfinderediting';
 import CKFinderUI from './src/ckfinderui';

--- a/types/ckeditor__ckeditor5-clipboard/index.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/clipboard.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Clipboard } from './src/clipboard';
 export { default as ClipboardPipeline } from './src/clipboardpipeline';

--- a/types/ckeditor__ckeditor5-clipboard/v27/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-clipboard/v27/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-src/clipboardobserver.d.ts

--- a/types/ckeditor__ckeditor5-clipboard/v27/ckeditor__ckeditor5-clipboard-tests.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/ckeditor__ckeditor5-clipboard-tests.ts
@@ -1,12 +1,15 @@
 import Clipboard from '@ckeditor/ckeditor5-clipboard';
+import ClipboardObserver from '@ckeditor/ckeditor5-clipboard/src/clipboardobserver';
 import normalizeClipboardData from '@ckeditor/ckeditor5-clipboard/src/utils/normalizeclipboarddata';
 import plainTextToHTML from '@ckeditor/ckeditor5-clipboard/src/utils/plaintexttohtml';
 import viewToPlainText from '@ckeditor/ckeditor5-clipboard/src/utils/viewtoplaintext';
 import { Editor } from '@ckeditor/ckeditor5-core';
 import { DowncastWriter, StylesProcessor, ViewDocument } from '@ckeditor/ckeditor5-engine';
+import View from '@ckeditor/ckeditor5-engine/src/view/view';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
+const viewElement = new DowncastWriter(new ViewDocument(new StylesProcessor())).createEmptyElement('div');
 
 new Clipboard.Clipboard(editor);
 Clipboard.Clipboard.requires.map(Plugin => new Plugin(editor).init());
@@ -25,4 +28,6 @@ plainTextToHTML(plainTextToHTML(''));
 
 normalizeClipboardData(plainTextToHTML(''));
 
-plainTextToHTML(viewToPlainText(new DowncastWriter(new ViewDocument(new StylesProcessor())).createEmptyElement('div')));
+plainTextToHTML(viewToPlainText(viewElement));
+
+new ClipboardObserver(new View(new StylesProcessor())).onDomEvent(new ClipboardEvent(''));

--- a/types/ckeditor__ckeditor5-clipboard/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/clipboard.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Clipboard from './src/clipboard';
 import ClipboardPipeline from './src/clipboardpipeline';
 import DragDrop from './src/dragdrop';

--- a/types/ckeditor__ckeditor5-cloud-services/index.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/cloud-services.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as CloudServices } from './src/cloudservices';
 export { default as CloudServicesCore } from './src/cloudservicescore';

--- a/types/ckeditor__ckeditor5-cloud-services/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/cloud-services.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import CloudServices from './src/cloudservices';
 import CloudServicesCore from './src/cloudservicescore';
 

--- a/types/ckeditor__ckeditor5-code-block/index.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/code-block.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as CodeBlock } from './src/codeblock';
 export { default as CodeBlockEditing } from './src/codeblockediting';

--- a/types/ckeditor__ckeditor5-code-block/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/code-block.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import CodeBlock from './src/codeblock';
 import CodeBlockEditing from './src/codeblockediting';
 import CodeBlockUI from './src/codeblockui';

--- a/types/ckeditor__ckeditor5-collaboration-core/index.d.ts
+++ b/types/ckeditor__ckeditor5-collaboration-core/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/module_collaboration-core_users.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import { User, Users } from './src/users';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-core/index.d.ts
+++ b/types/ckeditor__ckeditor5-core/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Plugin } from './src/plugin';
 export { default as Command } from './src/command';

--- a/types/ckeditor__ckeditor5-core/v11/index.d.ts
+++ b/types/ckeditor__ckeditor5-core/v11/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ckeditor/ckeditor5-core, https://ckeditor.com/ckeditor-5
 // Definitions by: denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 import { Conversion, DataController, EditingController, Model } from "@ckeditor/ckeditor5-engine";
 import { KeyEventData } from "@ckeditor/ckeditor5-engine/src/view/observer/keyobserver";

--- a/types/ckeditor__ckeditor5-core/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as attachToForm } from "./src/editor/utils/attachtoform";
 export { default as Command } from "./src/command";

--- a/types/ckeditor__ckeditor5-easy-image/index.d.ts
+++ b/types/ckeditor__ckeditor5-easy-image/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/easy-image.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as EasyImage } from './src/easyimage';
 export { default as CloudServicesUploadAdapter } from './src/cloudservicesuploadadapter';

--- a/types/ckeditor__ckeditor5-easy-image/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-easy-image/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/easy-image.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import EasyImage from './src/easyimage';
 import CloudServicesUploadAdapter from './src/cloudservicesuploadadapter';
 

--- a/types/ckeditor__ckeditor5-editor-balloon/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-balloon/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as BalloonEditor } from './src/ballooneditor';

--- a/types/ckeditor__ckeditor5-editor-balloon/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-balloon/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import BalloonEditor from './src/ballooneditor';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-editor-classic/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-classic/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import ClassicEditor from './src/classiceditor';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/editor-decoupled.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as DecoupledEditor } from './src/decouplededitor';

--- a/types/ckeditor__ckeditor5-editor-inline/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-inline/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/editor-inline.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as InlineEditor } from './src/inlineeditor';

--- a/types/ckeditor__ckeditor5-engine/index.d.ts
+++ b/types/ckeditor__ckeditor5-engine/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export * from './src/view/placeholder';
 

--- a/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/datacontroller.d.ts
@@ -44,8 +44,9 @@ export default class DataController implements Emitter, Observable {
     ): DocumentFragment;
     toView(modelElementOrFragment: Element | DocumentFragment, options?: Record<string, any>): ViewDocumentFragment;
 
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
+    set(option: Record<string, unknown>|string, options?: {
+        batchType?: "default" | "transparent"
+    }): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;

--- a/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
@@ -31,7 +31,7 @@ export default class DocumentSelection implements Emitter {
     containsEntireContent(element?: Element): boolean;
     destroy(): void;
     getAttribute(key: string): string | number | boolean | undefined;
-    getAttributeKeys(): IterableIterator<string>;
+    getAttributeKeys(): string[];
     getAttributes(): IterableIterator<[string, string | number | boolean]>;
     getFirstPosition(): Position | null;
     getFirstRange(): Range | null;

--- a/types/ckeditor__ckeditor5-engine/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export * from "./src/view/placeholder";
 

--- a/types/ckeditor__ckeditor5-enter/index.d.ts
+++ b/types/ckeditor__ckeditor5-enter/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/enter.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Enter } from "./src/enter";
 export { default as ShiftEnter } from "./src/shiftenter";

--- a/types/ckeditor__ckeditor5-essentials/index.d.ts
+++ b/types/ckeditor__ckeditor5-essentials/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-essentials
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Essentials } from './src/essentials';

--- a/types/ckeditor__ckeditor5-essentials/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-essentials/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-essentials
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Essentials from './src/essentials';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-export-pdf/index.d.ts
+++ b/types/ckeditor__ckeditor5-export-pdf/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-pdf.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as ExportPdf } from "./src/exportpdf";

--- a/types/ckeditor__ckeditor5-export-word/index.d.ts
+++ b/types/ckeditor__ckeditor5-export-word/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as ExportWord } from "./src/exportword";

--- a/types/ckeditor__ckeditor5-find-and-replace/index.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/find-and-replace.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as FindAndReplace } from './src/findandreplace';

--- a/types/ckeditor__ckeditor5-font/index.d.ts
+++ b/types/ckeditor__ckeditor5-font/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/font.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Font } from './src/font';
 export { default as FontBackgroundColor } from './src/fontbackgroundcolor';

--- a/types/ckeditor__ckeditor5-font/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/font.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Font from './src/font';
 import FontBackgroundColor from './src/fontbackgroundcolor';
 import FontColor from './src/fontcolor';

--- a/types/ckeditor__ckeditor5-heading/index.d.ts
+++ b/types/ckeditor__ckeditor5-heading/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/heading.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Heading } from './src/heading';
 export { default as HeadingEditing } from './src/headingediting';

--- a/types/ckeditor__ckeditor5-heading/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/heading.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Heading from './src/heading';
 import HeadingEditing from './src/headingediting';
 import HeadingUI from './src/headingui';

--- a/types/ckeditor__ckeditor5-highlight/index.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/highlight.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Highlight } from './src/highlight';
 export { default as HighlightEditing } from './src/highlightediting';

--- a/types/ckeditor__ckeditor5-highlight/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/highlight.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Highlight from './src/highlight';
 import HighlightEditing from './src/highlightediting';
 import HighlightUI from './src/highlightui';

--- a/types/ckeditor__ckeditor5-horizontal-line/index.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/horizontal-line.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as HorizontalLine } from './src/horizontalline';
 export { default as HorizontalLineEditing } from './src/horizontallineediting';

--- a/types/ckeditor__ckeditor5-horizontal-line/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/horizontal-line.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import HorizontalLine from './src/horizontalline';
 import HorizontalLineEditing from './src/horizontallineediting';
 import HorizontalLineUI from './src/horizontallineui';

--- a/types/ckeditor__ckeditor5-html-embed/index.d.ts
+++ b/types/ckeditor__ckeditor5-html-embed/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/html-embed.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as HtmlEmbed } from './src/htmlembed';
 export { default as HtmlEmbedEditing } from './src/htmlembedediting';
 export { default as HtmlEmbedUI } from './src/htmlembedui';

--- a/types/ckeditor__ckeditor5-html-support/index.d.ts
+++ b/types/ckeditor__ckeditor5-html-support/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/html-support.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as GeneralHtmlSupport } from './src/generalhtmlsupport';
 export { default as DataFilter } from './src/datafilter';

--- a/types/ckeditor__ckeditor5-image/index.d.ts
+++ b/types/ckeditor__ckeditor5-image/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 Ben Demboski <https://github.com/bendemboski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as AutoImage } from './src/autoimage';
 export { default as Image } from './src/image';

--- a/types/ckeditor__ckeditor5-image/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/image.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import AutoImage from './src/autoimage';
 import Image from './src/image';
 import ImageEditing from './src/image/imageediting';

--- a/types/ckeditor__ckeditor5-indent/index.d.ts
+++ b/types/ckeditor__ckeditor5-indent/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/indent.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Indent } from './src/indent';
 export { default as IndentEditing } from './src/indentediting';

--- a/types/ckeditor__ckeditor5-indent/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-indent/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/indent.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Indent from './src/indent';
 import IndentEditing from './src/indentediting';
 import IndentUI from './src/indentui';

--- a/types/ckeditor__ckeditor5-language/index.d.ts
+++ b/types/ckeditor__ckeditor5-language/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/language.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import TextPartLanguage from './src/textpartlanguage';
 import TextPartLanguageEditing from './src/textpartlanguageediting';
 import TextPartLanguageUI from './src/textpartlanguageui';

--- a/types/ckeditor__ckeditor5-link/index.d.ts
+++ b/types/ckeditor__ckeditor5-link/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/link.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Link } from './src/link';
 export { default as LinkEditing } from './src/linkediting';

--- a/types/ckeditor__ckeditor5-link/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/link.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Link from './src/link';
 import LinkEditing from './src/linkediting';
 import LinkUI from './src/linkui';

--- a/types/ckeditor__ckeditor5-list/index.d.ts
+++ b/types/ckeditor__ckeditor5-list/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/list.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import List from './src/list';
 import ListEditing from './src/listediting';
 import ListUI from './src/listui';

--- a/types/ckeditor__ckeditor5-markdown-gfm/index.d.ts
+++ b/types/ckeditor__ckeditor5-markdown-gfm/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/markdown-gfm.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Markdown } from './src/markdown';

--- a/types/ckeditor__ckeditor5-markdown-gfm/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-markdown-gfm/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/markdown-gfm.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Markdown from './src/markdown';
 declare const _default: {
     Markdown: typeof Markdown;

--- a/types/ckeditor__ckeditor5-media-embed/index.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/media-embed.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import MediaEmbed from './src/mediaembed';
 import MediaEmbedEditing from './src/mediaembedediting';
 import MediaEmbedUI from './src/mediaembedui';

--- a/types/ckeditor__ckeditor5-mention/index.d.ts
+++ b/types/ckeditor__ckeditor5-mention/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/mention.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as Mention } from './src/mention';
 export { default as MentionEditing } from './src/mentionediting';

--- a/types/ckeditor__ckeditor5-pagination/index.d.ts
+++ b/types/ckeditor__ckeditor5-pagination/index.d.ts
@@ -2,5 +2,5 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/pagination.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Pagination } from "./src/pagination";

--- a/types/ckeditor__ckeditor5-paragraph/index.d.ts
+++ b/types/ckeditor__ckeditor5-paragraph/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-paragraph
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Paragraph } from './src/paragraph';
 export { default as ParagraphButtonUI } from './src/paragraphbuttonui';

--- a/types/ckeditor__ckeditor5-paste-from-office/index.d.ts
+++ b/types/ckeditor__ckeditor5-paste-from-office/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/paste-from-office.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import PasteFromOffice from './src/pastefromoffice';
 
 declare const _default: {

--- a/types/ckeditor__ckeditor5-real-time-collaboration/index.d.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/module_real-time-collaboration_realtimecollaborationclient.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import PresenceList from './src/presencelist';
 import RealTimeCollaborationClient from './src/realtimecollaborationclient';
 import RealTimeCollaborativeComments from './src/realtimecollaborativecomments';

--- a/types/ckeditor__ckeditor5-remove-format/index.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/remove-format.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as RemoveFormat } from './src/removeformat';
 export { default as RemoveFormatEditing } from './src/removeformatediting';
 export { default as RemoveFormatUI } from './src/removeformatui';

--- a/types/ckeditor__ckeditor5-restricted-editing/index.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/restricted-editing.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as RestrictedEditingMode } from './src/restrictededitingmode';
 export { default as RestrictedEditingModeEditing } from './src/restrictededitingmodeediting';
 export { default as RestrictedEditingModeUI } from './src/restrictededitingmodeui';

--- a/types/ckeditor__ckeditor5-revision-history/index.d.ts
+++ b/types/ckeditor__ckeditor5-revision-history/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/revision-history.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Revision } from './src/revision';
 export { default as RevisionHistory } from './src/revisionhistory';
 export { default as RevisionsRepository } from './src/revisionsrepository';

--- a/types/ckeditor__ckeditor5-select-all/index.d.ts
+++ b/types/ckeditor__ckeditor5-select-all/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/select-all.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as SelectAll } from './src/selectall';
 export { default as SelectAllEditing } from './src/selectallediting';
 export { default as SelectAllUI } from './src/selectallui';

--- a/types/ckeditor__ckeditor5-special-characters/index.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/special-characters.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as SpecialCharacters } from './src/specialcharacters';
 export { default as SpecialCharactersArrows } from './src/specialcharactersarrows';
 export { default as SpecialCharactersText } from './src/specialcharacterstext';

--- a/types/ckeditor__ckeditor5-special-characters/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/special-characters.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import SpecialCharacters from './src/specialcharacters';
 import SpecialCharactersArrows from './src/specialcharactersarrows';
 import SpecialCharactersText from './src/specialcharacterstext';

--- a/types/ckeditor__ckeditor5-table/index.d.ts
+++ b/types/ckeditor__ckeditor5-table/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/module_table_table.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import Table from './src/table';
 import TableEditing from './src/tableediting';
 import TableUI from './src/tableui';

--- a/types/ckeditor__ckeditor5-track-changes/index.d.ts
+++ b/types/ckeditor__ckeditor5-track-changes/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/track-changes.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as TrackChanges } from './src/trackchanges';
 export { default as TrackChangesData } from './src/trackchangesdata';
 export { default as Suggestion } from './src/suggestion';

--- a/types/ckeditor__ckeditor5-typing/index.d.ts
+++ b/types/ckeditor__ckeditor5-typing/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Typing } from "./src/typing";
 export { default as Input } from "./src/input";
 export { default as Delete } from "./src/delete";

--- a/types/ckeditor__ckeditor5-ui/index.d.ts
+++ b/types/ckeditor__ckeditor5-ui/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ui
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as clickOutsideHandler } from "./src/bindings/clickoutsidehandler";
 export { default as injectCssTransitionDisabler } from "./src/bindings/injectcsstransitiondisabler";

--- a/types/ckeditor__ckeditor5-ui/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ui
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as clickOutsideHandler } from "./src/bindings/clickoutsidehandler";
 export { default as injectCssTransitionDisabler } from "./src/bindings/injectcsstransitiondisabler";

--- a/types/ckeditor__ckeditor5-undo/index.d.ts
+++ b/types/ckeditor__ckeditor5-undo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/undo.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Undo } from "./src/undo";
 export { default as UndoEditing } from "./src/undoediting";
 export { default as UndoUi } from "./src/undoui";

--- a/types/ckeditor__ckeditor5-upload/index.d.ts
+++ b/types/ckeditor__ckeditor5-upload/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/upload.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as FileRepository } from "./src/filerepository";
 export { default as FileDialogButtonView } from "./src/ui/filedialogbuttonview";
 export { default as Base64UploadAdapter } from "./src/adapters/base64uploadadapter";

--- a/types/ckeditor__ckeditor5-utils/index.d.ts
+++ b/types/ckeditor__ckeditor5-utils/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as env } from "./src/env";
 export { default as diff } from "./src/diff";

--- a/types/ckeditor__ckeditor5-utils/src/observablemixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/observablemixin.d.ts
@@ -1,6 +1,14 @@
 export interface BindChain {
-    to(observable: Observable, ...bindProperties: Array<Observable | string | (() => void)>): void;
-    toMany(observable: Observable[], ...bindProperties: Array<Observable | string | (() => void)>): void;
+    to(observable: Observable, ...bindProperties: Array<Observable | string>): void;
+    to(
+        observable: Observable,
+        ...args: [...bindProperties: Array<Observable | string>, callback: (...args: unknown[]) => void]
+    ): void;
+    toMany(observable: Observable[], ...bindProperties: Array<Observable | string>): void;
+    toMany(
+        observable: Observable[],
+        ...args: [...bindProperties: Array<Observable | string>, callback: (...args: unknown[]) => void]
+    ): void;
 }
 
 export interface Observable {

--- a/types/ckeditor__ckeditor5-utils/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Federico Panico <https://github.com/fedemp>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as env } from "./src/env";
 export { default as diff } from "./src/diff";

--- a/types/ckeditor__ckeditor5-watchdog/index.d.ts
+++ b/types/ckeditor__ckeditor5-watchdog/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/watchdog.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as ContextWatchdog } from './src/contextwatchdog';
 export { default as EditorWatchdog } from './src/editorwatchdog';

--- a/types/ckeditor__ckeditor5-watchdog/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-watchdog/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import ContextWatchdog from './src/contextwatchdog';
 import EditorWatchdog from './src/editorwatchdog';
 import Watchdog from './src/watchdog';

--- a/types/ckeditor__ckeditor5-widget/index.d.ts
+++ b/types/ckeditor__ckeditor5-widget/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/widget.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Widget } from "./src/widget";
 export { default as WidgetToolbarRepository } from "./src/widgettoolbarrepository";
 export { default as WidgetResize } from "./src/widgetresize";

--- a/types/ckeditor__ckeditor5-widget/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/widget.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 export { default as Widget } from "./src/widget";
 export { default as WidgetToolbarRepository } from "./src/widgettoolbarrepository";
 export { default as WidgetResize } from "./src/widgetresize";

--- a/types/ckeditor__ckeditor5-word-count/index.d.ts
+++ b/types/ckeditor__ckeditor5-word-count/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/word-count.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 
 export { default as WordCount } from './src/wordcount';

--- a/types/ckeditor__ckeditor5-word-count/v27/index.d.ts
+++ b/types/ckeditor__ckeditor5-word-count/v27/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/word-count.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.2
+// Minimum TypeScript Version: 4.3
 import WordCount from './src/wordcount';
 
 declare const _default: {


### PR DESCRIPTION
CKEditor has many instances of class properties that should be readable from the outside but only writable from its own class and its subclasses. For example, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55223/files#diff-a8fbf09751c2f8ff80c8aed6deb333f65f53546646697868db019f8db4d18c2f

The best approach to type this is

```ts
get foo():number;
protected set foo(newValue: number);
```

This feature requires TS 4.3 so I've updated all typings for CKEditor packages. "All" because due to dependencies, every package somehow relates to anoter.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/18123a72726a2f9f052189b89ec58218603d26da/packages/ckeditor5-source-editing/src/sourceediting.js#L362
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.