### PR TITLE
Allow Node TLS's 'alpnProtocol' to be false

### DIFF
--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -162,7 +162,7 @@ declare module 'tls' {
          * String containing the selected ALPN protocol.
          * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string | undefined;
+        alpnProtocol?: string | false | undefined;
         /**
          * Returns an object representing the local certificate. The returned object has
          * some properties corresponding to the fields of the certificate.

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -160,9 +160,10 @@ declare module 'tls' {
         encrypted: boolean;
         /**
          * String containing the selected ALPN protocol.
-         * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
+         * Before a handshake has completed, this value is always null.
+         * When a handshake is completed but not ALPN protocol was selected, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string | false | undefined;
+        alpnProtocol: string | false | null;
         /**
          * Returns an object representing the local certificate. The returned object has
          * some properties corresponding to the fields of the certificate.

--- a/types/node/v12/tls.d.ts
+++ b/types/node/v12/tls.d.ts
@@ -147,7 +147,7 @@ declare module 'tls' {
          * String containing the selected ALPN protocol.
          * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string | undefined;
+        alpnProtocol?: string | false | undefined;
 
         /**
          * Returns an object representing the local certificate. The returned

--- a/types/node/v12/tls.d.ts
+++ b/types/node/v12/tls.d.ts
@@ -145,9 +145,10 @@ declare module 'tls' {
 
         /**
          * String containing the selected ALPN protocol.
-         * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
+         * Before a handshake has completed, this value is always null.
+         * When a handshake is completed but not ALPN protocol was selected, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string | false | undefined;
+        alpnProtocol: string | false | null;
 
         /**
          * Returns an object representing the local certificate. The returned

--- a/types/node/v14/tls.d.ts
+++ b/types/node/v14/tls.d.ts
@@ -152,7 +152,7 @@ declare module 'tls' {
          * String containing the selected ALPN protocol.
          * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string | undefined;
+        alpnProtocol?: string | false | undefined;
 
         /**
          * Returns an object representing the local certificate. The returned

--- a/types/node/v14/tls.d.ts
+++ b/types/node/v14/tls.d.ts
@@ -150,9 +150,10 @@ declare module 'tls' {
 
         /**
          * String containing the selected ALPN protocol.
-         * When ALPN has no selected protocol, tlsSocket.alpnProtocol equals false.
+         * Before a handshake has completed, this value is always null.
+         * When a handshake is completed but not ALPN protocol was selected, tlsSocket.alpnProtocol equals false.
          */
-        alpnProtocol?: string | false | undefined;
+        alpnProtocol: string | false | null;
 
         /**
          * Returns an object representing the local certificate. The returned


### PR DESCRIPTION
Tiny change: as documented (in the node docs and the comment already present here) `alpnProtocol` is false when no ALPN protocol is selected.

I've left `undefined` here too, as it was before - I'm not sure if that can occur in some cases as well, e.g. when ALPN isn't configured at all, or isn't supported in the TLS version, etc.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change (skipping as it's a trivial change)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tls.html#tls_event_secureconnection (already documented in the comment here in these types)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.