### PR TITLE
ml-levenberg-marquardt: Fix name of minValues and maxValues in Options interface.

### DIFF
--- a/types/ml-levenberg-marquardt/index.d.ts
+++ b/types/ml-levenberg-marquardt/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/mljs/levenberg-marquardt#readme
 // Definitions by: m93a <https://github.com/m93a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 declare namespace LM {
     /**

--- a/types/ml-levenberg-marquardt/index.d.ts
+++ b/types/ml-levenberg-marquardt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ml-levenberg-marquardt 1.0
+// Type definitions for ml-levenberg-marquardt 3.1
 // Project: https://github.com/mljs/levenberg-marquardt#readme
 // Definitions by: m93a <https://github.com/m93a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -21,22 +21,48 @@ declare namespace LM {
 
     interface Options {
         /**
+         * Maximum time running before throw in seconds.
+         */
+        timeout: number;
+
+        /**
+         * Maximum values for the parameters.
+         * Default value: Array(parameters.length).fill(MAX_SAFE_INTEGER)
+         */
+        maxValues: number[];
+
+        /**
+         * Minimum values for the parameters.
+         * Default value: Array(parameters.length).fill(MIN_SAFE_INTEGER)
+         */
+        minValues: number[];
+
+        /**
+         * Initial guesses for the parameters.
+         * Default value: Array(parameters.length).fill(1)
+         */
+        initialValues: number[];
+
+         /**
+          * Weighting vector, if the length does not match with the number of data points, the vector is reconstructed with first value.
+          */
+        weights: number[];
+
+        /**
          * The Levenberg-Marquardt lambda parameter.
          * Default value: 0
          */
         damping: number;
 
         /**
-         * Initial guesses for the parameters.
-         * Default value: Array(parameters.lengh).fill(1)
+         * Factor to increase the damping (Levenberg-Marquardt parameter) when there is an improvement when updating parameters.
          */
-        initialValues: number[];
+        dampingStepUp: number;
 
         /**
-         * Adjustment for decrease the damping parameter.
-         * Default value: 10e-2
+         * factor to reduce the damping (Levenberg-Marquardt parameter) when there is not an improvement when updating parameters.
          */
-        gradientDifference: number;
+        dampingStepDown: number;
 
         /**
          * The maximum number of iterations before halting.
@@ -51,16 +77,19 @@ declare namespace LM {
         errorTolerance: number;
 
         /**
-         * Maximum values for the parameters.
-         * Default value: Array(data.x.length).fill(MAX_SAFE_INTEGER)
+         * If true the jacobian matrix is approximated by central differences otherwise by forward differences.
          */
-        maxValues: number[];
+        centralDifference: boolean;
 
         /**
-         * Minimum values for the parameters.
-         * Default value: Array(data.x.length).fill(MIN_SAFE_INTEGER)
+         * The step size to approximate the jacobian matrix.
          */
-        minValues: number[];
+        gradientDifference: number | number[];
+
+        /**
+         * The threshold to define an improvement through an update of parameters.
+         */
+        improvementThreshold: number;
     }
 
     interface Result {

--- a/types/ml-levenberg-marquardt/index.d.ts
+++ b/types/ml-levenberg-marquardt/index.d.ts
@@ -54,13 +54,13 @@ declare namespace LM {
          * Maximum values for the parameters.
          * Default value: Array(data.x.length).fill(MAX_SAFE_INTEGER)
          */
-        maxValue: number[];
+        maxValues: number[];
 
         /**
          * Minimum values for the parameters.
          * Default value: Array(data.x.length).fill(MIN_SAFE_INTEGER)
          */
-        minValue: number[];
+        minValues: number[];
     }
 
     interface Result {

--- a/types/ml-levenberg-marquardt/ml-levenberg-marquardt-tests.ts
+++ b/types/ml-levenberg-marquardt/ml-levenberg-marquardt-tests.ts
@@ -14,10 +14,14 @@ const data = {
 };
 
 const initialValues = [ 2, 4 ];
+const maxValues = [4, 8];
+const minValues = [0, 0];
 
 const options = {
   damping: 1.5,
   initialValues,
+  maxValues,
+  minValues,
   gradientDifference: 10e-2,
   maxIterations: 100,
   errorTolerance: 10e-3

--- a/types/ml-levenberg-marquardt/v1/index.d.ts
+++ b/types/ml-levenberg-marquardt/v1/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/mljs/levenberg-marquardt#readme
 // Definitions by: m93a <https://github.com/m93a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 declare namespace LM {
     /**

--- a/types/ml-levenberg-marquardt/v1/index.d.ts
+++ b/types/ml-levenberg-marquardt/v1/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for ml-levenberg-marquardt 1.0
+// Project: https://github.com/mljs/levenberg-marquardt#readme
+// Definitions by: m93a <https://github.com/m93a>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare namespace LM {
+    /**
+     * Function that receives an array of parameters and returns
+     * a function with the independent variable as a parameter.
+     */
+    type FittedFunction = (parameters: number[]) => (x: number) => number;
+
+    /**
+     * Coordinates of points to fit.
+     */
+    interface Data {
+        x: number[];
+        y: number[];
+    }
+
+    interface Options {
+        /**
+         * The Levenberg-Marquardt lambda parameter.
+         * Default value: 0
+         */
+        damping: number;
+
+        /**
+         * Initial guesses for the parameters.
+         * Default value: Array(parameters.lengh).fill(1)
+         */
+        initialValues: number[];
+
+        /**
+         * Adjustment for decrease the damping parameter.
+         * Default value: 10e-2
+         */
+        gradientDifference: number;
+
+        /**
+         * The maximum number of iterations before halting.
+         * Default value: 100
+         */
+        maxIterations: number;
+
+        /**
+         * Minimum uncertainty allowed for each point.
+         * Default value: 10e-3
+         */
+        errorTolerance: number;
+    }
+
+    interface Result {
+        iterations: number;
+        parameterError: number;
+        parameterValues: number[];
+    }
+}
+
+/** Implementation of the Levenberg-Marquardt curve fitting method. */
+declare function LM(d: LM.Data, fn: LM.FittedFunction, o?: Partial<LM.Options>): LM.Result;
+
+export = LM;

--- a/types/ml-levenberg-marquardt/v1/ml-levenberg-marquardt-tests.ts
+++ b/types/ml-levenberg-marquardt/v1/ml-levenberg-marquardt-tests.ts
@@ -1,0 +1,31 @@
+import LM = require('ml-levenberg-marquardt');
+
+function sinFunction([a, b]: number[]) {
+  return (t: number) => a * Math.sin(b * t);
+}
+
+const data = {
+  x: [
+    0, Math.PI / 2, Math.PI, Math.PI * 3 / 2
+  ],
+  y: [
+    0, 1, 0, -1
+  ]
+};
+
+const initialValues = [ 2, 4 ];
+
+const options = {
+  damping: 1.5,
+  initialValues,
+  gradientDifference: 10e-2,
+  maxIterations: 100,
+  errorTolerance: 10e-3
+};
+
+const fittedParams = LM(data, sinFunction, options);
+
+// this doesn't make sense but it uses fittedParams...
+if (fittedParams.iterations < 10) {
+    fittedParams.parameterValues[0] += fittedParams.parameterError;
+}

--- a/types/ml-levenberg-marquardt/v1/tsconfig.json
+++ b/types/ml-levenberg-marquardt/v1/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strictFunctionTypes": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "paths": {
+            "ml-levenberg-marquardt": [
+                "ml-levenberg-marquardt/v1"
+            ],
+            "ml-levenberg-marquardt/*": [
+                "ml-levenberg-marquardt/v1/*"
+            ]
+        },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ml-levenberg-marquardt-tests.ts"
+    ]
+}

--- a/types/ml-levenberg-marquardt/v1/tslint.json
+++ b/types/ml-levenberg-marquardt/v1/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/ml-levenberg-marquardt/v2/index.d.ts
+++ b/types/ml-levenberg-marquardt/v2/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/mljs/levenberg-marquardt#readme
 // Definitions by: m93a <https://github.com/m93a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 declare namespace LM {
     /**

--- a/types/ml-levenberg-marquardt/v2/index.d.ts
+++ b/types/ml-levenberg-marquardt/v2/index.d.ts
@@ -1,0 +1,76 @@
+// Type definitions for ml-levenberg-marquardt 2.1
+// Project: https://github.com/mljs/levenberg-marquardt#readme
+// Definitions by: m93a <https://github.com/m93a>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare namespace LM {
+    /**
+     * Function that receives an array of parameters and returns
+     * a function with the independent variable as a parameter.
+     */
+    type FittedFunction = (parameters: number[]) => (x: number) => number;
+
+    /**
+     * Coordinates of points to fit.
+     */
+    interface Data {
+        x: number[];
+        y: number[];
+    }
+
+    interface Options {
+        /**
+         * The Levenberg-Marquardt lambda parameter.
+         * Default value: 0
+         */
+        damping: number;
+
+        /**
+         * Initial guesses for the parameters.
+         * Default value: Array(parameters.lengh).fill(1)
+         */
+        initialValues: number[];
+
+        /**
+         * Adjustment for decrease the damping parameter.
+         * Default value: 10e-2
+         */
+        gradientDifference: number;
+
+        /**
+         * The maximum number of iterations before halting.
+         * Default value: 100
+         */
+        maxIterations: number;
+
+        /**
+         * Minimum uncertainty allowed for each point.
+         * Default value: 10e-3
+         */
+        errorTolerance: number;
+
+        /**
+         * Maximum values for the parameters.
+         * Default value: Array(parameters.length).fill(MAX_SAFE_INTEGER)
+         */
+         maxValues: number[];
+
+         /**
+          * Minimum values for the parameters.
+          * Default value: Array(parameters.length).fill(MIN_SAFE_INTEGER)
+          */
+         minValues: number[];
+    }
+
+    interface Result {
+        iterations: number;
+        parameterError: number;
+        parameterValues: number[];
+    }
+}
+
+/** Implementation of the Levenberg-Marquardt curve fitting method. */
+declare function LM(d: LM.Data, fn: LM.FittedFunction, o?: Partial<LM.Options>): LM.Result;
+
+export = LM;

--- a/types/ml-levenberg-marquardt/v2/ml-levenberg-marquardt-tests.ts
+++ b/types/ml-levenberg-marquardt/v2/ml-levenberg-marquardt-tests.ts
@@ -1,0 +1,35 @@
+import LM = require('ml-levenberg-marquardt');
+
+function sinFunction([a, b]: number[]) {
+  return (t: number) => a * Math.sin(b * t);
+}
+
+const data = {
+  x: [
+    0, Math.PI / 2, Math.PI, Math.PI * 3 / 2
+  ],
+  y: [
+    0, 1, 0, -1
+  ]
+};
+
+const initialValues = [ 2, 4 ];
+const maxValues = [4, 8];
+const minValues = [0, 0];
+
+const options = {
+  damping: 1.5,
+  initialValues,
+  maxValues,
+  minValues,
+  gradientDifference: 10e-2,
+  maxIterations: 100,
+  errorTolerance: 10e-3
+};
+
+const fittedParams = LM(data, sinFunction, options);
+
+// this doesn't make sense but it uses fittedParams...
+if (fittedParams.iterations < 10) {
+    fittedParams.parameterValues[0] += fittedParams.parameterError;
+}

--- a/types/ml-levenberg-marquardt/v2/tsconfig.json
+++ b/types/ml-levenberg-marquardt/v2/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strictFunctionTypes": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "paths": {
+            "ml-levenberg-marquardt": [
+                "ml-levenberg-marquardt/v2"
+            ],
+            "ml-levenberg-marquardt/*": [
+                "ml-levenberg-marquardt/v2/*"
+            ]
+        },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ml-levenberg-marquardt-tests.ts"
+    ]
+}

--- a/types/ml-levenberg-marquardt/v2/tslint.json
+++ b/types/ml-levenberg-marquardt/v2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- This PR fixes an error in the existing type definitions for [ml-levenberg-marquardt](https://github.com/mljs/levenberg-marquardt)

----

The `LM` function of ml-levenberg-marquardt takes an options argument; `index.d.ts` declares an interface for this options object. The options include arrays of minimum and maximum values for each parameter being fit by the `LM` function. This `index.d.ts` had previously named those arrays `maxValue` and `minValue`. This is an error; the `LM` function uses the `maxValues` and `minValues` fields of the options object. This PR corrects the error.

