### PR TITLE
Fixed fitBound coords types

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -1,53 +1,55 @@
-import GoogleMapReact, {
-    BootstrapURLKeys, MapOptions, FitBoundCoords,
-    Size,
-    fitBounds
-} from 'google-map-react';
+import GoogleMapReact, { BootstrapURLKeys, MapOptions, NESWBounds, Size, fitBounds } from 'google-map-react';
 import * as React from 'react';
 
 const center = { lat: 0, lng: 0 };
 
-const key: BootstrapURLKeys = { key: 'my-google-maps-key', libraries: "places" };
-const client: BootstrapURLKeys = { client: 'my-client-identifier', v: '3.28' , language: 'en', libraries: "places", region: "PR" };
+const key: BootstrapURLKeys = { key: 'my-google-maps-key', libraries: 'places' };
+const client: BootstrapURLKeys = {
+    client: 'my-client-identifier',
+    v: '3.28',
+    language: 'en',
+    libraries: 'places',
+    region: 'PR',
+};
 const options: MapOptions = {
     zoomControl: false,
     gestureHandling: 'cooperative',
     styles: [
         {
-            featureType: "administrative",
-            elementType: "all",
-            stylers: [ {saturation: "-100"} ]
+            featureType: 'administrative',
+            elementType: 'all',
+            stylers: [{ saturation: '-100' }],
         },
         {
-            featureType: "administrative.neighborhood",
-            stylers: [ {visibility: "off" } ]
+            featureType: 'administrative.neighborhood',
+            stylers: [{ visibility: 'off' }],
         },
         {
-            elementType: "labels.text.stroke",
-            stylers: [ {color: "#242f3e"} ]
+            elementType: 'labels.text.stroke',
+            stylers: [{ color: '#242f3e' }],
         },
         {
-            stylers: [ {color: "#fcfffd"} ]
-        }
+            stylers: [{ color: '#fcfffd' }],
+        },
     ],
 };
 
 <GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options} />;
 
-const bounds: FitBoundCoords = {
+const bounds: NESWBounds = {
     ne: {
-      lat: 55,
-      lng: 10,
+        lat: 55,
+        lng: 10,
     },
     sw: {
-      lat: 45,
-      lng: 20,
-    }
+        lat: 45,
+        lng: 20,
+    },
 };
 
 const size: Size = {
     width: 1280,
-    height: 640
+    height: 640,
 };
 
 fitBounds(bounds, size);

--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -1,5 +1,5 @@
 import GoogleMapReact, {
-    BootstrapURLKeys, MapOptions, NESWBounds,
+    BootstrapURLKeys, MapOptions, FitBoundCoords,
     Size,
     fitBounds
 } from 'google-map-react';
@@ -34,7 +34,7 @@ const options: MapOptions = {
 
 <GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options} />;
 
-const bounds: NESWBounds = {
+const bounds: FitBoundCoords = {
     ne: {
       lat: 55,
       lng: 10,

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -108,7 +108,6 @@ declare namespace googleMapReact {
         nw: Coords;
         se: Coords;
     }
-    type FitBoundCoords = NESWBounds | NWSEBounds;
 
     interface Coords {
         lat: number;
@@ -196,7 +195,7 @@ declare namespace googleMapReact {
     function convertNwSeToNeSw(boundCorder: { nw: Coords; se: Coords }): { ne: Coords; sw: Coords };
 
     function fitBounds(
-        bounds: FitBoundCoords,
+        bounds: NESWBounds | NWSEBounds,
         size: Size,
     ): {
         center: { lat: number; lng: number };

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -99,16 +99,16 @@ declare namespace googleMapReact {
         x: number;
         y: number;
     }
-    interface NeSwDiagonal {
+    interface NESWBounds {
         ne: Coords;
         sw: Coords;
     }
 
-    interface NwSeDiagonal {
+    interface NWSEBounds {
         nw: Coords;
         se: Coords;
     }
-    type FitBoundCoords = NeSwDiagonal | NwSeDiagonal;
+    type FitBoundCoords = NESWBounds | NWSEBounds;
 
     interface Coords {
         lat: number;

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -100,12 +100,15 @@ declare namespace googleMapReact {
         y: number;
     }
 
-    interface NESWBounds {
+    interface NeSwDiagonal{
         ne: Coords;
         sw: Coords;
-        nw?: Coords | undefined;
-        se?: Coords | undefined;
     }
+    interface NwSeDiagonal{
+        nw: Coords;
+        se: Coords;
+    }
+    type FitBoundCoords = NeSwDiagonal | NwSeDiagonal
 
     interface Coords {
         lat: number;
@@ -193,7 +196,7 @@ declare namespace googleMapReact {
     function convertNwSeToNeSw(boundCorder: { nw: Coords; se: Coords }): { ne: Coords; sw: Coords };
 
     function fitBounds(
-        bounds: NESWBounds,
+        bounds: FitBoundCoords,
         size: Size,
     ): {
         center: { lat: number; lng: number };

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -99,12 +99,12 @@ declare namespace googleMapReact {
         x: number;
         y: number;
     }
-
-    interface NeSwDiagonal{
+    interface NeSwDiagonal {
         ne: Coords;
         sw: Coords;
     }
-    interface NwSeDiagonal{
+
+    interface NwSeDiagonal {
         nw: Coords;
         se: Coords;
     }

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -108,7 +108,7 @@ declare namespace googleMapReact {
         nw: Coords;
         se: Coords;
     }
-    type FitBoundCoords = NeSwDiagonal | NwSeDiagonal
+    type FitBoundCoords = NeSwDiagonal | NwSeDiagonal;
 
     interface Coords {
         lat: number;


### PR DESCRIPTION

This PR is a fix for optional co-ordinates within Bounds argument in **fitBounds** function:

[Based on the implementation, **fitBounds** accepts **ne sw** or **nw se** values](https://github.com/google-map-react/google-map-react/blob/88038c293dff16d6211c564624c08925e4ff1987/src/utils/utils.js#L147)

This MR was created to fix a bug from [this](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43919/files) MR


