### PR TITLE
[webpack-dev-server] Allow passing string / array of strings to the static option

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -251,7 +251,7 @@ declare namespace WebpackDevServer {
          * This options allows to configure options for serving static files
          * from directory (by default 'public' directory).
          */
-        static?: boolean | string | Static | (string | Static)[] | undefined;
+        static?: boolean | string | Static | Array<string | Static> | undefined;
         /**
          * This option allows you to configure list of globs/directories/files
          * to watch for file changes.

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -251,7 +251,7 @@ declare namespace WebpackDevServer {
          * This options allows to configure options for serving static files
          * from directory (by default 'public' directory).
          */
-        static?: boolean | Static | undefined;
+        static?: boolean | string | Static | (string | Static)[] | undefined;
         /**
          * This option allows you to configure list of globs/directories/files
          * to watch for file changes.

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -165,6 +165,8 @@ const c3: WebpackDevServer.Configuration = {
     host: '127.0.0.1',
     port: 8080,
 
+    static: '/path/to/directory',
+
     devMiddleware: {
         stats: 'verbose',
     },
@@ -173,6 +175,8 @@ const c4: WebpackDevServer.Configuration = {
     // Host and port are required options to correct work.
     host: 'localhost',
     port: 8080,
+
+    static: ['/path/to/directory', '/path/to/another-directory'],
 
     devMiddleware: {
         writeToDisk: (filePath: string) => true,
@@ -211,20 +215,6 @@ const c6: WebpackDevServer.Configuration = {
         ],
         verbose: true,
     },
-};
-const c7: WebpackDevServer.Configuration = {
-    // Host and port are required options to correct work.
-    host: 'localhost',
-    port: 8080,
-
-    static: '/path/to/directory',
-};
-const c8: WebpackDevServer.Configuration = {
-    // Host and port are required options to correct work.
-    host: 'localhost',
-    port: 8080,
-
-    static: ['/path/to/directory', '/path/to/another-directory'],
 };
 
 // API example

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -212,6 +212,20 @@ const c6: WebpackDevServer.Configuration = {
         verbose: true,
     },
 };
+const c7: WebpackDevServer.Configuration = {
+    // Host and port are required options to correct work.
+    host: 'localhost',
+    port: 8080,
+
+    static: '/path/to/directory',
+};
+const c8: WebpackDevServer.Configuration = {
+    // Host and port are required options to correct work.
+    host: 'localhost',
+    port: 8080,
+
+    static: ['/path/to/directory', '/path/to/another-directory'],
+};
 
 // API example
 server = new WebpackDevServer(config, compiler);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/dev-server/#devserverstatic
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
