### PR TITLE
@ckeditor/ckeditor5-page-break: Use module augmentation for plugincollection Plugins with newly added plugin classes

### DIFF
--- a/types/ckeditor__ckeditor5-page-break/ckeditor__ckeditor5-page-break-tests.ts
+++ b/types/ckeditor__ckeditor5-page-break/ckeditor__ckeditor5-page-break-tests.ts
@@ -22,3 +22,12 @@ new PageBreakUI(editor).init();
 new PageBreakEditing(editor).init();
 
 new PageBreakCommand(editor).execute();
+
+// $ExpectType PageBreak
+editor.plugins.get('PageBreak');
+
+// $ExpectType PageBreakUI
+editor.plugins.get('PageBreakUI');
+
+// $ExpectType PageBreakEditing
+editor.plugins.get('PageBreakEditing');

--- a/types/ckeditor__ckeditor5-page-break/src/pagebreak.d.ts
+++ b/types/ckeditor__ckeditor5-page-break/src/pagebreak.d.ts
@@ -13,3 +13,9 @@ export default class PageBreak extends Plugin {
     static readonly requires: [typeof PageBreakEditing, typeof PageBreakUI, typeof Widget];
     static readonly pluginName: 'PageBreak';
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PageBreak: PageBreak;
+    }
+}

--- a/types/ckeditor__ckeditor5-page-break/src/pagebreakediting.d.ts
+++ b/types/ckeditor__ckeditor5-page-break/src/pagebreakediting.d.ts
@@ -6,3 +6,9 @@ export default class PageBreakEditing extends Plugin {
     static readonly pluginName: 'PageBreakEditing';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PageBreakEditing: PageBreakEditing;
+    }
+}

--- a/types/ckeditor__ckeditor5-page-break/src/pagebreakui.d.ts
+++ b/types/ckeditor__ckeditor5-page-break/src/pagebreakui.d.ts
@@ -6,3 +6,9 @@ export default class PageBreakUI extends Plugin {
     static readonly pluginName: 'PageBreakUI';
     init(): void;
 }
+
+declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
+    interface Plugins {
+        PageBreakUI: PageBreakUI;
+    }
+}


### PR DESCRIPTION
Applying changes from #55259 (module augmentation to allow `PluginCollection.get` to return the correct plugin type when passed the plugin name as a string) to the recently added `@ckeditor/ckeditor5-page-break` package (from #55201)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: ##55259
