### PR TITLE
[@types/bootstrap] always return instance from GetOrCreateInstanceFactory

### DIFF
--- a/types/bootstrap/js/dist/base-component.d.ts
+++ b/types/bootstrap/js/dist/base-component.d.ts
@@ -6,7 +6,7 @@ export type GetInstanceFactory<T> = (element: string | Element) => T | null;
 export type GetOrCreateInstanceFactory<T, C extends ComponentOptions = ComponentOptions> = (
     element: string | Element,
     config?: C,
-) => T | null;
+) => T;
 export type ComponentOptions = Record<string, any>;
 
 /**

--- a/types/bootstrap/test/alert-tests.ts
+++ b/types/bootstrap/test/alert-tests.ts
@@ -10,12 +10,13 @@ alert.dispose();
 
 // $ExpectType Alert | null
 Alert.getInstance(element);
-// $ExpectType Alert | null
+// $ExpectType Alert
 Alert.getOrCreateInstance(element);
 
 // $ExpectType void | undefined
 Alert.getInstance(element)?.close();
-Alert.getOrCreateInstance(element)?.close();
+// $ExpectType void
+Alert.getOrCreateInstance(element).close();
 
 Alert.VERSION; // $ExpectType string
 Alert.NAME; // $ExpectType "alert"

--- a/types/bootstrap/test/button-tests.ts
+++ b/types/bootstrap/test/button-tests.ts
@@ -8,7 +8,7 @@ new Button(element);
 
 // $ExpectType Button | null
 Button.getInstance(element);
-// $ExpectType Button | null
+// $ExpectType Button
 Button.getOrCreateInstance(element);
 
 // $ExpectType void

--- a/types/bootstrap/test/carousel-tests.ts
+++ b/types/bootstrap/test/carousel-tests.ts
@@ -8,7 +8,7 @@ new Carousel(element, { interval: 1000 });
 
 // $ExpectType Carousel | null
 Carousel.getInstance(element);
-// $ExpectType Carousel | null
+// $ExpectType Carousel
 Carousel.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/collapse-tests.ts
+++ b/types/bootstrap/test/collapse-tests.ts
@@ -8,7 +8,7 @@ new Collapse(element, { parent: '.parent' });
 
 // $ExpectType Collapse | null
 Collapse.getInstance(element);
-// $ExpectType Collapse | null
+// $ExpectType Collapse
 Collapse.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/dropdown-tests.ts
+++ b/types/bootstrap/test/dropdown-tests.ts
@@ -8,7 +8,7 @@ new Dropdown(element, { offset: [0, 2] }); // $ExpectType Dropdown
 
 // $ExpectType Dropdown | null
 Dropdown.getInstance(element);
-// $ExpectType Dropdown | null
+// $ExpectType Dropdown
 Dropdown.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/modal-tests.ts
+++ b/types/bootstrap/test/modal-tests.ts
@@ -8,7 +8,7 @@ new Modal(element, { backdrop: 'static' });
 
 // $ExpectType Modal | null
 Modal.getInstance(element);
-// $ExpectType Modal | null
+// $ExpectType Modal
 Modal.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/offcanvas-tests.ts
+++ b/types/bootstrap/test/offcanvas-tests.ts
@@ -8,7 +8,7 @@ new Offcanvas(element);
 
 // $ExpectType Offcanvas | null
 Offcanvas.getInstance(element);
-// $ExpectType Offcanvas | null
+// $ExpectType Offcanvas
 Offcanvas.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/popover-tests.ts
+++ b/types/bootstrap/test/popover-tests.ts
@@ -8,7 +8,7 @@ new Popover(element, { delay: 0.5, animation: true });
 
 // $ExpectType Popover | null
 Popover.getInstance(element);
-// $ExpectType Popover | null
+// $ExpectType Popover
 Popover.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/scrollspy-tests.ts
+++ b/types/bootstrap/test/scrollspy-tests.ts
@@ -8,7 +8,7 @@ new ScrollSpy(element, { offset: 10 });
 
 // $ExpectType ScrollSpy | null
 ScrollSpy.getInstance(element);
-// $ExpectType ScrollSpy | null
+// $ExpectType ScrollSpy
 ScrollSpy.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/tab-tests.ts
+++ b/types/bootstrap/test/tab-tests.ts
@@ -8,7 +8,7 @@ new Tab(element);
 
 // $ExpectType Tab | null
 Tab.getInstance(element);
-// $ExpectType Tab | null
+// $ExpectType Tab
 Tab.getOrCreateInstance(element);
 
 element.addEventListener(Tab.Events.hidden, event => {

--- a/types/bootstrap/test/toast-tests.ts
+++ b/types/bootstrap/test/toast-tests.ts
@@ -8,7 +8,7 @@ new Toast(element, { animation: false });
 
 // $ExpectType Toast | null
 Toast.getInstance(element);
-// $ExpectType Toast | null
+// $ExpectType Toast
 Toast.getOrCreateInstance(element);
 
 // $ExpectType string

--- a/types/bootstrap/test/tooltip-tests.ts
+++ b/types/bootstrap/test/tooltip-tests.ts
@@ -8,7 +8,7 @@ new Tooltip(element, { delay: 0.5, title: () => 'foo', customClass: () => 'custo
 
 // $ExpectType Tooltip | null
 Tooltip.getInstance(element);
-// $ExpectType Tooltip | null
+// $ExpectType Tooltip
 Tooltip.getOrCreateInstance(element);
 
 // $ExpectType string


### PR DESCRIPTION
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55537 the result of [`GetOrCreateInstanceFactory`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/bootstrap/js/dist/base-component.d.ts#L6) changed from `T` to `T | null`. 

If you look at the [original function](https://github.com/twbs/bootstrap/blob/51afe026ca1c08d228cb58cbe47f8c3d61167c96/js/src/base-component.js#L54) (and based on the name of the function), an instance should always be created/returned.