### PR TITLE
@ckeditor/ckeditor5-engine: view/model element obj is() type narrowing with name: string arg

### DIFF
--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -493,6 +493,18 @@ if (
 ) {
     const obj: Element | RootElement = modelObj;
 }
+if (modelObj.is("element", "div")) {
+    const obj: (Element | RootElement) & { name: "div"; } = modelObj;
+}
+if (modelObj.is("model:element", "div")) {
+    const obj: (Element | RootElement) & { name: "div"; } = modelObj;
+}
+if (modelObj.is("element", "div") || modelObj.is("element", "span")) {
+    const obj: Element | RootElement = modelObj;
+}
+if (modelObj.is("model:element", "div") || modelObj.is("model:element", "span")) {
+    const obj: Element | RootElement = modelObj;
+}
 if (
     modelObj.is("rootElement") ||
     modelObj.is("model:rootElement") ||
@@ -501,6 +513,53 @@ if (
 ) {
     const obj: RootElement = modelObj;
 }
+{
+    const obj = modelObj as RootElement;
+    if (obj.is("rootElement", "paragraph")) {
+        // $ExpectType RootElement & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("model:rootElement", "paragraph")) {
+        // $ExpectType RootElement & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("rootElement", "paragraph") || obj.is("rootElement", "blockQuote")) {
+        // $ExpectType (RootElement & { name: "paragraph"; }) | (RootElement & { name: "blockQuote"; })
+        obj;
+    }
+    if (obj.is("model:rootElement", "paragraph") || obj.is("model:rootElement", "blockQuote")) {
+        // $ExpectType (RootElement & { name: "paragraph"; }) | (RootElement & { name: "blockQuote"; })
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("rootElement") || obj.is("rootElement", "paragraph")) 1;
+    // $ExpectError
+    if (obj.is("model:rootElement") || obj.is("model:rootElement", "paragraph")) 1;
+}
+{
+    const obj = modelObj as Element;
+    if (obj.is("element", "paragraph")) {
+        // $ExpectType (RootElement | Element) & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("model:element", "paragraph")) {
+        // $ExpectType (RootElement | Element) & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("element", "paragraph") || obj.is("element", "blockQuote")) {
+        // $ExpectType "paragraph" | "blockQuote"
+        obj.name;
+    }
+    if (obj.is("model:element", "paragraph") || obj.is("model:element", "blockQuote")) {
+        // $ExpectType "paragraph" | "blockQuote"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("element") || obj.is("element", "paragraph")) 1;
+    // $ExpectError
+    if (obj.is("model:element") || obj.is("model:element", "paragraph")) 1;
+}
+
 if (modelObj.is("selection") || modelObj.is("model:selection")) {
     const obj: Selection | DocumentSelection = modelObj;
 }
@@ -588,6 +647,31 @@ if (
         | EmptyElement
         | RootEditableElement = viewObj;
 }
+
+{
+    const obj = viewObj as ViewElement;
+    if (obj.is("element", "p") || obj.is("element", "div")) {
+        // $ExpectType (Element & { name: "p"; }) | (Element & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:element", "p") || obj.is("view:element", "div")) {
+        // $ExpectType (Element & { name: "p"; }) | (Element & { name: "div"; })
+        obj;
+    }
+    if (obj.is("element", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    if (obj.is("view:element", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("element") || obj.is("element", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:element") || obj.is("view:element", "p")) 1;
+}
+
 if (
     viewObj.is("containerElement") ||
     viewObj.is("view:containerElement") ||
@@ -596,6 +680,31 @@ if (
 ) {
     const obj: ContainerElement | EditableElement | RootEditableElement = viewObj;
 }
+
+{
+    const obj = viewObj as ContainerElement;
+    if (obj.is("containerElement", "p") || obj.is("containerElement", "div")) {
+        // $ExpectType (ContainerElement & { name: "p"; }) | (ContainerElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:containerElement", "p") || obj.is("view:containerElement", "div")) {
+        // $ExpectType (ContainerElement & { name: "p"; }) | (ContainerElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("containerElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    if (obj.is("view:containerElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("containerElement") || obj.is("containerElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:containerElement") || obj.is("view:containerElement", "p")) 1;
+}
+
 if (
     viewObj.is("editableElement") ||
     viewObj.is("view:editableElement") ||
@@ -604,6 +713,30 @@ if (
 ) {
     const obj: EditableElement | RootEditableElement = viewObj;
 }
+{
+    const obj = viewObj as EditableElement;
+    if (obj.is("editableElement", "p") || obj.is("editableElement", "div")) {
+        // $ExpectType (EditableElement & { name: "p"; }) | (EditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:editableElement", "p") || obj.is("view:editableElement", "div")) {
+        // $ExpectType (EditableElement & { name: "p"; }) | (EditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("editableElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    if (obj.is("view:editableElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("editableElement") || obj.is("editableElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:editableElement") || obj.is("view:editableElement", "p")) 1;
+}
+
 if (
     viewObj.is("rootEditableElement") ||
     viewObj.is("view:rootEditableElement") ||
@@ -611,6 +744,29 @@ if (
     viewObj.is("view:rootEditableElement", "div")
 ) {
     const obj: RootEditableElement = viewObj;
+}
+{
+    const obj = viewObj as RootEditableElement;
+    if (obj.is("rootEditableElement", "p") || obj.is("rootEditableElement", "div")) {
+        // $ExpectType (RootEditableElement & { name: "p"; }) | (RootEditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:rootEditableElement", "p") || obj.is("view:rootEditableElement", "div")) {
+        // $ExpectType (RootEditableElement & { name: "p"; }) | (RootEditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("rootEditableElement", "p")) {
+        // $ExpectType RootEditableElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:rootEditableElement", "p")) {
+        // $ExpectType RootEditableElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("rootEditableElement") || obj.is("rootEditableElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:rootEditableElement") || obj.is("view:rootEditableElement", "p")) 1;
 }
 if (
     viewObj.is("rawElement") ||
@@ -620,6 +776,30 @@ if (
 ) {
     const obj: RawElement = viewObj;
 }
+{
+    const obj = viewObj as RawElement;
+    if (obj.is("rawElement", "p") || obj.is("rawElement", "div")) {
+        // $ExpectType (RawElement & { name: "p"; }) | (RawElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:rawElement", "p") || obj.is("view:rawElement", "div")) {
+        // $ExpectType (RawElement & { name: "p"; }) | (RawElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("rawElement", "p")) {
+        // $ExpectType RawElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:rawElement", "p")) {
+        // $ExpectType RawElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("rawElement") || obj.is("rawElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:rawElement") || obj.is("view:rawElement", "p")) 1;
+}
+
 if (
     viewObj.is("attributeElement") ||
     viewObj.is("view:attributeElement") ||
@@ -628,6 +808,30 @@ if (
 ) {
     const obj: AttributeElement = viewObj;
 }
+{
+    const obj = viewObj as AttributeElement;
+    if (obj.is("attributeElement", "p") || obj.is("attributeElement", "div")) {
+        // $ExpectType (AttributeElement & { name: "p"; }) | (AttributeElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:attributeElement", "p") || obj.is("view:attributeElement", "div")) {
+        // $ExpectType (AttributeElement & { name: "p"; }) | (AttributeElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("attributeElement", "p")) {
+        // $ExpectType AttributeElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:attributeElement", "p")) {
+        // $ExpectType AttributeElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("attributeElement") || obj.is("attributeElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:attributeElement") || obj.is("view:attributeElement", "p")) 1;
+}
+
 if (
     viewObj.is("uiElement") ||
     viewObj.is("view:uiElement") ||
@@ -636,6 +840,30 @@ if (
 ) {
     const obj: UIElement = viewObj;
 }
+{
+    const obj = viewObj as UIElement;
+    if (obj.is("uiElement", "p") || obj.is("uiElement", "div")) {
+        // $ExpectType (UIElement & { name: "p"; }) | (UIElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:uiElement", "p") || obj.is("view:uiElement", "div")) {
+        // $ExpectType (UIElement & { name: "p"; }) | (UIElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("uiElement", "p")) {
+        // $ExpectType UIElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:uiElement", "p")) {
+        // $ExpectType UIElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("uiElement") || obj.is("uiElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:uiElement") || obj.is("view:uiElement", "p")) 1;
+}
+
 if (
     viewObj.is("emptyElement") ||
     viewObj.is("view:emptyElement") ||
@@ -643,6 +871,29 @@ if (
     viewObj.is("view:emptyElement", "div")
 ) {
     const obj: EmptyElement = viewObj;
+}
+{
+    const obj = viewObj as EmptyElement;
+    if (obj.is("emptyElement", "hr") || obj.is("emptyElement", "img")) {
+        // $ExpectType (EmptyElement & { name: "hr"; }) | (EmptyElement & { name: "img"; })
+        obj;
+    }
+    if (obj.is("view:emptyElement", "hr") || obj.is("view:emptyElement", "img")) {
+        // $ExpectType (EmptyElement & { name: "hr"; }) | (EmptyElement & { name: "img"; })
+        obj;
+    }
+    if (obj.is("emptyElement", "hr")) {
+        // $ExpectType EmptyElement & { name: "hr"; }
+        obj;
+    }
+    if (obj.is("view:emptyElement", "hr")) {
+        // $ExpectType EmptyElement & { name: "hr"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("emptyElement") || obj.is("emptyElement", "hr")) 1;
+    // $ExpectError
+    if (obj.is("view:emptyElement") || obj.is("view:emptyElement", "hr")) 1;
 }
 
 // Selectable

--- a/types/ckeditor__ckeditor5-engine/src/model/documentfragment.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentfragment.d.ts
@@ -37,8 +37,10 @@ export default class DocumentFragment implements Iterable<Element | Text> {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     offsetToIndex(offset: number): number;
     toJSON(): Pick<DocumentFragment, "childCount" | "isEmpty" | "markers" | "maxOffset" | "parent" | "root">;

--- a/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/documentselection.d.ts
@@ -52,8 +52,10 @@ export default class DocumentSelection implements Emitter {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     observeMarkers(prefixOrName: string): void;
     refresh(): void;

--- a/types/ckeditor__ckeditor5-engine/src/model/markercollection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/markercollection.d.ts
@@ -42,7 +42,9 @@ export class Marker {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/node.d.ts
@@ -44,8 +44,10 @@ export default class Node {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isAfter(node: Node): boolean;
     isAttached(): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/position.d.ts
@@ -77,8 +77,10 @@ export default class Position {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isAfter(otherPosition: Position): boolean;
     isBefore(otherPosition: Position): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/range.d.ts
@@ -68,8 +68,10 @@ export default class Range implements Iterable<TreeWalkerValue> {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isEqual(otherRange: Range): boolean;
     isIntersecting(otherRange: Range): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
@@ -65,8 +65,10 @@ export default class Selection implements Emitter {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isEqual(otherSelection: Selection): boolean;
     removeAttribute(key: string): void;

--- a/types/ckeditor__ckeditor5-engine/src/model/text.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/text.d.ts
@@ -26,8 +26,10 @@ export default class Text extends Node {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     toJSON(): ReturnType<Node["toJSON"]> & {
         data: string;

--- a/types/ckeditor__ckeditor5-engine/src/model/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/textproxy.d.ts
@@ -44,7 +44,9 @@ export default class TextProxy {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/documentfragment.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/documentfragment.d.ts
@@ -51,7 +51,6 @@ export default class DocumentFragment implements Iterable<Node> {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -61,22 +60,47 @@ export default class DocumentFragment implements Iterable<Node> {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/documentselection.d.ts
@@ -55,7 +55,6 @@ export default class DocumentSelection {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -65,22 +64,47 @@ export default class DocumentSelection {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/node.d.ts
@@ -46,7 +46,6 @@ export default abstract class Node {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -56,22 +55,47 @@ export default abstract class Node {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/position.d.ts
@@ -69,7 +69,6 @@ export default class Position {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -79,22 +78,47 @@ export default class Position {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/range.d.ts
@@ -76,7 +76,6 @@ export default class Range implements Iterable<TreeWalkerValue> {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -86,22 +85,47 @@ export default class Range implements Iterable<TreeWalkerValue> {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/selection.d.ts
@@ -62,7 +62,6 @@ export default class Selection {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -72,22 +71,47 @@ export default class Selection {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/textproxy.d.ts
@@ -51,7 +51,6 @@ export default class TextProxy {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -61,22 +60,47 @@ export default class TextProxy {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/ckeditor__ckeditor5-engine-tests.ts
@@ -501,6 +501,54 @@ if (
 ) {
     const obj: RootElement = modelObj;
 }
+
+{
+    const obj = modelObj as RootElement;
+    if (obj.is("rootElement", "paragraph")) {
+        // $ExpectType RootElement & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("model:rootElement", "paragraph")) {
+        // $ExpectType RootElement & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("rootElement", "paragraph") || obj.is("rootElement", "blockQuote")) {
+        // $ExpectType (RootElement & { name: "paragraph"; }) | (RootElement & { name: "blockQuote"; })
+        obj;
+    }
+    if (obj.is("model:rootElement", "paragraph") || obj.is("model:rootElement", "blockQuote")) {
+        // $ExpectType (RootElement & { name: "paragraph"; }) | (RootElement & { name: "blockQuote"; })
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("rootElement") || obj.is("rootElement", "paragraph")) 1;
+    // $ExpectError
+    if (obj.is("model:rootElement") || obj.is("model:rootElement", "paragraph")) 1;
+}
+{
+    const obj = modelObj as Element;
+    if (obj.is("element", "paragraph")) {
+        // $ExpectType (RootElement | Element) & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("model:element", "paragraph")) {
+        // $ExpectType (RootElement | Element) & { name: "paragraph"; }
+        obj;
+    }
+    if (obj.is("element", "paragraph") || obj.is("element", "blockQuote")) {
+        // $ExpectType "paragraph" | "blockQuote"
+        obj.name;
+    }
+    if (obj.is("model:element", "paragraph") || obj.is("model:element", "blockQuote")) {
+        // $ExpectType "paragraph" | "blockQuote"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("element") || obj.is("element", "paragraph")) 1;
+    // $ExpectError
+    if (obj.is("model:element") || obj.is("model:element", "paragraph")) 1;
+}
+
 if (modelObj.is("selection") || modelObj.is("model:selection")) {
     const obj: Selection | DocumentSelection = modelObj;
 }
@@ -588,6 +636,31 @@ if (
         | EmptyElement
         | RootEditableElement = viewObj;
 }
+
+{
+    const obj = viewObj as ViewElement;
+    if (obj.is("element", "p") || obj.is("element", "div")) {
+        // $ExpectType (Element & { name: "p"; }) | (Element & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:element", "p") || obj.is("view:element", "div")) {
+        // $ExpectType (Element & { name: "p"; }) | (Element & { name: "div"; })
+        obj;
+    }
+    if (obj.is("element", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    if (obj.is("view:element", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("element") || obj.is("element", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:element") || obj.is("view:element", "p")) 1;
+}
+
 if (
     viewObj.is("containerElement") ||
     viewObj.is("view:containerElement") ||
@@ -596,6 +669,31 @@ if (
 ) {
     const obj: ContainerElement | EditableElement | RootEditableElement = viewObj;
 }
+
+{
+    const obj = viewObj as ContainerElement;
+    if (obj.is("containerElement", "p") || obj.is("containerElement", "div")) {
+        // $ExpectType (ContainerElement & { name: "p"; }) | (ContainerElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:containerElement", "p") || obj.is("view:containerElement", "div")) {
+        // $ExpectType (ContainerElement & { name: "p"; }) | (ContainerElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("containerElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    if (obj.is("view:containerElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("containerElement") || obj.is("containerElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:containerElement") || obj.is("view:containerElement", "p")) 1;
+}
+
 if (
     viewObj.is("editableElement") ||
     viewObj.is("view:editableElement") ||
@@ -604,6 +702,30 @@ if (
 ) {
     const obj: EditableElement | RootEditableElement = viewObj;
 }
+{
+    const obj = viewObj as EditableElement;
+    if (obj.is("editableElement", "p") || obj.is("editableElement", "div")) {
+        // $ExpectType (EditableElement & { name: "p"; }) | (EditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:editableElement", "p") || obj.is("view:editableElement", "div")) {
+        // $ExpectType (EditableElement & { name: "p"; }) | (EditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("editableElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    if (obj.is("view:editableElement", "p")) {
+        // $ExpectType "p"
+        obj.name;
+    }
+    // $ExpectError
+    if (obj.is("editableElement") || obj.is("editableElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:editableElement") || obj.is("view:editableElement", "p")) 1;
+}
+
 if (
     viewObj.is("rootEditableElement") ||
     viewObj.is("view:rootEditableElement") ||
@@ -611,6 +733,29 @@ if (
     viewObj.is("view:rootEditableElement", "div")
 ) {
     const obj: RootEditableElement = viewObj;
+}
+{
+    const obj = viewObj as RootEditableElement;
+    if (obj.is("rootEditableElement", "p") || obj.is("rootEditableElement", "div")) {
+        // $ExpectType (RootEditableElement & { name: "p"; }) | (RootEditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:rootEditableElement", "p") || obj.is("view:rootEditableElement", "div")) {
+        // $ExpectType (RootEditableElement & { name: "p"; }) | (RootEditableElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("rootEditableElement", "p")) {
+        // $ExpectType RootEditableElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:rootEditableElement", "p")) {
+        // $ExpectType RootEditableElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("rootEditableElement") || obj.is("rootEditableElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:rootEditableElement") || obj.is("view:rootEditableElement", "p")) 1;
 }
 if (
     viewObj.is("rawElement") ||
@@ -620,6 +765,30 @@ if (
 ) {
     const obj: RawElement = viewObj;
 }
+{
+    const obj = viewObj as RawElement;
+    if (obj.is("rawElement", "p") || obj.is("rawElement", "div")) {
+        // $ExpectType (RawElement & { name: "p"; }) | (RawElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:rawElement", "p") || obj.is("view:rawElement", "div")) {
+        // $ExpectType (RawElement & { name: "p"; }) | (RawElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("rawElement", "p")) {
+        // $ExpectType RawElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:rawElement", "p")) {
+        // $ExpectType RawElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("rawElement") || obj.is("rawElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:rawElement") || obj.is("view:rawElement", "p")) 1;
+}
+
 if (
     viewObj.is("attributeElement") ||
     viewObj.is("view:attributeElement") ||
@@ -628,6 +797,30 @@ if (
 ) {
     const obj: AttributeElement = viewObj;
 }
+{
+    const obj = viewObj as AttributeElement;
+    if (obj.is("attributeElement", "p") || obj.is("attributeElement", "div")) {
+        // $ExpectType (AttributeElement & { name: "p"; }) | (AttributeElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:attributeElement", "p") || obj.is("view:attributeElement", "div")) {
+        // $ExpectType (AttributeElement & { name: "p"; }) | (AttributeElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("attributeElement", "p")) {
+        // $ExpectType AttributeElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:attributeElement", "p")) {
+        // $ExpectType AttributeElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("attributeElement") || obj.is("attributeElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:attributeElement") || obj.is("view:attributeElement", "p")) 1;
+}
+
 if (
     viewObj.is("uiElement") ||
     viewObj.is("view:uiElement") ||
@@ -636,6 +829,30 @@ if (
 ) {
     const obj: UIElement = viewObj;
 }
+{
+    const obj = viewObj as UIElement;
+    if (obj.is("uiElement", "p") || obj.is("uiElement", "div")) {
+        // $ExpectType (UIElement & { name: "p"; }) | (UIElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("view:uiElement", "p") || obj.is("view:uiElement", "div")) {
+        // $ExpectType (UIElement & { name: "p"; }) | (UIElement & { name: "div"; })
+        obj;
+    }
+    if (obj.is("uiElement", "p")) {
+        // $ExpectType UIElement & { name: "p"; }
+        obj;
+    }
+    if (obj.is("view:uiElement", "p")) {
+        // $ExpectType UIElement & { name: "p"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("uiElement") || obj.is("uiElement", "p")) 1;
+    // $ExpectError
+    if (obj.is("view:uiElement") || obj.is("view:uiElement", "p")) 1;
+}
+
 if (
     viewObj.is("emptyElement") ||
     viewObj.is("view:emptyElement") ||
@@ -643,6 +860,29 @@ if (
     viewObj.is("view:emptyElement", "div")
 ) {
     const obj: EmptyElement = viewObj;
+}
+{
+    const obj = viewObj as EmptyElement;
+    if (obj.is("emptyElement", "hr") || obj.is("emptyElement", "img")) {
+        // $ExpectType (EmptyElement & { name: "hr"; }) | (EmptyElement & { name: "img"; })
+        obj;
+    }
+    if (obj.is("view:emptyElement", "hr") || obj.is("view:emptyElement", "img")) {
+        // $ExpectType (EmptyElement & { name: "hr"; }) | (EmptyElement & { name: "img"; })
+        obj;
+    }
+    if (obj.is("emptyElement", "hr")) {
+        // $ExpectType EmptyElement & { name: "hr"; }
+        obj;
+    }
+    if (obj.is("view:emptyElement", "hr")) {
+        // $ExpectType EmptyElement & { name: "hr"; }
+        obj;
+    }
+    // $ExpectError
+    if (obj.is("emptyElement") || obj.is("emptyElement", "hr")) 1;
+    // $ExpectError
+    if (obj.is("view:emptyElement") || obj.is("view:emptyElement", "hr")) 1;
 }
 
 // Selectable

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/documentfragment.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/documentfragment.d.ts
@@ -37,8 +37,10 @@ export default class DocumentFragment implements Iterable<Element | Text> {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     offsetToIndex(offset: number): number;
     toJSON(): Pick<DocumentFragment, "childCount" | "isEmpty" | "markers" | "maxOffset" | "parent" | "root">;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/documentselection.d.ts
@@ -52,8 +52,10 @@ export default class DocumentSelection implements Emitter {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     observeMarkers(prefixOrName: string): void;
     refresh(): void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/markercollection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/markercollection.d.ts
@@ -42,7 +42,9 @@ export class Marker {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/node.d.ts
@@ -44,8 +44,10 @@ export default class Node {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isAfter(node: Node): boolean;
     isAttached(): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/position.d.ts
@@ -77,8 +77,10 @@ export default class Position {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isAfter(otherPosition: Position): boolean;
     isBefore(otherPosition: Position): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/range.d.ts
@@ -68,8 +68,10 @@ export default class Range implements Iterable<TreeWalkerValue> {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isEqual(otherRange: Range): boolean;
     isIntersecting(otherRange: Range): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/selection.d.ts
@@ -65,8 +65,10 @@ export default class Selection implements Emitter {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     isEqual(otherSelection: Selection): boolean;
     removeAttribute(key: string): void;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/text.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/text.d.ts
@@ -26,8 +26,10 @@ export default class Text extends Node {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
     toJSON(): ReturnType<Node["toJSON"]> & {
         data: string;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/textproxy.d.ts
@@ -44,7 +44,9 @@ export default class TextProxy {
     is(type: "documentSelection" | "model:documentSelection"): this is DocumentSelection;
     is(type: "node" | "model:node"): this is Node | Element | Text | RootElement;
     is(type: "$text" | "model:$text" | "text" | "model:text"): this is Text;
-    is(type: "element" | "model:element", name?: string): this is Element | RootElement;
-    is(type: "rootElement" | "model:rootElement", name?: string): this is RootElement;
+    is(type: "element" | "model:element"): this is Element | RootElement;
+    is(type: "rootElement" | "model:rootElement"): this is RootElement;
+    is<K extends string>(type: "element" | "model:element", name: K): this is (Element | RootElement) & { name: K };
+    is<K extends string>(type: "rootElement" | "model:rootElement", name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/documentfragment.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/documentfragment.d.ts
@@ -51,7 +51,6 @@ export default class DocumentFragment implements Iterable<Node> {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -61,22 +60,47 @@ export default class DocumentFragment implements Iterable<Node> {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/documentselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/documentselection.d.ts
@@ -55,7 +55,6 @@ export default class DocumentSelection {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -65,22 +64,47 @@ export default class DocumentSelection {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/node.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/node.d.ts
@@ -46,7 +46,6 @@ export default abstract class Node {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -56,22 +55,47 @@ export default abstract class Node {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/position.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/position.d.ts
@@ -69,7 +69,6 @@ export default class Position {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -79,22 +78,47 @@ export default class Position {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/range.d.ts
@@ -76,7 +76,6 @@ export default class Range implements Iterable<TreeWalkerValue> {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -86,22 +85,47 @@ export default class Range implements Iterable<TreeWalkerValue> {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/selection.d.ts
@@ -62,7 +62,6 @@ export default class Selection {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -72,22 +71,47 @@ export default class Selection {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/textproxy.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/textproxy.d.ts
@@ -51,7 +51,6 @@ export default class TextProxy {
     is(type: "documentSelection" | "view:documentSelection"): this is DocumentSelection;
     is(
         type: "element" | "view:element",
-        name?: string,
     ): this is
         | Element
         | ContainerElement
@@ -61,22 +60,47 @@ export default class TextProxy {
         | UIElement
         | RawElement
         | EmptyElement;
-    is(type: "attributeElement" | "view:attributeElement", name?: string): this is AttributeElement;
+    is<K extends string>(
+        type: "element" | "view:element",
+        name: K,
+    ): this is (
+        | Element
+        | ContainerElement
+        | EditableElement
+        | RootEditableElement
+        | AttributeElement
+        | UIElement
+        | RawElement
+        | EmptyElement
+    ) & { name: K };
+    is(type: "attributeElement" | "view:attributeElement"): this is AttributeElement;
+    is<K extends string>(
+        type: "attributeElement" | "view:attributeElement",
+        name: K,
+    ): this is AttributeElement & { name: K };
     is(
         type: "containerElement" | "view:containerElement",
-        name?: string,
     ): this is ContainerElement | EditableElement | RootEditableElement;
-    is(
+    is<K extends string>(
+        type: "containerElement" | "view:containerElement",
+        name: K,
+    ): this is (ContainerElement | EditableElement | RootEditableElement) & { name: K };
+    is(type: "editableElement" | "view:editableElement"): this is EditableElement | RootEditableElement;
+    is<K extends string>(
         type: "editableElement" | "view:editableElement",
-        name?: string,
-    ): this is EditableElement | RootEditableElement;
-    is(
+        name: K,
+    ): this is (EditableElement | RootEditableElement) & { name: K };
+    is(type: "rootEditableElement" | "view:rootEditableElement"): this is RootEditableElement;
+    is<K extends string>(
         type: "rootEditableElement" | "view:rootEditableElement",
-        name?: string,
-    ): this is RootEditableElement;
-    is(type: "uiElement" | "view:uiElement", name?: string): this is UIElement;
-    is(type: "rawElement" | "view:rawElement", name?: string): this is RawElement;
-    is(type: "emptyElement" | "view:emptyElement", name?: string): this is EmptyElement;
+        name: K,
+    ): this is RootEditableElement & { name: K };
+    is(type: "uiElement" | "view:uiElement"): this is UIElement;
+    is<K extends string>(type: "uiElement" | "view:uiElement", name: K): this is UIElement & { name: K };
+    is(type: "rawElement" | "view:rawElement"): this is RawElement;
+    is<K extends string>(type: "rawElement" | "view:rawElement", name: K): this is RawElement & { name: K };
+    is(type: "emptyElement" | "view:emptyElement"): this is EmptyElement;
+    is<K extends string>(type: "emptyElement" | "view:emptyElement", name: K): this is EmptyElement & { name: K };
     is(type: "$textProxy" | "view:$textProxy" | "textProxy" | "view:textProxy"): this is TextProxy;
     is(type: "$text" | "view:$text" | "text" | "view:text"): this is Text;
     is(type: string, name?: string): boolean;


### PR DESCRIPTION
Fixes a shortcoming of #55181 as noted in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55181#issuecomment-905938620

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55181#issuecomment-905938620
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ (N/A)