### PR TITLE
feat(tampermonkey): Add GM.* api

### DIFF
--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -531,3 +531,157 @@ declare function GM_setClipboard(
     data: string,
     info?: string | { type?: string | undefined; mimetype?: string | undefined }
 ): void;
+
+// GM.*
+
+/**
+ * `GM` has all the `GM_*` apis in promisified form
+ */
+declare const GM: Readonly<{
+    // Styles
+
+    /**
+     * Adds the given style to the document and returns the injected style element.
+     */
+    addStyle(css: string): Promise<HTMLStyleElement>;
+
+    // Storage
+
+    /** Sets the value of `name` to the storage */
+    setValue(name: string, value: any): Promise<void>;
+
+    /** Gets the value of 'name' from storage */
+    getValue<TValue>(name: string, defaultValue?: TValue): Promise<TValue>;
+
+    /** Deletes 'name' from storage */
+    deleteValue(name: string): Promise<void>;
+
+    /** Lists all names of the storage */
+    listValues(): Promise<string[]>;
+
+    /**
+     * Adds a change listener to the storage and returns the listener ID.
+     * The `remote` argument of the callback function shows whether this value was
+     * modified from the instance of another tab (`true`) or within this script
+     * instance (`false`). Therefore this functionality can be used by scripts of
+     * different browser tabs to communicate with each other.
+     * @param name Name of the observed variable
+     */
+    addValueChangeListener(): Promise<number>;
+
+    /** Removes a change listener by its ID */
+    removeValueChangeListener(listenerId: number): Promise<void>;
+
+    // Resources
+
+    /** Get the content of a predefined `@resource` tag at the script header */
+    getResourceText(name: string): Promise<string>;
+
+    // note that it's `..Url`, not `URL` like the GM_ variant
+    /**
+     * Get the base64 encoded URI of a predefined `@resource` tag at the script
+     * header
+     */
+    getResourceUrl(name: string): Promise<string>;
+
+    // Menu commands
+
+    /**
+     * Register a menu to be displayed at the Tampermonkey menu at pages where this
+     * script runs and returns a menu command ID.
+     */
+    registerMenuCommand(name: string, onClick: () => void, accessKey?: string): Promise<number>;
+    /**
+     *  Unregister a menu command that was previously registered by
+     * `GM_registerMenuCommand` with the given menu command ID.
+     */
+    unregisterMenuCommand(menuCommandId: number): Promise<void>;
+
+    // Requests
+
+    // note the uppercase H in `Http`
+    /**
+     * Makes an xmlHttpRequest
+     *
+     * @throws {Tampermonkey.ErrorResponse}
+     */
+    xmlHttpRequest<TContext = any>(
+        // onload and the like still work
+        details: Tampermonkey.Request<TContext>, // tslint:disable-line:no-unnecessary-generics
+    ): Promise<Tampermonkey.Response<TContext>>;
+
+    // GM_download has two ways but GM.download doesn't
+    /**
+     * Downloads a given URL to the local disk
+     *
+     * @throws {Tampermonkey.DownloadErrorResponse}
+     */
+    download(details: Tampermonkey.DownloadRequest): Promise<void>;
+
+    // Tabs
+
+    /** Saves the tab object to reopen it after a page unload */
+    saveTab(obj: object): Promise<void>;
+
+    /** Gets a object that is persistent as long as this tab is open */
+    getTab(): Promise<any>;
+
+    /** Gets all tab objects as a hash to communicate with other script instances */
+    getTabs(): Promise<{ [tabId: number]: any }>;
+
+    // Utils
+    info: Tampermonkey.ScriptInfo;
+
+    /** Log a message to the console */
+    log(...message: any[]): Promise<void>;
+
+    /**
+     * Opens a new tab with this url.
+     * The options object can have the following properties:
+     * - `active` decides whether the new tab should be focused,
+     * - `insert` that inserts the new tab after the current one and
+     * - `setParent` makes the browser re-focus the current tab on close.
+     *
+     * Otherwise the new tab is just appended.
+     * If `options` is boolean (loadInBackground) it has the opposite meaning of
+     * active and was added to achieve Greasemonkey 3.x compatibility.
+     *
+     * If neither active nor loadInBackground is given, then the tab will not be
+     * focused.
+     * @returns Object with the function `close`, the listener `onclosed` and a flag
+     * called `closed`.
+     */
+    openInTab(url: string, options?: Tampermonkey.OpenTabOptions | boolean): Promise<Tampermonkey.OpenTabObject>;
+
+    /**
+     * Shows a HTML5 Desktop notification and/or highlight the current tab.
+     * @param ondone If specified used instead of `details.ondone`
+     * @returns True if the notification was clicked
+     */
+    notification(details: Tampermonkey.NotificationDetails, ondone?: Tampermonkey.NotificationOnDone): Promise<boolean>;
+
+    /**
+     * Shows a HTML5 Desktop notification and/or highlight the current tab.
+     * @param text Text of the notification
+     * @param title Notification title. If not specified the script name is used
+     * @param onclick Called in case the user clicks the notification
+     * @returns True if the notification was clicked
+     */
+    notification(
+        text: string,
+        title?: string,
+        image?: string,
+        onclick?: Tampermonkey.NotificationOnClick,
+    ): Promise<boolean>;
+
+    /**
+     * Copies data into the clipboard.
+     * The parameter 'info' can be an object like
+     * `{ type: 'text', mimetype: 'text/plain'}` or just a string expressing the
+     * type ("text" or "html").
+     */
+    setClipboard(
+        data: string,
+        info?: string | { type?: string | undefined; mimetype?: string | undefined },
+    ): Promise<void>;
+}>;

--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -365,6 +365,8 @@ declare namespace Tampermonkey {
         /** This refers to tampermonkey's version */
         version: string;
     }
+
+    type ContentType = string | { type?: string | undefined; mimetype?: string | undefined };
 }
 
 /**
@@ -529,7 +531,7 @@ declare function GM_notification(
  */
 declare function GM_setClipboard(
     data: string,
-    info?: string | { type?: string | undefined; mimetype?: string | undefined }
+    info?: Tampermonkey.ContentType,
 ): void;
 
 // GM.*
@@ -567,7 +569,7 @@ declare const GM: Readonly<{
      * different browser tabs to communicate with each other.
      * @param name Name of the observed variable
      */
-    addValueChangeListener(): Promise<number>;
+    addValueChangeListener(name: string, listener: Tampermonkey.ValueChangeListener): Promise<number>;
 
     /** Removes a change listener by its ID */
     removeValueChangeListener(listenerId: number): Promise<void>;
@@ -577,7 +579,6 @@ declare const GM: Readonly<{
     /** Get the content of a predefined `@resource` tag at the script header */
     getResourceText(name: string): Promise<string>;
 
-    // note that it's `..Url`, not `URL` like the GM_ variant
     /**
      * Get the base64 encoded URI of a predefined `@resource` tag at the script
      * header
@@ -589,6 +590,7 @@ declare const GM: Readonly<{
     /**
      * Register a menu to be displayed at the Tampermonkey menu at pages where this
      * script runs and returns a menu command ID.
+     * @param accessKey The key to use for keyboard shortcuts
      */
     registerMenuCommand(name: string, onClick: () => void, accessKey?: string): Promise<number>;
     /**
@@ -599,7 +601,6 @@ declare const GM: Readonly<{
 
     // Requests
 
-    // note the uppercase H in `Http`
     /**
      * Makes an xmlHttpRequest
      *
@@ -621,7 +622,7 @@ declare const GM: Readonly<{
     // Tabs
 
     /** Saves the tab object to reopen it after a page unload */
-    saveTab(obj: object): Promise<void>;
+    saveTab(obj: any): Promise<void>;
 
     /** Gets a object that is persistent as long as this tab is open */
     getTab(): Promise<any>;
@@ -682,6 +683,6 @@ declare const GM: Readonly<{
      */
     setClipboard(
         data: string,
-        info?: string | { type?: string | undefined; mimetype?: string | undefined },
+        info?: Tampermonkey.ContentType,
     ): Promise<void>;
 }>;

--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -440,7 +440,7 @@ declare function GM_registerMenuCommand(
 
 /**
  *  Unregister a menu command that was previously registered by
- * `GM_registerMenuCommand` with the given menu command ID.
+ * `GM_registerMenuCommand` or `GM.registerMenuCommand` with the given menu command ID.
  */
 declare function GM_unregisterMenuCommand(menuCommandId: number): void;
 
@@ -493,7 +493,7 @@ declare function GM_log(...message: any[]): void;
  *
  * If neither active nor loadInBackground is given, then the tab will not be
  * focused.
- * @returns Object with the function `close`, the listener `onclosed` and a flag
+ * @returns Object with the function `close`, the listener `onclose` and a flag
  * called `closed`.
  */
 declare function GM_openInTab(
@@ -595,7 +595,7 @@ declare const GM: Readonly<{
     registerMenuCommand(name: string, onClick: () => void, accessKey?: string): Promise<number>;
     /**
      *  Unregister a menu command that was previously registered by
-     * `GM_registerMenuCommand` with the given menu command ID.
+     * `GM_registerMenuCommand` or `GM.registerMenuCommand` with the given menu command ID.
      */
     unregisterMenuCommand(menuCommandId: number): Promise<void>;
 
@@ -611,7 +611,7 @@ declare const GM: Readonly<{
         details: Tampermonkey.Request<TContext>, // tslint:disable-line:no-unnecessary-generics
     ): Promise<Tampermonkey.Response<TContext>>;
 
-    // GM_download has two ways but GM.download doesn't
+    // GM_download has two signatures, GM.download has one
     /**
      * Downloads a given URL to the local disk
      *
@@ -649,7 +649,7 @@ declare const GM: Readonly<{
      *
      * If neither active nor loadInBackground is given, then the tab will not be
      * focused.
-     * @returns Object with the function `close`, the listener `onclosed` and a flag
+     * @returns Object with the function `close`, the listener `onclose` and a flag
      * called `closed`.
      */
     openInTab(url: string, options?: Tampermonkey.OpenTabOptions | boolean): Promise<Tampermonkey.OpenTabObject>;

--- a/types/tampermonkey/tampermonkey-tests.ts
+++ b/types/tampermonkey/tampermonkey-tests.ts
@@ -460,6 +460,18 @@ async () => {
     // $ExpectType string[]
     await GM.listValues();
 
+    // GM.addValueChangeListener
+
+    // $ExpectType number
+    await GM.addValueChangeListener('a', (name: string, oldValue: string, newValue: string, remote: boolean) => {});
+    // $ExpectType number
+    await GM.addValueChangeListener('a', (name: string, oldValue: number, newValue: number, remote: boolean) => {});
+
+    // GM.removeValueChangeListener
+
+    // $ExpectType void
+    await GM.removeValueChangeListener(2);
+
     // GM.getResourceText
 
     // $ExpectType string
@@ -642,7 +654,9 @@ async () => {
 
     // GM.getTab
 
-    const saveTabState: TabState = await GM.getTab();
+    // $ExpectType any
+    await GM.getTab();
+    const tab: Record<string, string> = await GM.getTab();
 
     // GM.getTabs
 

--- a/types/tampermonkey/tampermonkey-tests.ts
+++ b/types/tampermonkey/tampermonkey-tests.ts
@@ -421,3 +421,277 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
     isIncognito: false,
     downloadMode: 'native',
 };
+
+// GM.*
+
+// GM.info
+
+const exampleInfo1: Tampermonkey.ScriptInfo = GM.info;
+
+async () => {
+    // GM.addStyle
+
+    // $ExpectType HTMLStyleElement
+    await GM.addStyle('div {color: #000;}');
+
+    // GM.setValue
+
+    // $ExpectType void
+    await GM.setValue('str', 'string');
+    await GM.setValue('num', 0);
+    await GM.setValue('bool', true);
+    await GM.setValue('obj', {
+        nested: {
+            values: true,
+        },
+    });
+
+    // GM.getValue
+
+    // $ExpectType string
+    await GM.getValue<string>('str');
+
+    // GM.deleteValue
+
+    await GM.deleteValue('a');
+
+    // GM.listValues
+
+    // $ExpectType string[]
+    await GM.listValues();
+
+    // GM.getResourceText
+
+    // $ExpectType string
+    await GM.getResourceText('template');
+
+    // GM.getResourceUrl
+
+    // $ExpectType string
+    await GM.getResourceUrl('template');
+
+    // GM.registerMenuCommand
+
+    // $ExpectType number
+    await GM.registerMenuCommand('Do thing', () => {});
+    // $ExpectType number
+    await GM.registerMenuCommand('Do other thing', () => {}, 'T');
+
+    // GM.unregisterMenuCommand
+
+    // $ExpectType void
+    await GM.unregisterMenuCommand(1);
+
+    // GM.xmlHttpRequest
+
+    // Bare minimum
+
+    const minResponse = await GM.xmlHttpRequest({
+        url: 'https://github.com/',
+        method: 'GET',
+    });
+
+    // $ExpectType string
+    minResponse.finalUrl;
+    // $ExpectType number
+    minResponse.status;
+    // $ExpectType string
+    minResponse.responseText;
+
+    // GET request
+    await GM.xmlHttpRequest({
+        method: 'GET',
+        url: 'http://www.example.net/',
+        headers: {
+            'User-Agent': 'Mozilla/5.0',
+            Accept: 'text/xml',
+        },
+    });
+
+    // POST request
+    await GM.xmlHttpRequest({
+        method: 'POST',
+        url: 'http://www.example.net/login',
+        data: 'username=johndoe&password=xyz123',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+    });
+
+    // HEAD request
+    await GM.xmlHttpRequest({
+        url: 'http://www.example.com',
+        method: 'HEAD',
+    });
+
+    // All options
+    interface RequestContext {
+        form: {
+            name: string;
+        };
+    }
+
+    const allOptionsResponse = await GM.xmlHttpRequest<RequestContext>({
+        method: 'POST',
+        url: 'http://example.com/',
+        headers: { 'User-Agent': 'greasemonkey' },
+        data: 'foo=1&bar=2',
+        cookie: 'secret=42',
+        nocache: true,
+        revalidate: true,
+        binary: false,
+        timeout: 10,
+        context: {
+            form: {
+                name: 'Alice',
+            },
+        },
+        responseType: 'json',
+        overrideMimeType: 'text/plain',
+        anonymous: false,
+        user: 'guest',
+        password: 'abc123',
+        onabort() {},
+        onerror(response) {
+            // $ExpectType string
+            response.error;
+        },
+        onloadstart(response) {
+            // $ExpectType RequestContext
+            response.context;
+        },
+        onload(response) {
+            // $ExpectType RequestContext
+            response.context;
+        },
+        onprogress(response) {
+            // $ExpectType number
+            response.status;
+            // $ExpectType boolean
+            response.lengthComputable;
+            // $ExpectType number
+            response.loaded;
+            // $ExpectType number
+            response.total;
+        },
+        onreadystatechange(response) {
+            GM_log(response.context.form.name);
+        },
+        ontimeout() {},
+    });
+
+    // $ExpectType string
+    allOptionsResponse.finalUrl;
+    // $ExpectType RequestContext
+    allOptionsResponse.context;
+    // $ExpectType number
+    allOptionsResponse.status;
+    // $ExpectType string
+    allOptionsResponse.statusText;
+    // $ExpectType string
+    allOptionsResponse.responseText;
+    // $ExpectType ReadyState
+    allOptionsResponse.readyState;
+    // $ExpectType string
+    allOptionsResponse.responseHeaders;
+    // $ExpectType string
+    allOptionsResponse.responseText;
+    // $ExpectType Document | null
+    allOptionsResponse.responseXML;
+
+    // GM.download
+
+    // $ExpectType void
+    await GM.download({
+        url: 'http://tampermonkey.net/crx/tampermonkey.xml',
+        name: 'tampermonkey.xml',
+        headers: { 'User-Agent': 'greasemonkey' },
+        saveAs: true,
+        timeout: 3000,
+        onerror(response) {
+            response.error.toUpperCase();
+            // $ExpectType string | undefined
+            response.details;
+        },
+        ontimeout() {},
+        onload() {},
+        onprogress(response) {
+            // $ExpectType string
+            response.finalUrl;
+            // $ExpectType number
+            response.loaded;
+            // $ExpectType number
+            response.total;
+        },
+    });
+
+    interface TabState {
+        form: { name: string };
+    }
+
+    const tabState: TabState = {
+        form: {
+            name: 'Alice',
+        },
+    };
+
+    // GM.saveTab
+
+    // $ExpectType void
+    await GM.saveTab(tabState);
+
+    // GM.getTab
+
+    const saveTabState: TabState = await GM.getTab();
+
+    // GM.getTabs
+
+    const tab0 = (await GM.getTabs())[0];
+
+    // GM.log
+
+    // $ExpectType void
+    await GM.log(42);
+    await GM.log('Hello', 'World!');
+
+    // GM.openInTab
+
+    await GM.openInTab('https://example.org');
+    await GM.openInTab('https://example.org', true);
+
+    const openTabObject = await GM.openInTab('https://example.org', {
+        active: true,
+        insert: false,
+        setParent: true,
+    });
+    openTabObject.onclose = () => {};
+    // $ExpectType boolean
+    openTabObject.closed;
+    openTabObject.close();
+
+    // GM.notification
+
+    // Using globals from GM_notification tests above
+    // specifically textNotification and highlightNotification
+
+    // $ExpectType boolean
+    await GM.notification(textNotification);
+
+    // $ExpectType boolean
+    await GM.notification(highlightNotification);
+
+    // $ExpectType boolean
+    await GM.notification(textNotification, textNotification.ondone);
+
+    await GM.notification('text', 'title', 'https://tampermonkey.net/favicon.ico', () => {});
+
+    // GM.setClipboard
+
+    // $ExpectType void
+    await GM.setClipboard('Some text');
+    await GM.setClipboard('Some text', 'text');
+    await GM.setClipboard('Some text', {
+        type: 'text',
+        mimetype: 'text/plain',
+    });
+};


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

`GM.*` is more or less the [`GM_*`](https://www.tampermonkey.net/documentation.php) api, but it differs in some ways, like using proper camelcase, or returning the value that would get passed to `onload()`.  
Under the hood I think Tampermonkey just takes all the `GM_*` functions, wraps them in a promise and adds them to `GM` (if specified in the metadata) which is why there are many more than with [Violentmonkey](https://violentmonkey.github.io/api/gm/#gm) or [Greasemonkey](https://wiki.greasespot.net/Greasemonkey_Manual:API).