### PR TITLE
prosemirror-view@1.19.3: Fix `update` function in `NodeView`

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -683,7 +683,7 @@ export interface NodeView<S extends Schema = any> {
      * no `dom` property), updating its child nodes will be handled by
      * ProseMirror.
      */
-    update?: ((node: ProsemirrorNode<S>, decorations: Decoration[]) => boolean) | null;
+    update?: ((node: ProsemirrorNode<S>, decorations: Decoration[], innerDecorations: DecorationSet) => boolean) | null;
     /**
      * Can be used to override the way the node's selected status (as a
      * node selection) is displayed.

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-view 1.18
+// Type definitions for prosemirror-view 1.19.3
 // Project: https://github.com/ProseMirror/prosemirror-view
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-view 1.19.3
+// Type definitions for prosemirror-view 1.19
 // Project: https://github.com/ProseMirror/prosemirror-view
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>


### PR DESCRIPTION
prosemirror-view@1.19.3

The update function was missing the third argument - `DecorationSource`. The argument is there in the docs - https://prosemirror.net/docs/ref/#view.NodeView.update and when you run the code the argument is also there. I gave it the `DecorationSet` type because that's its type at runtime. The docs also mention that the `DecorationSource` is implemented by `DecorationSet` (https://prosemirror.net/docs/ref/#view.DecorationSource).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code that provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
