### PR TITLE
Updates @types/sharp@0.28 to account for all input types

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -11,7 +11,7 @@
 
 /// <reference types="node" />
 
-import { Duplex } from "stream";
+import { Duplex } from 'stream';
 
 //#region Constructor functions
 
@@ -23,7 +23,21 @@ import { Duplex } from "stream";
  * @returns A sharp instance that can be used to chain operations
  */
 declare function sharp(options?: sharp.SharpOptions): sharp.Sharp;
-declare function sharp(input?: string | Buffer, options?: sharp.SharpOptions): sharp.Sharp;
+declare function sharp(
+    input?:
+        | Buffer
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int8Array
+        | Uint16Array
+        | Int16Array
+        | Uint32Array
+        | Int32Array
+        | Float32Array
+        | Float64Array
+        | string,
+    options?: sharp.SharpOptions,
+): sharp.Sharp;
 
 declare namespace sharp {
     /** Object containing nested boolean values representing the available input and output formats/methods. */
@@ -422,7 +436,11 @@ declare namespace sharp {
          * @param options describes the modulation
          * @returns A sharp instance that can be used to chain operations
          */
-        modulate(options?: { brightness?: number | undefined; saturation?: number | undefined; hue?: number | undefined }): Sharp;
+        modulate(options?: {
+            brightness?: number | undefined;
+            saturation?: number | undefined;
+            hue?: number | undefined;
+        }): Sharp;
 
         //#endregion
 
@@ -885,7 +903,7 @@ declare namespace sharp {
         /** quality, integer 1-100 (optional, default 50) */
         quality?: number | undefined;
         /** compression format: av1, hevc (optional, default 'av1') */
-        compression?: "av1" | "hevc" | undefined;
+        compression?: 'av1' | 'hevc' | undefined;
         /** use lossless compression (optional, default false) */
         lossless?: boolean | undefined;
         /** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default 5) */
@@ -898,14 +916,14 @@ declare namespace sharp {
      * {@link https://sharp.pixelplumbing.com/install#custom-libvips installing a custom libvips}.
      */
     interface GifOptions extends OutputOptions, AnimationOptions {
-      /** Page height for animated output */
-      pageHeight?: number;
-      /** Number of animation iterations, use 0 for infinite animation (optional, default 0) */
-      loop?: number;
-      /** List of delays between animation frames (in milliseconds) */
-      delay?: number[];
-      /** Force GIF output, otherwise attempt to use input format (optional, default true) */
-      force?: boolean;
+        /** Page height for animated output */
+        pageHeight?: number;
+        /** Number of animation iterations, use 0 for infinite animation (optional, default 0) */
+        loop?: number;
+        /** List of delays between animation frames (in milliseconds) */
+        delay?: number[];
+        /** Force GIF output, otherwise attempt to use input format (optional, default true) */
+        force?: boolean;
     }
 
     interface TiffOptions extends OutputOptions {
@@ -1029,12 +1047,12 @@ declare namespace sharp {
     }
 
     interface ClaheOptions {
-      /** width of the region */
-      width: number;
-      /** height of the region */
-      height: number;
-      /** max slope of the cumulative contrast. (optional, default 3) */
-      maxSlope?: number | undefined;
+        /** width of the region */
+        width: number;
+        /** height of the region */
+        height: number;
+        /** max slope of the cumulative contrast. (optional, default 3) */
+        maxSlope?: number | undefined;
     }
 
     interface ThresholdOptions {
@@ -1124,65 +1142,65 @@ declare namespace sharp {
     }
 
     interface FitEnum {
-        contain: "contain";
-        cover: "cover";
-        fill: "fill";
-        inside: "inside";
-        outside: "outside";
+        contain: 'contain';
+        cover: 'cover';
+        fill: 'fill';
+        inside: 'inside';
+        outside: 'outside';
     }
 
     interface KernelEnum {
-        nearest: "nearest";
-        cubic: "cubic";
-        mitchell: "mitchell";
-        lanczos2: "lanczos2";
-        lanczos3: "lanczos3";
+        nearest: 'nearest';
+        cubic: 'cubic';
+        mitchell: 'mitchell';
+        lanczos2: 'lanczos2';
+        lanczos3: 'lanczos3';
     }
 
     interface BoolEnum {
-        and: "and";
-        or: "or";
-        eor: "eor";
+        and: 'and';
+        or: 'or';
+        eor: 'eor';
     }
 
     interface ColourspaceEnum {
         multiband: string;
-        "b-w": string;
+        'b-w': string;
         bw: string;
         cmyk: string;
         srgb: string;
     }
 
-    type TileLayout = "dz" | "iiif" | "zoomify" | "google";
+    type TileLayout = 'dz' | 'iiif' | 'zoomify' | 'google';
 
     type Blend =
-        | "clear"
-        | "source"
-        | "over"
-        | "in"
-        | "out"
-        | "atop"
-        | "dest"
-        | "dest-over"
-        | "dest-in"
-        | "dest-out"
-        | "dest-atop"
-        | "xor"
-        | "add"
-        | "saturate"
-        | "multiply"
-        | "screen"
-        | "overlay"
-        | "darken"
-        | "lighten"
-        | "colour-dodge"
-        | "colour-dodge"
-        | "colour-burn"
-        | "colour-burn"
-        | "hard-light"
-        | "soft-light"
-        | "difference"
-        | "exclusion";
+        | 'clear'
+        | 'source'
+        | 'over'
+        | 'in'
+        | 'out'
+        | 'atop'
+        | 'dest'
+        | 'dest-over'
+        | 'dest-in'
+        | 'dest-out'
+        | 'dest-atop'
+        | 'xor'
+        | 'add'
+        | 'saturate'
+        | 'multiply'
+        | 'screen'
+        | 'overlay'
+        | 'darken'
+        | 'lighten'
+        | 'colour-dodge'
+        | 'colour-dodge'
+        | 'colour-burn'
+        | 'colour-burn'
+        | 'hard-light'
+        | 'soft-light'
+        | 'difference'
+        | 'exclusion';
 
     type Gravity = number | string;
 

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -1,6 +1,6 @@
-import sharp = require("sharp");
+import sharp = require('sharp');
 
-import { createReadStream, createWriteStream } from "fs";
+import { createReadStream, createWriteStream } from 'fs';
 
 // Test samples taken from the official documentation
 
@@ -9,32 +9,32 @@ const readableStream: NodeJS.ReadableStream = createReadStream(input);
 const writableStream: NodeJS.WritableStream = createWriteStream(input);
 
 sharp(input)
-    .extractChannel("green")
-    .toFile("input_green.jpg", (err, info) => {
+    .extractChannel('green')
+    .toFile('input_green.jpg', (err, info) => {
         // info.channels === 1
         // input_green.jpg contains the green channel of the input image
     });
 
-sharp("3-channel-rgb-input.png")
+sharp('3-channel-rgb-input.png')
     .bandbool(sharp.bool.and)
-    .toFile("1-channel-output.png", (err, info) => {
+    .toFile('1-channel-output.png', (err, info) => {
         // The output will be a single channel image where each pixel `P = R & G & B`.
         // If `I(1,1) = [247, 170, 14] = [0b11110111, 0b10101010, 0b00001111]`
         // then `O(1,1) = 0b11110111 & 0b10101010 & 0b00001111 = 0b00000010 = 2`.
     });
 
-sharp("input.png")
+sharp('input.png')
     .rotate(180)
     .resize(300)
-    .flatten({ background: "#ff6600" })
-    .composite([{ input: "overlay.png", gravity: sharp.gravity.southeast }])
+    .flatten({ background: '#ff6600' })
+    .composite([{ input: 'overlay.png', gravity: sharp.gravity.southeast }])
     .sharpen()
     .withMetadata()
     .withMetadata({
         density: 96,
         orientation: 8,
-        icc: "some/path",
-        exif: { IFD0: { Copyright: "Wernham Hogg" } },
+        icc: 'some/path',
+        exif: { IFD0: { Copyright: 'Wernham Hogg' } },
     })
     .webp({
         quality: 90,
@@ -46,14 +46,14 @@ sharp("input.png")
         // sharpened, with metadata, 90% quality WebP image data. Phew!
     });
 
-sharp("input.jpg")
+sharp('input.jpg')
     .resize(300, 200)
-    .toFile("output.jpg", (err: Error) => {
+    .toFile('output.jpg', (err: Error) => {
         // output.jpg is a 300 pixels wide and 200 pixels high image
         // containing a scaled and cropped version of input.jpg
     });
 
-sharp("input.jpg").resize({ width: 300 }).blur(false).blur(true).toFile("output.jpg");
+sharp('input.jpg').resize({ width: 300 }).blur(false).blur(true).toFile('output.jpg');
 
 sharp({
     create: {
@@ -68,15 +68,15 @@ sharp({
 
 let transformer = sharp()
     .resize(300)
-    .on("info", (info: sharp.OutputInfo) => {
-        console.log("Image height is " + info.height);
+    .on('info', (info: sharp.OutputInfo) => {
+        console.log('Image height is ' + info.height);
     });
 readableStream.pipe(transformer).pipe(writableStream);
 
 console.log(sharp.format);
 console.log(sharp.versions);
 
-sharp.queue.on("change", (queueLength: number) => {
+sharp.queue.on('change', (queueLength: number) => {
     console.log(`Queue contains ${queueLength} task(s)`);
 });
 
@@ -114,7 +114,7 @@ readableStream.pipe(pipeline);
 
 sharp(input)
     .extract({ left: 0, top: 0, width: 100, height: 100 })
-    .toFile("output", (err: Error) => {
+    .toFile('output', (err: Error) => {
         // Extract a region of the input image, saving in the same format.
     });
 
@@ -122,7 +122,7 @@ sharp(input)
     .extract({ left: 0, top: 0, width: 100, height: 100 })
     .resize(200, 200)
     .extract({ left: 0, top: 0, width: 100, height: 100 })
-    .toFile("output", (err: Error) => {
+    .toFile('output', (err: Error) => {
         // Extract a region, resize, then extract from the resized image
     });
 
@@ -144,24 +144,24 @@ sharp(input)
         // of the input image with the horizontal Sobel operator
     });
 
-sharp("input.tiff")
+sharp('input.tiff')
     .png()
     .tile({
         size: 512,
     })
-    .toFile("output.dz", (err: Error, info: sharp.OutputInfo) => {
+    .toFile('output.dz', (err: Error, info: sharp.OutputInfo) => {
         // output.dzi is the Deep Zoom XML definition
         // output_files contains 512x512 tiles grouped by zoom level
     });
 
 sharp(input)
     .resize(200, 300, {
-        fit: "contain",
-        position: "north",
+        fit: 'contain',
+        position: 'north',
         kernel: sharp.kernel.lanczos2,
-        background: "white",
+        background: 'white',
     })
-    .toFile("output.tiff")
+    .toFile('output.tiff')
     .then(() => {
         // output.tiff is a 200 pixels wide and 300 pixels high image
         // containing a lanczos2/nohalo scaled version, embedded on a white canvas,
@@ -170,20 +170,20 @@ sharp(input)
 
 transformer = sharp()
     .resize(200, 200, {
-        fit: "cover",
+        fit: 'cover',
         position: sharp.strategy.entropy,
     })
-    .on("error", (err: Error) => {
+    .on('error', (err: Error) => {
         console.log(err);
     });
 // Read image data from readableStream
 // Write 200px square auto-cropped image data to writableStream
 readableStream.pipe(transformer).pipe(writableStream);
 
-sharp("input.gif")
+sharp('input.gif')
     .resize(200, 300, {
-        fit: "contain",
-        position: "north",
+        fit: 'contain',
+        position: 'north',
         background: { r: 0, g: 0, b: 0, alpha: 0 },
     })
     .toFormat(sharp.format.webp)
@@ -196,8 +196,8 @@ sharp("input.gif")
     });
 
 sharp(input)
-    .resize(200, 200, { fit: "inside" })
-    .toFormat("jpeg")
+    .resize(200, 200, { fit: 'inside' })
+    .toFormat('jpeg')
     .toBuffer()
     .then((outputBuffer: Buffer) => {
         // outputBuffer contains JPEG image data no wider than 200 pixels and no higher
@@ -206,7 +206,7 @@ sharp(input)
 
 sharp(input)
     .resize(100, 100)
-    .toFormat("jpg")
+    .toFormat('jpg')
     .toBuffer({ resolveWithObject: false })
     .then((outputBuffer: Buffer) => {
         // Resolves with a Buffer object when resolveWithObject is false
@@ -244,7 +244,7 @@ if (sharp.versions.cairo) {
     const cairoVersion: string = sharp.versions.cairo;
 }
 
-sharp("input.gif")
+sharp('input.gif')
     .linear(1)
     .linear(1, 0)
     .linear(null, 0)
@@ -261,7 +261,7 @@ sharp("input.gif")
 
 // From https://sharp.pixelplumbing.com/api-output#examples-9
 // Extract raw RGB pixel data from JPEG input
-sharp("input.jpg")
+sharp('input.jpg')
     .raw()
     .toBuffer({ resolveWithObject: true })
     .then(({ data, info }) => {
@@ -271,7 +271,7 @@ sharp("input.jpg")
 
 sharp(input).jpeg().jpeg({}).jpeg({
     progressive: false,
-    chromaSubsampling: "4:4:4",
+    chromaSubsampling: '4:4:4',
     trellisQuantisation: false,
     overshootDeringing: false,
     optimiseScans: false,
@@ -303,7 +303,7 @@ sharp(input)
     .avif({ quality: 50, lossless: false, speed: 5, chromaSubsampling: '4:2:0' })
     .heif()
     .heif({})
-    .heif({ quality: 50, compression: "hevc", lossless: false, speed: 5 })
+    .heif({ quality: 50, compression: 'hevc', lossless: false, speed: 5 })
     .toBuffer({ resolveWithObject: true })
     .then(({ data, info }) => {
         console.log(data);
@@ -313,14 +313,14 @@ sharp(input)
 sharp(input)
     .gif()
     .gif({})
-    .gif({pageHeight: 5, loop: 0, delay: [], force: true})
+    .gif({ pageHeight: 5, loop: 0, delay: [], force: true })
     .toBuffer({ resolveWithObject: true })
     .then(({ data, info }) => {
         console.log(data);
         console.log(info);
     });
 
-sharp("input.jpg")
+sharp('input.jpg')
     .stats()
     .then(stats => {
         const {
@@ -333,36 +333,32 @@ sharp("input.jpg")
 
 // From https://sharp.pixelplumbing.com/api-output#examples-9
 // Extract alpha channel as raw pixel data from PNG input
-sharp("input.png").ensureAlpha().ensureAlpha(0).extractChannel(3).toColourspace("b-w").raw().toBuffer();
+sharp('input.png').ensureAlpha().ensureAlpha(0).extractChannel(3).toColourspace('b-w').raw().toBuffer();
 
 // From https://sharp.pixelplumbing.com/api-constructor#examples-4
 // Convert an animated GIF to an animated WebP
-sharp("in.gif", { animated: true }).toFile("out.webp");
+sharp('in.gif', { animated: true }).toFile('out.webp');
 
 // From https://github.com/lovell/sharp/issues/2701
 // Type support for limitInputPixels
 sharp({
     create: {
-      background: "red",
-      channels: 4,
-      height: 25000,
-      width: 25000,
+        background: 'red',
+        channels: 4,
+        height: 25000,
+        width: 25000,
     },
     limitInputPixels: false,
-  })
-    .toFormat("png")
+})
+    .toFormat('png')
     .toBuffer()
-    .then((largeImage) =>
-      sharp(input).composite([{ input: largeImage, limitInputPixels: false }]),
-    );
+    .then(largeImage => sharp(input).composite([{ input: largeImage, limitInputPixels: false }]));
 
 // Taken from API documentation at
 // https://sharp.pixelplumbing.com/api-operation#clahe
 // introducted
-sharp("input.jpg")
-    .clahe({ width: 10, height: 10 })
-    .toFile("output.jpg");
+sharp('input.jpg').clahe({ width: 10, height: 10 }).toFile('output.jpg');
 
-sharp("input.jpg")
-    .clahe({ width: 10, height: 10, maxSlope: 5 })
-    .toFile("outfile.jpg");
+sharp('input.jpg').clahe({ width: 10, height: 10, maxSlope: 5 }).toFile('outfile.jpg');
+
+sharp(new Uint8Array(input.buffer)).toFile('output.jpg');


### PR DESCRIPTION
Ref: https://sharp.pixelplumbing.com/api-constructor#parameters

This applies to version 0.28 which matches whats in this file.

Sorry about the massive changes that's all from prettier. Actual changes are from line [26-40](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...josh-signal:patch-1#diff-3a3a3cb51b7f272cca4baf692cde8c1aa7b9265ca2b29e1e9d9ac5f40388bd10R26-R40)

`Buffer` extends `Uint8Array` but I left both in there to be explicit and to match the docs 100%.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sharp.pixelplumbing.com/api-constructor#parameters

