### PR TITLE
Add missing methods/attributes from spec to dom-serial

### DIFF
--- a/types/dom-serial/dom-serial-tests.ts
+++ b/types/dom-serial/dom-serial-tests.ts
@@ -19,10 +19,16 @@ async function connect() {
         parity: 'none',
         bufferSize: 128,
     });
+
+    port.onconnect = () => {};
+    port.ondisconnect = () => {};
+
     const info = port.getInfo();
     const vendor = info.vendor;
     port.writable.getWriter();
     port.readable.getReader();
+
+    await port.close();
 }
 
 navigator.serial.requestPort().then(port => {

--- a/types/dom-serial/index.d.ts
+++ b/types/dom-serial/index.d.ts
@@ -35,10 +35,13 @@ interface SerialOptions {
     flowControl?: FlowControlType | undefined;
 }
 
-interface SerialPort {
-    open(options: SerialOptions): Promise<void>;
+interface SerialPort extends EventTarget {
+    onconnect: EventHandler;
+    ondisconnect: EventHandler;
     readonly readable: ReadableStream; // Chromium implementation (spec: in)
     readonly writable: WritableStream; // Chromium implementation (spec: out)
+    open(options: SerialOptions): Promise<void>;
+    close(): Promise<void>;
     getInfo(): Partial<SerialPortInfo>;
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://wicg.github.io/serial/#serialport-interface
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

___

I have added the `close` method and `onconnect`/`ondisconnect` attributes to the `SerialPort` interface. They are described [here](https://wicg.github.io/serial/#serialport-interface) and have been implemented in chrome (the only browser to implement the spec at all).