### PR TITLE
Fix @ckeditor/utils Locale['t'] and constructor

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -55,7 +55,6 @@ import {
 } from '@ckeditor/ckeditor5-utils/src/unicode';
 
 declare const document: Document;
-declare const locale: Locale;
 declare let emitter: Emitter;
 declare let htmlElement: HTMLElement;
 declare let map: Map<string, number>;
@@ -539,8 +538,26 @@ keystrokes.destroy();
 
 // utils/locale ===============================================================
 
-locale.t('Label');
-locale.t("Created file '%0' in %1ms.", ['fileName', '100']);
+new Locale();
+new Locale({ uiLanguage: "en" });
+new Locale({ contentLanguage: "en" });
+new Locale({ uiLanguage: "en", contentLanguage: "en" });
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).contentLanguage;
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).uiLanguage;
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).uiLanguageDirection;
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).contentLanguageDirection;
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Label");
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Created file '%0' in %1ms.", ["fileName", "100"]);
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Created file in %1ms.", 5);
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", "");
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", [5]);
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", [5, ""]);
+// $ExpectError
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", false);
 
 // utils/mapsequal ============================================================
 

--- a/types/ckeditor__ckeditor5-utils/src/locale.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/locale.d.ts
@@ -1,8 +1,14 @@
+import { Message } from "./translation-service";
+
 /**
  * Represents the localization services.
  */
 export default class Locale {
-    constructor(options?: { uiLanguage: string; contentLanguage: string });
+	/**
+	 * Creates a new instance of the locale class. Learn more about
+	 * {@glink features/ui-language configuring the language of the editor}.
+	 */
+    constructor(options?: { uiLanguage?: string; contentLanguage?: string });
     /**
      * The editor UI language code in the [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) format.
      *
@@ -75,5 +81,7 @@ export default class Locale {
      *
      * For messages supporting plural forms the first value will determine the plural form.
      */
-    t: (message: string, values?: string[]) => string;
+    t(message: string | Message, values?: string | number | Array<string | number>): string;
+
+    private _t(message: string | Message, values?: string | number | Array<string | number>): string;
 }

--- a/types/ckeditor__ckeditor5-utils/src/translation-service.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/translation-service.d.ts
@@ -82,7 +82,7 @@ export function add(
  * The internationalization message interface. A message that implements this interface can be passed to the t() function to be translated to the target UI language.
  */
 export interface Message {
-    id: string;
-    plural: string;
+    id?: string;
+    plural?: string;
     string: string;
 }

--- a/types/ckeditor__ckeditor5-utils/v27/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/ckeditor__ckeditor5-utils-tests.ts
@@ -55,7 +55,6 @@ import {
 } from '@ckeditor/ckeditor5-utils/src/unicode';
 
 declare const document: Document;
-declare const locale: Locale;
 declare let emitter: Emitter;
 declare let htmlElement: HTMLElement;
 declare let map: Map<string, number>;
@@ -539,8 +538,26 @@ keystrokes.destroy();
 
 // utils/locale ===============================================================
 
-locale.t('Label');
-locale.t("Created file '%0' in %1ms.", ['fileName', '100']);
+new Locale();
+new Locale({ uiLanguage: "en" });
+new Locale({ contentLanguage: "en" });
+new Locale({ uiLanguage: "en", contentLanguage: "en" });
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).contentLanguage;
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).uiLanguage;
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).uiLanguageDirection;
+// $ExpectType string
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).contentLanguageDirection;
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Label");
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Created file '%0' in %1ms.", ["fileName", "100"]);
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Created file in %1ms.", 5);
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", "");
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", [5]);
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", [5, ""]);
+// $ExpectError
+new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", false);
 
 // utils/mapsequal ============================================================
 

--- a/types/ckeditor__ckeditor5-utils/v27/src/locale.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/locale.d.ts
@@ -1,8 +1,14 @@
+import { Message } from "./translation-service";
+
 /**
  * Represents the localization services.
  */
 export default class Locale {
-    constructor(options?: { uiLanguage: string; contentLanguage: string });
+	/**
+	 * Creates a new instance of the locale class. Learn more about
+	 * {@glink features/ui-language configuring the language of the editor}.
+	 */
+    constructor(options?: { uiLanguage?: string; contentLanguage?: string });
     /**
      * The editor UI language code in the [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) format.
      *
@@ -75,5 +81,7 @@ export default class Locale {
      *
      * For messages supporting plural forms the first value will determine the plural form.
      */
-    t: (message: string, values?: string[]) => string;
+    t(message: string | Message, values?: string | number | Array<string | number>): string;
+
+    private _t(message: string | Message, values?: string | number | Array<string | number>): string;
 }

--- a/types/ckeditor__ckeditor5-utils/v27/src/translation-service.d.ts
+++ b/types/ckeditor__ckeditor5-utils/v27/src/translation-service.d.ts
@@ -82,7 +82,7 @@ export function add(
  * The internationalization message interface. A message that implements this interface can be passed to the t() function to be translated to the target UI language.
  */
 export interface Message {
-    id: string;
-    plural: string;
+    id?: string;
+    plural?: string;
     string: string;
 }


### PR DESCRIPTION
Closes #53919

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor5/28.0.0/api/module_utils_translation-service-Message.html#member-id and https://ckeditor.com/docs/ckeditor5/latest/api/module_utils_locale-Locale.html#function-t
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
