### PR TITLE
add types for service-worker-updater

### DIFF
--- a/types/service-worker-updater/index.d.ts
+++ b/types/service-worker-updater/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for service-worker-updater 0.0
+// Project: https://github.com/cactoo/service-worker-updater#readme
+// Definitions by: mike castleman <https://github.com/mlc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Minimum TypeScript Version: 4.0
+
+import * as React from 'react';
+
+export type UpdateHandler = () => void;
+
+export interface CheckOptions {
+    checkInterval?: number;
+    updateOnLoad?: boolean;
+}
+
+export type UpdateHookResult = [hasUpdate: boolean, updateHandler: UpdateHandler];
+export function useSWUpdateChecker(opts?: CheckOptions): UpdateHookResult;
+
+export interface InjectedUpdateProps {
+    hasUpdate: boolean;
+    updateHandler: UpdateHandler;
+}
+
+export function withSWUpdateChecker<P extends InjectedUpdateProps>(
+    WrappedComponent: React.ComponentType<P>,
+    opts?: CheckOptions,
+): React.ComponentClass<Omit<P, keyof InjectedUpdateProps>>;

--- a/types/service-worker-updater/service-worker-updater-tests.tsx
+++ b/types/service-worker-updater/service-worker-updater-tests.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useSWUpdateChecker, withSWUpdateChecker, InjectedUpdateProps } from 'service-worker-updater';
+
+const HookExample: React.FC = () => {
+    const [hasUpdate, updateHandler] = useSWUpdateChecker();
+
+    if (hasUpdate) {
+        return <button type="button" onClick={updateHandler}>update</button>;
+    } else {
+        return null;
+    }
+};
+
+interface HOCExampleProps extends InjectedUpdateProps {
+    n: number;
+}
+
+class HOCExample extends React.Component<HOCExampleProps> {
+    render() {
+        const { n, hasUpdate, updateHandler } = this.props;
+        if (hasUpdate) {
+            return <button type="button" onClick={updateHandler}>update</button>;
+        } else {
+            return <span>{`n is ${n}`}</span>;
+        }
+    }
+}
+
+const DecoratedComponent = withSWUpdateChecker(HOCExample);
+
+const Demo: React.FC = () => (<DecoratedComponent n={45} />);

--- a/types/service-worker-updater/tsconfig.json
+++ b/types/service-worker-updater/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "service-worker-updater-tests.tsx"
+    ]
+}

--- a/types/service-worker-updater/tslint.json
+++ b/types/service-worker-updater/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
[service-worker-updater](https://github.com/cactoo/service-worker-updater) is a library for showing reload prompts using a service worker. This PR adds types for it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
