### PR TITLE
[scroll-into-view] Add missing lockX, lockY types

### DIFF
--- a/types/scroll-into-view/index.d.ts
+++ b/types/scroll-into-view/index.d.ts
@@ -27,6 +27,10 @@ declare module __ScrollIntoView {
         topOffset?: number | undefined
         /** pixels to offset left alignment */
         leftOffset?: number | undefined
+        /** boolean to prevent X scrolling */
+        lockX?: boolean | undefined
+        /** boolean to prevent Y scrolling */
+        lockY?: boolean | undefined
     }
 
     /** type will be 'complete' if the scroll completed or 'canceled' if the current scroll was canceled by a new scroll */
@@ -34,8 +38,8 @@ declare module __ScrollIntoView {
     type Callback = (type: callbackParameterType) => void
 
     interface ScrollIntoView {
-        (target: HTMLElement, callback?: __ScrollIntoView.Callback) : void
-        (target: HTMLElement, settings: __ScrollIntoView.Settings, callback?: __ScrollIntoView.Callback) :  void
+        (target: HTMLElement, callback?: __ScrollIntoView.Callback): void
+        (target: HTMLElement, settings: __ScrollIntoView.Settings, callback?: __ScrollIntoView.Callback): void
     }
 
 }

--- a/types/scroll-into-view/index.d.ts
+++ b/types/scroll-into-view/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for scroll-into-view 1.13.1
+// Type definitions for scroll-into-view 1.16.0
 // Project: https://github.com/KoryNunn/scroll-into-view
 // Definitions by: zivni <https://github.com/zivni>
 //                 Thibaut <https://github.com/Thibaut-Fatus>
+//                 goodCycle <https://github.com/goodCycle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module __ScrollIntoView {

--- a/types/scroll-into-view/scroll-into-view-tests.ts
+++ b/types/scroll-into-view/scroll-into-view-tests.ts
@@ -15,7 +15,9 @@ scrollIntoView(someElement, {
         top: 0,
         left: 1,
         topOffset: 20,
-        leftOffset: 20
+        leftOffset: 20,
+        lockX: false,
+        lockY: false,
     }
 });
 


### PR DESCRIPTION
I found that we have missing types `lockX`, `lockY` for the recent version(1.16.0) of scroll-into-view. Check the changes please.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/KoryNunn/scroll-into-view/commit/d18fb6c3e25c18051383cd7a7946a26cd8722a65 && [change-log for version 1.16.0](https://changelogit.korynunn.com/#korynunn/scroll-into-view)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

