### PR TITLE
[node] Update vm

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -43,6 +43,7 @@
 //                 Yongsheng Zhang <https://github.com/ZYSzys>
 //                 NodeJS Contributors <https://github.com/NodeJS>
 //                 Linus Unnebäck <https://github.com/LinusU>
+//                 wafuwafu13 <https://github.com/wafuwafu13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -87,7 +87,9 @@ import { inspect } from 'node:util';
 
 {
     const script = new Script('foo()', { cachedData: Buffer.from([]) });
+    console.log(script.cachedDataProduced);
     console.log(script.cachedDataRejected);
+    console.log(script.cachedData);
 }
 
 {

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -268,7 +268,7 @@ declare module 'vm' {
          */
         createCachedData(): Buffer;
 
-		/** @deprecated in favor of `script.createCachedData()` */
+        /** @deprecated in favor of `script.createCachedData()` */
         cachedDataProduced?: boolean | undefined;
         cachedDataRejected?: boolean | undefined;
         cachedData?: Buffer | undefined;

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -267,7 +267,9 @@ declare module 'vm' {
          * @since v10.6.0
          */
         createCachedData(): Buffer;
+		cachedDataProduced?: boolean | undefined;
         cachedDataRejected?: boolean | undefined;
+		cachedData?: Buffer | undefined;
     }
     /**
      * If given a `contextObject`, the `vm.createContext()` method will `prepare

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -269,9 +269,9 @@ declare module 'vm' {
         createCachedData(): Buffer;
 
 		/** @deprecated in favor of `script.createCachedData()` */
-		cachedDataProduced?: boolean | undefined;
+        cachedDataProduced?: boolean | undefined;
         cachedDataRejected?: boolean | undefined;
-		cachedData?: Buffer | undefined;
+        cachedData?: Buffer | undefined;
     }
     /**
      * If given a `contextObject`, the `vm.createContext()` method will `prepare

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -267,6 +267,8 @@ declare module 'vm' {
          * @since v10.6.0
          */
         createCachedData(): Buffer;
+
+		/** @deprecated in favor of `script.createCachedData()` */
 		cachedDataProduced?: boolean | undefined;
         cachedDataRejected?: boolean | undefined;
 		cachedData?: Buffer | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Doc: https://nodejs.org/api/vm.html#vm_class_vm_script
>produceCachedData <boolean> When true and no cachedData is present, V8 will attempt to produce code cache data for code. Upon success, a Buffer with V8's code cache data will be produced and stored in the cachedData property of the returned vm.Script instance. The cachedDataProduced value will be set to either true or false depending on whether code cache data is produced successfully.

Code: https://github.com/nodejs/node/blob/v16.7.0/lib/vm.js#L364-L370
Example: https://github.com/babel/babel/blob/b141c85b17414c864c12e8f65f2e14ee70018d38/packages/babel-helper-transform-fixture-test-runner/src/index.ts#L105-L109
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
