### PR TITLE
Make `flags` optional in `fs.open` in node

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1956,19 +1956,19 @@ declare module 'fs' {
      * @param [flags='r'] See `support of file system `flags``.
      * @param [mode=0o666]
      */
-    export function open(path: PathLike, flags: OpenMode, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, flags: OpenMode | undefined | null, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function open(path: PathLike, flags: OpenMode, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, flags: OpenMode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
     export namespace open {
         /**
          * Asynchronous open(2) - open and possibly create a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
          */
-        function __promisify__(path: PathLike, flags: OpenMode, mode?: Mode | null): Promise<number>;
+        function __promisify__(path: PathLike, flags?: OpenMode, mode?: Mode | null): Promise<number>;
     }
     /**
      * Returns an integer representing the file descriptor.
@@ -1979,7 +1979,7 @@ declare module 'fs' {
      * @param [flags='r']
      * @param [mode=0o666]
      */
-    export function openSync(path: PathLike, flags: OpenMode, mode?: Mode | null): number;
+    export function openSync(path: PathLike, flags?: OpenMode, mode?: Mode | null): number;
     /**
      * Change the file system timestamps of the object referenced by `path`.
      *

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -397,7 +397,7 @@ declare module 'fs/promises' {
      * @param [mode=0o666] Sets the file mode (permission and sticky bits) if the file is created.
      * @return Fulfills with a {FileHandle} object.
      */
-    function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
+    function open(path: PathLike, flags?: string | number, mode?: Mode): Promise<FileHandle>;
     /**
      * Renames `oldPath` to `newPath`.
      * @since v10.0.0

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -374,7 +374,7 @@ async function testPromisify() {
 }
 
 async () => {
-    const handle: FileHandle = await openAsync('test', 'r');
+    const handle: FileHandle = await openAsync('test');
     const writeStream = fs.createWriteStream('./index.d.ts', {
         fd: handle,
     });


### PR DESCRIPTION
Flags actually has a default of 'r' in `fsPromises.open`, meaning it should be optional in typescript

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: It is actually documented in the source code, right above the change.
