### PR TITLE
[minio] Updated return type of fPutObject and putObject

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -84,6 +84,11 @@ export interface ItemBucketMetadata {
     [key: string]: any;
 }
 
+export interface UploadedObjectInfo {
+    etag: string;
+    versionId: string | null;
+}
+
 // No need to export this. But without it - linter error.
 export class TargetConfig {
     setId(id: any): void;
@@ -126,14 +131,14 @@ export class Client {
     fGetObject(bucketName: string, objectName: string, filePath: string, callback: NoResultCallback): void;
     fGetObject(bucketName: string, objectName: string, filePath: string): Promise<void>;
 
-    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, callback: ResultCallback<string>): void;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, size: number, callback: ResultCallback<string>): void;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, size: number, metaData: ItemBucketMetadata, callback: ResultCallback<string>): void;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, size?: number, metaData?: ItemBucketMetadata): Promise<string>;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, metaData?: ItemBucketMetadata): Promise<string>;
+    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, callback: ResultCallback<UploadedObjectInfo>): void;
+    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, size: number, callback: ResultCallback<UploadedObjectInfo>): void;
+    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, size: number, metaData: ItemBucketMetadata, callback: ResultCallback<UploadedObjectInfo>): void;
+    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, size?: number, metaData?: ItemBucketMetadata): Promise<UploadedObjectInfo>;
+    putObject(bucketName: string, objectName: string, stream: ReadableStream|Buffer|string, metaData?: ItemBucketMetadata): Promise<UploadedObjectInfo>;
 
-    fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata, callback: ResultCallback<string>): void;
-    fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata): Promise<string>;
+    fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata, callback: ResultCallback<UploadedObjectInfo>): void;
+    fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata): Promise<UploadedObjectInfo>;
 
     copyObject(bucketName: string, objectName: string, sourceObject: string, conditions: CopyConditions, callback: ResultCallback<BucketItemCopy>): void;
     copyObject(bucketName: string, objectName: string, sourceObject: string, conditions: CopyConditions): Promise<BucketItemCopy>;

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -53,15 +53,15 @@ const metaData = {
     'X-Amz-Meta-Testing': 1234,
     example: 5678
 };
-minio.putObject('testBucket', 'hello.jpg', fs.createReadStream('hello.jpg'), (error: Error|null, etag: string) => { console.log(error, etag); });
-minio.putObject('testBucket', 'hello.jpg', new Buffer('string'), 100, (error: Error|null, etag: string) => { console.log(error, etag); });
-minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData, (error: Error|null, etag: string) => { console.log(error, etag); });
+minio.putObject('testBucket', 'hello.jpg', fs.createReadStream('hello.jpg'), (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
+minio.putObject('testBucket', 'hello.jpg', new Buffer('string'), 100, (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
+minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData, (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
 minio.putObject('testBucket', 'hello.jpg', fs.createReadStream('hello.jpg'));
 minio.putObject('testBucket', 'hello.jpg', new Buffer('string'), 100);
 minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData);
 minio.putObject('testBucket', 'hello.txt', 'hello.txt content', metaData);
 
-minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData, (error: Error|null, etag: string) => { console.log(error, etag); });
+minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData, (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
 minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData);
 
 const conditions = new Minio.CopyConditions();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.min.io/docs/javascript-client-api-reference.html#putObject and https://docs.min.io/docs/javascript-client-api-reference.html#fPutObject