### PR TITLE
openpgp: mark `keyId` argument as optional in `Key#getKeys` and `getSubkeys`

### DIFF
--- a/types/openpgp/index.d.ts
+++ b/types/openpgp/index.d.ts
@@ -1739,7 +1739,7 @@ export namespace key {
          * @param keyId
          * @returns
          */
-        getSubkeys(keyId: type.keyid.Keyid): any[];
+        getSubkeys(keyId?: type.keyid.Keyid): any[];
 
         /**
          * Returns an array containing all public or private keys matching keyId.
@@ -1747,7 +1747,7 @@ export namespace key {
          * @param keyId
          * @returns
          */
-        getKeys(keyId: type.keyid.Keyid): any[];
+        getKeys(keyId?: type.keyid.Keyid): any[];
 
         /**
          * Returns key IDs of all keys

--- a/types/openpgp/openpgp-tests.ts
+++ b/types/openpgp/openpgp-tests.ts
@@ -199,6 +199,8 @@ openpgp.initWorker({
 
 async () => {
     const publicKey = await openpgp.key.readArmored(spubkey);
+    publicKey.keys[0].getKeys();
+    publicKey.keys[0].getSubkeys();
 
     return publicKey.keys[0].primaryKey.getFingerprint(); /* as string*/
 };


### PR DESCRIPTION

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/openpgpjs/openpgpjs/blob/v4.10.10/src/key/key.js#L183
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

