### PR TITLE
fix(node): adjust type of `output` in return of `spawnSync`

### DIFF
--- a/types/cross-spawn/cross-spawn-tests.ts
+++ b/types/cross-spawn/cross-spawn-tests.ts
@@ -10,7 +10,7 @@ pw.on('error', (err: Error) => {
 });
 
 const r1: Error | undefined = spawn.sync('foo').error;
-const r2: string[] = spawn.sync('foo').output;
+const r2: Array<Buffer | null> = spawn.sync('foo').output;
 const r3: Buffer = spawn.sync('foo').stdout;
 const r4: Buffer = spawn.sync('foo').stderr;
 const r5: number | null = spawn.sync('foo').status;

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -1248,7 +1248,7 @@ declare module 'child_process' {
     }
     interface SpawnSyncReturns<T> {
         pid: number;
-        output: string[];
+        output: Array<T | null>;
         stdout: T;
         stderr: T;
         status: number | null;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -22,6 +22,9 @@ import { URL } from 'node:url';
     childProcess.spawnSync("echo test", { encoding: 'utf-8' });
     childProcess.spawnSync("echo test", { encoding: 'buffer' });
     childProcess.spawnSync("echo test", { cwd: new URL('file://aaaaaaaa')});
+
+    childProcess.spawnSync("echo test", { encoding: 'utf-8' }).output; // $ExpectType (string | null)[]
+    childProcess.spawnSync("echo test", { encoding: 'buffer' }).output; // $ExpectType (Buffer | null)[]
 }
 
 {

--- a/types/node/v12/child_process.d.ts
+++ b/types/node/v12/child_process.d.ts
@@ -437,7 +437,7 @@ declare module 'child_process' {
     }
     interface SpawnSyncReturns<T> {
         pid: number;
-        output: string[];
+        output: Array<T | null>;
         stdout: T;
         stderr: T;
         status: number | null;

--- a/types/node/v12/test/child_process.ts
+++ b/types/node/v12/test/child_process.ts
@@ -18,6 +18,9 @@ import { Writable, Readable, Pipe } from 'stream';
     childProcess.spawnSync("echo test", {windowsVerbatimArguments: false, argv0: "echo-test"});
     childProcess.spawnSync("echo test", {input: new Uint8Array([])});
     childProcess.spawnSync("echo test", {input: new DataView(new ArrayBuffer(1))});
+
+    childProcess.spawnSync("echo test", { encoding: 'utf-8' }).output; // $ExpectType (string | null)[]
+    childProcess.spawnSync("echo test", { encoding: 'buffer' }).output; // $ExpectType (Buffer | null)[]
 }
 
 {

--- a/types/node/v14/child_process.d.ts
+++ b/types/node/v14/child_process.d.ts
@@ -452,7 +452,7 @@ declare module 'child_process' {
     }
     interface SpawnSyncReturns<T> {
         pid: number;
-        output: string[];
+        output: Array<T | null>;
         stdout: T;
         stderr: T;
         status: number | null;

--- a/types/node/v14/test/child_process.ts
+++ b/types/node/v14/test/child_process.ts
@@ -20,6 +20,9 @@ import { Writable, Readable, Pipe } from 'stream';
     childProcess.spawnSync("echo test", {input: new DataView(new ArrayBuffer(1))});
     childProcess.spawnSync("echo test", { encoding: 'utf-8' });
     childProcess.spawnSync("echo test", { encoding: 'buffer' });
+
+    childProcess.spawnSync("echo test", { encoding: 'utf-8' }).output; // $ExpectType (string | null)[]
+    childProcess.spawnSync("echo test", { encoding: 'buffer' }).output; // $ExpectType (Buffer | null)[]
 }
 
 {

--- a/types/node/v15/child_process.d.ts
+++ b/types/node/v15/child_process.d.ts
@@ -473,7 +473,7 @@ declare module 'child_process' {
     }
     interface SpawnSyncReturns<T> {
         pid: number;
-        output: string[];
+        output: Array<T | null>;
         stdout: T;
         stderr: T;
         status: number | null;

--- a/types/node/v15/test/child_process.ts
+++ b/types/node/v15/test/child_process.ts
@@ -20,6 +20,9 @@ import { Writable, Readable, Pipe } from 'stream';
     childProcess.spawnSync("echo test", {input: new DataView(new ArrayBuffer(1))});
     childProcess.spawnSync("echo test", { encoding: 'utf-8' });
     childProcess.spawnSync("echo test", { encoding: 'buffer' });
+
+    childProcess.spawnSync("echo test", { encoding: 'utf-8' }).output; // $ExpectType (string | null)[]
+    childProcess.spawnSync("echo test", { encoding: 'buffer' }).output; // $ExpectType (Buffer | null)[]
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The node docs for [`spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options) say that the type of `output` is "`<Array>`", *but* they also say that `stdout` and `stderr` will be the value of `output[1]` & `output[2]` respectively, and that the type of those two properties will be `string | Buffer`. 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Have tested this all the way back to Node v6 to confirm, including that the `encoding` option affects the value - I suspect this could actually be a tuple of `[null | T, T, T]` but the docs don't indicate that strongly enough for me to make that change given that I can't really prove it.

Closes #42221
