### PR TITLE
[ssh2-sftp-client] update to v7

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -20,6 +20,7 @@ export = sftp;
 type FileInfoType = 'd' | '-' | 'l';
 
 declare class sftp {
+    constructor(name?: string);
     connect(options: sftp.ConnectOptions): Promise<ssh2.SFTPWrapper>;
 
     list(remoteFilePath: string, pattern?: string | RegExp): Promise<sftp.FileInfo[]>;

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ssh2-sftp-client 5.3
+// Type definitions for ssh2-sftp-client 7.0
 // Project: https://github.com/theophilusx/ssh2-sftp-client
 // Definitions by: igrayson <https://github.com/igrayson>
 //                 Ascari Andrea <https://github.com/ascariandrea>
@@ -10,6 +10,7 @@
 //                 Sam Galizia <https://github.com/sgalizia>
 //                 Tom Xu <https://github.com/hengkx>
 //                 Joseph Burger <https://github.com/candyapplecorn>
+//                 Emma Milner <https://github.com/tsop14>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ssh2 from 'ssh2';
@@ -32,7 +33,7 @@ declare class sftp {
     get(
         path: string,
         dst?: string | NodeJS.WritableStream,
-        options?: sftp.GetTransferOptions,
+        options?: sftp.TransferOptions,
     ): Promise<string | NodeJS.WritableStream | Buffer>;
 
     fastGet(remoteFilePath: string, localPath: string, options?: sftp.FastGetTransferOptions): Promise<string>;
@@ -57,7 +58,11 @@ declare class sftp {
 
     chmod(remotePath: string, mode: number | string): Promise<string>;
 
-    append(input: Buffer | NodeJS.ReadableStream, remotePath: string, options?: sftp.TransferOptions): Promise<string>;
+    append(
+        input: Buffer | NodeJS.ReadableStream,
+        remotePath: string,
+        options?: sftp.WriteStreamOptions,
+    ): Promise<string>;
 
     uploadDir(srcDir: string, destDir: string): Promise<string>;
 
@@ -74,29 +79,42 @@ declare class sftp {
 
 declare namespace sftp {
     interface ConnectOptions extends ssh2.ConnectConfig {
-        retries?: number | undefined;
-        retry_factor?: number | undefined;
-        retry_minTimeout?: number | undefined;
+        retries?: number;
+        retry_factor?: number;
+        retry_minTimeout?: number;
     }
 
     interface ModeOption {
-        mode?: number | undefined;
+        mode?: number | string;
     }
 
-    interface TransferOptions extends ModeOption {
-        flags?: 'w' | 'a' | undefined;
-        encoding?: null | string | undefined;
-        autoClose?: true | boolean | undefined;
+    interface PipeOptions {
+        end?: boolean;
     }
 
-    interface GetTransferOptions extends TransferOptions {
-        handle?: null | string | undefined;
+    interface ReadStreamOptions extends ModeOption {
+        flags?: 'r';
+        encoding?: null | string;
+        handle?: null | string;
+        autoClose?: boolean;
+    }
+
+    interface WriteStreamOptions extends ModeOption {
+        flags?: 'w' | 'a';
+        encoding?: null | string;
+        autoClose?: boolean;
+    }
+
+    interface TransferOptions {
+        pipeOptions?: PipeOptions;
+        writeStreamOptions?: WriteStreamOptions;
+        readStreamOptions?: ReadStreamOptions;
     }
 
     interface FastGetTransferOptions {
-        concurrency?: number | undefined;
-        chunkSize?: number | undefined;
-        step?: ((totalTransferred: number, chunk: number, total: number) => void) | undefined;
+        concurrency?: number;
+        chunkSize?: number;
+        step?: (totalTransferred: number, chunk: number, total: number) => void;
     }
 
     interface FastPutTransferOptions extends FastGetTransferOptions, ModeOption {}

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -52,7 +52,7 @@ declare class sftp {
 
     rmdir(remoteFilePath: string, recursive?: boolean): Promise<string>;
 
-    delete(remoteFilePath: string): Promise<string>;
+    delete(remoteFilePath: string, noErrorOK?: boolean): Promise<string>;
 
     rename(remoteSourcePath: string, remoteDestPath: string): Promise<string>;
 
@@ -64,9 +64,9 @@ declare class sftp {
         options?: sftp.WriteStreamOptions,
     ): Promise<string>;
 
-    uploadDir(srcDir: string, destDir: string): Promise<string>;
+    uploadDir(srcDir: string, destDir: string, filter?: string | RegExp): Promise<string>;
 
-    downloadDir(srcDir: string, destDir: string): Promise<string>;
+    downloadDir(srcDir: string, destDir: string, filter?: string | RegExp): Promise<string>;
 
     end(): Promise<void>;
 

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -2,7 +2,7 @@ import Client = require('ssh2-sftp-client');
 import * as fs from 'fs';
 
 (async () => {
-    const client = new Client();
+    const client = new Client('name');
 
     client
         .connect({

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
             port: 1234,
             privateKey: 'my private key rsa in openssh format',
             readyTimeout: 1000,
+            tryKeyboard: false,
         })
         .then(() => null);
 
@@ -32,14 +33,57 @@ import * as fs from 'fs';
     client.realPath('/remote/path').then(() => null);
 
     client.get('/remote/path').then(() => null);
+    client.get('/remote/path', fs.createWriteStream('/local/path/copy.txt')).then(() => null);
+    client
+        .get('/remote/path', fs.createWriteStream('/local/path/copy.txt'), {
+            readStreamOptions: {
+                flags: 'r',
+                encoding: null,
+                handle: null,
+                mode: 0o666,
+                autoClose: true,
+            },
+            pipeOptions: {
+                end: false,
+            },
+        })
+        .then(() => null);
 
     client.fastGet('/remote/path', 'local/path').then(() => null);
+    client
+        .fastGet('/remote/path', 'local/path', {
+            concurrency: 64,
+            chunkSize: 32768,
+            step: (total_transferred, chunk, total) => null,
+        })
+        .then(() => null);
 
     client.put('/local/path', '/remote/path').then(() => null);
     client.put(new Buffer('content'), '/remote/path').then(() => null);
     client.put(fs.createReadStream('Hello World'), '/remote/path').then(() => null);
+    client
+        .put(fs.createReadStream('Hello World'), '/remote/path', {
+            writeStreamOptions: {
+                flags: 'w',
+                encoding: null,
+                mode: 0o666,
+                autoClose: true,
+            },
+            pipeOptions: {
+                end: false,
+            },
+        })
+        .then(() => null);
 
     client.fastPut('/remote/path', 'local/path').then(() => null);
+    client
+        .fastPut('/remote/path', 'local/path', {
+            concurrency: 64,
+            chunkSize: 32768,
+            mode: '0o755', // mixed. Integer or string representing the file mode to set
+            step: (total_transferred, chunk, total) => null,
+        })
+        .then(() => null);
 
     client.cwd().then(() => null);
 
@@ -51,8 +95,17 @@ import * as fs from 'fs';
     client.rename('/remote/from', '/remote/to').then(() => null);
 
     client.chmod('/remote/path', 777).then(() => null);
+    client.chmod('/remote/path', '777').then(() => null);
 
     client.end().then(() => null);
 
     client.on('event', () => null);
+
+    client.append(new Buffer('content'), 'remote/to');
+    client.append(new Buffer('content'), 'remote/to', {
+        flags: 'a',
+        encoding: null,
+        mode: 0o666,
+        autoClose: true,
+    });
 })();

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -15,6 +15,8 @@ import * as fs from 'fs';
         .then(() => null);
 
     client.list('/remote/path').then(() => null);
+    client.list('/remote/path', /foobar$/).then(() => null);
+    client.list('/remote/path', 'foo*').then(() => null);
 
     const type = (await client.list('/remote/path'))[0].type;
     switch (type) {
@@ -91,17 +93,29 @@ import * as fs from 'fs';
     client.rmdir('/remote/path/dir', true).then(() => null);
 
     client.delete('remote/path').then(() => null);
+    client.delete('remote/path', true).then(() => null);
 
     client.rename('/remote/from', '/remote/to').then(() => null);
 
+    client.posixRename('/remote/path/old', 'remote/path/new');
+
     client.chmod('/remote/path', 777).then(() => null);
     client.chmod('/remote/path', '777').then(() => null);
+
+    client.realPath('./relative/remote/path').then(() => null);
+
+    client.uploadDir('/local/path', '/remote/path').then(() => null);
+    client.uploadDir('/local/path', '/remote/path', /foo*/).then(() => null);
+
+    client.downloadDir('/remote/path', '/local/path', /foo*/).then(() => null);
+    client.downloadDir('/remote/path', '/local/path', /foo*/).then(() => null);
 
     client.end().then(() => null);
 
     client.on('event', () => null);
 
     client.append(new Buffer('content'), 'remote/to');
+    client.append(fs.createReadStream('content'), 'remote/to');
     client.append(new Buffer('content'), 'remote/to', {
         flags: 'a',
         encoding: null,


### PR DESCRIPTION
> The options argument can be used to pass options to the underlying streams and pipe call used by this method. The argument is an object with three possible properties, readStreamOptions, writeStreamOptions and pipeOptions. The values for each of these properties should be an object containing the required options.

- renames existing `TransferOptions` => `WriteSteamOptions`
- creates a new `TransferOptions` with new options for read / write / pipe

> Breaking Change Expanded option handling for get() and put() methods. 
- `put` [options](https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-8) now uses updated options
- updates `get` [options](https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-6) to use options
- updates `append` [options](https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-10) to use `writeStreamOptions`

Other updates
- updates mode (octal) type to `number | string` as `fastPut` docs mention this is [mixed. Integer or string representing the file mode to set](https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-9)
- removes `| undefined` when using `?` on key



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/ssh2-sftp-client#sec-4>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
