### PR TITLE
feat(@types/node): add `stream/consumers`

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -113,6 +113,7 @@
 /// <reference path="repl.d.ts" />
 /// <reference path="stream.d.ts" />
 /// <reference path="stream/promises.d.ts" />
+/// <reference path="stream/consumers.d.ts" />
 /// <reference path="stream/web.d.ts" />
 /// <reference path="string_decoder.d.ts" />
 /// <reference path="timers.d.ts" />

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -19,6 +19,7 @@
 declare module 'stream' {
     import { EventEmitter, Abortable } from 'node:events';
     import * as streamPromises from 'node:stream/promises';
+    import * as streamConsumers from 'node:stream/consumers';
     class internal extends EventEmitter {
         pipe<T extends NodeJS.WritableStream>(
             destination: T,
@@ -1169,6 +1170,7 @@ declare module 'stream' {
             unref(): void;
         }
         const promises: typeof streamPromises;
+        const consumers: typeof streamConsumers;
     }
     export = internal;
 }

--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -1,0 +1,25 @@
+// Duplicates of interface in lib.dom.ts.
+// Duplicated here rather than referencing lib.dom.ts because doing so causes lib.dom.ts to be loaded for "test-all"
+// Which in turn causes tests to pass that shouldn't pass.
+//
+// This interface is not, and should not be, exported.
+interface Blob {
+    readonly size: number;
+    readonly type: string;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    slice(start?: number, end?: number, contentType?: string): Blob;
+    stream(): NodeJS.ReadableStream;
+    text(): Promise<string>;
+}
+
+declare module 'stream/consumers' {
+    import { Readable } from 'node:stream';
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Blob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+}
+declare module 'node:stream/consumers' {
+    export * from 'stream/consumers';
+}

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -4,6 +4,7 @@ import { createReadStream, createWriteStream } from 'node:fs';
 import { createGzip, constants } from 'node:zlib';
 import assert = require('node:assert');
 import { Http2ServerResponse } from 'node:http2';
+import { text, json, buffer } from 'node:stream/consumers';
 import { pipeline as pipelinePromise } from 'node:stream/promises';
 import { stdout } from 'node:process';
 import 'node:stream/web';
@@ -453,6 +454,27 @@ async function streamPipelineAsyncPromiseAbortTransform() {
             // $ExpectType void
             r;
         });
+}
+
+async function readableToString() {
+    const r = createReadStream('file.txt');
+
+    // $ExpectType string
+    await text(r);
+}
+
+async function readableToJson() {
+    const r = createReadStream('file.txt');
+
+    // $ExpectType unknown
+    await json(r);
+}
+
+async function readableToBuffer() {
+    const r = createReadStream('file.txt');
+
+    // $ExpectType Buffer
+    await buffer(r);
 }
 
 // http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options


### PR DESCRIPTION
This is a set of new functions added in Node 16.7. As the types are now 16.7.x, we can add them.

NodeJS docs: https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html#webstreams_utility_consumers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html#webstreams_utility_consumers
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~