### PR TITLE
fix(markdown-it): remove `undefined` from `Options.quotes` types

### DIFF
--- a/types/markdown-it/lib/index.d.ts
+++ b/types/markdown-it/lib/index.d.ts
@@ -76,7 +76,7 @@ declare namespace MarkdownIt {
          * `['«\xA0', '\xA0»', '‹\xA0', '\xA0›']` for French (including nbsp).
          * @default '“”‘’'
          */
-        quotes?: string | string[] | undefined;
+        quotes?: string | string[];
 
         /**
          * Highlighter function for fenced code blocks.

--- a/types/markdown-it/markdown-it-tests.ts
+++ b/types/markdown-it/markdown-it-tests.ts
@@ -18,10 +18,11 @@ import LinkifyIt = require('linkify-it');
     // test constuctor usage
     let md: MarkdownIt;
     const options: MarkdownIt.Options = {};
+    options.quotes; // $ExpectType string | string[] | undefined
     const presets: MarkdownIt.PresetName[] = ['commonmark', 'zero', 'default'];
 
     md = MarkdownIt();
-    md = new MarkdownIt();
+    md = new MarkdownIt({});
     md = MarkdownIt(options);
     md = new MarkdownIt(options);
 


### PR DESCRIPTION
Native package never checks if that property has a non-nullish value,
but just do a merge with defaults. Before 4.4 with exact property checks
is widely available and used, this specific property IDE hint to provide
`undefined`, leads to runtime error in the package (indexed access of
undefined value)

Fixes #55406

/cc @shellscape

https://github.com/markdown-it/markdown-it/blob/6e2de08a0b03d3d0dcc524b89710ce05f83a0283/lib/rules_core/smartquotes.js#L148-L149

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).