### PR TITLE
Ported updateConfig script from dtslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/utils": "latest",
         "@octokit/rest": "^16.0.0",
+        "@types/yargs": "^17.0.2",
         "danger": "^10.1.1",
         "dtslint": "latest",
         "prettier": "^2.1.1",
         "remark-cli": "^9.0.0",
         "remark-validate-links": "^10.0.2",
-        "typescript": "next"
+        "typescript": "next",
+        "yargs": "^17.1.1"
     },
     "husky": {
         "hooks": {

--- a/scripts/update-config/LintPackage.ts
+++ b/scripts/update-config/LintPackage.ts
@@ -1,0 +1,53 @@
+import * as fs from "fs";
+import * as stringify from "json-stable-stringify";
+import * as path from "path";
+import { Configuration as Config, ILinterOptions, Linter, LintResult } from "tslint";
+import * as ts from "typescript";
+import { isExternalDependency } from "./dependencies";
+
+/**
+ * Represents a package from the linter's perspective.
+ * For example, `DefinitelyTyped/types/react` and `DefinitelyTyped/types/react/v15` are different
+ * packages.
+ */
+export class LintPackage {
+    private files: ts.SourceFile[] = [];
+    private program: ts.Program;
+
+    constructor(private rootDir: string) {
+        this.program = Linter.createProgram(path.join(this.rootDir, "tsconfig.json"));
+    }
+
+    config(): Config.RawConfigFile {
+        return Config.readConfigurationFile(path.join(this.rootDir, "tslint.json"));
+    }
+
+    addFile(filePath: string): void {
+        const file = this.program.getSourceFile(filePath);
+        if (file) {
+            this.files.push(file);
+        }
+    }
+
+    lint(opts: ILinterOptions, config: Config.IConfigurationFile): LintResult {
+        const linter = new Linter(opts, this.program);
+        for (const file of this.files) {
+            if (ignoreFile(file, this.rootDir, this.program)) {
+                continue;
+            }
+            linter.lint(file.fileName, file.text, config);
+        }
+        return linter.getResult();
+    }
+
+    updateConfig(config: Config.RawConfigFile): void {
+        fs.writeFileSync(
+            path.join(this.rootDir, "tslint.json"),
+            stringify(config, { space: 4 }),
+            { encoding: "utf8", flag: "w" });
+    }
+}
+
+function ignoreFile(file: ts.SourceFile, dirPath: string, program: ts.Program): boolean {
+    return program.isSourceFileDefaultLibrary(file) || isExternalDependency(file, path.resolve(dirPath), program);
+}

--- a/scripts/update-config/dependencies.ts
+++ b/scripts/update-config/dependencies.ts
@@ -1,0 +1,19 @@
+import * as path from "path";
+import * as ts from "typescript";
+
+export function isExternalDependency(file: ts.SourceFile, dirPath: string, program: ts.Program): boolean {
+    return !startsWithDirectory(file.fileName, dirPath) || program.isSourceFileFromExternalLibrary(file);
+}
+
+export function normalizePath(file: string) {
+    // replaces '\' with '/' and forces all DOS drive letters to be upper-case
+    return path.normalize(file)
+        .replace(/\\/g, "/")
+        .replace(/^[a-z](?=:)/, c => c.toUpperCase());
+}
+
+function startsWithDirectory(filePath: string, dirPath: string): boolean {
+    const normalFilePath = normalizePath(filePath);
+    const normalDirPath = normalizePath(dirPath).replace(/\/$/, "");
+    return normalFilePath.startsWith(normalDirPath + "/") || normalFilePath.startsWith(normalDirPath + "\\");
+}

--- a/scripts/update-config/ignoredRules.ts
+++ b/scripts/update-config/ignoredRules.ts
@@ -1,0 +1,2 @@
+// Rule "expect" needs TypeScript version information, which this script doesn't collect.
+export const ignoredRules = new Set(["expect"]);

--- a/scripts/update-config/index.ts
+++ b/scripts/update-config/index.ts
@@ -1,0 +1,90 @@
+// This is a stand-alone script that updates TSLint configurations for DefinitelyTyped packages.
+// It runs all rules specified in `dt.json`, and updates the existing configuration for a package
+// by adding rule exemptions only for the rules that caused a lint failure.
+// For example, if a configuration specifies `"no-trailing-whitespace": false` and this rule
+// no longer produces an error, then it will not be disabled in the new configuration.
+// If you update or create a rule and now it causes new failures in DT, you can update the `dt.json`
+// configuration with your rule, then register a disabler function for your rule
+// (check `disableRules` function below), then run this script with your rule as argument.
+
+import * as fs from "fs";
+import * as path from "path";
+import { Configuration as Config } from "tslint";
+import * as yargs from "yargs";
+import { normalizePath } from "./dependencies";
+import { ignoredRules } from "./ignoredRules";
+import { updatePackage } from "./updatePackage";
+
+async function main() {
+    const args = await yargs
+        .usage(`\`$0 --dt=path-to-dt\` or \`$0 --package=path-to-dt-package\`
+'dt.json' is used as the base tslint config for running the linter.`)
+        .option("package", {
+            describe: "Path of DT package.",
+            type: "string",
+            conflicts: "dt",
+        })
+        .option("dt", {
+            describe: "Path of local DefinitelyTyped repository.",
+            type: "string",
+            conflicts: "package",
+        })
+        .option("rules", {
+            describe: "Names of the rules to be updated. Leave this empty to update all rules.",
+            type: "array",
+            string: true,
+            default: [],
+        })
+        .check(arg => {
+            if (!arg.package && !arg.dt) {
+                throw new Error("You must provide either argument 'package' or 'dt'.");
+            }
+            const unsupportedRules = arg.rules.filter(rule => ignoredRules.has(rule));
+            if (unsupportedRules.length > 0) {
+                throw new Error(`Rules ${unsupportedRules.join(", ")} are not supported at the moment.`);
+            }
+            return true;
+        }).argv;
+
+    const baseConfig = dtConfig(args.rules);
+
+    if (args.package) {
+        updatePackage(args.package, baseConfig);
+    } else if (args.dt) {
+        updateAll(args.dt, baseConfig);
+    }
+}
+
+function dtConfig(updatedRules: string[]): Config.IConfigurationFile {
+    const resolvedDtslint = require.resolve('dtslint');
+    const dtConfigPath = normalizePath(
+        path.join(
+            resolvedDtslint.slice(0, resolvedDtslint.lastIndexOf("dtslint")),
+            "dtslint/dt.json"
+        ),
+    );
+    const config = Config.findConfiguration(dtConfigPath).results;
+    if (!config) {
+        throw new Error(`Could not load config at ${dtConfigPath}.`);
+    }
+    // Disable ignored or non-updated rules.
+    for (const entry of config.rules.entries()) {
+        const [rule, ruleOpts] = entry;
+        if (ignoredRules.has(rule) || (updatedRules.length > 0 && !updatedRules.includes(rule))) {
+            ruleOpts.ruleSeverity = "off";
+        }
+    }
+    return config;
+}
+
+function updateAll(dtPath: string, config: Config.IConfigurationFile): void {
+    const packages = fs.readdirSync(path.join(dtPath, "types"));
+    for (const pkg of packages) {
+        updatePackage(path.join(dtPath, "types", pkg), config);
+    }
+}
+
+main().catch((error) => {
+    console.error(`Error in update-config: ${error}`)
+    process.exitCode = 1;
+});

--- a/scripts/update-config/npmNamingDisabler.ts
+++ b/scripts/update-config/npmNamingDisabler.ts
@@ -1,0 +1,37 @@
+import { defaultErrors, ErrorKind, ExportErrorKind, Mode } from "dts-critic";
+import * as Lint from "tslint";
+
+/**
+ * Given npm-naming lint failures, returns a rule configuration that prevents such failures.
+ */
+export function npmNamingDisabler(failures: Lint.IRuleFailureJson[]) {
+    const disabledErrors = new Set<ExportErrorKind>();
+    for (const ruleFailure of failures) {
+        if (ruleFailure.ruleName !== "npm-naming") {
+            throw new Error(`Expected failures of rule "npm-naming", found failures of rule ${ruleFailure.ruleName}.`);
+        }
+        const message = ruleFailure.failure;
+        // Name errors.
+        if (message.includes("must have a matching npm package")
+            || message.includes("must match a version that exists on npm")
+            || message.includes("conflicts with the existing npm package")) {
+            return false;
+        }
+        // Code errors.
+        if (message.includes("declaration should use 'export =' syntax")) {
+            disabledErrors.add(ErrorKind.NeedsExportEquals);
+        } else if (message.includes("declaration specifies 'export default' but the JavaScript source \
+            does not mention 'default' anywhere")) {
+            disabledErrors.add(ErrorKind.NoDefaultExport);
+        } else {
+            return [true, { mode: Mode.NameOnly }];
+        }
+    }
+
+    if ((defaultErrors as ExportErrorKind[]).every(error => disabledErrors.has(error))) {
+        return [true, { mode: Mode.NameOnly }];
+    }
+    const errors: Array<[ExportErrorKind, boolean]> = [];
+    disabledErrors.forEach(error => errors.push([error, false]));
+    return [true, { mode: Mode.Code, errors }];
+}

--- a/scripts/update-config/updatePackage.ts
+++ b/scripts/update-config/updatePackage.ts
@@ -1,0 +1,124 @@
+import * as cp from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { Configuration as Config, ILinterOptions, IRuleFailureJson, RuleFailure } from "tslint";
+
+import { ignoredRules } from "./ignoredRules";
+import { LintPackage } from "./LintPackage";
+import { npmNamingDisabler } from "./npmNamingDisabler";
+
+export function updatePackage(pkgPath: string, baseConfig: Config.IConfigurationFile): void {
+    installDependencies(pkgPath);
+    const packages = walkPackageDir(pkgPath);
+
+    const linterOpts: ILinterOptions = {
+        fix: false,
+    };
+
+    for (const pkg of packages) {
+        const results = pkg.lint(linterOpts, baseConfig);
+        if (results.failures.length > 0) {
+            const disabledRules = disableRules(results.failures);
+            const newConfig = mergeConfigRules(pkg.config(), disabledRules, baseConfig);
+            pkg.updateConfig(newConfig);
+        }
+    }
+}
+
+function walkPackageDir(rootDir: string): LintPackage[] {
+    const packages: LintPackage[] = [];
+
+    function walk(curPackage: LintPackage, dir: string): void {
+        for (const ent of fs.readdirSync(dir, { encoding: "utf8", withFileTypes: true })) {
+            const entPath = path.join(dir, ent.name);
+            if (ent.isFile()) {
+                curPackage.addFile(entPath);
+            } else if (ent.isDirectory() && ent.name !== "node_modules") {
+                if (isVersionDir(ent.name)) {
+                    const newPackage = new LintPackage(entPath);
+                    packages.push(newPackage);
+                    walk(newPackage, entPath);
+                } else {
+                    walk(curPackage, entPath);
+                }
+            }
+        }
+    }
+
+    const lintPackage = new LintPackage(rootDir);
+    packages.push(lintPackage);
+    walk(lintPackage, rootDir);
+    return packages;
+}
+
+/**
+ * Returns true if directory name matches a TypeScript or package version directory.
+ * Examples: `ts3.5`, `v11`, `v0.6` are all version names.
+ */
+function isVersionDir(dirName: string): boolean {
+    return /^ts\d+\.\d$/.test(dirName) || /^v\d+(\.\d+)?$/.test(dirName);
+}
+
+function installDependencies(pkgPath: string): void {
+    if (fs.existsSync(path.join(pkgPath, "package.json"))) {
+        cp.execSync(
+            "npm install --ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links",
+            {
+                encoding: "utf8",
+                cwd: pkgPath,
+            });
+    }
+}
+
+function mergeConfigRules(
+    config: Config.RawConfigFile,
+    newRules: Config.RawRulesConfig,
+    baseConfig: Config.IConfigurationFile): Config.RawConfigFile {
+    const activeRules: string[] = [];
+    baseConfig.rules.forEach((ruleOpts, ruleName) => {
+        if (ruleOpts.ruleSeverity !== "off") {
+            activeRules.push(ruleName);
+        }
+    });
+    const oldRules: Config.RawRulesConfig = config.rules || {};
+    let newRulesConfig: Config.RawRulesConfig = {};
+    for (const rule of Object.keys(oldRules)) {
+        if (activeRules.includes(rule)) {
+            continue;
+        }
+        newRulesConfig[rule] = oldRules[rule];
+    }
+    newRulesConfig = { ...newRulesConfig, ...newRules };
+    return { ...config, rules: newRulesConfig };
+}
+
+function disableRules(allFailures: RuleFailure[]): Config.RawRulesConfig {
+    const ruleToFailures: Map<string, IRuleFailureJson[]> = new Map();
+    for (const failure of allFailures) {
+        const failureJson = failure.toJson();
+        if (ruleToFailures.has(failureJson.ruleName)) {
+            ruleToFailures.get(failureJson.ruleName)!.push(failureJson);
+        } else {
+            ruleToFailures.set(failureJson.ruleName, [failureJson]);
+        }
+    }
+
+    const newRulesConfig: Config.RawRulesConfig = {};
+    ruleToFailures.forEach((failures, rule) => {
+        if (ignoredRules.has(rule)) {
+            return;
+        }
+        const disabler = rule === "npm-naming" ? npmNamingDisabler : defaultDisabler;
+        const opts: RuleOptions = disabler(failures);
+        newRulesConfig[rule] = opts;
+    });
+
+    return newRulesConfig;
+}
+
+type RuleOptions = boolean | unknown[];
+type RuleDisabler = (failures: IRuleFailureJson[]) => RuleOptions;
+
+const defaultDisabler: RuleDisabler = () => {
+    return false;
+};


### PR DESCRIPTION
Per https://github.com/microsoft/dtslint/issues/300#issuecomment-904979821, moves just the `updateConfig.ts` script from dtslint to a `scripts/update-config` directory here. There should be no logic changes, just shuffling files around and a couple of logic nits (switching `ignoredRules` to a Set and DRYing the call to `dtConfig`).

Example usage:

```ts
ts-node --project scripts\tsconfig.json scripts\update-config --package types/yargs
```

Note that ☝️ actually modifies the `yargs` `tslint.json`s to remove any `npm-naming` override and add `"no-redundant-undefined": false`. The logic hasn't changed from dtslint.