### PR TITLE
ckeditor5: Improved types for PluginCollection.get

### DIFF
--- a/types/ckeditor__ckeditor5-adapter-ckfinder/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
@@ -3,6 +3,7 @@ import * as utils from "@ckeditor/ckeditor5-adapter-ckfinder/src/utils";
 import { Editor, Plugin } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 if (!(CKFinderUploadAdapter instanceof Plugin)) {
     throw new Error("UploadAdapter must extend Plugin");
@@ -30,3 +31,6 @@ class Foo extends UploadAdapter {
         this.xhr;
     }
 }
+
+// $ExpectType CKFinderUploadAdapter
+editor.plugins.get("CKFinderUploadAdapter");

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/src/uploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/src/uploadadapter.d.ts
@@ -67,3 +67,9 @@ export class UploadAdapter implements IUploadAdapter {
      */
     private _sendRequest(file: File): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinderUploadAdapter: CKFinderUploadAdapter;
+    }
+}

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/v27/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/v27/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
@@ -3,6 +3,7 @@ import * as utils from "@ckeditor/ckeditor5-adapter-ckfinder/src/utils";
 import { Editor, Plugin } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 if (!(CKFinderUploadAdapter instanceof Plugin)) {
     throw new Error("UploadAdapter must extend Plugin");
@@ -30,3 +31,6 @@ class Foo extends UploadAdapter {
         this.xhr;
     }
 }
+
+// $ExpectType CKFinderUploadAdapter
+editor.plugins.get("CKFinderUploadAdapter");

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/v27/src/uploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/v27/src/uploadadapter.d.ts
@@ -67,3 +67,9 @@ export class UploadAdapter implements IUploadAdapter {
      */
     private _sendRequest(file: File): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinderUploadAdapter: CKFinderUploadAdapter;
+    }
+}

--- a/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
+++ b/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
@@ -1,10 +1,11 @@
-import { Alignment } from "@ckeditor/ckeditor5-alignment";
+import { Alignment, AlignmentEditing, AlignmentUI } from "@ckeditor/ckeditor5-alignment";
 import AlignmentCommand from "@ckeditor/ckeditor5-alignment/src/alignmentcommand";
 import * as utils from "@ckeditor/ckeditor5-alignment/src/utils";
 import { Editor } from "@ckeditor/ckeditor5-core";
 import { Locale } from "@ckeditor/ckeditor5-utils";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 new Alignment(new MyEditor());
 Alignment.requires.map(Plugin => {
@@ -32,3 +33,12 @@ const command = new AlignmentCommand(new MyEditor());
 // $ExpectError
 command.execute("foo");
 command.execute();
+
+// $ExpectType Alignment
+editor.plugins.get('Alignment');
+
+// $ExpectType AlignmentEditing
+editor.plugins.get('AlignmentEditing');
+
+// $ExpectType AlignmentUI
+editor.plugins.get('AlignmentUI');

--- a/types/ckeditor__ckeditor5-alignment/src/alignment.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignment.d.ts
@@ -10,3 +10,9 @@ export default class Alignment extends Plugin {
 export interface AlignmentConfig {
     options: Array<string | AlignmentFormat>;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Alignment: Alignment;
+    }
+}

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
@@ -9,3 +9,9 @@ export interface AlignmentFormat {
     className: string;
     name: "left" | "right" | "center" | "justify";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AlignmentEditing: AlignmentEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
@@ -10,3 +10,9 @@ export default class AlignmentUI extends Plugin {
     static readonly pluginName: "AlignmentUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AlignmentUI: AlignmentUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-alignment/v27/ckeditor__ckeditor5-alignment-tests.ts
+++ b/types/ckeditor__ckeditor5-alignment/v27/ckeditor__ckeditor5-alignment-tests.ts
@@ -1,10 +1,13 @@
 import Alignment from "@ckeditor/ckeditor5-alignment/src/alignment";
 import AlignmentCommand from "@ckeditor/ckeditor5-alignment/src/alignmentcommand";
+import AlignmentEditing from "@ckeditor/ckeditor5-alignment/src/alignmentediting";
+import AlignmentUI from "@ckeditor/ckeditor5-alignment/src/alignmentui";
 import * as utils from "@ckeditor/ckeditor5-alignment/src/utils";
 import { Editor } from "@ckeditor/ckeditor5-core";
 import { Locale } from "@ckeditor/ckeditor5-utils";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 let bool = true;
 
@@ -32,3 +35,12 @@ const command = new AlignmentCommand(new MyEditor());
 // $ExpectError
 command.execute("foo");
 command.execute();
+
+// $ExpectType Alignment
+editor.plugins.get('Alignment');
+
+// $ExpectType AlignmentEditing
+editor.plugins.get('AlignmentEditing');
+
+// $ExpectType AlignmentUI
+editor.plugins.get('AlignmentUI');

--- a/types/ckeditor__ckeditor5-alignment/v27/src/alignment.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/v27/src/alignment.d.ts
@@ -10,3 +10,9 @@ export default class Alignment extends Plugin {
 export interface AlignmentConfig {
     options: Array<string | AlignmentFormat>;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Alignment: Alignment;
+    }
+}

--- a/types/ckeditor__ckeditor5-alignment/v27/src/alignmentediting.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/v27/src/alignmentediting.d.ts
@@ -9,3 +9,9 @@ export interface AlignmentFormat {
     className: string;
     name: "left" | "right" | "center" | "justify";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AlignmentEditing: AlignmentEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-alignment/v27/src/alignmentui.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/v27/src/alignmentui.d.ts
@@ -10,3 +10,9 @@ export default class AlignmentUI extends Plugin {
     static readonly pluginName: "AlignmentUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AlignmentUI: AlignmentUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-autoformat/ckeditor__ckeditor5-autoformat-tests.ts
+++ b/types/ckeditor__ckeditor5-autoformat/ckeditor__ckeditor5-autoformat-tests.ts
@@ -4,6 +4,8 @@ import inlineAutoformatEditing from "@ckeditor/ckeditor5-autoformat/src/inlineau
 import { Editor } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
+
 const autoformat = new Autoformat(new MyEditor());
 autoformat.afterInit();
 
@@ -17,3 +19,6 @@ inlineAutoformatEditing(new MyEditor(), autoformat, /foo/, writer => {
     writer.createText("foo");
     return false;
 });
+
+// $ExpectType Autoformat
+editor.plugins.get('Autoformat');

--- a/types/ckeditor__ckeditor5-autoformat/src/autoformat.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/src/autoformat.d.ts
@@ -4,3 +4,9 @@ export default class Autoformat extends Plugin {
     static readonly pluginName: "Autoformat";
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Autoformat: Autoformat;
+    }
+}

--- a/types/ckeditor__ckeditor5-autoformat/v27/ckeditor__ckeditor5-autoformat-tests.ts
+++ b/types/ckeditor__ckeditor5-autoformat/v27/ckeditor__ckeditor5-autoformat-tests.ts
@@ -17,3 +17,6 @@ inlineAutoformatEditing(new MyEditor(), autoformat, /foo/, writer => {
     writer.createText("foo");
     return false;
 });
+
+// $ExpectType Autoformat
+(new MyEditor()).plugins.get('Autoformat');

--- a/types/ckeditor__ckeditor5-autoformat/v27/src/autoformat.d.ts
+++ b/types/ckeditor__ckeditor5-autoformat/v27/src/autoformat.d.ts
@@ -4,3 +4,9 @@ export default class Autoformat extends Plugin {
     static readonly pluginName: "Autoformat";
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Autoformat: Autoformat;
+    }
+}

--- a/types/ckeditor__ckeditor5-autosave/ckeditor__ckeditor5-autosave-tests.ts
+++ b/types/ckeditor__ckeditor5-autosave/ckeditor__ckeditor5-autosave-tests.ts
@@ -18,6 +18,9 @@ const adapter: AutosaveAdapter = {
     },
 };
 
+// $ExpectType AutoSave
+myEditor.plugins.get('AutoSave');
+
 let config: AutosaveConfig = {
     save(editor) {
         return Promise.reject(editor);

--- a/types/ckeditor__ckeditor5-autosave/src/autosave.d.ts
+++ b/types/ckeditor__ckeditor5-autosave/src/autosave.d.ts
@@ -20,3 +20,9 @@ export interface AutosaveConfig {
     waitingTime?: number | undefined;
     save?(editor: Editor): Promise<unknown>;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoSave: AutoSave;
+    }
+}

--- a/types/ckeditor__ckeditor5-autosave/v27/ckeditor__ckeditor5-autosave-tests.ts
+++ b/types/ckeditor__ckeditor5-autosave/v27/ckeditor__ckeditor5-autosave-tests.ts
@@ -3,6 +3,7 @@ import { AutosaveAdapter, AutosaveConfig } from "@ckeditor/ckeditor5-autosave/sr
 import { Editor } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
+const myEditor = new MyEditor();
 const plugin = new Autosave.Autosave(new MyEditor());
 plugin.once("click", () => {});
 const isContext: boolean = Autosave.Autosave.isContextPlugin;
@@ -14,6 +15,9 @@ const adapter: AutosaveAdapter = {
         return Promise.resolve(editor);
     },
 };
+
+// $ExpectType AutoSave
+myEditor.plugins.get('AutoSave');
 
 let config: AutosaveConfig = {
     save(editor: Editor) {

--- a/types/ckeditor__ckeditor5-autosave/v27/src/autosave.d.ts
+++ b/types/ckeditor__ckeditor5-autosave/v27/src/autosave.d.ts
@@ -20,3 +20,9 @@ export interface AutosaveConfig {
     waitingTime?: number | undefined;
     save?(editor: Editor): Promise<unknown>;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoSave: AutoSave;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/ckeditor__ckeditor5-basic-styles-tests.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/ckeditor__ckeditor5-basic-styles-tests.ts
@@ -1,7 +1,30 @@
-import { Bold, Code, Italic, Strikethrough, Subscript, Superscript, Underline } from '@ckeditor/ckeditor5-basic-styles';
+import {
+    Bold,
+    BoldEditing,
+    BoldUI,
+    Code,
+    CodeEditing,
+    CodeUI,
+    Italic,
+    ItalicEditing,
+    ItalicUI,
+    Strikethrough,
+    StrikethroughEditing,
+    StrikethroughUI,
+    Subscript,
+    SubscriptEditing,
+    SubscriptUI,
+    Superscript,
+    SuperscriptEditing,
+    SuperscriptUI,
+    Underline,
+    UnderlineEditing,
+    UnderlineUI,
+} from '@ckeditor/ckeditor5-basic-styles';
 import { Editor } from '@ckeditor/ckeditor5-core';
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 const plugins = [Bold, Italic, Underline, Strikethrough, Code, Subscript, Superscript] as const;
 plugins.map(Plugin => {
@@ -13,3 +36,66 @@ plugins.map(Plugin => {
     const required2 = new Required2(new MyEditor());
     required2.init();
 });
+
+// $ExpectType Bold
+editor.plugins.get('Bold');
+
+// $ExpectType BoldEditing
+editor.plugins.get('BoldEditing');
+
+// $ExpectType BoldUI
+editor.plugins.get('BoldUI');
+
+// $ExpectType Code
+editor.plugins.get('Code');
+
+// $ExpectType CodeEditing
+editor.plugins.get('CodeEditing');
+
+// $ExpectType CodeUI
+editor.plugins.get('CodeUI');
+
+// $ExpectType Italic
+editor.plugins.get('Italic');
+
+// $ExpectType ItalicEditing
+editor.plugins.get('ItalicEditing');
+
+// $ExpectType ItalicUI
+editor.plugins.get('ItalicUI');
+
+// $ExpectType Strikethrough
+editor.plugins.get('Strikethrough');
+
+// $ExpectType StrikethroughEditing
+editor.plugins.get('StrikethroughEditing');
+
+// $ExpectType StrikethroughUI
+editor.plugins.get('StrikethroughUI');
+
+// $ExpectType Subscript
+editor.plugins.get('Subscript');
+
+// $ExpectType SubscriptEditing
+editor.plugins.get('SubscriptEditing');
+
+// $ExpectType SubscriptUI
+editor.plugins.get('SubscriptUI');
+
+// $ExpectType Superscript
+editor.plugins.get('Superscript');
+
+// $ExpectType SuperscriptEditing
+editor.plugins.get('SuperscriptEditing');
+
+// $ExpectType SuperscriptUI
+editor.plugins.get('SuperscriptUI');
+
+// $ExpectType Underline
+editor.plugins.get('Underline');
+
+// $ExpectType UnderlineEditing
+editor.plugins.get('UnderlineEditing');
+
+// $ExpectType UnderlineUI
+editor.plugins.get('UnderlineUI');

--- a/types/ckeditor__ckeditor5-basic-styles/src/bold.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/bold.d.ts
@@ -6,3 +6,9 @@ export default class Bold extends Plugin {
     static readonly requires: [typeof BoldEditing, typeof BoldUI];
     static readonly pluginName: "Bold";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Bold: Bold;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/bold/boldediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/bold/boldediting.d.ts
@@ -4,3 +4,9 @@ export default class BoldEditing extends Plugin {
     static readonly pluginName: "BoldEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BoldEditing: BoldEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/bold/boldui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/bold/boldui.d.ts
@@ -4,3 +4,9 @@ export default class BoldUI extends Plugin {
     static readonly pluginName: "BoldUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BoldUI: BoldUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/code.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/code.d.ts
@@ -6,3 +6,9 @@ export default class Code extends Plugin {
     static readonly requires: [typeof CodeEditing, typeof CodeUI];
     static readonly pluginName: "Code";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Code: Code;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/code/codeediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/code/codeediting.d.ts
@@ -6,3 +6,9 @@ export default class CodeEditing extends Plugin {
     static readonly requires: [typeof TwoStepCaretMovement];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeEditing: CodeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/code/codeui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/code/codeui.d.ts
@@ -4,3 +4,9 @@ export default class CodeUI extends Plugin {
     static readonly pluginName: "CodeUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeUI: CodeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/italic.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/italic.d.ts
@@ -6,3 +6,9 @@ export default class Italic extends Plugin {
     static readonly requires: [typeof ItalicEditing, typeof ItalicUI];
     static readonly pluginName: "Italic";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Italic: Italic;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/italic/italicediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/italic/italicediting.d.ts
@@ -4,3 +4,9 @@ export default class ItalicEditing extends Plugin {
     static readonly pluginName: "ItalicEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ItalicEditing: ItalicEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/italic/italicui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/italic/italicui.d.ts
@@ -4,3 +4,9 @@ export default class ItalicUI extends Plugin {
     static readonly pluginName: "ItalicUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ItalicUI: ItalicUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/strikethrough.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/strikethrough.d.ts
@@ -6,3 +6,9 @@ export default class Strikethrough extends Plugin {
     static readonly requires: [typeof StrikethroughEditing, typeof StrikethroughUI];
     static readonly pluginName: "Strikethrough";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Strikethrough: Strikethrough;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/strikethrough/strikethroughediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/strikethrough/strikethroughediting.d.ts
@@ -4,3 +4,9 @@ export default class StrikethroughEditing extends Plugin {
     static readonly pluginName: "StrikethroughEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StrikethroughEditing: StrikethroughEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/strikethrough/strikethroughui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/strikethrough/strikethroughui.d.ts
@@ -4,3 +4,9 @@ export default class StrikethroughUI extends Plugin {
     static readonly pluginName: "StrikethroughUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StrikethroughUI: StrikethroughUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/subscript.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/subscript.d.ts
@@ -6,3 +6,9 @@ export default class Subscript extends Plugin {
     static readonly requires: [typeof SubscriptEditing, typeof SubscriptUI];
     static readonly pluginName: "Subscript";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Subscript: Subscript;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/subscript/subscriptediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/subscript/subscriptediting.d.ts
@@ -4,3 +4,9 @@ export default class SubscriptEditing extends Plugin {
     static readonly pluginName: "SubscriptEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SubscriptEditing: SubscriptEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/subscript/subscriptui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/subscript/subscriptui.d.ts
@@ -4,3 +4,9 @@ export default class SubscriptUI extends Plugin {
     static readonly pluginName: "SubscriptUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SubscriptUI: SubscriptUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/superscript.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/superscript.d.ts
@@ -6,3 +6,9 @@ export default class Superscript extends Plugin {
     static readonly requires: [typeof SuperscriptEditing, typeof SuperscriptUI];
     static readonly pluginName: "Superscript";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Superscript: Superscript;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/superscript/superscriptediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/superscript/superscriptediting.d.ts
@@ -4,3 +4,9 @@ export default class SuperscriptEditing extends Plugin {
     static readonly pluginName: "SuperscriptEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SuperscriptEditing: SuperscriptEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/superscript/superscriptui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/superscript/superscriptui.d.ts
@@ -4,3 +4,9 @@ export default class SuperscriptUI extends Plugin {
     static readonly pluginName: "SuperscriptUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SuperscriptUI: SuperscriptUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/underline.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/underline.d.ts
@@ -6,3 +6,9 @@ export default class Underline extends Plugin {
     static readonly requires: [typeof UnderlineEditing, typeof UnderlineUI];
     static readonly pluginName: "Underline";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Underline: Underline;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/underline/underlineediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/underline/underlineediting.d.ts
@@ -4,3 +4,9 @@ export default class UnderlineEditing extends Plugin {
     static readonly pluginName: "UnderlineEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        UnderlineEditing: UnderlineEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/src/underline/underlineui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/src/underline/underlineui.d.ts
@@ -4,3 +4,9 @@ export default class UnderlineUI extends Plugin {
     static readonly pluginName: "UnderlineUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        UnderlineUI: UnderlineUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/ckeditor__ckeditor5-basic-styles-tests.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/ckeditor__ckeditor5-basic-styles-tests.ts
@@ -1,9 +1,30 @@
-import Styles from "@ckeditor/ckeditor5-basic-styles";
 import { Editor } from "@ckeditor/ckeditor5-core";
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
+import BoldUI from '@ckeditor/ckeditor5-basic-styles/src/bold/boldui';
+import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
+import CodeEditing from '@ckeditor/ckeditor5-basic-styles/src/code/codeediting';
+import CodeUI from '@ckeditor/ckeditor5-basic-styles/src/code/codeui';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import ItalicEditing from '@ckeditor/ckeditor5-basic-styles/src/italic/italicediting';
+import ItalicUI from '@ckeditor/ckeditor5-basic-styles/src/italic/italicui';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import StrikethroughEditing from '@ckeditor/ckeditor5-basic-styles/src/strikethrough/strikethroughediting';
+import StrikethroughUI from '@ckeditor/ckeditor5-basic-styles/src/strikethrough/strikethroughui';
+import Subscript from '@ckeditor/ckeditor5-basic-styles/src/subscript';
+import SubscriptEditing from '@ckeditor/ckeditor5-basic-styles/src/subscript/subscriptediting';
+import SubscriptUI from '@ckeditor/ckeditor5-basic-styles/src/subscript/subscriptui';
+import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
+import SuperscriptEditing from '@ckeditor/ckeditor5-basic-styles/src/superscript/superscriptediting';
+import SuperscriptUI from '@ckeditor/ckeditor5-basic-styles/src/superscript/superscriptui';
+import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import UnderlineEditing from '@ckeditor/ckeditor5-basic-styles/src/underline/underlineediting';
+import UnderlineUI from '@ckeditor/ckeditor5-basic-styles/src/underline/underlineui';
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
-const plugins = [Styles.Bold, Styles.Italic, Styles.Underline, Styles.Strikethrough, Styles.Code, Styles.Subscript, Styles.Superscript] as const;
+const plugins = [Bold, Italic, Underline, Strikethrough, Code, Subscript, Superscript] as const;
 plugins.map(Plugin => {
     new Plugin(new MyEditor());
     const Required = Plugin.requires[0];
@@ -13,3 +34,66 @@ plugins.map(Plugin => {
     const required2 = new Required2(new MyEditor());
     required2.init();
 });
+
+// $ExpectType Bold
+editor.plugins.get('Bold');
+
+// $ExpectType BoldEditing
+editor.plugins.get('BoldEditing');
+
+// $ExpectType BoldUI
+editor.plugins.get('BoldUI');
+
+// $ExpectType Code
+editor.plugins.get('Code');
+
+// $ExpectType CodeEditing
+editor.plugins.get('CodeEditing');
+
+// $ExpectType CodeUI
+editor.plugins.get('CodeUI');
+
+// $ExpectType Italic
+editor.plugins.get('Italic');
+
+// $ExpectType ItalicEditing
+editor.plugins.get('ItalicEditing');
+
+// $ExpectType ItalicUI
+editor.plugins.get('ItalicUI');
+
+// $ExpectType Strikethrough
+editor.plugins.get('Strikethrough');
+
+// $ExpectType StrikethroughEditing
+editor.plugins.get('StrikethroughEditing');
+
+// $ExpectType StrikethroughUI
+editor.plugins.get('StrikethroughUI');
+
+// $ExpectType Subscript
+editor.plugins.get('Subscript');
+
+// $ExpectType SubscriptEditing
+editor.plugins.get('SubscriptEditing');
+
+// $ExpectType SubscriptUI
+editor.plugins.get('SubscriptUI');
+
+// $ExpectType Superscript
+editor.plugins.get('Superscript');
+
+// $ExpectType SuperscriptEditing
+editor.plugins.get('SuperscriptEditing');
+
+// $ExpectType SuperscriptUI
+editor.plugins.get('SuperscriptUI');
+
+// $ExpectType Underline
+editor.plugins.get('Underline');
+
+// $ExpectType UnderlineEditing
+editor.plugins.get('UnderlineEditing');
+
+// $ExpectType UnderlineUI
+editor.plugins.get('UnderlineUI');

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/bold.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/bold.d.ts
@@ -6,3 +6,9 @@ export default class Bold extends Plugin {
     static readonly requires: [typeof BoldEditing, typeof BoldUI];
     static readonly pluginName: "Bold";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Bold: Bold;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/bold/boldediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/bold/boldediting.d.ts
@@ -4,3 +4,9 @@ export default class BoldEditing extends Plugin {
     static readonly pluginName: "BoldEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BoldEditing: BoldEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/bold/boldui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/bold/boldui.d.ts
@@ -4,3 +4,9 @@ export default class BoldUI extends Plugin {
     static readonly pluginName: "BoldUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BoldUI: BoldUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/code.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/code.d.ts
@@ -6,3 +6,9 @@ export default class Code extends Plugin {
     static readonly requires: [typeof CodeEditing, typeof CodeUI];
     static readonly pluginName: "Code";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Code: Code;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/code/codeediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/code/codeediting.d.ts
@@ -6,3 +6,9 @@ export default class CodeEditing extends Plugin {
     static readonly requires: [typeof TwoStepCaretMovement];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeEditing: CodeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/code/codeui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/code/codeui.d.ts
@@ -4,3 +4,9 @@ export default class CodeUI extends Plugin {
     static readonly pluginName: "CodeUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeUI: CodeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/italic.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/italic.d.ts
@@ -6,3 +6,9 @@ export default class Italic extends Plugin {
     static readonly requires: [typeof ItalicEditing, typeof ItalicUI];
     static readonly pluginName: "Italic";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Italic: Italic;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/italic/italicediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/italic/italicediting.d.ts
@@ -4,3 +4,9 @@ export default class ItalicEditing extends Plugin {
     static readonly pluginName: "ItalicEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ItalicEditing: ItalicEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/italic/italicui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/italic/italicui.d.ts
@@ -4,3 +4,9 @@ export default class ItalicUI extends Plugin {
     static readonly pluginName: "ItalicUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ItalicUI: ItalicUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/strikethrough.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/strikethrough.d.ts
@@ -6,3 +6,9 @@ export default class Strikethrough extends Plugin {
     static readonly requires: [typeof StrikethroughEditing, typeof StrikethroughUI];
     static readonly pluginName: "Strikethrough";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Strikethrough: Strikethrough;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/strikethrough/strikethroughediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/strikethrough/strikethroughediting.d.ts
@@ -4,3 +4,9 @@ export default class StrikethroughEditing extends Plugin {
     static readonly pluginName: "StrikethroughEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StrikethroughEditing: StrikethroughEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/strikethrough/strikethroughui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/strikethrough/strikethroughui.d.ts
@@ -4,3 +4,9 @@ export default class StrikethroughUI extends Plugin {
     static readonly pluginName: "StrikethroughUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StrikethroughUI: StrikethroughUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/subscript.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/subscript.d.ts
@@ -6,3 +6,9 @@ export default class Subscript extends Plugin {
     static readonly requires: [typeof SubscriptEditing, typeof SubscriptUI];
     static readonly pluginName: "Subscript";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Subscript: Subscript;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/subscript/subscriptediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/subscript/subscriptediting.d.ts
@@ -4,3 +4,9 @@ export default class SubscriptEditing extends Plugin {
     static readonly pluginName: "SubscriptEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SubscriptEditing: SubscriptEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/subscript/subscriptui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/subscript/subscriptui.d.ts
@@ -4,3 +4,9 @@ export default class SubscriptUI extends Plugin {
     static readonly pluginName: "SubscriptUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SubscriptUI: SubscriptUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/superscript.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/superscript.d.ts
@@ -6,3 +6,9 @@ export default class Superscript extends Plugin {
     static readonly requires: [typeof SuperscriptEditing, typeof SuperscriptUI];
     static readonly pluginName: "Superscript";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Superscript: Superscript;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/superscript/superscriptediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/superscript/superscriptediting.d.ts
@@ -4,3 +4,9 @@ export default class SuperscriptEditing extends Plugin {
     static readonly pluginName: "SuperscriptEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SuperscriptEditing: SuperscriptEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/superscript/superscriptui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/superscript/superscriptui.d.ts
@@ -4,3 +4,9 @@ export default class SuperscriptUI extends Plugin {
     static readonly pluginName: "SuperscriptUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SuperscriptUI: SuperscriptUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/underline.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/underline.d.ts
@@ -6,3 +6,9 @@ export default class Underline extends Plugin {
     static readonly requires: [typeof UnderlineEditing, typeof UnderlineUI];
     static readonly pluginName: "Underline";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Underline: Underline;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/underline/underlineediting.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/underline/underlineediting.d.ts
@@ -4,3 +4,9 @@ export default class UnderlineEditing extends Plugin {
     static readonly pluginName: "UnderlineEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        UnderlineEditing: UnderlineEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-basic-styles/v27/src/underline/underlineui.d.ts
+++ b/types/ckeditor__ckeditor5-basic-styles/v27/src/underline/underlineui.d.ts
@@ -4,3 +4,9 @@ export default class UnderlineUI extends Plugin {
     static readonly pluginName: "UnderlineUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        UnderlineUI: UnderlineUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-block-quote/ckeditor__ckeditor5-block-quote-tests.ts
+++ b/types/ckeditor__ckeditor5-block-quote/ckeditor__ckeditor5-block-quote-tests.ts
@@ -16,3 +16,12 @@ new BlockQuoteUI(editor).init();
 
 new BlockQuoteCommand(editor).execute();
 new BlockQuoteCommand(editor).execute({ forceValue: true });
+
+// $ExpectType BlockQuote
+editor.plugins.get('BlockQuote');
+
+// $ExpectType BlockQuoteEditing
+editor.plugins.get('BlockQuoteEditing');
+
+// $ExpectType BlockQuoteUI
+editor.plugins.get('BlockQuoteUI');

--- a/types/ckeditor__ckeditor5-block-quote/src/blockquote.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/src/blockquote.d.ts
@@ -6,3 +6,9 @@ export default class BlockQuote extends Plugin {
     static readonly requires: [typeof BlockQuoteEditing, typeof BlockQuoteUI];
     static readonly pluginName: "BlockQuote";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockQuote: BlockQuote;
+    }
+}

--- a/types/ckeditor__ckeditor5-block-quote/src/blockquoteediting.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/src/blockquoteediting.d.ts
@@ -7,3 +7,9 @@ export default class BlockQuoteEditing extends Plugin {
     static readonly requires: [typeof Enter, typeof Delete];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockQuoteEditing: BlockQuoteEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-block-quote/src/blockquoteui.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/src/blockquoteui.d.ts
@@ -4,3 +4,9 @@ export default class BlockQuoteUI extends Plugin {
     static readonly pluginName: "BlockQuoteUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockQuoteUI: BlockQuoteUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-block-quote/v27/ckeditor__ckeditor5-block-quote-tests.ts
+++ b/types/ckeditor__ckeditor5-block-quote/v27/ckeditor__ckeditor5-block-quote-tests.ts
@@ -1,5 +1,8 @@
 import BQ from "@ckeditor/ckeditor5-block-quote";
 import BlockQuoteCommand from "@ckeditor/ckeditor5-block-quote/src/blockquotecommand";
+import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
+import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
+import BlockQuoteUI from '@ckeditor/ckeditor5-block-quote/src/blockquoteui';
 import { Editor } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
@@ -16,3 +19,12 @@ new BQ.BlockQuoteUI(editor).init();
 
 new BlockQuoteCommand(editor).execute();
 new BlockQuoteCommand(editor).execute({ forceValue: true });
+
+// $ExpectType BlockQuote
+editor.plugins.get('BlockQuote');
+
+// $ExpectType BlockQuoteEditing
+editor.plugins.get('BlockQuoteEditing');
+
+// $ExpectType BlockQuoteUI
+editor.plugins.get('BlockQuoteUI');

--- a/types/ckeditor__ckeditor5-block-quote/v27/src/blockquote.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/v27/src/blockquote.d.ts
@@ -6,3 +6,9 @@ export default class BlockQuote extends Plugin {
     static readonly requires: [typeof BlockQuoteEditing, typeof BlockQuoteUI];
     static readonly pluginName: "BlockQuote";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockQuote: BlockQuote;
+    }
+}

--- a/types/ckeditor__ckeditor5-block-quote/v27/src/blockquoteediting.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/v27/src/blockquoteediting.d.ts
@@ -7,3 +7,9 @@ export default class BlockQuoteEditing extends Plugin {
     static readonly requires: [typeof Enter, typeof Delete];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockQuoteEditing: BlockQuoteEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-block-quote/v27/src/blockquoteui.d.ts
+++ b/types/ckeditor__ckeditor5-block-quote/v27/src/blockquoteui.d.ts
@@ -4,3 +4,9 @@ export default class BlockQuoteUI extends Plugin {
     static readonly pluginName: "BlockQuoteUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockQuoteUI: BlockQuoteUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-ckfinder/ckeditor__ckeditor5-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/ckeditor__ckeditor5-ckfinder-tests.ts
@@ -14,11 +14,21 @@ const plugincollection = new PluginCollection(new BaseEditor(), [CKFinder]);
 class MyEditor extends Editor {
     plugins = plugincollection;
 }
+const editor = new MyEditor();
 
 const ckfinderui = new CKFinderUI(new MyEditor());
 ckfinderui.init();
 
 const ckfinderediting = new CKFinderEditing(new MyEditor());
 ckfinderediting.init();
+
+// $ExpectType CKFinder
+editor.plugins.get('CKFinder');
+
+// $ExpectType CKFinderEditing
+editor.plugins.get('CKFinderEditing');
+
+// $ExpectType CKFinderUI
+editor.plugins.get('CKFinderUI');
 
 new CKFinderCommand(new BaseEditor()).execute();

--- a/types/ckeditor__ckeditor5-ckfinder/src/ckfinder.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/src/ckfinder.d.ts
@@ -46,3 +46,9 @@ export interface CKFinderConfig {
           }
        ;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinder: CKFinder;
+    }
+}

--- a/types/ckeditor__ckeditor5-ckfinder/src/ckfinderediting.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/src/ckfinderediting.d.ts
@@ -7,3 +7,9 @@ export default class CKFinderEditing extends Plugin {
     static requires: [typeof Notification, typeof LinkEditing];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinderEditing: CKFinderEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-ckfinder/src/ckfinderui.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/src/ckfinderui.d.ts
@@ -4,3 +4,9 @@ export default class CKFinderUI extends Plugin {
     static pluginName: "CKFinderUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinderUI: CKFinderUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-ckfinder/v27/ckeditor__ckeditor5-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/ckeditor__ckeditor5-ckfinder-tests.ts
@@ -15,10 +15,21 @@ class MyEditor extends Editor {
     plugins = plugincollection;
 }
 
+const editor = new MyEditor();
+
 const ckfinderui = new CKFinder.CKFinderUI(new MyEditor());
 ckfinderui.init();
 
 const ckfinderediting = new CKFinder.CKFinderEditing(new MyEditor());
 ckfinderediting.init();
+
+// $ExpectType CKFinder
+editor.plugins.get('CKFinder');
+
+// $ExpectType CKFinderEditing
+editor.plugins.get('CKFinderEditing');
+
+// $ExpectType CKFinderUI
+editor.plugins.get('CKFinderUI');
 
 new CKFinderCommand(new BaseEditor()).execute();

--- a/types/ckeditor__ckeditor5-ckfinder/v27/src/ckfinder.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/src/ckfinder.d.ts
@@ -43,3 +43,9 @@ export interface CKFinderConfig {
         width?: string | number | undefined;
     } | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinder: CKFinder;
+    }
+}

--- a/types/ckeditor__ckeditor5-ckfinder/v27/src/ckfinderediting.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/src/ckfinderediting.d.ts
@@ -7,3 +7,9 @@ export default class CKFinderEditing extends Plugin {
     static requires: [typeof Notification, "ImageEditing", typeof LinkEditing];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinderEditing: CKFinderEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-ckfinder/v27/src/ckfinderui.d.ts
+++ b/types/ckeditor__ckeditor5-ckfinder/v27/src/ckfinderui.d.ts
@@ -4,3 +4,9 @@ export default class CKFinderUI extends Plugin {
     static pluginName: "CKFinderUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CKFinderUI: CKFinderUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/ckeditor__ckeditor5-clipboard-tests.ts
+++ b/types/ckeditor__ckeditor5-clipboard/ckeditor__ckeditor5-clipboard-tests.ts
@@ -31,3 +31,15 @@ normalizeClipboardData(plainTextToHTML(''));
 plainTextToHTML(viewToPlainText(viewElement));
 
 new ClipboardObserver(new View(new StylesProcessor())).onDomEvent(new ClipboardEvent(''));
+
+// $ExpectType Clipboard
+editor.plugins.get('Clipboard');
+
+// $ExpectType ClipboardPipeline
+editor.plugins.get('ClipboardPipeline');
+
+// $ExpectType DragDrop
+editor.plugins.get('DragDrop');
+
+// $ExpectType PastePlainText
+editor.plugins.get('PastePlainText');

--- a/types/ckeditor__ckeditor5-clipboard/src/clipboard.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/src/clipboard.d.ts
@@ -7,3 +7,9 @@ export default class Clipboard extends Plugin {
     static readonly pluginName: 'Clipboard';
     static readonly requires: [typeof ClipboardPipeline, typeof DragDrop, typeof PastePlainText];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Clipboard: Clipboard;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/src/clipboardpipeline.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/src/clipboardpipeline.d.ts
@@ -12,3 +12,9 @@ export interface ClipboardOutputEventData {
     readonly dataTransfer: DataTransfer;
     method: 'copy' | 'cut';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ClipboardPipeline: ClipboardPipeline;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/src/dragdrop.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/src/dragdrop.d.ts
@@ -8,3 +8,9 @@ export default class DragDrop extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        DragDrop: DragDrop;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/src/pasteplaintext.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/src/pasteplaintext.d.ts
@@ -6,3 +6,9 @@ export default class PastePlainText extends Plugin {
     static readonly requires: [typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PastePlainText: PastePlainText;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/v27/ckeditor__ckeditor5-clipboard-tests.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/ckeditor__ckeditor5-clipboard-tests.ts
@@ -5,6 +5,9 @@ import plainTextToHTML from '@ckeditor/ckeditor5-clipboard/src/utils/plaintextto
 import viewToPlainText from '@ckeditor/ckeditor5-clipboard/src/utils/viewtoplaintext';
 import { Editor } from '@ckeditor/ckeditor5-core';
 import { DowncastWriter, StylesProcessor, ViewDocument } from '@ckeditor/ckeditor5-engine';
+import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeline';
+import DragDrop from '@ckeditor/ckeditor5-clipboard/src/dragdrop';
+import PastePlainText from '@ckeditor/ckeditor5-clipboard/src/pasteplaintext';
 import View from '@ckeditor/ckeditor5-engine/src/view/view';
 
 class MyEditor extends Editor {}
@@ -27,6 +30,18 @@ new Clipboard.ClipboardPipeline(editor).init();
 plainTextToHTML(plainTextToHTML(''));
 
 normalizeClipboardData(plainTextToHTML(''));
+
+// $ExpectType Clipboard
+editor.plugins.get('Clipboard');
+
+// $ExpectType ClipboardPipeline
+editor.plugins.get('ClipboardPipeline');
+
+// $ExpectType DragDrop
+editor.plugins.get('DragDrop');
+
+// $ExpectType PastePlainText
+editor.plugins.get('PastePlainText');
 
 plainTextToHTML(viewToPlainText(viewElement));
 

--- a/types/ckeditor__ckeditor5-clipboard/v27/src/clipboard.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/src/clipboard.d.ts
@@ -7,3 +7,9 @@ export default class Clipboard extends Plugin {
     static readonly pluginName: 'Clipboard';
     static readonly requires: [typeof ClipboardPipeline, typeof DragDrop, typeof PastePlainText];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Clipboard: Clipboard;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/v27/src/clipboardpipeline.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/src/clipboardpipeline.d.ts
@@ -12,3 +12,9 @@ export interface ClipboardOutputEventData {
     readonly dataTransfer: DataTransfer;
     method: 'copy' | 'cut';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ClipboardPipeline: ClipboardPipeline;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/v27/src/dragdrop.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/src/dragdrop.d.ts
@@ -8,3 +8,9 @@ export default class DragDrop extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        DragDrop: DragDrop;
+    }
+}

--- a/types/ckeditor__ckeditor5-clipboard/v27/src/pasteplaintext.d.ts
+++ b/types/ckeditor__ckeditor5-clipboard/v27/src/pasteplaintext.d.ts
@@ -6,3 +6,9 @@ export default class PastePlainText extends Plugin {
     static readonly requires: [typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PastePlainText: PastePlainText;
+    }
+}

--- a/types/ckeditor__ckeditor5-cloud-services/ckeditor__ckeditor5-cloud-services-tests.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/ckeditor__ckeditor5-cloud-services-tests.ts
@@ -3,6 +3,7 @@ import Token from "@ckeditor/ckeditor5-cloud-services/src/token/token";
 import { Editor } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 const instance = new CloudServices(new MyEditor());
 instance.uploadUrl = "foo";
@@ -20,3 +21,9 @@ const core = new CloudServicesCore(new MyEditor());
 token = core.createToken("foo");
 token = core.createToken("foo", { autoRefresh: true, initValue: "bar" });
 core.createUploadGateway(token, "foo");
+
+// $ExpectType CloudServices
+editor.plugins.get('CloudServices');
+
+// $ExpectType CloudServicesCore
+editor.plugins.get('CloudServicesCore');

--- a/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/cloudservices.d.ts
@@ -43,3 +43,9 @@ export interface CloudServicesConfig {
     uploadUrl: string;
     webSocketUrl?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CloudServices: CloudServices;
+    }
+}

--- a/types/ckeditor__ckeditor5-cloud-services/src/cloudservicescore.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/cloudservicescore.d.ts
@@ -10,3 +10,9 @@ export default class CloudServicesCore extends ContextPlugin {
     ): Token;
     createUploadGateway(token: Token, apiAddress: string): UploadGateway;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CloudServicesCore: CloudServicesCore;
+    }
+}

--- a/types/ckeditor__ckeditor5-cloud-services/v27/ckeditor__ckeditor5-cloud-services-tests.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/ckeditor__ckeditor5-cloud-services-tests.ts
@@ -3,6 +3,7 @@ import { Editor } from "@ckeditor/ckeditor5-core";
 import Token from "@ckeditor/ckeditor5-cloud-services/src/token/token";
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
 const instance = new CloudServices.CloudServices(new MyEditor());
 instance.uploadUrl = "foo";
@@ -20,3 +21,9 @@ const core = new CloudServices.CloudServicesCore(new MyEditor());
 token = core.createToken("foo");
 token = core.createToken("foo", { autoRefresh: true, initValue: "bar" });
 core.createUploadGateway(token, "foo");
+
+// $ExpectType CloudServices
+editor.plugins.get('CloudServices');
+
+// $ExpectType CloudServicesCore
+editor.plugins.get('CloudServicesCore');

--- a/types/ckeditor__ckeditor5-cloud-services/v27/src/cloudservices.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/src/cloudservices.d.ts
@@ -43,3 +43,9 @@ export interface CloudServicesConfig {
     uploadUrl: string;
     webSocketUrl?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CloudServices: CloudServices;
+    }
+}

--- a/types/ckeditor__ckeditor5-cloud-services/v27/src/cloudservicescore.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/v27/src/cloudservicescore.d.ts
@@ -10,3 +10,9 @@ export default class CloudServicesCore extends ContextPlugin {
     ): Token;
     createUploadGateway(token: Token, apiAddress: string): UploadGateway;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CloudServicesCore: CloudServicesCore;
+    }
+}

--- a/types/ckeditor__ckeditor5-code-block/ckeditor__ckeditor5-code-block-tests.ts
+++ b/types/ckeditor__ckeditor5-code-block/ckeditor__ckeditor5-code-block-tests.ts
@@ -41,3 +41,12 @@ new IndentCodeBlockCommand(editor).refresh();
 
 new OutdentCodeBlockCommand(editor).execute();
 new OutdentCodeBlockCommand(editor).refresh();
+
+// $ExpectType CodeBlock
+editor.plugins.get('CodeBlock');
+
+// $ExpectType CodeBlockEditing
+editor.plugins.get('CodeBlockEditing');
+
+// $ExpectType CodeBlockUI
+editor.plugins.get('CodeBlockUI');

--- a/types/ckeditor__ckeditor5-code-block/src/codeblock.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/src/codeblock.d.ts
@@ -17,3 +17,9 @@ export interface CodeBlockLanguageDefinition {
     label: string;
     language: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlock: CodeBlock;
+    }
+}

--- a/types/ckeditor__ckeditor5-code-block/src/codeblockediting.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/src/codeblockediting.d.ts
@@ -7,3 +7,9 @@ export default class CodeBlockEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlockEditing: CodeBlockEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-code-block/src/codeblockui.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/src/codeblockui.d.ts
@@ -4,3 +4,9 @@ export default class CodeBlockUI extends Plugin {
     static readonly pluginName: 'CodeBlockUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlockUI: CodeBlockUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-code-block/v27/ckeditor__ckeditor5-code-block-tests.ts
+++ b/types/ckeditor__ckeditor5-code-block/v27/ckeditor__ckeditor5-code-block-tests.ts
@@ -1,5 +1,7 @@
 import Code from '@ckeditor/ckeditor5-code-block';
 import CodeCommand from '@ckeditor/ckeditor5-code-block/src/codeblockcommand';
+import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
+import CodeBlockUI from '@ckeditor/ckeditor5-code-block/src/codeblockui';
 import * as converters from '@ckeditor/ckeditor5-code-block/src/converters';
 import IndentCodeBlockCommand from '@ckeditor/ckeditor5-code-block/src/indentcodeblockcommand';
 import OutdentCodeBlockCommand from '@ckeditor/ckeditor5-code-block/src/outdentcodeblockcommand';
@@ -40,3 +42,12 @@ new IndentCodeBlockCommand(editor).refresh();
 
 new OutdentCodeBlockCommand(editor).execute();
 new OutdentCodeBlockCommand(editor).refresh();
+
+// $ExpectType CodeBlock
+editor.plugins.get('CodeBlock');
+
+// $ExpectType CodeBlockEditing
+editor.plugins.get('CodeBlockEditing');
+
+// $ExpectType CodeBlockUI
+editor.plugins.get('CodeBlockUI');

--- a/types/ckeditor__ckeditor5-code-block/v27/src/codeblock.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/v27/src/codeblock.d.ts
@@ -17,3 +17,9 @@ export interface CodeBlockLanguageDefinition {
     label: string;
     language: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlock: CodeBlock;
+    }
+}

--- a/types/ckeditor__ckeditor5-code-block/v27/src/codeblockediting.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/v27/src/codeblockediting.d.ts
@@ -7,3 +7,9 @@ export default class CodeBlockEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlockEditing: CodeBlockEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-code-block/v27/src/codeblockui.d.ts
+++ b/types/ckeditor__ckeditor5-code-block/v27/src/codeblockui.d.ts
@@ -4,3 +4,9 @@ export default class CodeBlockUI extends Plugin {
     static readonly pluginName: 'CodeBlockUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlockUI: CodeBlockUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
@@ -49,3 +49,9 @@ export default class PendingActions
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PendingActions: PendingActions;
+    }
+}

--- a/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
@@ -7,6 +7,9 @@ import ContextPlugin from "./contextplugin";
 import Editor from "./editor/editor";
 import Plugin, { PluginInterface, LoadedPlugins } from "./plugin";
 
+// tslint:disable-next-line:no-empty-interface
+export interface Plugins {}
+
 export default class PluginCollection implements Emitter, Iterable<[typeof Plugin, Plugin]> {
     constructor(
         context: Editor | Context,
@@ -19,6 +22,7 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
 
     get<T extends Plugin>(key: PluginInterface<T>): T;
     get<T extends ContextPlugin>(key: PluginInterface<T>): T;
+    get<T extends keyof Plugins>(key: T): Plugins[T];
     get(key: string): Plugin | ContextPlugin;
 
     has(key: PluginInterface | string): boolean;

--- a/types/ckeditor__ckeditor5-core/v27/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/pendingactions.d.ts
@@ -49,3 +49,9 @@ export default class PendingActions
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PendingActions: PendingActions;
+    }
+}

--- a/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
@@ -7,6 +7,9 @@ import ContextPlugin from "./contextplugin";
 import Editor from "./editor/editor";
 import Plugin, { PluginInterface, LoadedPlugins } from "./plugin";
 
+// tslint:disable-next-line:no-empty-interface
+export interface Plugins {}
+
 export default class PluginCollection implements Emitter, Iterable<[typeof Plugin, Plugin]> {
     constructor(
         context: Editor | Context,
@@ -19,6 +22,7 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
 
     get<T extends Plugin>(key: PluginInterface<T>): T;
     get<T extends ContextPlugin>(key: PluginInterface<T>): T;
+    get<T extends keyof Plugins>(key: T): Plugins[T];
     get(key: string): Plugin | ContextPlugin;
 
     has(key: PluginInterface | string): boolean;

--- a/types/ckeditor__ckeditor5-easy-image/ckeditor__ckeditor5-easy-image-tests.ts
+++ b/types/ckeditor__ckeditor5-easy-image/ckeditor__ckeditor5-easy-image-tests.ts
@@ -1,42 +1,14 @@
 import { Editor } from "@ckeditor/ckeditor5-core";
-import { ExportWord } from "@ckeditor/ckeditor5-export-word";
-import { ExportWordConfig } from "@ckeditor/ckeditor5-export-word/src/exportword";
+import { EasyImage, CloudServicesUploadAdapter } from '@ckeditor/ckeditor5-easy-image';
 
 class MyEditor extends Editor {}
+const editor = new MyEditor();
 
-const bool: boolean = ExportWord.isContextPlugin;
-const plugin = new ExportWord(new MyEditor());
-const promise = plugin.destroy?.();
-if (promise != null) {
-    promise.then(() => {});
-}
+new CloudServicesUploadAdapter(editor).init();
+new EasyImage(editor).init();
 
-let config: ExportWordConfig = {};
-config = {
-    converterOptions: {},
-};
-config = {
-    converterOptions: {
-        margin_top: 0,
-        margin_bottom: "15cm",
-        margin_right: "1cm",
-        margin_left: 0,
-        format: "A6",
-        auto_pagination: bool,
-    },
-};
-config = {
-    converterUrl: "",
-    fileName: "",
-    stylesheets: [""],
-    tokenUrl: false,
-};
+// $ExpectType CloudServicesUploadAdapter
+editor.plugins.get('CloudServicesUploadAdapter');
 
-config = {
-    tokenUrl() {
-        return Promise.resolve("");
-    },
-};
-config = {
-    tokenUrl: "",
-};
+// $ExpectType EasyImage
+editor.plugins.get('EasyImage');

--- a/types/ckeditor__ckeditor5-easy-image/src/cloudservicesuploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-easy-image/src/cloudservicesuploadadapter.d.ts
@@ -5,4 +5,11 @@ import { FileRepository } from '@ckeditor/ckeditor5-upload';
 export default class CloudServicesUploadAdapter extends Plugin {
     static pluginName: 'CloudServicesUploadAdapter';
     static requires: [typeof CloudServices, typeof FileRepository];
+    init(): void;
+}
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CloudServicesUploadAdapter: CloudServicesUploadAdapter;
+    }
 }

--- a/types/ckeditor__ckeditor5-easy-image/src/easyimage.d.ts
+++ b/types/ckeditor__ckeditor5-easy-image/src/easyimage.d.ts
@@ -7,3 +7,9 @@ export default class EasyImage extends Plugin {
     static pluginName: "EasyImage";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        EasyImage: EasyImage;
+    }
+}

--- a/types/ckeditor__ckeditor5-easy-image/v27/ckeditor__ckeditor5-easy-image-tests.ts
+++ b/types/ckeditor__ckeditor5-easy-image/v27/ckeditor__ckeditor5-easy-image-tests.ts
@@ -1,42 +1,15 @@
 import { Editor } from "@ckeditor/ckeditor5-core";
-import { ExportWord } from "@ckeditor/ckeditor5-export-word";
-import { ExportWordConfig } from "@ckeditor/ckeditor5-export-word/src/exportword";
+import EI from '@ckeditor/ckeditor5-easy-image';
 
 class MyEditor extends Editor {}
 
-const bool: boolean = ExportWord.isContextPlugin;
-const plugin = new ExportWord(new MyEditor());
-const promise = plugin.destroy?.();
-if (promise != null) {
-    promise.then(() => {});
-}
+new EI.CloudServicesUploadAdapter(new MyEditor()).init();
+new EI.EasyImage(new MyEditor()).init();
 
-let config: ExportWordConfig = {};
-config = {
-    converterOptions: {},
-};
-config = {
-    converterOptions: {
-        margin_top: 0,
-        margin_bottom: "15cm",
-        margin_right: "1cm",
-        margin_left: 0,
-        format: "A6",
-        auto_pagination: bool,
-    },
-};
-config = {
-    converterUrl: "",
-    fileName: "",
-    stylesheets: [""],
-    tokenUrl: false,
-};
+const editor = new MyEditor();
 
-config = {
-    tokenUrl() {
-        return Promise.resolve("");
-    },
-};
-config = {
-    tokenUrl: "",
-};
+// $ExpectType CloudServicesUploadAdapter
+editor.plugins.get('CloudServicesUploadAdapter');
+
+// $ExpectType EasyImage
+editor.plugins.get('EasyImage');

--- a/types/ckeditor__ckeditor5-easy-image/v27/src/cloudservicesuploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-easy-image/v27/src/cloudservicesuploadadapter.d.ts
@@ -5,4 +5,11 @@ import { FileRepository } from '@ckeditor/ckeditor5-upload';
 export default class CloudServicesUploadAdapter extends Plugin {
     static pluginName: 'CloudServicesUploadAdapter';
     static requires: [typeof CloudServices, typeof FileRepository];
+    init(): void;
+}
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CloudServicesUploadAdapter: CloudServicesUploadAdapter;
+    }
 }

--- a/types/ckeditor__ckeditor5-easy-image/v27/src/easyimage.d.ts
+++ b/types/ckeditor__ckeditor5-easy-image/v27/src/easyimage.d.ts
@@ -4,4 +4,11 @@ import CloudServicesUploadAdapter from "./cloudservicesuploadadapter";
 export default class EasyImage extends Plugin {
     static requires: [typeof CloudServicesUploadAdapter, "Image", "ImageUpload"];
     static pluginName: "EasyImage";
+    init(): void;
+}
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        EasyImage: EasyImage;
+    }
 }

--- a/types/ckeditor__ckeditor5-enter/ckeditor__ckeditor5-enter-tests.ts
+++ b/types/ckeditor__ckeditor5-enter/ckeditor__ckeditor5-enter-tests.ts
@@ -27,3 +27,9 @@ const shiftEnterCommand = new ShiftEnterCommand(myEditor);
 shiftEnterCommand.execute();
 
 const result: Generator<number> = utils.getCopyOnEnterAttributes(new Schema(), [4, 5, 6]);
+
+// $ExpectType Enter
+myEditor.plugins.get('Enter');
+
+// $ExpectType ShiftEnter
+myEditor.plugins.get('ShiftEnter');

--- a/types/ckeditor__ckeditor5-enter/src/enter.d.ts
+++ b/types/ckeditor__ckeditor5-enter/src/enter.d.ts
@@ -4,3 +4,9 @@ export default class Enter extends Plugin {
     static readonly pluginName: "Enter";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Enter: Enter;
+    }
+}

--- a/types/ckeditor__ckeditor5-enter/src/shiftenter.d.ts
+++ b/types/ckeditor__ckeditor5-enter/src/shiftenter.d.ts
@@ -4,3 +4,9 @@ export default class ShiftEnter extends Plugin {
     static readonly pluginName: "ShiftEnter";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ShiftEnter: ShiftEnter;
+    }
+}

--- a/types/ckeditor__ckeditor5-essentials/ckeditor__ckeditor5-essentials-tests.ts
+++ b/types/ckeditor__ckeditor5-essentials/ckeditor__ckeditor5-essentials-tests.ts
@@ -8,3 +8,6 @@ const name: "Essentials" = Essentials.pluginName;
 let constructor: typeof Plugin = Essentials;
 constructor = Essentials.requires[5];
 const plugin: Plugin = new Essentials(new MyEditor());
+
+// $ExpectType Essentials
+new MyEditor().plugins.get('Essentials');

--- a/types/ckeditor__ckeditor5-essentials/src/essentials.d.ts
+++ b/types/ckeditor__ckeditor5-essentials/src/essentials.d.ts
@@ -9,3 +9,9 @@ export default class Essentials extends Plugin {
     static requires: [typeof Clipboard, typeof Enter, typeof SelectAll, typeof ShiftEnter, typeof Typing, typeof Undo];
     static pluginName: 'Essentials';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Essentials: Essentials;
+    }
+}

--- a/types/ckeditor__ckeditor5-essentials/v27/ckeditor__ckeditor5-essentials-tests.ts
+++ b/types/ckeditor__ckeditor5-essentials/v27/ckeditor__ckeditor5-essentials-tests.ts
@@ -8,3 +8,6 @@ const name: "Essentials" = Essentials.Essentials.pluginName;
 let constructor: typeof Plugin = Essentials.Essentials;
 constructor = Essentials.Essentials.requires[5];
 const plugin: Plugin = new Essentials.Essentials(new MyEditor());
+
+// $ExpectType Essentials
+new MyEditor().plugins.get('Essentials');

--- a/types/ckeditor__ckeditor5-essentials/v27/src/essentials.d.ts
+++ b/types/ckeditor__ckeditor5-essentials/v27/src/essentials.d.ts
@@ -9,3 +9,9 @@ export default class Essentials extends Plugin {
     static requires: [typeof Clipboard, typeof Enter, typeof SelectAll, typeof ShiftEnter, typeof Typing, typeof Undo];
     static pluginName: 'Essentials';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Essentials: Essentials;
+    }
+}

--- a/types/ckeditor__ckeditor5-export-pdf/ckeditor__ckeditor5-export-pdf-tests.ts
+++ b/types/ckeditor__ckeditor5-export-pdf/ckeditor__ckeditor5-export-pdf-tests.ts
@@ -51,3 +51,6 @@ config = {
 config = {
     tokenUrl: "",
 };
+
+// $ExpectType ExportPdf
+(new MyEditor()).plugins.get('ExportPdf');

--- a/types/ckeditor__ckeditor5-export-pdf/src/exportpdf.d.ts
+++ b/types/ckeditor__ckeditor5-export-pdf/src/exportpdf.d.ts
@@ -25,3 +25,9 @@ export interface ExportPdfConfig {
     stylesheets?: string[] | undefined;
     tokenUrl?: boolean | string | (() => Promise<string>) | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ExportPdf: ExportPdf;
+    }
+}

--- a/types/ckeditor__ckeditor5-export-word/ckeditor__ckeditor5-export-word-tests.ts
+++ b/types/ckeditor__ckeditor5-export-word/ckeditor__ckeditor5-export-word-tests.ts
@@ -42,3 +42,6 @@ config = {
 config = {
     tokenUrl: "",
 };
+
+// $ExpectType ExportWord
+new MyEditor().plugins.get('ExportWord');

--- a/types/ckeditor__ckeditor5-export-word/src/exportword.d.ts
+++ b/types/ckeditor__ckeditor5-export-word/src/exportword.d.ts
@@ -58,3 +58,9 @@ export interface ExportWordConfig {
     stylesheets?: string[] | undefined;
     tokenUrl?: false | string | (() => Promise<string>) | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ExportWord: ExportWord;
+    }
+}

--- a/types/ckeditor__ckeditor5-find-and-replace/ckeditor__ckeditor5-find-and-replace-tests.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/ckeditor__ckeditor5-find-and-replace-tests.ts
@@ -64,3 +64,12 @@ utils.updateFindResultFromRange(range, new Model(), (str, options) => {
     str.startsWith('');
     return utils.findByTextCallback(str, options);
 });
+
+// $ExpectType FindAndReplace
+editor.plugins.get('FindAndReplace');
+
+// $ExpectType FindAndReplaceEditing
+editor.plugins.get('FindAndReplaceEditing');
+
+// $ExpectType FindAndReplaceUI
+editor.plugins.get('FindAndReplaceUI');

--- a/types/ckeditor__ckeditor5-find-and-replace/src/findandreplace.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/src/findandreplace.d.ts
@@ -7,3 +7,9 @@ export default class FindAndReplace extends Plugin {
     static readonly pluginName: 'FindAndReplace';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FindAndReplace: FindAndReplace;
+    }
+}

--- a/types/ckeditor__ckeditor5-find-and-replace/src/findandreplaceediting.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/src/findandreplaceediting.d.ts
@@ -54,3 +54,9 @@ export default class FindAndReplaceEditing extends Plugin {
      */
     stop(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FindAndReplaceEditing: FindAndReplaceEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-find-and-replace/src/findandreplaceui.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/src/findandreplaceui.d.ts
@@ -26,3 +26,9 @@ export default class FindAndReplaceUI extends Plugin {
 
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FindAndReplaceUI: FindAndReplaceUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/ckeditor__ckeditor5-font-tests.ts
+++ b/types/ckeditor__ckeditor5-font/ckeditor__ckeditor5-font-tests.ts
@@ -66,3 +66,42 @@ new ColorTableView(new Locale(), {
 });
 
 new ColorUI(editor, { commandName: '', icon: '', componentName: '', dropdownLabel: '' }).init();
+
+// $ExpectType Font
+editor.plugins.get('Font');
+
+// $ExpectType FontBackgroundColor
+editor.plugins.get('FontBackgroundColor');
+
+// $ExpectType FontBackgroundColorEditing
+editor.plugins.get('FontBackgroundColorEditing');
+
+// $ExpectType FontBackgroundColorUI
+editor.plugins.get('FontBackgroundColorUI');
+
+// $ExpectType FontColor
+editor.plugins.get('FontColor');
+
+// $ExpectType FontColorEditing
+editor.plugins.get('FontColorEditing');
+
+// $ExpectType FontColorUI
+editor.plugins.get('FontColorUI');
+
+// $ExpectType FontFamily
+editor.plugins.get('FontFamily');
+
+// $ExpectType FontFamilyEditing
+editor.plugins.get('FontFamilyEditing');
+
+// $ExpectType FontFamilyUI
+editor.plugins.get('FontFamilyUI');
+
+// $ExpectType FontSize
+editor.plugins.get('FontSize');
+
+// $ExpectType FontSizeEditing
+editor.plugins.get('FontSizeEditing');
+
+// $ExpectType FontSizeUI
+editor.plugins.get('FontSizeUI');

--- a/types/ckeditor__ckeditor5-font/src/font.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/font.d.ts
@@ -8,3 +8,9 @@ export default class Font extends Plugin {
     static readonly requires: [typeof FontFamily, typeof FontSize, typeof FontColor, typeof FontBackgroundColor];
     static readonly pluginName: 'Font';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Font: Font;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontbackgroundcolor.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontbackgroundcolor.d.ts
@@ -12,3 +12,9 @@ export interface FontBackgroundColorConfig {
     columns?: number | undefined;
     documentColors?: number | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontBackgroundColor: FontBackgroundColor;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class FontBackgroundColorEditing extends Plugin {
     static readonly pluginName: 'FontBackgroundColorEditing';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontBackgroundColorEditing: FontBackgroundColorEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.d.ts
@@ -5,3 +5,9 @@ export default class FontBackgroundColorUI extends ColorUI {
     constructor(editor: Editor);
     static readonly pluginName: 'FontBackgroundColorUI';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontBackgroundColorUI: FontBackgroundColorUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontcolor.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontcolor.d.ts
@@ -12,3 +12,9 @@ export interface FontColorConfig {
     columns?: number | undefined;
     documentColors?: number | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontColor: FontColor;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontcolor/fontcolorediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontcolor/fontcolorediting.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class FontColorEditing extends Plugin {
     static readonly pluginName: 'FontColorEditing';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontColorEditing: FontColorEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontcolor/fontcolorui.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontcolor/fontcolorui.d.ts
@@ -5,3 +5,9 @@ export default class FontColorUI extends ColorUI {
     constructor(editor: Editor);
     static readonly pluginName: 'FontColorUI';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontColorUI: FontColorUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontfamily.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontfamily.d.ts
@@ -19,3 +19,9 @@ export interface FontFamilyConfig {
     options?: Array<string | FontFamilyOption> | undefined;
     supportAllValues?: boolean | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontFamily: FontFamily;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontfamily/fontfamilyediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontfamily/fontfamilyediting.d.ts
@@ -4,3 +4,9 @@ export default class FontFamilyEditing extends Plugin {
     static readonly pluginName: 'FontFamilyEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontFamilyEditing: FontFamilyEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontfamily/fontfamilyui.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontfamily/fontfamilyui.d.ts
@@ -4,3 +4,9 @@ export default class FontFamilyUI extends Plugin {
     static readonly pluginName: 'FontFamilyUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontFamilyUI: FontFamilyUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontsize.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontsize.d.ts
@@ -19,3 +19,9 @@ export interface FontSizeConfig {
     options?: Array<string | number | FontSizeOption> | undefined;
     supportAllValues?: boolean | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontSize: FontSize;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontsize/fontsizeediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontsize/fontsizeediting.d.ts
@@ -4,3 +4,9 @@ export default class FontSizeEditing extends Plugin {
     static readonly pluginName: 'FontSizeEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontSizeEditing: FontSizeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/src/fontsize/fontsizeui.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/fontsize/fontsizeui.d.ts
@@ -4,3 +4,9 @@ export default class FontSizeUI extends Plugin {
     static readonly pluginName: 'FontSizeUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontSizeUI: FontSizeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/ckeditor__ckeditor5-font-tests.ts
+++ b/types/ckeditor__ckeditor5-font/v27/ckeditor__ckeditor5-font-tests.ts
@@ -4,6 +4,19 @@ import DocumentColorCollection from '@ckeditor/ckeditor5-font/src/documentcolorc
 import ColorTableView from '@ckeditor/ckeditor5-font/src/ui/colortableview';
 import ColorUI from '@ckeditor/ckeditor5-font/src/ui/colorui';
 import { Locale } from '@ckeditor/ckeditor5-utils';
+// import Font from '@ckeditor/ckeditor5-font/src/font';
+// import FontBackgroundColor from '@ckeditor/ckeditor5-font/src/fontbackgroundcolor';
+// import FontBackgroundColorUI from '@ckeditor/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcoloreditingui';
+// import FontBackgroundColorEditing from '@ckeditor/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting';
+// import FontColor from '@ckeditor/ckeditor5-font/src/fontcolor';
+// import FontColorEditing from '@ckeditor/ckeditor5-font/src/fontcolor/fontcolorediting';
+// import FontColorUI from '@ckeditor/ckeditor5-font/src/fontcolor/fontcolorui';
+// import FontFamily from '@ckeditor/ckeditor5-font/src/fontfamily';
+// import FontFamilyEditing from '@ckeditor/ckeditor5-font/src/fontfamily/fontfamilyediting';
+// import FontFamilyUI from '@ckeditor/ckeditor5-font/src/fontfamily/fontfamilyui';
+// import FontSize from '@ckeditor/ckeditor5-font/src/fontsize';
+// import FontSizeEditing from '@ckeditor/ckeditor5-font/src/fontsize/fontsizeediting';
+// import FontSizeUI from '@ckeditor/ckeditor5-font/src/fontsize/fontsizeui';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -52,3 +65,39 @@ new ColorTableView(new Locale(), {
 });
 
 new ColorUI(editor, { commandName: '', icon: '', componentName: '', dropdownLabel: '' }).init();
+
+// $ExpectType Font
+editor.plugins.get('Font');
+
+// $ExpectType FontBackgroundColor
+editor.plugins.get('FontBackgroundColor');
+
+// $ExpectType FontBackgroundColorEditing
+editor.plugins.get('FontBackgroundColorEditing');
+
+// $ExpectType FontBackgroundColorUI
+editor.plugins.get('FontBackgroundColorUI');
+
+// $ExpectType FontColor
+editor.plugins.get('FontColor');
+
+// $ExpectType FontColorEditing
+editor.plugins.get('FontColorEditing');
+
+// $ExpectType FontFamily
+editor.plugins.get('FontFamily');
+
+// $ExpectType FontFamilyEditing
+editor.plugins.get('FontFamilyEditing');
+
+// $ExpectType FontFamilyUI
+editor.plugins.get('FontFamilyUI');
+
+// $ExpectType FontSize
+editor.plugins.get('FontSize');
+
+// $ExpectType FontSizeEditing
+editor.plugins.get('FontSizeEditing');
+
+// $ExpectType FontSizeUI
+editor.plugins.get('FontSizeUI');

--- a/types/ckeditor__ckeditor5-font/v27/src/font.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/font.d.ts
@@ -8,3 +8,9 @@ export default class Font extends Plugin {
     static readonly requires: [typeof FontFamily, typeof FontSize, typeof FontColor, typeof FontBackgroundColor];
     static readonly pluginName: 'Font';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Font: Font;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontbackgroundcolor.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontbackgroundcolor.d.ts
@@ -12,3 +12,9 @@ export interface FontBackgroundColorConfig {
     columns?: number;
     documentColors?: number;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontBackgroundColor: FontBackgroundColor;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontbackgroundcolor/fontbackgroundcolorediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontbackgroundcolor/fontbackgroundcolorediting.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class FontBackgroundColorEditing extends Plugin {
     static readonly pluginName: 'FontBackgroundColorEditing';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontBackgroundColorEditing: FontBackgroundColorEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontbackgroundcolor/fontbackgroundcolorui.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontbackgroundcolor/fontbackgroundcolorui.d.ts
@@ -5,3 +5,9 @@ export default class FontBackgroundColorUI extends ColorUI {
     constructor(editor: Editor);
     static readonly pluginName: 'FontBackgroundColorUI';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontBackgroundColorUI: FontBackgroundColorUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontcolor.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontcolor.d.ts
@@ -12,3 +12,9 @@ export interface FontColorConfig {
     columns?: number;
     documentColors?: number;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontColor: FontColor;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontcolor/fontcolorediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontcolor/fontcolorediting.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class FontColorEditing extends Plugin {
     static readonly pluginName: 'FontColorEditing';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontColorEditing: FontColorEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontcolor/fontcolorui.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontcolor/fontcolorui.d.ts
@@ -5,3 +5,9 @@ export default class FontColorUI extends ColorUI {
     constructor(editor: Editor);
     static readonly pluginName: 'FontColorUI';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontColorUI: FontColorUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontfamily.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontfamily.d.ts
@@ -19,3 +19,9 @@ export interface FontFamilyConfig {
     options?: Array<string | FontFamilyOption>;
     supportAllValues?: boolean;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontFamily: FontFamily;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontfamily/fontfamilyediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontfamily/fontfamilyediting.d.ts
@@ -4,3 +4,9 @@ export default class FontFamilyEditing extends Plugin {
     static readonly pluginName: 'FontFamilyEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontFamilyEditing: FontFamilyEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontfamily/fontfamilyui.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontfamily/fontfamilyui.d.ts
@@ -4,3 +4,9 @@ export default class FontFamilyUI extends Plugin {
     static readonly pluginName: 'FontFamilyUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontFamilyUI: FontFamilyUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontsize.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontsize.d.ts
@@ -19,3 +19,9 @@ export interface FontSizeConfig {
     options?: Array<string | number | FontSizeOption>;
     supportAllValues?: boolean;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontSize: FontSize;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontsize/fontsizeediting.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontsize/fontsizeediting.d.ts
@@ -4,3 +4,9 @@ export default class FontSizeEditing extends Plugin {
     static readonly pluginName: 'FontSizeEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontSizeEditing: FontSizeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-font/v27/src/fontsize/fontsizeui.d.ts
+++ b/types/ckeditor__ckeditor5-font/v27/src/fontsize/fontsizeui.d.ts
@@ -4,3 +4,9 @@ export default class FontSizeUI extends Plugin {
     static readonly pluginName: 'FontSizeUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FontSizeUI: FontSizeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/ckeditor__ckeditor5-heading-tests.ts
+++ b/types/ckeditor__ckeditor5-heading/ckeditor__ckeditor5-heading-tests.ts
@@ -38,3 +38,18 @@ utils.getLocalizedOptions(myEditor).forEach(value => {
     value.model === "";
     value.class === "";
 });
+
+// $ExpectType Heading
+myEditor.plugins.get('Heading');
+
+// $ExpectType HeadingButtonsUI
+myEditor.plugins.get('HeadingButtonsUI');
+
+// $ExpectType HeadingEditing
+myEditor.plugins.get('HeadingEditing');
+
+// $ExpectType HeadingUI
+myEditor.plugins.get('HeadingUI');
+
+// $ExpectType Title
+myEditor.plugins.get('Title');

--- a/types/ckeditor__ckeditor5-heading/src/heading.d.ts
+++ b/types/ckeditor__ckeditor5-heading/src/heading.d.ts
@@ -19,3 +19,9 @@ export interface HeadingOption {
     title: string;
     view?: ElementDefinition | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Heading: Heading;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/src/headingbuttonsui.d.ts
+++ b/types/ckeditor__ckeditor5-heading/src/headingbuttonsui.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from "@ckeditor/ckeditor5-core";
 export default class HeadingButtonsUI extends Plugin {
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HeadingButtonsUI: HeadingButtonsUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/src/headingediting.d.ts
+++ b/types/ckeditor__ckeditor5-heading/src/headingediting.d.ts
@@ -7,3 +7,9 @@ export default class HeadingEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HeadingEditing: HeadingEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/src/headingui.d.ts
+++ b/types/ckeditor__ckeditor5-heading/src/headingui.d.ts
@@ -4,3 +4,9 @@ export default class HeadingUI extends Plugin {
     static readonly pluginName: "HeadingUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HeadingUI: HeadingUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/src/title.d.ts
+++ b/types/ckeditor__ckeditor5-heading/src/title.d.ts
@@ -12,3 +12,9 @@ export default class Title extends Plugin {
 export interface TitleConfig {
     placeholder?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Title: Title;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/v27/ckeditor__ckeditor5-heading-tests.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/ckeditor__ckeditor5-heading-tests.ts
@@ -26,3 +26,18 @@ str = title.getBody();
 str = title.getBody({ rootName: str });
 str = title.getBody({ trim: "none" });
 str = title.getBody({ rootName: str, trim: "none" });
+
+// $ExpectType Heading
+myEditor.plugins.get('Heading');
+
+// $ExpectType HeadingButtonsUI
+myEditor.plugins.get('HeadingButtonsUI');
+
+// $ExpectType HeadingEditing
+myEditor.plugins.get('HeadingEditing');
+
+// $ExpectType HeadingUI
+myEditor.plugins.get('HeadingUI');
+
+// $ExpectType Title
+myEditor.plugins.get('Title');

--- a/types/ckeditor__ckeditor5-heading/v27/src/heading.d.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/src/heading.d.ts
@@ -19,3 +19,9 @@ export interface HeadingOption {
     title: string;
     view?: ElementDefinition | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Heading: Heading;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/v27/src/headingbuttonsui.d.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/src/headingbuttonsui.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from "@ckeditor/ckeditor5-core";
 export default class HeadingButtonsUI extends Plugin {
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HeadingButtonsUI: HeadingButtonsUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/v27/src/headingediting.d.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/src/headingediting.d.ts
@@ -7,3 +7,9 @@ export default class HeadingEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HeadingEditing: HeadingEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/v27/src/headingui.d.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/src/headingui.d.ts
@@ -4,3 +4,9 @@ export default class HeadingUI extends Plugin {
     static readonly pluginName: "HeadingUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HeadingUI: HeadingUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-heading/v27/src/title.d.ts
+++ b/types/ckeditor__ckeditor5-heading/v27/src/title.d.ts
@@ -12,3 +12,9 @@ export default class Title extends Plugin {
 export interface TitleConfig {
     placeholder?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Title: Title;
+    }
+}

--- a/types/ckeditor__ckeditor5-highlight/ckeditor__ckeditor5-highlight-tests.ts
+++ b/types/ckeditor__ckeditor5-highlight/ckeditor__ckeditor5-highlight-tests.ts
@@ -12,3 +12,12 @@ new HighlightEditing(editor);
 
 new HighlightCommand(editor).execute();
 new HighlightCommand(editor).execute({ value: '' });
+
+// $ExpectType Highlight
+editor.plugins.get('Highlight');
+
+// $ExpectType HighlightEditing
+editor.plugins.get('HighlightEditing');
+
+// $ExpectType HighlightUI
+editor.plugins.get('HighlightUI');

--- a/types/ckeditor__ckeditor5-highlight/src/highlight.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/src/highlight.d.ts
@@ -18,3 +18,9 @@ export interface HighlightOption {
 export interface HighlightConfig {
     options: HighlightOption[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Highlight: Highlight;
+    }
+}

--- a/types/ckeditor__ckeditor5-highlight/src/highlightediting.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/src/highlightediting.d.ts
@@ -4,3 +4,9 @@ export default class HighlightEditing extends Plugin {
     static readonly pluginName: 'HighlightEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HighlightEditing: HighlightEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-highlight/src/highlightui.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/src/highlightui.d.ts
@@ -12,3 +12,9 @@ export default class HighlightUI extends Plugin {
     static readonly pluginName: 'HighlightUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HighlightUI: HighlightUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-highlight/v27/ckeditor__ckeditor5-highlight-tests.ts
+++ b/types/ckeditor__ckeditor5-highlight/v27/ckeditor__ckeditor5-highlight-tests.ts
@@ -11,3 +11,12 @@ new HL.HighlightUI(editor);
 new HL.HighlightEditing(editor);
 
 new HLCommand(editor).execute();
+
+// $ExpectType Highlight
+editor.plugins.get('Highlight');
+
+// $ExpectType HighlightEditing
+editor.plugins.get('HighlightEditing');
+
+// $ExpectType HighlightUI
+editor.plugins.get('HighlightUI');

--- a/types/ckeditor__ckeditor5-highlight/v27/src/highlight.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/v27/src/highlight.d.ts
@@ -18,3 +18,9 @@ export interface HighlightOption {
 export interface HighlightConfig {
     options: HighlightOption[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Highlight: Highlight;
+    }
+}

--- a/types/ckeditor__ckeditor5-highlight/v27/src/highlightediting.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/v27/src/highlightediting.d.ts
@@ -4,3 +4,9 @@ export default class HighlightEditing extends Plugin {
     static readonly pluginName: 'HighlightEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HighlightEditing: HighlightEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-highlight/v27/src/highlightui.d.ts
+++ b/types/ckeditor__ckeditor5-highlight/v27/src/highlightui.d.ts
@@ -12,3 +12,9 @@ export default class HighlightUI extends Plugin {
     static readonly pluginName: 'HighlightUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HighlightUI: HighlightUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-horizontal-line/ckeditor__ckeditor5-horizontal-line-tests.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/ckeditor__ckeditor5-horizontal-line-tests.ts
@@ -13,3 +13,12 @@ new HorizontalLineEditing(editor);
 
 new HorizontalLineCommand(editor).execute();
 new HorizontalLineCommand(editor).refresh();
+
+// $ExpectType HorizontalLine
+editor.plugins.get('HorizontalLine');
+
+// $ExpectType HorizontalLineEditing
+editor.plugins.get('HorizontalLineEditing');
+
+// $ExpectType HorizontalLineUI
+editor.plugins.get('HorizontalLineUI');

--- a/types/ckeditor__ckeditor5-horizontal-line/src/horizontalline.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/src/horizontalline.d.ts
@@ -7,3 +7,9 @@ export default class HorizontalLine extends Plugin {
     static readonly requires: [typeof HorizontalLineEditing, typeof HorizontalLineUI, typeof Widget];
     static readonly pluginName: 'HorizontalLine';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HorizontalLine: HorizontalLine;
+    }
+}

--- a/types/ckeditor__ckeditor5-horizontal-line/src/horizontallineediting.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/src/horizontallineediting.d.ts
@@ -4,3 +4,9 @@ export default class HorizontalLineEditing extends Plugin {
     static readonly pluginName: 'HorizontalLineEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HorizontalLineEditing: HorizontalLineEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-horizontal-line/src/horizontallineui.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/src/horizontallineui.d.ts
@@ -4,3 +4,9 @@ export default class HorizontalLineUI extends Plugin {
     static readonly pluginName: 'HorizontalLineUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HorizontalLineUI: HorizontalLineUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-horizontal-line/v27/ckeditor__ckeditor5-horizontal-line-tests.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/v27/ckeditor__ckeditor5-horizontal-line-tests.ts
@@ -13,3 +13,12 @@ new HL.HorizontalLineEditing(editor);
 
 new HorizontalLineCommand(editor).execute();
 new HorizontalLineCommand(editor).refresh();
+
+// $ExpectType HorizontalLine
+editor.plugins.get('HorizontalLine');
+
+// $ExpectType HorizontalLineEditing
+editor.plugins.get('HorizontalLineEditing');
+
+// $ExpectType HorizontalLineUI
+editor.plugins.get('HorizontalLineUI');

--- a/types/ckeditor__ckeditor5-horizontal-line/v27/src/horizontalline.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/v27/src/horizontalline.d.ts
@@ -7,3 +7,9 @@ export default class HorizontalLine extends Plugin {
     static readonly requires: [typeof HorizontalLineEditing, typeof HorizontalLineUI, typeof Widget];
     static readonly pluginName: 'HorizontalLine';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HorizontalLine: HorizontalLine;
+    }
+}

--- a/types/ckeditor__ckeditor5-horizontal-line/v27/src/horizontallineediting.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/v27/src/horizontallineediting.d.ts
@@ -4,3 +4,9 @@ export default class HorizontalLineEditing extends Plugin {
     static readonly pluginName: 'HorizontalLineEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HorizontalLineEditing: HorizontalLineEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-horizontal-line/v27/src/horizontallineui.d.ts
+++ b/types/ckeditor__ckeditor5-horizontal-line/v27/src/horizontallineui.d.ts
@@ -4,3 +4,9 @@ export default class HorizontalLineUI extends Plugin {
     static readonly pluginName: 'HorizontalLineUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HorizontalLineUI: HorizontalLineUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-embed/ckeditor__ckeditor5-html-embed-tests.ts
+++ b/types/ckeditor__ckeditor5-html-embed/ckeditor__ckeditor5-html-embed-tests.ts
@@ -16,3 +16,12 @@ new InsertHtmlEmbedCommand(editor).refresh();
 
 new UpdateHtmlEmbedCommand(editor).execute('');
 new UpdateHtmlEmbedCommand(editor).refresh();
+
+// $ExpectType HtmlEmbed
+editor.plugins.get('HtmlEmbed');
+
+// $ExpectType HtmlEmbedEditing
+editor.plugins.get('HtmlEmbedEditing');
+
+// $ExpectType HtmlEmbedUI
+editor.plugins.get('HtmlEmbedUI');

--- a/types/ckeditor__ckeditor5-html-embed/src/htmlembed.d.ts
+++ b/types/ckeditor__ckeditor5-html-embed/src/htmlembed.d.ts
@@ -16,3 +16,9 @@ export interface HtmlEmbedSanitizeOutput {
     html: string;
     hasChanged: boolean;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HtmlEmbed: HtmlEmbed;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-embed/src/htmlembedediting.d.ts
+++ b/types/ckeditor__ckeditor5-html-embed/src/htmlembedediting.d.ts
@@ -4,3 +4,9 @@ export default class HtmlEmbedEditing extends Plugin {
     static readonly pluginName: 'HtmlEmbedEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HtmlEmbedEditing: HtmlEmbedEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-embed/src/htmlembedui.d.ts
+++ b/types/ckeditor__ckeditor5-html-embed/src/htmlembedui.d.ts
@@ -4,3 +4,9 @@ export default class HtmlEmbedUI extends Plugin {
     static readonly pluginName: 'HtmlEmbedUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        HtmlEmbedUI: HtmlEmbedUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-support/ckeditor__ckeditor5-html-support-tests.ts
+++ b/types/ckeditor__ckeditor5-html-support/ckeditor__ckeditor5-html-support-tests.ts
@@ -84,3 +84,18 @@ TableElementSupport.requires.forEach(Plugin => new Plugin(editor));
 
 schemas.block.concat([]);
 schemas.inline.concat([]).lastIndexOf(schemas.inline[0]) === 0;
+
+// $ExpectType CodeBlockHtmlSupport
+editor.plugins.get('CodeBlockHtmlSupport');
+
+// $ExpectType DataFilter
+editor.plugins.get('DataFilter');
+
+// $ExpectType DataSchema
+editor.plugins.get('DataSchema');
+
+// $ExpectType GeneralHtmlSupport
+editor.plugins.get('GeneralHtmlSupport');
+
+// $ExpectType TableElementSupport
+editor.plugins.get('TableElementSupport');

--- a/types/ckeditor__ckeditor5-html-support/src/datafilter.d.ts
+++ b/types/ckeditor__ckeditor5-html-support/src/datafilter.d.ts
@@ -59,3 +59,9 @@ export default class DataFilter extends Plugin {
      */
     disallowAttributes(config: MatcherPattern): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        DataFilter: DataFilter;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-support/src/dataschema.d.ts
+++ b/types/ckeditor__ckeditor5-html-support/src/dataschema.d.ts
@@ -68,3 +68,9 @@ export interface DataSchemaInlineElementDefinition extends DataSchemaDefinition 
     isInline: boolean;
     priority?: number | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        DataSchema: DataSchema;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-support/src/generalhtmlsupport.d.ts
+++ b/types/ckeditor__ckeditor5-html-support/src/generalhtmlsupport.d.ts
@@ -20,3 +20,9 @@ export interface GeneralHtmlSupportConfig {
     allow?: MatcherPattern[] | undefined;
     disallow?: MatcherPattern[] | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        GeneralHtmlSupport: GeneralHtmlSupport;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-support/src/integrations/codeblock.d.ts
+++ b/types/ckeditor__ckeditor5-html-support/src/integrations/codeblock.d.ts
@@ -5,3 +5,9 @@ export default class CodeBlockHtmlSupport extends Plugin {
     static readonly requires: [typeof DataFilter];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        CodeBlockHtmlSupport: CodeBlockHtmlSupport;
+    }
+}

--- a/types/ckeditor__ckeditor5-html-support/src/integrations/table.d.ts
+++ b/types/ckeditor__ckeditor5-html-support/src/integrations/table.d.ts
@@ -8,3 +8,9 @@ export default class TableElementSupport extends Plugin {
     static readonly requires: [typeof DataFilter];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableElementSupport: TableElementSupport;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/ckeditor__ckeditor5-image-tests.ts
+++ b/types/ckeditor__ckeditor5-image/ckeditor__ckeditor5-image-tests.ts
@@ -26,6 +26,7 @@ import {
     ImageTextAlternativeUI,
     ImageToolbar,
     ImageUpload,
+    ImageUploadEditing,
     ImageUploadProgress,
     ImageUploadUI,
 } from '@ckeditor/ckeditor5-image';
@@ -35,9 +36,12 @@ import ImageTypeCommand from '@ckeditor/ckeditor5-image/src/image/imagetypecomma
 import ImageInsertCommand from '@ckeditor/ckeditor5-image/src/image/insertimagecommand';
 import * as ImageUIUtils from '@ckeditor/ckeditor5-image/src/image/ui/utils';
 import ImageBlock from '@ckeditor/ckeditor5-image/src/imageblock';
+import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting';
 import ImageCaptionUI from '@ckeditor/ckeditor5-image/src/imagecaption/imagecaptionui';
 import ToggleImageCaptionCommand from '@ckeditor/ckeditor5-image/src/imagecaption/toggleimagecaptioncommand';
 import * as ImageCaptionUtils from '@ckeditor/ckeditor5-image/src/imagecaption/utils';
+import ImageInline from '@ckeditor/ckeditor5-image/src/imageinline';
+import ImageInlineEditing from '@ckeditor/ckeditor5-image/src/image/imageinlineediting';
 import ImageInsertFormRowView from '@ckeditor/ckeditor5-image/src/imageinsert/ui/imageinsertformrowview';
 import ImageInsertPanelView from '@ckeditor/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview';
 import * as ImageInsertUtils from '@ckeditor/ckeditor5-image/src/imageinsert/utils';
@@ -47,7 +51,7 @@ import ImageStyleCommand from '@ckeditor/ckeditor5-image/src/imagestyle/imagesty
 import ImageStyleUtils from '@ckeditor/ckeditor5-image/src/imagestyle/utils';
 import ImageAlternateCommand from '@ckeditor/ckeditor5-image/src/imagetextalternative/imagetextalternativecommand';
 import TextAlternativeFormView from '@ckeditor/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview';
-import ImageUploadEditing, { isHtmlIncluded } from '@ckeditor/ckeditor5-image/src/imageupload/imageuploadediting';
+import { isHtmlIncluded } from '@ckeditor/ckeditor5-image/src/imageupload/imageuploadediting';
 import ImageUploadCommand from '@ckeditor/ckeditor5-image/src/imageupload/uploadimagecommand';
 import * as ImageUploadUtils from '@ckeditor/ckeditor5-image/src/imageupload/utils';
 import ImageUtils from '@ckeditor/ckeditor5-image/src/imageutils';
@@ -257,3 +261,90 @@ new MyEditor({
         },
     },
 });
+
+// $ExpectType AutoImage
+editor.plugins.get('AutoImage');
+
+// $ExpectType Image
+editor.plugins.get('Image');
+
+// $ExpectType ImageBlock
+editor.plugins.get('ImageBlock');
+
+// $ExpectType ImageBlockEditing
+editor.plugins.get('ImageBlockEditing');
+
+// $ExpectType ImageCaption
+editor.plugins.get('ImageCaption');
+
+// $ExpectType ImageCaptionEditing
+editor.plugins.get('ImageCaptionEditing');
+
+// $ExpectType ImageCaptionUI
+editor.plugins.get('ImageCaptionUI');
+
+// $ExpectType ImageEditing
+editor.plugins.get('ImageEditing');
+
+// $ExpectType ImageInline
+editor.plugins.get('ImageInline');
+
+// $ExpectType ImageInlineEditing
+editor.plugins.get('ImageInlineEditing');
+
+// $ExpectType ImageInsert
+editor.plugins.get('ImageInsert');
+
+// $ExpectType ImageInsertUI
+editor.plugins.get('ImageInsertUI');
+
+// $ExpectType ImageResize
+editor.plugins.get('ImageResize');
+
+// $ExpectType ImageResizeButtons
+editor.plugins.get('ImageResizeButtons');
+
+// $ExpectType ImageResizeEditing
+editor.plugins.get('ImageResizeEditing');
+
+// $ExpectType ImageResizeHandles
+editor.plugins.get('ImageResizeHandles');
+
+// $ExpectType ImageStyle
+editor.plugins.get('ImageStyle');
+
+// $ExpectType ImageStyleEditing
+editor.plugins.get('ImageStyleEditing');
+
+// $ExpectType ImageStyleUI
+editor.plugins.get('ImageStyleUI');
+
+// $ExpectType ImageTextAlternative
+editor.plugins.get('ImageTextAlternative');
+
+// $ExpectType ImageTextAlternativeEditing
+editor.plugins.get('ImageTextAlternativeEditing');
+
+// $ExpectType ImageTextAlternativeUI
+editor.plugins.get('ImageTextAlternativeUI');
+
+// $ExpectType ImageToolbar
+editor.plugins.get('ImageToolbar');
+
+// $ExpectType ImageUpload
+editor.plugins.get('ImageUpload');
+
+// $ExpectType ImageUploadEditing
+editor.plugins.get('ImageUploadEditing');
+
+// $ExpectType ImageUploadProgress
+editor.plugins.get('ImageUploadProgress');
+
+// $ExpectType ImageUploadUI
+editor.plugins.get('ImageUploadUI');
+
+// $ExpectType ImageUtils
+editor.plugins.get('ImageUtils');
+
+// $ExpectType PictureEditing
+editor.plugins.get('PictureEditing');

--- a/types/ckeditor__ckeditor5-image/src/autoimage.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/autoimage.d.ts
@@ -8,3 +8,9 @@ export default class AutoImage extends Plugin {
     static readonly pluginName: 'AutoImage';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoImage: AutoImage;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/image.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/image.d.ts
@@ -19,3 +19,9 @@ export interface ImageConfig {
     toolbar?: string[] | undefined;
     upload?: ImageUploadConfig | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Image: Image;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/image/imageblockediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/image/imageblockediting.d.ts
@@ -8,3 +8,9 @@ export default class ImageBlockEditing extends Plugin {
     static readonly pluginName: 'ImageBlockEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageBlockEditing: ImageBlockEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/image/imageediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/image/imageediting.d.ts
@@ -4,3 +4,9 @@ export default class ImageEditing extends Plugin {
     static readonly pluginName: 'ImageEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageEditing: ImageEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/image/imageinlineediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/image/imageinlineediting.d.ts
@@ -8,3 +8,9 @@ export default class ImageInlineEditing extends Plugin {
     static readonly pluginName: 'ImageInlineEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageInlineEditing: ImageInlineEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageblock.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageblock.d.ts
@@ -7,3 +7,9 @@ export default class ImageBlock extends Plugin {
     static readonly requires: [typeof ImageBlockEditing, typeof Widget, typeof ImageTextAlternative];
     static readonly pluginName: 'ImageBlock';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageBlock: ImageBlock;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagecaption.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagecaption.d.ts
@@ -5,3 +5,9 @@ export default class ImageCaption extends Plugin {
     static readonly requires: [typeof ImageCaptionEditing];
     static readonly pluginName: 'ImageCaption';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageCaption: ImageCaption;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagecaption/imagecaptionediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagecaption/imagecaptionediting.d.ts
@@ -6,3 +6,9 @@ export default class ImageCaptionEditing extends Plugin {
     static readonly requires: [typeof ImageUtils];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageCaptionEditing: ImageCaptionEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagecaption/imagecaptionui.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagecaption/imagecaptionui.d.ts
@@ -6,3 +6,9 @@ export default class ImageCaptionUI extends Plugin {
     static readonly pluginName: 'ImageCaptionUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageCaptionUI: ImageCaptionUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageinline.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageinline.d.ts
@@ -7,3 +7,9 @@ export default class ImageInline extends Plugin {
     static readonly requires: [typeof ImageInlineEditing, typeof Widget, typeof ImageTextAlternative];
     static pluginName: 'ImageInline';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageInline: ImageInline;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageinsert.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageinsert.d.ts
@@ -10,3 +10,9 @@ export default class ImageInsert extends Plugin {
 export interface ImageInsertConfig {
     type?: 'inline' | 'block' | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageInsert: ImageInsert;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageinsert/imageinsertui.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageinsert/imageinsertui.d.ts
@@ -3,3 +3,9 @@ export default class ImageInsertUI extends Plugin {
     static readonly pluginName: 'ImageInsertUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageInsertUI: ImageInsertUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageresize.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageresize.d.ts
@@ -7,3 +7,9 @@ export default class ImageResize extends Plugin {
     static readonly requires: [typeof ImageResizeEditing, typeof ImageResizeHandles, typeof ImageResizeButtons];
     static readonly pluginName: 'ImageResize';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResize: ImageResize;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageresize/imageresizebuttons.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageresize/imageresizebuttons.d.ts
@@ -13,3 +13,9 @@ export interface ImageResizeOption {
     icon?: 'small' | 'medium' | 'large' | 'original' | undefined;
     value: string | null;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResizeButtons: ImageResizeButtons;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageresize/imageresizeediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageresize/imageresizeediting.d.ts
@@ -6,3 +6,9 @@ export default class ImageResizeEditing extends Plugin {
     static readonly requires: [typeof ImageUtils];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResizeEditing: ImageResizeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageresize/imageresizehandles.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageresize/imageresizehandles.d.ts
@@ -6,3 +6,9 @@ export default class ImageResizeHandles extends Plugin {
     static readonly pluginName: 'ImageResizeHandles';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResizeHandles: ImageResizeHandles;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagestyle.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagestyle.d.ts
@@ -23,3 +23,9 @@ export interface ImageStyleOptionDefinition {
     name: string;
     title?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageStyle: ImageStyle;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagestyle/imagestyleediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagestyle/imagestyleediting.d.ts
@@ -6,3 +6,9 @@ export default class ImageStyleEditing extends Plugin {
     static readonly requires: [typeof ImageUtils];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageStyleEditing: ImageStyleEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagestyle/imagestyleui.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagestyle/imagestyleui.d.ts
@@ -16,3 +16,9 @@ export default class ImageStyleUI extends Plugin {
     };
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageStyleUI: ImageStyleUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagetextalternative.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagetextalternative.d.ts
@@ -6,3 +6,9 @@ export default class ImageTextAlternative extends Plugin {
     static readonly requires: [typeof ImageTextAlternativeEditing, typeof ImageTextAlternativeUI];
     static readonly pluginName: 'ImageTextAlternative';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageTextAlternative: ImageTextAlternative;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagetextalternative/imagetextalternativeediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagetextalternative/imagetextalternativeediting.d.ts
@@ -6,3 +6,9 @@ export default class ImageTextAlternativeEditing extends Plugin {
     static readonly requires: [typeof ImageUtils];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageTextAlternativeEditing: ImageTextAlternativeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagetextalternative/imagetextalternativeui.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagetextalternative/imagetextalternativeui.d.ts
@@ -7,3 +7,9 @@ export default class ImageTextAlternativeUI extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageTextAlternativeUI: ImageTextAlternativeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imagetoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imagetoolbar.d.ts
@@ -7,3 +7,9 @@ export default class ImageToolbar extends Plugin {
     static readonly pluginName: 'ImageToolbar';
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageToolbar: ImageToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageupload.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageupload.d.ts
@@ -11,3 +11,9 @@ export default class ImageUpload extends Plugin {
 export interface ImageUploadConfig {
     types: string[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUpload: ImageUpload;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadediting.d.ts
@@ -13,3 +13,9 @@ export default class ImageUploadEditing extends Plugin {
 }
 
 export function isHtmlIncluded(dataTransfer: DataTransfer): boolean;
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUploadEditing: ImageUploadEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadprogress.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadprogress.d.ts
@@ -7,3 +7,9 @@ export default class ImageUploadProgress extends Plugin {
     init(): void;
     uploadStatusChange(evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUploadProgress: ImageUploadProgress;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadui.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageupload/imageuploadui.d.ts
@@ -4,3 +4,9 @@ export default class ImageUploadUI extends Plugin {
     static readonly pluginName: 'ImageUploadUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUploadUI: ImageUploadUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/src/imageutils.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/imageutils.d.ts
@@ -28,7 +28,7 @@ export default class ImageUtils extends Plugin {
      * Handles inserting single file. This method unifies image insertion using {@link module:widget/utils~findOptimalInsertionRange}
      * method.
      *
-     *    const imageUtils = editor.plugins.get( 'ImageUtils' );
+     *    editor.plugins.get( 'ImageUtils' );
      *
      *    imageUtils.insertImage( { src: 'path/to/image.jpg' } );
      */
@@ -59,4 +59,10 @@ export default class ImageUtils extends Plugin {
      * The `<img>` can be located deep in other elements, so this helper performs a deep tree search.
      */
     findViewImgElement(figureView: ViewElement): ViewElement;
+}
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUtils: ImageUtils;
+    }
 }

--- a/types/ckeditor__ckeditor5-image/src/pictureediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/src/pictureediting.d.ts
@@ -7,3 +7,9 @@ export default class PictureEditing extends Plugin {
     static readonly pluginName: 'PictureEditing';
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PictureEditing: PictureEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/ckeditor__ckeditor5-image-tests.ts
+++ b/types/ckeditor__ckeditor5-image/v27/ckeditor__ckeditor5-image-tests.ts
@@ -199,3 +199,69 @@ new MyEditor({
         ],
     },
 });
+
+// $ExpectType AutoImage
+editor.plugins.get('AutoImage');
+
+// $ExpectType Image
+editor.plugins.get('Image');
+
+// $ExpectType ImageCaption
+editor.plugins.get('ImageCaption');
+
+// $ExpectType ImageCaptionEditing
+editor.plugins.get('ImageCaptionEditing');
+
+// $ExpectType ImageEditing
+editor.plugins.get('ImageEditing');
+
+// $ExpectType ImageInsert
+editor.plugins.get('ImageInsert');
+
+// $ExpectType ImageInsertUI
+editor.plugins.get('ImageInsertUI');
+
+// $ExpectType ImageResize
+editor.plugins.get('ImageResize');
+
+// $ExpectType ImageResizeButtons
+editor.plugins.get('ImageResizeButtons');
+
+// $ExpectType ImageResizeEditing
+editor.plugins.get('ImageResizeEditing');
+
+// $ExpectType ImageResizeHandles
+editor.plugins.get('ImageResizeHandles');
+
+// $ExpectType ImageStyle
+editor.plugins.get('ImageStyle');
+
+// $ExpectType ImageStyleEditing
+editor.plugins.get('ImageStyleEditing');
+
+// $ExpectType ImageStyleUI
+editor.plugins.get('ImageStyleUI');
+
+// $ExpectType ImageTextAlternative
+editor.plugins.get('ImageTextAlternative');
+
+// $ExpectType ImageTextAlternativeEditing
+editor.plugins.get('ImageTextAlternativeEditing');
+
+// $ExpectType ImageTextAlternativeUI
+editor.plugins.get('ImageTextAlternativeUI');
+
+// $ExpectType ImageToolbar
+editor.plugins.get('ImageToolbar');
+
+// $ExpectType ImageUpload
+editor.plugins.get('ImageUpload');
+
+// $ExpectType ImageUploadEditing
+editor.plugins.get('ImageUploadEditing');
+
+// $ExpectType ImageUploadProgress
+editor.plugins.get('ImageUploadProgress');
+
+// $ExpectType ImageUploadUI
+editor.plugins.get('ImageUploadUI');

--- a/types/ckeditor__ckeditor5-image/v27/src/autoimage.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/autoimage.d.ts
@@ -7,3 +7,9 @@ export default class AutoImage extends Plugin {
     static readonly pluginName: 'AutoImage';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoImage: AutoImage;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/image.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/image.d.ts
@@ -22,3 +22,9 @@ export interface ImageConfig {
     toolbar?: string[] | undefined;
     upload?: ImageUploadConfig | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Image: Image;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/image/imageediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/image/imageediting.d.ts
@@ -4,3 +4,9 @@ export default class ImageEditing extends Plugin {
     static readonly pluginName: 'ImageEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageEditing: ImageEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagecaption.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagecaption.d.ts
@@ -5,3 +5,9 @@ export default class ImageCaption extends Plugin {
     static readonly requires: [typeof ImageCaptionEditing];
     static readonly pluginName: 'ImageCaption';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageCaption: ImageCaption;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagecaption/imagecaptionediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagecaption/imagecaptionediting.d.ts
@@ -3,3 +3,9 @@ export default class ImageCaptionEditing extends Plugin {
     static readonly pluginName: 'ImageCaptionEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageCaptionEditing: ImageCaptionEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageinsert.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageinsert.d.ts
@@ -10,3 +10,9 @@ export default class ImageInsert extends Plugin {
 export interface ImageInsertConfig {
     integrations: string[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageInsert: ImageInsert;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageinsert/imageinsertui.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageinsert/imageinsertui.d.ts
@@ -3,3 +3,9 @@ export default class ImageInsertUI extends Plugin {
     static readonly pluginName: 'ImageInsertUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageInsertUI: ImageInsertUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageresize.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageresize.d.ts
@@ -7,3 +7,9 @@ export default class ImageResize extends Plugin {
     static readonly requires: [typeof ImageResizeEditing, typeof ImageResizeHandles, typeof ImageResizeButtons];
     static readonly pluginName: 'ImageResize';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResize: ImageResize;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageresize/imageresizebuttons.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageresize/imageresizebuttons.d.ts
@@ -13,3 +13,9 @@ export interface ImageResizeOption {
     icon?: 'small' | 'medium' | 'large' | 'original';
     value: string | null;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResizeButtons: ImageResizeButtons;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageresize/imageresizehandles.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageresize/imageresizehandles.d.ts
@@ -6,3 +6,9 @@ export default class ImageResizeHandles extends Plugin {
     static readonly pluginName: 'ImageResizeHandles';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageResizeHandles: ImageResizeHandles;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagestyle.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagestyle.d.ts
@@ -6,3 +6,9 @@ export default class ImageStyle extends Plugin {
     static readonly requires: [typeof ImageStyleEditing, typeof ImageStyleUI];
     static readonly pluginName: 'ImageStyle';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageStyle: ImageStyle;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagestyle/imagestyleediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagestyle/imagestyleediting.d.ts
@@ -12,3 +12,9 @@ export interface ImageStyleFormat {
     name: string;
     title?: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageStyleEditing: ImageStyleEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagestyle/imagestyleui.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagestyle/imagestyleui.d.ts
@@ -11,3 +11,9 @@ export default class ImageStyleUI extends Plugin {
     };
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageStyleUI: ImageStyleUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagetextalternative.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagetextalternative.d.ts
@@ -6,3 +6,9 @@ export default class ImageTextAlternative extends Plugin {
     static readonly requires: [typeof ImageTextAlternativeEditing, typeof ImageTextAlternativeUI];
     static readonly pluginName: 'ImageTextAlternative';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageTextAlternative: ImageTextAlternative;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagetextalternative/imagetextalternativeediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagetextalternative/imagetextalternativeediting.d.ts
@@ -4,3 +4,9 @@ export default class ImageTextAlternativeEditing extends Plugin {
     static readonly pluginName: 'ImageTextAlternativeEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageTextAlternativeEditing: ImageTextAlternativeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagetextalternative/imagetextalternativeui.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagetextalternative/imagetextalternativeui.d.ts
@@ -7,3 +7,9 @@ export default class ImageTextAlternativeUI extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageTextAlternativeUI: ImageTextAlternativeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imagetoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imagetoolbar.d.ts
@@ -6,3 +6,9 @@ export default class ImageToolbar extends Plugin {
     static readonly pluginName: 'ImageToolbar';
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageToolbar: ImageToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageupload.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageupload.d.ts
@@ -11,3 +11,9 @@ export default class ImageUpload extends Plugin {
 export interface ImageUploadConfig {
     types: string[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUpload: ImageUpload;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadediting.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadediting.d.ts
@@ -11,3 +11,9 @@ export default class ImageUploadEditing extends Plugin {
 }
 
 export function isHtmlIncluded(dataTransfer: DataTransfer): boolean;
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUploadEditing: ImageUploadEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadprogress.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadprogress.d.ts
@@ -7,3 +7,9 @@ export default class ImageUploadProgress extends Plugin {
     init(): void;
     uploadStatusChange(evt: EventInfo, data: Record<string, unknown>, conversionApi: DowncastConversionApi): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUploadProgress: ImageUploadProgress;
+    }
+}

--- a/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadui.d.ts
+++ b/types/ckeditor__ckeditor5-image/v27/src/imageupload/imageuploadui.d.ts
@@ -4,3 +4,9 @@ export default class ImageUploadUI extends Plugin {
     static readonly pluginName: 'ImageUploadUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ImageUploadUI: ImageUploadUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/ckeditor__ckeditor5-indent-tests.ts
+++ b/types/ckeditor__ckeditor5-indent/ckeditor__ckeditor5-indent-tests.ts
@@ -27,3 +27,15 @@ new IndentUsingOffset({ direction: 'backward', offset: 1, unit: '' }).isForward 
 
 new IndentUsingClasses({ direction: 'forward', classes: [''] }).isForward === !0;
 new IndentUsingClasses({ direction: 'forward', classes: [''] }).classes.map(c => c.startsWith(''));
+
+// $ExpectType Indent
+editor.plugins.get('Indent');
+
+// $ExpectType IndentBlock
+editor.plugins.get('IndentBlock');
+
+// $ExpectType IndentEditing
+editor.plugins.get('IndentEditing');
+
+// $ExpectType IndentUI
+editor.plugins.get('IndentUI');

--- a/types/ckeditor__ckeditor5-indent/src/indent.d.ts
+++ b/types/ckeditor__ckeditor5-indent/src/indent.d.ts
@@ -6,3 +6,9 @@ export default class Indent extends Plugin {
     static readonly pluginName: 'Indent';
     static readonly requires: [typeof IndentEditing, typeof IndentUI];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Indent: Indent;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/src/indentblock.d.ts
+++ b/types/ckeditor__ckeditor5-indent/src/indentblock.d.ts
@@ -11,3 +11,9 @@ export interface IndentBlockConfig {
     offset?: number | undefined;
     unit?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        IndentBlock: IndentBlock;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/src/indentediting.d.ts
+++ b/types/ckeditor__ckeditor5-indent/src/indentediting.d.ts
@@ -4,3 +4,9 @@ export default class IndentEditing extends Plugin {
     static readonly pluginName: 'IndentEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        IndentEditing: IndentEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/src/indentui.d.ts
+++ b/types/ckeditor__ckeditor5-indent/src/indentui.d.ts
@@ -4,3 +4,9 @@ export default class IndentUI extends Plugin {
     static readonly pluginName: 'IndentUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        IndentUI: IndentUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/v27/ckeditor__ckeditor5-indent-tests.ts
+++ b/types/ckeditor__ckeditor5-indent/v27/ckeditor__ckeditor5-indent-tests.ts
@@ -27,3 +27,15 @@ new IndentUsingOffset({ direction: 'backward', offset: 1, unit: '' }).isForward 
 
 new IndentUsingClasses({ direction: 'forward', classes: [''] }).isForward === !0;
 new IndentUsingClasses({ direction: 'forward', classes: [''] }).classes.map(c => c.startsWith(''));
+
+// $ExpectType Indent
+editor.plugins.get('Indent');
+
+// $ExpectType IndentBlock
+editor.plugins.get('IndentBlock');
+
+// $ExpectType IndentEditing
+editor.plugins.get('IndentEditing');
+
+// $ExpectType IndentUI
+editor.plugins.get('IndentUI');

--- a/types/ckeditor__ckeditor5-indent/v27/src/indent.d.ts
+++ b/types/ckeditor__ckeditor5-indent/v27/src/indent.d.ts
@@ -6,3 +6,9 @@ export default class Indent extends Plugin {
     static readonly pluginName: 'Indent';
     static readonly requires: [typeof IndentEditing, typeof IndentUI];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Indent: Indent;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/v27/src/indentblock.d.ts
+++ b/types/ckeditor__ckeditor5-indent/v27/src/indentblock.d.ts
@@ -11,3 +11,9 @@ export interface IndentBlockConfig {
     offset?: number | undefined;
     unit?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        IndentBlock: IndentBlock;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/v27/src/indentediting.d.ts
+++ b/types/ckeditor__ckeditor5-indent/v27/src/indentediting.d.ts
@@ -4,3 +4,9 @@ export default class IndentEditing extends Plugin {
     static readonly pluginName: 'IndentEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        IndentEditing: IndentEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-indent/v27/src/indentui.d.ts
+++ b/types/ckeditor__ckeditor5-indent/v27/src/indentui.d.ts
@@ -4,3 +4,9 @@ export default class IndentUI extends Plugin {
     static readonly pluginName: 'IndentUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        IndentUI: IndentUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-language/ckeditor__ckeditor5-language-tests.ts
+++ b/types/ckeditor__ckeditor5-language/ckeditor__ckeditor5-language-tests.ts
@@ -2,6 +2,9 @@ import { Editor } from '@ckeditor/ckeditor5-core';
 import Lang from '@ckeditor/ckeditor5-language';
 import Command from '@ckeditor/ckeditor5-language/src/textpartlanguagecommand';
 import * as utils from '@ckeditor/ckeditor5-language/src/utils';
+import TextPartLanguage from '@ckeditor/ckeditor5-language/src/textpartlanguage';
+import TextPartLanguageEditing from '@ckeditor/ckeditor5-language/src/textpartlanguageediting';
+import TextPartLanguageUI from '@ckeditor/ckeditor5-language/src/textpartlanguageui';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -27,3 +30,12 @@ new Command(editor).execute({
 
 utils.stringifyLanguageAttribute('', 'ltr');
 utils.stringifyLanguageAttribute.call(this, utils.parseLanguageAttribute(''));
+
+// $ExpectType TextPartLanguage
+editor.plugins.get('TextPartLanguage');
+
+// $ExpectType TextPartLanguageEditing
+editor.plugins.get('TextPartLanguageEditing');
+
+// $ExpectType TextPartLanguageUI
+editor.plugins.get('TextPartLanguageUI');

--- a/types/ckeditor__ckeditor5-language/src/textpartlanguage.d.ts
+++ b/types/ckeditor__ckeditor5-language/src/textpartlanguage.d.ts
@@ -12,3 +12,9 @@ export interface TextPartLanguageOption {
     textDirection?: 'ltr' | 'rtl' | undefined;
     title: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TextPartLanguage: TextPartLanguage;
+    }
+}

--- a/types/ckeditor__ckeditor5-language/src/textpartlanguageediting.d.ts
+++ b/types/ckeditor__ckeditor5-language/src/textpartlanguageediting.d.ts
@@ -4,3 +4,9 @@ export default class TextPartLanguageEditing extends Plugin {
     static readonly pluginName: 'TextPartLanguageEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TextPartLanguageEditing: TextPartLanguageEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-language/src/textpartlanguageui.d.ts
+++ b/types/ckeditor__ckeditor5-language/src/textpartlanguageui.d.ts
@@ -4,3 +4,9 @@ export default class TextPartLanguageUI extends Plugin {
     static readonly pluginName: 'TextPartLanguageUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TextPartLanguageUI: TextPartLanguageUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/ckeditor__ckeditor5-link-tests.ts
+++ b/types/ckeditor__ckeditor5-link/ckeditor__ckeditor5-link-tests.ts
@@ -4,7 +4,15 @@ import { DowncastConversionApi } from '@ckeditor/ckeditor5-engine/src/conversion
 import Schema from '@ckeditor/ckeditor5-engine/src/model/schema';
 import Writer from '@ckeditor/ckeditor5-engine/src/model/writer';
 import Document from '@ckeditor/ckeditor5-engine/src/view/document';
-import { AutoLink, Link, LinkEditing, LinkImage, LinkImageUI, LinkUI } from '@ckeditor/ckeditor5-link';
+import {
+    AutoLink,
+    Link,
+    LinkEditing,
+    LinkImage,
+    LinkImageEditing,
+    LinkImageUI,
+    LinkUI,
+} from '@ckeditor/ckeditor5-link';
 import LinkCommand from '@ckeditor/ckeditor5-link/src/linkcommand';
 import UnlinkCommand from '@ckeditor/ckeditor5-link/src/unlinkcommand';
 import * as utils from '@ckeditor/ckeditor5-link/src/utils';
@@ -64,3 +72,24 @@ utils.isLinkableElement(new Writer().createElement('div'), new Schema());
 utils.isEmail('') === ''.startsWith('');
 
 utils.addLinkProtocolIfApplicable('', '') === ''.startsWith('');
+
+// $ExpectType AutoLink
+editor.plugins.get('AutoLink');
+
+// $ExpectType Link
+editor.plugins.get('Link');
+
+// $ExpectType LinkEditing
+editor.plugins.get('LinkEditing');
+
+// $ExpectType LinkImage
+editor.plugins.get('LinkImage');
+
+// $ExpectType LinkImageEditing
+editor.plugins.get('LinkImageEditing');
+
+// $ExpectType LinkImageUI
+editor.plugins.get('LinkImageUI');
+
+// $ExpectType LinkUI
+editor.plugins.get('LinkUI');

--- a/types/ckeditor__ckeditor5-link/src/autolink.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/autolink.d.ts
@@ -5,3 +5,9 @@ export default class AutoLink extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoLink: AutoLink;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/src/link.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/link.d.ts
@@ -30,3 +30,9 @@ export interface LinkConfig {
     decorators?: Record<string, LinkDecoratorDefinition> | undefined;
     defaultProtocol?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Link: Link;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/src/linkediting.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/linkediting.d.ts
@@ -7,3 +7,9 @@ export default class LinkEditing extends Plugin {
     static readonly requires: [typeof TwoStepCaretMovement, typeof Input, typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkEditing: LinkEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/src/linkimage.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/linkimage.d.ts
@@ -6,3 +6,9 @@ export default class LinkImage extends Plugin {
     static readonly requires: [typeof LinkImageEditing, typeof LinkImageUI];
     static readonly pluginName: 'LinkImage';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImage: LinkImage;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/src/linkimageediting.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/linkimageediting.d.ts
@@ -8,3 +8,9 @@ export default class LinkImageEditing extends Plugin {
     static readonly pluginName: 'LinkImageEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImageEditing: LinkImageEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/src/linkimageui.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/linkimageui.d.ts
@@ -8,3 +8,9 @@ export default class LinkImageUI extends Plugin {
     static readonly pluginName: 'LinkImageUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImageUI: LinkImageUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/src/linkui.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/linkui.d.ts
@@ -11,3 +11,9 @@ export default class LinkUI extends Plugin {
     readonly actionsView: LinkActionsView;
     readonly formview: LinkFormView;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkUI: LinkUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/ckeditor__ckeditor5-link-tests.ts
+++ b/types/ckeditor__ckeditor5-link/v27/ckeditor__ckeditor5-link-tests.ts
@@ -3,6 +3,7 @@ import Link from '@ckeditor/ckeditor5-link';
 import { View } from '@ckeditor/ckeditor5-ui';
 import LinkCommand from '@ckeditor/ckeditor5-link/src/linkcommand';
 import UnlinkCommand from '@ckeditor/ckeditor5-link/src/unlinkcommand';
+import AutoLink from '@ckeditor/ckeditor5-link/src/autolink';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -39,3 +40,24 @@ new LinkCommand(editor).execute();
 new UnlinkCommand(editor).execute();
 // $ExpectError
 new UnlinkCommand(editor).execute('');
+
+// $ExpectType AutoLink
+editor.plugins.get('AutoLink');
+
+// $ExpectType Link
+editor.plugins.get('Link');
+
+// $ExpectType LinkEditing
+editor.plugins.get('LinkEditing');
+
+// $ExpectType LinkImage
+editor.plugins.get('LinkImage');
+
+// $ExpectType LinkImageEditing
+editor.plugins.get('LinkImageEditing');
+
+// $ExpectType LinkImageUI
+editor.plugins.get('LinkImageUI');
+
+// $ExpectType LinkUI
+editor.plugins.get('LinkUI');

--- a/types/ckeditor__ckeditor5-link/v27/src/autolink.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/autolink.d.ts
@@ -5,3 +5,9 @@ export default class AutoLink extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoLink: AutoLink;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/src/link.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/link.d.ts
@@ -30,3 +30,9 @@ export interface LinkConfig {
     decorators?: Record<string, LinkDecoratorDefinition>;
     defaultProtocol?: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Link: Link;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/src/linkediting.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/linkediting.d.ts
@@ -7,3 +7,9 @@ export default class LinkEditing extends Plugin {
     static readonly requires: [typeof TwoStepCaretMovement, typeof Input, typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkEditing: LinkEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/src/linkimage.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/linkimage.d.ts
@@ -6,3 +6,9 @@ export default class LinkImage extends Plugin {
     static readonly requires: [typeof LinkImageEditing, typeof LinkImageUI];
     static readonly pluginName: 'LinkImage';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImage: LinkImage;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/src/linkimageediting.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/linkimageediting.d.ts
@@ -7,3 +7,9 @@ export default class LinkImageEditing extends Plugin {
     static readonly pluginName: 'LinkImageEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImageEditing: LinkImageEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/src/linkimageui.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/linkimageui.d.ts
@@ -8,3 +8,9 @@ export default class LinkImageUI extends Plugin {
     static readonly pluginName: 'LinkImageUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImageUI: LinkImageUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v27/src/linkui.d.ts
+++ b/types/ckeditor__ckeditor5-link/v27/src/linkui.d.ts
@@ -11,3 +11,9 @@ export default class LinkUI extends Plugin {
     readonly actionsView: LinkActionsView;
     readonly formview: LinkFormView;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkUI: LinkUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/ckeditor__ckeditor5-link-tests.ts
+++ b/types/ckeditor__ckeditor5-link/v28/ckeditor__ckeditor5-link-tests.ts
@@ -64,3 +64,24 @@ utils.isImageAllowed(new Writer().createElement('div'), new Schema());
 utils.isEmail('') === ''.startsWith('');
 
 utils.addLinkProtocolIfApplicable('', '') === ''.startsWith('');
+
+// $ExpectType AutoLink
+editor.plugins.get('AutoLink');
+
+// $ExpectType Link
+editor.plugins.get('Link');
+
+// $ExpectType LinkEditing
+editor.plugins.get('LinkEditing');
+
+// $ExpectType LinkImage
+editor.plugins.get('LinkImage');
+
+// $ExpectType LinkImageEditing
+editor.plugins.get('LinkImageEditing');
+
+// $ExpectType LinkImageUI
+editor.plugins.get('LinkImageUI');
+
+// $ExpectType LinkUI
+editor.plugins.get('LinkUI');

--- a/types/ckeditor__ckeditor5-link/v28/src/autolink.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/autolink.d.ts
@@ -5,3 +5,9 @@ export default class AutoLink extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoLink: AutoLink;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/src/link.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/link.d.ts
@@ -30,3 +30,9 @@ export interface LinkConfig {
     decorators?: Record<string, LinkDecoratorDefinition> | undefined;
     defaultProtocol?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Link: Link;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/src/linkediting.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/linkediting.d.ts
@@ -7,3 +7,9 @@ export default class LinkEditing extends Plugin {
     static readonly requires: [typeof TwoStepCaretMovement, typeof Input, typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkEditing: LinkEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/src/linkimage.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/linkimage.d.ts
@@ -6,3 +6,9 @@ export default class LinkImage extends Plugin {
     static readonly requires: [typeof LinkImageEditing, typeof LinkImageUI];
     static readonly pluginName: 'LinkImage';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImage: LinkImage;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/src/linkimageediting.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/linkimageediting.d.ts
@@ -7,3 +7,9 @@ export default class LinkImageEditing extends Plugin {
     static readonly pluginName: 'LinkImageEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImageEditing: LinkImageEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/src/linkimageui.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/linkimageui.d.ts
@@ -8,3 +8,9 @@ export default class LinkImageUI extends Plugin {
     static readonly pluginName: 'LinkImageUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkImageUI: LinkImageUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-link/v28/src/linkui.d.ts
+++ b/types/ckeditor__ckeditor5-link/v28/src/linkui.d.ts
@@ -11,3 +11,9 @@ export default class LinkUI extends Plugin {
     readonly actionsView: LinkActionsView;
     readonly formview: LinkFormView;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        LinkUI: LinkUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/ckeditor__ckeditor5-list-tests.ts
+++ b/types/ckeditor__ckeditor5-list/ckeditor__ckeditor5-list-tests.ts
@@ -61,3 +61,30 @@ const emptyElement = new DowncastWriter(new Document(new StylesProcessor())).cre
 utils.findNestedList(emptyElement);
 utils.mergeViewLists(new DowncastWriter(new Document(new StylesProcessor())), emptyElement, emptyElement);
 utils.positionAfterUiElements(new Position(new DocumentFragment(), 1));
+
+// $ExpectType List
+editor.plugins.get('List');
+
+// $ExpectType ListEditing
+editor.plugins.get('ListEditing');
+
+// $ExpectType ListStyle
+editor.plugins.get('ListStyle');
+
+// $ExpectType ListStyleEditing
+editor.plugins.get('ListStyleEditing');
+
+// $ExpectType ListStyleUI
+editor.plugins.get('ListStyleUI');
+
+// $ExpectType ListUI
+editor.plugins.get('ListUI');
+
+// $ExpectType TodoList
+editor.plugins.get('TodoList');
+
+// $ExpectType TodoListEditing
+editor.plugins.get('TodoListEditing');
+
+// $ExpectType TodoListUI
+editor.plugins.get('TodoListUI');

--- a/types/ckeditor__ckeditor5-list/src/list.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/list.d.ts
@@ -6,3 +6,9 @@ export default class List extends Plugin {
     static readonly requires: [typeof ListEditing, typeof ListUI];
     static readonly pluginName: 'List';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        List: List;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/listediting.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/listediting.d.ts
@@ -8,3 +8,9 @@ export default class ListEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListEditing: ListEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/liststyle.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/liststyle.d.ts
@@ -6,3 +6,9 @@ export default class ListStyle extends Plugin {
     static readonly requires: [typeof ListStyleEditing, typeof ListStyleUI];
     static readonly pluginName: 'ListStyle';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListStyle: ListStyle;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/liststyleediting.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/liststyleediting.d.ts
@@ -7,3 +7,9 @@ export default class ListStyleEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListStyleEditing: ListStyleEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/liststyleui.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/liststyleui.d.ts
@@ -4,3 +4,9 @@ export default class ListStyleUI extends Plugin {
     static readonly pluginName: 'ListStyleUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListStyleUI: ListStyleUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/listui.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/listui.d.ts
@@ -4,3 +4,9 @@ export default class ListUI extends Plugin {
     static readonly pluginName: 'ListUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListUI: ListUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/todolist.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/todolist.d.ts
@@ -6,3 +6,9 @@ export default class TodoList extends Plugin {
     static readonly requires: [typeof TodoListEditing, typeof TodoListUI];
     static readonly pluginName: 'TodoList';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TodoList: TodoList;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/todolistediting.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/todolistediting.d.ts
@@ -6,3 +6,9 @@ export default class TodoListEditing extends Plugin {
     static readonly requires: [typeof ListEditing];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TodoListEditing: TodoListEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/src/todolistui.d.ts
+++ b/types/ckeditor__ckeditor5-list/src/todolistui.d.ts
@@ -4,3 +4,9 @@ export default class TodoListUI extends Plugin {
     static readonly pluginName: 'TodoListUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TodoListUI: TodoListUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/ckeditor__ckeditor5-list-tests.ts
+++ b/types/ckeditor__ckeditor5-list/v27/ckeditor__ckeditor5-list-tests.ts
@@ -61,3 +61,30 @@ const emptyElement = new DowncastWriter(new Document(new StylesProcessor())).cre
 utils.findNestedList(emptyElement);
 utils.mergeViewLists(new DowncastWriter(new Document(new StylesProcessor())), emptyElement, emptyElement);
 utils.positionAfterUiElements(new Position(new DocumentFragment(), 1));
+
+// $ExpectType List
+editor.plugins.get('List');
+
+// $ExpectType ListEditing
+editor.plugins.get('ListEditing');
+
+// $ExpectType ListStyle
+editor.plugins.get('ListStyle');
+
+// $ExpectType ListStyleEditing
+editor.plugins.get('ListStyleEditing');
+
+// $ExpectType ListStyleUI
+editor.plugins.get('ListStyleUI');
+
+// $ExpectType ListUI
+editor.plugins.get('ListUI');
+
+// $ExpectType TodoList
+editor.plugins.get('TodoList');
+
+// $ExpectType TodoListEditing
+editor.plugins.get('TodoListEditing');
+
+// $ExpectType TodoListUI
+editor.plugins.get('TodoListUI');

--- a/types/ckeditor__ckeditor5-list/v27/src/list.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/list.d.ts
@@ -6,3 +6,9 @@ export default class List extends Plugin {
     static readonly requires: [typeof ListEditing, typeof ListUI];
     static readonly pluginName: 'List';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        List: List;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/listediting.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/listediting.d.ts
@@ -8,3 +8,9 @@ export default class ListEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListEditing: ListEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/liststyle.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/liststyle.d.ts
@@ -6,3 +6,9 @@ export default class ListStyle extends Plugin {
     static readonly requires: [typeof ListStyleEditing, typeof ListStyleUI];
     static readonly pluginName: 'ListStyle';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListStyle: ListStyle;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/liststyleediting.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/liststyleediting.d.ts
@@ -7,3 +7,9 @@ export default class ListStyleEditing extends Plugin {
     init(): void;
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListStyleEditing: ListStyleEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/liststyleui.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/liststyleui.d.ts
@@ -4,3 +4,9 @@ export default class ListStyleUI extends Plugin {
     static readonly pluginName: 'ListStyleUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListStyleUI: ListStyleUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/listui.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/listui.d.ts
@@ -4,3 +4,9 @@ export default class ListUI extends Plugin {
     static readonly pluginName: 'ListUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ListUI: ListUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/todolist.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/todolist.d.ts
@@ -6,3 +6,9 @@ export default class TodoList extends Plugin {
     static readonly requires: [typeof TodoListEditing, typeof TodoListUI];
     static readonly pluginName: 'TodoList';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TodoList: TodoList;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/todolistediting.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/todolistediting.d.ts
@@ -6,3 +6,9 @@ export default class TodoListEditing extends Plugin {
     static readonly requires: [typeof ListEditing];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TodoListEditing: TodoListEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-list/v27/src/todolistui.d.ts
+++ b/types/ckeditor__ckeditor5-list/v27/src/todolistui.d.ts
@@ -4,3 +4,9 @@ export default class TodoListUI extends Plugin {
     static readonly pluginName: 'TodoListUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TodoListUI: TodoListUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-markdown-gfm/ckeditor__ckeditor5-markdown-gfm-tests.ts
+++ b/types/ckeditor__ckeditor5-markdown-gfm/ckeditor__ckeditor5-markdown-gfm-tests.ts
@@ -23,3 +23,6 @@ new GFMDataProcessor(new Document(new StylesProcessor())).registerRawContentMatc
 html2markdown('').startsWith('');
 
 markdown2html('').startsWith('');
+
+// $ExpectType Markdown
+editor.plugins.get('Markdown');

--- a/types/ckeditor__ckeditor5-markdown-gfm/src/markdown.d.ts
+++ b/types/ckeditor__ckeditor5-markdown-gfm/src/markdown.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class Markdown extends Plugin {
     static readonly pluginName: 'Markdown';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Markdown: Markdown;
+    }
+}

--- a/types/ckeditor__ckeditor5-markdown-gfm/v27/ckeditor__ckeditor5-markdown-gfm-tests.ts
+++ b/types/ckeditor__ckeditor5-markdown-gfm/v27/ckeditor__ckeditor5-markdown-gfm-tests.ts
@@ -6,6 +6,7 @@ import GFM from '@ckeditor/ckeditor5-markdown-gfm';
 import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor';
 import html2markdown from '@ckeditor/ckeditor5-markdown-gfm/src/html2markdown/html2markdown';
 import markdown2html from '@ckeditor/ckeditor5-markdown-gfm/src/markdown2html/markdown2html';
+import Markdown from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -23,3 +24,6 @@ new GFMDataProcessor(new Document(new StylesProcessor())).registerRawContentMatc
 html2markdown('').startsWith('');
 
 markdown2html('').startsWith('');
+
+// $ExpectType Markdown
+editor.plugins.get('Markdown');

--- a/types/ckeditor__ckeditor5-markdown-gfm/v27/src/markdown.d.ts
+++ b/types/ckeditor__ckeditor5-markdown-gfm/v27/src/markdown.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class Markdown extends Plugin {
     static readonly pluginName: 'Markdown';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Markdown: Markdown;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/ckeditor__ckeditor5-media-embed-tests.ts
+++ b/types/ckeditor__ckeditor5-media-embed/ckeditor__ckeditor5-media-embed-tests.ts
@@ -69,3 +69,18 @@ utils.createMediaFigureElement(
 );
 utils.getSelectedMediaViewWidget(new Selection());
 utils.getSelectedMediaModelWidget(new ModelSelection(null));
+
+// $ExpectType AutoMediaEmbed
+editor.plugins.get('AutoMediaEmbed');
+
+// $ExpectType MediaEmbed
+editor.plugins.get('MediaEmbed');
+
+// $ExpectType MediaEmbedEditing
+editor.plugins.get('MediaEmbedEditing');
+
+// $ExpectType MediaEmbedToolbar
+editor.plugins.get('MediaEmbedToolbar');
+
+// $ExpectType MediaEmbedUI
+editor.plugins.get('MediaEmbedUI');

--- a/types/ckeditor__ckeditor5-media-embed/src/automediaembed.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/src/automediaembed.d.ts
@@ -7,3 +7,9 @@ export default class AutoMediaEmbed extends Plugin {
     static readonly pluginName: 'AutoMediaEmbed';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoMediaEmbed: AutoMediaEmbed;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/src/mediaembed.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/src/mediaembed.d.ts
@@ -23,3 +23,9 @@ export interface MediaEmbedProvider {
     name: string;
     url: RegExp | RegExp[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbed: MediaEmbed;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/src/mediaembedediting.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/src/mediaembedediting.d.ts
@@ -6,3 +6,9 @@ export default class MediaEmbedEditing extends Plugin {
     readonly registry: MediaRegistry;
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbedEditing: MediaEmbedEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/src/mediaembedtoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/src/mediaembedtoolbar.d.ts
@@ -6,3 +6,9 @@ export default class MediaEmbedToolbar extends Plugin {
     static readonly pluginName: 'MediaEmbedToolbar';
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbedToolbar: MediaEmbedToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/src/mediaembedui.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/src/mediaembedui.d.ts
@@ -6,3 +6,9 @@ export default class MediaEmbedUI extends Plugin {
     static readonly pluginName: 'MediaEmbedUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbedUI: MediaEmbedUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/v27/ckeditor__ckeditor5-media-embed-tests.ts
+++ b/types/ckeditor__ckeditor5-media-embed/v27/ckeditor__ckeditor5-media-embed-tests.ts
@@ -63,3 +63,18 @@ utils.createMediaFigureElement(
 );
 utils.getSelectedMediaViewWidget(new Selection());
 utils.getSelectedMediaModelWidget(new ModelSelection(null));
+
+// $ExpectType AutoMediaEmbed
+editor.plugins.get('AutoMediaEmbed');
+
+// $ExpectType MediaEmbed
+editor.plugins.get('MediaEmbed');
+
+// $ExpectType MediaEmbedEditing
+editor.plugins.get('MediaEmbedEditing');
+
+// $ExpectType MediaEmbedToolbar
+editor.plugins.get('MediaEmbedToolbar');
+
+// $ExpectType MediaEmbedUI
+editor.plugins.get('MediaEmbedUI');

--- a/types/ckeditor__ckeditor5-media-embed/v27/src/automediaembed.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/v27/src/automediaembed.d.ts
@@ -7,3 +7,9 @@ export default class AutoMediaEmbed extends Plugin {
     static readonly pluginName: 'AutoMediaEmbed';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        AutoMediaEmbed: AutoMediaEmbed;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembed.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembed.d.ts
@@ -23,3 +23,9 @@ export interface MediaEmbedProvider {
     name: string;
     url: RegExp | RegExp[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbed: MediaEmbed;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembedediting.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembedediting.d.ts
@@ -6,3 +6,9 @@ export default class MediaEmbedEditing extends Plugin {
     readonly registry: MediaRegistry;
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbedEditing: MediaEmbedEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembedtoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembedtoolbar.d.ts
@@ -6,3 +6,9 @@ export default class MediaEmbedToolbar extends Plugin {
     static readonly pluginName: 'MediaEmbedToolbar';
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbedToolbar: MediaEmbedToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembedui.d.ts
+++ b/types/ckeditor__ckeditor5-media-embed/v27/src/mediaembedui.d.ts
@@ -6,3 +6,9 @@ export default class MediaEmbedUI extends Plugin {
     static readonly pluginName: 'MediaEmbedUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MediaEmbedUI: MediaEmbedUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-mention/ckeditor__ckeditor5-mention-tests.ts
+++ b/types/ckeditor__ckeditor5-mention/ckeditor__ckeditor5-mention-tests.ts
@@ -63,3 +63,12 @@ new MentionListItemView().children.first!.highlight();
 
 new MentionsView().selected.children.first!.highlight();
 new MentionsView().items.first!.highlight();
+
+// $ExpectType Mention
+myEditor.plugins.get('Mention');
+
+// $ExpectType MentionEditing
+myEditor.plugins.get('MentionEditing');
+
+// $ExpectType MentionUI
+myEditor.plugins.get('MentionUI');

--- a/types/ckeditor__ckeditor5-mention/src/mention.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mention.d.ts
@@ -45,3 +45,9 @@ export interface MentionFeedItem {
     id: string;
     text: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Mention: Mention;
+    }
+}

--- a/types/ckeditor__ckeditor5-mention/src/mentionediting.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mentionediting.d.ts
@@ -11,3 +11,9 @@ export default class MentionEditing extends Plugin {
     static readonly pluginName: 'MentionEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MentionEditing: MentionEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-mention/src/mentionui.d.ts
+++ b/types/ckeditor__ckeditor5-mention/src/mentionui.d.ts
@@ -10,3 +10,9 @@ export default class MentionUI extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        MentionUI: MentionUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-pagination/ckeditor__ckeditor5-pagination-tests.ts
+++ b/types/ckeditor__ckeditor5-pagination/ckeditor__ckeditor5-pagination-tests.ts
@@ -17,3 +17,6 @@ const config: PaginationConfig = {
     pageWidth: '',
     pageHeight: '',
 };
+
+// $ExpectType Pagination
+editor.plugins.get('Pagination');

--- a/types/ckeditor__ckeditor5-pagination/src/pagination.d.ts
+++ b/types/ckeditor__ckeditor5-pagination/src/pagination.d.ts
@@ -19,3 +19,9 @@ export interface PaginationMarginsConfig {
     right: string;
     top: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Pagination: Pagination;
+    }
+}

--- a/types/ckeditor__ckeditor5-paragraph/ckeditor__ckeditor5-paragraph-tests.ts
+++ b/types/ckeditor__ckeditor5-paragraph/ckeditor__ckeditor5-paragraph-tests.ts
@@ -23,3 +23,9 @@ pc.execute();
 const bool: boolean = pc.value;
 // $ExpectError
 pc.value = true;
+
+// $ExpectType Paragraph
+editor.plugins.get('Paragraph');
+
+// $ExpectType ParagraphButtonUI
+editor.plugins.get('ParagraphButtonUI');

--- a/types/ckeditor__ckeditor5-paragraph/src/paragraph.d.ts
+++ b/types/ckeditor__ckeditor5-paragraph/src/paragraph.d.ts
@@ -7,3 +7,9 @@ export default class Paragraph extends Plugin {
     >;
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Paragraph: Paragraph;
+    }
+}

--- a/types/ckeditor__ckeditor5-paragraph/src/paragraphbuttonui.d.ts
+++ b/types/ckeditor__ckeditor5-paragraph/src/paragraphbuttonui.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class ParagraphButtonUI extends Plugin {
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ParagraphButtonUI: ParagraphButtonUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-paste-from-office/ckeditor__ckeditor5-paste-from-office-tests.ts
+++ b/types/ckeditor__ckeditor5-paste-from-office/ckeditor__ckeditor5-paste-from-office-tests.ts
@@ -52,3 +52,6 @@ normalizeSpacing('').startsWith('');
 normalizeSpacerunSpans(document);
 
 removeBoldWrapper(documentFragment, new UpcastWriter(doc));
+
+// $ExpectType PasteFromOffice
+editor.plugins.get('PasteFromOffice');

--- a/types/ckeditor__ckeditor5-paste-from-office/src/pastefromoffice.d.ts
+++ b/types/ckeditor__ckeditor5-paste-from-office/src/pastefromoffice.d.ts
@@ -9,3 +9,9 @@ export default class PasteFromOffice extends Plugin {
     static readonly requires: [typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PasteFromOffice: PasteFromOffice;
+    }
+}

--- a/types/ckeditor__ckeditor5-paste-from-office/v27/ckeditor__ckeditor5-paste-from-office-tests.ts
+++ b/types/ckeditor__ckeditor5-paste-from-office/v27/ckeditor__ckeditor5-paste-from-office-tests.ts
@@ -52,3 +52,6 @@ normalizeSpacing('').startsWith('');
 normalizeSpacerunSpans(document);
 
 removeBoldWrapper(documentFragment, new UpcastWriter(doc));
+
+// $ExpectType PasteFromOffice
+editor.plugins.get('PasteFromOffice');

--- a/types/ckeditor__ckeditor5-paste-from-office/v27/src/pastefromoffice.d.ts
+++ b/types/ckeditor__ckeditor5-paste-from-office/v27/src/pastefromoffice.d.ts
@@ -9,3 +9,9 @@ export default class PasteFromOffice extends Plugin {
     static readonly requires: [typeof ClipboardPipeline];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PasteFromOffice: PasteFromOffice;
+    }
+}

--- a/types/ckeditor__ckeditor5-real-time-collaboration/ckeditor__ckeditor5-real-time-collaboration-tests.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/ckeditor__ckeditor5-real-time-collaboration-tests.ts
@@ -2,6 +2,7 @@ import { Users } from '@ckeditor/ckeditor5-collaboration-core/src/users';
 import { Editor } from '@ckeditor/ckeditor5-core';
 import RTC from '@ckeditor/ckeditor5-real-time-collaboration';
 import { Collection } from '@ckeditor/ckeditor5-utils';
+import PresenceList from '@ckeditor/ckeditor5-real-time-collaboration/src/presencelist';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -21,3 +22,18 @@ new RTC.RealTimeCollaborativeEditing(editor);
 new RTC.RealTimeCollaborativeComments(editor);
 
 new RTC.RealTimeCollaborativeTrackChanges(editor);
+
+// $ExpectType PresenceList
+editor.plugins.get('PresenceList');
+
+// $ExpectType RealTimeCollaborationClient
+editor.plugins.get('RealTimeCollaborationClient');
+
+// $ExpectType RealTimeCollaborativeComments
+editor.plugins.get('RealTimeCollaborativeComments');
+
+// $ExpectType RealTimeCollaborativeEditing
+editor.plugins.get('RealTimeCollaborativeEditing');
+
+// $ExpectType RealTimeCollaborativeTrackChanges
+editor.plugins.get('RealTimeCollaborativeTrackChanges');

--- a/types/ckeditor__ckeditor5-real-time-collaboration/src/presencelist.d.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/src/presencelist.d.ts
@@ -3,3 +3,9 @@ import { ContextPlugin } from '@ckeditor/ckeditor5-core';
 export default class PresenceList extends ContextPlugin {
     static readonly pluginName: 'PresenceList';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PresenceList: PresenceList;
+    }
+}

--- a/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborationclient.d.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborationclient.d.ts
@@ -6,3 +6,9 @@ export default class RealTimeCollaborationClient extends Plugin {
     readonly lastSyncVersion: number;
     readonly offset: number;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RealTimeCollaborationClient: RealTimeCollaborationClient;
+    }
+}

--- a/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborativecomments.d.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborativecomments.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class RealTimeCollaborativeComments extends Plugin {
     static readonly pluginName: 'RealTimeCollaborativeComments';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RealTimeCollaborativeComments: RealTimeCollaborativeComments;
+    }
+}

--- a/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborativeediting.d.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborativeediting.d.ts
@@ -7,3 +7,9 @@ export default class RealTimeCollaborativeEditing extends Plugin {
 export interface RealTimeCollaborationConfig {
     channelId?: string | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RealTimeCollaborativeEditing: RealTimeCollaborativeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborativetrackchanges.d.ts
+++ b/types/ckeditor__ckeditor5-real-time-collaboration/src/realtimecollaborativetrackchanges.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class RealTimeCollaborativeTrackChanges extends Plugin {
     static readonly pluginName: 'RealTimeCollaborativeTrackChanges';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RealTimeCollaborativeTrackChanges: RealTimeCollaborativeTrackChanges;
+    }
+}

--- a/types/ckeditor__ckeditor5-remove-format/ckeditor__ckeditor5-remove-format-tests.ts
+++ b/types/ckeditor__ckeditor5-remove-format/ckeditor__ckeditor5-remove-format-tests.ts
@@ -10,3 +10,12 @@ RemoveFormat.requires.forEach(Plugin => new Plugin(editor).init());
 
 new RemoveFormatCommand(editor).refresh();
 new RemoveFormatCommand(editor).execute();
+
+// $ExpectType RemoveFormat
+editor.plugins.get('RemoveFormat');
+
+// $ExpectType RemoveFormatEditing
+editor.plugins.get('RemoveFormatEditing');
+
+// $ExpectType RemoveFormatUI
+editor.plugins.get('RemoveFormatUI');

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformat.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformat.d.ts
@@ -6,3 +6,9 @@ export default class RemoveFormat extends Plugin {
     static readonly requires: [typeof RemoveFormatEditing, typeof RemoveFormatUI];
     static readonly pluginName: 'RemoveFormat';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RemoveFormat: RemoveFormat;
+    }
+}

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformatediting.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformatediting.d.ts
@@ -4,3 +4,9 @@ export default class RemoveFormatEditing extends Plugin {
     static readonly pluginName: 'RemoveFormatEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RemoveFormatEditing: RemoveFormatEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-remove-format/src/removeformatui.d.ts
+++ b/types/ckeditor__ckeditor5-remove-format/src/removeformatui.d.ts
@@ -4,3 +4,9 @@ export default class RemoveFormatUI extends Plugin {
     static readonly pluginName: 'RemoveFormatUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RemoveFormatUI: RemoveFormatUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-restricted-editing/ckeditor__ckeditor5-restricted-editing-tests.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/ckeditor__ckeditor5-restricted-editing-tests.ts
@@ -53,3 +53,21 @@ utils.isPositionInRangeBoundaries(
     new Range(new Position(Element.fromJSON({name: 'div'}), [0])),
     new Position(Element.fromJSON({name: 'div'}), [0]),
 );
+
+// $ExpectType RestrictedEditingMode
+editor.plugins.get('RestrictedEditingMode');
+
+// $ExpectType RestrictedEditingModeEditing
+editor.plugins.get('RestrictedEditingModeEditing');
+
+// $ExpectType RestrictedEditingModeUI
+editor.plugins.get('RestrictedEditingModeUI');
+
+// $ExpectType StandardEditingMode
+editor.plugins.get('StandardEditingMode');
+
+// $ExpectType StandardEditingModeEditing
+editor.plugins.get('StandardEditingModeEditing');
+
+// $ExpectType StandardEditingModeUI
+editor.plugins.get('StandardEditingModeUI');

--- a/types/ckeditor__ckeditor5-restricted-editing/src/restrictededitingmode.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/src/restrictededitingmode.d.ts
@@ -11,3 +11,9 @@ export interface RestrictedEditingModeConfig {
     allowedAttributes: string[];
     allowedCommands: string[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RestrictedEditingMode: RestrictedEditingMode;
+    }
+}

--- a/types/ckeditor__ckeditor5-restricted-editing/src/restrictededitingmodeediting.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/src/restrictededitingmodeediting.d.ts
@@ -5,3 +5,9 @@ export default class RestrictedEditingModeEditing extends Plugin {
     init(): void;
     enableCommand(commandName: string): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RestrictedEditingModeEditing: RestrictedEditingModeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-restricted-editing/src/restrictededitingmodeui.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/src/restrictededitingmodeui.d.ts
@@ -4,3 +4,9 @@ export default class RestrictedEditingModeUI extends Plugin {
     static readonly pluginName: 'RestrictedEditingModeUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        RestrictedEditingModeUI: RestrictedEditingModeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-restricted-editing/src/standardeditingmode.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/src/standardeditingmode.d.ts
@@ -6,3 +6,9 @@ export default class StandardEditingMode extends Plugin {
     static readonly pluginName: 'StandardEditingMode';
     static requires: [typeof StandardEditingModeEditing, typeof StandardEditingModeUI];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StandardEditingMode: StandardEditingMode;
+    }
+}

--- a/types/ckeditor__ckeditor5-restricted-editing/src/standardeditingmodeediting.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/src/standardeditingmodeediting.d.ts
@@ -4,3 +4,9 @@ export default class StandardEditingModeEditing extends Plugin {
     static readonly pluginName: 'StandardEditingModeEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StandardEditingModeEditing: StandardEditingModeEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-restricted-editing/src/standardeditingmodeui.d.ts
+++ b/types/ckeditor__ckeditor5-restricted-editing/src/standardeditingmodeui.d.ts
@@ -3,3 +3,9 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
 export default class StandardEditingModeUI extends Plugin {
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        StandardEditingModeUI: StandardEditingModeUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-select-all/ckeditor__ckeditor5-select-all-tests.ts
+++ b/types/ckeditor__ckeditor5-select-all/ckeditor__ckeditor5-select-all-tests.ts
@@ -15,3 +15,12 @@ new SelectAll.SelectAllEditing(editor).init();
 new SelectAllCommand(editor).execute();
 // $ExpectError
 new SelectAllCommand(editor).execute(true);
+
+// $ExpectType SelectAll
+editor.plugins.get('SelectAll');
+
+// $ExpectType SelectAllEditing
+editor.plugins.get('SelectAllEditing');
+
+// $ExpectType SelectAllUI
+editor.plugins.get('SelectAllUI');

--- a/types/ckeditor__ckeditor5-select-all/src/selectall.d.ts
+++ b/types/ckeditor__ckeditor5-select-all/src/selectall.d.ts
@@ -6,3 +6,9 @@ export default class SelectAll extends Plugin {
     static readonly requires: [typeof SelectAllEditing, typeof SelectAllUI];
     static readonly pluginName: 'SelectAll';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SelectAll: SelectAll;
+    }
+}

--- a/types/ckeditor__ckeditor5-select-all/src/selectallediting.d.ts
+++ b/types/ckeditor__ckeditor5-select-all/src/selectallediting.d.ts
@@ -4,3 +4,9 @@ export default class SelectAllEditing extends Plugin {
     static readonly pluginName: 'SelectAllEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SelectAllEditing: SelectAllEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-select-all/src/selectallui.d.ts
+++ b/types/ckeditor__ckeditor5-select-all/src/selectallui.d.ts
@@ -4,3 +4,9 @@ export default class SelectAllUI extends Plugin {
     static readonly pluginName: 'SelectAllUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SelectAllUI: SelectAllUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-source-editing/ckeditor__ckeditor5-source-editing-tests.ts
+++ b/types/ckeditor__ckeditor5-source-editing/ckeditor__ckeditor5-source-editing-tests.ts
@@ -20,3 +20,6 @@ formatHtml('') === true;
 // $ExpectError
 formatHtml(5);
 formatHtml('') === '';
+
+// $ExpectType SourceEditing
+editor.plugins.get('SourceEditing');

--- a/types/ckeditor__ckeditor5-source-editing/src/sourceediting.d.ts
+++ b/types/ckeditor__ckeditor5-source-editing/src/sourceediting.d.ts
@@ -58,3 +58,9 @@ export default class SourceEditing extends Plugin {
      */
     private _isAllowedToHandleSourceEditingMode(): boolean;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SourceEditing: SourceEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/ckeditor__ckeditor5-special-characters-tests.ts
+++ b/types/ckeditor__ckeditor5-special-characters/ckeditor__ckeditor5-special-characters-tests.ts
@@ -2,6 +2,9 @@ import { Editor, EditorUI } from '@ckeditor/ckeditor5-core';
 import { EditorWithUI } from '@ckeditor/ckeditor5-core/src/editor/editorwithui';
 import {
     SpecialCharacters,
+    SpecialCharactersArrows,
+    SpecialCharactersCurrency,
+    SpecialCharactersEssentials,
     SpecialCharactersLatin,
     SpecialCharactersMathematical,
     SpecialCharactersText,
@@ -50,3 +53,24 @@ new CharacterGridView().destroy();
 
 new CharacterInfoView().render();
 new CharacterInfoView().destroy();
+
+// $ExpectType SpecialCharacters
+editor.plugins.get('SpecialCharacters');
+
+// $ExpectType SpecialCharactersArrows
+editor.plugins.get('SpecialCharactersArrows');
+
+// $ExpectType SpecialCharactersCurrency
+editor.plugins.get('SpecialCharactersCurrency');
+
+// $ExpectType SpecialCharactersEssentials
+editor.plugins.get('SpecialCharactersEssentials');
+
+// $ExpectType SpecialCharactersLatin
+editor.plugins.get('SpecialCharactersLatin');
+
+// $ExpectType SpecialCharactersMathematical
+editor.plugins.get('SpecialCharactersMathematical');
+
+// $ExpectType SpecialCharactersText
+editor.plugins.get('SpecialCharactersText');

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharacters.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharacters.d.ts
@@ -15,3 +15,9 @@ export interface SpecialCharacterDefinition {
     title: string;
     character: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharacters: SpecialCharacters;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharactersarrows.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharactersarrows.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersArrows extends Plugin {
     static readonly pluginName: "SpecialCharactersArrows";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersArrows: SpecialCharactersArrows;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharacterscurrency.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharacterscurrency.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersCurrency extends Plugin {
     static readonly pluginName: "SpecialCharactersCurrency";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersCurrency: SpecialCharactersCurrency;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharactersessentials.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharactersessentials.d.ts
@@ -14,3 +14,9 @@ export default class SpecialCharactersEssentials extends Plugin {
         typeof SpecialCharactersLatin,
     ];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersEssentials: SpecialCharactersEssentials;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharacterslatin.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharacterslatin.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersLatin extends Plugin {
     static readonly pluginName: "SpecialCharactersLatin";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersLatin: SpecialCharactersLatin;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharactersmathematical.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharactersmathematical.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersMathematical extends Plugin {
     static readonly pluginName: "SpecialCharactersMathematical";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersMathematical: SpecialCharactersMathematical;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/src/specialcharacterstext.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/src/specialcharacterstext.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersText extends Plugin {
     static readonly pluginName: "SpecialCharactersText";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersText: SpecialCharactersText;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/ckeditor__ckeditor5-special-characters-tests.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/ckeditor__ckeditor5-special-characters-tests.ts
@@ -21,3 +21,26 @@ const specialCharactersLatin = new SC.SpecialCharactersLatin(new MyEditor());
 specialCharactersLatin.init();
 const specialCharactersMathematical = new SC.SpecialCharactersMathematical(new MyEditor());
 specialCharactersMathematical.init();
+
+const editor = new MyEditor();
+
+// $ExpectType SpecialCharacters
+editor.plugins.get('SpecialCharacters');
+
+// $ExpectType SpecialCharactersArrows
+editor.plugins.get('SpecialCharactersArrows');
+
+// $ExpectType SpecialCharactersCurrency
+editor.plugins.get('SpecialCharactersCurrency');
+
+// $ExpectType SpecialCharactersEssentials
+editor.plugins.get('SpecialCharactersEssentials');
+
+// $ExpectType SpecialCharactersLatin
+editor.plugins.get('SpecialCharactersLatin');
+
+// $ExpectType SpecialCharactersMathematical
+editor.plugins.get('SpecialCharactersMathematical');
+
+// $ExpectType SpecialCharactersText
+editor.plugins.get('SpecialCharactersText');

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacters.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacters.d.ts
@@ -15,3 +15,9 @@ export interface SpecialCharacterDefinition {
     title: string;
     character: string;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharacters: SpecialCharacters;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharactersarrows.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharactersarrows.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersArrows extends Plugin {
     static readonly pluginName: "SpecialCharactersArrows";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersArrows: SpecialCharactersArrows;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacterscurrency.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacterscurrency.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersCurrency extends Plugin {
     static readonly pluginName: "SpecialCharactersCurrency";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersCurrency: SpecialCharactersCurrency;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharactersessentials.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharactersessentials.d.ts
@@ -14,3 +14,9 @@ export default class SpecialCharactersEssentials extends Plugin {
         typeof SpecialCharactersLatin,
     ];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersEssentials: SpecialCharactersEssentials;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacterslatin.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacterslatin.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersLatin extends Plugin {
     static readonly pluginName: "SpecialCharactersLatin";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersLatin: SpecialCharactersLatin;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharactersmathematical.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharactersmathematical.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersMathematical extends Plugin {
     static readonly pluginName: "SpecialCharactersMathematical";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersMathematical: SpecialCharactersMathematical;
+    }
+}

--- a/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacterstext.d.ts
+++ b/types/ckeditor__ckeditor5-special-characters/v27/src/specialcharacterstext.d.ts
@@ -4,3 +4,9 @@ export default class SpecialCharactersText extends Plugin {
     static readonly pluginName: "SpecialCharactersText";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SpecialCharactersText: SpecialCharactersText;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/ckeditor__ckeditor5-table-tests.ts
+++ b/types/ckeditor__ckeditor5-table/ckeditor__ckeditor5-table-tests.ts
@@ -69,3 +69,48 @@ new CKTable.TableCellPropertiesUI(editor).destroy();
 
 CKTable.TableCellPropertiesEditing.requires.map(Plugin => new Plugin(editor).init());
 new CKTable.TableCellPropertiesEditing(editor).init();
+
+// $ExpectType Table
+editor.plugins.get('Table');
+
+// $ExpectType TableCellProperties
+editor.plugins.get('TableCellProperties');
+
+// $ExpectType TableCellPropertiesEditing
+editor.plugins.get('TableCellPropertiesEditing');
+
+// $ExpectType TableCellPropertiesUI
+editor.plugins.get('TableCellPropertiesUI');
+
+// $ExpectType TableClipboard
+editor.plugins.get('TableClipboard');
+
+// $ExpectType TableEditing
+editor.plugins.get('TableEditing');
+
+// $ExpectType TableKeyboard
+editor.plugins.get('TableKeyboard');
+
+// $ExpectType TableMouse
+editor.plugins.get('TableMouse');
+
+// $ExpectType TableProperties
+editor.plugins.get('TableProperties');
+
+// $ExpectType TablePropertiesEditing
+editor.plugins.get('TablePropertiesEditing');
+
+// $ExpectType TablePropertiesUI
+editor.plugins.get('TablePropertiesUI');
+
+// $ExpectType TableSelection
+editor.plugins.get('TableSelection');
+
+// $ExpectType TableToolbar
+editor.plugins.get('TableToolbar');
+
+// $ExpectType TableUI
+editor.plugins.get('TableUI');
+
+// $ExpectType TableUtils
+editor.plugins.get('TableUtils');

--- a/types/ckeditor__ckeditor5-table/src/table.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/table.d.ts
@@ -40,3 +40,9 @@ export type TableColorConfig =
           label: string;
           hasBorder?: boolean | undefined;
       };
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Table: Table;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tablecellproperties.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tablecellproperties.d.ts
@@ -6,3 +6,9 @@ export default class TableCellProperties extends Plugin {
     static readonly pluginName: 'TableCellProperties';
     static readonly requires: [typeof TableCellPropertiesEditing, typeof TableCellPropertiesUI];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableCellProperties: TableCellProperties;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.d.ts
@@ -6,3 +6,9 @@ export default class TableCellPropertiesEditing extends Plugin {
     static readonly requires: [typeof TableEditing];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableCellPropertiesEditing: TableCellPropertiesEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.d.ts
@@ -7,3 +7,9 @@ export default class TableCellPropertiesUI extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableCellPropertiesUI: TableCellPropertiesUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableclipboard.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableclipboard.d.ts
@@ -7,3 +7,9 @@ export default class TableClipboard extends Plugin {
     static readonly requires: [typeof TableSelection, typeof TableUtils];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableClipboard: TableClipboard;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableediting.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableediting.d.ts
@@ -6,3 +6,9 @@ export default class TableEditing extends Plugin {
     static readonly requires: [typeof TableUtils];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableEditing: TableEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tablekeyboard.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tablekeyboard.d.ts
@@ -6,3 +6,9 @@ export default class TableKeyboard extends Plugin {
     static readonly requires: [typeof TableSelection];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableKeyboard: TableKeyboard;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tablemouse.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tablemouse.d.ts
@@ -6,3 +6,9 @@ export default class TableMouse extends Plugin {
     static readonly requires: [typeof TableSelection];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableMouse: TableMouse;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableproperties.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableproperties.d.ts
@@ -6,3 +6,9 @@ export default class TableProperties extends Plugin {
     static readonly pluginName: 'TableProperties';
     static readonly requires: [typeof TablePropertiesEditing, typeof TablePropertiesUI];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableProperties: TableProperties;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableproperties/tablepropertiesediting.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableproperties/tablepropertiesediting.d.ts
@@ -6,3 +6,9 @@ export default class TablePropertiesEditing extends Plugin {
     static readonly requires: [typeof TableEditing];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TablePropertiesEditing: TablePropertiesEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableproperties/tablepropertiesui.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableproperties/tablepropertiesui.d.ts
@@ -7,3 +7,9 @@ export default class TablePropertiesUI extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TablePropertiesUI: TablePropertiesUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableselection.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableselection.d.ts
@@ -13,3 +13,9 @@ export default class TableSelection extends Plugin {
     getFocusCell(): Element;
     getAnchorCell(): Element;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableSelection: TableSelection;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tabletoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tabletoolbar.d.ts
@@ -6,3 +6,9 @@ export default class TableToolbar extends Plugin {
     static readonly pluginName: 'TableToolbar';
     afterInit(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableToolbar: TableToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableui.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableui.d.ts
@@ -4,3 +4,9 @@ export default class TableUI extends Plugin {
     static readonly pluginName: 'TableUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableUI: TableUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-table/src/tableutils.d.ts
+++ b/types/ckeditor__ckeditor5-table/src/tableutils.d.ts
@@ -19,3 +19,9 @@ export default class TableUtils extends Plugin {
     getColumns(table: Element): number;
     getRows(table: Element): number;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TableUtils: TableUtils;
+    }
+}

--- a/types/ckeditor__ckeditor5-track-changes/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-track-changes/OTHER_FILES.txt
@@ -6,5 +6,4 @@ src/commands/discardallsuggestionscommand.d.ts
 src/commands/discardsuggestionsinselection.d.ts
 src/suggestiondescriptionfactory.d.ts
 src/trackchangescommand.d.ts
-src/trackchangesediting.d.ts
 src/ui/view/suggestionthreadview.d.ts

--- a/types/ckeditor__ckeditor5-track-changes/ckeditor__ckeditor5-track-changes-tests.ts
+++ b/types/ckeditor__ckeditor5-track-changes/ckeditor__ckeditor5-track-changes-tests.ts
@@ -29,3 +29,12 @@ const range: Range = suggestion.getRanges()[0];
 const data = new TrackChanges.TrackChangesData(editor);
 data.getDataWithAcceptedSuggestions({ rootName: '' });
 data.getDataWithDiscardedSuggestions({ rootName: '', trim: 'empty' }).then(str => str.startsWith(''));
+
+// $ExpectType TrackChanges
+editor.plugins.get('TrackChanges');
+
+// $ExpectType TrackChangesData
+editor.plugins.get('TrackChangesData');
+
+// $ExpectType TrackChangesEditing
+editor.plugins.get('TrackChangesEditing');

--- a/types/ckeditor__ckeditor5-track-changes/src/trackchanges.d.ts
+++ b/types/ckeditor__ckeditor5-track-changes/src/trackchanges.d.ts
@@ -1,6 +1,8 @@
 import BaseSuggestionThreadView from './ui/view/basesuggestionthreadview';
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import Suggestion from './suggestion';
+import './trackchangesediting';
+import './trackchangesui';
 
 export interface SuggestionData {
     attributes: Record<string, unknown>;
@@ -43,4 +45,10 @@ export default class TrackChanges extends Plugin {
     addSuggestion(suggestionData: SuggestionData): Suggestion;
     getSuggestion(id: string): Suggestion;
     getSuggestions(options?: { skipNotAttached?: boolean | undefined; toJSON?: boolean | undefined }): Suggestion[];
+}
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TrackChanges: TrackChanges;
+    }
 }

--- a/types/ckeditor__ckeditor5-track-changes/src/trackchangesdata.d.ts
+++ b/types/ckeditor__ckeditor5-track-changes/src/trackchangesdata.d.ts
@@ -5,3 +5,9 @@ export default class TrackChangesData extends Plugin {
     getDataWithAcceptedSuggestions(options?: Parameters<DataController['get']>[0]): Promise<string>;
     getDataWithDiscardedSuggestions(options?: Parameters<DataController['get']>[0]): Promise<string>;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TrackChangesData: TrackChangesData;
+    }
+}

--- a/types/ckeditor__ckeditor5-track-changes/src/trackchangesediting.d.ts
+++ b/types/ckeditor__ckeditor5-track-changes/src/trackchangesediting.d.ts
@@ -36,3 +36,9 @@ export default class TrackChangesEditing extends Plugin {
     markMultiRangeDeletion(ranges: Range[], subType?: string, attributes?: Record<string, unknown>): Suggestion;
     markMultiRangeInsertion(ranges: Range[], subType?: string, attributes?: Record<string, unknown>): Suggestion;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TrackChangesEditing: TrackChangesEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-track-changes/src/trackchangesui.d.ts
+++ b/types/ckeditor__ckeditor5-track-changes/src/trackchangesui.d.ts
@@ -1,12 +1,12 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
 
-export default class ImageResizeEditing extends Plugin {
-    static readonly pluginName: 'ImageResizeEditing';
+export default class TrackChangesUI extends Plugin {
+    static readonly pluginName: 'TrackChangesUI';
     init(): void;
 }
 
 declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
     interface Plugins {
-        ImageResizeEditing: ImageResizeEditing;
+        TrackChangesUI: TrackChangesUI;
     }
 }

--- a/types/ckeditor__ckeditor5-typing/ckeditor__ckeditor5-typing-tests.ts
+++ b/types/ckeditor__ckeditor5-typing/ckeditor__ckeditor5-typing-tests.ts
@@ -61,3 +61,18 @@ findAttributeRange(new Position(Element.fromJSON({ name: "div" }), [3]), "", "",
 getLastTextLine(new Range(new Position(Element.fromJSON({ name: "div" }), [4])), new Model());
 
 injectUnsafeKeystrokesHandling(editor);
+
+// $ExpectType Delete
+editor.plugins.get('Delete');
+
+// $ExpectType Input
+editor.plugins.get('Input');
+
+// $ExpectType TextTransformation
+editor.plugins.get('TextTransformation');
+
+// $ExpectType TwoStepCaretMovement
+editor.plugins.get('TwoStepCaretMovement');
+
+// $ExpectType Typing
+editor.plugins.get('Typing');

--- a/types/ckeditor__ckeditor5-typing/src/delete.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/delete.d.ts
@@ -4,3 +4,9 @@ export default class Delete extends Plugin {
     static readonly pluginName: "Delete";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Delete: Delete;
+    }
+}

--- a/types/ckeditor__ckeditor5-typing/src/input.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/input.d.ts
@@ -6,3 +6,9 @@ export default class Input extends Plugin {
     init(): void;
     isInput(batch: Batch): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Input: Input;
+    }
+}

--- a/types/ckeditor__ckeditor5-typing/src/texttransformation.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/texttransformation.d.ts
@@ -15,3 +15,9 @@ export interface TextTransformationConfig {
     include: TextTransformationDescription[];
     remove: TextTransformationDescription[];
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TextTransformation: TextTransformation;
+    }
+}

--- a/types/ckeditor__ckeditor5-typing/src/twostepcaretmovement.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/twostepcaretmovement.d.ts
@@ -5,3 +5,9 @@ export default class TwoStepCaretMovement extends Plugin {
     init(): void;
     registerAttribute(attribute: string): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        TwoStepCaretMovement: TwoStepCaretMovement;
+    }
+}

--- a/types/ckeditor__ckeditor5-typing/src/typing.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/typing.d.ts
@@ -12,3 +12,9 @@ export interface TypingConfig {
     transformations: TextTransformationConfig;
     undoStep: number;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Typing: Typing;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
@@ -508,3 +508,15 @@ new ListSeparatorView().element!.tagName.startsWith('foo');
  */
 new ToolbarLineBreakView().render();
 new ToolbarLineBreakView().element!.tagName.startsWith('foo');
+
+// $ExpectType BalloonToolbar
+editor.plugins.get('BalloonToolbar');
+
+// $ExpectType BlockToolbar
+editor.plugins.get('BlockToolbar');
+
+// $ExpectType ContextualBalloon
+editor.plugins.get('ContextualBalloon');
+
+// $ExpectType Notification
+editor.plugins.get('Notification');

--- a/types/ckeditor__ckeditor5-ui/src/notification/notification.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/notification/notification.d.ts
@@ -31,3 +31,9 @@ export default class Notification extends ContextPlugin implements Emitter {
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Notification: Notification;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/src/panel/balloon/contextualballoon.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/panel/balloon/contextualballoon.d.ts
@@ -37,3 +37,9 @@ export class RotatorView extends View {
     hideView(): void;
     showView(view: View): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ContextualBalloon: ContextualBalloon;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/src/toolbar/balloon/balloontoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/toolbar/balloon/balloontoolbar.d.ts
@@ -9,3 +9,9 @@ export default class BalloonToolbar extends Plugin {
     hide(): void;
     show(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BalloonToolbar: BalloonToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/src/toolbar/block/blocktoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/toolbar/block/blocktoolbar.d.ts
@@ -8,3 +8,9 @@ export default class BlockToolbar extends Plugin {
     panelView: BalloonPanelView;
     toolbarView: ToolbarView;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockToolbar: BlockToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/v27/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/ckeditor__ckeditor5-ui-tests.ts
@@ -508,3 +508,15 @@ new ListSeparatorView().element!.tagName.startsWith("foo");
  */
 new ToolbarLineBreakView().render();
 new ToolbarLineBreakView().element!.tagName.startsWith("foo");
+
+// $ExpectType BalloonToolbar
+editor.plugins.get('BalloonToolbar');
+
+// $ExpectType BlockToolbar
+editor.plugins.get('BlockToolbar');
+
+// $ExpectType ContextualBalloon
+editor.plugins.get('ContextualBalloon');
+
+// $ExpectType Notification
+editor.plugins.get('Notification');

--- a/types/ckeditor__ckeditor5-ui/v27/src/notification/notification.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/notification/notification.d.ts
@@ -31,3 +31,9 @@ export default class Notification extends ContextPlugin implements Emitter {
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Notification: Notification;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/v27/src/panel/balloon/contextualballoon.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/panel/balloon/contextualballoon.d.ts
@@ -37,3 +37,9 @@ export class RotatorView extends View {
     hideView(): void;
     showView(view: View): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        ContextualBalloon: ContextualBalloon;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/v27/src/toolbar/balloon/balloontoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/toolbar/balloon/balloontoolbar.d.ts
@@ -9,3 +9,9 @@ export default class BalloonToolbar extends Plugin {
     hide(): void;
     show(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BalloonToolbar: BalloonToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-ui/v27/src/toolbar/block/blocktoolbar.d.ts
+++ b/types/ckeditor__ckeditor5-ui/v27/src/toolbar/block/blocktoolbar.d.ts
@@ -8,3 +8,9 @@ export default class BlockToolbar extends Plugin {
     panelView: BalloonPanelView;
     toolbarView: ToolbarView;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        BlockToolbar: BlockToolbar;
+    }
+}

--- a/types/ckeditor__ckeditor5-undo/ckeditor__ckeditor5-undo-tests.ts
+++ b/types/ckeditor__ckeditor5-undo/ckeditor__ckeditor5-undo-tests.ts
@@ -1,6 +1,7 @@
 import { Editor } from "@ckeditor/ckeditor5-core";
 import Batch from "@ckeditor/ckeditor5-engine/src/model/batch";
-import { Undo } from "@ckeditor/ckeditor5-undo";
+import { Undo, UndoEditing } from "@ckeditor/ckeditor5-undo";
+import UndoUI from "@ckeditor/ckeditor5-undo/src/undoui";
 import RedoCommand from "@ckeditor/ckeditor5-undo/src/redocommand";
 import UndoCommand from "@ckeditor/ckeditor5-undo/src/undocommand";
 
@@ -21,3 +22,12 @@ const redo = new RedoCommand(editor);
 redo.execute();
 // $ExpectError
 redo.execute(new Batch());
+
+// $ExpectType Undo
+editor.plugins.get('Undo');
+
+// $ExpectType UndoEditing
+editor.plugins.get('UndoEditing');
+
+// $ExpectType UndoUI
+editor.plugins.get('UndoUI');

--- a/types/ckeditor__ckeditor5-undo/src/undo.d.ts
+++ b/types/ckeditor__ckeditor5-undo/src/undo.d.ts
@@ -6,3 +6,9 @@ export default class Undo extends Plugin {
     static readonly requires: [typeof UndoEditing, typeof UndoUI];
     static readonly pluginName: "Undo";
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Undo: Undo;
+    }
+}

--- a/types/ckeditor__ckeditor5-undo/src/undoediting.d.ts
+++ b/types/ckeditor__ckeditor5-undo/src/undoediting.d.ts
@@ -4,3 +4,9 @@ export default class UndoEditing extends Plugin {
     static readonly pluginName: "UndoEditing";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        UndoEditing: UndoEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-undo/src/undoui.d.ts
+++ b/types/ckeditor__ckeditor5-undo/src/undoui.d.ts
@@ -4,3 +4,9 @@ export default class UndoUI extends Plugin {
     static readonly pluginName: "UndoUI";
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        UndoUI: UndoUI;
+    }
+}

--- a/types/ckeditor__ckeditor5-upload/ckeditor__ckeditor5-upload-tests.ts
+++ b/types/ckeditor__ckeditor5-upload/ckeditor__ckeditor5-upload-tests.ts
@@ -10,6 +10,8 @@ import { FileLoader } from "@ckeditor/ckeditor5-upload/src/filerepository";
 
 class MyEditor extends Editor {}
 
+const editor = new MyEditor();
+
 const config: SimpleUploadConfig = {
     uploadUrl: "",
     withCredentials: true,
@@ -43,3 +45,12 @@ base64UploadAdapter.init();
 
 const simpleUploadAdapter = new SimpleUploadAdapter(new MyEditor());
 simpleUploadAdapter.init();
+
+// $ExpectType Base64UploadAdapter
+editor.plugins.get('Base64UploadAdapter');
+
+// $ExpectType FileRepository
+editor.plugins.get('FileRepository');
+
+// $ExpectType SimpleUploadAdapter
+editor.plugins.get('SimpleUploadAdapter');

--- a/types/ckeditor__ckeditor5-upload/src/adapters/base64uploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-upload/src/adapters/base64uploadadapter.d.ts
@@ -7,3 +7,9 @@ export default class Base64UploadAdapter extends Plugin {
 
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Base64UploadAdapter: Base64UploadAdapter;
+    }
+}

--- a/types/ckeditor__ckeditor5-upload/src/adapters/simpleuploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-upload/src/adapters/simpleuploadadapter.d.ts
@@ -12,3 +12,9 @@ export interface SimpleUploadConfig {
     uploadUrl?: string | undefined;
     withCredentials?: boolean | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        SimpleUploadAdapter: SimpleUploadAdapter;
+    }
+}

--- a/types/ckeditor__ckeditor5-upload/src/filerepository.d.ts
+++ b/types/ckeditor__ckeditor5-upload/src/filerepository.d.ts
@@ -39,3 +39,9 @@ export interface UploadAdapter {
     abort(): void;
     upload(): Promise<Record<string, string>>;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        FileRepository: FileRepository;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/ckeditor__ckeditor5-widget-tests.ts
+++ b/types/ckeditor__ckeditor5-widget/ckeditor__ckeditor5-widget-tests.ts
@@ -96,3 +96,15 @@ toWidget(containerElement, new DowncastWriter(new Document(new StylesProcessor()
 
 new SizeView().render();
 new SizeView().isRendered === bool;
+
+// $ExpectType Widget
+editor.plugins.get('Widget');
+
+// $ExpectType WidgetResize
+editor.plugins.get('WidgetResize');
+
+// $ExpectType WidgetToolbarRepository
+editor.plugins.get('WidgetToolbarRepository');
+
+// $ExpectType WidgetTypeAround
+editor.plugins.get('WidgetTypeAround');

--- a/types/ckeditor__ckeditor5-widget/src/widget.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widget.d.ts
@@ -7,3 +7,9 @@ export default class Widget extends Plugin {
     static readonly requires: [typeof WidgetTypeAround, typeof Delete];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Widget: Widget;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/src/widgetresize.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgetresize.d.ts
@@ -23,3 +23,9 @@ export default class WidgetResize extends Plugin {
     attachTo(options?: ResizerOptions): Resizer;
     getResizerByViewElement(viewElement: ContainerElement): Resizer | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WidgetResize: WidgetResize;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/src/widgettoolbarrepository.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgettoolbarrepository.d.ts
@@ -26,3 +26,9 @@ export interface WidgetRepositoryToolbarDefinition {
     getRelatedElement: (el: Selection | DocumentSelection) => EngineView;
     view: View;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WidgetToolbarRepository: WidgetToolbarRepository;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/src/widgettypearound/widgettypearound.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgettypearound/widgettypearound.d.ts
@@ -8,3 +8,9 @@ export default class WidgetTypeAround extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WidgetTypeAround: WidgetTypeAround;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/v27/ckeditor__ckeditor5-widget-tests.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/ckeditor__ckeditor5-widget-tests.ts
@@ -77,3 +77,15 @@ CKWidget.setHighlightHandling(
 );
 CKWidget.setLabel(containerElement, () => 'foo', new DowncastWriter(new Document(new StylesProcessor())));
 CKWidget.toWidget(containerElement, new DowncastWriter(new Document(new StylesProcessor())));
+
+// $ExpectType Widget
+editor.plugins.get('Widget');
+
+// $ExpectType WidgetResize
+editor.plugins.get('WidgetResize');
+
+// $ExpectType WidgetToolbarRepository
+editor.plugins.get('WidgetToolbarRepository');
+
+// $ExpectType WidgetTypeAround
+editor.plugins.get('WidgetTypeAround');

--- a/types/ckeditor__ckeditor5-widget/v27/src/widget.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/widget.d.ts
@@ -7,3 +7,9 @@ export default class Widget extends Plugin {
     static readonly requires: [typeof WidgetTypeAround, typeof Delete];
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        Widget: Widget;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/v27/src/widgetresize.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/widgetresize.d.ts
@@ -23,3 +23,9 @@ export default class WidgetResize extends Plugin {
     attachTo(options?: ResizerOptions): Resizer;
     getResizerByViewElement(viewElement: ContainerElement): Resizer | undefined;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WidgetResize: WidgetResize;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/v27/src/widgettoolbarrepository.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/widgettoolbarrepository.d.ts
@@ -26,3 +26,9 @@ export interface WidgetRepositoryToolbarDefinition {
     getRelatedElement: (el: Selection | DocumentSelection) => EngineView;
     view: View;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WidgetToolbarRepository: WidgetToolbarRepository;
+    }
+}

--- a/types/ckeditor__ckeditor5-widget/v27/src/widgettypearound/widgettypearound.d.ts
+++ b/types/ckeditor__ckeditor5-widget/v27/src/widgettypearound/widgettypearound.d.ts
@@ -8,3 +8,9 @@ export default class WidgetTypeAround extends Plugin {
     init(): void;
     destroy(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WidgetTypeAround: WidgetTypeAround;
+    }
+}

--- a/types/ckeditor__ckeditor5-word-count/ckeditor__ckeditor5-word-count-tests.ts
+++ b/types/ckeditor__ckeditor5-word-count/ckeditor__ckeditor5-word-count-tests.ts
@@ -27,3 +27,6 @@ const config: WordCountConfig = {
 };
 
 const foo: string = utils.modelElementToPlainText(Element.fromJSON({ name: 'foo' }));
+
+// $ExpectType WordCount
+myEditor.plugins.get('WordCount');

--- a/types/ckeditor__ckeditor5-word-count/src/wordcount.d.ts
+++ b/types/ckeditor__ckeditor5-word-count/src/wordcount.d.ts
@@ -17,3 +17,9 @@ export interface WordCountConfig {
     displayWords?: boolean | undefined;
     onUpdate?(stats: { readonly words: number; readonly characters: number }): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WordCount: WordCount;
+    }
+}

--- a/types/ckeditor__ckeditor5-word-count/v27/ckeditor__ckeditor5-word-count-tests.ts
+++ b/types/ckeditor__ckeditor5-word-count/v27/ckeditor__ckeditor5-word-count-tests.ts
@@ -27,3 +27,6 @@ const config: WordCountConfig = {
 };
 
 const foo: string = utils.modelElementToPlainText(Element.fromJSON({ name: "foo" }));
+
+// $ExpectType WordCount
+myEditor.plugins.get('WordCount');

--- a/types/ckeditor__ckeditor5-word-count/v27/src/wordcount.d.ts
+++ b/types/ckeditor__ckeditor5-word-count/v27/src/wordcount.d.ts
@@ -17,3 +17,9 @@ export interface WordCountConfig {
     displayWords?: boolean | undefined;
     onUpdate?(stats: { readonly words: number; readonly characters: number }): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        WordCount: WordCount;
+    }
+}


### PR DESCRIPTION
This change makes it so that `PluginCollection.get` (i.e. `Editor.plugins.get`) has as its return type the specific `Plugin` subclass when called with a string plugin name.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`PluginCollection.get()`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginCollection.html#function-get)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header (**N/A**)
