### PR TITLE
feat: add missing ORM APIs

### DIFF
--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -49,6 +49,7 @@ declare namespace Waterline {
         loadCollection(collection: CollectionClass): void;
         registerModel(collection: CollectionClass): void;
         initialize: (config: Config, cb: (err: Error, ontology: Ontology) => any) => any;
+        teardown(done?: Function): void;
         collections: any;
     }
 
@@ -307,6 +308,13 @@ declare namespace Waterline {
         native(cb: (err: Error, collection: any) => void): void;
         stream(criteria: any, writeEnd: any): NodeJS.WritableStream | Error;
     }
+
+    export interface StartOptions {
+        adapters: Record<string, Adapter>;
+        datastores: Record<string, DatastoreConfig & { identity?: undefined }>;
+        models: Record<string, CollectionDefinition>;
+        defaultModelSettings?: CollectionDefinition;
+    }
 }
 
 declare interface WaterlineStatic {
@@ -317,6 +325,8 @@ declare interface WaterlineStatic {
         extend: (params: Waterline.CollectionDefinition) => Waterline.CollectionClass;
     };
     new(): Waterline.Waterline;
+    start<CB extends (err: Error | undefined, orm: Waterline.Waterline) => unknown>(options: Waterline.StartOptions, done: CB): CB;
+    stop<CB extends (err: Error | undefined) => unknown>(orm: Waterline.Waterline, done: CB): ReturnType<CB>;
 }
 
 declare var Waterline: WaterlineStatic;

--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -122,6 +122,62 @@ const attributes: Waterline.Attribute = {
     autoIncrement: true,
     required: true,
 };
+
+// Experimental lifecycle commands
+
+Waterline.start({
+    adapters: {
+        memory: {}
+    },
+    datastores: {
+        default: {
+            adapter: 'memory'
+        }
+    },
+    models: {
+        person: {
+            identity: 'person',
+            connection: 'local-postgresql',
+
+            attributes: {
+                // Don"t allow two objects with the same value
+                lastName: {
+                    type: 'string',
+                    unique: true,
+                },
+
+                // Ensure a value is set
+                age: {
+                    type: 'integer',
+                    required: true,
+                },
+
+                // Set a default value if no value is set
+                phoneNumber: {
+                    type: 'string',
+                    defaultsTo: '111-222-3333',
+                },
+
+                // Create an auto-incrementing value (not supported by all datastores)
+                incrementMe: {
+                    type: 'integer',
+                    autoIncrement: true,
+                },
+
+                // Index a value for faster queries
+                emailAddress: {
+                    type: 'email', // Email type will get validated by the ORM
+                    index: true,
+                },
+            },
+        }
+    }
+}, (err, orm) => {
+    orm.teardown();
+    orm.teardown(() => {});
+    Waterline.stop(orm, err => {});
+});
+
 // https://github.com/balderdashy/waterline-docs/blob/master/models/validations.md
 const validations: Waterline.AttributeValidations = {
     custom: () => true,


### PR DESCRIPTION
The `StartOptions` interface is in a bit of an awkward place; Depending on private typings within the `Waterline` namespace while being referenced within the `WaterlineStatic` interface. As an intermediary, it is exported; Though I'm open to suggestion for a less hacky solution.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- Create it with `dts-gen --dt`, not by basing it on an existing project.
- Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - `Waterline.start()`
        https://github.com/balderdashy/waterline/blob/7b467a46e8f8edac5a21114e23392b87136ab09d/lib/waterline.js#L827-L941
    - `Waterline.stop()`
        https://github.com/balderdashy/waterline/blob/7b467a46e8f8edac5a21114e23392b87136ab09d/lib/waterline.js#L951-L987
    - `new Waterline().teardown()`
        https://github.com/balderdashy/waterline/blob/7b467a46e8f8edac5a21114e23392b87136ab09d/lib/waterline.js#L732-L771
    - `interface StartOptions` (inferred from `Waterline.start()` code)
        https://github.com/balderdashy/waterline/blob/7b467a46e8f8edac5a21114e23392b87136ab09d/lib/waterline.js#L836-L860
        https://github.com/balderdashy/waterline/blob/7b467a46e8f8edac5a21114e23392b87136ab09d/lib/waterline.js#L866-L877
        https://github.com/balderdashy/waterline/blob/7b467a46e8f8edac5a21114e23392b87136ab09d/lib/waterline.js#L888-L909

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the https://github.com/balderdashy/waterline/blob/master/lib/waterline.js#L827-L941version number in the header.

If removing a declaration:
- If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- Delete the package's directory.
- Add it to `notNeededPackages.json`.
