### PR TITLE
@types/akamai-edgeworkers - Added TransformStream and related interfaces of WHATWG Streams API in the Types definitions

### DIFF
--- a/types/akamai-edgeworkers/index.d.ts
+++ b/types/akamai-edgeworkers/index.d.ts
@@ -5,6 +5,9 @@
 //                 Swathi Bala <https://github.com/swathimr>
 //                 Aman Nanner <https://github.com/ananner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+//
+// Modifyed by: Shige Fukushima <sfukushi@akamai.com>
+//
 
 declare namespace EW {
     interface ReadsHeaders {
@@ -780,6 +783,38 @@ declare module "streams" {
     interface TransformStream<I = any, O = any> {
         readonly readable: ReadableStream<O>;
         readonly writable: WritableStream<I>;
+    }
+
+    const TransformStream: {
+        prototype: TransformStream;
+        new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
+    };
+
+    interface Transformer<I = any, O = any> {
+        flush?: TransformerFlushCallback<O>;
+        readableType?: undefined;
+        start?: TransformerStartCallback<O>;
+        transform?: TransformerTransformCallback<I, O>;
+        writableType?: undefined;
+    }
+
+    interface TransformerFlushCallback<O> {
+        (controller: TransformStreamDefaultController<O>): void | Promise<void>;
+    }
+
+    interface TransformerStartCallback<O> {
+        (controller: TransformStreamDefaultController<O>): void | Promise<void>;
+    }
+
+    interface TransformerTransformCallback<I, O> {
+        (chunk: I, controller: TransformStreamDefaultController<O>): void | Promise<void>;
+    }
+
+    interface TransformStreamDefaultController<O = any> {
+        readonly desiredSize: number | null;
+        enqueue(chunk: O): void;
+        error(reason?: any): void;
+        terminate(): void;
     }
 
     interface CountQueuingStrategy {

--- a/types/akamai-edgeworkers/test/transformstream.ts
+++ b/types/akamai-edgeworkers/test/transformstream.ts
@@ -1,0 +1,31 @@
+// This is a functional scenario. It should be possible to compile and
+// deploy thi as an EdgeWorker. When it runs, it will stream a resource
+// back, replacing all of the text with UPPER CASE. The resource
+// in question doesn't matter.
+import { httpRequest } from 'http-request';
+import { createResponse } from 'create-response';
+import { TransformStream } from 'streams';
+import { TextDecoderStream, TextEncoderStream } from 'text-encode-transform';
+
+class ToUpperCaseStream extends TransformStream<string, string> {
+    constructor() {
+        function start(controller: any): void { }
+        function transform(chunk: any, controller: any): void {
+            controller.enqueue(chunk.toUpperCase());
+        }
+        function flush(controller: any): void { }
+        super({ start, transform, flush });
+    }
+}
+
+export function responseProvider(request: EW.ResponseProviderRequest) {
+    return httpRequest('http://www.mofroyo.co/us/en/index.html').then(response => {
+        const responseHeader = JSON.stringify(request.getHeaders()); // get headers from response provider event
+        const httpRequestHeader = JSON.stringify(response.getHeaders()); // get headers from httprequest
+        return createResponse(
+            response.status,
+            {"resp-header": responseHeader, "httpreq-header": httpRequestHeader}, // passing both these headers should return them in response
+            response.body.pipeThrough(new TextDecoderStream()).pipeThrough(new ToUpperCaseStream()).pipeThrough(new TextEncoderStream())
+        );
+    });
+}

--- a/types/akamai-edgeworkers/tsconfig.json
+++ b/types/akamai-edgeworkers/tsconfig.json
@@ -27,6 +27,7 @@
         "test/set_variable.ts", 
         "test/scenario-stream.ts",
         "test/stream.ts",
+        "test/transformstream.ts",
         "test/url-search-params-tests.ts"
     ]
 }


### PR DESCRIPTION

This modification is aligned with the current Akamai EdgeWorkers implementation of WHATWG TransformStream.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
