### PR TITLE
[simple-peer] Add missing trickle options to typedefs

### DIFF
--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -33,9 +33,9 @@ declare namespace SimplePeer {
         streams?: MediaStream[] | undefined;
         /** set to `false` to disable [trickle ICE](http://webrtchacks.com/trickle-ice/) and get a single 'signal' event (slower) */
         trickle?: boolean | undefined;
-        /** similar to `trickle`, needs to be set to false to disable trickling, defaults to `false` */
+        /** similar to `trickle`, needs to be set to `false` to disable trickling, defaults to `false` */
         allowHalfTrickle?: boolean | undefined;
-        /** if `trickle` is set to false, determines how long to wait before providing offer or answer, default value is 5000 milliseconds  */
+        /** if `trickle` is set to `false`, determines how long to wait before providing an offer or answer; default value is 5000 milliseconds  */
         iceCompleteTimeout?: number | undefined;
         /** custom webrtc implementation, mainly useful in node to specify in the [wrtc](https://npmjs.com/package/wrtc) package. */
         wrtc?: {

--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -31,8 +31,12 @@ declare namespace SimplePeer {
         stream?: MediaStream | undefined;
         /** an array of MediaStreams returned from [`getUserMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) */
         streams?: MediaStream[] | undefined;
-        /**  set to `false` to disable [trickle ICE](http://webrtchacks.com/trickle-ice/) and get a single 'signal' event (slower) */
+        /** set to `false` to disable [trickle ICE](http://webrtchacks.com/trickle-ice/) and get a single 'signal' event (slower) */
         trickle?: boolean | undefined;
+        /** similar to `trickle`, needs to be set to false to disable trickling, defaults to `false` */
+        allowHalfTrickle?: boolean | undefined;
+        /** if `trickle` is set to false, determines how long to wait before providing offer or answer, default value is 5000 milliseconds  */
+        iceCompleteTimeout?: number | undefined;
         /** custom webrtc implementation, mainly useful in node to specify in the [wrtc](https://npmjs.com/package/wrtc) package. */
         wrtc?: {
             RTCPeerConnection: typeof RTCPeerConnection;

--- a/types/simple-peer/simple-peer-tests.ts
+++ b/types/simple-peer/simple-peer-tests.ts
@@ -9,6 +9,8 @@ declare const stream: MediaStream;
         initiator: location.hash === "#1",
         trickle: false,
         stream,
+        iceCompleteTimeout: 500,
+        allowHalfTrickle: false
     });
 
     p.on("error", err => console.log("error", err));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: The added options are being read in the constructor here: https://github.com/feross/simple-peer/blob/master/index.js#L52-L53
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.