### PR TITLE
Add allowHalfOpen to Node's Duplex stream

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -790,6 +790,7 @@ declare module 'stream' {
             readonly writableLength: number;
             readonly writableObjectMode: boolean;
             readonly writableCorked: number;
+            allowHalfOpen: boolean;
             constructor(opts?: DuplexOptions);
             _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
             _writev?(

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -497,6 +497,12 @@ function stream_readable_pipe_test() {
     rs.close();
 }
 
+function stream_duplex_allowHalfOpen_test() {
+    const d = new Duplex();
+    assert(typeof d.allowHalfOpen === 'boolean');
+    d.allowHalfOpen = true;
+}
+
 addAbortSignal(new AbortSignal(), new Readable());
 
 {

--- a/types/node/v12/stream.d.ts
+++ b/types/node/v12/stream.d.ts
@@ -230,6 +230,7 @@ declare module 'stream' {
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
             readonly writableObjectMode: boolean;
+            allowHalfOpen: boolean;
             constructor(opts?: DuplexOptions);
             _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
             _writev?(chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;

--- a/types/node/v14/stream.d.ts
+++ b/types/node/v14/stream.d.ts
@@ -251,6 +251,7 @@ declare module 'stream' {
             readonly writableLength: number;
             readonly writableObjectMode: boolean;
             readonly writableCorked: number;
+            allowHalfOpen: boolean;
             constructor(opts?: DuplexOptions);
             _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
             _writev?(chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  https://github.com/nodejs/node/commit/d14878dc7c6d23038b59e837fcd61f8b35fced30 (documentation only just merged, but supported in Node back to v0.9.4)

Note that unlike the other readonly Duplex properties this property _is_ writable. I've included a write in the tests to make sure nobody tries to helpfully fix that :smile:.