### PR TITLE
Add workspace.isTrusted for vscode-noteook-renderer

### DIFF
--- a/types/vscode-notebook-renderer/index.d.ts
+++ b/types/vscode-notebook-renderer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package vscode-notebook-renderer 1.57
+// Type definitions for non-npm package vscode-notebook-renderer 1.60
 // Project: https://github.com/microsoft/vscode-docs/blob/notebook/api/extension-guides/notebook.md
 // Definitions by: Connor Peet <https://github.com/connor4312>, Matt Bierner <https://github.com/mjbvz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -96,6 +96,16 @@ export interface RendererContext<TState> {
      * object in the extension host.
      */
     onDidReceiveMessage?: VSCodeEvent<any> | undefined;
+
+    /**
+     * Information about the current workspace.
+     */
+    readonly workspace: {
+        /**
+         * When true, the user has explicitly trusted the contents of the workspace.
+         */
+        readonly isTrusted: boolean;
+    };
 }
 
 /**


### PR DESCRIPTION
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/vscode/issues/130951
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
