### PR TITLE
aws-lambda / api-gateway-authorizer / BaseStatement / Effect

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -30,6 +30,7 @@ import {
     ProxyCallback,
     ProxyHandler,
     Statement,
+    Effect,
     APIGatewayProxyStructuredResultV2,
 } from "aws-lambda";
 
@@ -464,36 +465,42 @@ const legacyAuthorizerHandler: CustomAuthorizerHandler = async (event, context, 
     return result;
 };
 
+declare let effect: Effect;
+
 function createPolicyDocument(): PolicyDocument {
     let statement: Statement = {
         Action: str,
-        Effect: str,
+        Effect: effect,
         Resource: str,
     };
 
     // $ExpectError
-    statement = { Effect: str, Action: str, Principal: 123, };
+    statement = { Effect: effect, Action: str, Principal: 123, };
 
     // Bad Resource
     // $ExpectError
-    statement = { Effect: str, Action: str, Resource: 123, };
+    statement = { Effect: effect, Action: str, Resource: 123, };
 
     // Bad Resource with valid Principal
     // $ExpectError
-    statement = { Effect: str, Action: str, Principal: { Service: str }, Resource: 123, };
+    statement = { Effect: effect, Action: str, Principal: { Service: str }, Resource: 123, };
 
     // Bad principal with valid Resource
     // $ExpectError
-    statement = { Effect: str, Action: str, Principal: 123, Resource: str, };
+    statement = { Effect: effect, Action: str, Principal: 123, Resource: str, };
 
     // No Effect
     // $ExpectError
     statement = { Action: str, Principal: str };
 
+    // String effect
+    // $ExpectError
+    statement = { Effect: str, Action: str, Resource: str };
+
     statement = {
         Sid: str,
         Action: [str, str],
-        Effect: str,
+        Effect: effect,
         Resource: [str, str],
         Condition: {
             condition1: { key: 'value' },
@@ -511,11 +518,11 @@ function createPolicyDocument(): PolicyDocument {
         NotPrincipal: [str, str],
     };
 
-    statement = { Action: str, Principal: str, Effect: str };
+    statement = { Action: str, Principal: str, Effect: effect };
 
-    statement = { Action: str, NotPrincipal: { Service: str }, Effect: str };
+    statement = { Action: str, NotPrincipal: { Service: str }, Effect: effect };
 
-    statement = { Effect: str, NotAction: str, NotResource: str };
+    statement = { Effect: effect, NotAction: str, NotResource: str };
 
     let policyDocument: PolicyDocument = { Version: str, Statement: [statement] };
 

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -146,6 +146,11 @@ export interface Condition {
 }
 
 /**
+ * IAM PolicyStatement effect.
+ */
+export type Effect = 'Allow' | 'Deny';
+
+/**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Statement.
  * https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-control-access-policy-language-overview.html
  * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
@@ -153,7 +158,7 @@ export interface Condition {
 export type Statement = BaseStatement & StatementAction & (StatementResource | StatementPrincipal);
 
 export interface BaseStatement {
-    Effect: string;
+    Effect: Effect;
     Sid?: string | undefined;
     Condition?: ConditionBlock | undefined;
 }


### PR DESCRIPTION
The `Effect` value of a policy statement only allows the values "Allow" and "Deny". All other values are invalid. This includes values like "ALLOW" and "deny".

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policydocument
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
