### PR TITLE
Add @types/draco3dgltf

### DIFF
--- a/types/draco3dgltf/draco3dgltf-tests.ts
+++ b/types/draco3dgltf/draco3dgltf-tests.ts
@@ -1,0 +1,13 @@
+import { createEncoderModule, createDecoderModule, EncoderModule, DecoderModule } from 'draco3dgltf';
+
+// Additional tests in '../draco3d/draco3d-tests.ts'.
+
+createEncoderModule().then((encoderModule: EncoderModule) => {
+    const encoder = new encoderModule.Encoder();
+    encoderModule.destroy(encoder);
+});
+
+createDecoderModule().then((decoderModule: DecoderModule) => {
+    const decoder = new decoderModule.Decoder();
+    decoderModule.destroy(decoder);
+});

--- a/types/draco3dgltf/index.d.ts
+++ b/types/draco3dgltf/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for draco3dgltf 1.4
+// Project: https://github.com/google/draco#readme
+// Definitions by: Don McCurdy <https://github.com/donmccurdy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// The 'draco3d' and 'draco3dgltf' packages have identical APIs, but the latter
+// has a modified implementation for compatibility with the glTF file format's
+// KHR_draco_mesh_compression extension.
+// See: https://github.com/google/draco/issues/717
+export * from 'draco3d';

--- a/types/draco3dgltf/tsconfig.json
+++ b/types/draco3dgltf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "draco3dgltf-tests.ts"
+    ]
+}

--- a/types/draco3dgltf/tslint.json
+++ b/types/draco3dgltf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
The 'draco3d' and 'draco3dgltf' packages have identical APIs, but the latter
has a modified implementation for compatibility with the glTF file format's
KHR_draco_mesh_compression extension.

See: https://github.com/google/draco/issues/717

/cc  @joshuaellis 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

