### PR TITLE
pino-http: add autologging ignore type

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-http 5.4
+// Type definitions for pino-http 5.7
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>
@@ -46,6 +46,7 @@ declare namespace PinoHttp {
     }
 
     interface AutoLoggingOptions {
+        ignore?: ((req: IncomingMessage) => boolean);
         ignorePaths?: Array<string | RegExp> | undefined;
         getPath?: ((req: IncomingMessage) => string | undefined) | undefined;
     }

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -28,6 +28,7 @@ pinoHttp({ genReqId: req => Buffer.allocUnsafe(16) });
 pinoHttp({ useLevel: 'error' });
 pinoHttp({ prettyPrint: true });
 pinoHttp({ autoLogging: false });
+pinoHttp({ autoLogging: { ignore: req => req.headers['user-agent'] === 'ELB-HealthChecker/2.0' } });
 pinoHttp({ autoLogging: { ignorePaths: ['/health'] } });
 pinoHttp({ autoLogging: { ignorePaths: [/\/health/] } });
 pinoHttp({ autoLogging: { ignorePaths: ['/health'], getPath: req => req.url } });


### PR DESCRIPTION
autologging ignore was just introduced in pino 5.7.0 via https://github.com/pinojs/pino-http/pull/153