### PR TITLE
@types/mui-datatables - Added missing row attribute to logic

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -169,7 +169,7 @@ export interface MUIDataTableFilterOptions {
      *
      * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
-    logic?: ((prop: string, filterValue: any[]) => boolean) | undefined;
+    logic?: ((prop: string, filterValue: any[], row: any[]) => boolean) | undefined;
     /**
      * A function to customize filter choices.
      * Use case: changing empty strings to "(empty)" in a dropdown.

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -157,13 +157,15 @@ export interface MUIDataTableFilterOptions {
      *
      * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
-    display?: ((
-        filterList: MUIDataTableState['filterList'],
-        onChange: (val: string | string[], index: number, column: MUIDataTableColumn) => void,
-        index: number,
-        column: MUIDataTableColumn,
-        filterData: MUIDataTableState['filterData'],
-    ) => void) | undefined;
+    display?:
+        | ((
+              filterList: MUIDataTableState['filterList'],
+              onChange: (val: string | string[], index: number, column: MUIDataTableColumn) => void,
+              index: number,
+              column: MUIDataTableColumn,
+              filterData: MUIDataTableState['filterData'],
+          ) => void)
+        | undefined;
     /**
      * custom filter logic.
      *
@@ -194,11 +196,13 @@ export interface MUIDataTableCustomFilterListOptions {
      *
      * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
-    update?: ((
-        filterList: MUIDataTableState['filterList'],
-        filterPos: number,
-        index: number,
-    ) => MUIDataTableState['filterList']) | undefined;
+    update?:
+        | ((
+              filterList: MUIDataTableState['filterList'],
+              filterPos: number,
+              index: number,
+          ) => MUIDataTableState['filterList'])
+        | undefined;
 }
 
 export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
@@ -220,11 +224,9 @@ export interface MUIDataTableColumnOptions {
      *
      * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js)
      */
-    customBodyRender?: ((
-        value: any,
-        tableMeta: MUIDataTableMeta,
-        updateValue: (value: string) => void,
-    ) => string | React.ReactNode) | undefined;
+    customBodyRender?:
+        | ((value: any, tableMeta: MUIDataTableMeta, updateValue: (value: string) => void) => string | React.ReactNode)
+        | undefined;
     /**
      * Similar to and performing better than `customBodyRender`, however with the following caveats:
      * 1. The value returned from this function is not used for filtering, so the filter dialog will use the raw data from the data array.
@@ -247,11 +249,13 @@ export interface MUIDataTableColumnOptions {
     /** @deprecated use customFilterListOptions.render */
     customFilterListRender?: ((value: any) => string) | undefined;
     /** Function that returns a string or React component. Used as display for column header. */
-    customHeadRender?: ((
-        columnMeta: MUIDataTableCustomHeadRenderer,
-        handleToggleColumn: (columnIndex: number) => void,
-        sortOrder: MUISortOptions,
-    ) => string | React.ReactNode) | undefined;
+    customHeadRender?:
+        | ((
+              columnMeta: MUIDataTableCustomHeadRenderer,
+              handleToggleColumn: (columnIndex: number) => void,
+              sortOrder: MUISortOptions,
+          ) => string | React.ReactNode)
+        | undefined;
     /**
      * Determines if the column can be dragged.
      * The draggableColumns.enabled option must also be true.
@@ -336,7 +340,9 @@ export interface MUIDataTableColumnOptions {
      *
      * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js)
      */
-    sortCompare?: ((order: MUISortOptions['direction']) => (obj1: { data: any }, obj2: { data: any }) => number) | undefined;
+    sortCompare?:
+        | ((order: MUISortOptions['direction']) => (obj1: { data: any }, obj2: { data: any }) => number)
+        | undefined;
     /**
      * Causes the first click on a column to sort by desc rather than asc.
      *
@@ -861,31 +867,33 @@ export interface MUIDataTableCheckboxProps {
 }
 
 export interface MUIDataTableProps {
-  columns: MUIDataTableColumnDef[];
-  components?: Partial<{
-    Checkbox: RenderCustomComponent<MUIDataTableCheckboxProps> | React.ReactNode;
-    ExpandButton: RenderCustomComponent<MUIDataTableExpandButton> | React.ReactNode;
-    TableBody: RenderCustomComponent<MUIDataTableBody> | React.ReactNode;
-    TableViewCol: RenderCustomComponent<MUIDataTableViewCol> | React.ReactNode;
-    TableFilterList: RenderCustomComponent<MUIDataTableFilterList> | React.ReactNode;
-    TableFooter: RenderCustomComponent<MUIDataTableFooter> | React.ReactNode;
-    TableHead: RenderCustomComponent<MUIDataTableHead> | React.ReactNode;
-    TableResize: RenderCustomComponent<MUIDataTableResize> | React.ReactNode;
-    TableToolbar: RenderCustomComponent<MUIDataTableToolbar> | React.ReactNode;
-    TableToolbarSelect: RenderCustomComponent<MUIDataTableToolbarSelect> | React.ReactNode;
-    Tooltip: React.ReactNode;
-    icons: Partial<{
-      SearchIcon: React.ReactNode;
-      DownloadIcon: React.ReactNode;
-      PrintIcon: React.ReactNode;
-      ViewColumnIcon: React.ReactNode;
-      FilterIcon: React.ReactNode;
-    }>
-  }> | undefined;
-  data: Array<object | number[] | string[]>;
-  options?: MUIDataTableOptions | undefined;
-  title: string | React.ReactNode;
-  innerRef?: React.RefObject<React.Component<MUIDataTableProps, MUIDataTableState> | null | undefined> | undefined;
+    columns: MUIDataTableColumnDef[];
+    components?:
+        | Partial<{
+              Checkbox: RenderCustomComponent<MUIDataTableCheckboxProps> | React.ReactNode;
+              ExpandButton: RenderCustomComponent<MUIDataTableExpandButton> | React.ReactNode;
+              TableBody: RenderCustomComponent<MUIDataTableBody> | React.ReactNode;
+              TableViewCol: RenderCustomComponent<MUIDataTableViewCol> | React.ReactNode;
+              TableFilterList: RenderCustomComponent<MUIDataTableFilterList> | React.ReactNode;
+              TableFooter: RenderCustomComponent<MUIDataTableFooter> | React.ReactNode;
+              TableHead: RenderCustomComponent<MUIDataTableHead> | React.ReactNode;
+              TableResize: RenderCustomComponent<MUIDataTableResize> | React.ReactNode;
+              TableToolbar: RenderCustomComponent<MUIDataTableToolbar> | React.ReactNode;
+              TableToolbarSelect: RenderCustomComponent<MUIDataTableToolbarSelect> | React.ReactNode;
+              Tooltip: React.ReactNode;
+              icons: Partial<{
+                  SearchIcon: React.ReactNode;
+                  DownloadIcon: React.ReactNode;
+                  PrintIcon: React.ReactNode;
+                  ViewColumnIcon: React.ReactNode;
+                  FilterIcon: React.ReactNode;
+              }>;
+          }>
+        | undefined;
+    data: Array<object | number[] | string[]>;
+    options?: MUIDataTableOptions | undefined;
+    title: string | React.ReactNode;
+    innerRef?: React.RefObject<React.Component<MUIDataTableProps, MUIDataTableState> | null | undefined> | undefined;
 }
 
 export interface MUIDataTableExpandButton {
@@ -1148,21 +1156,9 @@ export default MUIDataTable;
 
 declare module '@material-ui/core/styles/overrides' {
     interface ComponentNameToClassKey {
-        MUIDataTable:
-            | 'root'
-            | 'caption'
-            | 'liveAnnounce'
-            | 'paper'
-            | 'responsiveScroll'
-            | 'tableRoot'
-            ;
+        MUIDataTable: 'root' | 'caption' | 'liveAnnounce' | 'paper' | 'responsiveScroll' | 'tableRoot';
 
-        MUIDataTableBody:
-            | 'root'
-            | 'emptyTitle'
-            | 'lastSimpleCell'
-            | 'lastStackedCell'
-            ;
+        MUIDataTableBody: 'root' | 'emptyTitle' | 'lastSimpleCell' | 'lastStackedCell';
 
         MUIDataTableBodyCell:
             | 'root'
@@ -1176,15 +1172,9 @@ declare module '@material-ui/core/styles/overrides' {
             | 'stackedCommonAlways'
             | 'stackedHeader'
             | 'stackedParent'
-            | 'stackedParentAlways'
-            ;
+            | 'stackedParentAlways';
 
-        MUIDataTableBodyRow:
-            | 'root'
-            | 'hoverCursor'
-            | 'responsiveSimple'
-            | 'responsiveStacked'
-            ;
+        MUIDataTableBodyRow: 'root' | 'hoverCursor' | 'responsiveSimple' | 'responsiveStacked';
 
         MUIDataTableFilter:
             | 'root'
@@ -1201,19 +1191,13 @@ declare module '@material-ui/core/styles/overrides' {
             | 'noMargin'
             | 'reset'
             | 'resetLink'
-            | 'title'
-            ;
+            | 'title';
 
         MUIDataTableFilterList: 'root' | 'chip';
 
         MUIDataTableFooter: 'root';
 
-        MUIDataTableHead:
-            | 'main'
-            | 'responsiveSimple'
-            | 'responsiveStacked'
-            | 'responsiveStackedAlways'
-            ;
+        MUIDataTableHead: 'main' | 'responsiveSimple' | 'responsiveStacked' | 'responsiveStackedAlways';
 
         MUIDataTableHeadCell:
             | 'root'
@@ -1228,19 +1212,11 @@ declare module '@material-ui/core/styles/overrides' {
             | 'sortActive'
             | 'sortLabelRoot'
             | 'toolButton'
-            | 'tooltip'
-            ;
+            | 'tooltip';
 
         MUIDataTableHeadRow: 'root';
 
-        MUIDataTableJumpToPage:
-            | 'root'
-            | 'caption'
-            | 'input'
-            | 'select'
-            | 'selectIcon'
-            | 'selectRoot'
-            ;
+        MUIDataTableJumpToPage: 'root' | 'caption' | 'input' | 'select' | 'selectIcon' | 'selectRoot';
 
         MUIDataTablePagination:
             | 'root'
@@ -1248,17 +1224,11 @@ declare module '@material-ui/core/styles/overrides' {
             | 'navContainer'
             | 'selectRoot'
             | 'tableCellContainer'
-            | 'toolbar'
-            ;
+            | 'toolbar';
 
         MUIDataTableResize: 'root' | 'resizer';
 
-        MUIDataTableSearch:
-            | 'clearIcon'
-            | 'main'
-            | 'searchIcon'
-            | 'searchText'
-            ;
+        MUIDataTableSearch: 'clearIcon' | 'main' | 'searchIcon' | 'searchText';
 
         MUIDataTableSelectCell:
             | 'root'
@@ -1271,8 +1241,7 @@ declare module '@material-ui/core/styles/overrides' {
             | 'fixedLeft'
             | 'headerCell'
             | 'hide'
-            | 'icon'
-            ;
+            | 'icon';
 
         MUIDataTableToolbar:
             | 'root'
@@ -1291,15 +1260,9 @@ declare module '@material-ui/core/styles/overrides' {
             | 'left'
             | 'searchIcon'
             | 'titleRoot'
-            | 'titleText'
-            ;
+            | 'titleText';
 
-        MUIDataTableToolbarSelect:
-            | 'root'
-            | 'deleteIcon'
-            | 'iconButton'
-            | 'title'
-            ;
+        MUIDataTableToolbarSelect: 'root' | 'deleteIcon' | 'iconButton' | 'title';
 
         MUIDataTableViewCol:
             | 'root'
@@ -1309,7 +1272,6 @@ declare module '@material-ui/core/styles/overrides' {
             | 'formControl'
             | 'formGroup'
             | 'label'
-            | 'title'
-            ;
+            | 'title';
     }
 }

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -169,7 +169,7 @@ export interface MUIDataTableFilterOptions {
      *
      * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
-    logic?: ((prop: string, filterValue: any[], row: any[]) => boolean) | undefined;
+    logic?: ((prop: string, filterValue: any[], row?: any[]) => boolean) | undefined;
     /**
      * A function to customize filter choices.
      * Use case: changing empty strings to "(empty)" in a dropdown.

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -43,6 +43,17 @@ const MuiCustomTable: React.FC<Props> = props => {
             label: 'Color',
             options: {
                 filter: true,
+                filterOptions: {
+                    logic: (prop: string, filterValue: any[], row: any[] | undefined) => {
+                        if(prop === "test") return true;
+                        if(filterValue.includes("test")) {
+                            return false;
+                        }
+                        if(row && row.length < 1) return false;
+                        return true;
+                        }     
+                    }
+                },
                 customFilterListOptions: {
                     render: (value: string) => value.toUpperCase(),
                 },

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -45,12 +45,12 @@ const MuiCustomTable: React.FC<Props> = props => {
                 filter: true,
                 filterOptions: {
                     logic: (prop: string, filterValue: any[], row: any[] | undefined) => {
-                        if(prop === "test") return true;
+                        if(prop === "test") return true
                         if(filterValue.includes("test")) {
-                            return false;
+                            return false
                         }
-                        if(row && row.length < 1) return false;
-                        return true;
+                        if(row && row.length < 1) return false
+                        return true
                         }     
                     }
                 },

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,4 +1,12 @@
-import MUIDataTable, { ExpandButton, MUIDataTableCheckboxProps, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps, MUIDataTableState, Popover } from 'mui-datatables';
+import MUIDataTable, {
+    ExpandButton,
+    MUIDataTableCheckboxProps,
+    MUIDataTableColumn,
+    MUIDataTableOptions,
+    MUIDataTableProps,
+    MUIDataTableState,
+    Popover,
+} from 'mui-datatables';
 import * as React from 'react';
 import { createMuiTheme, Checkbox, Radio } from '@material-ui/core';
 
@@ -45,14 +53,10 @@ const MuiCustomTable: React.FC<Props> = props => {
                 filter: true,
                 filterOptions: {
                     logic: (prop: string, filterValue: any[], row: any[] | undefined) => {
-                        if(prop === "test") return true
-                        if(filterValue.includes("test")) {
-                            return false
-                        }
-                        if(row && row.length < 1) return false
-                        return true
-                        }     
-                    }
+                        if (prop === 'test') return true;
+                        if (filterValue.length === 0) return true;
+                        return true;
+                    },
                 },
                 customFilterListOptions: {
                     render: (value: string) => value.toUpperCase(),
@@ -63,7 +67,7 @@ const MuiCustomTable: React.FC<Props> = props => {
             name: 'amount',
             label: 'Amount',
             options: {
-                customHeadLabelRender: (options) => {
+                customHeadLabelRender: options => {
                     return <p>Some customize Header - {options.name}</p>;
                 },
             },
@@ -185,7 +189,9 @@ const MuiCustomTable: React.FC<Props> = props => {
         },
     };
 
-    return <MUIDataTable title={props.title} data={data} columns={columns} options={TableOptions} innerRef={tableRef} />;
+    return (
+        <MUIDataTable title={props.title} data={data} columns={columns} options={TableOptions} innerRef={tableRef} />
+    );
 };
 
 const TableFruits = [
@@ -227,12 +233,12 @@ const todoOptions: MUIDataTableOptions = {
 <MuiCustomTable title="Todo Table" data={Todos} options={todoOptions} />;
 
 const CustomCheckbox = (props: MUIDataTableCheckboxProps) => {
-    const newProps = {...props};
+    const newProps = { ...props };
     newProps.color = props['data-description'] === 'row-select' ? 'secondary' : 'primary';
     if (props['data-description'] === 'row-select') {
-      return (<Radio {...newProps} />);
+        return <Radio {...newProps} />;
     } else {
-      return (<Checkbox {...newProps} />);
+        return <Checkbox {...newProps} />;
     }
 };
 
@@ -243,8 +249,8 @@ const customComponents: MUIDataTableProps['components'] = {
     icons: {
         DownloadIcon: <>DownloadIcon</>,
         FilterIcon: <>FilterIcon</>,
-        SearchIcon: <>SearchIcon</>
-    }
+        SearchIcon: <>SearchIcon</>,
+    },
 };
 
 <MuiCustomTable title="Todo Table" data={Todos} options={todoOptions} components={customComponents} />;
@@ -262,13 +268,18 @@ const MuiTheme = createMuiTheme({
     overrides: {
         MUIDataTable: {
             root: {
-                fontWeight: 300
-            }
+                fontWeight: 300,
+            },
         },
         MUIDataTableBody: {
-            emptyTitle: {}
-        }
-    }
+            emptyTitle: {},
+        },
+    },
 });
 
-<Popover classes={{ icon: 'icon_class' }} content={<span>content</span>} trigger={<button>trigger</button>} refExit={() => {}} />;
+<Popover
+    classes={{ icon: 'icon_class' }}
+    content={<span>content</span>}
+    trigger={<button>trigger</button>}
+    refExit={() => {}}
+/>;


### PR DESCRIPTION
Added the missing row attribute to the logic function of the MUIDataTableFilterOptions interface.



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blob/207a730e05aa4c4cc86c622cb27a68db7a8974ce/examples/customize-filter/index.js#L62

