### PR TITLE
Bencode: define overloads for `decode` function

### DIFF
--- a/types/bencode/bencode-tests.ts
+++ b/types/bencode/bencode-tests.ts
@@ -4,3 +4,6 @@ bencode.byteLength("abcde"); // $ExpectType number
 bencode.encodingLength("abcde"); // $ExpectType number
 bencode.encode([1, 2, 3, 4], new Buffer([]), 1); // $ExpectType Buffer
 bencode.decode(new Buffer("abcde"), 1, 3); // $ExpectType any
+bencode.decode(new Buffer("abcde"), 1, 3, 'utf-8'); // $ExpectType any
+bencode.decode(new Buffer("abcde"), 1, 'utf-8'); // $ExpectType any
+bencode.decode(new Buffer("abcde"), 'utf-8'); // $ExpectType any

--- a/types/bencode/index.d.ts
+++ b/types/bencode/index.d.ts
@@ -8,6 +8,8 @@
 export function byteLength(value: any): number;
 export function encodingLength(value: any): number;
 export function encode(data: any, buffer?: Buffer, offset?: number): Buffer;
+export function decode(data: Buffer, encoding?: string): any;
+export function decode(data: Buffer, start?: number, encoding?: string): any;
 export function decode(
     data: Buffer,
     start?: number,


### PR DESCRIPTION
`decode` function acts as an ***overloaded*** function, where `encoding` can be either 2nd/3rd/4th argument. But ts throws if used that way, since encoding's `string` type cannot be assigned to `number|undefined` type

So this PR defines the required overloads.

Function defined [here](https://github.com/webtorrent/node-bencode/blob/1bf04a25691f0118c3e456a020cdcf4ab9c553c8/lib/decode.js#L57)