### PR TITLE
chore(doubleclick-gpt): add  removeEventListener method to base service class

### DIFF
--- a/types/doubleclick-gpt/doubleclick-gpt-tests.ts
+++ b/types/doubleclick-gpt/doubleclick-gpt-tests.ts
@@ -295,7 +295,7 @@ const impressionViewableListener = (event: googletag.events.ImpressionViewableEv
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-}
+};
 googletag.pubads().addEventListener("impressionViewable", impressionViewableListener);
 googletag.pubads().removeEventListener("impressionViewable", impressionViewableListener);
 
@@ -303,7 +303,7 @@ const slotRequestedListener = (event: googletag.events.SlotRequestedEvent) => {
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-}
+};
 googletag.pubads().addEventListener("slotRequested", slotRequestedListener);
 googletag.pubads().removeEventListener("slotRequested", slotRequestedListener);
 
@@ -311,7 +311,7 @@ const slotResponseReceivedListener = (event: googletag.events.SlotResponseReceiv
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-}
+};
 googletag.pubads().addEventListener("slotResponseReceived", slotResponseReceivedListener);
 googletag.pubads().removeEventListener("slotResponseReceived", slotResponseReceivedListener);
 
@@ -319,7 +319,7 @@ const slotVisibilityChangedListener = (event: googletag.events.SlotVisibilityCha
     if (event.slot === targetSlot) {
         console.log(event.inViewPercentage);
     }
-}
+};
 googletag.pubads().addEventListener("slotVisibilityChanged", slotVisibilityChangedListener);
 googletag.pubads().removeEventListener("slotVisibilityChanged", slotVisibilityChangedListener);
 

--- a/types/doubleclick-gpt/doubleclick-gpt-tests.ts
+++ b/types/doubleclick-gpt/doubleclick-gpt-tests.ts
@@ -263,13 +263,15 @@ googletag.pubads().updateCorrelator();
 // The listener will be called only when the pubads service renders a slot.
 // To listen to companion ads, add a similar listener to
 // googletag.companionAds().
-googletag.pubads().addEventListener("slotRenderEnded", (event) => {
+const slotRenderEndedListener1 = (event: googletag.events.SlotRenderEndedEvent) => {
     console.log("Slot has been rendered:");
     console.log(event.isEmpty);
     console.log(event.lineItemId);
     console.log(event.creativeId);
     console.log(event.campaignId);
-});
+};
+googletag.pubads().addEventListener("slotRenderEnded", slotRenderEndedListener1);
+googletag.pubads().removeEventListener("slotRenderEnded", slotRenderEndedListener1);
 
 // 2. Slot render ended listener, slot specific logic.
 // Listeners operate at service level, which means that you cannot add a
@@ -277,39 +279,49 @@ googletag.pubads().addEventListener("slotRenderEnded", (event) => {
 // however, programmatically filter a listener to respond only to a certain
 // ad slot, using this pattern:
 let targetSlot = slot1;
-googletag.pubads().addEventListener("slotRenderEnded", (event) => {
+const slotRenderEndedListener2 = (event: googletag.events.SlotRenderEndedEvent) => {
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-});
+};
+googletag.pubads().addEventListener("slotRenderEnded", slotRenderEndedListener2);
+googletag.pubads().removeEventListener("slotRenderEnded", slotRenderEndedListener2);
 
 // 3. Impression viewable listener, slot specific logic.
 // The listener will be called when the impression is considered viewable.
 // This event also operates at service level, but, as above, you can filter
 // to respond only to a certain ad slot by using this pattern:
-googletag.pubads().addEventListener("impressionViewable", (event) => {
+const impressionViewableListener = (event: googletag.events.ImpressionViewableEvent) => {
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-});
+}
+googletag.pubads().addEventListener("impressionViewable", impressionViewableListener);
+googletag.pubads().removeEventListener("impressionViewable", impressionViewableListener);
 
-googletag.pubads().addEventListener("slotRequested", (event) => {
+const slotRequestedListener = (event: googletag.events.SlotRequestedEvent) => {
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-});
+}
+googletag.pubads().addEventListener("slotRequested", slotRequestedListener);
+googletag.pubads().removeEventListener("slotRequested", slotRequestedListener);
 
-googletag.pubads().addEventListener("slotResponseReceived", (event) => {
+const slotResponseReceivedListener = (event: googletag.events.SlotResponseReceived) => {
     if (event.slot === targetSlot) {
         // Slot specific logic.
     }
-});
+}
+googletag.pubads().addEventListener("slotResponseReceived", slotResponseReceivedListener);
+googletag.pubads().removeEventListener("slotResponseReceived", slotResponseReceivedListener);
 
-googletag.pubads().addEventListener("slotVisibilityChanged", (event) => {
+const slotVisibilityChangedListener = (event: googletag.events.SlotVisibilityChangedEvent) => {
     if (event.slot === targetSlot) {
         console.log(event.inViewPercentage);
     }
-});
+}
+googletag.pubads().addEventListener("slotVisibilityChanged", slotVisibilityChangedListener);
+googletag.pubads().removeEventListener("slotVisibilityChanged", slotVisibilityChangedListener);
 
 let mapping1 = googletag.sizeMapping().
         addSize([1024, 768], [970, 250]).

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -30,29 +30,29 @@ declare namespace googletag {
 
     interface Service {
         addEventListener(
-          eventType: "slotRenderEnded",
+            eventType: "slotRenderEnded",
             listener: (event: events.SlotRenderEndedEvent) => void
         ): Service;
         addEventListener(
             eventType: "slotRequested",
-              listener: (event: events.SlotRequestedEvent) => void
+            listener: (event: events.SlotRequestedEvent) => void
         ): Service;
         addEventListener(
             eventType: "slotResponseReceived",
-              listener: (event: events.SlotResponseReceived) => void
+            listener: (event: events.SlotResponseReceived) => void
         ): Service;
         addEventListener(
-          eventType: "slotVisibilityChanged",
+            eventType: "slotVisibilityChanged",
             listener: (event: events.SlotVisibilityChangedEvent) => void
         ): Service;
         addEventListener(
-          eventType: string,
+            eventType: string,
             listener: (event: events.Event) => void
         ): Service;
         getSlots(): Slot[];
         removeEventListener(
             eventType: "slotRenderEnded",
-              listener: (event: events.SlotRenderEndedEvent) => void
+            listener: (event: events.SlotRenderEndedEvent) => void
           ): Service;
         removeEventListener(
             eventType: "slotRequested",
@@ -63,11 +63,11 @@ declare namespace googletag {
             listener: (event: events.SlotResponseReceived) => void
         ): Service;
         removeEventListener(
-        eventType: "slotVisibilityChanged",
+            eventType: "slotVisibilityChanged",
             listener: (event: events.SlotVisibilityChangedEvent) => void
         ): Service;
         removeEventListener(
-        eventType: string,
+            eventType: string,
             listener: (event: events.Event) => void
         ): Service;
     }

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -50,6 +50,26 @@ declare namespace googletag {
             listener: (event: events.Event) => void
         ): Service;
         getSlots(): Slot[];
+        removeEventListener(
+            eventType: "slotRenderEnded",
+              listener: (event: events.SlotRenderEndedEvent) => void
+          ): Service;
+        removeEventListener(
+            eventType: "slotRequested",
+            listener: (event: events.SlotRequestedEvent) => void
+        ): Service;
+        removeEventListener(
+            eventType: "slotResponseReceived",
+            listener: (event: events.SlotResponseReceived) => void
+        ): Service;
+        removeEventListener(
+        eventType: "slotVisibilityChanged",
+            listener: (event: events.SlotVisibilityChangedEvent) => void
+        ): Service;
+        removeEventListener(
+        eventType: string,
+            listener: (event: events.Event) => void
+        ): Service;
     }
 
     interface CompanionAdsService extends Service {


### PR DESCRIPTION
### double-click gpt `removeEventListener`

Earlier this month, GPT added the `removeEventListener` method to its base service class `googletag.Service`.

- see release notes: [Week of August 9, 2021](https://developers.google.com/publisher-tag/release-notes#2021-08-09)

It belongs to the same base service class containing the `addEventListener` and `getSlots` methods:

- see [`googletag.Service` API docs](https://developers.google.com/publisher-tag/reference#googletag.service)

Further documentation on this can be found [here](https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener).



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

