### PR TITLE
Fix @ckeditor Command, MultiCommand, and Plugin

### DIFF
--- a/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
@@ -10,8 +10,9 @@ import {
     EditorUI,
 } from '@ckeditor/ckeditor5-core';
 import View from '@ckeditor/ckeditor5-ui/src/view';
-
-let comm: Command;
+import PluginCollection from '@ckeditor/ckeditor5-core/src/plugincollection';
+import CommandCollection from '@ckeditor/ckeditor5-core/src/commandcollection';
+import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
 
 /**
  * Editor
@@ -33,13 +34,18 @@ class MyEditor extends Editor {
 const PluginArray: Array<typeof Plugin | typeof ContextPlugin | string> = MyEditor.builtinPlugins;
 PluginArray.forEach(plugin => typeof plugin !== 'string' && plugin.pluginName);
 
-const editor = new MyEditor(document.createElement('div'));
+let editor: Editor = new MyEditor(document.createElement('div'));
 const editorState: 'initializing' | 'ready' | 'destroyed' = editor.state;
 // $ExpectError
 editor.state = editorState;
 editor.focus();
 editor.destroy().then(() => {});
-editor.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
+editor.initPlugins().then(loaded => {
+    loaded.forEach(Plugin => {
+        class Foo extends Plugin {}
+        new Foo(editor);
+    });
+});
 
 MyEditor.defaultConfig = {
     placeholder: 'foo',
@@ -54,9 +60,7 @@ MyEditor.defaultConfig = { foo: 5 };
  */
 
 class MyPlugin extends Plugin {
-    get pluginName() {
-        return 'MyPlugin';
-    }
+    readonly pluginName: 'MyPlugin';
 
     myMethod() {
         return null;
@@ -93,19 +97,25 @@ class MyEmptyEditor extends Editor {
  * Command
  */
 class SomeCommand extends Command {
-    execute() {}
+    execute(
+        a?: string | number | Record<string, unknown>,
+        b?: string | Record<string, unknown>,
+        c?: boolean | unknown[],
+        d?: boolean | unknown[],
+        e?: number,
+    ): void {
+        console.log(a, b, c, d, e);
+    }
 }
-const command = new Command(new MyEmptyEditor());
+const command = new SomeCommand(editor);
 command.execute();
 command.execute('foo', 'bar', true, false, 50033);
 command.execute(4545454, 'refresh', [], []);
 command.execute({}, { foo: 5 });
 
-const ed: Editor = command.editor;
+editor = command.editor;
 
 const bool: boolean = command.isEnabled;
-
-comm = new Command(editor);
 
 command.destroy();
 
@@ -118,6 +128,10 @@ delete command.value;
 
 command.isEnabled = false;
 command.isEnabled = true;
+command.on('foo', () => {});
+command.on('execute', () => {}, { priority: 'highest' });
+command.forceDisabled('foo');
+command.clearForceDisabled('foo');
 // $ExpectError
 delete command.isEnabled;
 
@@ -128,26 +142,28 @@ delete command.isEnabled;
 const context = new Context();
 const contextWithConfig = new Context({ foo: 'foo' });
 context.destroy().then(() => {});
-contextWithConfig.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
+contextWithConfig.initPlugins().then(loaded => {
+    loaded.forEach(Plugin => {
+        class Foo extends Plugin {}
+        new Foo(editor);
+    });
+});
 
 /**
  * ContextPlugin
  */
-const CPlugin = new ContextPlugin(context) && new ContextPlugin(editor);
-const afterInitPromise = CPlugin.afterInit?.();
-if (afterInitPromise != null) {
-    afterInitPromise.then(() => {});
-}
-
 class MyCPlugin extends ContextPlugin {
-    get pluginName() {
-        return 'MyCPlugin';
-    }
-
+    readonly pluginName: 'MyCPlugin';
     builtinPlugins: [MyPlugin];
     myCMethod() {
         return null;
     }
+}
+
+const cPlugin = new MyCPlugin(context) && new MyCPlugin(editor);
+const afterInitPromise = cPlugin.afterInit?.();
+if (afterInitPromise != null) {
+    afterInitPromise.then(() => {});
 }
 
 editor.plugins.get(MyCPlugin).myCMethod();
@@ -155,6 +171,13 @@ editor.plugins.get(MyCPlugin).myCMethod();
 
 context.plugins.get(MyCPlugin).myCMethod();
 (context.plugins.get('MyCPlugin') as MyCPlugin).myCMethod();
+
+const pContext = cPlugin.context;
+if (pContext instanceof Editor) {
+    pContext.initPlugins();
+}
+
+cPlugin.destroy();
 
 /**
  * DataApiMixin
@@ -176,9 +199,99 @@ attachToForm(editor);
 /**
  * MultiCommand
  */
-const MC = new MultiCommand(editor);
-MC.registerChildCommand(comm);
+const multiCommand = new MultiCommand(editor);
+multiCommand.registerChildCommand(command);
+multiCommand.destroy();
+// $ExpectType boolean
+multiCommand.isEnabled;
+multiCommand.isEnabled = bool;
+const mcresult = multiCommand.execute();
+if (Array.isArray(mcresult)) {
+    mcresult.forEach(v => v);
+}
 
 /* EditorUI */
 new EditorUI(editor).componentFactory.editor === editor;
 new EditorUI(editor).componentFactory.add('', locale => new View(locale));
+
+/* PluginCollection */
+const plugins = new PluginCollection(
+    editor,
+    [MyPlugin, MyCPlugin],
+    [
+        [MyPlugin, new MyPlugin(editor)],
+        [MyCPlugin, new MyCPlugin(editor)],
+    ],
+);
+new PluginCollection(editor, [], [[MyPlugin, new MyPlugin(editor)]]);
+new PluginCollection(editor, []);
+plugins.init([]).then(loaded =>
+    loaded.forEach(Plugin => {
+        if (Plugin instanceof MyPlugin) {
+            Plugin.myMethod() === null;
+        }
+    }),
+);
+plugins.init([MyPlugin, MyCPlugin, 'foo'], [MyCPlugin]);
+plugins.init([MyPlugin, MyCPlugin, 'foo'], [MyCPlugin], [myPlugin]);
+const cplugin = plugins.get(MyCPlugin);
+cplugin.myCMethod() === null;
+const plugin = plugins.get(MyPlugin);
+plugin.myMethod() === null;
+const unknownPlugin = plugins.get('');
+if (unknownPlugin instanceof MyPlugin) {
+    unknownPlugin.myMethod() === null;
+}
+
+// $ExpectType boolean
+plugins.has('foo');
+// $ExpectType boolean
+plugins.has(MyPlugin);
+// $ExpectType boolean
+plugins.has(MyCPlugin);
+
+// $ExpectError
+plugins.destroy().then(value => value === '');
+plugins.destroy().then(value => value === undefined);
+
+/*
+ * CommandCollection
+ */
+class TheCommand extends Command {
+    execute() {}
+}
+const collection = new CommandCollection();
+const theCommand = new TheCommand(editor);
+collection.add('foo', theCommand);
+// $ExpectType Command | undefined
+collection.get('foo');
+const result = collection.execute('foo', 1, 2);
+if (Array.isArray(result)) {
+    result.forEach(v => v);
+}
+collection.execute('foo');
+// $ExpectType string[]
+Array.from(collection.names());
+// $ExpectType Command[]
+Array.from(collection.commands());
+
+/*
+ * PendingActions
+ */
+PendingActions.pluginName === 'PendingActions';
+PendingActions.isContextPlugin === true;
+const pendingActions = new PendingActions(editor);
+// $ExpectType boolean
+pendingActions.hasAny;
+pendingActions.hasAny = true;
+const action = pendingActions.add('action');
+action.message === 'action';
+action.message = 'foo';
+// $ExpectError
+pendingActions.add({});
+pendingActions.remove(action);
+// $ExpectType (Observable & { message: string; }) | null
+pendingActions.first;
+// $ExpectType (Observable & { message: string; })[]
+Array.from(pendingActions);
+Array.from(pendingActions)[0].message === '';

--- a/types/ckeditor__ckeditor5-core/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/command.d.ts
@@ -13,7 +13,7 @@ export default class Command implements Emitter, Observable {
     constructor(editor: Editor);
     clearForceDisabled(id: string): void;
     destroy(): void;
-    execute(...options: any[]): void;
+    execute(...options: any[]): unknown;
     forceDisabled(id: string): void;
     refresh(): void;
 

--- a/types/ckeditor__ckeditor5-core/src/commandcollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/commandcollection.d.ts
@@ -6,7 +6,7 @@ export default class CommandCollection implements Iterable<[string, Command]> {
     add(commandName: string, command: Command): void;
     commands(): Iterable<Command>;
     destroy(): void;
-    execute(commandName: string, ...args: unknown[]): any;
+    execute(commandName: string, ...args: unknown[]): unknown;
     get(commandName: string): Command | undefined;
     names(): Iterable<string>;
 }

--- a/types/ckeditor__ckeditor5-core/src/contextplugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/contextplugin.d.ts
@@ -1,18 +1,17 @@
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import Context from "./context";
 import Editor from "./editor/editor";
-import Plugin from "./plugin";
 
 export default class ContextPlugin implements Observable {
     readonly context: Context | Editor;
 
-    static readonly isContextPlugin: boolean;
+    static readonly isContextPlugin: true;
     static readonly pluginName?: string | undefined;
-    static readonly requires?: Array<typeof Plugin> | undefined;
+    static readonly requires?: Array<typeof ContextPlugin> | undefined;
 
     constructor(context: Context | Editor);
     afterInit?(): Promise<void> | void;
-    destroy?(): Promise<void> | void;
+    destroy(): Promise<void> | void;
     init?(): Promise<void> | void;
 
     set(option: Record<string, unknown>): void;
@@ -20,4 +19,8 @@ export default class ContextPlugin implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+}
+
+export interface ContextPluginInterface<T = ContextPlugin> {
+    new (context: Editor | Context): T;
 }

--- a/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
@@ -1,4 +1,4 @@
-import * as engine from "@ckeditor/ckeditor5-engine";
+import { Conversion, Model, DataController, EditingController, DomEventData } from "@ckeditor/ckeditor5-engine";
 import Config from "@ckeditor/ckeditor5-utils/src/config";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
@@ -8,55 +8,51 @@ import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import CommandCollection from "../commandcollection";
 import ContextPlugin from "../contextplugin";
 import EditingKeystrokeHandler from "../editingkeystrokehandler";
-import Plugin, { LoadedPlugins } from "../plugin";
+import Plugin from "../plugin";
 import PluginCollection from "../plugincollection";
 import { EditorConfig } from "./editorconfig";
 
 export default abstract class Editor implements Emitter, Observable {
     readonly commands: CommandCollection;
     readonly config: Config;
-    readonly conversion: engine.Conversion;
-    readonly data: engine.DataController;
-    readonly editing: engine.EditingController;
+    readonly conversion: Conversion;
+    readonly data: DataController;
+    readonly editing: EditingController;
     isReadOnly: boolean;
     readonly keystrokes: EditingKeystrokeHandler;
     readonly locale: Locale;
-    readonly model: engine.Model;
+    readonly model: Model;
     readonly plugins: PluginCollection;
     readonly state: "initializing" | "ready" | "destroyed";
 
-    static builtinPlugins: Array<typeof Plugin|typeof ContextPlugin|string>;
+    static builtinPlugins: Array<typeof Plugin | typeof ContextPlugin | string>;
     static defaultConfig?: EditorConfig | undefined;
 
     constructor(config?: EditorConfig);
     destroy(): Promise<void>;
     execute(commandName: string, ...args: unknown[]): any;
     focus(): void;
-    initPlugins(): Promise<LoadedPlugins>;
+    initPlugins(): ReturnType<PluginCollection["init"]>;
     t: Locale["t"];
 
     on: (
         event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
         event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: engine.DomEventData) => void): void;
+    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     listenTo(
         emitter: Emitter,
         event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority?: PriorityString | number | undefined },
     ): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: engine.DomEventData) => void,
-    ): void;
+    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;

--- a/types/ckeditor__ckeditor5-core/src/multicommand.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/multicommand.d.ts
@@ -1,7 +1,5 @@
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import Command from "./command";
 
-export default class MultiCommand extends Command implements Emitter, Observable {
+export default class MultiCommand extends Command {
     registerChildCommand(command: Command): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/pendingactions.d.ts
@@ -10,9 +10,10 @@ export default class PendingActions
     extends ContextPlugin
     implements Emitter, Observable, Iterable<Observable & { message: string }> {
     readonly first: null | (Observable & { message: string });
-    readonly hasAny: boolean;
+    hasAny: boolean;
 
     static pluginName: "PendingActions";
+    static isContextPlugin: true;
 
     constructor(editor: Editor);
     [Symbol.iterator](): Iterator<Observable & { message: string }>;

--- a/types/ckeditor__ckeditor5-core/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugin.d.ts
@@ -58,4 +58,4 @@ export interface PluginInterface<T = Plugin> {
     new (editor: Editor): T;
 }
 
-export type LoadedPlugins = Array<typeof Plugin|typeof ContextPlugin>;
+export type LoadedPlugins = Array<typeof Plugin | typeof ContextPlugin>;

--- a/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugincollection.d.ts
@@ -3,21 +3,22 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Context from "./context";
-import ContextPlugin from "./contextplugin";
+import ContextPlugin, { ContextPluginInterface } from "./contextplugin";
 import Editor from "./editor/editor";
 import Plugin, { PluginInterface, LoadedPlugins } from "./plugin";
 
 // tslint:disable-next-line:no-empty-interface
 export interface Plugins {}
 
-export default class PluginCollection implements Emitter, Iterable<[typeof Plugin, Plugin]> {
+export default class PluginCollection
+    implements Emitter, Iterable<[typeof Plugin, Plugin] | [typeof ContextPlugin, ContextPlugin]> {
     constructor(
         context: Editor | Context,
-        availablePlugins?: Array<typeof Plugin>,
-        contextPlugins?: Iterable<[typeof Plugin, Plugin]>,
+        availablePlugins?: Array<typeof Plugin | typeof ContextPlugin>,
+        contextPlugins?: Array<[typeof Plugin, Plugin] | [typeof ContextPlugin, ContextPlugin]>,
     );
 
-    [Symbol.iterator](): Iterator<[typeof Plugin, Plugin]>;
+    [Symbol.iterator](): Iterator<[typeof Plugin, Plugin] | [typeof ContextPlugin, ContextPlugin]>;
     destroy(): Promise<void>;
 
     get<T extends Plugin>(key: PluginInterface<T>): T;
@@ -25,12 +26,12 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
     get<T extends keyof Plugins>(key: T): Plugins[T];
     get(key: string): Plugin | ContextPlugin;
 
-    has(key: PluginInterface | string): boolean;
+    has(key: PluginInterface | ContextPluginInterface | string): boolean;
 
     init(
-        plugins: Array<(() => Plugin) | string>,
-        pluginsToRemove: Array<(() => Plugin) | string>,
-        pluginsSubstitutions: Array<() => Plugin>,
+        plugins?: Array<typeof Plugin | typeof ContextPlugin | string>,
+        pluginsToRemove?: Array<typeof Plugin | typeof ContextPlugin | string>,
+        pluginsSubstitutions?: Array<Plugin | ContextPlugin | string>,
     ): Promise<LoadedPlugins>;
 
     on: (

--- a/types/ckeditor__ckeditor5-core/v27/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-core/v27/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-src/pendingactions.d.ts

--- a/types/ckeditor__ckeditor5-core/v27/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/v27/ckeditor__ckeditor5-core-tests.ts
@@ -10,8 +10,9 @@ import {
     EditorUI,
 } from '@ckeditor/ckeditor5-core';
 import View from '@ckeditor/ckeditor5-ui/src/view';
-
-let comm: Command;
+import PluginCollection from '@ckeditor/ckeditor5-core/src/plugincollection';
+import CommandCollection from '@ckeditor/ckeditor5-core/src/commandcollection';
+import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
 
 /**
  * Editor
@@ -33,13 +34,18 @@ class MyEditor extends Editor {
 const PluginArray: Array<typeof Plugin | typeof ContextPlugin | string> = MyEditor.builtinPlugins;
 PluginArray.forEach(plugin => typeof plugin !== 'string' && plugin.pluginName);
 
-const editor = new MyEditor(document.createElement('div'));
+let editor: Editor = new MyEditor(document.createElement('div'));
 const editorState: 'initializing' | 'ready' | 'destroyed' = editor.state;
 // $ExpectError
 editor.state = editorState;
 editor.focus();
 editor.destroy().then(() => {});
-editor.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
+editor.initPlugins().then(loaded => {
+    loaded.forEach(Plugin => {
+        class Foo extends Plugin {}
+        new Foo(editor);
+    });
+});
 
 MyEditor.defaultConfig = {
     placeholder: 'foo',
@@ -91,23 +97,25 @@ class MyEmptyEditor extends Editor {
  * Command
  */
 class SomeCommand extends Command {
-    execute(...args: unknown[]) {
-        console.log(args);
+    execute(
+        a?: string | number | Record<string, unknown>,
+        b?: string | Record<string, unknown>,
+        c?: boolean | unknown[],
+        d?: boolean | unknown[],
+        e?: number,
+    ): void {
+        console.log(a, b, c, d, e);
     }
 }
-const command = new SomeCommand(new MyEmptyEditor());
+const command = new SomeCommand(editor);
 command.execute();
 command.execute('foo', 'bar', true, false, 50033);
 command.execute(4545454, 'refresh', [], []);
 command.execute({}, { foo: 5 });
 
-// $ExpectType Editor
-command.editor;
+editor = command.editor;
 
-// $ExpectType boolean
-command.isEnabled;
-
-comm = new Command(editor);
+const bool: boolean = command.isEnabled;
 
 command.destroy();
 
@@ -120,6 +128,10 @@ delete command.value;
 
 command.isEnabled = false;
 command.isEnabled = true;
+command.on('foo', () => {});
+command.on('execute', () => {}, { priority: 'highest' });
+command.forceDisabled('foo');
+command.clearForceDisabled('foo');
 // $ExpectError
 delete command.isEnabled;
 
@@ -130,17 +142,16 @@ delete command.isEnabled;
 const context = new Context();
 const contextWithConfig = new Context({ foo: 'foo' });
 context.destroy().then(() => {});
-contextWithConfig.initPlugins().then(plugins => plugins.map(plugin => plugin.pluginName));
+contextWithConfig.initPlugins().then(loaded => {
+    loaded.forEach(Plugin => {
+        class Foo extends Plugin {}
+        new Foo(editor);
+    });
+});
 
 /**
  * ContextPlugin
  */
-const CPlugin = new ContextPlugin(context) && new ContextPlugin(editor);
-const afterInitPromise = CPlugin.afterInit?.();
-if (afterInitPromise != null) {
-    afterInitPromise.then(() => {});
-}
-
 class MyCPlugin extends ContextPlugin {
     readonly pluginName: 'MyCPlugin';
     builtinPlugins: [MyPlugin];
@@ -149,11 +160,24 @@ class MyCPlugin extends ContextPlugin {
     }
 }
 
+const cPlugin = new MyCPlugin(context) && new MyCPlugin(editor);
+const afterInitPromise = cPlugin.afterInit?.();
+if (afterInitPromise != null) {
+    afterInitPromise.then(() => {});
+}
+
 editor.plugins.get(MyCPlugin).myCMethod();
 (editor.plugins.get('MyCPlugin') as MyCPlugin).myCMethod();
 
 context.plugins.get(MyCPlugin).myCMethod();
 (context.plugins.get('MyCPlugin') as MyCPlugin).myCMethod();
+
+const pContext = cPlugin.context;
+if (pContext instanceof Editor) {
+    pContext.initPlugins();
+}
+
+cPlugin.destroy();
 
 /**
  * DataApiMixin
@@ -175,9 +199,99 @@ attachToForm(editor);
 /**
  * MultiCommand
  */
-const MC = new MultiCommand(editor);
-MC.registerChildCommand(comm);
+const multiCommand = new MultiCommand(editor);
+multiCommand.registerChildCommand(command);
+multiCommand.destroy();
+// $ExpectType boolean
+multiCommand.isEnabled;
+multiCommand.isEnabled = bool;
+const mcresult = multiCommand.execute();
+if (Array.isArray(mcresult)) {
+    mcresult.forEach(v => v);
+}
 
 /* EditorUI */
 new EditorUI(editor).componentFactory.editor === editor;
 new EditorUI(editor).componentFactory.add('', locale => new View(locale));
+
+/* PluginCollection */
+const plugins = new PluginCollection(
+    editor,
+    [MyPlugin, MyCPlugin],
+    [
+        [MyPlugin, new MyPlugin(editor)],
+        [MyCPlugin, new MyCPlugin(editor)],
+    ],
+);
+new PluginCollection(editor, [], [[MyPlugin, new MyPlugin(editor)]]);
+new PluginCollection(editor, []);
+plugins.init([]).then(loaded =>
+    loaded.forEach(Plugin => {
+        if (Plugin instanceof MyPlugin) {
+            Plugin.myMethod() === null;
+        }
+    }),
+);
+plugins.init([MyPlugin, MyCPlugin, 'foo'], [MyCPlugin]);
+plugins.init([MyPlugin, MyCPlugin, 'foo'], [MyCPlugin], [myPlugin]);
+const cplugin = plugins.get(MyCPlugin);
+cplugin.myCMethod() === null;
+const plugin = plugins.get(MyPlugin);
+plugin.myMethod() === null;
+const unknownPlugin = plugins.get('');
+if (unknownPlugin instanceof MyPlugin) {
+    unknownPlugin.myMethod() === null;
+}
+
+// $ExpectType boolean
+plugins.has('foo');
+// $ExpectType boolean
+plugins.has(MyPlugin);
+// $ExpectType boolean
+plugins.has(MyCPlugin);
+
+// $ExpectError
+plugins.destroy().then(value => value === '');
+plugins.destroy().then(value => value === undefined);
+
+/*
+ * CommandCollection
+ */
+class TheCommand extends Command {
+    execute() {}
+}
+const collection = new CommandCollection();
+const theCommand = new TheCommand(editor);
+collection.add('foo', theCommand);
+// $ExpectType Command | undefined
+collection.get('foo');
+const result = collection.execute('foo', 1, 2);
+if (Array.isArray(result)) {
+    result.forEach(v => v);
+}
+collection.execute('foo');
+// $ExpectType string[]
+Array.from(collection.names());
+// $ExpectType Command[]
+Array.from(collection.commands());
+
+/*
+ * PendingActions
+ */
+PendingActions.pluginName === 'PendingActions';
+PendingActions.isContextPlugin === true;
+const pendingActions = new PendingActions(editor);
+// $ExpectType boolean
+pendingActions.hasAny;
+pendingActions.hasAny = true;
+const action = pendingActions.add('action');
+action.message === 'action';
+action.message = 'foo';
+// $ExpectError
+pendingActions.add({});
+pendingActions.remove(action);
+// $ExpectType (Observable & { message: string; }) | null
+pendingActions.first;
+// $ExpectType (Observable & { message: string; })[]
+Array.from(pendingActions);
+Array.from(pendingActions)[0].message === '';

--- a/types/ckeditor__ckeditor5-core/v27/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/command.d.ts
@@ -13,7 +13,7 @@ export default class Command implements Emitter, Observable {
     constructor(editor: Editor);
     clearForceDisabled(id: string): void;
     destroy(): void;
-    execute(...options: any[]): void;
+    execute(...options: any[]): unknown;
     forceDisabled(id: string): void;
     refresh(): void;
 

--- a/types/ckeditor__ckeditor5-core/v27/src/commandcollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/commandcollection.d.ts
@@ -6,7 +6,7 @@ export default class CommandCollection implements Iterable<[string, Command]> {
     add(commandName: string, command: Command): void;
     commands(): Iterable<Command>;
     destroy(): void;
-    execute(commandName: string, ...args: unknown[]): any;
+    execute(commandName: string, ...args: unknown[]): unknown;
     get(commandName: string): Command | undefined;
     names(): Iterable<string>;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/contextplugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/contextplugin.d.ts
@@ -1,18 +1,17 @@
 import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import Context from "./context";
 import Editor from "./editor/editor";
-import Plugin from "./plugin";
 
 export default class ContextPlugin implements Observable {
     readonly context: Context | Editor;
 
-    static readonly isContextPlugin: boolean;
+    static readonly isContextPlugin: true;
     static readonly pluginName?: string | undefined;
-    static readonly requires?: Array<typeof Plugin> | undefined;
+    static readonly requires?: Array<typeof ContextPlugin> | undefined;
 
     constructor(context: Context | Editor);
     afterInit?(): Promise<void> | void;
-    destroy?(): Promise<void> | void;
+    destroy(): Promise<void> | void;
     init?(): Promise<void> | void;
 
     set(option: Record<string, unknown>): void;
@@ -20,4 +19,8 @@ export default class ContextPlugin implements Observable {
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;
+}
+
+export interface ContextPluginInterface<T = ContextPlugin> {
+    new (context: Editor | Context): T;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/editor/editor.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/editor/editor.d.ts
@@ -1,4 +1,4 @@
-import * as engine from "@ckeditor/ckeditor5-engine";
+import { Conversion, Model, DataController, EditingController, DomEventData } from "@ckeditor/ckeditor5-engine";
 import Config from "@ckeditor/ckeditor5-utils/src/config";
 import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
@@ -8,55 +8,51 @@ import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import CommandCollection from "../commandcollection";
 import ContextPlugin from "../contextplugin";
 import EditingKeystrokeHandler from "../editingkeystrokehandler";
-import Plugin, { LoadedPlugins } from "../plugin";
+import Plugin from "../plugin";
 import PluginCollection from "../plugincollection";
 import { EditorConfig } from "./editorconfig";
 
 export default abstract class Editor implements Emitter, Observable {
     readonly commands: CommandCollection;
     readonly config: Config;
-    readonly conversion: engine.Conversion;
-    readonly data: engine.DataController;
-    readonly editing: engine.EditingController;
+    readonly conversion: Conversion;
+    readonly data: DataController;
+    readonly editing: EditingController;
     isReadOnly: boolean;
     readonly keystrokes: EditingKeystrokeHandler;
     readonly locale: Locale;
-    readonly model: engine.Model;
+    readonly model: Model;
     readonly plugins: PluginCollection;
     readonly state: "initializing" | "ready" | "destroyed";
 
-    static builtinPlugins: Array<typeof Plugin|typeof ContextPlugin|string>;
+    static builtinPlugins: Array<typeof Plugin | typeof ContextPlugin | string>;
     static defaultConfig?: EditorConfig | undefined;
 
     constructor(config?: EditorConfig);
     destroy(): Promise<void>;
     execute(commandName: string, ...args: unknown[]): any;
     focus(): void;
-    initPlugins(): Promise<LoadedPlugins>;
+    initPlugins(): ReturnType<PluginCollection["init"]>;
     t: Locale["t"];
 
     on: (
         event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ) => void;
     once(
         event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority: PriorityString | number },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: engine.DomEventData) => void): void;
+    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     listenTo(
         emitter: Emitter,
         event: string,
-        callback: (info: EventInfo, data: engine.DomEventData) => void,
+        callback: (info: EventInfo, data: DomEventData) => void,
         options?: { priority?: PriorityString | number | undefined },
     ): void;
-    stopListening(
-        emitter?: Emitter,
-        event?: string,
-        callback?: (info: EventInfo, data: engine.DomEventData) => void,
-    ): void;
+    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
     fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;

--- a/types/ckeditor__ckeditor5-core/v27/src/multicommand.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/multicommand.d.ts
@@ -1,7 +1,5 @@
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import Command from "./command";
 
-export default class MultiCommand extends Command implements Emitter, Observable {
+export default class MultiCommand extends Command {
     registerChildCommand(command: Command): void;
 }

--- a/types/ckeditor__ckeditor5-core/v27/src/pendingactions.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/pendingactions.d.ts
@@ -10,9 +10,10 @@ export default class PendingActions
     extends ContextPlugin
     implements Emitter, Observable, Iterable<Observable & { message: string }> {
     readonly first: null | (Observable & { message: string });
-    readonly hasAny: boolean;
+    hasAny: boolean;
 
     static pluginName: "PendingActions";
+    static isContextPlugin: true;
 
     constructor(editor: Editor);
     [Symbol.iterator](): Iterator<Observable & { message: string }>;

--- a/types/ckeditor__ckeditor5-core/v27/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugin.d.ts
@@ -58,4 +58,4 @@ export interface PluginInterface<T = Plugin> {
     new (editor: Editor): T;
 }
 
-export type LoadedPlugins = Array<typeof Plugin|typeof ContextPlugin>;
+export type LoadedPlugins = Array<typeof Plugin | typeof ContextPlugin>;

--- a/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
+++ b/types/ckeditor__ckeditor5-core/v27/src/plugincollection.d.ts
@@ -3,21 +3,22 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Context from "./context";
-import ContextPlugin from "./contextplugin";
+import ContextPlugin, { ContextPluginInterface } from "./contextplugin";
 import Editor from "./editor/editor";
 import Plugin, { PluginInterface, LoadedPlugins } from "./plugin";
 
 // tslint:disable-next-line:no-empty-interface
 export interface Plugins {}
 
-export default class PluginCollection implements Emitter, Iterable<[typeof Plugin, Plugin]> {
+export default class PluginCollection
+    implements Emitter, Iterable<[typeof Plugin, Plugin] | [typeof ContextPlugin, ContextPlugin]> {
     constructor(
         context: Editor | Context,
-        availablePlugins?: Array<typeof Plugin>,
-        contextPlugins?: Iterable<[typeof Plugin, Plugin]>,
+        availablePlugins?: Array<typeof Plugin | typeof ContextPlugin>,
+        contextPlugins?: Array<[typeof Plugin, Plugin] | [typeof ContextPlugin, ContextPlugin]>,
     );
 
-    [Symbol.iterator](): Iterator<[typeof Plugin, Plugin]>;
+    [Symbol.iterator](): Iterator<[typeof Plugin, Plugin] | [typeof ContextPlugin, ContextPlugin]>;
     destroy(): Promise<void>;
 
     get<T extends Plugin>(key: PluginInterface<T>): T;
@@ -25,12 +26,12 @@ export default class PluginCollection implements Emitter, Iterable<[typeof Plugi
     get<T extends keyof Plugins>(key: T): Plugins[T];
     get(key: string): Plugin | ContextPlugin;
 
-    has(key: PluginInterface | string): boolean;
+    has(key: PluginInterface | ContextPluginInterface | string): boolean;
 
     init(
-        plugins: Array<(() => Plugin) | string>,
-        pluginsToRemove: Array<(() => Plugin) | string>,
-        pluginsSubstitutions: Array<() => Plugin>,
+        plugins?: Array<typeof Plugin | typeof ContextPlugin | string>,
+        pluginsToRemove?: Array<typeof Plugin | typeof ContextPlugin | string>,
+        pluginsSubstitutions?: Array<Plugin | ContextPlugin | string>,
     ): Promise<LoadedPlugins>;
 
     on: (


### PR DESCRIPTION
* `ContexPlugin` can only require other `ContextPlugin` instances.
* Since `MultiCommand` extends Command, it does not need to implement `Emitter` and `Observable`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.