### PR TITLE
feat: improve AppSync

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -38,6 +38,7 @@
 //                 Zach Anthony <https://github.com/zach-anthony>
 //                 Peter Savnik <https://github.com/savnik>
 //                 Sven Milewski <https://github.com/svenmilewski>
+//                 Benoit Boure <https://github.com/bboure>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -1,4 +1,11 @@
-import { AppSyncIdentityCognito, AppSyncIdentityIAM, AppSyncResolverHandler } from 'aws-lambda';
+import {
+    AppSyncBatchResolverHandler,
+    AppSyncIdentityCognito,
+    AppSyncIdentityIAM,
+    AppSyncIdentityLambda,
+    AppSyncIdentityOIDC,
+    AppSyncResolverHandler,
+} from 'aws-lambda';
 
 declare let objectOrNull: {} | null;
 declare let prevResultOrNull: { result: { [key: string]: any } } | null;
@@ -41,6 +48,12 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event,
     str = (event.identity as AppSyncIdentityCognito).username;
     anyObj = (event.identity as AppSyncIdentityCognito).claims;
 
+    str = (event.identity as AppSyncIdentityOIDC).sub;
+    str = (event.identity as AppSyncIdentityOIDC).issuer;
+    anyObj = (event.identity as AppSyncIdentityOIDC).claims;
+
+    anyObj = (event.identity as AppSyncIdentityLambda).resolverContext;
+
     strOrUndefined = event.request.headers.host;
 
     str = event.info.fieldName;
@@ -61,7 +74,61 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event,
     };
 };
 
-const handlerWithDefinedSourceTypes: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = async (event, context) => {
+const batchHandler: AppSyncBatchResolverHandler<TestArguments, TestEntity> = async (events, context) => {
+    array = events;
+    events.forEach(event => {
+        str = event.arguments.id;
+        str = event.arguments.query;
+
+        str = (event.identity as AppSyncIdentityIAM).accountId;
+        str = (event.identity as AppSyncIdentityIAM).cognitoIdentityAuthProvider;
+        str = (event.identity as AppSyncIdentityIAM).cognitoIdentityAuthType;
+        str = (event.identity as AppSyncIdentityIAM).cognitoIdentityId;
+        str = (event.identity as AppSyncIdentityIAM).cognitoIdentityPoolId;
+        str = (event.identity as AppSyncIdentityIAM).sourceIp[0];
+        str = (event.identity as AppSyncIdentityIAM).userArn;
+        str = (event.identity as AppSyncIdentityIAM).username;
+
+        str = (event.identity as AppSyncIdentityCognito).defaultAuthStrategy;
+        str = (event.identity as AppSyncIdentityCognito).issuer;
+        str = (event.identity as AppSyncIdentityCognito).sourceIp[0];
+        str = (event.identity as AppSyncIdentityCognito).sub;
+        str = (event.identity as AppSyncIdentityCognito).username;
+        anyObj = (event.identity as AppSyncIdentityCognito).claims;
+
+        str = (event.identity as AppSyncIdentityOIDC).sub;
+        str = (event.identity as AppSyncIdentityOIDC).issuer;
+        anyObj = (event.identity as AppSyncIdentityOIDC).claims;
+
+        anyObj = (event.identity as AppSyncIdentityLambda).resolverContext;
+
+        strOrUndefined = event.request.headers.host;
+
+        str = event.info.fieldName;
+        str = event.info.parentTypeName;
+        str = event.info.selectionSetGraphQL;
+        anyObj = event.info.variables;
+        str = event.info.selectionSetList[0];
+
+        objectOrNull = event.source;
+        prevResultOrNull = event.prev;
+        anyObj = (event.prev as { result: { [key: string]: any } }).result;
+        anyObj = event.stash;
+    });
+
+    return [
+        {
+            id: '',
+            name: '',
+            check: true,
+        },
+    ];
+};
+
+const handlerWithDefinedSourceTypes: AppSyncResolverHandler<TestArguments, TestEntity, TestSource> = async (
+    event,
+    context,
+) => {
     strOrUndefined = event.source ? event.source.id : undefined;
     strOrUndefined = event.source ? event.source.firstName : undefined;
     strOrUndefined = event.source ? event.source.lastName : undefined;
@@ -72,4 +139,25 @@ const handlerWithDefinedSourceTypes: AppSyncResolverHandler<TestArguments, TestE
         name: '',
         check: true,
     };
+};
+
+const batchHandlerWithDefinedSourceTypes: AppSyncBatchResolverHandler<TestArguments, TestEntity, TestSource> = async (
+    events,
+    context,
+) => {
+    array = events;
+    events.forEach(event => {
+        strOrUndefined = event.source ? event.source.id : undefined;
+        strOrUndefined = event.source ? event.source.firstName : undefined;
+        strOrUndefined = event.source ? event.source.lastName : undefined;
+        numOrUndefined = event.source ? event.source.age : undefined;
+    });
+
+    return [
+        {
+            id: '',
+            name: '',
+            check: true,
+        },
+    ];
 };

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -1,20 +1,44 @@
 import { Handler } from '../handler';
 
-export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, any> | null> = Handler<AppSyncResolverEvent<TArguments, TSource>, TResults | TResults[]>;
+export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, any> | null> = Handler<
+    AppSyncResolverEvent<TArguments, TSource>,
+    TResults
+>;
+
+// https:docs.aws.amazon.com/appsync/latest/devguide/tutorial-lambda-resolvers.html#advanced-use-case-batching
+export type AppSyncBatchResolverHandler<TArguments, TResults, TSource = Record<string, any> | null> = Handler<
+    AppSyncResolverEvent<TArguments, TSource>[],
+    TResults[]
+>;
+
+// See https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-lambda-authorization
+export type AppSyncAuthorizerHander<TResolverContext = undefined> = Handler<
+    AppSyncAuthorizerEvent,
+    AppSyncAuthorizerResult<TResolverContext>
+>;
 
 export interface AppSyncResolverEventHeaders {
     [name: string]: string | undefined;
 }
+
+export type AppSyncIdentity =
+    | AppSyncIdentityIAM
+    | AppSyncIdentityCognito
+    | AppSyncIdentityOIDC
+    | AppSyncIdentityLambda
+    | undefined
+    | null;
 
 /**
  * See https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html
  *
  * @param TArguments type of the arguments
  * @param TSource type of the source
+ * @param TAuthorizer type of the Authorizer
  */
 export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> | null> {
     arguments: TArguments;
-    identity?: AppSyncIdentityIAM | AppSyncIdentityCognito | undefined;
+    identity?: AppSyncIdentity;
     source: TSource;
     request: {
         headers: AppSyncResolverEventHeaders;
@@ -30,6 +54,23 @@ export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> 
     stash: { [key: string]: any };
 }
 
+export interface AppSyncAuthorizerEvent {
+    authorizationToken: string;
+    requestContext: {
+        apiId: string;
+        accountId: string;
+        requestId: string;
+        queryString: string;
+        variables: { [key: string]: any };
+    };
+}
+
+export interface AppSyncAuthorizerResult<TResolverContext = undefined> {
+    isAuthorized: boolean;
+    resolverContext?: TResolverContext;
+    deniedFields?: string[];
+    ttlOverride?: number;
+}
 export interface AppSyncIdentityIAM {
     accountId: string;
     cognitoIdentityPoolId: string;
@@ -49,4 +90,14 @@ export interface AppSyncIdentityCognito {
     sourceIp: string[];
     defaultAuthStrategy: string;
     groups: string[] | null;
+}
+
+export interface AppSyncIdentityOIDC {
+    claims: any;
+    issuer: string;
+    sub: string;
+}
+
+export interface AppSyncIdentityLambda {
+    resolverContext: any;
 }

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -1,14 +1,14 @@
 import { Handler } from '../handler';
 
-export type AppSyncResolverHandler<TArguments, TResults, TSource = Record<string, any> | null> = Handler<
+export type AppSyncResolverHandler<TArguments, TResult, TSource = Record<string, any> | null> = Handler<
     AppSyncResolverEvent<TArguments, TSource>,
-    TResults
+    TResult
 >;
 
 // https:docs.aws.amazon.com/appsync/latest/devguide/tutorial-lambda-resolvers.html#advanced-use-case-batching
-export type AppSyncBatchResolverHandler<TArguments, TResults, TSource = Record<string, any> | null> = Handler<
-    AppSyncResolverEvent<TArguments, TSource>[],
-    TResults[]
+export type AppSyncBatchResolverHandler<TArguments, TResult, TSource = Record<string, any> | null> = Handler<
+    Array<AppSyncResolverEvent<TArguments, TSource>>,
+    TResult[]
 >;
 
 // See https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-lambda-authorization
@@ -34,7 +34,6 @@ export type AppSyncIdentity =
  *
  * @param TArguments type of the arguments
  * @param TSource type of the source
- * @param TAuthorizer type of the Authorizer
  */
 export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> | null> {
     arguments: TArguments;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) 
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-lambda-authorization
- https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-lambda-resolvers.html#advanced-use-case-batching 

-----

## ⚠️ Warning: Breaking change

`AppSyncResolverHandler`should not add a return type as an array of `TResults` (second param). If your return type is an array, you should explicitly indicate it as such in the second argument of the type. So, I removed that. Also, please let me know if there was a reason for it @hoegertn

If this was added as an attempt to support [Batch resolvers](https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-lambda-resolvers.html#advanced-use-case-batching) (which was wrong anyway), there is now an `AppSyncBatchResolverHandler` type.

Note: I am not sure how to handle breaking change in this case (major version bump?), if someone can please enlighten me on this subject, please do. Otherwise, I'm happy to rollback the breaking change to avoid it.
