### PR TITLE
Add`dimensions` field  to SignalMetric interface

### DIFF
--- a/types/signalfx/index.d.ts
+++ b/types/signalfx/index.d.ts
@@ -19,6 +19,7 @@ export interface SignalMetric {
     metric: string;
     value: number;
     timestamp?: number | undefined;
+    dimensions?: object | undefined;
 }
 
 export interface SignalReport {

--- a/types/signalfx/signalfx-tests.ts
+++ b/types/signalfx/signalfx-tests.ts
@@ -1,4 +1,10 @@
 import * as signalfx from 'signalfx';
 
 const sgnlfx = new signalfx.Ingest('1');
-sgnlfx.send({});
+sgnlfx.send({
+  gauges: [{
+    metric: "metric",
+    value: 1,
+    dimensions: {}
+  }]
+});


### PR DESCRIPTION
This pull-request fixes an error of type definition, used in signalfx npm package. 
Actual data point may have dimensions field, which, then will be extended by globalDimensions.

Here is a link to code, where we can see, how signal fx processes messages before sending them.

 https://github.com/signalfx/signalfx-nodejs/blob/main/lib/client/ingest/signal_fx_client.js#L123

