### PR TITLE
fix(jira-client): `listProjects` should return an array

### DIFF
--- a/types/jira-client/index.d.ts
+++ b/types/jira-client/index.d.ts
@@ -424,7 +424,7 @@ declare class JiraApi {
      * List all Viewable Projects
      * [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id289193)
      */
-    listProjects(): Promise<JiraApi.JsonResponse>;
+    listProjects(): Promise<JiraApi.JsonResponse[]>;
 
     /**
      * Add a comment to an issue


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-get
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `listProjects` function of `jira-client` returns an array, so the type should be edited accordingly.