### PR TITLE
Codeowners update script: Pull before push

### DIFF
--- a/.github/workflows/UpdateCodeowners.yml
+++ b/.github/workflows/UpdateCodeowners.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # https://crontab.guru/#5_8_*_*_1
     - cron: "5 8 * * 1"
+  workflow_dispatch:
 
 jobs:
   update:

--- a/scripts/update-codeowners.js
+++ b/scripts/update-codeowners.js
@@ -28,6 +28,7 @@ main().then(() => {
     runSequence([
         ["git", ["add", ".github/CODEOWNERS"]], // Add CODEOWNERS
         ["git", ["commit", "-m", `"🤖 Update CODEOWNERS"`]], // Commit all changes
+        ["git", ["pull"]], // Ensure we're up-to-date
         ["git", ["push"]] // push the branch
     ]);
     console.log(`Pushed new commit.`);


### PR DESCRIPTION
We got a fail because in the time between creating the codeowners and then pushing new commits were merged: https://github.com/DefinitelyTyped/DefinitelyTyped/runs/3459550861?check_suite_focus=true