### PR TITLE
Added pp paramter to jasmineToString()

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -393,7 +393,7 @@ declare namespace jasmine {
 
     interface Any extends AsymmetricMatcher<any> {
         new (expectedClass: any): any;
-        jasmineToString(): string;
+        jasmineToString(prettyPrint: typeof pp): string;
     }
 
     interface AsymmetricMatcher<TValue> {
@@ -401,7 +401,7 @@ declare namespace jasmine {
          * customTesters are deprecated and will be replaced with matcherUtils in the future.
          */
         asymmetricMatch(other: TValue, matchersUtil?: MatchersUtil | ReadonlyArray<CustomEqualityTester>): boolean;
-        jasmineToString?(): string;
+        jasmineToString?(prettyPrint: typeof pp): string;
     }
 
     // taken from TypeScript lib.core.es6.d.ts, applicable to CustomMatchers.contains()
@@ -412,13 +412,13 @@ declare namespace jasmine {
 
     interface ArrayContaining<T> extends AsymmetricMatcher<any> {
         new?(sample: ArrayLike<T>): ArrayLike<T>;
-        jasmineToString(): string;
+        jasmineToString(prettyPrint: typeof pp): string;
     }
 
     interface ObjectContaining<T> extends AsymmetricMatcher<T> {
         new?(sample: { [K in keyof T]?: any }): { [K in keyof T]?: any };
 
-        jasmineToString?(): string;
+        jasmineToString?(prettyPrint: typeof pp): string;
     }
 
     interface Clock {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1289,6 +1289,9 @@ describe("custom asymmetry", () => {
             const secondValue = actual.split(",")[1];
             return matchersUtil.equals(secondValue, "bar");
         },
+        jasmineToString(pp) {
+            return 'an asymmetric tester for ' + pp('bar');
+        }
     };
 
     it("dives in deep", () => {


### PR DESCRIPTION
Since 3.6, Jasmine passes a pretty-print function (same as `MatchersUtil#pp`) to `jasmineToString`. `jasmineToString` will be called on any object during diff building if it exists. The place where it shows up in API docs and type signatures is on the asymmetric equality tester interface.


Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [✓] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://jasmine.github.io/api/3.9/AsymmetricEqualityTester.html#jasmineToString>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.