### PR TITLE
Correct undoItem and redoItem types.

### DIFF
--- a/types/prosemirror-menu/index.d.ts
+++ b/types/prosemirror-menu/index.d.ts
@@ -183,11 +183,11 @@ export let selectParentNodeItem: MenuItem;
 /**
  * Menu item for the `undo` command.
  */
-export function undoItem(p: { [key: string]: any }): MenuItem;
+export function undoItem: MenuItem;
 /**
  * Menu item for the `redo` command.
  */
-export function redoItem(p: { [key: string]: any }): MenuItem;
+export function redoItem: MenuItem;
 /**
  * Build a menu item for wrapping the selection in a given node type.
  * Adds `run` and `select` properties to the ones present in


### PR DESCRIPTION
The JS sources define `undoItem` and `redoItem` by constructing two MenuItem class instances. The existing type definition is wrong, since these are not functions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/ProseMirror/prosemirror-menu/blob/master/src/menu.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

