### PR TITLE
Fix type definition for onPassword prop in react-pdf lib

### DIFF
--- a/types/react-pdf/dist/Document.d.ts
+++ b/types/react-pdf/dist/Document.d.ts
@@ -90,7 +90,7 @@ export interface Props {
      * Function called when a password-protected PDF is loaded.
      * Defaults to a function that prompts the user for password.
      */
-    onPassword?: ((callback: (...args: any[]) => any) => void) | undefined;
+    onPassword?: ((callback: (...args: any[]) => any) => void, reason: string) | undefined;
 
     /**
      * Function called in case of an error while retrieving document source from `file` prop.

--- a/types/react-pdf/dist/Document.d.ts
+++ b/types/react-pdf/dist/Document.d.ts
@@ -90,7 +90,7 @@ export interface Props {
      * Function called when a password-protected PDF is loaded.
      * Defaults to a function that prompts the user for password.
      */
-    onPassword?: ((callback: (...args: any[]) => any) => void, reason: string) | undefined;
+    onPassword?: ((callback: (password: string) => void, reason: string) => void) | undefined;
 
     /**
      * Function called in case of an error while retrieving document source from `file` prop.


### PR DESCRIPTION
The type definition of `onPassword` property is wrong in react-pdf `Document`

[the implementation](https://github.com/wojtekmaj/react-pdf/blob/a129be07b57dae74274f0b82af1e84eb8bbe77fd/src/Document.jsx#L118) comes from [here](https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib-PDFDocumentLoadingTask.html)

If someone want to add a test for this, be my guest, but I think that it would be over-complicated and not so much needed. Anyway, there was no test before my change.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
