### PR TITLE
nunjucks: Add env.on('load', ...) type, fix loader types

### DIFF
--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -1,14 +1,11 @@
-// Type definitions for nunjucks 3.1
+// Type definitions for nunjucks 3.2
 // Project: http://mozilla.github.io/nunjucks/, https://github.com/mozilla/nunjucks
 // Definitions by: Ruben Slabbert <https://github.com/RubenSlabbert>
 //                 Matthew Burstein <https://github.com/MatthewBurstein>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-export type TemplateCallback<T> = (
-  err: lib.TemplateError | null,
-  res: T | null,
-) => void;
+export type TemplateCallback<T> = (err: lib.TemplateError | null, res: T | null) => void;
 export type Callback<E, T> = (err: E | null, res: T | null) => void;
 
 export function render(name: string, context?: object): string;
@@ -29,11 +26,11 @@ export interface PrecompileOptions {
     env?: Environment | undefined;
     include?: string[] | undefined;
     exclude?: string[] | undefined;
-    wrapper?(templates: { name: string, template: string }, opts: PrecompileOptions): string;
+    wrapper?(templates: { name: string; template: string }, opts: PrecompileOptions): string;
 }
 
 export class Template {
-    constructor(src: string, env?: Environment, eagerCompile?: boolean);
+    constructor(src: string, env?: Environment, path?: string, eagerCompile?: boolean);
     render(context?: object): string;
     render(context?: object, callback?: TemplateCallback<string>): void;
 }
@@ -48,19 +45,23 @@ export interface ConfigureOptions {
     lstripBlocks?: boolean | undefined;
     watch?: boolean | undefined;
     noCache?: boolean | undefined;
-    web?: {
-        useCache?: boolean | undefined,
-        async?: boolean | undefined
-    } | undefined;
+    web?:
+        | {
+              useCache?: boolean | undefined;
+              async?: boolean | undefined;
+          }
+        | undefined;
     express?: object | undefined;
-    tags?: {
-        blockStart?: string | undefined,
-        blockEnd?: string | undefined,
-        variableStart?: string | undefined,
-        variableEnd?: string | undefined,
-        commentStart?: string | undefined,
-        commentEnd?: string | undefined
-    } | undefined;
+    tags?:
+        | {
+              blockStart?: string | undefined;
+              blockEnd?: string | undefined;
+              variableStart?: string | undefined;
+              variableEnd?: string | undefined;
+              commentStart?: string | undefined;
+              commentEnd?: string | undefined;
+          }
+        | undefined;
 }
 
 export class Environment {
@@ -90,6 +91,11 @@ export class Environment {
     getTemplate(name: string, eagerCompile?: boolean, callback?: Callback<Error, Template>): void;
 
     express(app: object): void;
+
+    on(
+        event: 'load',
+        fn: (name: string, source: { src: string; path: string; noCache: boolean }, loader: Loader) => void,
+    ): void;
 }
 
 export interface Extension {
@@ -122,27 +128,39 @@ export interface LoaderSource {
     noCache: boolean;
 }
 
-export interface FileSystemLoaderOptions {
+export interface LoaderOptions {
     /** if true, the system will automatically update templates when they are changed on the filesystem */
-    watch?: boolean | undefined;
+    watch?: boolean;
 
     /**  if true, the system will avoid using a cache and templates will be recompiled every single time */
-    noCache?: boolean | undefined;
+    noCache?: boolean;
 }
 
+export type FileSystemLoaderOptions = LoaderOptions;
+export type NodeResolveLoaderOptions = LoaderOptions;
+
 export class FileSystemLoader extends Loader implements ILoader {
-    init(searchPaths: string[], opts: any): void;
-    getSource(name: string): LoaderSource;
     constructor(searchPaths?: string | string[], opts?: FileSystemLoaderOptions);
+    getSource(name: string): LoaderSource;
+}
+
+export class NodeResolveLoader extends Loader implements ILoader {
+    constructor(searchPaths?: string | string[], opts?: NodeResolveLoaderOptions);
+    getSource(name: string): LoaderSource;
+}
+
+export interface WebLoaderOptions {
+    useCache?: boolean;
+    async?: boolean;
 }
 
 export class WebLoader extends Loader implements ILoader {
-    constructor(baseUrl: string, opts?: any);
+    constructor(baseUrl?: string, opts?: WebLoaderOptions);
     getSource(name: string): LoaderSource;
 }
 
 export class PrecompiledLoader extends Loader implements ILoader {
-    init(searchPaths: string[], opts: any): void;
+    constructor(compiledTemplates?: any[]);
     getSource(name: string): LoaderSource;
 }
 

--- a/types/nunjucks/nunjucks-tests.ts
+++ b/types/nunjucks/nunjucks-tests.ts
@@ -1,17 +1,14 @@
-import nunjucks = require("nunjucks");
+import nunjucks = require('nunjucks');
 
 nunjucks.configure({ autoescape: false });
 
-let rendered = nunjucks.render("./noexists.html");
+let rendered = nunjucks.render('./noexists.html');
 
 nunjucks.render('foo.html', { username: 'James' });
-nunjucks.render(
-  'async.html',
-  (err: nunjucks.lib.TemplateError | null, res: string | null) => {},
-);
+nunjucks.render('async.html', (err: nunjucks.lib.TemplateError | null, res: string | null) => {});
 
-const ctx = { items: ["Hello", "this", "is", "for", "testing"] };
-const src = "{% for item in items %}{{item}}{% endfor %}";
+const ctx = { items: ['Hello', 'this', 'is', 'for', 'testing'] };
+const src = '{% for item in items %}{{item}}{% endfor %}';
 
 rendered = nunjucks.renderString(src, ctx);
 nunjucks.renderString('Hello {{ username }}', { username: 'James' });
@@ -21,7 +18,7 @@ rendered = compiled.render(ctx);
 nunjucks.compile('Hello {{ username }}').render({ username: 'James' });
 
 rendered = nunjucks.precompileString(src, {
-    name: "TestyWesty"
+    name: 'TestyWesty',
 });
 
 const template = new nunjucks.Template(src);
@@ -31,17 +28,19 @@ let env = nunjucks.configure({ autoescape: false });
 nunjucks.configure('/views');
 nunjucks.configure('views', {
     autoescape: true,
-    watch: true
+    watch: true,
 });
 rendered = env.renderString(src, ctx);
 
+env.on('load', (name, source, loader) => {});
+
 let extension: nunjucks.Extension = {
-  tags: ["glitter", "star wars", "Age of Empires"],
-  parse(parser, nodes, lexer) {
-      return "The parser api is complicated";
-  }
+    tags: ['glitter', 'star wars', 'Age of Empires'],
+    parse(parser, nodes, lexer) {
+        return 'The parser api is complicated';
+    },
 };
-env = env.addExtension("SpawnGlitter", extension);
+env = env.addExtension('SpawnGlitter', extension);
 const hasExtension: boolean = env.hasExtension('SpawnGlitter');
 extension = env.getExtension('SpawnGlitter');
 env.removeExtension('SpawnGlitter');
@@ -50,16 +49,16 @@ env = env.addGlobal('key', 'value');
 const value = env.getGlobal('key');
 
 env = env.addFilter('testFilter', arg => arg, false);
-const testFilter: ((arg: any) => any) = env.getFilter('testFilter');
+const testFilter: (arg: any) => any = env.getFilter('testFilter');
 
 nunjucks.installJinjaCompat();
 
 class MyLoader extends nunjucks.Loader implements nunjucks.ILoader {
     getSource(name: string): nunjucks.LoaderSource {
         return {
-            src: "Amadala",
-            path: "The Right One",
-            noCache: false
+            src: 'Amadala',
+            path: 'The Right One',
+            noCache: false,
         };
     }
 }
@@ -70,13 +69,13 @@ env = new nunjucks.Environment(new MyLoader());
 const MyOtherLoader = nunjucks.FileSystemLoader.extend({
     getSource(name: string): nunjucks.LoaderSource {
         return {
-            src: "Amadala",
-            path: "The Right One",
-            noCache: false
+            src: 'Amadala',
+            path: 'The Right One',
+            noCache: false,
         };
-    }
+    },
 });
 
 env = new nunjucks.Environment(new MyOtherLoader());
 
-new nunjucks.runtime.SafeString("an unsafe string");
+new nunjucks.runtime.SafeString('an unsafe string');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mozilla.github.io/nunjucks/api.html#load-event
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
