### PR TITLE
@wordpress/blocks: Register block from metadata

### DIFF
--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -117,11 +117,15 @@ export function registerBlockStyle(blockName: string, styleVariation: BlockStyle
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.
  *
- * @param name - Block name.
+ * @param blockNameOrMetadata - Block type name or its metadata.
  * @param settings - Block settings.
  *
  * @returns The block if it has been successfully registered, otherwise `undefined`.
  */
+export function registerBlockType<T extends Record<string, any> = {}>(
+    metadata: BlockConfiguration<T>,
+    settings?: BlockConfiguration<T>,
+): Block<T> | undefined;
 export function registerBlockType<T extends Record<string, any> = {}>(
     name: string,
     settings: BlockConfiguration<T>

--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -122,14 +122,14 @@ export function registerBlockStyle(blockName: string, styleVariation: BlockStyle
  *
  * @returns The block if it has been successfully registered, otherwise `undefined`.
  */
-export function registerBlockType<T extends Record<string, any> = {}>(
-    metadata: BlockConfiguration<T>,
-    settings?: BlockConfiguration<T>,
-): Block<T> | undefined;
-export function registerBlockType<T extends Record<string, any> = {}>(
+export function registerBlockType<TAttributes extends Record<string, any> = {}>(
+    metadata: BlockConfiguration<TAttributes>,
+    settings?: BlockConfiguration<TAttributes>,
+): Block<TAttributes> | undefined;
+export function registerBlockType<TAttributes extends Record<string, any> = {}>(
     name: string,
-    settings: BlockConfiguration<T>
-): Block<T> | undefined;
+    settings: BlockConfiguration<TAttributes>,
+): Block<TAttributes> | undefined;
 
 /**
  * Assigns the default block name.

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/blocks 9.0
+// Type definitions for @wordpress/blocks 9.1
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>
@@ -48,6 +48,12 @@ export interface BlockStyle {
 
 export interface Block<T extends Record<string, any> = {}> {
     /**
+     * The version of the Block API used by the block.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#api-version}
+     */
+    readonly apiVersion?: number;
+    /**
      * Attributes for the block.
      */
     readonly attributes: {
@@ -71,6 +77,32 @@ export interface Block<T extends Record<string, any> = {}> {
      */
     readonly edit?: ComponentType<BlockEditProps<T>> | undefined;
     /**
+     * Block type editor script definition.
+     * It will only be enqueued in the context of the editor.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script}
+     */
+    readonly editorScript?: string;
+    /**
+     * Block type editor style definition.
+     * It will only be enqueued in the context of the editor.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style}
+     */
+    readonly editorStyle?: string;
+    /**
+     * It provides structured example data for the block.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#example}
+     */
+    readonly example?: {
+        readonly attributes: {
+            readonly [k in keyof T]: any;
+        };
+        readonly innerBlocks?: any[];
+        readonly viewportWidth?: number;
+    };
+    /**
      * Icon for the block.
      */
     readonly icon: BlockIconNormalized;
@@ -84,6 +116,14 @@ export interface Block<T extends Record<string, any> = {}> {
      */
     readonly parent?: readonly string[] | undefined;
     /**
+     * Context provided for available access by descendants of blocks of this
+     * type, in the form of an object which maps a context name to one of the
+     * block’s own attribute.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#provides-context}
+     */
+    readonly providesContext?: Record<string, string>;
+    /**
      * This is set internally when registering the type.
      */
     readonly name: string;
@@ -91,6 +131,21 @@ export interface Block<T extends Record<string, any> = {}> {
      * Component to render on the frontend.
      */
     readonly save: ComponentType<BlockSaveProps<T>>;
+    /**
+     * Block type frontend script definition.
+     * It will be enqueued both in the editor and when viewing the content on
+     * the front of the site.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script}
+     */
+    readonly script?: string;
+    /**
+     * Block type editor style definition.
+     * It will only be enqueued in the context of the editor.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style}
+     */
+    readonly style?: string;
     /**
      * Block styles.
      *
@@ -101,6 +156,12 @@ export interface Block<T extends Record<string, any> = {}> {
      * Optional block extended support features.
      */
     readonly supports?: BlockSupports | undefined;
+    /**
+     * The gettext text domain of the plugin/block.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain}
+     */
+    readonly textdomain?: string;
     /**
      * This is the display title for your block, which can be translated
      * with our translation functions.
@@ -119,6 +180,19 @@ export interface Block<T extends Record<string, any> = {}> {
          */
         readonly to?: readonly Transform[] | undefined;
     } | undefined;
+    /**
+     * Array of the names of context values to inherit from an ancestor
+     * provider.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#context}
+     */
+    readonly usesContext?: string[];
+    /**
+     * The current version number of the block, such as 1.0 or 1.0.3.
+     *
+     * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#version}
+     */
+    readonly version?: string;
     /**
      * Sets attributes on the topmost parent element of the current block.
      */

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -97,7 +97,7 @@ export interface Block<T extends Record<string, any> = {}> {
      */
     readonly example?: {
         readonly attributes: Readonly<T>;
-        readonly innerBlocks?: any[];
+        readonly innerBlocks?: ReadonlyArray<{ name: string; attributes: Record<string, any> }>;
         readonly viewportWidth?: number;
     };
     /**

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -46,6 +46,20 @@ export interface BlockStyle {
     readonly isDefault?: boolean | undefined;
 }
 
+/**
+ * Internal type for the innerBlocks property inside of the example
+ *
+ * @internal
+ * @see Block.example
+ * @see {@link https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55245#discussion_r692208988}
+ */
+type BlockExampleInnerBlock = ReadonlyArray<
+    Partial<Block> &
+        Pick<Block, 'name' | 'attributes'> & {
+            innerBlocks?: BlockExampleInnerBlock;
+        }
+>;
+
 export interface Block<T extends Record<string, any> = {}> {
     /**
      * The version of the Block API used by the block.
@@ -97,7 +111,7 @@ export interface Block<T extends Record<string, any> = {}> {
      */
     readonly example?: {
         readonly attributes: Readonly<T>;
-        readonly innerBlocks?: ReadonlyArray<{ name: string; attributes: Record<string, any> }>;
+        readonly innerBlocks?: BlockExampleInnerBlock;
         readonly viewportWidth?: number;
     };
     /**

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -53,12 +53,10 @@ export interface BlockStyle {
  * @see Block.example
  * @see {@link https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55245#discussion_r692208988}
  */
-type BlockExampleInnerBlock = ReadonlyArray<
-    Partial<Block> &
-        Pick<Block, 'name' | 'attributes'> & {
-            innerBlocks?: BlockExampleInnerBlock;
-        }
->;
+type BlockExampleInnerBlock = Partial<Block> &
+    Pick<Block, 'name' | 'attributes'> & {
+        innerBlocks?: ReadonlyArray<BlockExampleInnerBlock>;
+    };
 
 export interface Block<T extends Record<string, any> = {}> {
     /**
@@ -109,11 +107,7 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#example}
      */
-    readonly example?: {
-        readonly attributes: Readonly<T>;
-        readonly innerBlocks?: BlockExampleInnerBlock;
-        readonly viewportWidth?: number;
-    };
+    readonly example?: Readonly<Partial<Block> & { innerBlocks: ReadonlyArray<BlockExampleInnerBlock> }>;
     /**
      * Icon for the block.
      */

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -96,9 +96,7 @@ export interface Block<T extends Record<string, any> = {}> {
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#example}
      */
     readonly example?: {
-        readonly attributes: {
-            readonly [k in keyof T]: any;
-        };
+        readonly attributes: Readonly<T>;
         readonly innerBlocks?: any[];
         readonly viewportWidth?: number;
     };

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -107,7 +107,7 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#example}
      */
-    readonly example?: Readonly<Partial<Block> & { innerBlocks: ReadonlyArray<BlockExampleInnerBlock> }>;
+    readonly example?: Readonly<Partial<Block> & { innerBlocks?: ReadonlyArray<BlockExampleInnerBlock> }>;
     /**
      * Icon for the block.
      */

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -120,7 +120,7 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#provides-context}
      */
-    readonly providesContext?: Record<string, string>;
+    readonly providesContext?: Record<string, keyof T>;
     /**
      * This is set internally when registering the type.
      */

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -404,6 +404,14 @@ blocks.registerBlockType({
         attributes: {
             message: 'This is a notice!',
         },
+        innerBlocks: [
+            {
+                name: 'core/paragraph',
+                attributes: {
+                    content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
+                },
+            },
+        ],
     },
     editorScript: 'file:./build/index.js',
     script: 'file:./build/script.js',

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -410,6 +410,15 @@ blocks.registerBlockType({
                 attributes: {
                     content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
                 },
+                innerBlocks: [
+                    {
+                        name: 'core/paragraph',
+                        attributes: {
+                            content:
+                                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
+                        },
+                    },
+                ],
             },
         ],
     },

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -369,6 +369,48 @@ blocks.registerBlockType<{ foo: string }>('my/foo', {
     category: 'common',
 });
 
+// Register with block.json metadata
+// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/
+blocks.registerBlockType({
+    apiVersion: 2,
+    name: 'my-plugin/notice',
+    title: 'Notice',
+    category: 'text',
+    parent: ['core/group'],
+    icon: 'star-half',
+    description: 'Shows warning, error or success notices…',
+    keywords: ['alert', 'message'],
+    version: '1.0.3',
+    textdomain: 'my-plugin',
+    attributes: {
+        message: {
+            type: 'string',
+            source: 'html',
+            selector: '.message',
+        },
+    },
+    providesContext: {
+        'my-plugin/message': 'message',
+    },
+    usesContext: ['groupId'],
+    supports: {
+        align: true,
+    },
+    styles: [
+        { name: 'default', label: 'Default', isDefault: true },
+        { name: 'other', label: 'Other' },
+    ],
+    example: {
+        attributes: {
+            message: 'This is a notice!',
+        },
+    },
+    editorScript: 'file:./build/index.js',
+    script: 'file:./build/script.js',
+    editorStyle: 'file:./build/index.css',
+    style: 'file:./build/style.css',
+});
+
 // $ExpectType void
 blocks.setDefaultBlockName('my/foo');
 


### PR DESCRIPTION
Hi,

the `registerBlockType` method now accepts metadata input from the `block.json` metadata.

## Changes

- Extends the `registerBlockType` to accept the metadata as first and optionally second argument.
- Extends the `Block` type with the missing properties from the metadata (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration)

## Related docs

- This was introduced in version `9.1.0`: https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/CHANGELOG.md#910-2021-05-20
- Related PR: https://github.com/WordPress/gutenberg/pull/32030

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.