### PR TITLE
[twitch-ext] Added missing Authorized.helixToken property

### DIFF
--- a/types/twitch-ext/index.d.ts
+++ b/types/twitch-ext/index.d.ts
@@ -449,6 +449,11 @@ declare namespace Twitch.ext {
         token: string;
 
         /**
+         * JWT that can be used for front end API requests.
+         */
+        helixToken: string;
+
+        /**
          * Opaque user ID.
          */
         userId: string;

--- a/types/twitch-ext/twitch-ext-tests.ts
+++ b/types/twitch-ext/twitch-ext-tests.ts
@@ -3,6 +3,7 @@ console.log(`Running ${Twitch.ext.version} on ${Twitch.ext.environment}`);
 Twitch.ext.onAuthorized(auth => {
     console.log('The JWT that will be passed to the EBS is', auth.token);
     console.log('The channel ID is', auth.channelId);
+    console.log('JWT that can be used for front end API requests is', auth.helixToken);
 });
 
 Twitch.ext.onContext((context, changed) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Lately twitch added new property to `Twitch.ext.onAuthorized` response: `helixToken`. Here is a documentation proof of its existence:
https://dev.twitch.tv/docs/extensions/reference#helper-extensions

and here is a reference how to use it from client perspective:
https://dev.twitch.tv/docs/extensions/frontend-api-usage

