### PR TITLE
Fix @ckeditor/adapter-ckfinder UploadAdapter.xhr

### DIFF
--- a/types/ckeditor__ckeditor5-adapter-ckfinder/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
@@ -1,14 +1,14 @@
-import UploadAdapter from "@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter";
+import CKFinderUploadAdapter, { UploadAdapter } from "@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter";
 import * as utils from "@ckeditor/ckeditor5-adapter-ckfinder/src/utils";
 import { Editor, Plugin } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
 
-if (!(UploadAdapter instanceof Plugin)) {
+if (!(CKFinderUploadAdapter instanceof Plugin)) {
     throw new Error("UploadAdapter must extend Plugin");
 }
-UploadAdapter.requires.forEach(Plugin => new Plugin(new MyEditor()));
-new UploadAdapter(new MyEditor()).init();
+CKFinderUploadAdapter.requires.forEach(Plugin => new Plugin(new MyEditor()));
+new CKFinderUploadAdapter(new MyEditor()).init();
 
 // $ExpectType string | null
 utils.getCookie("");
@@ -23,3 +23,10 @@ utils.setCookie("foo", 5);
 utils.getCsrfToken();
 // $ExpectError
 utils.getCookie(null);
+
+class Foo extends UploadAdapter {
+    method() {
+        // $ExpectType XMLHttpRequest | undefined
+        this.xhr;
+    }
+}

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/src/uploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/src/uploadadapter.d.ts
@@ -35,7 +35,7 @@ export class UploadAdapter implements IUploadAdapter {
      * Locale translation method.
      */
     readonly t: Locale['t'];
-    protected xhr: XMLHttpRequest;
+    protected xhr?: XMLHttpRequest;
     /**
      * Creates a new adapter instance.
      */

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/v27/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/v27/ckeditor__ckeditor5-adapter-ckfinder-tests.ts
@@ -1,14 +1,14 @@
-import UploadAdapter from "@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter";
+import CKFinderUploadAdapter, { UploadAdapter } from "@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter";
 import * as utils from "@ckeditor/ckeditor5-adapter-ckfinder/src/utils";
 import { Editor, Plugin } from "@ckeditor/ckeditor5-core";
 
 class MyEditor extends Editor {}
 
-if (!(UploadAdapter instanceof Plugin)) {
+if (!(CKFinderUploadAdapter instanceof Plugin)) {
     throw new Error("UploadAdapter must extend Plugin");
 }
-UploadAdapter.requires.forEach(Plugin => new Plugin(new MyEditor()));
-new UploadAdapter(new MyEditor()).init();
+CKFinderUploadAdapter.requires.forEach(Plugin => new Plugin(new MyEditor()));
+new CKFinderUploadAdapter(new MyEditor()).init();
 
 // $ExpectType string | null
 utils.getCookie("");
@@ -23,3 +23,10 @@ utils.setCookie("foo", 5);
 utils.getCsrfToken();
 // $ExpectError
 utils.getCookie(null);
+
+class Foo extends UploadAdapter {
+    method() {
+        // $ExpectType XMLHttpRequest | undefined
+        this.xhr;
+    }
+}

--- a/types/ckeditor__ckeditor5-adapter-ckfinder/v27/src/uploadadapter.d.ts
+++ b/types/ckeditor__ckeditor5-adapter-ckfinder/v27/src/uploadadapter.d.ts
@@ -35,7 +35,7 @@ export class UploadAdapter implements IUploadAdapter {
      * Locale translation method.
      */
     readonly t: Locale['t'];
-    protected xhr: XMLHttpRequest;
+    protected xhr?: XMLHttpRequest;
     /**
      * Creates a new adapter instance.
      */


### PR DESCRIPTION
`xhr` is not set by the constructor, so it's `undefined` until a method defines it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/c2725effb435695c8de696f95c188eef8bf7e169/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.js#L129
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.