### PR TITLE
[leaflet] Add `Bounds.valid()` and `Bounds()`

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -232,8 +232,7 @@ export type BoundsLiteral = [PointTuple, PointTuple];
 
 export class Bounds {
     constructor(topLeft: PointExpression, bottomRight: PointExpression);
-    constructor(points: Point[] | BoundsLiteral);
-    constructor();
+    constructor(points?: Point[] | BoundsLiteral);
     extend(point: PointExpression): this;
     getCenter(round?: boolean): Point;
     getBottomLeft(): Point;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -233,6 +233,7 @@ export type BoundsLiteral = [PointTuple, PointTuple];
 export class Bounds {
     constructor(topLeft: PointExpression, bottomRight: PointExpression);
     constructor(points: Point[] | BoundsLiteral);
+    constructor();
     extend(point: PointExpression): this;
     getCenter(round?: boolean): Point;
     getBottomLeft(): Point;
@@ -243,6 +244,7 @@ export class Bounds {
     contains(pointOrBounds: BoundsExpression | PointExpression): boolean;
     intersects(otherBounds: BoundsExpression): boolean;
     overlaps(otherBounds: BoundsExpression): boolean;
+    isValid(): boolean;
 
     min?: Point | undefined;
     max?: Point | undefined;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -64,6 +64,7 @@ bounds = L.bounds(pointTuple, pointTuple);
 bounds = L.bounds([point, point]);
 bounds = L.bounds(boundsLiteral);
 
+bounds = new L.Bounds();
 bounds = new L.Bounds(point, point);
 bounds = new L.Bounds(pointTuple, pointTuple);
 bounds = new L.Bounds([point, point]);
@@ -73,6 +74,8 @@ const topLeft = bounds.getTopLeft();
 const topRight = bounds.getTopRight();
 const bottomLeft = bounds.getBottomLeft();
 const bottomRight = bounds.getBottomRight();
+
+bounds.isValid();
 
 let points: L.Point[];
 points = L.LineUtil.simplify([point, point], 1);


### PR DESCRIPTION
The empty Bounds constructor can be used to iteratively extend a Bounds object (like in [Polyline._project()](https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/layer/vector/Polyline.js#L202)).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Bounds.isValid()](https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/geometry/Bounds.js#L157), [Bounds()](https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/geometry/Bounds.js#L29)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.