### PR TITLE
[luxon] Minor fixes and improvements

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -160,9 +160,10 @@ export interface DateTimeFormatPreset {
     hourCycle?: 'h23';
 }
 
+export type ToLocalePartsType = keyof Omit<DateTimeFormatPreset, 'hourCycle'> | 'literal';
 export type ToLocalePartsOutput = [
     {
-        type: keyof Omit<DateTimeFormatPreset, 'hourCycle'> | 'literal';
+        type: ToLocalePartsType;
         value: string;
     },
 ];
@@ -358,7 +359,7 @@ export class DateTime {
      * @param options - configuration options for the DateTime
      * @param options.zone - the zone to place the DateTime into
      */
-    static fromJSDate(date?: Date, options?: { zone?: string | Zone }): DateTime;
+    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTime;
 
     /**
      * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
@@ -420,7 +421,7 @@ export class DateTime {
      * @example
      * DateTime.fromObject({ weekYear: 2016, weekNumber: 2, weekday: 3 }).toISODate() //=> '2016-01-13'
      */
-    static fromObject(obj?: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
+    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
 
     /**
      * Create a DateTime from an ISO 8601 string
@@ -444,7 +445,7 @@ export class DateTime {
      * @example
      * DateTime.fromISO('2016-W05-4')
      */
-    static fromISO(text?: string, opts?: DateTimeOptions): DateTime;
+    static fromISO(text: string, opts?: DateTimeOptions): DateTime;
 
     /**
      * Create a DateTime from an RFC 2822 string
@@ -489,7 +490,7 @@ export class DateTime {
      * @example
      * DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
      */
-    static fromHTTP(text?: string, opts?: DateTimeOptions): DateTime;
+    static fromHTTP(text: string, opts?: DateTimeOptions): DateTime;
 
     /**
      * Create a DateTime from an input string and format string.
@@ -541,7 +542,7 @@ export class DateTime {
      * @example
      * DateTime.fromSQL('09:12:34.342')
      */
-    static fromSQL(text?: string, opts?: DateTimeOptions): DateTime;
+    static fromSQL(text: string, opts?: DateTimeOptions): DateTime;
 
     /**
      * Create an invalid DateTime.
@@ -866,7 +867,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).reconfigure({ locale: 'en-GB' })
      */
-    reconfigure(properties?: LocaleOptions): DateTime;
+    reconfigure(properties: LocaleOptions): DateTime;
 
     /**
      * "Set" the locale. Returns a newly-constructed DateTime.
@@ -875,7 +876,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).setLocale('en-GB')
      */
-    setLocale(locale?: string): DateTime;
+    setLocale(locale: string): DateTime;
 
     /**
      * "Set" the values of specified units. Returns a newly-constructed DateTime.
@@ -892,7 +893,7 @@ export class DateTime {
      * @example
      * dt.set({ year: 2005, ordinal: 234 })
      */
-    set(values?: DateObjectUnits): DateTime;
+    set(values: DateObjectUnits): DateTime;
 
     /**
      * Adding hours, minutes, seconds, or milliseconds increases the timestamp by the right number of milliseconds. Adding days, months, or years shifts the calendar,

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -103,6 +103,7 @@ export interface LocaleOptions {
     outputCalendar?: CalendarSystem | undefined;
     numberingSystem?: NumberingSystem | undefined;
 }
+export type ResolvedLocaleOptions = Required<LocaleOptions>;
 
 export interface DateTimeOptions extends LocaleOptions {
     /**
@@ -145,6 +146,26 @@ export interface DateObjectUnits {
 }
 
 export type ConversionAccuracy = 'casual' | 'longterm';
+
+export type DateTimeFormatPresetValue = 'numeric' | 'short' | 'long';
+export interface DateTimeFormatPreset {
+    year?: DateTimeFormatPresetValue;
+    month?: DateTimeFormatPresetValue;
+    day?: DateTimeFormatPresetValue;
+    weekday?: DateTimeFormatPresetValue;
+    hour?: DateTimeFormatPresetValue;
+    minute?: DateTimeFormatPresetValue;
+    second?: DateTimeFormatPresetValue;
+    timeZoneName?: DateTimeFormatPresetValue;
+    hourCycle?: 'h23';
+}
+
+export type ToLocalePartsOutput = [
+    {
+        type: keyof Omit<DateTimeFormatPreset, 'hourCycle'> | 'literal';
+        value: string;
+    },
+];
 
 export interface DiffOptions {
     conversionAccuracy?: ConversionAccuracy | undefined;
@@ -231,15 +252,37 @@ export class DateTime {
      * DateTime.local(2017, 3, 12, 5, 45, 10, 765)       //~> 2017-03-12T05:45:10.765
      */
     static local(
-        year?: number,
-        month?: number,
-        day?: number,
-        hour?: number,
-        minute?: number,
-        second?: number,
-        millisecond?: number,
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        millisecond: number,
         opts?: DateTimeJSOptions,
     ): DateTime;
+    static local(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        opts?: DateTimeJSOptions,
+    ): DateTime;
+    static local(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        opts?: DateTimeJSOptions,
+    ): DateTime;
+    static local(year: number, month: number, day: number, hour: number, opts?: DateTimeJSOptions): DateTime;
+    static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTime;
+    static local(year: number, month: number, opts?: DateTimeJSOptions): DateTime;
+    static local(year: number, opts?: DateTimeJSOptions): DateTime;
+    static local(opts?: DateTimeJSOptions): DateTime;
 
     /**
      * Create a DateTime in UTC
@@ -276,15 +319,37 @@ export class DateTime {
      * DateTime.utc(2017, 3, 12, 5, 45, 10, 765, { locale: "fr") //~> 2017-03-12T05:45:10.765Z with a French locale
      */
     static utc(
-        year?: number,
-        month?: number,
-        day?: number,
-        hour?: number,
-        minute?: number,
-        second?: number,
-        millisecond?: number,
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        millisecond: number,
         options?: LocaleOptions,
     ): DateTime;
+    static utc(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        options?: LocaleOptions,
+    ): DateTime;
+    static utc(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        options?: LocaleOptions,
+    ): DateTime;
+    static utc(year: number, month: number, day: number, hour: number, options?: LocaleOptions): DateTime;
+    static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTime;
+    static utc(year: number, month: number, options?: LocaleOptions): DateTime;
+    static utc(year: number, options?: LocaleOptions): DateTime;
+    static utc(options?: LocaleOptions): DateTime;
 
     /**
      * Create a DateTime from a JavaScript Date object. Uses the default zone.
@@ -293,7 +358,7 @@ export class DateTime {
      * @param options - configuration options for the DateTime
      * @param options.zone - the zone to place the DateTime into
      */
-    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTime;
+    static fromJSDate(date?: Date, options?: { zone?: string | Zone }): DateTime;
 
     /**
      * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
@@ -355,7 +420,7 @@ export class DateTime {
      * @example
      * DateTime.fromObject({ weekYear: 2016, weekNumber: 2, weekday: 3 }).toISODate() //=> '2016-01-13'
      */
-    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
+    static fromObject(obj?: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
 
     /**
      * Create a DateTime from an ISO 8601 string
@@ -379,7 +444,7 @@ export class DateTime {
      * @example
      * DateTime.fromISO('2016-W05-4')
      */
-    static fromISO(text: string, opts?: DateTimeOptions): DateTime;
+    static fromISO(text?: string, opts?: DateTimeOptions): DateTime;
 
     /**
      * Create a DateTime from an RFC 2822 string
@@ -424,7 +489,7 @@ export class DateTime {
      * @example
      * DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
      */
-    static fromHTTP(text: string, opts?: DateTimeOptions): DateTime;
+    static fromHTTP(text?: string, opts?: DateTimeOptions): DateTime;
 
     /**
      * Create a DateTime from an input string and format string.
@@ -476,7 +541,7 @@ export class DateTime {
      * @example
      * DateTime.fromSQL('09:12:34.342')
      */
-    static fromSQL(text: string, opts?: DateTimeOptions): DateTime;
+    static fromSQL(text?: string, opts?: DateTimeOptions): DateTime;
 
     /**
      * Create an invalid DateTime.
@@ -642,7 +707,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).ordinal //=> 145
      */
-    get ordinal(): number | DateTime;
+    get ordinal(): number;
 
     /**
      * Get the human readable short month name, such as 'Oct'.
@@ -759,7 +824,7 @@ export class DateTime {
      *
      * @param opts - the same options as toLocaleString
      */
-    resolvedLocaleOptions(opts?: LocaleOptions & DateTimeFormatOptions): Intl.ResolvedDateTimeFormatOptions;
+    resolvedLocaleOptions(opts?: LocaleOptions | DateTimeFormatOptions): ResolvedLocaleOptions;
 
     // TRANSFORM
 
@@ -801,7 +866,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).reconfigure({ locale: 'en-GB' })
      */
-    reconfigure(properties: LocaleOptions): DateTime;
+    reconfigure(properties?: LocaleOptions): DateTime;
 
     /**
      * "Set" the locale. Returns a newly-constructed DateTime.
@@ -810,7 +875,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).setLocale('en-GB')
      */
-    setLocale(locale: string): DateTime;
+    setLocale(locale?: string): DateTime;
 
     /**
      * "Set" the values of specified units. Returns a newly-constructed DateTime.
@@ -827,7 +892,7 @@ export class DateTime {
      * @example
      * dt.set({ year: 2005, ordinal: 234 })
      */
-    set(values: DateObjectUnits): DateTime;
+    set(values?: DateObjectUnits): DateTime;
 
     /**
      * Adding hours, minutes, seconds, or milliseconds increases the timestamp by the right number of milliseconds. Adding days, months, or years shifts the calendar,
@@ -943,7 +1008,7 @@ export class DateTime {
      * @example
      * DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }); //=> '11:32'
      */
-    toLocaleString(formatOpts?: DateTimeFormatOptions, opts?: LocaleOptions): string;
+    toLocaleString(formatOpts?: DateTimeFormatPreset | DateTimeFormatOptions, opts?: LocaleOptions): string;
 
     /**
      * Returns an array of format "parts", meaning individual tokens along with metadata. This is allows callers to post-process individual sections of the formatted output.
@@ -961,7 +1026,7 @@ export class DateTime {
      *                                 //=>   { type: 'year', value: '1982' }
      *                                 //=> ]
      */
-    toLocaleParts(opts: DateTimeFormatOptions): Intl.DateTimeFormat[];
+    toLocaleParts(opts?: DateTimeFormatPreset | DateTimeFormatOptions): ToLocalePartsOutput;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime
@@ -1287,110 +1352,110 @@ export class DateTime {
     /**
      * {@link DateTime.toLocaleString} format like 10/14/1983
      */
-    static get DATE_SHORT(): DateTimeFormatOptions;
+    static get DATE_SHORT(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Oct 14, 1983'
      */
-    static get DATE_MED(): DateTimeFormatOptions;
+    static get DATE_MED(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Fri, Oct 14, 1983'
      */
-    static get DATE_MED_WITH_WEEKDAY(): DateTimeFormatOptions;
+    static get DATE_MED_WITH_WEEKDAY(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'October 14, 1983'
      */
-    static get DATE_FULL(): DateTimeFormatOptions;
+    static get DATE_FULL(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Tuesday, October 14, 1983'
      */
-    static get DATE_HUGE(): DateTimeFormatOptions;
+    static get DATE_HUGE(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30 AM'. Only 12-hour if the locale is.
      */
-    static get TIME_SIMPLE(): DateTimeFormatOptions;
+    static get TIME_SIMPLE(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30:23 AM'. Only 12-hour if the locale is.
      */
-    static get TIME_WITH_SECONDS(): DateTimeFormatOptions;
+    static get TIME_WITH_SECONDS(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30:23 AM EDT'. Only 12-hour if the locale is.
      */
-    static get TIME_WITH_SHORT_OFFSET(): DateTimeFormatOptions;
+    static get TIME_WITH_SHORT_OFFSET(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30:23 AM Eastern Daylight Time'. Only 12-hour if the locale is.
      */
-    static get TIME_WITH_LONG_OFFSET(): DateTimeFormatOptions;
+    static get TIME_WITH_LONG_OFFSET(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30', always 24-hour.
      */
-    static get TIME_24_SIMPLE(): DateTimeFormatOptions;
+    static get TIME_24_SIMPLE(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30:23', always 24-hour.
      */
-    static get TIME_24_WITH_SECONDS(): DateTimeFormatOptions;
+    static get TIME_24_WITH_SECONDS(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30:23 EDT', always 24-hour.
      */
-    static get TIME_24_WITH_SHORT_OFFSET(): DateTimeFormatOptions;
+    static get TIME_24_WITH_SHORT_OFFSET(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '09:30:23 Eastern Daylight Time', always 24-hour.
      */
-    static get TIME_24_WITH_LONG_OFFSET(): DateTimeFormatOptions;
+    static get TIME_24_WITH_LONG_OFFSET(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '10/14/1983, 9:30 AM'. Only 12-hour if the locale is.
      */
-    static get DATETIME_SHORT(): DateTimeFormatOptions;
+    static get DATETIME_SHORT(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like '10/14/1983, 9:30:33 AM'. Only 12-hour if the locale is.
      */
-    static get DATETIME_SHORT_WITH_SECONDS(): DateTimeFormatOptions;
+    static get DATETIME_SHORT_WITH_SECONDS(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Oct 14, 1983, 9:30 AM'. Only 12-hour if the locale is.
      */
-    static get DATETIME_MED(): DateTimeFormatOptions;
+    static get DATETIME_MED(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Oct 14, 1983, 9:30:33 AM'. Only 12-hour if the locale is.
      */
-    static get DATETIME_MED_WITH_SECONDS(): DateTimeFormatOptions;
+    static get DATETIME_MED_WITH_SECONDS(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Fri, 14 Oct 1983, 9:30 AM'. Only 12-hour if the locale is.
      */
-    static get DATETIME_MED_WITH_WEEKDAY(): DateTimeFormatOptions;
+    static get DATETIME_MED_WITH_WEEKDAY(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'October 14, 1983, 9:30 AM EDT'. Only 12-hour if the locale is.
      */
-    static get DATETIME_FULL(): DateTimeFormatOptions;
+    static get DATETIME_FULL(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'October 14, 1983, 9:30:33 AM EDT'. Only 12-hour if the locale is.
      */
-    static get DATETIME_FULL_WITH_SECONDS(): DateTimeFormatOptions;
+    static get DATETIME_FULL_WITH_SECONDS(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Friday, October 14, 1983, 9:30 AM Eastern Daylight Time'. Only 12-hour if the locale is.
      */
-    static get DATETIME_HUGE(): DateTimeFormatOptions;
+    static get DATETIME_HUGE(): DateTimeFormatPreset;
 
     /**
      * {@link DateTime.toLocaleString} format like 'Friday, October 14, 1983, 9:30:33 AM Eastern Daylight Time'. Only 12-hour if the locale is.
      */
-    static get DATETIME_HUGE_WITH_SECONDS(): DateTimeFormatOptions;
+    static get DATETIME_HUGE_WITH_SECONDS(): DateTimeFormatPreset;
 }

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -160,14 +160,6 @@ export interface DateTimeFormatPreset {
     hourCycle?: 'h23';
 }
 
-export type ToLocalePartsType = keyof Omit<DateTimeFormatPreset, 'hourCycle'> | 'literal';
-export type ToLocalePartsOutput = [
-    {
-        type: ToLocalePartsType;
-        value: string;
-    },
-];
-
 export interface DiffOptions {
     conversionAccuracy?: ConversionAccuracy | undefined;
 }
@@ -1027,7 +1019,7 @@ export class DateTime {
      *                                 //=>   { type: 'year', value: '1982' }
      *                                 //=> ]
      */
-    toLocaleParts(opts?: DateTimeFormatPreset | DateTimeFormatOptions): ToLocalePartsOutput;
+    toLocaleParts(opts?: DateTimeFormatPreset | DateTimeFormatOptions): Intl.DateTimeFormatPart[];
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime

--- a/types/luxon/test/luxon-tests.global.ts
+++ b/types/luxon/test/luxon-tests.global.ts
@@ -1,7 +1,7 @@
 // just couple of lines to be sure basic global script support
 // is in place
 luxon.VERSION; // $ExpectType string
-luxon.DateTime.DATETIME_MED; // $ExpectType DateTimeFormatOptions
+luxon.DateTime.DATETIME_MED; // $ExpectType DateTimeFormatPreset
 luxon.DateTime.local(2017, 5, 15, 8, 30);
 luxon.DateTime.now();
 new luxon.IANAZone('America/Los_Angeles');

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -104,6 +104,7 @@ dt.toISOWeekDate(); // $ExpectType string
 dt.toJSDate(); // $ExpectType Date
 dt.toJSON(); // $ExpectType string
 dt.toLocaleParts(); // $ExpectType ToLocalePartsOutput
+dt.toLocaleParts()[0].type; // $ExpectType ToLocalePartsType
 dt.toLocaleParts()[0].value; // $ExpectType string
 dt.toLocaleString(); // $ExpectType string
 dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string
@@ -329,17 +330,17 @@ Settings.defaultOutputCalendar = 'persian';
 DateTime.fromISO('2014-08-06T13:07:04.054').toFormat('yyyy LLL dd'); // $ExpectType string
 
 /* Parsing */
-DateTime.fromObject(); // $ExpectType DateTime
+DateTime.fromObject(); // $ExpectError
 DateTime.fromObject({}, { zone: 'America/Los_Angeles' }); // $ExpectType DateTime
-DateTime.fromISO(); // $ExpectType DateTime
+DateTime.fromISO(); // $ExpectError
 DateTime.fromISO('2016-05-25'); // $ExpectType DateTime
-DateTime.fromJSDate(); // $ExpectType DateTime
+DateTime.fromJSDate(); // $ExpectError
 DateTime.fromJSDate(new Date()); // $ExpectType DateTime
 DateTime.fromRFC2822(); // $ExpectError
 DateTime.fromRFC2822('Tue, 01 Nov 2016 13:23:12 +0630'); // $ExpectType DateTime
-DateTime.fromHTTP(); // $ExpectType DateTime
+DateTime.fromHTTP(); // $ExpectError
 DateTime.fromHTTP('Sunday, 06-Nov-94 08:49:37 GMT'); // $ExpectType DateTime
-DateTime.fromSQL(); // $ExpectType DateTime
+DateTime.fromSQL(); // $ExpectError
 DateTime.fromSQL('2017-05-15 09:24:15'); // $ExpectType DateTime
 DateTime.fromMillis(); // $ExpectError
 DateTime.fromMillis(1542674993410); // $ExpectType DateTime

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -103,8 +103,8 @@ dt.toISOTime({ format: 'basic' }); // $ExpectType string
 dt.toISOWeekDate(); // $ExpectType string
 dt.toJSDate(); // $ExpectType Date
 dt.toJSON(); // $ExpectType string
-dt.toLocaleParts(); // $ExpectType ToLocalePartsOutput
-dt.toLocaleParts()[0].type; // $ExpectType ToLocalePartsType
+dt.toLocaleParts(); // $ExpectType DateTimeFormatPart[]
+dt.toLocaleParts()[0].type; // $ExpectType DateTimeFormatPartTypes
 dt.toLocaleParts()[0].value; // $ExpectType string
 dt.toLocaleString(); // $ExpectType string
 dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -17,10 +17,17 @@ import {
 VERSION; // $ExpectType string
 
 /* DateTime */
-DateTime.DATETIME_MED; // $ExpectType DateTimeFormatOptions
-DateTime.DATETIME_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
-DateTime.DATE_MED; // $ExpectType DateTimeFormatOptions
-DateTime.DATE_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
+DateTime.DATETIME_MED; // $ExpectType DateTimeFormatPreset
+DateTime.DATETIME_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatPreset
+DateTime.DATE_MED; // $ExpectType DateTimeFormatPreset
+DateTime.DATE_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatPreset
+
+DateTime.local({ zone: 'Atlantic/Azores' }); // $ExpectType DateTime
+DateTime.local(2021, 8, 28, { zone: 'Atlantic/Azores' }); // $ExpectType DateTime
+DateTime.utc(); // $ExpectType DateTime
+DateTime.utc({ locale: 'en-US' }); // $ExpectType DateTime
+DateTime.utc(2018, 5, 31, 23, { numberingSystem: 'arabext' }); // $ExpectType DateTime
+DateTime.utc(2019, { locale: 'en-GB' }, 5); // $ExpectError
 
 const dt = DateTime.local(2017, 5, 15, 8, 30);
 
@@ -74,16 +81,16 @@ const fromIso2 = DateTime.fromISO('2017-05-15T08:30:00'); // => May 15, 2017 at 
 DateTime.local().toString(); // => '2017-09-14T03:20:34.091-04:00'
 
 const getters = DateTime.local();
-getters.year;
-getters.month;
-getters.day;
-getters.second;
-getters.weekday;
-getters.zoneName;
-getters.offset;
-getters.daysInMonth;
-getters.ordinal;
-getters.isInLeapYear;
+getters.year; // $ExpectType number
+getters.month; // $ExpectType number
+getters.day; // $ExpectType number
+getters.second; // $ExpectType number
+getters.weekday; // $ExpectType number
+getters.zoneName; // $ExpectType string
+getters.offset; // $ExpectType number
+getters.daysInMonth; // $ExpectType number
+getters.ordinal; // $ExpectType number
+getters.isInLeapYear; // $ExpectType boolean
 
 dt.toBSON(); // $ExpectType Date
 dt.toHTTP(); // $ExpectType string
@@ -96,6 +103,8 @@ dt.toISOTime({ format: 'basic' }); // $ExpectType string
 dt.toISOWeekDate(); // $ExpectType string
 dt.toJSDate(); // $ExpectType Date
 dt.toJSON(); // $ExpectType string
+dt.toLocaleParts(); // $ExpectType ToLocalePartsOutput
+dt.toLocaleParts()[0].value; // $ExpectType string
 dt.toLocaleString(); // $ExpectType string
 dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string
 dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string
@@ -267,7 +276,7 @@ Settings.defaultLocale = 'fr';
 DateTime.local().locale; // $ExpectType string
 
 Settings.defaultLocale = DateTime.local().resolvedLocaleOptions().locale;
-DateTime.local().resolvedLocaleOptions({ locale: 'de' });
+DateTime.local().resolvedLocaleOptions({ locale: 'de' }); // $ExpectType Required<LocaleOptions>
 
 dt.setLocale('fr').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
 dt.toLocaleString({ ...DateTime.DATE_FULL }, { locale: 'es' }); // $ExpectType string
@@ -310,6 +319,7 @@ DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $
 
 const dtHebrew = DateTime.local().reconfigure({ outputCalendar: 'hebrew' });
 dtHebrew.outputCalendar; // $ExpectType string
+dtHebrew.numberingSystem; // $ExpectType string
 dtHebrew.toLocaleString(); // $ExpectType string
 
 DateTime.fromObject({}, { outputCalendar: 'buddhist' }).toLocaleString(DateTime.DATE_FULL);
@@ -319,14 +329,23 @@ Settings.defaultOutputCalendar = 'persian';
 DateTime.fromISO('2014-08-06T13:07:04.054').toFormat('yyyy LLL dd'); // $ExpectType string
 
 /* Parsing */
+DateTime.fromObject(); // $ExpectType DateTime
 DateTime.fromObject({}, { zone: 'America/Los_Angeles' }); // $ExpectType DateTime
+DateTime.fromISO(); // $ExpectType DateTime
 DateTime.fromISO('2016-05-25'); // $ExpectType DateTime
+DateTime.fromJSDate(); // $ExpectType DateTime
 DateTime.fromJSDate(new Date()); // $ExpectType DateTime
+DateTime.fromRFC2822(); // $ExpectError
 DateTime.fromRFC2822('Tue, 01 Nov 2016 13:23:12 +0630'); // $ExpectType DateTime
+DateTime.fromHTTP(); // $ExpectType DateTime
 DateTime.fromHTTP('Sunday, 06-Nov-94 08:49:37 GMT'); // $ExpectType DateTime
+DateTime.fromSQL(); // $ExpectType DateTime
 DateTime.fromSQL('2017-05-15 09:24:15'); // $ExpectType DateTime
+DateTime.fromMillis(); // $ExpectError
 DateTime.fromMillis(1542674993410); // $ExpectType DateTime
+DateTime.fromSeconds(); // $ExpectError
 DateTime.fromSeconds(1542674993); // $ExpectType DateTime
+DateTime.fromFormat(); // $ExpectError
 DateTime.fromFormat('May 25 1982', 'LLLL dd yyyy'); // $ExpectType DateTime
 DateTime.fromFormat('mai 25 1982', 'LLLL dd yyyy', { locale: 'fr' }); // $ExpectType DateTime
 


### PR DESCRIPTION
### Luxon
#### DateTime
Added overloads for local() and utc(). (Are now necessary due to the object param after the number params).
Marked several params as optional where Luxon doesn't throw errors.
Fixed typing errors in ordinal getter, resolvedLocaleOptions, toLocaleString, toLocaleParts, and all format presets.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://moment.github.io/luxon/api-docs/index.html