### PR TITLE
async: fix types for async.auto with Promise as result

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -340,9 +340,8 @@ export function cargoQueue<T, E = Error>(
     concurrency?: number,
     payload?: number,
 ): QueueObject<T>;
-export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency: number): Promise<R>;
+export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency?: number): Promise<R>;
 export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency: number, callback: AsyncResultCallback<R, E>): void;
-export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>): Promise<R>;
 export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, callback: AsyncResultCallback<R, E>): void;
 export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;
 

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -340,8 +340,10 @@ export function cargoQueue<T, E = Error>(
     concurrency?: number,
     payload?: number,
 ): QueueObject<T>;
-export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency?: number, callback?: AsyncResultCallback<R, E>): void;
-export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, callback?: AsyncResultCallback<R, E>): void;
+export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency: number): Promise<R>;
+export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency: number, callback: AsyncResultCallback<R, E>): void;
+export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>): Promise<R>;
+export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, callback: AsyncResultCallback<R, E>): void;
 export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;
 
 export interface RetryOptions<E> {

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -308,6 +308,19 @@ async.auto({
 });
 
 async.auto({
+    get_data: async () => { },
+    make_folder: async () => { },
+
+    // arrays with different types are not accepted by TypeScript.
+    write_file: ['get_data', 'make_folder', (async () => {
+        return filename;
+    }) as any],
+
+    // arrays with different types are not accepted by TypeScript.
+    email_link: ['write_file', (async (results: any) => { }) as any]
+}); // $ExpectType Promise<T{}>
+
+async.auto({
         get_data: (callback: AsyncResultCallback<any>) => { },
         make_folder: (callback: AsyncResultCallback<any>) => { },
 
@@ -326,6 +339,21 @@ interface A {
     write_file: any;
     email_link: any;
 }
+
+async.auto<A>({
+        get_data: async () => { },
+        make_folder: async () => { },
+
+        // arrays with different types are not accepted by TypeScript.
+        write_file: ['get_data', 'make_folder', (async () => {
+            return filename;
+        }) as any],
+
+        // arrays with different types are not accepted by TypeScript.
+        email_link: ['write_file', (async (results: any) => { }) as any]
+    },
+    1
+); // $ExpectType Promise<T{}>
 
 async.auto<A>({
         get_data: (callback: AsyncResultCallback<any>) => { },

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -293,8 +293,17 @@ cargo.push({ name: 'foo' }, (err: Error) => { console.log('finished processing f
 cargo.push({ name: 'bar' }, (err: Error) => { console.log('finished processing bar'); });
 cargo.push({ name: 'baz' }, (err: Error) => { console.log('finished processing baz'); });
 
+interface A {
+    get_data: any;
+    make_folder: any;
+    write_file: any;
+    email_link: any;
+}
+
 const filename = '';
-async.auto({
+
+// $ExpectType void
+async.auto<A>({
     get_data: (callback: AsyncResultCallback<any>) => { },
     make_folder: (callback: AsyncResultCallback<any>) => { },
 
@@ -305,9 +314,10 @@ async.auto({
 
     // arrays with different types are not accepted by TypeScript.
     email_link: ['write_file', ((callback: AsyncResultCallback<any>, results: any) => { }) as any]
-});
+}, (err, results) => { console.log('finished auto'); });
 
-async.auto({
+// $ExpectType Promise<A>
+async.auto<A>({
     get_data: async () => { },
     make_folder: async () => { },
 
@@ -318,9 +328,10 @@ async.auto({
 
     // arrays with different types are not accepted by TypeScript.
     email_link: ['write_file', (async (results: any) => { }) as any]
-}); // $ExpectType Promise<T{}>
+});
 
-async.auto({
+// $ExpectType void
+async.auto<A>({
         get_data: (callback: AsyncResultCallback<any>) => { },
         make_folder: (callback: AsyncResultCallback<any>) => { },
 
@@ -333,13 +344,7 @@ async.auto({
     (err, results) => { console.log('finished auto'); }
 );
 
-interface A {
-    get_data: any;
-    make_folder: any;
-    write_file: any;
-    email_link: any;
-}
-
+// $ExpectType Promise<A>
 async.auto<A>({
         get_data: async () => { },
         make_folder: async () => { },
@@ -353,8 +358,9 @@ async.auto<A>({
         email_link: ['write_file', (async (results: any) => { }) as any]
     },
     1
-); // $ExpectType Promise<T{}>
+);
 
+// $ExpectType void
 async.auto<A>({
         get_data: (callback: AsyncResultCallback<any>) => { },
         make_folder: (callback: AsyncResultCallback<any>) => { },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://caolan.github.io/async/v3/docs.html#auto
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A the current types are wrong for all recent versions.
