### PR TITLE
Update Pendo Metadata to support Array of strings

### DIFF
--- a/types/pendo-io-browser/index.d.ts
+++ b/types/pendo-io-browser/index.d.ts
@@ -12,7 +12,7 @@ declare namespace pendo {
     }
 
     interface Metadata {
-        [key: string]: string | number | boolean;
+        [key: string]: string | number | boolean | string[];
     }
 
     type IdentityMetadata = { id?: string | undefined; } & Metadata;

--- a/types/pendo-io-browser/index.d.ts
+++ b/types/pendo-io-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Pendo.io Agent 2.16
+// Type definitions for non-npm package Pendo.io Agent 2.17
 // Project: https://www.pendo.io/
 // Definitions by: Aaron Beall <https://github.com/aaronbeall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pendo-io-browser/pendo-io-browser-tests.ts
+++ b/types/pendo-io-browser/pendo-io-browser-tests.ts
@@ -13,7 +13,8 @@ pendo.initialize({
     },
     account: {
         id: "PUT_ACCOUNT_ID_HERE",
-        name: "CorpSchmorp"
+        name: "CorpSchmorp",
+        tags: ["t-1", "t-2"]
     }
 });
 
@@ -93,4 +94,4 @@ pendo.onGuideDismissed();
 
 pendo.feedback.loginAndRedirect();
 const a = document.createElement("a");
-pendo.feedback.loginAndRedirect({anchor: a});
+pendo.feedback.loginAndRedirect({ anchor: a });


### PR DESCRIPTION
Summary
Pendo supports a list of strings in the initialization options. There is an example on this page.
https://support.pendo.io/hc/en-us/articles/360046272771-Developer-s-Guide-To-Installing-the-Pendo-Snippet.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://support.pendo.io/hc/en-us/articles/360046272771-Developer-s-Guide-To-Installing-the-Pendo-Snippet>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.