### PR TITLE
Fix @ckeditor/alignment: missing properties

### DIFF
--- a/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
+++ b/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
@@ -19,16 +19,19 @@ utils.isDefault("left", new Locale());
 // $ExpectType boolean
 utils.isSupported("left");
 utils.supportedOptions.length === 4;
-const normalizedOptions = utils.normalizeAlignmentOptions(["foo"]);
-if (typeof normalizedOptions !== "string") {
-    normalizedOptions[0].name.startsWith("");
-}
+// $ExpectType AlignmentFormat[]
+utils.normalizeAlignmentOptions(["left"]);
 
 // $ExpectError
 utils.normalizeAlignmentOptions([{ name: "foo", className: "bar" }]);
 utils.normalizeAlignmentOptions([{ name: "left", className: "bar" }]);
+utils.normalizeAlignmentOptions([{ name: "left" }]);
 
 const command = new AlignmentCommand(new MyEditor());
 // $ExpectError
 command.execute("foo");
+// $ExpectError
+command.execute({value: "foo"});
 command.execute();
+command.execute({value: "left"});
+command.execute({value: undefined});

--- a/types/ckeditor__ckeditor5-alignment/src/alignment.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignment.d.ts
@@ -1,12 +1,26 @@
 import { Plugin } from "@ckeditor/ckeditor5-core";
 import AlignmentEditing, { AlignmentFormat } from "./alignmentediting";
 import AlignmentUI from "./alignmentui";
-
+/**
+ * The text alignment plugin.
+ *
+ * For a detailed overview, check the {@glink features/text-alignment Text alignment feature documentation}
+ * and the {@glink api/alignment package page}.
+ *
+ * This is a "glue" plugin which loads the {@link module:alignment/alignmentediting~AlignmentEditing} and
+ * {@link module:alignment/alignmentui~AlignmentUI} plugins.
+ */
 export default class Alignment extends Plugin {
     static readonly requires: [typeof AlignmentEditing, typeof AlignmentUI];
     static readonly pluginName: "Alignment";
 }
-
 export interface AlignmentConfig {
-    options: Array<string | AlignmentFormat>;
+    options: Array<AlignmentFormat["name"] | AlignmentFormat>;
+}
+declare global {
+    namespace CKEditor {
+        interface NodeAttributes {
+            "alignment": AlignmentFormat["name"];
+        }
+    }
 }

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
@@ -1,5 +1,20 @@
 import { Command } from "@ckeditor/ckeditor5-core";
-
+import { AlignmentFormat } from "./alignmentediting";
+/**
+ * The alignment command plugin.
+ */
 export default class AlignmentCommand extends Command {
-    execute(): void;
+    value?: AlignmentFormat["name"] | boolean;
+    refresh(): void;
+    /**
+     * Executes the command. Applies the alignment `value` to the selected blocks.
+     * If no `value` is passed, the `value` is the default one or it is equal to the currently selected block"s alignment attribute,
+     * the command will remove the attribute from the selected blocks.
+     * @fires execute
+     */
+    execute(options?: { value?: AlignmentCommand["value"] }): void;
+    /**
+     * Checks whether a block can have alignment set.
+     */
+    private _canBeAligned;
 }

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
@@ -1,11 +1,22 @@
 import { Plugin } from "@ckeditor/ckeditor5-core";
-
+/**
+ * The alignment editing feature. It introduces the {@link module:alignment/alignmentcommand~AlignmentCommand command} and adds
+ * the `alignment` attribute for block elements in the {@link module:engine/model/model~Model model}.
+ */
 export default class AlignmentEditing extends Plugin {
     static readonly pluginName: "AlignmentEditing";
     init(): void;
 }
 
+/**
+ * The alignment configuration format descriptor.
+ *
+ *  const alignmentFormat = {
+ *   name: "right",
+ *   className: "my-align-right-class"
+ *  }
+ */
 export interface AlignmentFormat {
-    className: string;
+    className?: string;
     name: "left" | "right" | "center" | "justify";
 }

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
@@ -1,6 +1,22 @@
 import { Plugin } from "@ckeditor/ckeditor5-core";
-
+/**
+ * The default alignment UI plugin.
+ *
+ * It introduces the `'alignment:left'`, `'alignment:right'`, `'alignment:center'` and `'alignment:justify'` buttons
+ * and the `'alignment'` dropdown.
+ */
 export default class AlignmentUI extends Plugin {
+    /**
+     * Returns the localized option titles provided by the plugin.
+     *
+     * The following localized titles corresponding with
+     * {@link module:alignment/alignment~AlignmentConfig#options} are available:
+     *
+     * * `'left'`,
+     * * `'right'`,
+     * * `'center'`,
+     * * `'justify'`.
+     */
     readonly localizedOptionTitles: {
         left: string;
         right: string;
@@ -9,4 +25,8 @@ export default class AlignmentUI extends Plugin {
     };
     static readonly pluginName: "AlignmentUI";
     init(): void;
+    /**
+     * Helper method for initializing the button and linking it with an appropriate command.
+     */
+    private _addButton;
 }

--- a/types/ckeditor__ckeditor5-alignment/src/utils.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/utils.d.ts
@@ -1,8 +1,24 @@
 import { Locale } from "@ckeditor/ckeditor5-utils";
 import { AlignmentFormat } from "./alignmentediting";
-
-export const supportedOptions: ["left", "right", "center", "justify"];
-
-export function isDefault(alignment: string, locale: Locale): boolean;
-export function isSupported(option: string): boolean;
-export function normalizeAlignmentOptions(configuredOptions: Array<string | AlignmentFormat>): AlignmentFormat[];
+/**
+ * The list of supported alignment options:
+ *
+ * * `'left'`,
+ * * `'right'`,
+ * * `'center'`,
+ * * `'justify'`
+ */
+export const supportedOptions: readonly ["left", "right", "center", "justify"];
+/**
+ * Checks whether the passed option is supported by {@link module:alignment/alignmentediting~AlignmentEditing}.
+ */
+export function isSupported(option: any): boolean;
+/**
+ * Checks whether alignment is the default one considering the direction
+ * of the editor content.
+ */
+export function isDefault(alignment: AlignmentFormat['name'] | undefined, locale: Locale): boolean;
+/**
+ * Brings the configuration to the common form, an array of objects.
+ */
+export function normalizeAlignmentOptions(configuredOptions: Array<AlignmentFormat["name"] | AlignmentFormat>): AlignmentFormat[];

--- a/types/ckeditor__ckeditor5-engine/src/conversion/conversion.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/conversion.d.ts
@@ -21,12 +21,21 @@ export default class Conversion {
     addAlias(alias: string, dispatcher: DowncastDispatcher | UpcastDispatcher): void;
     attributeToAttribute(definition?: {
         model: string | { name?: string | undefined; key: string; values: string[] };
-        view: string | Record<string, { name?: string | undefined; key: string; value: string[] | Record<string, string> }>;
+        view:
+            | string
+            | Record<
+                  string,
+                  {
+                      name?: string | undefined;
+                      key: string;
+                      value?: string[] | string | undefined | Record<string, string>;
+                  }
+              >;
         upcastAlso?: MatcherPattern | MatcherPattern[] | undefined;
     }): void;
     attributeToElement(definition: ConverterDefinition): void;
     elementToElement(definition: ConverterDefinition): void;
-    for(groupName: 'dataDowncast' | 'editingDowncast' | 'downcast'): DowncastHelpers;
-    for(groupName: 'upcast'): UpcastHelpers;
+    for(groupName: "dataDowncast" | "editingDowncast" | "downcast"): DowncastHelpers;
+    for(groupName: "upcast"): UpcastHelpers;
     for(groupName: string): DowncastHelpers | UpcastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcasthelpers.d.ts
@@ -31,9 +31,8 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastHelpers> 
         view:
             | string
             | { key: string; value: string }
-            | ((
-                  modelAttributeValue: any,
-              ) => {
+            | Record<string, { key: string; value: Record<string, string> }>
+            | ((modelAttributeValue: string) => {
                   key: string;
                   value: string | string[] | Record<string, string>;
               });

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
@@ -12,7 +12,13 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
             | {
                   key: string;
                   name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  value?:
+                      | RegExp
+                      | string
+                      | ((value: any) => boolean)
+                      | { styles: Record<string, string | RegExp> }
+                      | Record<string, string>
+                      | undefined;
               };
 
         model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };

--- a/types/ckeditor__ckeditor5-engine/src/model/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/node.d.ts
@@ -13,6 +13,13 @@ import Selection from "./selection";
 import Text from "./text";
 import { toMap } from "@ckeditor/ckeditor5-utils";
 
+declare global {
+    namespace CKEditor {
+        // tslint:disable-next-line:no-empty-interface
+        interface NodeAttributes {}
+    }
+}
+
 export type NodeSet = Node | TextProxy | string | NodeList | DocumentFragment | Iterable<NodeSet>;
 
 export default class Node {
@@ -27,6 +34,7 @@ export default class Node {
 
     constructor(attrs?: Parameters<typeof toMap>[0]);
     getAncestors(options?: { includeSelf?: boolean | undefined; parentFirst?: boolean | undefined }): Array<Element | DocumentFragment>;
+    getAttribute<T extends keyof CKEditor.NodeAttributes>(key: T): CKEditor.NodeAttributes[T] | undefined;
     getAttribute(key: string): string | undefined;
     getAttributeKeys(): IterableIterator<string>;
     getAttributes(): IterableIterator<[string, string | number | boolean]>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/latest/api/alignment.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.