### PR TITLE
@types/chromecast-caf-receiver -- Add getStartAbsoluteTime() to Chromecast receiver

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -564,6 +564,11 @@ export class PlayerManager {
     getDurationSec(): number;
 
     /**
+     * Gets media start time in absolute time for live. Time is in Epoch time.
+     */
+    getStartAbsoluteTime(): number | null;
+
+    /**
      * @returns live seekable range with start and end time in seconds. The values
      *     are media time based.
      */


### PR DESCRIPTION
This adds a missing method from the Chromecast Receiver PlayerManager

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). 
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.PlayerManager#getStartAbsoluteTime
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
