### PR TITLE
Fix @types/chai Allow chaining with a/an

### DIFF
--- a/types/chai/v2/index.d.ts
+++ b/types/chai/v2/index.d.ts
@@ -49,8 +49,8 @@ declare namespace Chai {
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
         not: Assertion;
         deep: Deep;
-        a: TypeComparison;
-        an: TypeComparison;
+        a: Assertion;
+        an: Assertion;
         include: Include;
         contain: Include;
         ok: Assertion;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/bdd/ see section `.a(type[, msg])`, last few lines
- [ ] If this PR ~brings the type definitions up to date with a new version of the JS library~, update the version number in the header.

----

The current types don't allow using `.a.` or `.an.` as part of a readable assertion chain. The actual example in the doc fails type check

```
error TS2339: Property 'property' does not exist on type 'TypeComparison'.

12       expect({ b: 2 }).to.have.a.property('b');
                                    ~~~~~~~~
```
